### PR TITLE
[FLINK-25758] Fix license issue with flink-gs-fs-hadoop

### DIFF
--- a/flink-filesystems/flink-gs-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-gs-fs-hadoop/pom.xml
@@ -124,6 +124,11 @@ under the License.
 					<groupId>org.codehaus.mojo</groupId>
 					<artifactId>animal-sniffer-annotations</artifactId>
 				</exclusion>
+				<!-- exclude dependency because of its GPLv2 license, see https://github.com/apache/flink/pull/15599#issuecomment-850241316 -->
+				<exclusion>
+					<groupId>javax.annotation</groupId>
+					<artifactId>javax.annotation-api</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 
@@ -214,8 +219,6 @@ under the License.
 										<exclude>META-INF/*.SF</exclude>
 										<exclude>META-INF/*.DSA</exclude>
 										<exclude>META-INF/*.RSA</exclude>
-										<!-- exclude javax.annotation because of GPLv2 license, see https://github.com/apache/flink/pull/15599#issuecomment-850241316 -->
-										<exclude>javax/annotation/**</exclude>
 									</excludes>
 								</filter>
 							</filters>

--- a/flink-filesystems/flink-gs-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-gs-fs-hadoop/pom.xml
@@ -86,6 +86,11 @@ under the License.
 					<groupId>com.google.guava</groupId>
 					<artifactId>failureaccess</artifactId>
 				</exclusion>
+				<!-- exclude dependency because of its GPLv2 license, see https://github.com/apache/flink/pull/15599#issuecomment-850241316 -->
+				<exclusion>
+					<groupId>javax.annotation</groupId>
+					<artifactId>javax.annotation-api</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 

--- a/flink-filesystems/flink-gs-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-gs-fs-hadoop/pom.xml
@@ -86,11 +86,6 @@ under the License.
 					<groupId>com.google.guava</groupId>
 					<artifactId>failureaccess</artifactId>
 				</exclusion>
-				<!-- exclude dependency because of its GPLv2 license, see https://github.com/apache/flink/pull/15599#issuecomment-850241316 -->
-				<exclusion>
-					<groupId>javax.annotation</groupId>
-					<artifactId>javax.annotation-api</artifactId>
-				</exclusion>
 			</exclusions>
 		</dependency>
 
@@ -214,6 +209,8 @@ under the License.
 										<exclude>META-INF/*.SF</exclude>
 										<exclude>META-INF/*.DSA</exclude>
 										<exclude>META-INF/*.RSA</exclude>
+										<!-- exclude javax.annotation because of GPLv2 license, see https://github.com/apache/flink/pull/15599#issuecomment-850241316 -->
+										<exclude>javax/annotation/**</exclude>
 									</excludes>
 								</filter>
 							</filters>


### PR DESCRIPTION
This PR is based on #18452. It adds a fix up commit to exclude the `javax.annotation-api` dependency.

cc @galenwarren 