### PR TITLE
[FLINK-24041][connector] Fixing reversed insertion of failed requests

### DIFF
--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/sink/writer/AsyncSinkWriter.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/sink/writer/AsyncSinkWriter.java
@@ -348,7 +348,9 @@ public abstract class AsyncSinkWriter<InputT, RequestEntryT extends Serializable
         lastSendTimestamp = requestStartTime;
         ackTime = System.currentTimeMillis();
         inFlightRequestsCount--;
-        failedRequestEntries.forEach(failedEntry -> addEntryToBuffer(failedEntry, true));
+        List<RequestEntryT> requestsList = new ArrayList<>(failedRequestEntries);
+        Collections.reverse(requestsList);
+        requestsList.forEach(failedEntry -> addEntryToBuffer(failedEntry, true));
     }
 
     private void addEntryToBuffer(RequestEntryT entry, boolean insertAtHead) {

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/sink/writer/AsyncSinkWriterTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/sink/writer/AsyncSinkWriterTest.java
@@ -338,7 +338,7 @@ public class AsyncSinkWriterTest {
         sink.prepareCommit(true);
 
         // Everything is saved
-        assertEquals(Arrays.asList(25, 55, 965, 75, 95, 45, 550, 955, 35, 535), res);
+        assertEquals(Arrays.asList(25, 55, 965, 75, 95, 45, 955, 550, 35, 535), res);
         assertEquals(0, sink.snapshotState().get(0).size());
     }
 
@@ -538,6 +538,37 @@ public class AsyncSinkWriterTest {
         // inflight request is processed, buffer: [225, 3, 4, 5, 6, 325]
         assertEquals(Arrays.asList(1, 2, 225, 3, 4), res);
         // Buffer: [5, 6, 325]; 0 inflight
+    }
+
+    @Test
+    public void testThatIntermittentlyFailingEntriesAreEnqueuedOnToTheBufferWithCorrectOrder()
+            throws IOException, InterruptedException {
+        AsyncSinkWriterImpl sink =
+                new AsyncSinkWriterImplBuilder()
+                        .context(sinkInitContext)
+                        .maxBatchSize(10)
+                        .maxInFlightRequests(1)
+                        .maxBufferedRequests(100)
+                        .maxBatchSizeInBytes(210)
+                        .maxTimeInBufferMS(1000)
+                        .maxRecordSizeInBytes(110)
+                        .simulateFailures(true)
+                        .build();
+
+        sink.write(String.valueOf(228)); // Buffer: 100/210B; 1/10 elements; 0 inflight
+        sink.write(String.valueOf(225)); // Buffer: 200/210B; 2/10 elements; 0 inflight
+        sink.write(String.valueOf(1)); //   Buffer: 204/210B; 3/10 elements; 0 inflight
+        sink.write(String.valueOf(2)); //   Buffer: 208/210B; 4/10 elements; 0 inflight
+        sink.write(String.valueOf(3)); //   Buffer: 212/210B; 5/10 elements; 0 inflight -- flushing
+        assertEquals(2, res.size()); // Request was [228, 225, 1, 2], element 228, 225 failed
+        sink.write(String.valueOf(4)); //   Buffer:   8/210B; 2/10 elements; 2 inflight
+        sink.write(String.valueOf(5)); //   Buffer:  12/210B; 3/10 elements; 2 inflight
+        sink.write(String.valueOf(6)); //   Buffer:  16/210B; 4/10 elements; 2 inflight
+        sink.write(String.valueOf(328)); // Buffer: 116/210B; 5/10 elements; 2 inflight
+        sink.write(String.valueOf(325)); // Buffer: 216/210B; 6/10 elements; 2 inflight -- flushing
+        // inflight request is processed, buffer: [228, 225, 3, 4, 5, 6, 328, 325]
+        assertEquals(Arrays.asList(1, 2, 228, 225, 3, 4), res);
+        // Buffer: [5, 6, 328, 325]; 0 inflight
     }
 
     @Test


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
 Fixing reversed insertion of failed requests in `AsyncSinkBase`.


## Brief change log

  - fixed implementation of `completeRequest` function in `AsyncSinkWriter`.


## Verifying this change

This change added tests and can be verified as follows:

- Added unit test to capture previous behavior.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
