### PR TITLE
[FLINK-20830][Kubernetes]Add type of Headless_Cluster_IP for external…

### DIFF
--- a/docs/layouts/shortcodes/generated/kubernetes_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_config_configuration.html
@@ -192,7 +192,7 @@
             <td><h5>kubernetes.rest-service.exposed.type</h5></td>
             <td style="word-wrap: break-word;">ClusterIP</td>
             <td><p>Enum</p></td>
-            <td>The exposed type of the rest service. The exposed rest service could be used to access the Flink’s Web UI and REST endpoint.<br /><br />Possible values:<ul><li>"ClusterIP"</li><li>"NodePort"</li><li>"LoadBalancer"</li></ul></td>
+            <td>The exposed type of the rest service. The exposed rest service could be used to access the Flink’s Web UI and REST endpoint.<br /><br />Possible values:<ul><li>"ClusterIP"</li><li>"NodePort"</li><li>"LoadBalancer"</li><li>"Headless_ClusterIP"</li></ul></td>
         </tr>
         <tr>
             <td><h5>kubernetes.secrets</h5></td>

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesClusterDescriptor.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesClusterDescriptor.java
@@ -126,15 +126,16 @@ public class KubernetesClusterDescriptor implements ClusterDescriptor<String> {
 
     private String getWebMonitorAddress(Configuration configuration) throws Exception {
         AddressResolution resolution = AddressResolution.TRY_ADDRESS_RESOLUTION;
-        if (configuration.get(KubernetesConfigOptions.REST_SERVICE_EXPOSED_TYPE)
-                == KubernetesConfigOptions.ServiceExposedType.ClusterIP) {
+        final KubernetesConfigOptions.ServiceExposedType serviceType =
+                configuration.get(KubernetesConfigOptions.REST_SERVICE_EXPOSED_TYPE);
+        if (serviceType.isClusterIP()) {
             resolution = AddressResolution.NO_ADDRESS_RESOLUTION;
             LOG.warn(
                     "Please note that Flink client operations(e.g. cancel, list, stop,"
                             + " savepoint, etc.) won't work from outside the Kubernetes cluster"
                             + " since '{}' has been set to {}.",
                     KubernetesConfigOptions.REST_SERVICE_EXPOSED_TYPE.key(),
-                    KubernetesConfigOptions.ServiceExposedType.ClusterIP);
+                    serviceType);
         }
         return HighAvailabilityServicesUtils.getWebMonitorAddress(configuration, resolution);
     }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
@@ -24,6 +24,11 @@ import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.ExternalResourceOptions;
 import org.apache.flink.configuration.description.Description;
+import org.apache.flink.kubernetes.kubeclient.services.ClusterIPService;
+import org.apache.flink.kubernetes.kubeclient.services.HeadlessClusterIPService;
+import org.apache.flink.kubernetes.kubeclient.services.LoadBalancerService;
+import org.apache.flink.kubernetes.kubeclient.services.NodePortService;
+import org.apache.flink.kubernetes.kubeclient.services.ServiceType;
 import org.apache.flink.kubernetes.utils.Constants;
 import org.apache.flink.runtime.util.EnvironmentInformation;
 
@@ -511,9 +516,25 @@ public class KubernetesConfigOptions {
 
     /** The flink rest service exposed type. */
     public enum ServiceExposedType {
-        ClusterIP,
-        NodePort,
-        LoadBalancer
+        ClusterIP(ClusterIPService.INSTANCE),
+        NodePort(NodePortService.INSTANCE),
+        LoadBalancer(LoadBalancerService.INSTANCE),
+        Headless_ClusterIP(HeadlessClusterIPService.INSTANCE);
+
+        private final ServiceType serviceType;
+
+        ServiceExposedType(ServiceType serviceType) {
+            this.serviceType = serviceType;
+        }
+
+        public ServiceType serviceType() {
+            return serviceType;
+        }
+
+        /** Check whether it is ClusterIP type. */
+        public boolean isClusterIP() {
+            return this == ClusterIP || this == Headless_ClusterIP;
+        }
     }
 
     /** The flink rest service exposed type. */

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClient.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClient.java
@@ -31,6 +31,7 @@ import org.apache.flink.kubernetes.kubeclient.resources.KubernetesPod;
 import org.apache.flink.kubernetes.kubeclient.resources.KubernetesPodsWatcher;
 import org.apache.flink.kubernetes.kubeclient.resources.KubernetesService;
 import org.apache.flink.kubernetes.kubeclient.resources.KubernetesWatch;
+import org.apache.flink.kubernetes.kubeclient.services.ServiceType;
 import org.apache.flink.kubernetes.utils.Constants;
 import org.apache.flink.kubernetes.utils.KubernetesUtils;
 import org.apache.flink.runtime.persistence.PossibleInconsistentStateException;
@@ -181,10 +182,10 @@ public class Fabric8FlinkKubeClient implements FlinkKubeClient {
         final int restPort = getRestPortFromExternalService(service);
 
         final KubernetesConfigOptions.ServiceExposedType serviceExposedType =
-                KubernetesConfigOptions.ServiceExposedType.valueOf(service.getSpec().getType());
+                ServiceType.classify(service);
 
         // Return the external service.namespace directly when using ClusterIP.
-        if (serviceExposedType == KubernetesConfigOptions.ServiceExposedType.ClusterIP) {
+        if (serviceExposedType.isClusterIP()) {
             return Optional.of(
                     new Endpoint(
                             ExternalServiceDecorator.getNamespacedExternalServiceName(

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/ExternalServiceDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/ExternalServiceDecorator.java
@@ -23,7 +23,6 @@ import org.apache.flink.kubernetes.utils.Constants;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Service;
-import io.fabric8.kubernetes.api.model.ServiceBuilder;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -42,37 +41,21 @@ public class ExternalServiceDecorator extends AbstractKubernetesStepDecorator {
 
     @Override
     public List<HasMetadata> buildAccompanyingKubernetesResources() throws IOException {
-        final String serviceName =
-                getExternalServiceName(kubernetesJobManagerParameters.getClusterId());
+        final Service service =
+                kubernetesJobManagerParameters
+                        .getRestServiceExposedType()
+                        .serviceType()
+                        .buildUpExternalRestService(kubernetesJobManagerParameters);
 
-        final Service externalService =
-                new ServiceBuilder()
-                        .withApiVersion(Constants.API_VERSION)
-                        .withNewMetadata()
-                        .withName(serviceName)
-                        .withLabels(kubernetesJobManagerParameters.getCommonLabels())
-                        .withAnnotations(kubernetesJobManagerParameters.getRestServiceAnnotations())
-                        .endMetadata()
-                        .withNewSpec()
-                        .withType(kubernetesJobManagerParameters.getRestServiceExposedType().name())
-                        .withSelector(kubernetesJobManagerParameters.getSelectors())
-                        .addNewPort()
-                        .withName(Constants.REST_PORT_NAME)
-                        .withPort(kubernetesJobManagerParameters.getRestPort())
-                        .withNewTargetPort(kubernetesJobManagerParameters.getRestBindPort())
-                        .endPort()
-                        .endSpec()
-                        .build();
-
-        return Collections.singletonList(externalService);
+        return Collections.singletonList(service);
     }
 
-    /** Generate name of the external Service. */
+    /** Generate name of the external rest Service. */
     public static String getExternalServiceName(String clusterId) {
         return clusterId + Constants.FLINK_REST_SERVICE_SUFFIX;
     }
 
-    /** Generate namespaced name of the external Service. */
+    /** Generate namespaced name of the external rest Service. */
     public static String getNamespacedExternalServiceName(String clusterId, String namespace) {
         return getExternalServiceName(clusterId) + "." + namespace;
     }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/InternalServiceDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/InternalServiceDecorator.java
@@ -20,11 +20,10 @@ package org.apache.flink.kubernetes.kubeclient.decorators;
 
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.kubernetes.kubeclient.parameters.KubernetesJobManagerParameters;
-import org.apache.flink.kubernetes.utils.Constants;
+import org.apache.flink.kubernetes.kubeclient.services.HeadlessClusterIPService;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Service;
-import io.fabric8.kubernetes.api.model.ServiceBuilder;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -55,25 +54,8 @@ public class InternalServiceDecorator extends AbstractKubernetesStepDecorator {
                 getInternalServiceName(kubernetesJobManagerParameters.getClusterId());
 
         final Service headlessService =
-                new ServiceBuilder()
-                        .withApiVersion(Constants.API_VERSION)
-                        .withNewMetadata()
-                        .withName(serviceName)
-                        .withLabels(kubernetesJobManagerParameters.getCommonLabels())
-                        .endMetadata()
-                        .withNewSpec()
-                        .withClusterIP(Constants.HEADLESS_SERVICE_CLUSTER_IP)
-                        .withSelector(kubernetesJobManagerParameters.getSelectors())
-                        .addNewPort()
-                        .withName(Constants.JOB_MANAGER_RPC_PORT_NAME)
-                        .withPort(kubernetesJobManagerParameters.getRPCPort())
-                        .endPort()
-                        .addNewPort()
-                        .withName(Constants.BLOB_SERVER_PORT_NAME)
-                        .withPort(kubernetesJobManagerParameters.getBlobServerPort())
-                        .endPort()
-                        .endSpec()
-                        .build();
+                HeadlessClusterIPService.INSTANCE.buildUpInternalService(
+                        kubernetesJobManagerParameters);
 
         // Set job manager address to namespaced service name
         final String namespace = kubernetesJobManagerParameters.getNamespace();

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/services/ClusterIPService.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/services/ClusterIPService.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.kubeclient.services;
+
+import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
+import org.apache.flink.kubernetes.kubeclient.parameters.KubernetesJobManagerParameters;
+
+import io.fabric8.kubernetes.api.model.Service;
+
+/** The service type of ClusterIP. */
+public class ClusterIPService extends ServiceType {
+
+    public static final ClusterIPService INSTANCE = new ClusterIPService();
+
+    @Override
+    public Service buildUpInternalService(
+            KubernetesJobManagerParameters kubernetesJobManagerParameters) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getType() {
+        return KubernetesConfigOptions.ServiceExposedType.ClusterIP.name();
+    }
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/services/HeadlessClusterIPService.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/services/HeadlessClusterIPService.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.kubeclient.services;
+
+import org.apache.flink.kubernetes.kubeclient.decorators.InternalServiceDecorator;
+import org.apache.flink.kubernetes.kubeclient.parameters.KubernetesJobManagerParameters;
+import org.apache.flink.kubernetes.utils.Constants;
+
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServiceBuilder;
+
+/** The service type of Headless ClusterIP, which is an variant of ClusterIP. */
+public class HeadlessClusterIPService extends ClusterIPService {
+
+    public static final HeadlessClusterIPService INSTANCE = new HeadlessClusterIPService();
+    public static final String HEADLESS_CLUSTER_IP = "None";
+
+    @Override
+    public Service buildUpExternalRestService(
+            KubernetesJobManagerParameters kubernetesJobManagerParameters) {
+        final Service service = super.buildUpExternalRestService(kubernetesJobManagerParameters);
+        service.getSpec().setClusterIP(HEADLESS_CLUSTER_IP);
+        return service;
+    }
+
+    @Override
+    public Service buildUpInternalService(
+            KubernetesJobManagerParameters kubernetesJobManagerParameters) {
+        String serviceName =
+                InternalServiceDecorator.getInternalServiceName(
+                        kubernetesJobManagerParameters.getClusterId());
+        return new ServiceBuilder()
+                .withApiVersion(Constants.API_VERSION)
+                .withNewMetadata()
+                .withName(serviceName)
+                .withLabels(kubernetesJobManagerParameters.getCommonLabels())
+                .endMetadata()
+                .withNewSpec()
+                .withClusterIP(HEADLESS_CLUSTER_IP)
+                .withSelector(kubernetesJobManagerParameters.getSelectors())
+                .addNewPort()
+                .withName(Constants.JOB_MANAGER_RPC_PORT_NAME)
+                .withPort(kubernetesJobManagerParameters.getRPCPort())
+                .endPort()
+                .addNewPort()
+                .withName(Constants.BLOB_SERVER_PORT_NAME)
+                .withPort(kubernetesJobManagerParameters.getBlobServerPort())
+                .endPort()
+                .endSpec()
+                .build();
+    }
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/services/LoadBalancerService.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/services/LoadBalancerService.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.kubeclient.services;
+
+import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
+import org.apache.flink.kubernetes.kubeclient.parameters.KubernetesJobManagerParameters;
+
+import io.fabric8.kubernetes.api.model.Service;
+
+/** The service type of LoadBalancer. */
+public class LoadBalancerService extends ServiceType {
+
+    public static final LoadBalancerService INSTANCE = new LoadBalancerService();
+
+    @Override
+    public Service buildUpInternalService(
+            KubernetesJobManagerParameters kubernetesJobManagerParameters) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getType() {
+        return KubernetesConfigOptions.ServiceExposedType.LoadBalancer.name();
+    }
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/services/NodePortService.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/services/NodePortService.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.kubeclient.services;
+
+import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
+import org.apache.flink.kubernetes.kubeclient.parameters.KubernetesJobManagerParameters;
+
+import io.fabric8.kubernetes.api.model.Service;
+
+/** The service type of NodePort. */
+public class NodePortService extends ServiceType {
+
+    public static final NodePortService INSTANCE = new NodePortService();
+
+    private NodePortService() {}
+
+    @Override
+    public Service buildUpInternalService(
+            KubernetesJobManagerParameters kubernetesJobManagerParameters) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getType() {
+        return KubernetesConfigOptions.ServiceExposedType.NodePort.name();
+    }
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/services/ServiceType.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/services/ServiceType.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.kubeclient.services;
+
+import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
+import org.apache.flink.kubernetes.kubeclient.decorators.ExternalServiceDecorator;
+import org.apache.flink.kubernetes.kubeclient.parameters.KubernetesJobManagerParameters;
+import org.apache.flink.kubernetes.utils.Constants;
+
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServiceBuilder;
+
+/** An abstract class represents the service type that flink supported. */
+public abstract class ServiceType {
+
+    /**
+     * Build up the external rest service template, according to the jobManager parameters.
+     *
+     * @param kubernetesJobManagerParameters the parameters of jobManager.
+     * @return the external rest service
+     */
+    public Service buildUpExternalRestService(
+            KubernetesJobManagerParameters kubernetesJobManagerParameters) {
+        final String serviceName =
+                ExternalServiceDecorator.getExternalServiceName(
+                        kubernetesJobManagerParameters.getClusterId());
+
+        return new ServiceBuilder()
+                .withApiVersion(Constants.API_VERSION)
+                .withNewMetadata()
+                .withName(serviceName)
+                .withLabels(kubernetesJobManagerParameters.getCommonLabels())
+                .withAnnotations(kubernetesJobManagerParameters.getRestServiceAnnotations())
+                .endMetadata()
+                .withNewSpec()
+                .withType(
+                        kubernetesJobManagerParameters
+                                .getRestServiceExposedType()
+                                .serviceType()
+                                .getType())
+                .withSelector(kubernetesJobManagerParameters.getSelectors())
+                .addNewPort()
+                .withName(Constants.REST_PORT_NAME)
+                .withPort(kubernetesJobManagerParameters.getRestPort())
+                .withNewTargetPort(kubernetesJobManagerParameters.getRestBindPort())
+                .endPort()
+                .endSpec()
+                .build();
+    }
+
+    /**
+     * Build up the internal service template, according to the jobManager parameters.
+     *
+     * @param kubernetesJobManagerParameters the parameters of jobManager.
+     * @return the internal service
+     */
+    public abstract Service buildUpInternalService(
+            KubernetesJobManagerParameters kubernetesJobManagerParameters);
+
+    /**
+     * Gets the type of the target kubernetes service.
+     *
+     * @return the type of the target kubernetes service.
+     */
+    public abstract String getType();
+
+    // Helper method
+    public static KubernetesConfigOptions.ServiceExposedType classify(Service service) {
+        KubernetesConfigOptions.ServiceExposedType type =
+                KubernetesConfigOptions.ServiceExposedType.valueOf(service.getSpec().getType());
+        if (type == KubernetesConfigOptions.ServiceExposedType.ClusterIP) {
+            if (HeadlessClusterIPService.HEADLESS_CLUSTER_IP.equals(
+                    service.getSpec().getClusterIP())) {
+                type = KubernetesConfigOptions.ServiceExposedType.Headless_ClusterIP;
+            }
+        }
+        return type;
+    }
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/Constants.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/Constants.java
@@ -85,8 +85,6 @@ public class Constants {
 
     public static final String POD_IP_FIELD_PATH = "status.podIP";
 
-    public static final String HEADLESS_SERVICE_CLUSTER_IP = "None";
-
     public static final int MAXIMUM_CHARACTERS_OF_CLUSTER_ID = 45;
 
     public static final String RESTART_POLICY_OF_NEVER = "Never";

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/ExternalServiceDecoratorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/ExternalServiceDecoratorTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.kubernetes.kubeclient.decorators;
 
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.kubeclient.KubernetesJobManagerTestBase;
+import org.apache.flink.kubernetes.kubeclient.services.HeadlessClusterIPService;
 import org.apache.flink.kubernetes.utils.Constants;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
@@ -118,5 +119,21 @@ public class ExternalServiceDecoratorTest extends KubernetesJobManagerTestBase {
         assertEquals(
                 KubernetesConfigOptions.ServiceExposedType.ClusterIP.name(),
                 ((Service) servicesWithClusterIP.get(0)).getSpec().getType());
+    }
+
+    @Test
+    public void testSetServiceExposedTypeWithHeadless() throws IOException {
+
+        this.flinkConfig.set(
+                KubernetesConfigOptions.REST_SERVICE_EXPOSED_TYPE,
+                KubernetesConfigOptions.ServiceExposedType.Headless_ClusterIP);
+        final List<HasMetadata> servicesWithHeadlessClusterIP =
+                this.externalServiceDecorator.buildAccompanyingKubernetesResources();
+        assertThat(
+                ((Service) servicesWithHeadlessClusterIP.get(0)).getSpec().getType(),
+                is(KubernetesConfigOptions.ServiceExposedType.ClusterIP.name()));
+        assertThat(
+                ((Service) servicesWithHeadlessClusterIP.get(0)).getSpec().getClusterIP(),
+                is(HeadlessClusterIPService.HEADLESS_CLUSTER_IP));
     }
 }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesJobManagerFactoryTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesJobManagerFactoryTest.java
@@ -35,6 +35,7 @@ import org.apache.flink.kubernetes.kubeclient.decorators.FlinkConfMountDecorator
 import org.apache.flink.kubernetes.kubeclient.decorators.HadoopConfMountDecorator;
 import org.apache.flink.kubernetes.kubeclient.decorators.InternalServiceDecorator;
 import org.apache.flink.kubernetes.kubeclient.decorators.KerberosMountDecorator;
+import org.apache.flink.kubernetes.kubeclient.services.HeadlessClusterIPService;
 import org.apache.flink.kubernetes.utils.Constants;
 import org.apache.flink.kubernetes.utils.KubernetesUtils;
 
@@ -287,7 +288,7 @@ public class KubernetesJobManagerFactoryTest extends KubernetesJobManagerTestBas
 
         assertNull(resultInternalService.getSpec().getType());
         assertEquals(
-                Constants.HEADLESS_SERVICE_CLUSTER_IP,
+                HeadlessClusterIPService.HEADLESS_CLUSTER_IP,
                 resultInternalService.getSpec().getClusterIP());
         assertEquals(2, resultInternalService.getSpec().getPorts().size());
         assertEquals(3, resultInternalService.getSpec().getSelector().size());

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/services/ServiceTypeTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/services/ServiceTypeTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.kubeclient.services;
+
+import org.apache.flink.kubernetes.KubernetesClientTestBase;
+import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+/** Tests for {@link ServiceType}. */
+public class ServiceTypeTest extends KubernetesClientTestBase {
+
+    @Test
+    public void testServiceClassify() {
+        assertThat(
+                ServiceType.classify(buildExternalServiceWithClusterIP()),
+                is(KubernetesConfigOptions.ServiceExposedType.ClusterIP));
+        assertThat(
+                ServiceType.classify(buildExternalServiceWithHeadlessClusterIP()),
+                is(KubernetesConfigOptions.ServiceExposedType.Headless_ClusterIP));
+        assertThat(
+                ServiceType.classify(buildExternalServiceWithNodePort()),
+                is(KubernetesConfigOptions.ServiceExposedType.NodePort));
+        assertThat(
+                ServiceType.classify(buildExternalServiceWithLoadBalancer("", "")),
+                is(KubernetesConfigOptions.ServiceExposedType.LoadBalancer));
+    }
+}


### PR DESCRIPTION
… rest service

## What is the purpose of the change

This pull request is meant to add a new service type `Healess_Cluster_IP` as the rest external service type.

## Brief change log

 - Add a new abstract class `ServiceType` to represent the flink inner service type which will be responsible for the build service. I will create a follow up pull request to move the `getEndpoint` methods to each subtype of `ServiceType`.

## Verifying this change

This change added tests and can be verified as follows:

  - *org.apache.flink.kubernetes.kubeclient.services.ServiceTypeTest#testServiceClassify*
  - *org.apache.flink.kubernetes.kubeclient.decorators.ExternalServiceDecoratorTest#testSetServiceExposedType*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
