### PR TITLE
[FLINK-25774][network] Restrict the maximum number of buffers can be used per result partition for sort-shuffle

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/NettyShuffleUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/NettyShuffleUtils.java
@@ -64,15 +64,15 @@ public class NettyShuffleUtils {
             final int sortShuffleMinBuffers,
             final int numSubpartitions,
             final ResultPartitionType type) {
-        int min =
-                type.isBlocking() && numSubpartitions >= sortShuffleMinParallelism
-                        ? sortShuffleMinBuffers
-                        : numSubpartitions + 1;
+        boolean isSortShuffle = type.isBlocking() && numSubpartitions >= sortShuffleMinParallelism;
+        int min = isSortShuffle ? sortShuffleMinBuffers : numSubpartitions + 1;
         int max =
                 type.isBounded()
                         ? numSubpartitions * configuredNetworkBuffersPerChannel
                                 + numFloatingBuffersPerGate
-                        : NetworkBufferPool.UNBOUNDED_POOL_SIZE;
+                        : (isSortShuffle
+                                ? Math.max(min, 4 * numSubpartitions)
+                                : NetworkBufferPool.UNBOUNDED_POOL_SIZE);
         // for each upstream hash-based blocking/pipelined subpartition, at least one buffer is
         // needed even the configured network buffers per channel is 0 and this behavior is for
         // performance. If it's not guaranteed that each subpartition can get at least one buffer,


### PR DESCRIPTION
## What is the purpose of the change

Currently, for sort-shuffle, the maximum number of buffers can be used per result partition is Integer.MAX_VALUE. However, if too many buffers are taken by one result partition, other result partitions and input gates may spend too much time waiting for buffers which can influence performance. This ticket aims to restrict the maximum number of buffers can be used per result partition and the selected value is an empirical one based on the TPC-DS test results.

## Brief change log

  - Use Math.max(min, 4 * numSubpartitions) as the maximum number of buffers can be used per result partition for sort-shuffle.


## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
