### PR TITLE
[FLINK-25790][flink-gs-fs-hadoop] Support authentication via core-site.xml in GCS FileSystem plugin

### DIFF
--- a/flink-filesystems/flink-gs-fs-hadoop/src/main/java/org/apache/flink/fs/gs/GSFileSystem.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/main/java/org/apache/flink/fs/gs/GSFileSystem.java
@@ -24,11 +24,17 @@ import org.apache.flink.fs.gs.writer.GSRecoverableWriter;
 import org.apache.flink.runtime.fs.hdfs.HadoopFileSystem;
 import org.apache.flink.util.Preconditions;
 
+import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
+import org.apache.hadoop.conf.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.Optional;
 
 /** Provides recoverable-writer functionality for the standard GoogleHadoopFileSystem. */
 class GSFileSystem extends HadoopFileSystem {
@@ -39,17 +45,67 @@ class GSFileSystem extends HadoopFileSystem {
 
     GSFileSystem(GoogleHadoopFileSystem googleHadoopFileSystem, GSFileSystemOptions options) {
         super(Preconditions.checkNotNull(googleHadoopFileSystem));
-        LOGGER.info("Creating GSFileSystem with options {}", options);
-
         this.options = Preconditions.checkNotNull(options);
+        LOGGER.info("Creating GSFileSystem with options {}", options);
     }
 
     @Override
-    public RecoverableWriter createRecoverableWriter() {
-        LOGGER.info("Creating recoverable writer with options {}", options);
+    public RecoverableWriter createRecoverableWriter() throws IOException {
 
-        // create the Google storage service instance
-        Storage storage = StorageOptions.getDefaultInstance().getService();
+        // follow the same rules as for the Hadoop connector, i.e.
+        // 1) only use service credentials at all if Hadoop
+        // "google.cloud.auth.service.account.enable" is true (default: true)
+        // 2) use GOOGLE_APPLICATION_CREDENTIALS as location of credentials, if supplied
+        // 3) use Hadoop "google.cloud.auth.service.account.json.keyfile" as location of
+        // credentials, if supplied
+        // 4) use no credentials
+
+        // store any credentials we are to use, here
+        Optional<String> credentialsPath = Optional.empty();
+
+        // only look for credentials if service account support is enabled
+        Configuration hadoopConfig = getHadoopFileSystem().getConf();
+        boolean enableServiceAccount =
+                hadoopConfig.getBoolean("google.cloud.auth.service.account.enable", true);
+        if (enableServiceAccount) {
+
+            // load google application credentials, and then fall back to
+            // "google.cloud.auth.service.account.json.keyfile" from Hadoop
+            credentialsPath = Optional.ofNullable(System.getenv("GOOGLE_APPLICATION_CREDENTIALS"));
+            if (credentialsPath.isPresent()) {
+                LOGGER.info(
+                        "Recoverable writer is using GOOGLE_APPLICATION_CREDENTIALS at {}",
+                        credentialsPath.get());
+            } else {
+                credentialsPath =
+                        Optional.ofNullable(
+                                hadoopConfig.get("google.cloud.auth.service.account.json.keyfile"));
+                credentialsPath.ifPresent(
+                        path ->
+                                LOGGER.info(
+                                        "Recoverable writer is using credentials from Hadoop at {}",
+                                        path));
+            }
+        }
+
+        // construct the storage instance, using credentials if provided
+        Storage storage;
+        if (credentialsPath.isPresent()) {
+            LOGGER.info(
+                    "Creating GSRecoverableWriter using credentials from {}",
+                    credentialsPath.get());
+            try (FileInputStream credentialsStream = new FileInputStream(credentialsPath.get())) {
+                GoogleCredentials credentials = GoogleCredentials.fromStream(credentialsStream);
+                storage =
+                        StorageOptions.newBuilder()
+                                .setCredentials(credentials)
+                                .build()
+                                .getService();
+            }
+        } else {
+            LOGGER.info("Creating GSRecoverableWriter using no credentials");
+            storage = StorageOptions.newBuilder().build().getService();
+        }
 
         // create the GS blob storage wrapper
         GSBlobStorageImpl blobStorage = new GSBlobStorageImpl(storage);

--- a/flink-filesystems/flink-gs-fs-hadoop/src/main/java/org/apache/flink/fs/gs/GSFileSystem.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/main/java/org/apache/flink/fs/gs/GSFileSystem.java
@@ -24,93 +24,38 @@ import org.apache.flink.fs.gs.writer.GSRecoverableWriter;
 import org.apache.flink.runtime.fs.hdfs.HadoopFileSystem;
 import org.apache.flink.util.Preconditions;
 
-import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem;
 import com.google.cloud.storage.Storage;
-import com.google.cloud.storage.StorageOptions;
-import org.apache.hadoop.conf.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.util.Optional;
-
-/** Provides recoverable-writer functionality for the standard GoogleHadoopFileSystem. */
+/** FileSystem implementation that wraps GoogleHadoopFileSystem and supports RecoverableWriter. */
 class GSFileSystem extends HadoopFileSystem {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GSFileSystem.class);
 
-    private final GSFileSystemOptions options;
+    private final GSFileSystemOptions fileSystemOptions;
 
-    GSFileSystem(GoogleHadoopFileSystem googleHadoopFileSystem, GSFileSystemOptions options) {
+    private final Storage storage;
+
+    GSFileSystem(
+            GoogleHadoopFileSystem googleHadoopFileSystem,
+            Storage storage,
+            GSFileSystemOptions fileSystemOptions) {
         super(Preconditions.checkNotNull(googleHadoopFileSystem));
-        this.options = Preconditions.checkNotNull(options);
-        LOGGER.info("Creating GSFileSystem with options {}", options);
+        this.fileSystemOptions = Preconditions.checkNotNull(fileSystemOptions);
+        this.storage = Preconditions.checkNotNull(storage);
+        LOGGER.info("Creating GSFileSystem with file-system options {}", fileSystemOptions);
     }
 
     @Override
-    public RecoverableWriter createRecoverableWriter() throws IOException {
-
-        // follow the same rules as for the Hadoop connector, i.e.
-        // 1) only use service credentials at all if Hadoop
-        // "google.cloud.auth.service.account.enable" is true (default: true)
-        // 2) use GOOGLE_APPLICATION_CREDENTIALS as location of credentials, if supplied
-        // 3) use Hadoop "google.cloud.auth.service.account.json.keyfile" as location of
-        // credentials, if supplied
-        // 4) use no credentials
-
-        // store any credentials we are to use, here
-        Optional<String> credentialsPath = Optional.empty();
-
-        // only look for credentials if service account support is enabled
-        Configuration hadoopConfig = getHadoopFileSystem().getConf();
-        boolean enableServiceAccount =
-                hadoopConfig.getBoolean("google.cloud.auth.service.account.enable", true);
-        if (enableServiceAccount) {
-
-            // load google application credentials, and then fall back to
-            // "google.cloud.auth.service.account.json.keyfile" from Hadoop
-            credentialsPath = Optional.ofNullable(System.getenv("GOOGLE_APPLICATION_CREDENTIALS"));
-            if (credentialsPath.isPresent()) {
-                LOGGER.info(
-                        "Recoverable writer is using GOOGLE_APPLICATION_CREDENTIALS at {}",
-                        credentialsPath.get());
-            } else {
-                credentialsPath =
-                        Optional.ofNullable(
-                                hadoopConfig.get("google.cloud.auth.service.account.json.keyfile"));
-                credentialsPath.ifPresent(
-                        path ->
-                                LOGGER.info(
-                                        "Recoverable writer is using credentials from Hadoop at {}",
-                                        path));
-            }
-        }
-
-        // construct the storage instance, using credentials if provided
-        Storage storage;
-        if (credentialsPath.isPresent()) {
-            LOGGER.info(
-                    "Creating GSRecoverableWriter using credentials from {}",
-                    credentialsPath.get());
-            try (FileInputStream credentialsStream = new FileInputStream(credentialsPath.get())) {
-                GoogleCredentials credentials = GoogleCredentials.fromStream(credentialsStream);
-                storage =
-                        StorageOptions.newBuilder()
-                                .setCredentials(credentials)
-                                .build()
-                                .getService();
-            }
-        } else {
-            LOGGER.info("Creating GSRecoverableWriter using no credentials");
-            storage = StorageOptions.newBuilder().build().getService();
-        }
+    public RecoverableWriter createRecoverableWriter() {
+        LOGGER.info("Creating GSRecoverableWriter with file-system options {}", fileSystemOptions);
 
         // create the GS blob storage wrapper
         GSBlobStorageImpl blobStorage = new GSBlobStorageImpl(storage);
 
         // construct the recoverable writer with the blob storage wrapper and the options
-        return new GSRecoverableWriter(blobStorage, options);
+        return new GSRecoverableWriter(blobStorage, fileSystemOptions);
     }
 }

--- a/flink-filesystems/flink-gs-fs-hadoop/src/main/java/org/apache/flink/fs/gs/GSFileSystem.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/main/java/org/apache/flink/fs/gs/GSFileSystem.java
@@ -45,7 +45,6 @@ class GSFileSystem extends HadoopFileSystem {
         super(Preconditions.checkNotNull(googleHadoopFileSystem));
         this.fileSystemOptions = Preconditions.checkNotNull(fileSystemOptions);
         this.storage = Preconditions.checkNotNull(storage);
-        LOGGER.info("Creating GSFileSystem with file-system options {}", fileSystemOptions);
     }
 
     @Override

--- a/flink-filesystems/flink-gs-fs-hadoop/src/main/java/org/apache/flink/fs/gs/utils/ConfigUtils.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/main/java/org/apache/flink/fs/gs/utils/ConfigUtils.java
@@ -1,0 +1,202 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.gs.utils;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.runtime.util.HadoopConfigLoader;
+
+import com.google.cloud.storage.StorageOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.Collections;
+import java.util.Optional;
+
+/** Utilities class for configuration of Hadoop and Google Storage. */
+public class ConfigUtils {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConfigUtils.class);
+
+    private static final String HADOOP_CONFIG_PREFIX = "fs.gs.";
+
+    private static final String[] FLINK_CONFIG_PREFIXES = {"gs.", HADOOP_CONFIG_PREFIX};
+
+    private static final String[][] MIRRORED_CONFIG_KEYS = {};
+
+    private static final String FLINK_SHADING_PREFIX = "";
+
+    /**
+     * Loads the Hadoop configuration, by loading from a Hadoop conf dir (if one exists) and then
+     * overlaying properties derived from the Flink config.
+     *
+     * @param flinkConfig The Flink config
+     * @param configContext The config context.
+     * @return The Hadoop config.
+     */
+    public static org.apache.hadoop.conf.Configuration getHadoopConfiguration(
+            Configuration flinkConfig, ConfigContext configContext) {
+
+        // create a starting hadoop configuration
+        org.apache.hadoop.conf.Configuration hadoopConfig =
+                new org.apache.hadoop.conf.Configuration();
+
+        // look for a hadoop configuration directory and load configuration from it if found
+        Optional<String> hadoopConfigDir =
+                Optional.ofNullable(flinkConfig.get(CoreOptions.FLINK_HADOOP_CONF_DIR));
+        if (!hadoopConfigDir.isPresent()) {
+            hadoopConfigDir = configContext.getenv("HADOOP_CONF_DIR");
+        }
+        hadoopConfigDir.ifPresent(
+                configDir -> {
+                    LOGGER.info("Loading Hadoop config resources from {}", configDir);
+                    configContext.addHadoopResourcesFromDir(hadoopConfig, configDir);
+                });
+
+        // now, load hadoop config from flink and add to base hadoop config
+        HadoopConfigLoader hadoopConfigLoader =
+                new HadoopConfigLoader(
+                        FLINK_CONFIG_PREFIXES,
+                        MIRRORED_CONFIG_KEYS,
+                        HADOOP_CONFIG_PREFIX,
+                        Collections.emptySet(),
+                        Collections.emptySet(),
+                        FLINK_SHADING_PREFIX);
+        hadoopConfigLoader.setFlinkConfig(flinkConfig);
+        org.apache.hadoop.conf.Configuration flinkHadoopConfig =
+                hadoopConfigLoader.getOrLoadHadoopConfig();
+        hadoopConfig.addResource(flinkHadoopConfig);
+
+        // reload the config resources and return it
+        hadoopConfig.reloadConfiguration();
+        return hadoopConfig;
+    }
+
+    /**
+     * Creates a StorageOptions instance for the given Hadoop config and environment.
+     *
+     * @param hadoopConfig The Hadoop config.
+     * @param configContext The config context.
+     * @return The StorageOptions instance.
+     */
+    public static StorageOptions getStorageOptions(
+            org.apache.hadoop.conf.Configuration hadoopConfig, ConfigContext configContext) {
+
+        // follow the same rules as for the Hadoop connector, i.e.
+        // 1) only use service credentials at all if Hadoop
+        // "google.cloud.auth.service.account.enable" is true (default: true)
+        // 2) use GOOGLE_APPLICATION_CREDENTIALS as location of credentials, if supplied
+        // 3) use Hadoop "google.cloud.auth.service.account.json.keyfile" as location of
+        // credentials, if supplied
+        // 4) use no credentials
+
+        // store any credentials we are to use, here
+        Optional<String> credentialsPath = Optional.empty();
+
+        // only look for credentials if service account support is enabled
+        boolean enableServiceAccount =
+                hadoopConfig.getBoolean("google.cloud.auth.service.account.enable", true);
+        if (enableServiceAccount) {
+
+            // load google application credentials, and then fall back to
+            // "google.cloud.auth.service.account.json.keyfile" from Hadoop
+            credentialsPath = configContext.getenv("GOOGLE_APPLICATION_CREDENTIALS");
+            if (credentialsPath.isPresent()) {
+                LOGGER.info(
+                        "GSRecoverableWriter is using GOOGLE_APPLICATION_CREDENTIALS at {}",
+                        credentialsPath.get());
+            } else {
+                credentialsPath =
+                        Optional.ofNullable(
+                                hadoopConfig.get("google.cloud.auth.service.account.json.keyfile"));
+                credentialsPath.ifPresent(
+                        path ->
+                                LOGGER.info(
+                                        "GSRecoverableWriter is using credentials from Hadoop at {}",
+                                        path));
+            }
+        }
+
+        // construct the storage options
+        StorageOptions.Builder storageOptionsBuilder = StorageOptions.newBuilder();
+        if (credentialsPath.isPresent()) {
+            LOGGER.info(
+                    "Creating GSRecoverableWriter using credentials from {}",
+                    credentialsPath.get());
+            configContext.setStorageCredentialsFromFile(
+                    storageOptionsBuilder, credentialsPath.get());
+        } else {
+            LOGGER.info("Creating GSRecoverableWriter using no credentials");
+        }
+
+        return storageOptionsBuilder.build();
+    }
+
+    /**
+     * Helper to serialize a Hadoop config to a string, for logging.
+     *
+     * @param hadoopConfig The Hadoop config.
+     * @return A string with the Hadoop properties.
+     * @throws RuntimeException On underlying IO failure
+     */
+    public static String stringifyHadoopConfig(org.apache.hadoop.conf.Configuration hadoopConfig)
+            throws RuntimeException {
+        try (Writer writer = new StringWriter()) {
+            org.apache.hadoop.conf.Configuration.dumpConfiguration(hadoopConfig, writer);
+            return writer.toString();
+        } catch (IOException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    /**
+     * Interface that provides context-specific config helper functions, factored out to support
+     * unit testing. *
+     */
+    public interface ConfigContext {
+        /**
+         * Returns a named environment variable.
+         *
+         * @param name Name of variable
+         * @return Value of variable
+         */
+        Optional<String> getenv(String name);
+
+        /**
+         * Adds resources to the Hadoop configuration for the provided Hadoop config dir directory.
+         *
+         * @param config The Hadoop configuration.
+         * @param configDir The Hadoop config directory.
+         */
+        void addHadoopResourcesFromDir(
+                org.apache.hadoop.conf.Configuration config, String configDir);
+
+        /**
+         * Assigns credentials to the storage options builder from credentials at the given path.
+         *
+         * @param storageOptionsBuilder The storage options builder.
+         * @param credentialsPath The path of the credentials file.
+         */
+        void setStorageCredentialsFromFile(
+                StorageOptions.Builder storageOptionsBuilder, String credentialsPath);
+    }
+}

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/TestUtils.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/TestUtils.java
@@ -18,8 +18,42 @@
 
 package org.apache.flink.fs.gs;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /** Constants for testing purposes. */
 public class TestUtils {
 
     public static final long RANDOM_SEED = 27;
+
+    /**
+     * Helper to create a hadoop configuration from a map.
+     *
+     * @param values Map of values
+     * @return Hadoop config
+     */
+    public static org.apache.hadoop.conf.Configuration hadoopConfigFromMap(
+            Map<String, String> values) {
+        org.apache.hadoop.conf.Configuration hadoopConfig =
+                new org.apache.hadoop.conf.Configuration();
+        for (Map.Entry<String, String> entry : values.entrySet()) {
+            hadoopConfig.set(entry.getKey(), entry.getValue());
+        }
+        return hadoopConfig;
+    }
+
+    /**
+     * Helper to translate Hadoop config to a map.
+     *
+     * @param hadoopConfig The Hadoop config
+     * @return The map of keys/values
+     */
+    public static Map<String, String> hadoopConfigToMap(
+            org.apache.hadoop.conf.Configuration hadoopConfig) {
+        HashMap<String, String> map = new HashMap<>();
+        for (Map.Entry<String, String> entry : hadoopConfig) {
+            map.put(entry.getKey(), entry.getValue());
+        }
+        return map;
+    }
 }

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/utils/ConfigUtilsHadoopTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/utils/ConfigUtilsHadoopTest.java
@@ -1,0 +1,303 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.gs.utils;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.fs.gs.TestUtils;
+
+import org.apache.flink.shaded.guava30.com.google.common.collect.MapDifference;
+import org.apache.flink.shaded.guava30.com.google.common.collect.Maps;
+
+import com.google.cloud.storage.StorageOptions;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import javax.annotation.Nullable;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** Test construction of Hadoop config in GSFileSystemFactory. */
+@RunWith(Parameterized.class)
+public class ConfigUtilsHadoopTest {
+
+    /* The test case description. */
+    @Parameterized.Parameter(value = 0)
+    public String description;
+
+    /* The value to use for the HADOOP_CONF_DIR environment variable. */
+    @Parameterized.Parameter(value = 1)
+    public @Nullable String envHadoopConfDir;
+
+    /* The value to use for the Flink config. */
+    @Parameterized.Parameter(value = 2)
+    public Configuration flinkConfig;
+
+    /* The additional Hadoop resources to add to the hadoop config when hadoop conf dir is present. */
+    @Parameterized.Parameter(value = 3)
+    public org.apache.hadoop.conf.Configuration additionalHadoopConfig;
+
+    /* The expected Hadoop configuration. */
+    @Parameterized.Parameter(value = 4)
+    public org.apache.hadoop.conf.Configuration expectedHadoopConfig;
+
+    @Parameterized.Parameters(name = "description={0}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(
+                new Object[][] {
+                    {
+                        "no env hadoop conf dir, no flink hadoop conf dir, no flink hadoop options, no hadoop options in conf dir",
+                        null,
+                        Configuration.fromMap(new HashMap<>()),
+                        TestUtils.hadoopConfigFromMap(new HashMap<>()),
+                        TestUtils.hadoopConfigFromMap(new HashMap<>()),
+                    },
+                    {
+                        "no env hadoop conf dir, no flink hadoop conf dir, no flink hadoop options, hadoop options in conf dir",
+                        null,
+                        Configuration.fromMap(new HashMap<>()),
+                        TestUtils.hadoopConfigFromMap(
+                                new HashMap<String, String>() {
+                                    {
+                                        put("fs.gs.project.id", "project-id");
+                                    }
+                                }),
+                        TestUtils.hadoopConfigFromMap(new HashMap<>()),
+                    },
+                    {
+                        "env hadoop conf dir, no flink hadoop conf dir, no flink hadoop options, hadoop options in conf dir",
+                        "/hadoop/conf",
+                        Configuration.fromMap(new HashMap<>()),
+                        TestUtils.hadoopConfigFromMap(
+                                new HashMap<String, String>() {
+                                    {
+                                        put("fs.gs.project.id", "project-id");
+                                    }
+                                }),
+                        TestUtils.hadoopConfigFromMap(
+                                new HashMap<String, String>() {
+                                    {
+                                        put("fs.gs.project.id", "project-id");
+                                    }
+                                }),
+                    },
+                    {
+                        "no env hadoop conf dir, flink hadoop conf dir, no flink hadoop options, hadoop options in conf dir",
+                        null,
+                        Configuration.fromMap(
+                                new HashMap<String, String>() {
+                                    {
+                                        put("env.hadoop.conf.dir", "/hadoop/conf");
+                                    }
+                                }),
+                        TestUtils.hadoopConfigFromMap(
+                                new HashMap<String, String>() {
+                                    {
+                                        put("fs.gs.project.id", "project-id");
+                                    }
+                                }),
+                        TestUtils.hadoopConfigFromMap(
+                                new HashMap<String, String>() {
+                                    {
+                                        put("fs.gs.project.id", "project-id");
+                                    }
+                                }),
+                    },
+                    {
+                        "env hadoop conf dir, flink hadoop conf dir, no flink hadoop options, hadoop options in conf dir",
+                        "/hadoop/conf1",
+                        Configuration.fromMap(
+                                new HashMap<String, String>() {
+                                    {
+                                        put("env.hadoop.conf.dir", "/hadoop/conf2");
+                                    }
+                                }),
+                        TestUtils.hadoopConfigFromMap(
+                                new HashMap<String, String>() {
+                                    {
+                                        put("fs.gs.project.id", "project-id");
+                                    }
+                                }),
+                        TestUtils.hadoopConfigFromMap(
+                                new HashMap<String, String>() {
+                                    {
+                                        put("fs.gs.project.id", "project-id");
+                                    }
+                                }),
+                    },
+                    {
+                        "env hadoop conf dir, no flink hadoop conf dir, flink hadoop options, hadoop options in conf dir",
+                        "/hadoop/conf",
+                        Configuration.fromMap(
+                                new HashMap<String, String>() {
+                                    {
+                                        put("gs.block.size", "10000");
+                                    }
+                                }),
+                        TestUtils.hadoopConfigFromMap(
+                                new HashMap<String, String>() {
+                                    {
+                                        put("fs.gs.project.id", "project-id");
+                                    }
+                                }),
+                        TestUtils.hadoopConfigFromMap(
+                                new HashMap<String, String>() {
+                                    {
+                                        put("fs.gs.block.size", "10000");
+                                        put("fs.gs.project.id", "project-id");
+                                    }
+                                }),
+                    },
+                    {
+                        "env hadoop conf dir, no flink hadoop conf dir, flink hadoop options, hadoop options in conf dir, hadoop options overlap",
+                        "/hadoop/conf",
+                        Configuration.fromMap(
+                                new HashMap<String, String>() {
+                                    {
+                                        put("gs.project.id", "project-id-1");
+                                    }
+                                }),
+                        TestUtils.hadoopConfigFromMap(
+                                new HashMap<String, String>() {
+                                    {
+                                        put("fs.gs.project.id", "project-id-2");
+                                    }
+                                }),
+                        TestUtils.hadoopConfigFromMap(
+                                new HashMap<String, String>() {
+                                    {
+                                        put("fs.gs.project.id", "project-id-1");
+                                    }
+                                }),
+                    },
+                    {
+                        "env hadoop conf dir, no flink hadoop conf dir, no flink hadoop options, hadoop enabled auth options in conf dir",
+                        "/hadoop/conf",
+                        Configuration.fromMap(new HashMap<>()),
+                        TestUtils.hadoopConfigFromMap(
+                                new HashMap<String, String>() {
+                                    {
+                                        put("google.cloud.auth.service.account.enable", "true");
+                                        put(
+                                                "google.cloud.auth.service.account.json.keyfile",
+                                                "/opt/file.json");
+                                    }
+                                }),
+                        TestUtils.hadoopConfigFromMap(
+                                new HashMap<String, String>() {
+                                    {
+                                        put("google.cloud.auth.service.account.enable", "true");
+                                        put(
+                                                "google.cloud.auth.service.account.json.keyfile",
+                                                "/opt/file.json");
+                                    }
+                                }),
+                    },
+                    {
+                        "env hadoop conf dir, no flink hadoop conf dir, no flink hadoop options, hadoop disabled auth options in conf dir",
+                        "/hadoop/conf",
+                        Configuration.fromMap(new HashMap<>()),
+                        TestUtils.hadoopConfigFromMap(
+                                new HashMap<String, String>() {
+                                    {
+                                        put("google.cloud.auth.service.account.enable", "false");
+                                        put(
+                                                "google.cloud.auth.service.account.json.keyfile",
+                                                "/opt/file.json");
+                                    }
+                                }),
+                        TestUtils.hadoopConfigFromMap(
+                                new HashMap<String, String>() {
+                                    {
+                                        put("google.cloud.auth.service.account.enable", "false");
+                                        put(
+                                                "google.cloud.auth.service.account.json.keyfile",
+                                                "/opt/file.json");
+                                    }
+                                }),
+                    },
+                });
+    }
+
+    private @Nullable String expectedHadoopConfigDir;
+
+    @Before
+    public void before() {
+
+        // determine which hadoop conf dir we expect to receive
+        expectedHadoopConfigDir = flinkConfig.get(CoreOptions.FLINK_HADOOP_CONF_DIR);
+        if (expectedHadoopConfigDir == null) {
+            expectedHadoopConfigDir = envHadoopConfDir;
+        }
+    }
+
+    @Test
+    public void shouldProperlyCreateHadoopConfig() {
+        final String[] actualHadoopConfigDir = {null};
+
+        // get the hadoop configuration
+        org.apache.hadoop.conf.Configuration hadoopConfig =
+                ConfigUtils.getHadoopConfiguration(
+                        flinkConfig,
+                        new ConfigUtils.ConfigContext() {
+                            @Override
+                            public Optional<String> getenv(String name) {
+                                if ("HADOOP_CONF_DIR".equals(name)) {
+                                    return Optional.ofNullable(envHadoopConfDir);
+                                }
+                                return Optional.empty();
+                            }
+
+                            @Override
+                            public void addHadoopResourcesFromDir(
+                                    org.apache.hadoop.conf.Configuration config, String configDir) {
+                                actualHadoopConfigDir[0] = configDir;
+                                config.addResource(additionalHadoopConfig);
+                            }
+
+                            @Override
+                            public void setStorageCredentialsFromFile(
+                                    StorageOptions.Builder storageOptionsBuilder,
+                                    String credentialsPath) {
+                                throw new UnsupportedOperationException();
+                            }
+                        });
+
+        assertEquals(expectedHadoopConfigDir, actualHadoopConfigDir[0]);
+
+        Map<String, String> expectedHadoopConfigMap =
+                TestUtils.hadoopConfigToMap(expectedHadoopConfig);
+        Map<String, String> hadoopConfigMap = TestUtils.hadoopConfigToMap(hadoopConfig);
+        MapDifference<String, String> difference =
+                Maps.difference(expectedHadoopConfigMap, hadoopConfigMap);
+
+        assertEquals(Collections.EMPTY_MAP, difference.entriesDiffering());
+        assertEquals(Collections.EMPTY_MAP, difference.entriesOnlyOnLeft());
+        assertEquals(Collections.EMPTY_MAP, difference.entriesOnlyOnRight());
+    }
+}

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/utils/ConfigUtilsStorageTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/utils/ConfigUtilsStorageTest.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.gs.utils;
+
+import org.apache.flink.fs.gs.TestUtils;
+
+import com.google.cloud.storage.StorageOptions;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import javax.annotation.Nullable;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/** Test construction of Storage instance in GSFileSystemFactory. */
+@RunWith(Parameterized.class)
+public class ConfigUtilsStorageTest {
+
+    /* The test case description. */
+    @Parameterized.Parameter(value = 0)
+    public String description;
+
+    /* The value to use for the GOOGLE_APPLICATION_CREDENTIALS environment variable. */
+    @Parameterized.Parameter(value = 1)
+    public @Nullable String envGoogleApplicationCredentials;
+
+    /* The Hadoop config. */
+    @Parameterized.Parameter(value = 2)
+    public org.apache.hadoop.conf.Configuration hadoopConfig;
+
+    /* The expected credentials file to use. */
+    @Parameterized.Parameter(value = 3)
+    public @Nullable String expectedCredentialsFile;
+
+    @Parameterized.Parameters(name = "description={0}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(
+                new Object[][] {
+                    {
+                        "no GAC in env, no credentials in hadoop conf",
+                        null,
+                        TestUtils.hadoopConfigFromMap(new HashMap<>()),
+                        null,
+                    },
+                    {
+                        "GAC in env, no credentials in hadoop conf",
+                        "/opt/file.json",
+                        TestUtils.hadoopConfigFromMap(new HashMap<>()),
+                        "/opt/file.json",
+                    },
+                    {
+                        "no GAC in env, credentials in hadoop conf",
+                        null,
+                        TestUtils.hadoopConfigFromMap(
+                                new HashMap<String, String>() {
+                                    {
+                                        put(
+                                                "google.cloud.auth.service.account.json.keyfile",
+                                                "/opt/file.json");
+                                    }
+                                }),
+                        "/opt/file.json",
+                    },
+                    {
+                        "GAC in env, credentials in hadoop conf, GAC should take precedence",
+                        "/opt/file1.json",
+                        TestUtils.hadoopConfigFromMap(
+                                new HashMap<String, String>() {
+                                    {
+                                        put(
+                                                "google.cloud.auth.service.account.json.keyfile",
+                                                "/opt/file2.json");
+                                    }
+                                }),
+                        "/opt/file1.json",
+                    },
+                    {
+                        "GAC in env, no credentials in hadoop conf, service accounts disabled",
+                        "/opt/file.json",
+                        TestUtils.hadoopConfigFromMap(
+                                new HashMap<String, String>() {
+                                    {
+                                        put("google.cloud.auth.service.account.enable", "false");
+                                    }
+                                }),
+                        null,
+                    },
+                    {
+                        "no GAC in env, credentials in hadoop conf, service accounts disabled",
+                        null,
+                        TestUtils.hadoopConfigFromMap(
+                                new HashMap<String, String>() {
+                                    {
+                                        put("google.cloud.auth.service.account.enable", "false");
+                                        put(
+                                                "google.cloud.auth.service.account.json.keyfile",
+                                                "/opt/file.json");
+                                    }
+                                }),
+                        null,
+                    },
+                });
+    }
+
+    @Test
+    public void shouldProperlyCreateStorageOptions() {
+
+        final String[] actualCredentialsPath = {null};
+
+        StorageOptions storageOptions =
+                ConfigUtils.getStorageOptions(
+                        hadoopConfig,
+                        new ConfigUtils.ConfigContext() {
+                            @Override
+                            public Optional<String> getenv(String name) {
+                                if ("GOOGLE_APPLICATION_CREDENTIALS".equals(name)) {
+                                    return Optional.ofNullable(envGoogleApplicationCredentials);
+                                }
+                                return Optional.empty();
+                            }
+
+                            @Override
+                            public void addHadoopResourcesFromDir(
+                                    Configuration config, String configDir) {
+                                throw new UnsupportedOperationException();
+                            }
+
+                            @Override
+                            public void setStorageCredentialsFromFile(
+                                    StorageOptions.Builder storageOptionsBuilder,
+                                    String credentialsPath) {
+                                actualCredentialsPath[0] = credentialsPath;
+                            }
+                        });
+
+        assertNotNull(storageOptions);
+        assertEquals(expectedCredentialsFile, actualCredentialsPath[0]);
+    }
+}

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/utils/TestingConfigContext.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/utils/TestingConfigContext.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.gs.utils;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import org.apache.hadoop.conf.Configuration;
+
+import java.util.Map;
+import java.util.Optional;
+
+/** Implementation of ConfigUtils.ConfigContext for testing. */
+public class TestingConfigContext implements ConfigUtils.ConfigContext {
+
+    private final Map<String, String> envs;
+    private final Map<String, org.apache.hadoop.conf.Configuration> hadoopConfigs;
+    private final Map<String, GoogleCredentials> credentials;
+
+    public TestingConfigContext(
+            Map<String, String> envs,
+            Map<String, org.apache.hadoop.conf.Configuration> hadoopConfigs,
+            Map<String, GoogleCredentials> credentials) {
+        this.envs = envs;
+        this.hadoopConfigs = hadoopConfigs;
+        this.credentials = credentials;
+    }
+
+    @Override
+    public Optional<String> getenv(String name) {
+        return Optional.ofNullable(envs.get(name));
+    }
+
+    @Override
+    public Configuration loadHadoopConfigFromDir(String configDir) {
+        return Optional.ofNullable(hadoopConfigs.get(configDir))
+                .orElseThrow(IllegalArgumentException::new);
+    }
+
+    @Override
+    public GoogleCredentials loadStorageCredentialsFromFile(String credentialsPath) {
+        return Optional.ofNullable(credentials.get(credentialsPath))
+                .orElseThrow(IllegalArgumentException::new);
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

For the GCS FileSystem plugin, use the same authentication options for the RecoverableWriter portion as is done for the normal FileSystem portion. This means that it will use GOOGLE_APPLICATION_CREDENTIALS, if it exists, but will also use the `google.cloud.auth.service.account.json.keyfile` property from Hadoop config.

To have both portions of the plugin use the same rules, each of them will only consider using service credentials if the Hadoop property `google.cloud.auth.service.account.enable` is `true` or unspecified (i.e. the default value is `true`).

## Brief change log

- Update `GSFileSystemFactory` to read Hadoop config from the location specified in `CoreOptions.FLINK_HADOOP_CONF_DIR` or in the `HADOOP_CONF_DIR` environment variable and to combine it with Hadoop config values from the Flink config
-  Update `GSFileSystem` to look for credentials in either `GOOGLE_APPLICATION_CREDENTIALS` or `google.cloud.auth.service.account.json.keyfile`, if `google.cloud.auth.service.account.enable` is not false, when constructing the `Storage` instance for the `RecoverableWriter`
- 
## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) No
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) No
  - The serializers: (yes / no / don't know) No
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) No
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know) No
  - The S3 file system connector: (yes / no / don't know) No

## Documentation

  - Does this pull request introduce a new feature? (yes / no) Yes
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) Will be documented via https://github.com/apache/flink/pull/18430
