### PR TITLE
[FLINK-25788][Table SQL / API] Add show connectors command 

### DIFF
--- a/docs/content.zh/docs/dev/table/sql/show.md
+++ b/docs/content.zh/docs/dev/table/sql/show.md
@@ -196,6 +196,17 @@ tEnv.executeSql("SHOW FULL MODULES").print();
 // |        hive | false |
 // +-------------+-------+
 
+// show connectors
+tEnv.executeSql("SHOW CONNECTORS").print();
+// +----------------+
+// | connector name |
+// +----------------+
+// |     filesystem |
+// |        datagen |
+// |      blackhole |
+// |          print |
+// +----------------+
+
 ```
 {{< /tab >}}
 {{< tab "Scala" >}}
@@ -298,6 +309,17 @@ tEnv.executeSql("SHOW FULL MODULES").print()
 // |        core |  true |
 // |        hive | false |
 // +-------------+-------+
+
+// show connectors
+tEnv.executeSql("SHOW CONNECTORS").print()
+// +----------------+
+// | connector name |
+// +----------------+
+// |     filesystem |
+// |        datagen |
+// |      blackhole |
+// |          print |
+// +----------------+
 
 ```
 {{< /tab >}}
@@ -478,6 +500,18 @@ Flink SQL> SHOW FULL MODULES;
 Flink SQL> SHOW JARS;
 /path/to/addedJar.jar
 
+
+
+Flink SQL> SHOW CONNECTORS;
++----------------+
+| connector name |
++----------------+
+|     filesystem |
+|        datagen |
+|      blackhole |
+|          print |
++----------------+
+5 rows in set
 
 ```
 {{< /tab >}}
@@ -670,5 +704,11 @@ SHOW JARS
 展示所有通过 [`ADD JAR`]({{< ref "docs/dev/table/sql/jar" >}}#add-jar) 语句加入到 session classloader 中的 jar。
 
 <span class="label label-danger">Attention</span> 当前 SHOW JARS 命令只能在 [SQL CLI]({{< ref "docs/dev/table/sqlClient" >}}) 中使用。
+
+## SHOW CONNECTORS
+
+```sql
+SHOW CONNECTORS;
+```
 
 {{< top >}}

--- a/docs/content/docs/dev/table/sql/show.md
+++ b/docs/content/docs/dev/table/sql/show.md
@@ -43,6 +43,7 @@ Flink SQL supports the following SHOW statements for now:
 - SHOW FUNCTIONS
 - SHOW MODULES
 - SHOW JARS
+- SHOW CONNECTORS
 
 ## Run a SHOW statement
 
@@ -196,6 +197,17 @@ tEnv.executeSql("SHOW FULL MODULES").print();
 // |        hive | false |
 // +-------------+-------+
 
+// show connectors
+tEnv.executeSql("SHOW CONNECTORS").print();
+// +----------------+
+// | connector name |
+// +----------------+
+// |     filesystem |
+// |        datagen |
+// |      blackhole |
+// |          print |
+// +----------------+
+
 ```
 {{< /tab >}}
 {{< tab "Scala" >}}
@@ -298,6 +310,17 @@ tEnv.executeSql("SHOW FULL MODULES").print()
 // |        core |  true |
 // |        hive | false |
 // +-------------+-------+
+
+// show connectors
+tEnv.executeSql("SHOW CONNECTORS").print()
+// +----------------+
+// | connector name |
+// +----------------+
+// |     filesystem |
+// |        datagen |
+// |      blackhole |
+// |          print |
+// +----------------+
 
 ```
 {{< /tab >}}
@@ -478,6 +501,17 @@ Flink SQL> SHOW FULL MODULES;
 Flink SQL> SHOW JARS;
 /path/to/addedJar.jar
 
+
+Flink SQL> SHOW CONNECTORS;
++----------------+
+| connector name |
++----------------+
+|     filesystem |
+|        datagen |
+|      blackhole |
+|          print |
++----------------+
+5 rows in set
 
 ```
 {{< /tab >}}
@@ -670,5 +704,13 @@ SHOW JARS
 Show all added jars in the session classloader which are added by [`ADD JAR`]({{< ref "docs/dev/table/sql/jar" >}}#add-jar) statements.
 
 <span class="label label-danger">Attention</span> Currently `SHOW JARS` only works in the [SQL CLI]({{< ref "docs/dev/table/sqlClient" >}}).
+
+## SHOW CONNECTORS
+
+```sql
+SHOW CONNECTORS;
+```
+
+Show all available connectors the session classloader.
 
 {{< top >}}

--- a/flink-table/flink-sql-client/src/test/resources/sql/function.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/function.q
@@ -23,6 +23,24 @@ SHOW JARS;
 $VAR_UDF_JAR_PATH
 !ok
 
+SHOW CONNECTORS;
++----------------+
+| connector name |
++----------------+
+| test-connector |
+|        datagen |
+|      blackhole |
+|          print |
+|     filesystem |
+|         values |
+|      test-file |
+|        harness |
+|    test_source |
+|      test-lock |
++----------------+
+10 rows in set
+!ok
+
 # this also tests user classloader because the LowerUDF is in user jar
 create function func1 as 'LowerUDF' LANGUAGE JAVA;
 [INFO] Execute statement succeed.

--- a/flink-table/flink-sql-parser-hive/src/main/codegen/data/Parser.tdd
+++ b/flink-table/flink-sql-parser-hive/src/main/codegen/data/Parser.tdd
@@ -83,6 +83,7 @@
     "org.apache.flink.sql.parser.dql.SqlDescribeDatabase"
     "org.apache.flink.sql.parser.dql.SqlLoadModule"
     "org.apache.flink.sql.parser.dql.SqlShowCatalogs"
+    "org.apache.flink.sql.parser.dql.SqlShowConnectors"
     "org.apache.flink.sql.parser.dql.SqlShowCurrentCatalog"
     "org.apache.flink.sql.parser.dql.SqlShowDatabases"
     "org.apache.flink.sql.parser.dql.SqlShowCurrentDatabase"
@@ -116,6 +117,7 @@
     "CHANGE"
     "COLLECTION"
     "COLUMNS"
+    "CONNECTORS"
     "COMMENT"
     "DATABASES"
     "DBPROPERTIES"
@@ -208,6 +210,7 @@
     "CONDITION_NUMBER"
     "CONNECTION"
     "CONNECTION_NAME"
+    "CONNECTORS"
     "CONSTRAINT_CATALOG"
     "CONSTRAINT_NAME"
     "CONSTRAINTS"
@@ -551,6 +554,7 @@
     "SqlAddJar()"
     "SqlRemoveJar()"
     "SqlShowJars()"
+    "SqlShowConnectors()"
   ]
 
   # List of methods for parsing custom literals.

--- a/flink-table/flink-sql-parser-hive/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser-hive/src/main/codegen/includes/parserImpls.ftl
@@ -1675,3 +1675,17 @@ SqlShowJars SqlShowJars() :
         return new SqlShowJars(getPos());
     }
 }
+
+/**
+* Parses a show connectors statement.
+* SHOW CONNECTORS;
+*/
+SqlShowConnectors SqlShowConnectors() :
+{
+}
+{
+    <SHOW> <CONNECTORS>
+    {
+        return new SqlShowConnectors(getPos());
+    }
+}

--- a/flink-table/flink-sql-parser-hive/src/test/java/org/apache/flink/sql/parser/hive/FlinkHiveSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser-hive/src/test/java/org/apache/flink/sql/parser/hive/FlinkHiveSqlParserImplTest.java
@@ -480,6 +480,11 @@ public class FlinkHiveSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
+    public void testShowConnectors() {
+        sql("show connectors").ok("SHOW CONNECTORS");
+    }
+
+    @Test
     public void testLoadModule() {
         sql("load module hive").ok("LOAD MODULE `HIVE`");
 

--- a/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
+++ b/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
@@ -74,6 +74,7 @@
     "org.apache.flink.sql.parser.dql.SqlRichExplain"
     "org.apache.flink.sql.parser.dql.SqlLoadModule"
     "org.apache.flink.sql.parser.dql.SqlShowCatalogs"
+    "org.apache.flink.sql.parser.dql.SqlShowConnectors"
     "org.apache.flink.sql.parser.dql.SqlShowCurrentCatalog"
     "org.apache.flink.sql.parser.dql.SqlShowDatabases"
     "org.apache.flink.sql.parser.dql.SqlShowCurrentDatabase"
@@ -115,6 +116,7 @@
     "COMMENT"
     "COMPACT"
     "COLUMNS"
+    "CONNECTORS"
     "DATABASES"
     "ENFORCED"
     "ESTIMATED_COST"
@@ -193,6 +195,7 @@
     "CONDITION_NUMBER"
     "CONNECTION"
     "CONNECTION_NAME"
+    "CONNECTORS"
     "CONSTRAINT_CATALOG"
     "CONSTRAINT_NAME"
     "CONSTRAINTS"
@@ -528,6 +531,7 @@
     "SqlShowJars()"
     "SqlSet()"
     "SqlReset()"
+    "SqlShowConnectors()"
   ]
 
   # List of methods for parsing custom literals.

--- a/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
@@ -1904,3 +1904,17 @@ SqlNode SqlReset() :
         return new SqlReset(span.end(this), key);
     }
 }
+
+/**
+* Parses a show connectors statement.
+* SHOW CONNECTORS;
+*/
+SqlShowConnectors SqlShowConnectors() :
+{
+}
+{
+    <SHOW> <CONNECTORS>
+    {
+        return new SqlShowConnectors(getPos());
+    }
+}

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowConnectors.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowConnectors.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.sql.parser.dql;
+
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+import java.util.Collections;
+import java.util.List;
+
+/** SHOW CONNECTORS sql call. */
+public class SqlShowConnectors extends SqlCall {
+
+    public static final SqlSpecialOperator OPERATOR =
+            new SqlSpecialOperator("SHOW CONNECTORS", SqlKind.OTHER);
+
+    public SqlShowConnectors(SqlParserPos pos) {
+        super(pos);
+    }
+
+    @Override
+    public SqlOperator getOperator() {
+        return OPERATOR;
+    }
+
+    @Override
+    public List<SqlNode> getOperandList() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+        writer.keyword("SHOW CONNECTORS");
+    }
+}

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -1522,6 +1522,11 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
+    public void testShowConnectors() {
+        sql("show connectors").ok("SHOW CONNECTORS");
+    }
+
+    @Test
     public void testSetReset() {
         sql("SET").ok("SET");
         sql("SET 'test-key' = 'test-value'").ok("SET 'test-key' = 'test-value'");

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ShowConnectorsOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ShowConnectorsOperation.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.operations;
+
+/** Operation to describe a SHOW CONNECTORS statement. */
+public class ShowConnectorsOperation implements ShowOperation {
+
+    @Override
+    public String asSummaryString() {
+        return "SHOW CONNECTORS";
+    }
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FactoryUtil.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FactoryUtil.java
@@ -793,7 +793,7 @@ public final class FactoryUtil {
         return (T) foundFactories.get(0);
     }
 
-    static List<Factory> discoverFactories(ClassLoader classLoader) {
+    public static List<Factory> discoverFactories(ClassLoader classLoader) {
         final List<Factory> result = new LinkedList<>();
         ServiceLoaderUtil.load(Factory.class, classLoader)
                 .forEach(

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
@@ -64,6 +64,7 @@ import org.apache.flink.sql.parser.dql.SqlRichDescribeTable;
 import org.apache.flink.sql.parser.dql.SqlRichExplain;
 import org.apache.flink.sql.parser.dql.SqlShowCatalogs;
 import org.apache.flink.sql.parser.dql.SqlShowColumns;
+import org.apache.flink.sql.parser.dql.SqlShowConnectors;
 import org.apache.flink.sql.parser.dql.SqlShowCreateTable;
 import org.apache.flink.sql.parser.dql.SqlShowCreateView;
 import org.apache.flink.sql.parser.dql.SqlShowCurrentCatalog;
@@ -111,6 +112,7 @@ import org.apache.flink.table.operations.ModifyOperation;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.ShowCatalogsOperation;
 import org.apache.flink.table.operations.ShowColumnsOperation;
+import org.apache.flink.table.operations.ShowConnectorsOperation;
 import org.apache.flink.table.operations.ShowCreateTableOperation;
 import org.apache.flink.table.operations.ShowCreateViewOperation;
 import org.apache.flink.table.operations.ShowCurrentCatalogOperation;
@@ -313,6 +315,8 @@ public class SqlToOperationConverter {
             return Optional.of(converter.convertShowJars((SqlShowJars) validated));
         } else if (validated instanceof RichSqlInsert) {
             return Optional.of(converter.convertSqlInsert((RichSqlInsert) validated));
+        } else if (validated instanceof SqlShowConnectors) {
+            return Optional.of(converter.convertShowConnectors((SqlShowConnectors) validated));
         } else if (validated instanceof SqlBeginStatementSet) {
             return Optional.of(
                     converter.convertBeginStatementSet((SqlBeginStatementSet) validated));
@@ -1093,6 +1097,10 @@ public class SqlToOperationConverter {
 
     private Operation convertShowJars(SqlShowJars sqlShowJars) {
         return new ShowJarsOperation();
+    }
+
+    private Operation convertShowConnectors(SqlShowConnectors sqlShowConnectors) {
+        return new ShowConnectorsOperation();
     }
 
     /** Convert UNLOAD MODULE statement. */

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/calcite/FlinkPlannerImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/calcite/FlinkPlannerImpl.scala
@@ -140,7 +140,8 @@ class FlinkPlannerImpl(
         || sqlNode.isInstanceOf[SqlBeginStatementSet]
         || sqlNode.isInstanceOf[SqlEndStatementSet]
         || sqlNode.isInstanceOf[SqlSet]
-        || sqlNode.isInstanceOf[SqlReset]) {
+        || sqlNode.isInstanceOf[SqlReset]
+        || sqlNode.isInstanceOf[SqlShowConnectors]) {
         return sqlNode
       }
       sqlNode match {


### PR DESCRIPTION
## What is the purpose of the change

This PR introduces a command `SHOW CONNECTORS`

## Brief change log

- Added support `SHOW CONNECTORS` in parser, converter
- Make _org.apache.flink.table.factories.FactoryUtil#discoverFactory_ public
- Added test in `function.q`


## Verifying this change

 Added test in `function.q`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes) 
    Make _org.apache.flink.table.factories.FactoryUtil#discoverFactory_ public
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes )
  - If yes, how is the feature documented? (docs )
