### PR TITLE
[FLINK-25787][flink-connector-gcp-pubsub]  Adding endpoint support in Pubsub Source / Sink

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -27,7 +27,7 @@
 # we change the version for the complete docs when forking of a release branch
 # etc.
 # The full version string as referenced in Maven (e.g. 1.2.1)
-version: "1.12.3"
+version: "1.12.5"
 # For stable releases, leave the bugfix version out (e.g. 1.2). For snapshot
 # release this should be the same as the regular version
 version_title: 1.12

--- a/flink-annotations/pom.xml
+++ b/flink-annotations/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-clients/pom.xml
+++ b/flink-clients/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/flink-connector-base/pom.xml
+++ b/flink-connectors/flink-connector-base/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/flink-connector-cassandra/pom.xml
+++ b/flink-connectors/flink-connector-cassandra/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/flink-connector-elasticsearch-base/pom.xml
+++ b/flink-connectors/flink-connector-elasticsearch-base/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/flink-connector-elasticsearch5/pom.xml
+++ b/flink-connectors/flink-connector-elasticsearch5/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/flink-connector-elasticsearch6/pom.xml
+++ b/flink-connectors/flink-connector-elasticsearch6/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/flink-connector-elasticsearch7/pom.xml
+++ b/flink-connectors/flink-connector-elasticsearch7/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<artifactId>flink-connectors</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/flink-connector-files/pom.xml
+++ b/flink-connectors/flink-connector-files/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/flink-connector-gcp-pubsub/pom.xml
+++ b/flink-connectors/flink-connector-gcp-pubsub/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/streaming/connectors/gcp/pubsub/DefaultPubSubSubscriberFactory.java
+++ b/flink-connectors/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/streaming/connectors/gcp/pubsub/DefaultPubSubSubscriberFactory.java
@@ -22,7 +22,6 @@ import org.apache.flink.streaming.connectors.gcp.pubsub.common.PubSubSubscriber;
 import org.apache.flink.streaming.connectors.gcp.pubsub.common.PubSubSubscriberFactory;
 
 import com.google.auth.Credentials;
-import com.google.cloud.pubsub.v1.stub.SubscriberStubSettings;
 import com.google.pubsub.v1.PullRequest;
 import com.google.pubsub.v1.SubscriberGrpc;
 import io.grpc.ManagedChannel;
@@ -39,22 +38,25 @@ class DefaultPubSubSubscriberFactory implements PubSubSubscriberFactory {
     private final Duration timeout;
     private final int maxMessagesPerPull;
     private final String projectSubscriptionName;
+    private final String endpoint;
 
     DefaultPubSubSubscriberFactory(
             String projectSubscriptionName,
             int retries,
             Duration pullTimeout,
-            int maxMessagesPerPull) {
+            int maxMessagesPerPull,
+            String endpoint) {
         this.retries = retries;
         this.timeout = pullTimeout;
         this.maxMessagesPerPull = maxMessagesPerPull;
         this.projectSubscriptionName = projectSubscriptionName;
+        this.endpoint = endpoint;
     }
 
     @Override
     public PubSubSubscriber getSubscriber(Credentials credentials) throws IOException {
         ManagedChannel channel =
-                NettyChannelBuilder.forTarget(SubscriberStubSettings.getDefaultEndpoint())
+                NettyChannelBuilder.forTarget(endpoint)
                         .negotiationType(NegotiationType.TLS)
                         .sslContext(GrpcSslContexts.forClient().ciphers(null).build())
                         .build();

--- a/flink-connectors/flink-connector-gcp-pubsub/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/PubSubConsumingTest.java
+++ b/flink-connectors/flink-connector-gcp-pubsub/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/PubSubConsumingTest.java
@@ -54,6 +54,7 @@ public class PubSubConsumingTest {
                 new TestPubSubSubscriber(
                         receivedMessage("1", pubSubMessage("A")),
                         receivedMessage("2", pubSubMessage("B")));
+        // Pubsub source without endpoint
         PubSubSource<String> pubSubSource =
                 PubSubSource.newBuilder()
                         .withDeserializationSchema(new SimpleStringSchema())
@@ -89,6 +90,8 @@ public class PubSubConsumingTest {
                         receivedMessage("2", pubSubMessage("B")),
                         receivedMessage("3", pubSubMessage("C")),
                         receivedMessage("4", pubSubMessage("D")));
+
+        // Pubsub source with endpoint
         PubSubSource<String> pubSubSource =
                 PubSubSource.newBuilder()
                         .withDeserializationSchema(
@@ -102,6 +105,7 @@ public class PubSubConsumingTest {
                         .withSubscriptionName("fakeSubscription")
                         .withPubSubSubscriberFactory(credentials -> testPubSubSubscriber)
                         .withCredentials(mock(Credentials.class))
+                        .withEndpoint("us-central1-pubsub.googleapis.com:443")
                         .build();
 
         Object lock = new Object();

--- a/flink-connectors/flink-connector-hbase-1.4/pom.xml
+++ b/flink-connectors/flink-connector-hbase-1.4/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/flink-connector-hbase-2.2/pom.xml
+++ b/flink-connectors/flink-connector-hbase-2.2/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/flink-connector-hbase-base/pom.xml
+++ b/flink-connectors/flink-connector-hbase-base/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/flink-connector-hive/pom.xml
+++ b/flink-connectors/flink-connector-hive/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/flink-connector-jdbc/pom.xml
+++ b/flink-connectors/flink-connector-jdbc/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/flink-connector-kafka/pom.xml
+++ b/flink-connectors/flink-connector-kafka/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<artifactId>flink-connectors</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/flink-connector-kinesis/pom.xml
+++ b/flink-connectors/flink-connector-kinesis/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/flink-connector-nifi/pom.xml
+++ b/flink-connectors/flink-connector-nifi/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/flink-connector-rabbitmq/pom.xml
+++ b/flink-connectors/flink-connector-rabbitmq/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/flink-connector-twitter/pom.xml
+++ b/flink-connectors/flink-connector-twitter/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/flink-file-sink-common/pom.xml
+++ b/flink-connectors/flink-file-sink-common/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/flink-hadoop-compatibility/pom.xml
+++ b/flink-connectors/flink-hadoop-compatibility/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/flink-hcatalog/pom.xml
+++ b/flink-connectors/flink-hcatalog/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/flink-sql-connector-elasticsearch6/pom.xml
+++ b/flink-connectors/flink-sql-connector-elasticsearch6/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/flink-sql-connector-elasticsearch7/pom.xml
+++ b/flink-connectors/flink-sql-connector-elasticsearch7/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/flink-sql-connector-hbase-1.4/pom.xml
+++ b/flink-connectors/flink-sql-connector-hbase-1.4/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<artifactId>flink-connectors</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/flink-connectors/flink-sql-connector-hbase-2.2/pom.xml
+++ b/flink-connectors/flink-sql-connector-hbase-2.2/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<artifactId>flink-connectors</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/flink-connectors/flink-sql-connector-hive-1.2.2/pom.xml
+++ b/flink-connectors/flink-sql-connector-hive-1.2.2/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/flink-sql-connector-hive-2.2.0/pom.xml
+++ b/flink-connectors/flink-sql-connector-hive-2.2.0/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/flink-sql-connector-hive-2.3.6/pom.xml
+++ b/flink-connectors/flink-sql-connector-hive-2.3.6/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/flink-sql-connector-hive-3.1.2/pom.xml
+++ b/flink-connectors/flink-sql-connector-hive-3.1.2/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/flink-sql-connector-kafka/pom.xml
+++ b/flink-connectors/flink-sql-connector-kafka/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<artifactId>flink-connectors</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/flink-sql-connector-kinesis/pom.xml
+++ b/flink-connectors/flink-sql-connector-kinesis/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<artifactId>flink-connectors</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/pom.xml
+++ b/flink-connectors/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-container/pom.xml
+++ b/flink-container/pom.xml
@@ -24,7 +24,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-contrib/flink-connector-wikiedits/pom.xml
+++ b/flink-contrib/flink-connector-wikiedits/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-contrib</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-contrib/pom.xml
+++ b/flink-contrib/pom.xml
@@ -27,7 +27,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-core/pom.xml
+++ b/flink-core/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-docs/pom.xml
+++ b/flink-docs/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-end-to-end-tests/flink-batch-sql-test/pom.xml
+++ b/flink-end-to-end-tests/flink-batch-sql-test/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-end-to-end-tests/flink-cli-test/pom.xml
+++ b/flink-end-to-end-tests/flink-cli-test/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-end-to-end-tests/flink-confluent-schema-registry/pom.xml
+++ b/flink-end-to-end-tests/flink-confluent-schema-registry/pom.xml
@@ -22,7 +22,7 @@ under the License.
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/flink-end-to-end-tests/flink-connector-gcp-pubsub-emulator-tests/pom.xml
+++ b/flink-end-to-end-tests/flink-connector-gcp-pubsub-emulator-tests/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-end-to-end-tests</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-end-to-end-tests/flink-dataset-allround-test/pom.xml
+++ b/flink-end-to-end-tests/flink-dataset-allround-test/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-end-to-end-tests</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-end-to-end-tests/flink-dataset-fine-grained-recovery-test/pom.xml
+++ b/flink-end-to-end-tests/flink-dataset-fine-grained-recovery-test/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-end-to-end-tests</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-end-to-end-tests/flink-datastream-allround-test/pom.xml
+++ b/flink-end-to-end-tests/flink-datastream-allround-test/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-end-to-end-tests</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-end-to-end-tests/flink-distributed-cache-via-blob-test/pom.xml
+++ b/flink-end-to-end-tests/flink-distributed-cache-via-blob-test/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-end-to-end-tests/flink-elasticsearch5-test/pom.xml
+++ b/flink-end-to-end-tests/flink-elasticsearch5-test/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-end-to-end-tests</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-end-to-end-tests/flink-elasticsearch6-test/pom.xml
+++ b/flink-end-to-end-tests/flink-elasticsearch6-test/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-end-to-end-tests</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-end-to-end-tests/flink-elasticsearch7-test/pom.xml
+++ b/flink-end-to-end-tests/flink-elasticsearch7-test/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-end-to-end-tests</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/pom.xml
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/pom.xml
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/pom.xml
@@ -22,7 +22,7 @@ under the License.
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/flink-end-to-end-tests/flink-end-to-end-tests-hbase/pom.xml
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-hbase/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/flink-end-to-end-tests/flink-file-sink-test/pom.xml
+++ b/flink-end-to-end-tests/flink-file-sink-test/pom.xml
@@ -22,7 +22,7 @@ under the License.
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/flink-end-to-end-tests/flink-heavy-deployment-stress-test/pom.xml
+++ b/flink-end-to-end-tests/flink-heavy-deployment-stress-test/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-end-to-end-tests</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-end-to-end-tests/flink-high-parallelism-iterations-test/pom.xml
+++ b/flink-end-to-end-tests/flink-high-parallelism-iterations-test/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-end-to-end-tests</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-end-to-end-tests/flink-local-recovery-and-allocation-test/pom.xml
+++ b/flink-end-to-end-tests/flink-local-recovery-and-allocation-test/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/flink-end-to-end-tests/flink-metrics-availability-test/pom.xml
+++ b/flink-end-to-end-tests/flink-metrics-availability-test/pom.xml
@@ -22,7 +22,7 @@ under the License.
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-end-to-end-tests/flink-metrics-reporter-prometheus-test/pom.xml
+++ b/flink-end-to-end-tests/flink-metrics-reporter-prometheus-test/pom.xml
@@ -22,7 +22,7 @@ under the License.
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-end-to-end-tests/flink-netty-shuffle-memory-control-test/pom.xml
+++ b/flink-end-to-end-tests/flink-netty-shuffle-memory-control-test/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-end-to-end-tests</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-end-to-end-tests/flink-parent-child-classloading-test-lib-package/pom.xml
+++ b/flink-end-to-end-tests/flink-parent-child-classloading-test-lib-package/pom.xml
@@ -29,7 +29,7 @@
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-end-to-end-tests/flink-parent-child-classloading-test-program/pom.xml
+++ b/flink-end-to-end-tests/flink-parent-child-classloading-test-program/pom.xml
@@ -29,7 +29,7 @@
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-end-to-end-tests/flink-plugins-test/another-dummy-fs/pom.xml
+++ b/flink-end-to-end-tests/flink-plugins-test/another-dummy-fs/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<artifactId>flink-plugins-test</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/flink-end-to-end-tests/flink-plugins-test/dummy-fs/pom.xml
+++ b/flink-end-to-end-tests/flink-plugins-test/dummy-fs/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<artifactId>flink-plugins-test</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/flink-end-to-end-tests/flink-plugins-test/pom.xml
+++ b/flink-end-to-end-tests/flink-plugins-test/pom.xml
@@ -25,7 +25,7 @@ under the License.
     <parent>
         <artifactId>flink-end-to-end-tests</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>1.12-SNAPSHOT</version>
+        <version>1.12.5</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/flink-end-to-end-tests/flink-python-test/pom.xml
+++ b/flink-end-to-end-tests/flink-python-test/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/flink-end-to-end-tests/flink-queryable-state-test/pom.xml
+++ b/flink-end-to-end-tests/flink-queryable-state-test/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/flink-end-to-end-tests/flink-quickstart-test/pom.xml
+++ b/flink-end-to-end-tests/flink-quickstart-test/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-end-to-end-tests</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/flink-end-to-end-tests/flink-rocksdb-state-memory-control-test/pom.xml
+++ b/flink-end-to-end-tests/flink-rocksdb-state-memory-control-test/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/flink-end-to-end-tests/flink-sql-client-test/pom.xml
+++ b/flink-end-to-end-tests/flink-sql-client-test/pom.xml
@@ -22,7 +22,7 @@ under the License.
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/flink-end-to-end-tests/flink-state-evolution-test/pom.xml
+++ b/flink-end-to-end-tests/flink-state-evolution-test/pom.xml
@@ -22,7 +22,7 @@ under the License.
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/flink-end-to-end-tests/flink-stream-sql-test/pom.xml
+++ b/flink-end-to-end-tests/flink-stream-sql-test/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-end-to-end-tests/flink-stream-state-ttl-test/pom.xml
+++ b/flink-end-to-end-tests/flink-stream-state-ttl-test/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-end-to-end-tests</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-end-to-end-tests/flink-stream-stateful-job-upgrade-test/pom.xml
+++ b/flink-end-to-end-tests/flink-stream-stateful-job-upgrade-test/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/flink-end-to-end-tests/flink-streaming-kafka-test-base/pom.xml
+++ b/flink-end-to-end-tests/flink-streaming-kafka-test-base/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/flink-end-to-end-tests/flink-streaming-kafka-test/pom.xml
+++ b/flink-end-to-end-tests/flink-streaming-kafka-test/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/flink-end-to-end-tests/flink-streaming-kinesis-test/pom.xml
+++ b/flink-end-to-end-tests/flink-streaming-kinesis-test/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/flink-end-to-end-tests/flink-tpcds-test/pom.xml
+++ b/flink-end-to-end-tests/flink-tpcds-test/pom.xml
@@ -21,7 +21,7 @@ under the License.
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/flink-end-to-end-tests/flink-tpch-test/pom.xml
+++ b/flink-end-to-end-tests/flink-tpch-test/pom.xml
@@ -21,7 +21,7 @@ under the License.
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/flink-end-to-end-tests/pom.xml
+++ b/flink-end-to-end-tests/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-examples/flink-examples-batch/pom.xml
+++ b/flink-examples/flink-examples-batch/pom.xml
@@ -24,7 +24,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-examples</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-examples/flink-examples-build-helper/flink-examples-streaming-gcp-pubsub/pom.xml
+++ b/flink-examples/flink-examples-build-helper/flink-examples-streaming-gcp-pubsub/pom.xml
@@ -24,7 +24,7 @@ under the License.
 	<parent>
 		<artifactId>flink-examples-build-helper</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-examples/flink-examples-build-helper/flink-examples-streaming-state-machine/pom.xml
+++ b/flink-examples/flink-examples-build-helper/flink-examples-streaming-state-machine/pom.xml
@@ -24,7 +24,7 @@ under the License.
 	<parent>
 		<artifactId>flink-examples-build-helper</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-examples/flink-examples-build-helper/flink-examples-streaming-twitter/pom.xml
+++ b/flink-examples/flink-examples-build-helper/flink-examples-streaming-twitter/pom.xml
@@ -24,7 +24,7 @@ under the License.
 	<parent>
 		<artifactId>flink-examples-build-helper</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-examples/flink-examples-build-helper/pom.xml
+++ b/flink-examples/flink-examples-build-helper/pom.xml
@@ -24,7 +24,7 @@ under the License.
 	<parent>
 		<artifactId>flink-examples</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-examples/flink-examples-streaming/pom.xml
+++ b/flink-examples/flink-examples-streaming/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-examples</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-examples/flink-examples-table/pom.xml
+++ b/flink-examples/flink-examples-table/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-examples</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-examples/pom.xml
+++ b/flink-examples/pom.xml
@@ -24,7 +24,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-external-resources/flink-external-resource-gpu/pom.xml
+++ b/flink-external-resources/flink-external-resource-gpu/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<artifactId>flink-external-resources</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-external-resources/pom.xml
+++ b/flink-external-resources/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-filesystems/flink-azure-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-azure-fs-hadoop/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-filesystems</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-filesystems/flink-fs-hadoop-shaded/pom.xml
+++ b/flink-filesystems/flink-fs-hadoop-shaded/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-filesystems</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-filesystems/flink-hadoop-fs/pom.xml
+++ b/flink-filesystems/flink-hadoop-fs/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-filesystems</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-filesystems/flink-mapr-fs/pom.xml
+++ b/flink-filesystems/flink-mapr-fs/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-filesystems</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-filesystems/flink-oss-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-oss-fs-hadoop/pom.xml
@@ -21,7 +21,7 @@ under the License.
 	<parent>
 		<artifactId>flink-filesystems</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/flink-filesystems/flink-s3-fs-base/pom.xml
+++ b/flink-filesystems/flink-s3-fs-base/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-filesystems</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-filesystems/flink-s3-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-s3-fs-hadoop/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-filesystems</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-filesystems/flink-s3-fs-presto/pom.xml
+++ b/flink-filesystems/flink-s3-fs-presto/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-filesystems</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-filesystems/flink-swift-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-swift-fs-hadoop/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-filesystems</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-filesystems/pom.xml
+++ b/flink-filesystems/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-formats/flink-avro-confluent-registry/pom.xml
+++ b/flink-formats/flink-avro-confluent-registry/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<artifactId>flink-formats</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/flink-formats/flink-avro/pom.xml
+++ b/flink-formats/flink-avro/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-formats</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-formats/flink-compress/pom.xml
+++ b/flink-formats/flink-compress/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-formats</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-formats/flink-csv/pom.xml
+++ b/flink-formats/flink-csv/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-formats</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-formats/flink-hadoop-bulk/pom.xml
+++ b/flink-formats/flink-hadoop-bulk/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-formats</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-formats/flink-json/pom.xml
+++ b/flink-formats/flink-json/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-formats</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-formats/flink-orc-nohive/pom.xml
+++ b/flink-formats/flink-orc-nohive/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-formats</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-formats/flink-orc/pom.xml
+++ b/flink-formats/flink-orc/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-formats</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-formats/flink-parquet/pom.xml
+++ b/flink-formats/flink-parquet/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-formats</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-formats/flink-sequence-file/pom.xml
+++ b/flink-formats/flink-sequence-file/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-formats</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-formats/flink-sql-avro-confluent-registry/pom.xml
+++ b/flink-formats/flink-sql-avro-confluent-registry/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-formats</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-formats/flink-sql-avro/pom.xml
+++ b/flink-formats/flink-sql-avro/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-formats</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-formats/flink-sql-orc/pom.xml
+++ b/flink-formats/flink-sql-orc/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-formats</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-formats/flink-sql-parquet/pom.xml
+++ b/flink-formats/flink-sql-parquet/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-formats</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-formats/pom.xml
+++ b/flink-formats/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-fs-tests/pom.xml
+++ b/flink-fs-tests/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-java/pom.xml
+++ b/flink-java/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-kubernetes/pom.xml
+++ b/flink-kubernetes/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-libraries/flink-cep-scala/pom.xml
+++ b/flink-libraries/flink-cep-scala/pom.xml
@@ -26,7 +26,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-libraries</artifactId>
-        <version>1.12-SNAPSHOT</version>
+        <version>1.12.5</version>
         <relativePath>..</relativePath>
     </parent>
     

--- a/flink-libraries/flink-cep/pom.xml
+++ b/flink-libraries/flink-cep/pom.xml
@@ -26,7 +26,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-libraries</artifactId>
-        <version>1.12-SNAPSHOT</version>
+        <version>1.12.5</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/flink-libraries/flink-gelly-examples/pom.xml
+++ b/flink-libraries/flink-gelly-examples/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-libraries</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-libraries/flink-gelly-scala/pom.xml
+++ b/flink-libraries/flink-gelly-scala/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-libraries</artifactId>
-        <version>1.12-SNAPSHOT</version>
+        <version>1.12.5</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/flink-libraries/flink-gelly/pom.xml
+++ b/flink-libraries/flink-gelly/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-libraries</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-libraries/flink-state-processing-api/pom.xml
+++ b/flink-libraries/flink-state-processing-api/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-libraries</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-libraries/pom.xml
+++ b/flink-libraries/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-mesos/pom.xml
+++ b/flink-mesos/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 	

--- a/flink-metrics/flink-metrics-core/pom.xml
+++ b/flink-metrics/flink-metrics-core/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-metrics</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-metrics/flink-metrics-datadog/pom.xml
+++ b/flink-metrics/flink-metrics-datadog/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-metrics</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-metrics/flink-metrics-dropwizard/pom.xml
+++ b/flink-metrics/flink-metrics-dropwizard/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-metrics</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-metrics/flink-metrics-graphite/pom.xml
+++ b/flink-metrics/flink-metrics-graphite/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-metrics</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-metrics/flink-metrics-influxdb/pom.xml
+++ b/flink-metrics/flink-metrics-influxdb/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-metrics</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-metrics/flink-metrics-jmx/pom.xml
+++ b/flink-metrics/flink-metrics-jmx/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-metrics</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-metrics/flink-metrics-prometheus/pom.xml
+++ b/flink-metrics/flink-metrics-prometheus/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-metrics</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-metrics/flink-metrics-slf4j/pom.xml
+++ b/flink-metrics/flink-metrics-slf4j/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-metrics</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-metrics/flink-metrics-statsd/pom.xml
+++ b/flink-metrics/flink-metrics-statsd/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-metrics</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-metrics/pom.xml
+++ b/flink-metrics/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-ml-parent/flink-ml-api/pom.xml
+++ b/flink-ml-parent/flink-ml-api/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-ml-parent</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 	</parent>
 
 	<artifactId>flink-ml-api</artifactId>

--- a/flink-ml-parent/flink-ml-lib/pom.xml
+++ b/flink-ml-parent/flink-ml-lib/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-ml-parent</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 	</parent>
 
 	<artifactId>flink-ml-lib_${scala.binary.version}</artifactId>

--- a/flink-ml-parent/flink-ml-uber/pom.xml
+++ b/flink-ml-parent/flink-ml-uber/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-ml-parent</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 	</parent>
 
 	<artifactId>flink-ml-uber_${scala.binary.version}</artifactId>

--- a/flink-ml-parent/pom.xml
+++ b/flink-ml-parent/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-optimizer/pom.xml
+++ b/flink-optimizer/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-python/pom.xml
+++ b/flink-python/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-python/pyflink/version.py
+++ b/flink-python/pyflink/version.py
@@ -20,4 +20,4 @@
 The pyflink version will be consistent with the flink version and follow the PEP440.
 .. seealso:: https://www.python.org/dev/peps/pep-0440
 """
-__version__ = "1.12.dev0"
+__version__ = "1.12.5"

--- a/flink-queryable-state/flink-queryable-state-client-java/pom.xml
+++ b/flink-queryable-state/flink-queryable-state-client-java/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-queryable-state</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-queryable-state/flink-queryable-state-runtime/pom.xml
+++ b/flink-queryable-state/flink-queryable-state-runtime/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-queryable-state</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-queryable-state/pom.xml
+++ b/flink-queryable-state/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-quickstart/flink-quickstart-java/pom.xml
+++ b/flink-quickstart/flink-quickstart-java/pom.xml
@@ -27,7 +27,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-quickstart</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-quickstart/flink-quickstart-scala/pom.xml
+++ b/flink-quickstart/flink-quickstart-scala/pom.xml
@@ -27,7 +27,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-quickstart</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-quickstart/pom.xml
+++ b/flink-quickstart/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-runtime-web/pom.xml
+++ b/flink-runtime-web/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-scala-shell/pom.xml
+++ b/flink-scala-shell/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-scala/pom.xml
+++ b/flink-scala/pom.xml
@@ -24,7 +24,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-state-backends/flink-statebackend-heap-spillable/pom.xml
+++ b/flink-state-backends/flink-statebackend-heap-spillable/pom.xml
@@ -27,7 +27,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-state-backends</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-state-backends/flink-statebackend-rocksdb/pom.xml
+++ b/flink-state-backends/flink-statebackend-rocksdb/pom.xml
@@ -27,7 +27,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-state-backends</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-state-backends/pom.xml
+++ b/flink-state-backends/pom.xml
@@ -27,7 +27,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-streaming-java/pom.xml
+++ b/flink-streaming-java/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-streaming-scala/pom.xml
+++ b/flink-streaming-scala/pom.xml
@@ -24,7 +24,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-table/flink-sql-client/pom.xml
+++ b/flink-table/flink-sql-client/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-table</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-table/flink-sql-parser-hive/pom.xml
+++ b/flink-table/flink-sql-parser-hive/pom.xml
@@ -24,7 +24,7 @@ under the License.
 	<parent>
 		<artifactId>flink-table</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 	</parent>
 
 	<artifactId>flink-sql-parser-hive</artifactId>

--- a/flink-table/flink-sql-parser/pom.xml
+++ b/flink-table/flink-sql-parser/pom.xml
@@ -24,7 +24,7 @@ under the License.
 	<parent>
 		<artifactId>flink-table</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 	</parent>
 
 	<artifactId>flink-sql-parser</artifactId>

--- a/flink-table/flink-table-api-java-bridge/pom.xml
+++ b/flink-table/flink-table-api-java-bridge/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-table</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-table/flink-table-api-java/pom.xml
+++ b/flink-table/flink-table-api-java/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-table</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-table/flink-table-api-scala-bridge/pom.xml
+++ b/flink-table/flink-table-api-scala-bridge/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-table</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-table/flink-table-api-scala/pom.xml
+++ b/flink-table/flink-table-api-scala/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-table</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-table/flink-table-common/pom.xml
+++ b/flink-table/flink-table-common/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-table</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-table/flink-table-planner-blink/pom.xml
+++ b/flink-table/flink-table-planner-blink/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-table</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-table/flink-table-planner/pom.xml
+++ b/flink-table/flink-table-planner/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-table</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-table/flink-table-runtime-blink/pom.xml
+++ b/flink-table/flink-table-runtime-blink/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-table</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-table/flink-table-uber-blink/pom.xml
+++ b/flink-table/flink-table-uber-blink/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-table</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-table/flink-table-uber/pom.xml
+++ b/flink-table/flink-table-uber/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-table</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-table/pom.xml
+++ b/flink-table/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-test-utils-parent/flink-connector-test-utils/pom.xml
+++ b/flink-test-utils-parent/flink-connector-test-utils/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-test-utils-parent</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-test-utils-parent/flink-test-utils-junit/pom.xml
+++ b/flink-test-utils-parent/flink-test-utils-junit/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-test-utils-parent</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-test-utils-parent/flink-test-utils/pom.xml
+++ b/flink-test-utils-parent/flink-test-utils/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-test-utils-parent</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-test-utils-parent/pom.xml
+++ b/flink-test-utils-parent/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-tests/pom.xml
+++ b/flink-tests/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-walkthroughs/flink-walkthrough-common/pom.xml
+++ b/flink-walkthroughs/flink-walkthrough-common/pom.xml
@@ -27,7 +27,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-walkthroughs</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-walkthroughs/flink-walkthrough-datastream-java/pom.xml
+++ b/flink-walkthroughs/flink-walkthrough-datastream-java/pom.xml
@@ -27,7 +27,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-walkthroughs</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-walkthroughs/flink-walkthrough-datastream-scala/pom.xml
+++ b/flink-walkthroughs/flink-walkthrough-datastream-scala/pom.xml
@@ -27,7 +27,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-walkthroughs</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-walkthroughs/pom.xml
+++ b/flink-walkthroughs/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-yarn-tests/pom.xml
+++ b/flink-yarn-tests/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-yarn/pom.xml
+++ b/flink-yarn/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ under the License.
 
 	<groupId>org.apache.flink</groupId>
 	<artifactId>flink-parent</artifactId>
-	<version>1.12-SNAPSHOT</version>
+	<version>1.12.5</version>
 
 	<name>Flink : </name>
 	<packaging>pom</packaging>
@@ -164,7 +164,7 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>force-shading</artifactId>
-			<version>1.12-SNAPSHOT</version>
+			<version>1.12.5</version>
 		</dependency>
 
 		<!-- Root dependencies for all projects -->

--- a/tools/ci/java-ci-tools/pom.xml
+++ b/tools/ci/java-ci-tools/pom.xml
@@ -25,12 +25,12 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>1.12.5</version>
 		<relativePath>../../..</relativePath>
 	</parent>
 
 	<artifactId>java-ci-tools</artifactId>
-	<version>1.12-SNAPSHOT</version>
+	<version>1.12.5</version>
 	<name>Flink : Tools : CI : Java</name>
 
 	<dependencies>

--- a/tools/force-shading/pom.xml
+++ b/tools/force-shading/pom.xml
@@ -38,7 +38,7 @@ under the License.
 
 	<groupId>org.apache.flink</groupId>
 	<artifactId>force-shading</artifactId>
-	<version>1.12-SNAPSHOT</version>
+	<version>1.12.5</version>
 	<name>Flink : Tools : Force Shading</name>
 
 	<packaging>jar</packaging>


### PR DESCRIPTION
## What is the purpose of the change

Adding option to pass regionalEndpoint in Pubsub Source / Sink


## Brief change log

- Added `withEndpoint` in Pubsub Source/Sink builder.



## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests.
- PubSubConsumingTest


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? (yes / no): no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
