### PR TITLE
[FLINK-25312][hive] HiveCatalog supports Flink's managed table

### DIFF
--- a/flink-connectors/flink-connector-hive/pom.xml
+++ b/flink-connectors/flink-connector-hive/pom.xml
@@ -514,6 +514,12 @@ under the License.
 		<!-- Tests -->
 
 		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-table-common</artifactId>
 			<version>${project.version}</version>

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/HiveTableUtil.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/HiveTableUtil.java
@@ -40,6 +40,7 @@ import org.apache.flink.table.expressions.ExpressionVisitor;
 import org.apache.flink.table.expressions.FieldReferenceExpression;
 import org.apache.flink.table.expressions.TypeLiteralExpression;
 import org.apache.flink.table.expressions.ValueLiteralExpression;
+import org.apache.flink.table.factories.ManagedTableFactory;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 import org.apache.flink.table.functions.FunctionDefinition;
 import org.apache.flink.table.functions.hive.conversion.HiveInspectors;
@@ -351,8 +352,9 @@ public class HiveTableUtil {
             ObjectPath tablePath,
             CatalogBaseTable baseTable,
             Table oldHiveTable,
-            HiveConf hiveConf) {
-        Table newHiveTable = instantiateHiveTable(tablePath, baseTable, hiveConf);
+            HiveConf hiveConf,
+            boolean managedTable) {
+        Table newHiveTable = instantiateHiveTable(tablePath, baseTable, hiveConf, managedTable);
         // client.alter_table() requires a valid location
         // thus, if new table doesn't have that, it reuses location of the old table
         if (!newHiveTable.getSd().isSetLocation()) {
@@ -362,7 +364,7 @@ public class HiveTableUtil {
     }
 
     public static Table instantiateHiveTable(
-            ObjectPath tablePath, CatalogBaseTable table, HiveConf hiveConf) {
+            ObjectPath tablePath, CatalogBaseTable table, HiveConf hiveConf, boolean managedTable) {
         final boolean isView = table instanceof CatalogView;
         // let Hive set default parameters for us, e.g. serialization.format
         Table hiveTable =
@@ -371,6 +373,9 @@ public class HiveTableUtil {
         hiveTable.setCreateTime((int) (System.currentTimeMillis() / 1000));
 
         Map<String, String> properties = new HashMap<>(table.getOptions());
+        if (managedTable) {
+            properties.put(CONNECTOR.key(), ManagedTableFactory.DEFAULT_IDENTIFIER);
+        }
         // Table comment
         if (table.getComment() != null) {
             properties.put(HiveCatalogConfig.COMMENT, table.getComment());

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogITCase.java
@@ -43,7 +43,6 @@ import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.FileUtils;
 
 import org.junit.AfterClass;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -63,10 +62,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -75,9 +72,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.apache.flink.table.api.Expressions.$;
 import static org.apache.flink.table.api.config.ExecutionConfigOptions.TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * IT case for HiveCatalog. TODO: move to flink-connector-hive-test end-to-end test module once it's
@@ -128,9 +123,8 @@ public class HiveCatalogITCase {
         List<Row> result = CollectionUtil.iteratorToList(t.execute().collect());
 
         // assert query result
-        assertEquals(
-                new HashSet<>(Arrays.asList(Row.of("1", 1), Row.of("2", 2), Row.of("3", 3))),
-                new HashSet<>(result));
+        assertThat(result)
+                .containsExactlyInAnyOrder(Row.of("1", 1), Row.of("2", 2), Row.of("3", 3));
 
         tableEnv.executeSql("ALTER TABLE test2 RENAME TO newtable");
 
@@ -139,9 +133,8 @@ public class HiveCatalogITCase {
         result = CollectionUtil.iteratorToList(t.execute().collect());
 
         // assert query result
-        assertEquals(
-                new HashSet<>(Arrays.asList(Row.of("1", 1), Row.of("2", 2), Row.of("3", 3))),
-                new HashSet<>(result));
+        assertThat(result)
+                .containsExactlyInAnyOrder(Row.of("1", 1), Row.of("2", 2), Row.of("3", 3));
 
         tableEnv.executeSql("DROP TABLE newtable");
     }
@@ -190,7 +183,7 @@ public class HiveCatalogITCase {
         result.sort(Comparator.comparing(String::valueOf));
 
         // assert query result
-        assertEquals(Arrays.asList(Row.of("1", 1), Row.of("2", 2), Row.of("3", 3)), result);
+        assertThat(result).containsExactly(Row.of("1", 1), Row.of("2", 2), Row.of("3", 3));
 
         tableEnv.executeSql(
                         String.format(
@@ -204,11 +197,11 @@ public class HiveCatalogITCase {
         String readLine;
         for (int i = 0; i < 3; i++) {
             readLine = reader.readLine();
-            assertEquals(String.format("%d,%d", i + 1, i + 1), readLine);
+            assertThat(readLine).isEqualTo(String.format("%d,%d", i + 1, i + 1));
         }
 
         // No more line
-        assertNull(reader.readLine());
+        assertThat(reader.readLine()).isNull();
 
         tableEnv.executeSql(String.format("DROP TABLE %s", sourceTableName));
         tableEnv.executeSql(String.format("DROP TABLE %s", sinkTableName));
@@ -252,7 +245,7 @@ public class HiveCatalogITCase {
         String expected =
                 "2019-12-12 00:00:05.0,2019-12-12 00:00:04.004001,3,50.00\n"
                         + "2019-12-12 00:00:10.0,2019-12-12 00:00:06.006001,2,5.33\n";
-        assertEquals(expected, FileUtils.readFileUtf8(new File(new URI(sinkPath))));
+        assertThat(FileUtils.readFileUtf8(new File(new URI(sinkPath)))).isEqualTo(expected);
     }
 
     @Test
@@ -270,7 +263,7 @@ public class HiveCatalogITCase {
         List<Row> rows =
                 CollectionUtil.iteratorToList(
                         tableEnv.executeSql("SELECT * FROM proctime_src").collect());
-        Assert.assertEquals(5, rows.size());
+        assertThat(rows).hasSize(5);
         tableEnv.executeSql("DROP TABLE proctime_src");
     }
 
@@ -292,7 +285,7 @@ public class HiveCatalogITCase {
                                 .select($("price"), $("ts"), $("l_proctime"))
                                 .execute()
                                 .collect());
-        Assert.assertEquals(5, rows.size());
+        assertThat(rows).hasSize(5);
         tableEnv.executeSql("DROP TABLE proctime_src");
     }
 
@@ -374,10 +367,9 @@ public class HiveCatalogITCase {
                                     }
                                 })
                         .orElse(null);
-        assertNotNull(tableSchema);
-        assertEquals(
-                tableSchema.getPrimaryKey(),
-                Optional.of(UniqueConstraint.primaryKey("ct1", Collections.singletonList("uuid"))));
+        assertThat(tableSchema).isNotNull();
+        assertThat(tableSchema.getPrimaryKey())
+                .hasValue(UniqueConstraint.primaryKey("ct1", Collections.singletonList("uuid")));
         tableEnv.executeSql("DROP TABLE pk_src");
     }
 
@@ -409,7 +401,7 @@ public class HiveCatalogITCase {
             tEnv.executeSql("insert into print_table select * from csv_table").await();
 
             // assert query result
-            assertEquals("+I[1, 1]\n+I[2, 2]\n+I[3, 3]\n", arrayOutputStream.toString());
+            assertThat(arrayOutputStream.toString()).isEqualTo("+I[1, 1]\n+I[2, 2]\n+I[3, 3]\n");
         } finally {
             if (System.out != originalSystemOut) {
                 System.out.close();
@@ -483,11 +475,14 @@ public class HiveCatalogITCase {
         CatalogBaseTable catalogTable =
                 builtInCat.getTable(
                         new ObjectPath(EnvironmentSettings.DEFAULT_BUILTIN_DATABASE, "copy"));
-        assertEquals(1, catalogTable.getOptions().size());
-        assertEquals("COLLECTION", catalogTable.getOptions().get(FactoryUtil.CONNECTOR.key()));
-        assertEquals(1, catalogTable.getSchema().getFieldCount());
-        assertEquals("x", catalogTable.getSchema().getFieldNames()[0]);
-        assertEquals(DataTypes.INT(), catalogTable.getSchema().getFieldDataTypes()[0]);
+        assertThat(catalogTable.getOptions()).hasSize(1);
+        assertThat(catalogTable.getOptions())
+                .containsEntry(FactoryUtil.CONNECTOR.key(), "COLLECTION");
+        assertThat(catalogTable.getSchema().getFieldCount()).isEqualTo(1);
+        assertThat(catalogTable.getSchema().getFieldNames())
+                .hasSameElementsAs(Collections.singletonList("x"));
+        assertThat(catalogTable.getSchema().getFieldDataTypes())
+                .hasSameElementsAs(Collections.singletonList(DataTypes.INT()));
     }
 
     @Test
@@ -506,38 +501,38 @@ public class HiveCatalogITCase {
             CatalogView catalogView =
                     (CatalogView) hiveCatalog.getTable(new ObjectPath("db1", "v1"));
             Schema viewSchema = catalogView.getUnresolvedSchema();
-            assertEquals(
-                    Schema.newBuilder()
-                            .fromFields(
-                                    new String[] {"x", "ts"},
-                                    new AbstractDataType[] {
-                                        DataTypes.INT(), DataTypes.TIMESTAMP(3)
-                                    })
-                            .build(),
-                    viewSchema);
+            assertThat(viewSchema)
+                    .isEqualTo(
+                            Schema.newBuilder()
+                                    .fromFields(
+                                            new String[] {"x", "ts"},
+                                            new AbstractDataType[] {
+                                                DataTypes.INT(), DataTypes.TIMESTAMP(3)
+                                            })
+                                    .build());
 
             List<Row> results =
                     CollectionUtil.iteratorToList(
                             tableEnv.executeSql("select x from v1").collect());
-            assertEquals(3, results.size());
+            assertThat(results).hasSize(3);
 
             tableEnv.executeSql(
                     "create view v2 (v2_x,v2_ts) comment 'v2 comment' as select x,cast(ts as timestamp_ltz(3)) from v1");
             catalogView = (CatalogView) hiveCatalog.getTable(new ObjectPath("db1", "v2"));
-            assertEquals(
-                    Schema.newBuilder()
-                            .fromFields(
-                                    new String[] {"v2_x", "v2_ts"},
-                                    new AbstractDataType[] {
-                                        DataTypes.INT(), DataTypes.TIMESTAMP_LTZ(3)
-                                    })
-                            .build(),
-                    catalogView.getUnresolvedSchema());
-            assertEquals("v2 comment", catalogView.getComment());
+            assertThat(catalogView.getUnresolvedSchema())
+                    .isEqualTo(
+                            Schema.newBuilder()
+                                    .fromFields(
+                                            new String[] {"v2_x", "v2_ts"},
+                                            new AbstractDataType[] {
+                                                DataTypes.INT(), DataTypes.TIMESTAMP_LTZ(3)
+                                            })
+                                    .build());
+            assertThat(catalogView.getComment()).isEqualTo("v2 comment");
             results =
                     CollectionUtil.iteratorToList(
                             tableEnv.executeSql("select * from v2").collect());
-            assertEquals(3, results.size());
+            assertThat(results).hasSize(3);
         } finally {
             tableEnv.executeSql("drop database db1 cascade");
         }

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogITCase.java
@@ -33,9 +33,12 @@ import org.apache.flink.table.catalog.CatalogBaseTable;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.CatalogTableImpl;
 import org.apache.flink.table.catalog.CatalogView;
+import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.flink.table.catalog.exceptions.TableNotExistException;
 import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.flink.table.factories.ManagedTableFactory;
+import org.apache.flink.table.factories.TestManagedTableFactory;
 import org.apache.flink.table.planner.factories.utils.TestCollectionTableFactory;
 import org.apache.flink.table.types.AbstractDataType;
 import org.apache.flink.types.Row;
@@ -69,9 +72,12 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.apache.flink.table.api.Expressions.$;
 import static org.apache.flink.table.api.config.ExecutionConfigOptions.TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM;
+import static org.apache.flink.table.catalog.CatalogPropertiesUtil.FLINK_PROPERTY_PREFIX;
+import static org.apache.flink.table.factories.FactoryUtil.CONNECTOR;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -535,6 +541,58 @@ public class HiveCatalogITCase {
             assertThat(results).hasSize(3);
         } finally {
             tableEnv.executeSql("drop database db1 cascade");
+        }
+    }
+
+    @Test
+    public void testCreateAndGetManagedTable() throws Exception {
+        TableEnvironment tableEnv = TableEnvironment.create(EnvironmentSettings.inStreamingMode());
+        String catalog = "myhive";
+        String database = "default";
+        String table = "managed_table";
+        ObjectIdentifier tableIdentifier = ObjectIdentifier.of(catalog, database, table);
+        try {
+            TestManagedTableFactory.MANAGED_TABLES.put(tableIdentifier, new AtomicReference<>());
+            tableEnv.registerCatalog(catalog, hiveCatalog);
+            tableEnv.useCatalog(catalog);
+            final String sql =
+                    String.format(
+                            "CREATE TABLE %s (\n"
+                                    + "  uuid varchar(40) not null,\n"
+                                    + "  price DECIMAL(10, 2),\n"
+                                    + "  currency STRING,\n"
+                                    + "  ts6 TIMESTAMP(6),\n"
+                                    + "  ts AS CAST(ts6 AS TIMESTAMP(3)),\n"
+                                    + "  WATERMARK FOR ts AS ts,\n"
+                                    + "  constraint ct1 PRIMARY KEY(uuid) NOT ENFORCED)\n",
+                            table);
+            tableEnv.executeSql(sql);
+
+            Map<String, String> expectedOptions = new HashMap<>();
+            expectedOptions.put(
+                    TestManagedTableFactory.ENRICHED_KEY, TestManagedTableFactory.ENRICHED_VALUE);
+
+            assertThat(TestManagedTableFactory.MANAGED_TABLES.get(tableIdentifier).get())
+                    .containsExactlyInAnyOrderEntriesOf(expectedOptions);
+
+            Map<String, String> expectedParameters = new HashMap<>();
+            expectedOptions.forEach((k, v) -> expectedParameters.put(FLINK_PROPERTY_PREFIX + k, v));
+            expectedParameters.put(
+                    FLINK_PROPERTY_PREFIX + CONNECTOR.key(),
+                    ManagedTableFactory.DEFAULT_IDENTIFIER);
+
+            assertThat(hiveCatalog.getHiveTable(tableIdentifier.toObjectPath()).getParameters())
+                    .containsAllEntriesOf(expectedParameters);
+
+            assertThat(hiveCatalog.getTable(tableIdentifier.toObjectPath()).getOptions())
+                    .containsExactlyEntriesOf(
+                            Collections.singletonMap(
+                                    TestManagedTableFactory.ENRICHED_KEY,
+                                    TestManagedTableFactory.ENRICHED_VALUE));
+
+        } finally {
+            tableEnv.executeSql(String.format("DROP TABLE %s", table));
+            assertThat(TestManagedTableFactory.MANAGED_TABLES.get(tableIdentifier).get()).isNull();
         }
     }
 }

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogTest.java
@@ -38,10 +38,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.apache.flink.table.factories.FactoryUtil.CONNECTOR;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for HiveCatalog. */
 public class HiveCatalogTest {
@@ -76,10 +73,9 @@ public class HiveCatalogTest {
                         HiveTestUtils.createHiveConf());
 
         Map<String, String> prop = hiveTable.getParameters();
-        assertFalse(HiveCatalog.isHiveTable(prop));
-        assertTrue(
-                prop.keySet().stream()
-                        .allMatch(k -> k.startsWith(CatalogPropertiesUtil.FLINK_PROPERTY_PREFIX)));
+        assertThat(HiveCatalog.isHiveTable(prop)).isFalse();
+        assertThat(prop.keySet())
+                .allMatch(k -> k.startsWith(CatalogPropertiesUtil.FLINK_PROPERTY_PREFIX));
     }
 
     @Test
@@ -94,10 +90,9 @@ public class HiveCatalogTest {
                         HiveTestUtils.createHiveConf());
 
         Map<String, String> prop = hiveTable.getParameters();
-        assertTrue(HiveCatalog.isHiveTable(prop));
-        assertTrue(
-                prop.keySet().stream()
-                        .noneMatch(k -> k.startsWith(CatalogPropertiesUtil.FLINK_PROPERTY_PREFIX)));
+        assertThat(HiveCatalog.isHiveTable(prop)).isTrue();
+        assertThat(prop.keySet())
+                .noneMatch(k -> k.startsWith(CatalogPropertiesUtil.FLINK_PROPERTY_PREFIX));
     }
 
     @Test
@@ -113,16 +108,17 @@ public class HiveCatalogTest {
         hiveCatalog.createTable(hiveObjectPath, new CatalogTableImpl(schema, options, null), false);
 
         CatalogBaseTable hiveTable = hiveCatalog.getTable(hiveObjectPath);
-        assertEquals(hiveTable.getOptions().get("url"), "jdbc:clickhouse://host:port/testUrl1");
-        assertEquals(
-                hiveTable.getOptions().get("flink.url"), "jdbc:clickhouse://host:port/testUrl2");
+        assertThat(hiveTable.getOptions())
+                .containsEntry("url", "jdbc:clickhouse://host:port/testUrl1");
+        assertThat(hiveTable.getOptions())
+                .containsEntry("flink.url", "jdbc:clickhouse://host:port/testUrl2");
     }
 
     @Test
     public void testCreateHiveConf() {
         // hive-conf-dir not specified, should read hive-site from classpath
         HiveConf hiveConf = HiveCatalog.createHiveConf(null, null);
-        assertEquals("common-val", hiveConf.get("common-key"));
+        assertThat(hiveConf.get("common-key")).isEqualTo("common-val");
         // hive-conf-dir specified, shouldn't read hive-site from classpath
         String hiveConfDir =
                 Thread.currentThread()
@@ -130,7 +126,7 @@ public class HiveCatalogTest {
                         .getResource("test-catalog-factory-conf")
                         .getPath();
         hiveConf = HiveCatalog.createHiveConf(hiveConfDir, null);
-        assertNull(hiveConf.get("common-key", null));
+        assertThat(hiveConf.get("common-key")).isNull();
     }
 
     @Test
@@ -148,7 +144,7 @@ public class HiveCatalogTest {
                 false);
 
         CatalogBaseTable catalogTable = hiveCatalog.getTable(hiveObjectPath);
-        assertEquals(TableSchema.builder().build(), catalogTable.getSchema());
+        assertThat(catalogTable.getSchema()).isEqualTo(TableSchema.builder().build());
     }
 
     private static Map<String, String> getLegacyFileSystemConnectorOptions(String path) {

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogTest.java
@@ -18,27 +18,34 @@
 
 package org.apache.flink.table.catalog.hive;
 
+import org.apache.flink.connector.datagen.table.DataGenTableSourceFactory;
 import org.apache.flink.sql.parser.hive.ddl.SqlCreateHiveTable;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.catalog.CatalogBaseTable;
 import org.apache.flink.table.catalog.CatalogPropertiesUtil;
+import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.CatalogTableImpl;
 import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.flink.table.catalog.hive.util.HiveTableUtil;
 import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.flink.table.factories.ManagedTableFactory;
 
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.api.Table;
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.apache.flink.table.catalog.CatalogPropertiesUtil.FLINK_PROPERTY_PREFIX;
 import static org.apache.flink.table.factories.FactoryUtil.CONNECTOR;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test for HiveCatalog. */
 public class HiveCatalogTest {
@@ -49,6 +56,7 @@ public class HiveCatalogTest {
                     .field("age", DataTypes.INT())
                     .build();
     private static HiveCatalog hiveCatalog;
+    private final ObjectPath tablePath = new ObjectPath("default", "test");
 
     @BeforeClass
     public static void createCatalog() {
@@ -63,6 +71,131 @@ public class HiveCatalogTest {
         }
     }
 
+    @After
+    public void after() throws Exception {
+        hiveCatalog.dropTable(tablePath, true);
+    }
+
+    @Test
+    public void testCreateAndGetFlinkManagedTable() throws Exception {
+        CatalogTable table =
+                new CatalogTableImpl(schema, Collections.emptyMap(), "Flink managed table");
+        hiveCatalog.createTable(tablePath, table, false);
+        Table hiveTable = hiveCatalog.getHiveTable(tablePath);
+        assertThat(hiveTable.getParameters())
+                .containsEntry(
+                        FLINK_PROPERTY_PREFIX + CONNECTOR.key(),
+                        ManagedTableFactory.DEFAULT_IDENTIFIER);
+        CatalogBaseTable retrievedTable = hiveCatalog.instantiateCatalogTable(hiveTable);
+        assertThat(retrievedTable.getOptions()).isEmpty();
+    }
+
+    @Test
+    public void testAlterFlinkNonManagedTableToFlinkManagedTable() throws Exception {
+        Map<String, String> originOptions =
+                Collections.singletonMap(
+                        FactoryUtil.CONNECTOR.key(), DataGenTableSourceFactory.IDENTIFIER);
+        CatalogTable originTable =
+                new CatalogTableImpl(schema, originOptions, "Flink non-managed table");
+        hiveCatalog.createTable(tablePath, originTable, false);
+
+        Map<String, String> newOptions = Collections.emptyMap();
+        CatalogTable newTable = new CatalogTableImpl(schema, newOptions, "Flink managed table");
+        assertThatThrownBy(() -> hiveCatalog.alterTable(tablePath, newTable, false))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Changing catalog table type is not allowed. "
+                                + "Existing table type is 'FLINK_NON_MANAGED_TABLE', but new table type is 'FLINK_MANAGED_TABLE'");
+    }
+
+    @Test
+    public void testAlterFlinkNonManagedTableToHiveTable() throws Exception {
+        Map<String, String> originOptions =
+                Collections.singletonMap(
+                        FactoryUtil.CONNECTOR.key(), DataGenTableSourceFactory.IDENTIFIER);
+        CatalogTable originTable =
+                new CatalogTableImpl(schema, originOptions, "Flink non-managed table");
+        hiveCatalog.createTable(tablePath, originTable, false);
+
+        Map<String, String> newOptions = getLegacyFileSystemConnectorOptions("/test_path");
+        newOptions.put(FactoryUtil.CONNECTOR.key(), SqlCreateHiveTable.IDENTIFIER);
+        CatalogTable newTable = new CatalogTableImpl(schema, newOptions, "Hive table");
+        assertThatThrownBy(() -> hiveCatalog.alterTable(tablePath, newTable, false))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Changing catalog table type is not allowed. "
+                                + "Existing table type is 'FLINK_NON_MANAGED_TABLE', but new table type is 'HIVE_TABLE'");
+    }
+
+    @Test
+    public void testAlterFlinkManagedTableToFlinkManagedTable() throws Exception {
+        Map<String, String> originOptions = Collections.emptyMap();
+        CatalogTable originTable =
+                new CatalogTableImpl(schema, originOptions, "Flink managed table");
+        hiveCatalog.createTable(tablePath, originTable, false);
+
+        Map<String, String> newOptions =
+                Collections.singletonMap(
+                        FactoryUtil.CONNECTOR.key(), DataGenTableSourceFactory.IDENTIFIER);
+        CatalogTable newTable = new CatalogTableImpl(schema, newOptions, "Flink non-managed table");
+        assertThatThrownBy(() -> hiveCatalog.alterTable(tablePath, newTable, false))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Changing catalog table type is not allowed. "
+                                + "Existing table type is 'FLINK_MANAGED_TABLE', but new table type is 'FLINK_NON_MANAGED_TABLE'");
+    }
+
+    @Test
+    public void testAlterFlinkManagedTableToHiveTable() throws Exception {
+        Map<String, String> originOptions = Collections.emptyMap();
+        CatalogTable originTable =
+                new CatalogTableImpl(schema, originOptions, "Flink managed table");
+        hiveCatalog.createTable(tablePath, originTable, false);
+
+        Map<String, String> newOptions = getLegacyFileSystemConnectorOptions("/test_path");
+        newOptions.put(FactoryUtil.CONNECTOR.key(), SqlCreateHiveTable.IDENTIFIER);
+        CatalogTable newTable = new CatalogTableImpl(schema, newOptions, "Hive table");
+        assertThatThrownBy(() -> hiveCatalog.alterTable(tablePath, newTable, false))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Changing catalog table type is not allowed. "
+                                + "Existing table type is 'FLINK_MANAGED_TABLE', but new table type is 'HIVE_TABLE'");
+    }
+
+    @Test
+    public void testAlterHiveTableToFlinkManagedTable() throws Exception {
+        Map<String, String> originOptions = getLegacyFileSystemConnectorOptions("/test_path");
+        originOptions.put(FactoryUtil.CONNECTOR.key(), SqlCreateHiveTable.IDENTIFIER);
+        CatalogTable originTable = new CatalogTableImpl(schema, originOptions, "Hive table");
+        hiveCatalog.createTable(tablePath, originTable, false);
+
+        Map<String, String> newOptions = Collections.emptyMap();
+        CatalogTable newTable = new CatalogTableImpl(schema, newOptions, "Flink managed table");
+        assertThatThrownBy(() -> hiveCatalog.alterTable(tablePath, newTable, false))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Changing catalog table type is not allowed. "
+                                + "Existing table type is 'HIVE_TABLE', but new table type is 'FLINK_MANAGED_TABLE'");
+    }
+
+    @Test
+    public void testAlterHiveTableToFlinkNonManagedTable() throws Exception {
+        Map<String, String> originOptions = getLegacyFileSystemConnectorOptions("/test_path");
+        originOptions.put(FactoryUtil.CONNECTOR.key(), SqlCreateHiveTable.IDENTIFIER);
+        CatalogTable originTable = new CatalogTableImpl(schema, originOptions, "Hive table");
+        hiveCatalog.createTable(tablePath, originTable, false);
+
+        Map<String, String> newOptions =
+                Collections.singletonMap(
+                        FactoryUtil.CONNECTOR.key(), DataGenTableSourceFactory.IDENTIFIER);
+        CatalogTable newTable = new CatalogTableImpl(schema, newOptions, "Flink managed table");
+        assertThatThrownBy(() -> hiveCatalog.alterTable(tablePath, newTable, false))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Changing catalog table type is not allowed. "
+                                + "Existing table type is 'HIVE_TABLE', but new table type is 'FLINK_NON_MANAGED_TABLE'");
+    }
+
     @Test
     public void testCreateGenericTable() {
         Table hiveTable =
@@ -70,7 +203,8 @@ public class HiveCatalogTest {
                         new ObjectPath("test", "test"),
                         new CatalogTableImpl(
                                 schema, getLegacyFileSystemConnectorOptions("/test_path"), null),
-                        HiveTestUtils.createHiveConf());
+                        HiveTestUtils.createHiveConf(),
+                        false);
 
         Map<String, String> prop = hiveTable.getParameters();
         assertThat(HiveCatalog.isHiveTable(prop)).isFalse();
@@ -87,7 +221,8 @@ public class HiveCatalogTest {
                 HiveTableUtil.instantiateHiveTable(
                         new ObjectPath("test", "test"),
                         new CatalogTableImpl(schema, options, null),
-                        HiveTestUtils.createHiveConf());
+                        HiveTestUtils.createHiveConf(),
+                        false);
 
         Map<String, String> prop = hiveTable.getParameters();
         assertThat(HiveCatalog.isHiveTable(prop)).isTrue();

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/ManagedTableListener.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/ManagedTableListener.java
@@ -104,8 +104,7 @@ public class ManagedTableListener {
     }
 
     /** Check a resolved catalog table is Flink's managed table or not. */
-    public static boolean isManagedTable(
-            @Nullable Catalog catalog, ResolvedCatalogBaseTable<?> table) {
+    public static boolean isManagedTable(@Nullable Catalog catalog, CatalogBaseTable table) {
         if (catalog == null || !catalog.supportsManagedTable()) {
             // catalog not support managed table
             return false;
@@ -135,8 +134,11 @@ public class ManagedTableListener {
             return false;
         }
 
+        if (table instanceof ResolvedCatalogBaseTable) {
+            table = ((ResolvedCatalogBaseTable<?>) table).getOrigin();
+        }
         // ConnectorCatalogTable is not managed table
-        return !(table.getOrigin() instanceof ConnectorCatalogTable);
+        return !(table instanceof ConnectorCatalogTable);
     }
 
     /** Enrich options for creating managed table. */


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to let `HiveCatalog` support Flink's managed table. More details can be found at [FLIP-188](https://cwiki.apache.org/confluence/display/FLINK/FLIP-188%3A+Introduce+Built-in+Dynamic+Table+Storage)

## Brief changelog

This PR contains two commits.
  - 5c2d53d2 migrate `HiveCatalogTest` and `HiveCatalogITCase` to use assertJ
  - d7dc483a let hive support Flink's managed table
    -   enable `HiveCatalog#supportsManagedTable`
    -   inject `connector = 'default'` for `HiveCatalog#createTable` and remove `connector = 'default'` for `HiveCatalog#getTable`
    -  disallow `alter table` changing the catalog table type between `HIVE_TABLE`, `FLINK_MANAGED_TABLE` and `FLINK_NON_MANAGED_TABLE.`
  

## Verifying this change

This change added tests and can be verified as follows:
- Extend `HiveCatalogTest` to verify table parameters and options when creating and getting Flink's managed table, and verify the expected exception thrown when alter table is changing the catalog table type.
- Extend `HiveCatalogITCase` to verify enriched options and connector key is injected when creating and getting Flink's managed table

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**yes** / no) add test dependency
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
