### PR TITLE
[FLINK-25290][tests] add table tests for connector testframe

### DIFF
--- a/flink-connectors/flink-connector-kafka/pom.xml
+++ b/flink-connectors/flink-connector-kafka/pom.xml
@@ -248,6 +248,7 @@ under the License.
 							<includes>
 								<include>**/KafkaTestEnvironment*</include>
 								<include>**/testutils/*</include>
+								<include>**/testutils/table/*</include>
 								<include>META-INF/LICENSE</include>
 								<include>META-INF/NOTICE</include>
 							</includes>
@@ -272,6 +273,7 @@ under the License.
 							<includes>
 								<include>**/KafkaTestEnvironment*</include>
 								<include>**/testutils/*</include>
+								<include>**/testutils/table/*</include>
 								<include>META-INF/LICENSE</include>
 								<include>META-INF/NOTICE</include>
 							</includes>

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/testutils/KafkaSinkExternalContext.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/testutils/KafkaSinkExternalContext.java
@@ -92,7 +92,7 @@ public class KafkaSinkExternalContext implements DataStreamSinkV2ExternalContext
         kafkaAdminClient = createAdminClient();
     }
 
-    private void createTopic(String topicName, int numPartitions, short replicationFactor) {
+    protected void createTopic(String topicName, int numPartitions, short replicationFactor) {
         LOG.debug(
                 "Creating new Kafka topic {} with {} partitions and {} replicas",
                 topicName,

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/testutils/table/KafkaTableDataReader.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/testutils/table/KafkaTableDataReader.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.sink.testutils.table;
+
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.connector.testframe.external.ExternalSystemDataReader;
+import org.apache.flink.formats.csv.CsvRowDataDeserializationSchema;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.RowType;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.WakeupException;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+
+/** Kafka table data reader. */
+public class KafkaTableDataReader implements ExternalSystemDataReader<RowData> {
+    private final KafkaConsumer<String, byte[]> consumer;
+    private final DataType physicalDataType;
+    private final DeserializationSchema<RowData> deserializer;
+
+    public KafkaTableDataReader(
+            Properties properties,
+            Set<TopicPartition> partitions,
+            DataType physicalDataType,
+            TypeInformation<RowData> typeInformation) {
+        this.consumer = new KafkaConsumer<>(properties);
+        consumer.assign(partitions);
+        consumer.seekToBeginning(partitions);
+        this.physicalDataType = physicalDataType;
+
+        final RowType rowType = (RowType) physicalDataType.getLogicalType();
+        final CsvRowDataDeserializationSchema.Builder schemaBuilder =
+                new CsvRowDataDeserializationSchema.Builder(rowType, typeInformation);
+        this.deserializer = schemaBuilder.build();
+    }
+
+    @Override
+    public List<RowData> poll(Duration timeout) {
+        List<RowData> result = new LinkedList<>();
+        ConsumerRecords<String, byte[]> consumerRecords;
+        try {
+            consumerRecords = consumer.poll(timeout);
+        } catch (WakeupException we) {
+            return Collections.emptyList();
+        }
+        Iterator<ConsumerRecord<String, byte[]>> iterator = consumerRecords.iterator();
+        while (iterator.hasNext()) {
+            try {
+                result.add(deserializer.deserialize(iterator.next().value()));
+            } catch (IOException e) {
+                throw new IllegalArgumentException("Error when deserializing from kafka.", e);
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public void close() throws Exception {
+        consumer.close();
+    }
+}

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/testutils/table/KafkaTableSinkExternalContext.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/testutils/table/KafkaTableSinkExternalContext.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.sink.testutils.table;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.typeutils.GenericTypeInfo;
+import org.apache.flink.connector.kafka.sink.testutils.KafkaSinkExternalContext;
+import org.apache.flink.connector.testframe.external.ExternalSystemDataReader;
+import org.apache.flink.connector.testframe.external.sink.TableSinkExternalContext;
+import org.apache.flink.connector.testframe.external.sink.TestingSinkSettings;
+import org.apache.flink.formats.csv.CsvFormatFactory;
+import org.apache.flink.streaming.api.CheckpointingMode;
+import org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.flink.table.types.DataType;
+
+import org.apache.kafka.clients.admin.NewPartitions;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.TopicPartitionInfo;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URL;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+import static org.apache.flink.streaming.connectors.kafka.table.KafkaDynamicTableFactory.IDENTIFIER;
+import static org.apache.flink.table.factories.FactoryUtil.CONNECTOR;
+
+/** Kafka table sink external context. */
+public class KafkaTableSinkExternalContext extends KafkaSinkExternalContext
+        implements TableSinkExternalContext {
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaTableSinkExternalContext.class);
+
+    public KafkaTableSinkExternalContext(String bootstrapServers, List<URL> connectorJarPaths) {
+        super(bootstrapServers, connectorJarPaths);
+    }
+
+    @Override
+    public Map<String, String> getSinkTableOptions(TestingSinkSettings sinkSettings) {
+        if (numSplits == 0) {
+            createTopic(topicName, 1, (short) 1);
+            numSplits++;
+        } else {
+            LOG.debug("Creating new partition for topic {}", topicName);
+            kafkaAdminClient.createPartitions(
+                    Collections.singletonMap(topicName, NewPartitions.increaseTo(++numSplits)));
+        }
+
+        Map<String, String> tableOptions = new HashMap<>();
+        tableOptions.put(CONNECTOR.key(), IDENTIFIER);
+        tableOptions.put(KafkaConnectorOptions.TOPIC.key(), topicName);
+        tableOptions.put(KafkaConnectorOptions.PROPS_BOOTSTRAP_SERVERS.key(), bootstrapServers);
+        tableOptions.put(KafkaConnectorOptions.SCAN_STARTUP_MODE.key(), "earliest-offset");
+        tableOptions.put(KafkaConnectorOptions.PROPS_GROUP_ID.key(), "flink-kafka-test");
+        tableOptions.put(FactoryUtil.FORMAT.key(), new CsvFormatFactory().factoryIdentifier());
+        return tableOptions;
+    }
+
+    @Override
+    public ExternalSystemDataReader<RowData> createSinkRowDataReader(
+            TestingSinkSettings sinkSettings, DataType physicalDataType) {
+        LOG.info("Fetching descriptions for topic: {}", topicName);
+        final Map<String, TopicDescription> topicMetadata =
+                getTopicMetadata(Arrays.asList(topicName));
+
+        Set<TopicPartition> subscribedPartitions = new HashSet<>();
+        for (TopicDescription topic : topicMetadata.values()) {
+            for (TopicPartitionInfo partition : topic.partitions()) {
+                subscribedPartitions.add(new TopicPartition(topic.name(), partition.partition()));
+            }
+        }
+
+        Properties properties = new Properties();
+        properties.setProperty(
+                ConsumerConfig.GROUP_ID_CONFIG,
+                "flink-kafka-test" + subscribedPartitions.hashCode());
+        properties.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        properties.setProperty(
+                ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
+                StringDeserializer.class.getCanonicalName());
+        properties.setProperty(
+                ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
+                ByteArrayDeserializer.class.getCanonicalName());
+        if (CheckpointingMode.EXACTLY_ONCE.equals(sinkSettings.getCheckpointingMode())) {
+            // default is read_uncommitted
+            properties.setProperty(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed");
+        }
+        properties.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        return new KafkaTableDataReader(
+                properties,
+                subscribedPartitions,
+                physicalDataType,
+                getTableDataTypeInformation(physicalDataType));
+    }
+
+    private TypeInformation<RowData> getTableDataTypeInformation(DataType physicalDataType) {
+        return new GenericTypeInfo<>(RowData.class);
+    }
+}

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/testutils/table/KafkaTableSinkExternalContextFactory.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/testutils/table/KafkaTableSinkExternalContextFactory.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.sink.testutils.table;
+
+import org.apache.flink.connector.testframe.external.ExternalContextFactory;
+
+import org.testcontainers.containers.KafkaContainer;
+
+import java.net.URL;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/** Kafka table sink external context factory. */
+public class KafkaTableSinkExternalContextFactory
+        implements ExternalContextFactory<KafkaTableSinkExternalContext> {
+
+    private final KafkaContainer kafkaContainer;
+    private final List<URL> connectorJars;
+
+    public KafkaTableSinkExternalContextFactory(
+            KafkaContainer kafkaContainer, List<URL> connectorJars) {
+        this.kafkaContainer = kafkaContainer;
+        this.connectorJars = connectorJars;
+    }
+
+    protected String getBootstrapServer() {
+        final String internalEndpoints =
+                kafkaContainer.getNetworkAliases().stream()
+                        .map(host -> String.join(":", host, Integer.toString(9092)))
+                        .collect(Collectors.joining(","));
+        return String.join(",", kafkaContainer.getBootstrapServers(), internalEndpoints);
+    }
+
+    @Override
+    public KafkaTableSinkExternalContext createExternalContext(String testName) {
+        return new KafkaTableSinkExternalContext(getBootstrapServer(), connectorJars);
+    }
+}

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/KafkaSourceITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/KafkaSourceITCase.java
@@ -26,6 +26,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.kafka.source.enumerator.initializer.OffsetsInitializer;
 import org.apache.flink.connector.kafka.source.reader.deserializer.KafkaRecordDeserializationSchema;
+import org.apache.flink.connector.kafka.source.testutils.table.KafkaTableSourceExternalContextFactory;
 import org.apache.flink.connector.kafka.testutils.KafkaSourceExternalContextFactory;
 import org.apache.flink.connector.kafka.testutils.KafkaSourceTestEnv;
 import org.apache.flink.connector.testframe.environment.MiniClusterTestEnvironment;
@@ -35,6 +36,7 @@ import org.apache.flink.connector.testframe.junit.annotations.TestEnv;
 import org.apache.flink.connector.testframe.junit.annotations.TestExternalSystem;
 import org.apache.flink.connector.testframe.junit.annotations.TestSemantics;
 import org.apache.flink.connector.testframe.testsuites.SourceTestSuiteBase;
+import org.apache.flink.connector.testframe.testsuites.TableSourceTestSuiteBase;
 import org.apache.flink.streaming.api.CheckpointingMode;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -42,6 +44,8 @@ import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
 import org.apache.flink.streaming.api.operators.StreamMap;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.types.DataType;
 import org.apache.flink.util.CloseableIterator;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.DockerImageVersions;
@@ -291,6 +295,60 @@ public class KafkaSourceITCase {
         KafkaSourceExternalContextFactory multipleTopic =
                 new KafkaSourceExternalContextFactory(
                         kafka.getContainer(), Collections.emptyList(), TOPIC);
+    }
+
+    @Nested
+    class IntegrationTableTests extends TableSourceTestSuiteBase {
+        @SuppressWarnings("unused")
+        @TestSemantics
+        CheckpointingMode[] semantics = new CheckpointingMode[] {CheckpointingMode.EXACTLY_ONCE};
+
+        // Defines test environment on Flink MiniCluster
+        @SuppressWarnings("unused")
+        @TestEnv
+        MiniClusterTestEnvironment flink = new MiniClusterTestEnvironment();
+
+        // Defines external system
+        @TestExternalSystem
+        DefaultContainerizedExternalSystem<KafkaContainer> kafka =
+                DefaultContainerizedExternalSystem.builder()
+                        .fromContainer(
+                                new KafkaContainer(
+                                        DockerImageName.parse(DockerImageVersions.KAFKA)))
+                        .build();
+
+        // Defines 2 External context Factories, so test cases will be invoked twice using these two
+        // kinds of external contexts.
+        @SuppressWarnings("unused")
+        @TestContext
+        KafkaTableSourceExternalContextFactory singleTopic =
+                new KafkaTableSourceExternalContextFactory(
+                        kafka.getContainer(), Collections.emptyList(), PARTITION);
+
+        @SuppressWarnings("unused")
+        @TestContext
+        KafkaTableSourceExternalContextFactory multipleTopic =
+                new KafkaTableSourceExternalContextFactory(
+                        kafka.getContainer(), Collections.emptyList(), TOPIC);
+
+        @Override
+        public List<DataType> supportTypes() {
+            return Arrays.asList(
+                    DataTypes.CHAR(2),
+                    DataTypes.STRING(),
+                    DataTypes.VARCHAR(3),
+                    DataTypes.INT(),
+                    DataTypes.BIGINT(),
+                    DataTypes.SMALLINT(),
+                    DataTypes.TINYINT(),
+                    DataTypes.DOUBLE(),
+                    DataTypes.FLOAT(),
+                    DataTypes.BOOLEAN(),
+                    DataTypes.DATE(),
+                    DataTypes.TIME(),
+                    DataTypes.TIMESTAMP(),
+                    DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE());
+        }
     }
 
     // -----------------

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/testutils/table/KafkaTableDataWriter.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/testutils/table/KafkaTableDataWriter.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.source.testutils.table;
+
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.testframe.external.ExternalSystemSplitDataWriter;
+import org.apache.flink.formats.csv.CsvFormatFactory;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.DataType;
+
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.List;
+import java.util.Properties;
+
+/** Kafka table data writer. */
+public class KafkaTableDataWriter implements ExternalSystemSplitDataWriter<RowData> {
+
+    private final KafkaProducer<byte[], byte[]> kafkaProducer;
+    private final TopicPartition topicPartition;
+    private final DataType physicalDataType;
+    private final SerializationSchema<RowData> serializer;
+
+    public KafkaTableDataWriter(
+            Properties producerProperties,
+            TopicPartition topicPartition,
+            DataType physicalDataType) {
+        this.kafkaProducer = new KafkaProducer<>(producerProperties);
+        this.topicPartition = topicPartition;
+        this.physicalDataType = physicalDataType;
+        this.serializer =
+                new CsvFormatFactory()
+                        .createEncodingFormat(null, new Configuration())
+                        .createRuntimeEncoder(null, physicalDataType);
+    }
+
+    @Override
+    public void writeRecords(List<RowData> records) {
+        for (RowData record : records) {
+            ProducerRecord<byte[], byte[]> producerRecord =
+                    new ProducerRecord<>(
+                            topicPartition.topic(),
+                            topicPartition.partition(),
+                            null,
+                            serializer.serialize(record));
+            kafkaProducer.send(producerRecord);
+        }
+        kafkaProducer.flush();
+    }
+
+    @Override
+    public void close() {
+        kafkaProducer.close();
+    }
+
+    public TopicPartition getTopicPartition() {
+        return topicPartition;
+    }
+}

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/testutils/table/KafkaTableSourceExternalContext.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/testutils/table/KafkaTableSourceExternalContext.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.source.testutils.table;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.kafka.testutils.KafkaSourceExternalContext;
+import org.apache.flink.connector.testframe.external.ExternalSystemSplitDataWriter;
+import org.apache.flink.connector.testframe.external.source.TableSourceExternalContext;
+import org.apache.flink.connector.testframe.external.source.TestingSourceSettings;
+import org.apache.flink.formats.csv.CsvFormatFactory;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.flink.table.types.DataType;
+
+import org.apache.kafka.clients.admin.NewPartitions;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.common.TopicPartition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.PROPS_BOOTSTRAP_SERVERS;
+import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.PROPS_GROUP_ID;
+import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.SCAN_STARTUP_MODE;
+import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.ScanStartupMode.EARLIEST_OFFSET;
+import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.TOPIC_PATTERN;
+import static org.apache.flink.streaming.connectors.kafka.table.KafkaDynamicTableFactory.IDENTIFIER;
+
+/** Kafka table source external context. */
+public class KafkaTableSourceExternalContext extends KafkaSourceExternalContext
+        implements TableSourceExternalContext {
+    private static final Logger LOG =
+            LoggerFactory.getLogger(KafkaTableSourceExternalContext.class);
+    private final List<KafkaTableDataWriter> writers = new ArrayList<>();
+
+    public KafkaTableSourceExternalContext(
+            String bootstrapServers,
+            SplitMappingMode splitMappingMode,
+            List<URL> connectorJarPaths) {
+        super(bootstrapServers, splitMappingMode, connectorJarPaths);
+    }
+
+    @Override
+    public Map<String, String> getSourceTableOptions(TestingSourceSettings sourceSettings) {
+        Configuration conf = new Configuration();
+        conf.set(FactoryUtil.CONNECTOR, IDENTIFIER);
+        conf.set(PROPS_GROUP_ID, randomize(GROUP_ID_PREFIX));
+        conf.set(PROPS_BOOTSTRAP_SERVERS, bootstrapServers);
+        conf.set(FactoryUtil.FORMAT, new CsvFormatFactory().factoryIdentifier());
+        conf.set(TOPIC_PATTERN, TOPIC_NAME_PREFIX + ".*");
+        conf.set(SCAN_STARTUP_MODE, EARLIEST_OFFSET);
+        return conf.toMap();
+    }
+
+    @Override
+    public ExternalSystemSplitDataWriter<RowData> createSplitRowDataWriter(
+            TestingSourceSettings sourceOptions, DataType physicalDataType) {
+        KafkaTableDataWriter writer;
+        try {
+            switch (splitMappingMode) {
+                case TOPIC:
+                    writer = createSinglePartitionTopic(writers.size(), physicalDataType);
+                    break;
+                case PARTITION:
+                    writer = scaleOutTopic(this.topicName, physicalDataType);
+                    break;
+                default:
+                    throw new IllegalArgumentException(
+                            "Split mode should be either TOPIC or PARTITION");
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to create new splits", e);
+        }
+        writers.add(writer);
+        return writer;
+    }
+
+    @Override
+    public void close() throws Exception {
+        final List<String> topics = new ArrayList<>();
+        writers.forEach(
+                writer -> {
+                    topics.add(writer.getTopicPartition().topic());
+                    writer.close();
+                });
+        adminClient.deleteTopics(topics).all().get();
+    }
+
+    private KafkaTableDataWriter createSinglePartitionTopic(
+            int topicIndex, DataType physicalDataType) throws Exception {
+        String newTopicName = topicName + "-" + topicIndex;
+        LOG.info("Creating topic '{}'", newTopicName);
+        adminClient
+                .createTopics(Collections.singletonList(new NewTopic(newTopicName, 1, (short) 1)))
+                .all()
+                .get();
+        return new KafkaTableDataWriter(
+                getKafkaProducerProperties(topicIndex),
+                new TopicPartition(newTopicName, 0),
+                physicalDataType);
+    }
+
+    private KafkaTableDataWriter scaleOutTopic(String topicName, DataType physicalDataType)
+            throws Exception {
+        final Set<String> topics = adminClient.listTopics().names().get();
+        if (topics.contains(topicName)) {
+            final Map<String, TopicDescription> topicDescriptions =
+                    adminClient.describeTopics(Collections.singletonList(topicName)).all().get();
+            final int numPartitions = topicDescriptions.get(topicName).partitions().size();
+            LOG.info("Creating partition {} for topic '{}'", numPartitions + 1, topicName);
+            adminClient
+                    .createPartitions(
+                            Collections.singletonMap(
+                                    topicName, NewPartitions.increaseTo(numPartitions + 1)))
+                    .all()
+                    .get();
+            return new KafkaTableDataWriter(
+                    getKafkaProducerProperties(numPartitions),
+                    new TopicPartition(topicName, numPartitions),
+                    physicalDataType);
+        } else {
+            LOG.info("Creating topic '{}'", topicName);
+            adminClient.createTopics(
+                    Collections.singletonList(new NewTopic(topicName, 1, (short) 1)));
+            return new KafkaTableDataWriter(
+                    getKafkaProducerProperties(0),
+                    new TopicPartition(topicName, 0),
+                    physicalDataType);
+        }
+    }
+}

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/testutils/table/KafkaTableSourceExternalContextFactory.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/testutils/table/KafkaTableSourceExternalContextFactory.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.source.testutils.table;
+
+import org.apache.flink.connector.kafka.testutils.KafkaSourceExternalContext;
+import org.apache.flink.connector.testframe.external.ExternalContextFactory;
+
+import org.testcontainers.containers.KafkaContainer;
+
+import java.net.URL;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/** Kafka table source external context factory. */
+public class KafkaTableSourceExternalContextFactory
+        implements ExternalContextFactory<KafkaTableSourceExternalContext> {
+
+    private final KafkaContainer kafkaContainer;
+    private final List<URL> connectorJars;
+    private final KafkaSourceExternalContext.SplitMappingMode splitMappingMode;
+
+    public KafkaTableSourceExternalContextFactory(
+            KafkaContainer kafkaContainer,
+            List<URL> connectorJars,
+            KafkaSourceExternalContext.SplitMappingMode splitMappingMode) {
+        this.kafkaContainer = kafkaContainer;
+        this.connectorJars = connectorJars;
+        this.splitMappingMode = splitMappingMode;
+    }
+
+    protected String getBootstrapServer() {
+        final String internalEndpoints =
+                kafkaContainer.getNetworkAliases().stream()
+                        .map(host -> String.join(":", host, Integer.toString(9092)))
+                        .collect(Collectors.joining(","));
+        return String.join(",", kafkaContainer.getBootstrapServers(), internalEndpoints);
+    }
+
+    @Override
+    public KafkaTableSourceExternalContext createExternalContext(String testName) {
+        return new KafkaTableSourceExternalContext(
+                getBootstrapServer(), this.splitMappingMode, this.connectorJars);
+    }
+}

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/testutils/KafkaSourceExternalContext.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/testutils/KafkaSourceExternalContext.java
@@ -58,17 +58,17 @@ import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 public class KafkaSourceExternalContext implements DataStreamSourceExternalContext<String> {
 
     private static final Logger LOG = LoggerFactory.getLogger(KafkaSourceExternalContext.class);
-    private static final String TOPIC_NAME_PREFIX = "kafka-test-topic-";
-    private static final Pattern TOPIC_NAME_PATTERN = Pattern.compile(TOPIC_NAME_PREFIX + ".*");
-    private static final String GROUP_ID_PREFIX = "kafka-source-external-context-";
+    protected static final String TOPIC_NAME_PREFIX = "kafka-test-topic-";
+    protected static final Pattern TOPIC_NAME_PATTERN = Pattern.compile(TOPIC_NAME_PREFIX + ".*");
+    protected static final String GROUP_ID_PREFIX = "kafka-source-external-context-";
     private static final int NUM_RECORDS_UPPER_BOUND = 500;
     private static final int NUM_RECORDS_LOWER_BOUND = 100;
 
     private final List<URL> connectorJarPaths;
-    private final String bootstrapServers;
-    private final String topicName;
-    private final SplitMappingMode splitMappingMode;
-    private final AdminClient adminClient;
+    protected final String bootstrapServers;
+    protected final String topicName;
+    protected final SplitMappingMode splitMappingMode;
+    protected final AdminClient adminClient;
     private final List<KafkaPartitionDataWriter> writers = new ArrayList<>();
 
     protected KafkaSourceExternalContext(
@@ -165,7 +165,7 @@ public class KafkaSourceExternalContext implements DataStreamSourceExternalConte
         return "KafkaSource-" + splitMappingMode.toString();
     }
 
-    private String randomize(String prefix) {
+    protected String randomize(String prefix) {
         return prefix + ThreadLocalRandom.current().nextLong(0, Long.MAX_VALUE);
     }
 
@@ -211,7 +211,7 @@ public class KafkaSourceExternalContext implements DataStreamSourceExternalConte
         }
     }
 
-    private Properties getKafkaProducerProperties(int producerId) {
+    protected Properties getKafkaProducerProperties(int producerId) {
         Properties kafkaProducerProperties = new Properties();
         kafkaProducerProperties.setProperty(
                 ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/pom.xml
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/pom.xml
@@ -99,9 +99,21 @@ under the License.
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-csv</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<!-- Used by maven-dependency-plugin -->
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-sql-avro-confluent-registry</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-planner_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
@@ -237,6 +249,14 @@ under the License.
 							<artifactId>kafka-clients</artifactId>
 							<version>2.8.1</version>
 							<destFileName>kafka-clients.jar</destFileName>
+							<type>jar</type>
+							<outputDirectory>${project.build.directory}/dependencies</outputDirectory>
+						</artifactItem>
+						<artifactItem>
+							<groupId>org.apache.flink</groupId>
+							<artifactId>flink-table-api-java-bridge</artifactId>
+							<version>${project.version}</version>
+							<destFileName>table-java-bridge.jar</destFileName>
 							<type>jar</type>
 							<outputDirectory>${project.build.directory}/dependencies</outputDirectory>
 						</artifactItem>

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/KafkaTableSinkE2ECase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/KafkaTableSinkE2ECase.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.tests.util.kafka;
+
+import org.apache.flink.connector.kafka.sink.testutils.table.KafkaTableSinkExternalContextFactory;
+import org.apache.flink.connector.testframe.external.DefaultContainerizedExternalSystem;
+import org.apache.flink.connector.testframe.junit.annotations.TestContext;
+import org.apache.flink.connector.testframe.junit.annotations.TestEnv;
+import org.apache.flink.connector.testframe.junit.annotations.TestExternalSystem;
+import org.apache.flink.connector.testframe.junit.annotations.TestSemantics;
+import org.apache.flink.connector.testframe.testsuites.TableSinkTestSuiteBase;
+import org.apache.flink.streaming.api.CheckpointingMode;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.tests.util.TestUtils;
+import org.apache.flink.tests.util.flink.FlinkContainerTestEnvironment;
+import org.apache.flink.util.DockerImageVersions;
+
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.Arrays;
+import java.util.List;
+
+/** Kafka table sink E2E test based on connector testing framework. */
+@SuppressWarnings("unused")
+public class KafkaTableSinkE2ECase extends TableSinkTestSuiteBase {
+    private static final String KAFKA_HOSTNAME = "kafka";
+
+    // Defines TestEnvironment
+    @TestEnv FlinkContainerTestEnvironment flink = new FlinkContainerTestEnvironment(1, 6);
+
+    @TestExternalSystem
+    DefaultContainerizedExternalSystem<KafkaContainer> kafka =
+            DefaultContainerizedExternalSystem.builder()
+                    .fromContainer(
+                            new KafkaContainer(DockerImageName.parse(DockerImageVersions.KAFKA))
+                                    .withNetworkAliases(KAFKA_HOSTNAME))
+                    .bindWithFlinkContainer(flink.getFlinkContainers().getJobManager())
+                    .build();
+
+    @TestSemantics
+    CheckpointingMode[] semantics =
+            new CheckpointingMode[] {
+                CheckpointingMode.EXACTLY_ONCE, CheckpointingMode.AT_LEAST_ONCE
+            };
+
+    @TestContext
+    KafkaTableSinkExternalContextFactory contextFactory =
+            new KafkaTableSinkExternalContextFactory(
+                    kafka.getContainer(),
+                    Arrays.asList(
+                            TestUtils.getResource("kafka-connector.jar")
+                                    .toAbsolutePath()
+                                    .toUri()
+                                    .toURL(),
+                            TestUtils.getResource("kafka-clients.jar")
+                                    .toAbsolutePath()
+                                    .toUri()
+                                    .toURL(),
+                            TestUtils.getResource("table-java-bridge.jar")
+                                    .toAbsolutePath()
+                                    .toUri()
+                                    .toURL()));
+
+    public KafkaTableSinkE2ECase() throws Exception {}
+
+    @Override
+    public List<DataType> supportTypes() {
+        return Arrays.asList(
+                DataTypes.CHAR(2),
+                DataTypes.STRING(),
+                DataTypes.VARCHAR(3),
+                DataTypes.INT(),
+                DataTypes.BIGINT(),
+                DataTypes.SMALLINT(),
+                DataTypes.TINYINT(),
+                DataTypes.DOUBLE(),
+                DataTypes.FLOAT(),
+                DataTypes.BOOLEAN(),
+                DataTypes.DATE(),
+                DataTypes.TIME(),
+                DataTypes.TIMESTAMP(),
+                DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE());
+    }
+}

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/KafkaTableSourceE2ECase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/KafkaTableSourceE2ECase.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.tests.util.kafka;
+
+import org.apache.flink.connector.kafka.source.testutils.table.KafkaTableSourceExternalContextFactory;
+import org.apache.flink.connector.kafka.testutils.KafkaSourceExternalContext;
+import org.apache.flink.connector.testframe.external.DefaultContainerizedExternalSystem;
+import org.apache.flink.connector.testframe.junit.annotations.TestContext;
+import org.apache.flink.connector.testframe.junit.annotations.TestEnv;
+import org.apache.flink.connector.testframe.junit.annotations.TestExternalSystem;
+import org.apache.flink.connector.testframe.junit.annotations.TestSemantics;
+import org.apache.flink.connector.testframe.testsuites.TableSourceTestSuiteBase;
+import org.apache.flink.streaming.api.CheckpointingMode;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.tests.util.TestUtils;
+import org.apache.flink.tests.util.flink.FlinkContainerTestEnvironment;
+import org.apache.flink.util.DockerImageVersions;
+
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.Arrays;
+import java.util.List;
+
+/** Kafka table source E2E test based on connector testing framework. */
+@SuppressWarnings("unused")
+public class KafkaTableSourceE2ECase extends TableSourceTestSuiteBase {
+    private static final String KAFKA_HOSTNAME = "kafka";
+
+    @TestSemantics
+    CheckpointingMode[] semantics = new CheckpointingMode[] {CheckpointingMode.EXACTLY_ONCE};
+
+    // Defines TestEnvironment
+    @TestEnv FlinkContainerTestEnvironment flink = new FlinkContainerTestEnvironment(1, 6);
+
+    // Defines ConnectorExternalSystem
+    @TestExternalSystem
+    DefaultContainerizedExternalSystem<KafkaContainer> kafka =
+            DefaultContainerizedExternalSystem.builder()
+                    .fromContainer(
+                            new KafkaContainer(DockerImageName.parse(DockerImageVersions.KAFKA))
+                                    .withNetworkAliases(KAFKA_HOSTNAME))
+                    .bindWithFlinkContainer(flink.getFlinkContainers().getJobManager())
+                    .build();
+
+    // Defines 2 External context Factories, so test cases will be invoked twice using these two
+    // kinds of external contexts.
+    @TestContext
+    KafkaTableSourceExternalContextFactory topicSplitContext =
+            new KafkaTableSourceExternalContextFactory(
+                    kafka.getContainer(),
+                    Arrays.asList(
+                            TestUtils.getResource("kafka-connector.jar")
+                                    .toAbsolutePath()
+                                    .toUri()
+                                    .toURL(),
+                            TestUtils.getResource("kafka-clients.jar")
+                                    .toAbsolutePath()
+                                    .toUri()
+                                    .toURL(),
+                            TestUtils.getResource("table-java-bridge.jar")
+                                    .toAbsolutePath()
+                                    .toUri()
+                                    .toURL()),
+                    KafkaSourceExternalContext.SplitMappingMode.TOPIC);
+
+    @TestContext
+    KafkaTableSourceExternalContextFactory partitionSplitContext =
+            new KafkaTableSourceExternalContextFactory(
+                    kafka.getContainer(),
+                    Arrays.asList(
+                            TestUtils.getResource("kafka-connector.jar")
+                                    .toAbsolutePath()
+                                    .toUri()
+                                    .toURL(),
+                            TestUtils.getResource("kafka-clients.jar")
+                                    .toAbsolutePath()
+                                    .toUri()
+                                    .toURL(),
+                            TestUtils.getResource("table-java-bridge.jar")
+                                    .toAbsolutePath()
+                                    .toUri()
+                                    .toURL()),
+                    KafkaSourceExternalContext.SplitMappingMode.PARTITION);
+
+    public KafkaTableSourceE2ECase() throws Exception {}
+
+    @Override
+    public List<DataType> supportTypes() {
+        return Arrays.asList(
+                DataTypes.CHAR(2),
+                DataTypes.STRING(),
+                DataTypes.VARCHAR(3),
+                DataTypes.INT(),
+                DataTypes.BIGINT(),
+                DataTypes.SMALLINT(),
+                DataTypes.TINYINT(),
+                DataTypes.DOUBLE(),
+                DataTypes.FLOAT(),
+                DataTypes.BOOLEAN(),
+                DataTypes.DATE(),
+                DataTypes.TIME(),
+                DataTypes.TIMESTAMP(),
+                DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE());
+    }
+}

--- a/flink-test-utils-parent/flink-connector-test-utils/pom.xml
+++ b/flink-test-utils-parent/flink-connector-test-utils/pom.xml
@@ -66,6 +66,12 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-api-java-bridge</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>testcontainers</artifactId>
 		</dependency>

--- a/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/testsuites/AbstractTableTestSuiteBase.java
+++ b/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/testsuites/AbstractTableTestSuiteBase.java
@@ -1,0 +1,491 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.testframe.testsuites;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.connector.testframe.junit.extensions.ConnectorTestingExtension;
+import org.apache.flink.connector.testframe.junit.extensions.TestCaseInvocationContextProvider;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.types.AtomicDataType;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.BinaryType;
+import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.CharType;
+import org.apache.flink.table.types.logical.DateType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.DoubleType;
+import org.apache.flink.table.types.logical.FloatType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.SmallIntType;
+import org.apache.flink.table.types.logical.TimeType;
+import org.apache.flink.table.types.logical.TimestampType;
+import org.apache.flink.table.types.logical.TinyIntType;
+import org.apache.flink.table.types.logical.VarBinaryType;
+import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.table.types.logical.ZonedTimestampType;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.TestLoggerExtension;
+
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static java.util.stream.Collectors.joining;
+import static org.apache.flink.types.RowKind.INSERT;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+/** Abstract class for table test suites. */
+@ExtendWith({
+    ConnectorTestingExtension.class,
+    TestLoggerExtension.class,
+    TestCaseInvocationContextProvider.class
+})
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Experimental
+public abstract class AbstractTableTestSuiteBase {
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractTableTestSuiteBase.class);
+
+    private DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+    private DateTimeFormatter timeFormat = DateTimeFormatter.ofPattern("HH:mm:ss");
+    private DateTimeFormatter timestampFormat =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS");
+    private DateTimeFormatter flinkTimestampFormat =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS");
+
+    public abstract List<DataType> supportTypes();
+
+    /** Generate the select sql. */
+    protected String getSelectSql(String tableName) {
+        String query = "SELECT * FROM " + tableName;
+        LOG.info("Query result: " + query);
+        return query;
+    }
+
+    /** Generate the create table sql. */
+    protected String getCreateTableSql(
+            String tableName, Map<String, String> tableOptions, List<DataType> dataTypes) {
+        String createTableSql =
+                String.format(
+                        "CREATE TABLE `%s` (\n" + " %s\n" + ") WITH (\n" + "%s\n" + ")",
+                        tableName, getSchemaInSql(dataTypes), getTableOptions(tableOptions));
+        LOG.info("Create table: " + createTableSql);
+        return createTableSql;
+    }
+
+    private String getTableOptions(Map<String, String> tableOptions) {
+        return tableOptions.entrySet().stream()
+                .map(e -> String.format("'%s'='%s'", e.getKey(), e.getValue()))
+                .collect(joining(",\n"));
+    }
+
+    /** Generate the schema part in the create table sql. */
+    private String getSchemaInSql(List<DataType> dataTypes) {
+        return IntStream.range(0, dataTypes.size())
+                .mapToObj(
+                        index -> {
+                            DataType dataType = dataTypes.get(index);
+                            return String.format(
+                                    "`%s` %s",
+                                    getFieldName(index, dataType), getTypeForSql(dataType));
+                        })
+                .collect(joining(",\n"));
+    }
+
+    /** Get the table schema . */
+    protected DataType getTableSchema(List<DataType> dataTypes) {
+        return ResolvedSchema.of(
+                        IntStream.range(0, dataTypes.size())
+                                .mapToObj(
+                                        index -> {
+                                            DataType dataType = dataTypes.get(index);
+                                            return Column.physical(
+                                                    getFieldName(index, dataType), dataType);
+                                        })
+                                .collect(Collectors.toList()))
+                .toPhysicalRowDataType();
+    }
+
+    public static RowData convertToRowData(Row row, DataType dataType) {
+        List<DataType> dataTypes = DataType.getFieldDataTypes(dataType);
+        assertThat(dataTypes.size()).isEqualTo(row.getArity());
+
+        Object[] fieldVals = new Object[row.getArity()];
+        for (int i = 0; i < fieldVals.length; i++) {
+            fieldVals[i] = convertToInternalType(row.getField(i), dataTypes.get(i));
+        }
+        return GenericRowData.ofKind(INSERT, fieldVals);
+    }
+
+    private String getTypeForSql(DataType type) {
+        return type.getLogicalType().toString();
+    }
+
+    private String getFieldName(int index, DataType type) {
+        return type.getLogicalType().getClass().getSimpleName().toLowerCase() + index;
+    }
+
+    protected Tuple2<String, List<RowData>> initialValues(
+            String tableName, long seed, int uppedBound, int lowerBound, List<DataType> dataTypes) {
+        Random random = new Random(seed);
+        int recordNum = random.nextInt(uppedBound - lowerBound) + lowerBound;
+        List<List<Tuple2<String, Object>>> testData = new LinkedList<>();
+        for (int i = 0; i < recordNum; i++) {
+            testData.add(generateSinkData(dataTypes));
+        }
+        String initialValueSql =
+                String.format(
+                        "INSERT INTO %s VALUES %s",
+                        tableName,
+                        testData.stream()
+                                .map(l -> l.stream().map(o -> o.f0).collect(joining(",")))
+                                .map(s -> "(" + s + ")")
+                                .collect(joining(",")));
+        LOG.info("Insert data: " + initialValueSql);
+        return Tuple2.of(initialValueSql, getExpectedResult(testData));
+    }
+
+    private List<RowData> getExpectedResult(List<List<Tuple2<String, Object>>> testData) {
+        List<RowData> expected = new LinkedList<>();
+        for (List<Tuple2<String, Object>> row : testData) {
+            Object[] fields = new Object[row.size()];
+            for (int i = 0; i < fields.length; i++) {
+                fields[i] = row.get(i).f1;
+            }
+            expected.add(GenericRowData.ofKind(INSERT, fields));
+        }
+        return expected;
+    }
+
+    protected RowData generateTestRowData(int spiltId, List<DataType> supportTypes) {
+        Object[] fieldVals = new Object[supportTypes.size()];
+        for (int i = 0; i < fieldVals.length; i++) {
+            fieldVals[i] = generateTestDataForField(spiltId, supportTypes.get(i));
+        }
+        return GenericRowData.ofKind(INSERT, fieldVals);
+    }
+
+    private List<Tuple2<String, Object>> generateSinkData(List<DataType> supportTypes) {
+        // f0 ---- sql value, f1 ---- expected value
+        List<Tuple2<String, Object>> oneRow = new LinkedList<>();
+        for (DataType dataType : supportTypes) {
+            oneRow.add(getOneFieldData(dataType));
+        }
+        return oneRow;
+    }
+
+    private String generateRandomString(int length) {
+        Random random = new Random();
+        String alphaNumericString =
+                "ABCDEFGHIJKLMNOPQRSTUVWXYZ" + "abcdefghijklmnopqrstuvwxyz" + "0123456789";
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < length + 1; ++i) {
+            sb.append(alphaNumericString.charAt(random.nextInt(alphaNumericString.length())));
+        }
+        return sb.toString();
+    }
+
+    /** Get the internal data structure for different {@link DataType}. */
+    public static Object convertToInternalType(Object val, DataType type) {
+        LogicalType logicalType = type.getLogicalType();
+        // String
+        if (logicalType instanceof CharType || logicalType instanceof VarCharType) {
+            return StringData.fromString((String) val);
+        }
+        // boolean
+        if (logicalType instanceof BooleanType) {
+            return val;
+        }
+        // byte[]
+        if (logicalType instanceof BinaryType || logicalType instanceof VarBinaryType) {
+            return val;
+        }
+        // BigDecimal
+        if (logicalType instanceof DecimalType) {
+            BigDecimal bd = new BigDecimal((double) val);
+            return DecimalData.fromBigDecimal(bd, bd.precision(), 9);
+        }
+        // byte
+        if (logicalType instanceof TinyIntType) {
+            return val;
+        }
+        // short
+        if (logicalType instanceof SmallIntType) {
+            return val;
+        }
+        // int
+        if (logicalType instanceof IntType) {
+            return val;
+        }
+        // long
+        if (logicalType instanceof BigIntType) {
+            return val;
+        }
+        // float
+        if (logicalType instanceof FloatType) {
+            return val;
+        }
+        // double
+        if (logicalType instanceof DoubleType) {
+            return val;
+        }
+        // LocalDate
+        if (logicalType instanceof DateType) {
+            return (int) ((LocalDate) val).toEpochDay();
+        }
+        // LocalTime
+        if (logicalType instanceof TimeType) {
+            return (int) (((LocalTime) val).toNanoOfDay() / 1000 / 1000) / 1000 * 1000;
+        }
+        // LocalDateTime | OffsetDateTime
+        if (logicalType instanceof TimestampType || logicalType instanceof ZonedTimestampType) {
+            return TimestampData.fromLocalDateTime((LocalDateTime) val);
+        }
+        // Instant
+        if (logicalType instanceof LocalZonedTimestampType) {
+            return TimestampData.fromLocalDateTime(
+                    ((Instant) val).atZone(ZoneOffset.UTC).toLocalDateTime());
+        }
+        throw new IllegalArgumentException("Cannot convert val[%s] for type[%s]");
+    }
+
+    /** Return flink internal data. */
+    private Object generateTestDataForField(int splitId, DataType type) {
+        if (type instanceof AtomicDataType) {
+            Random random = new Random();
+            LogicalType logicalType = type.getLogicalType();
+            // String
+            if (logicalType instanceof CharType) {
+                return StringData.fromString(
+                        String.format(
+                                "%d-%s",
+                                splitId,
+                                generateRandomString(((CharType) logicalType).getLength())));
+            }
+            if (logicalType instanceof VarCharType) {
+                int length = ((VarCharType) logicalType).getLength();
+                return StringData.fromString(
+                        generateRandomString(random.nextInt(length > 10 ? 10 : length)));
+            }
+            // boolean
+            if (logicalType instanceof BooleanType) {
+                return random.nextInt(10) % 2 == 0;
+            }
+            // byte[]
+            if (logicalType instanceof BinaryType || logicalType instanceof VarBinaryType) {
+                return generateRandomString(random.nextInt(3)).getBytes();
+            }
+            // BigDecimal
+            if (logicalType instanceof DecimalType) {
+                BigDecimal bd = new BigDecimal(random.nextDouble());
+                return DecimalData.fromBigDecimal(bd, bd.precision(), 9);
+            }
+            // byte
+            if (logicalType instanceof TinyIntType) {
+                return (byte) random.nextInt(100);
+            }
+            // short
+            if (logicalType instanceof SmallIntType) {
+                return (short) random.nextInt(20);
+            }
+            // int
+            if (logicalType instanceof IntType) {
+                return random.nextInt();
+            }
+            // long
+            if (logicalType instanceof BigIntType) {
+                return random.nextLong();
+            }
+            // float
+            if (logicalType instanceof FloatType) {
+                return (float) Math.round(random.nextFloat() * 10000) / 10000;
+            }
+            // double
+            if (logicalType instanceof DoubleType) {
+                return (double) Math.round(random.nextDouble() * 1000000) / 1000000;
+            }
+            // LocalDate
+            if (logicalType instanceof DateType) {
+                return (int) LocalDate.now().toEpochDay();
+            }
+            // LocalTime
+            if (logicalType instanceof TimeType) {
+                ((TimeType) logicalType).getPrecision();
+                return (int) (LocalTime.now().toNanoOfDay() / 1000 / 1000) / 1000 * 1000;
+            }
+            // LocalDateTime | OffsetDateTime | Instant
+            if (logicalType instanceof TimestampType
+                    || logicalType instanceof ZonedTimestampType
+                    || logicalType instanceof LocalZonedTimestampType) {
+                return TimestampData.fromLocalDateTime(
+                        getLocalDateTime(System.currentTimeMillis()));
+            }
+        }
+        throw new IllegalArgumentException("Not support non AtomicDataType.");
+    }
+
+    /** Return flink internal data and sql field. */
+    private Tuple2<String, Object> getOneFieldData(DataType type) {
+        if (type instanceof AtomicDataType) {
+            Random random = new Random();
+            LogicalType logicalType = type.getLogicalType();
+            // String
+            if (logicalType instanceof CharType) {
+                String randomString = generateRandomString(((CharType) logicalType).getLength());
+                return Tuple2.of(
+                        "'" + randomString + "'", convertToInternalType(randomString, type));
+            }
+            if (logicalType instanceof VarCharType) {
+                int length = ((VarCharType) logicalType).getLength();
+                String randomString =
+                        generateRandomString(random.nextInt(length > 10 ? 10 : length));
+                return Tuple2.of(
+                        "'" + randomString + "'", convertToInternalType(randomString, type));
+            }
+            // boolean
+            if (logicalType instanceof BooleanType) {
+                boolean booleanVal = random.nextInt(10) % 2 == 0;
+                return Tuple2.of(
+                        String.valueOf(booleanVal), convertToInternalType(booleanVal, type));
+            }
+            // byte[]
+            if (logicalType instanceof BinaryType || logicalType instanceof VarBinaryType) {
+                String randomString = generateRandomString(random.nextInt(3));
+                return Tuple2.of(
+                        "'" + randomString + "'",
+                        convertToInternalType(randomString.getBytes(), type));
+            }
+            // BigDecimal
+            if (logicalType instanceof DecimalType) {
+                double target = random.nextDouble();
+                BigDecimal decimal = new BigDecimal(target);
+                return Tuple2.of(decimal.toString(), convertToInternalType(target, type));
+            }
+            // byte
+            if (logicalType instanceof TinyIntType) {
+                byte byteVal = (byte) random.nextInt(100);
+                return Tuple2.of(
+                        String.format("CAST ('%d' AS TINYINT)", byteVal),
+                        convertToInternalType(byteVal, type));
+            }
+            // short
+            if (logicalType instanceof SmallIntType) {
+                short shortVal = (short) random.nextInt(20);
+                return Tuple2.of(
+                        String.format("CAST ('%d' AS SMALLINT)", shortVal),
+                        convertToInternalType(shortVal, type));
+            }
+            // int
+            if (logicalType instanceof IntType) {
+                int intVal = random.nextInt();
+                return Tuple2.of(String.valueOf(intVal), convertToInternalType(intVal, type));
+            }
+            // long
+            if (logicalType instanceof BigIntType) {
+                long longVal = random.nextLong();
+                return Tuple2.of(String.valueOf(longVal), convertToInternalType(longVal, type));
+            }
+            // float
+            if (logicalType instanceof FloatType) {
+                float floatVal = (float) Math.round(random.nextFloat() * 10000) / 10000;
+                return Tuple2.of(
+                        String.format("CAST ('%s' AS FLOAT)", String.valueOf(floatVal)),
+                        convertToInternalType(floatVal, type));
+            }
+            // double
+            if (logicalType instanceof DoubleType) {
+                double doubleVal = (double) Math.round(random.nextDouble() * 1000000) / 1000000;
+                return Tuple2.of(String.valueOf(doubleVal), convertToInternalType(doubleVal, type));
+            }
+            // LocalDate
+            if (logicalType instanceof DateType) {
+                LocalDate target = getLocalDate(System.currentTimeMillis());
+                return Tuple2.of(
+                        String.format("DATE '%s'", target.format(dateFormat)),
+                        convertToInternalType(target, type));
+            }
+            // LocalTime
+            if (logicalType instanceof TimeType) {
+                LocalTime target = getLocalTime(System.currentTimeMillis());
+                return Tuple2.of(
+                        String.format("TIME '%s'", target.format(timeFormat)),
+                        convertToInternalType(target, type));
+            }
+            // LocalDateTime
+            if (logicalType instanceof TimestampType) {
+                LocalDateTime localDateTime = getLocalDateTime(System.currentTimeMillis());
+                return Tuple2.of(
+                        String.format("TIMESTAMP '%s'", localDateTime.format(timestampFormat)),
+                        convertToInternalType(localDateTime, type));
+            }
+            // OffsetDateTime
+            if (logicalType instanceof ZonedTimestampType) {
+                LocalDateTime localDateTime = getLocalDateTime(System.currentTimeMillis());
+                return Tuple2.of(
+                        String.format("TIMESTAMP '%s'", localDateTime.format(timestampFormat)),
+                        convertToInternalType(localDateTime, type));
+            }
+            // Instant
+            if (logicalType instanceof LocalZonedTimestampType) {
+                long ms = System.currentTimeMillis();
+                LocalDateTime localDateTime = getLocalDateTime(ms);
+                return Tuple2.of(
+                        String.format("TO_TIMESTAMP_LTZ(%d, 3)", ms),
+                        convertToInternalType(Instant.ofEpochMilli(ms), type));
+            }
+        }
+        throw new IllegalArgumentException("Not support non AtomicDataType.");
+    }
+
+    private LocalDate getLocalDate(long ms) {
+        return Instant.ofEpochMilli(ms).atZone(ZoneOffset.UTC).toLocalDate();
+    }
+
+    private LocalTime getLocalTime(long ms) {
+        return Instant.ofEpochMilli(ms).atZone(ZoneOffset.UTC).toLocalTime();
+    }
+
+    private LocalDateTime getLocalDateTime(long ms) {
+        return Instant.ofEpochMilli(ms).atZone(ZoneOffset.UTC).toLocalDateTime();
+    }
+}

--- a/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/testsuites/TableSinkTestSuiteBase.java
+++ b/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/testsuites/TableSinkTestSuiteBase.java
@@ -1,0 +1,212 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.testframe.testsuites;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.connector.testframe.environment.TestEnvironment;
+import org.apache.flink.connector.testframe.environment.TestEnvironmentSettings;
+import org.apache.flink.connector.testframe.external.ExternalSystemDataReader;
+import org.apache.flink.connector.testframe.external.sink.TableSinkExternalContext;
+import org.apache.flink.connector.testframe.external.sink.TestingSinkSettings;
+import org.apache.flink.streaming.api.CheckpointingMode;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.DataType;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.TestTemplate;
+import org.opentest4j.TestAbortedException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.apache.flink.streaming.api.CheckpointingMode.AT_LEAST_ONCE;
+import static org.apache.flink.streaming.api.CheckpointingMode.EXACTLY_ONCE;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+/** Base class for table sink test suites. */
+public abstract class TableSinkTestSuiteBase extends AbstractTableTestSuiteBase {
+    private static final Logger LOG = LoggerFactory.getLogger(TableSinkTestSuiteBase.class);
+
+    private static final int NUM_RECORDS_UPPER_BOUND = 200;
+    private static final int NUM_RECORDS_LOWER_BOUND = 100;
+
+    /**
+     * Test connector table sink.
+     *
+     * <p>This test will insert records to the sink table, and read back.
+     */
+    @TestTemplate
+    @DisplayName("Test table sink basic write")
+    public void testBaseWrite(
+            TestEnvironment testEnv,
+            TableSinkExternalContext externalContext,
+            CheckpointingMode semantic)
+            throws Exception {
+        testTableTypes(testEnv, externalContext, semantic, Arrays.asList(DataTypes.STRING()));
+    }
+
+    /**
+     * Test data types for connector table sink.
+     *
+     * <p>This test will insert records to the sink table, and read back.
+     *
+     * <p>Now only test basic types.
+     */
+    @TestTemplate
+    @DisplayName("Test table sink data type")
+    public void testTableDataType(
+            TestEnvironment testEnv,
+            TableSinkExternalContext externalContext,
+            CheckpointingMode semantic)
+            throws Exception {
+        testTableTypes(testEnv, externalContext, semantic, supportTypes());
+    }
+
+    private void testTableTypes(
+            TestEnvironment testEnv,
+            TableSinkExternalContext externalContext,
+            CheckpointingMode semantic,
+            List<DataType> supportTypes)
+            throws Exception {
+        TestingSinkSettings sinkOptions = getTestingSinkOptions(semantic);
+        StreamExecutionEnvironment env =
+                testEnv.createExecutionEnvironment(
+                        TestEnvironmentSettings.builder()
+                                .setConnectorJarPaths(externalContext.getConnectorJarPaths())
+                                .build());
+        StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
+        Map<String, String> tableOptions = getTableOptions(externalContext, sinkOptions);
+        String tableName = "TableSinkTest" + semantic.toString().replaceAll("-", "");
+        tEnv.executeSql(getCreateTableSql(tableName, tableOptions, supportTypes));
+
+        Tuple2<String, List<RowData>> tuple2 =
+                initialValues(
+                        tableName,
+                        ThreadLocalRandom.current().nextLong(),
+                        NUM_RECORDS_UPPER_BOUND,
+                        NUM_RECORDS_LOWER_BOUND,
+                        supportTypes);
+        String initialValuesSql = tuple2.f0;
+        tEnv.executeSql(initialValuesSql).await();
+
+        List<RowData> expectedResult = tuple2.f1;
+        assertThat(
+                        checkGetEnoughRecordsWithSemantic(
+                                expectedResult,
+                                pollAndAppendResultData(
+                                        new ArrayList<>(),
+                                        externalContext.createSinkRowDataReader(
+                                                sinkOptions, getTableSchema(supportTypes)),
+                                        expectedResult,
+                                        30,
+                                        semantic),
+                                semantic))
+                .isTrue();
+    }
+
+    private TestingSinkSettings getTestingSinkOptions(CheckpointingMode checkpointingMode) {
+        return TestingSinkSettings.builder().setCheckpointingMode(checkpointingMode).build();
+    }
+
+    private Map<String, String> getTableOptions(
+            TableSinkExternalContext externalContext, TestingSinkSettings sinkSettings) {
+        try {
+            return externalContext.getSinkTableOptions(sinkSettings);
+        } catch (UnsupportedOperationException e) {
+            // abort the test
+            throw new TestAbortedException("Not support this test.", e);
+        }
+    }
+
+    /**
+     * Poll records from the sink.
+     *
+     * @param result Append records to which list
+     * @param reader The sink reader
+     * @param expected The expected list which help to stop polling
+     * @param retryTimes The retry times
+     * @param semantic The semantic
+     * @return Collection of records in the Sink
+     */
+    private List<RowData> pollAndAppendResultData(
+            List<RowData> result,
+            ExternalSystemDataReader<RowData> reader,
+            List<RowData> expected,
+            int retryTimes,
+            CheckpointingMode semantic) {
+        long timeoutMs = 1000L;
+        int retryIndex = 0;
+
+        while (retryIndex++ < retryTimes
+                && !checkGetEnoughRecordsWithSemantic(expected, result, semantic)) {
+            result.addAll(reader.poll(Duration.ofMillis(timeoutMs)));
+        }
+        return result;
+    }
+
+    /**
+     * Check whether the polling should stop.
+     *
+     * @param expected The expected list which help to stop polling
+     * @param result The records that have been read
+     * @param semantic The semantic
+     * @return Whether the polling should stop
+     */
+    private boolean checkGetEnoughRecordsWithSemantic(
+            List<RowData> expected, List<RowData> result, CheckpointingMode semantic) {
+        checkNotNull(expected);
+        checkNotNull(result);
+        if (EXACTLY_ONCE.equals(semantic)) {
+            return expected.size() <= result.size();
+        } else if (AT_LEAST_ONCE.equals(semantic)) {
+            Set<Integer> matchedIndex = new HashSet<>();
+            for (RowData record : expected) {
+                int before = matchedIndex.size();
+                for (int i = 0; i < result.size(); i++) {
+                    if (matchedIndex.contains(i)) {
+                        continue;
+                    }
+                    if (record.equals(result.get(i))) {
+                        matchedIndex.add(i);
+                        break;
+                    }
+                }
+                // if not find the record in the result
+                if (before == matchedIndex.size()) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        throw new IllegalStateException(
+                String.format("%s delivery guarantee doesn't support test.", semantic.name()));
+    }
+}

--- a/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/testsuites/TableSourceTestSuiteBase.java
+++ b/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/testsuites/TableSourceTestSuiteBase.java
@@ -1,0 +1,271 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.testframe.testsuites;
+
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.connector.testframe.environment.TestEnvironment;
+import org.apache.flink.connector.testframe.environment.TestEnvironmentSettings;
+import org.apache.flink.connector.testframe.external.source.TableSourceExternalContext;
+import org.apache.flink.connector.testframe.external.source.TestingSourceSettings;
+import org.apache.flink.connector.testframe.utils.CollectIteratorAssertions;
+import org.apache.flink.streaming.api.CheckpointingMode;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.CloseableIterator;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.TestTemplate;
+import org.opentest4j.TestAbortedException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Consumer;
+
+import static org.apache.flink.connector.testframe.utils.ConnectorTestConstants.DEFAULT_COLLECT_DATA_TIMEOUT;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+/** Base class for table source test suites. */
+public abstract class TableSourceTestSuiteBase extends AbstractTableTestSuiteBase {
+    private static final Logger LOG = LoggerFactory.getLogger(TableSourceTestSuiteBase.class);
+
+    private static final int NUM_RECORDS_UPPER_BOUND = 500;
+    private static final int NUM_RECORDS_LOWER_BOUND = 100;
+
+    /**
+     * Test data types for connector table source.
+     *
+     * <p>This test will insert records, and read back via a Flink job from the source table.
+     */
+    @TestTemplate
+    @DisplayName("Test table source basic read")
+    public void testBasicRead(
+            TestEnvironment testEnv,
+            TableSourceExternalContext externalContext,
+            CheckpointingMode semantic)
+            throws Exception {
+        testTableTypes(testEnv, externalContext, semantic, Arrays.asList(DataTypes.STRING()));
+    }
+
+    /**
+     * Test data types for connector table source.
+     *
+     * <p>This test will insert records, and read back via a Flink job from the source table.
+     *
+     * <p>Now only test basic types.
+     */
+    @TestTemplate
+    @DisplayName("Test table source data type")
+    public void testTableDataType(
+            TestEnvironment testEnv,
+            TableSourceExternalContext externalContext,
+            CheckpointingMode semantic)
+            throws Exception {
+        testTableTypes(testEnv, externalContext, semantic, supportTypes());
+    }
+
+    private void testTableTypes(
+            TestEnvironment testEnv,
+            TableSourceExternalContext externalContext,
+            CheckpointingMode semantic,
+            List<DataType> supportTypes)
+            throws Exception {
+        TestingSourceSettings sourceSettings =
+                getTestingSourceOptions(Boundedness.CONTINUOUS_UNBOUNDED, semantic);
+        StreamExecutionEnvironment env =
+                testEnv.createExecutionEnvironment(
+                        TestEnvironmentSettings.builder()
+                                .setConnectorJarPaths(externalContext.getConnectorJarPaths())
+                                .build());
+        env.setRestartStrategy(RestartStrategies.noRestart());
+
+        StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
+        Map<String, String> tableOptions = getTableOptions(externalContext, sourceSettings);
+        String tableName = "TableSourceTest" + semantic.toString().replaceAll("-", "");
+        String createTableSql = getCreateTableSql(tableName, tableOptions, supportTypes);
+        tEnv.executeSql(createTableSql);
+
+        List<List<RowData>> testRecordCollections = new LinkedList<>();
+        final DataType tableSchema = getTableSchema(supportTypes);
+        int splitNum = 4;
+        for (int i = 0; i < splitNum; i++) {
+            testRecordCollections.add(
+                    generateAndWriteTestData(
+                            i, externalContext, sourceSettings, tableSchema, supportTypes));
+        }
+
+        DataStream<Row> result =
+                tEnv.toDataStream(tEnv.sqlQuery(getSelectSql(tableName)), tableSchema);
+        try (final CloseableIterator<RowData> resultIterator =
+                new RowDataConverterIterator(
+                        result.executeAndCollect("Table type test"), tableSchema)) {
+            checkResultWithSemantic(
+                    resultIterator,
+                    testRecordCollections,
+                    semantic,
+                    getTestDataSize(testRecordCollections));
+        }
+    }
+
+    /**
+     * Get the size of test data.
+     *
+     * @param collections test data
+     * @return the size of test data
+     */
+    protected int getTestDataSize(List<List<RowData>> collections) {
+        int sumSize = 0;
+        for (Collection<RowData> collection : collections) {
+            sumSize += collection.size();
+        }
+        return sumSize;
+    }
+
+    /**
+     * Compare the test data with the result.
+     *
+     * <p>If the source is bounded, limit should be null.
+     *
+     * @param resultIterator the data read from the job
+     * @param testData the test data
+     * @param semantic the supported semantic, see {@link CheckpointingMode}
+     * @param limit expected number of the data to read from the job
+     */
+    private void checkResultWithSemantic(
+            CloseableIterator<RowData> resultIterator,
+            List<List<RowData>> testData,
+            CheckpointingMode semantic,
+            Integer limit) {
+        if (limit != null) {
+            assertThat(
+                            CompletableFuture.supplyAsync(
+                                    () -> {
+                                        CollectIteratorAssertions.assertThat(resultIterator)
+                                                .withNumRecordsLimit(limit)
+                                                .matchesRecordsFromSource(testData, semantic);
+                                        return true;
+                                    }))
+                    .succeedsWithin(DEFAULT_COLLECT_DATA_TIMEOUT);
+        } else {
+            CollectIteratorAssertions.assertThat(resultIterator)
+                    .matchesRecordsFromSource(testData, semantic);
+        }
+    }
+
+    /**
+     * Generate a set of test records and write it to the given split writer.
+     *
+     * @param externalContext External context
+     * @return List of generated test records
+     */
+    protected List<RowData> generateAndWriteTestData(
+            int splitIndex,
+            TableSourceExternalContext externalContext,
+            TestingSourceSettings sourceSettings,
+            DataType physicalDataType,
+            List<DataType> supportTypes) {
+        final List<RowData> testRecords =
+                generateTestData(splitIndex, ThreadLocalRandom.current().nextLong(), supportTypes);
+        LOG.debug("Writing {} records to external system", testRecords.size());
+        externalContext
+                .createSplitRowDataWriter(sourceSettings, physicalDataType)
+                .writeRecords(testRecords);
+        return testRecords;
+    }
+
+    protected List<RowData> generateTestData(
+            int splitIndex, long seed, List<DataType> supportTypes) {
+        Random random = new Random(seed);
+        List<RowData> testRecords = new ArrayList<>();
+        int recordNum =
+                random.nextInt(NUM_RECORDS_UPPER_BOUND - NUM_RECORDS_LOWER_BOUND)
+                        + NUM_RECORDS_LOWER_BOUND;
+        for (int i = 0; i < recordNum; i++) {
+            testRecords.add(generateTestRowData(splitIndex, supportTypes));
+        }
+        return testRecords;
+    }
+
+    private TestingSourceSettings getTestingSourceOptions(
+            Boundedness boundedness, CheckpointingMode checkpointingMode) {
+        return TestingSourceSettings.builder()
+                .setCheckpointingMode(checkpointingMode)
+                .setBoundedness(boundedness)
+                .build();
+    }
+
+    private Map<String, String> getTableOptions(
+            TableSourceExternalContext externalContext, TestingSourceSettings sourceSettings) {
+        try {
+            return externalContext.getSourceTableOptions(sourceSettings);
+        } catch (UnsupportedOperationException e) {
+            // abort the test
+            throw new TestAbortedException("Not support this test.", e);
+        }
+    }
+
+    class RowDataConverterIterator implements CloseableIterator<RowData> {
+        private final CloseableIterator<Row> rowIterator;
+        private final DataType schema;
+
+        public RowDataConverterIterator(CloseableIterator<Row> rowIterator, DataType schema) {
+            this.rowIterator = rowIterator;
+            this.schema = schema;
+        }
+
+        @Override
+        public void close() throws Exception {
+            rowIterator.close();
+        }
+
+        @Override
+        public boolean hasNext() {
+            return rowIterator.hasNext();
+        }
+
+        @Override
+        public RowData next() {
+            return convertToRowData(rowIterator.next(), schema);
+        }
+
+        @Override
+        public void remove() {
+            rowIterator.remove();
+        }
+
+        @Override
+        public void forEachRemaining(Consumer action) {
+            rowIterator.forEachRemaining(action);
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This pull request adds table tests for the connector testframe.

## Brief change log

  - add table tests for the connector testframe
  - add table tests for the Kafka connector

## Verifying this change

This change added tests in the connector testframe.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
