### PR TITLE
[FLINK-25016][build] Upgrade to Netty 4.1.70 

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/FileUploadHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/FileUploadHandler.java
@@ -24,13 +24,11 @@ import org.apache.flink.runtime.rest.messages.ErrorResponseBody;
 import org.apache.flink.runtime.rest.util.RestConstants;
 import org.apache.flink.util.FileUtils;
 
-import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
 import org.apache.flink.shaded.netty4.io.netty.buffer.Unpooled;
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelHandlerContext;
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelInboundHandler;
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelPipeline;
 import org.apache.flink.shaded.netty4.io.netty.channel.SimpleChannelInboundHandler;
-import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpConstants;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpContent;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpHeaders;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpMethod;
@@ -146,33 +144,7 @@ public class FileUploadHandler extends SimpleChannelInboundHandler<HttpObject> {
                 // meanwhile
                 RestServerEndpoint.createUploadDir(uploadDir, LOG, false);
 
-                HttpContent httpContent = (HttpContent) msg;
-                final ByteBuf content = httpContent.content();
-
-                // the following is a defense mechanism against
-                // https://github.com/netty/netty/issues/11668
-                // if the CRLF prefix of a multipart delimiter is split across 2 chunks an exception
-                // is thrown
-                // if CR is the last byte of the current chunk, then we pessimistically assume that
-                // this case occurred
-                // exclude the trailing CR from the current chunk, and add it to the front of the
-                // next received chunk
-                if (addCRPrefix) {
-                    final byte[] contentWithLeadingCR = new byte[1 + content.readableBytes()];
-                    contentWithLeadingCR[0] = HttpConstants.CR;
-                    content.getBytes(0, contentWithLeadingCR, 1, content.readableBytes());
-
-                    httpContent = httpContent.replace(Unpooled.wrappedBuffer(contentWithLeadingCR));
-                    addCRPrefix = false;
-                } else {
-                    if (content.writerIndex() > 0
-                            && content.getByte(content.writerIndex() - 1) == HttpConstants.CR) {
-                        // we may run into https://github.com/netty/netty/issues/11668
-                        // hide CR from this chunk, add it to the next received chunk
-                        content.writerIndex(content.writerIndex() - 1);
-                        addCRPrefix = true;
-                    }
-                }
+                final HttpContent httpContent = (HttpContent) msg;
                 currentHttpPostRequestDecoder.offer(httpContent);
 
                 while (httpContent != LastHttpContent.EMPTY_LAST_CONTENT

--- a/pom.xml
+++ b/pom.xml
@@ -320,13 +320,13 @@ under the License.
 			<dependency>
 				<groupId>org.apache.flink</groupId>
 				<artifactId>flink-shaded-netty</artifactId>
-				<version>4.1.65.Final-14.0</version>
+				<version>4.1.70.Final-${flink.shaded.version}</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.apache.flink</groupId>
 				<artifactId>flink-shaded-netty-tcnative-dynamic</artifactId>
-				<version>2.0.39.Final-14.0</version>
+				<version>2.0.44.Final-${flink.shaded.version}</version>
 				<scope>test</scope>
 			</dependency>
 


### PR DESCRIPTION
Based on #18463.

The new netty version contains a proper fix for the CLRF issue, so we can remove our safeguard again.