### PR TITLE
[FLINK-25485][connector/jdbc] Append default JDBC URL option of batch writing in MySQL.

### DIFF
--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/dialect/JdbcDialect.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/dialect/JdbcDialect.java
@@ -149,7 +149,7 @@ public interface JdbcDialect extends Serializable {
      *
      * @return A JDBC url.
      */
-    default String appendUrlSuffix(String url) {
+    default String appendDefaultUrlProperties(String url) {
         return url;
     }
 }

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/dialect/JdbcDialect.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/dialect/JdbcDialect.java
@@ -144,10 +144,12 @@ public interface JdbcDialect extends Serializable {
             String tableName, String[] selectFields, String[] conditionFields);
 
     /**
-     * Some database need require additional JDBC options，such as MySQL require
-     * rewriteBatchedStatements=true to enable batch writing. Inspired by the Alibaba DataX.
+     * Appends default JDBC properties to url for current dialect. Some database dialects will set
+     * default JDBC properties for performance or optimization consideration, such as MySQL dialect
+     * uses 'rewriteBatchedStatements=true' to enable execute multiple MySQL statements in batch
+     * mode.
      *
-     * @return A JDBC url.
+     * @return A JDBC url that has appended the default properties.
      */
     default String appendDefaultUrlProperties(String url) {
         return url;

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/dialect/JdbcDialect.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/dialect/JdbcDialect.java
@@ -142,4 +142,14 @@ public interface JdbcDialect extends Serializable {
      */
     String getSelectFromStatement(
             String tableName, String[] selectFields, String[] conditionFields);
+
+    /**
+     * Some database need require additional JDBC options，such as MySQL require
+     * rewriteBatchedStatements=true to enable batch writing. Inspired by the Alibaba DataX.
+     *
+     * @return A JDBC url.
+     */
+    default String appendUrlSuffix(String url) {
+        return url;
+    }
 }

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/dialect/mysql/MySqlDialect.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/dialect/mysql/MySqlDialect.java
@@ -126,4 +126,14 @@ public class MySqlDialect extends AbstractDialect {
                 LogicalTypeRoot.TIME_WITHOUT_TIME_ZONE,
                 LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE);
     }
+
+    @Override
+    public String appendUrlSuffix(String url) {
+        String suffix = "rewriteBatchedStatements=true";
+        if (url.contains("?")) {
+            return url + "&" + suffix;
+        } else {
+            return url + "?" + suffix;
+        }
+    }
 }

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/dialect/mysql/MySqlDialect.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/dialect/mysql/MySqlDialect.java
@@ -47,6 +47,10 @@ public class MySqlDialect extends AbstractDialect {
     private static final int MAX_DECIMAL_PRECISION = 65;
     private static final int MIN_DECIMAL_PRECISION = 1;
 
+    // Set true will enable MySQL batch write mode.
+    // https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-connp-props-performance-extensions.html#cj-conn-prop_rewriteBatchedStatements
+    private static final String BATCH_WRITE_OPTION = "rewriteBatchedStatements";
+
     @Override
     public JdbcRowConverter getRowConverter(RowType rowType) {
         return new MySQLRowConverter(rowType);
@@ -128,12 +132,16 @@ public class MySqlDialect extends AbstractDialect {
     }
 
     @Override
-    public String appendUrlSuffix(String url) {
-        String suffix = "rewriteBatchedStatements=true";
-        if (url.contains("?")) {
-            return url + "&" + suffix;
+    public String appendDefaultUrlProperties(String url) {
+        if (!url.contains(BATCH_WRITE_OPTION)) {
+            String defaultUrlProperties = BATCH_WRITE_OPTION + "=true";
+            if (url.contains("?")) {
+                return url + "&" + defaultUrlProperties;
+            } else {
+                return url + "?" + defaultUrlProperties;
+            }
         } else {
-            return url + "?" + suffix;
+            return url;
         }
     }
 }

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/dialect/mysql/MySqlDialect.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/dialect/mysql/MySqlDialect.java
@@ -47,9 +47,9 @@ public class MySqlDialect extends AbstractDialect {
     private static final int MAX_DECIMAL_PRECISION = 65;
     private static final int MIN_DECIMAL_PRECISION = 1;
 
-    // Set true will enable MySQL batch write mode.
+    // The JDBC option to enable execute multiple MySQL statements in batch mode:
     // https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-connp-props-performance-extensions.html#cj-conn-prop_rewriteBatchedStatements
-    private static final String BATCH_WRITE_OPTION = "rewriteBatchedStatements";
+    private static final String REWRITE_BATCHED_STATEMENTS = "rewriteBatchedStatements";
 
     @Override
     public JdbcRowConverter getRowConverter(RowType rowType) {
@@ -133,8 +133,8 @@ public class MySqlDialect extends AbstractDialect {
 
     @Override
     public String appendDefaultUrlProperties(String url) {
-        if (!url.contains(BATCH_WRITE_OPTION)) {
-            String defaultUrlProperties = BATCH_WRITE_OPTION + "=true";
+        if (!url.contains(REWRITE_BATCHED_STATEMENTS)) {
+            String defaultUrlProperties = REWRITE_BATCHED_STATEMENTS + "=true";
             if (url.contains("?")) {
                 return url + "&" + defaultUrlProperties;
             } else {

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/options/JdbcConnectorOptions.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/options/JdbcConnectorOptions.java
@@ -181,7 +181,7 @@ public class JdbcConnectorOptions extends JdbcConnectionOptions {
             }
 
             return new JdbcConnectorOptions(
-                    dialect.appendUrlSuffix(dbURL),
+                    dialect.appendDefaultUrlProperties(dbURL),
                     tableName,
                     driverName,
                     username,

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/options/JdbcConnectorOptions.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/options/JdbcConnectorOptions.java
@@ -181,7 +181,7 @@ public class JdbcConnectorOptions extends JdbcConnectionOptions {
             }
 
             return new JdbcConnectorOptions(
-                    dbURL,
+                    dialect.appendUrlSuffix(dbURL),
                     tableName,
                     driverName,
                     username,

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/dialect/mysql/MySqlDialectTest.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/dialect/mysql/MySqlDialectTest.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.dialect.mysql;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MySqlDialectTest {
+
+    @Test
+    void testAppendUrlSuffix() {
+        MySqlDialect dialect = new MySqlDialect();
+        assertThat(dialect.appendUrlSuffix("jdbc:mysql://localhost:3306/foo"))
+                .isEqualTo("jdbc:mysql://localhost:3306/foo?rewriteBatchedStatements=true");
+        assertThat(dialect.appendUrlSuffix("jdbc:mysql://localhost:3306/foo?foo=bar"))
+                .isEqualTo("jdbc:mysql://localhost:3306/foo?foo=bar&rewriteBatchedStatements=true");
+    }
+}

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/dialect/mysql/MySqlDialectTest.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/dialect/mysql/MySqlDialectTest.java
@@ -22,7 +22,8 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class MySqlDialectTest {
+/** Tests for {@link MySqlDialect}. */
+public class MySqlDialectTest {
 
     @Test
     void testAppendDefaultUrlProperties() {

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/dialect/mysql/MySqlDialectTest.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/dialect/mysql/MySqlDialectTest.java
@@ -25,11 +25,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 class MySqlDialectTest {
 
     @Test
-    void testAppendUrlSuffix() {
+    void testAppendDefaultUrlProperties() {
         MySqlDialect dialect = new MySqlDialect();
-        assertThat(dialect.appendUrlSuffix("jdbc:mysql://localhost:3306/foo"))
+        assertThat(dialect.appendDefaultUrlProperties("jdbc:mysql://localhost:3306/foo"))
                 .isEqualTo("jdbc:mysql://localhost:3306/foo?rewriteBatchedStatements=true");
-        assertThat(dialect.appendUrlSuffix("jdbc:mysql://localhost:3306/foo?foo=bar"))
+        assertThat(dialect.appendDefaultUrlProperties("jdbc:mysql://localhost:3306/foo?foo=bar"))
                 .isEqualTo("jdbc:mysql://localhost:3306/foo?foo=bar&rewriteBatchedStatements=true");
+        assertThat(dialect.appendDefaultUrlProperties("jdbc:mysql://localhost:3306/foo?foo=bar&rewriteBatchedStatements=false"))
+                .isEqualTo("jdbc:mysql://localhost:3306/foo?foo=bar&rewriteBatchedStatements=false");
     }
 }

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/dialect/mysql/MySqlDialectTest.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/dialect/mysql/MySqlDialectTest.java
@@ -31,7 +31,10 @@ class MySqlDialectTest {
                 .isEqualTo("jdbc:mysql://localhost:3306/foo?rewriteBatchedStatements=true");
         assertThat(dialect.appendDefaultUrlProperties("jdbc:mysql://localhost:3306/foo?foo=bar"))
                 .isEqualTo("jdbc:mysql://localhost:3306/foo?foo=bar&rewriteBatchedStatements=true");
-        assertThat(dialect.appendDefaultUrlProperties("jdbc:mysql://localhost:3306/foo?foo=bar&rewriteBatchedStatements=false"))
-                .isEqualTo("jdbc:mysql://localhost:3306/foo?foo=bar&rewriteBatchedStatements=false");
+        assertThat(
+                        dialect.appendDefaultUrlProperties(
+                                "jdbc:mysql://localhost:3306/foo?foo=bar&rewriteBatchedStatements=false"))
+                .isEqualTo(
+                        "jdbc:mysql://localhost:3306/foo?foo=bar&rewriteBatchedStatements=false");
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

When we directly use buffer-flush options of the mysql sink (sink.buffer-flush.max-rows and sink.buffer-flush.interval) can not increase throughput.
We must set 'rewriteBatchedStatements=true' into mysql jdbc url, for 'sink.buffer-flush' to take effect.
Such as: 'jdbc:mysql://ip:3306/dbname?rewriteBatchedStatements=true'

## Brief change log

  - *Added a method appendUrlSuffix in MySQLDialect to append 'rewriteBatchedStatements=true'.*
  - *Added appendUrlSuffix default method in JdbcDialect interface to do nothing.*
  - *use appendUrlSuffix in JdbcConnectionOptions#Builder#build() method*

## Verifying this change

*(example:)*
  - *Added a test case in MySqlDialect to test appendUrlSuffix*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
