### PR TITLE
[FLINK-25794][sql-runtime] Clean cache after memory segments in it after they are released to MemoryManager

### DIFF
--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/hashtable/BinaryHashTableTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/hashtable/BinaryHashTableTest.java
@@ -1074,6 +1074,7 @@ public class BinaryHashTableTest {
         area.freeMemory();
         table.close();
         Assert.assertEquals(35, table.getInternalPool().freePages());
+        table.free();
     }
 
     // ============================================================================================


### PR DESCRIPTION
## What is the purpose of the change

This pr aims to clean cache in `LazyMemorySegmentPool` after memory segments in it are released to `MemoryManager`

## Verifying this change
This change added tests and can be verified as follows:
  - *Added test `ResettableExternalBufferTest.testSegmentPoolCleanCache` that validates the cache is cleared in  `LazyMemorySegmentPool.cleanCache`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
