### PR TITLE
[FLINK-25787][flink-connector-gcp-pubsub] Adding endpoint support in Pubsub Source / Sink

### DIFF
--- a/flink-connectors/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/streaming/connectors/gcp/pubsub/DefaultPubSubSubscriberFactory.java
+++ b/flink-connectors/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/streaming/connectors/gcp/pubsub/DefaultPubSubSubscriberFactory.java
@@ -22,7 +22,6 @@ import org.apache.flink.streaming.connectors.gcp.pubsub.common.PubSubSubscriber;
 import org.apache.flink.streaming.connectors.gcp.pubsub.common.PubSubSubscriberFactory;
 
 import com.google.auth.Credentials;
-import com.google.cloud.pubsub.v1.stub.SubscriberStubSettings;
 import com.google.pubsub.v1.PullRequest;
 import com.google.pubsub.v1.SubscriberGrpc;
 import io.grpc.ManagedChannel;
@@ -39,22 +38,25 @@ class DefaultPubSubSubscriberFactory implements PubSubSubscriberFactory {
     private final Duration timeout;
     private final int maxMessagesPerPull;
     private final String projectSubscriptionName;
+    private final String endpoint;
 
     DefaultPubSubSubscriberFactory(
             String projectSubscriptionName,
             int retries,
             Duration pullTimeout,
-            int maxMessagesPerPull) {
+            int maxMessagesPerPull,
+            String endpoint) {
         this.retries = retries;
         this.timeout = pullTimeout;
         this.maxMessagesPerPull = maxMessagesPerPull;
         this.projectSubscriptionName = projectSubscriptionName;
+        this.endpoint = endpoint;
     }
 
     @Override
     public PubSubSubscriber getSubscriber(Credentials credentials) throws IOException {
         ManagedChannel channel =
-                NettyChannelBuilder.forTarget(SubscriberStubSettings.getDefaultEndpoint())
+                NettyChannelBuilder.forTarget(endpoint)
                         .negotiationType(NegotiationType.TLS)
                         .sslContext(GrpcSslContexts.forClient().ciphers(null).build())
                         .build();

--- a/flink-connectors/flink-connector-gcp-pubsub/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/PubSubConsumingTest.java
+++ b/flink-connectors/flink-connector-gcp-pubsub/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/PubSubConsumingTest.java
@@ -54,6 +54,7 @@ public class PubSubConsumingTest {
                 new TestPubSubSubscriber(
                         receivedMessage("1", pubSubMessage("A")),
                         receivedMessage("2", pubSubMessage("B")));
+        // Pubsub source without endpoint
         PubSubSource<String> pubSubSource =
                 PubSubSource.newBuilder()
                         .withDeserializationSchema(new SimpleStringSchema())
@@ -89,6 +90,8 @@ public class PubSubConsumingTest {
                         receivedMessage("2", pubSubMessage("B")),
                         receivedMessage("3", pubSubMessage("C")),
                         receivedMessage("4", pubSubMessage("D")));
+
+        // Pubsub source with endpoint
         PubSubSource<String> pubSubSource =
                 PubSubSource.newBuilder()
                         .withDeserializationSchema(
@@ -102,6 +105,7 @@ public class PubSubConsumingTest {
                         .withSubscriptionName("fakeSubscription")
                         .withPubSubSubscriberFactory(credentials -> testPubSubSubscriber)
                         .withCredentials(mock(Credentials.class))
+                        .withEndpoint("us-central1-pubsub.googleapis.com:443")
                         .build();
 
         Object lock = new Object();


### PR DESCRIPTION
## What is the purpose of the change

Adding option to pass regionalEndpoint in Pubsub Source / Sink

Detail added here: https://issues.apache.org/jira/browse/FLINK-25787

## Brief change log

- Added `withEndpoint` in Pubsub Source/Sink builder.



## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests.
- PubSubConsumingTest


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? (yes / no): no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
