### PR TITLE
[FLINK-25796][network] Avoid record copy for result partition of sort-shuffle if there are enough buffers for better performance

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/HashBasedDataBuffer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/HashBasedDataBuffer.java
@@ -1,0 +1,313 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition;
+
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.core.memory.MemorySegmentFactory;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.BufferBuilder;
+import org.apache.flink.runtime.io.network.buffer.BufferConsumer;
+import org.apache.flink.runtime.io.network.buffer.BufferPool;
+import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
+import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayDeque;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * * A {@link DataBuffer} implementation which sorts all appended records only by subpartition
+ * index. Records of the same subpartition keep the appended order.
+ *
+ * <p>Different from the {@link SortBasedDataBuffer}, in this {@link DataBuffer} implementation,
+ * memory segment boundary serves as the nature data boundary of different subpartitions, which
+ * means that one memory segment can never contain data from different subpartitions.
+ */
+public class HashBasedDataBuffer implements DataBuffer {
+
+    /** A buffer pool to request memory segments from. */
+    private final BufferPool bufferPool;
+
+    /** Number of guaranteed buffers can be allocated from the buffer pool for data sort. */
+    private final int numGuaranteedBuffers;
+
+    /** Buffers containing data for all subpartitions. */
+    private final ArrayDeque<BufferConsumer>[] buffers;
+
+    // ---------------------------------------------------------------------------------------------
+    // Statistics and states
+    // ---------------------------------------------------------------------------------------------
+
+    /** Total number of bytes already appended to this sort buffer. */
+    private long numTotalBytes;
+
+    /** Total number of records already appended to this sort buffer. */
+    private long numTotalRecords;
+
+    /** Whether this sort buffer is full and ready to read data from. */
+    private boolean isFull;
+
+    /** Whether this sort buffer is finished. One can only read a finished sort buffer. */
+    private boolean isFinished;
+
+    /** Whether this sort buffer is released. A released sort buffer can not be used. */
+    private boolean isReleased;
+
+    // ---------------------------------------------------------------------------------------------
+    // For writing
+    // ---------------------------------------------------------------------------------------------
+
+    /** Partial buffers to be appended data for each channel. */
+    private final BufferBuilder[] builders;
+
+    /** Total number of network buffers already occupied currently by this sort buffer. */
+    private int numBuffersOccupied;
+
+    // ---------------------------------------------------------------------------------------------
+    // For reading
+    // ---------------------------------------------------------------------------------------------
+
+    /** Used to index the current available channel to read data from. */
+    private int readOrderIndex;
+
+    /** Data of different subpartitions in this sort buffer will be read in this order. */
+    private final int[] subpartitionReadOrder;
+
+    /** Total number of bytes already read from this sort buffer. */
+    private long numTotalBytesRead;
+
+    public HashBasedDataBuffer(
+            BufferPool bufferPool,
+            int numSubpartitions,
+            int numGuaranteedBuffers,
+            @Nullable int[] customReadOrder) {
+        checkArgument(numGuaranteedBuffers > 0, "No guaranteed buffers for sort.");
+
+        this.bufferPool = checkNotNull(bufferPool);
+        this.numGuaranteedBuffers = numGuaranteedBuffers;
+
+        this.builders = new BufferBuilder[numSubpartitions];
+        this.buffers = new ArrayDeque[numSubpartitions];
+        for (int channel = 0; channel < numSubpartitions; ++channel) {
+            this.buffers[channel] = new ArrayDeque<>();
+        }
+
+        this.subpartitionReadOrder = new int[numSubpartitions];
+        if (customReadOrder != null) {
+            checkArgument(customReadOrder.length == numSubpartitions, "Illegal data read order.");
+            System.arraycopy(customReadOrder, 0, this.subpartitionReadOrder, 0, numSubpartitions);
+        } else {
+            for (int channel = 0; channel < numSubpartitions; ++channel) {
+                this.subpartitionReadOrder[channel] = channel;
+            }
+        }
+    }
+
+    /**
+     * Partial data of the target record can be written if this {@link HashBasedDataBuffer} is full.
+     * The remaining data of the target record will be written to the next data region (a new data
+     * buffer or this data buffer after reset).
+     */
+    @Override
+    public boolean append(ByteBuffer source, int targetChannel, Buffer.DataType dataType)
+            throws IOException {
+        checkArgument(source.hasRemaining(), "Cannot append empty data.");
+        checkState(!isFull, "Sort buffer is already full.");
+        checkState(!isFinished, "Sort buffer is already finished.");
+        checkState(!isReleased, "Sort buffer is already released.");
+
+        int totalBytes = source.remaining();
+        if (dataType.isBuffer()) {
+            writeRecord(source, targetChannel);
+        } else {
+            writeEvent(source, targetChannel, dataType);
+        }
+
+        isFull = source.hasRemaining();
+        if (!isFull) {
+            ++numTotalRecords;
+        }
+        numTotalBytes += totalBytes - source.remaining();
+        return isFull;
+    }
+
+    private void writeEvent(ByteBuffer source, int targetChannel, Buffer.DataType dataType) {
+        BufferBuilder builder = builders[targetChannel];
+        if (builder != null) {
+            builder.finish();
+            buffers[targetChannel].add(builder.createBufferConsumerFromBeginning());
+            builder.close();
+            builders[targetChannel] = null;
+        }
+
+        MemorySegment segment =
+                MemorySegmentFactory.allocateUnpooledOffHeapMemory(source.remaining());
+        segment.put(0, source, segment.size());
+        BufferConsumer consumer =
+                new BufferConsumer(
+                        new NetworkBuffer(segment, FreeingBufferRecycler.INSTANCE, dataType),
+                        segment.size());
+        buffers[targetChannel].add(consumer);
+    }
+
+    private void writeRecord(ByteBuffer source, int targetChannel) throws IOException {
+        do {
+            BufferBuilder builder = builders[targetChannel];
+            if (builder == null) {
+                builder = requestBufferFromPool();
+                if (builder == null) {
+                    break;
+                }
+                ++numBuffersOccupied;
+                builders[targetChannel] = builder;
+            }
+
+            builder.append(source);
+            if (builder.isFull()) {
+                builder.finish();
+                buffers[targetChannel].add(builder.createBufferConsumerFromBeginning());
+                builder.close();
+                builders[targetChannel] = null;
+            }
+        } while (source.hasRemaining());
+    }
+
+    private BufferBuilder requestBufferFromPool() throws IOException {
+        try {
+            // blocking request buffers if there is still guaranteed memory
+            if (numBuffersOccupied < numGuaranteedBuffers) {
+                return bufferPool.requestBufferBuilderBlocking();
+            }
+        } catch (InterruptedException e) {
+            throw new IOException("Interrupted while requesting buffer.", e);
+        }
+
+        return bufferPool.requestBufferBuilder();
+    }
+
+    @Override
+    public BufferWithChannel getNextBuffer(MemorySegment transitBuffer) {
+        checkState(isFull, "Sort buffer is not ready to be read.");
+        checkState(!isReleased, "Sort buffer is already released.");
+
+        BufferWithChannel buffer = null;
+        if (!hasRemaining() || readOrderIndex >= subpartitionReadOrder.length) {
+            return null;
+        }
+
+        int targetChannel = subpartitionReadOrder[readOrderIndex];
+        while (buffer == null) {
+            BufferConsumer consumer = buffers[targetChannel].poll();
+            if (consumer != null) {
+                buffer = new BufferWithChannel(consumer.build(), targetChannel);
+                numBuffersOccupied -= buffer.getBuffer().isBuffer() ? 1 : 0;
+                numTotalBytesRead += buffer.getBuffer().readableBytes();
+                consumer.close();
+            } else {
+                if (++readOrderIndex >= subpartitionReadOrder.length) {
+                    break;
+                }
+                targetChannel = subpartitionReadOrder[readOrderIndex];
+            }
+        }
+        return buffer;
+    }
+
+    @Override
+    public long numTotalRecords() {
+        return numTotalRecords;
+    }
+
+    @Override
+    public long numTotalBytes() {
+        return numTotalBytes;
+    }
+
+    @Override
+    public boolean hasRemaining() {
+        return numTotalBytesRead < numTotalBytes;
+    }
+
+    @Override
+    public void reset() {
+        checkState(!isFinished, "Sort buffer has been finished.");
+        checkState(!isReleased, "Sort buffer has been released.");
+
+        isFull = false;
+        readOrderIndex = 0;
+    }
+
+    @Override
+    public void finish() {
+        checkState(!isFull, "DataBuffer must not be full.");
+        checkState(!isFinished, "DataBuffer is already finished.");
+
+        isFull = true;
+        isFinished = true;
+        for (int channel = 0; channel < builders.length; ++channel) {
+            BufferBuilder builder = builders[channel];
+            if (builder != null) {
+                builder.finish();
+                buffers[channel].add(builder.createBufferConsumerFromBeginning());
+                builder.close();
+                builders[channel] = null;
+            }
+        }
+    }
+
+    @Override
+    public boolean isFinished() {
+        return isFinished;
+    }
+
+    @Override
+    public void release() {
+        if (isReleased) {
+            return;
+        }
+        isReleased = true;
+
+        for (int channel = 0; channel < builders.length; ++channel) {
+            BufferBuilder builder = builders[channel];
+            if (builder != null) {
+                builder.close();
+                builders[channel] = null;
+            }
+        }
+
+        for (ArrayDeque<BufferConsumer> buffer : buffers) {
+            BufferConsumer consumer = buffer.poll();
+            while (consumer != null) {
+                consumer.close();
+                consumer = buffer.poll();
+            }
+        }
+    }
+
+    @Override
+    public boolean isReleased() {
+        return isReleased;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartition.java
@@ -54,10 +54,10 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
 
 /**
- * {@link SortMergeResultPartition} appends records and events to {@link SortBuffer} and after the
- * {@link SortBuffer} is full, all data in the {@link SortBuffer} will be copied and spilled to a
+ * {@link SortMergeResultPartition} appends records and events to {@link DataBuffer} and after the
+ * {@link DataBuffer} is full, all data in the {@link DataBuffer} will be copied and spilled to a
  * {@link PartitionedFile} in subpartition index order sequentially. Large records that can not be
- * appended to an empty {@link SortBuffer} will be spilled to the result {@link PartitionedFile}
+ * appended to an empty {@link DataBuffer} will be spilled to the result {@link PartitionedFile}
  * separately.
  */
 @NotThreadSafe
@@ -68,6 +68,14 @@ public class SortMergeResultPartition extends ResultPartition {
      * value (8M) which can not be configured.
      */
     private static final int NUM_WRITE_BUFFER_BYTES = 8 * 1024 * 1024;
+
+    /**
+     * Expected number of buffers for data batch writing. 512 mean that at most 1024 buffers
+     * (including the headers) will be written in one request. This value is selected because that
+     * the writev system call has a limit on the maximum number of buffers can be written in one
+     * invoke whose advertised value is 1024 (please see writev man page for more information).
+     */
+    private static final int EXPECTED_WRITE_BATCH_SIZE = 512;
 
     private final Object lock = new Object();
 
@@ -93,7 +101,7 @@ public class SortMergeResultPartition extends ResultPartition {
      */
     private final String resultFileBasePath;
 
-    /** Subpartition orders of coping data from {@link SortBuffer} and writing to file. */
+    /** Subpartition orders of coping data from {@link DataBuffer} and writing to file. */
     private final int[] subpartitionOrder;
 
     /**
@@ -107,16 +115,22 @@ public class SortMergeResultPartition extends ResultPartition {
     private final SortMergeResultPartitionReadScheduler readScheduler;
 
     /**
-     * Number of guaranteed network buffers can be used by {@link #unicastSortBuffer} and {@link
-     * #broadcastSortBuffer}.
+     * Number of guaranteed network buffers can be used by {@link #unicastDataBuffer} and {@link
+     * #broadcastDataBuffer}.
      */
     private int numBuffersForSort;
 
-    /** {@link SortBuffer} for records sent by {@link #broadcastRecord(ByteBuffer)}. */
-    private SortBuffer broadcastSortBuffer;
+    /**
+     * If true, {@link HashBasedDataBuffer} will be used, otherwise, {@link SortBasedDataBuffer}
+     * will be used.
+     */
+    private boolean useHashBuffer;
 
-    /** {@link SortBuffer} for records sent by {@link #emitRecord(ByteBuffer, int)}. */
-    private SortBuffer unicastSortBuffer;
+    /** {@link DataBuffer} for records sent by {@link #broadcastRecord(ByteBuffer)}. */
+    private DataBuffer broadcastDataBuffer;
+
+    /** {@link DataBuffer} for records sent by {@link #emitRecord(ByteBuffer, int)}. */
+    private DataBuffer unicastDataBuffer;
 
     public SortMergeResultPartition(
             String owningTaskName,
@@ -175,23 +189,29 @@ public class SortMergeResultPartition extends ResultPartition {
         readBufferPool.initialize();
         super.setup();
 
-        int expectedWriteBuffers = NUM_WRITE_BUFFER_BYTES / networkBufferSize;
-        if (networkBufferSize > NUM_WRITE_BUFFER_BYTES) {
-            expectedWriteBuffers = 1;
-        }
-
         int numRequiredBuffer = bufferPool.getNumberOfRequiredMemorySegments();
-        int numWriteBuffers = Math.min(numRequiredBuffer / 2, expectedWriteBuffers);
-        if (numWriteBuffers < 1) {
+        if (numRequiredBuffer < 2) {
             throw new IOException(
                     String.format(
                             "Too few sort buffers, please increase %s.",
                             NettyShuffleEnvironmentOptions.NETWORK_SORT_SHUFFLE_MIN_BUFFERS));
         }
-        numBuffersForSort = numRequiredBuffer - numWriteBuffers;
+
+        int expectedWriteBuffers = 0;
+        if (numRequiredBuffer >= 2 * numSubpartitions) {
+            useHashBuffer = true;
+        } else if (networkBufferSize >= NUM_WRITE_BUFFER_BYTES) {
+            expectedWriteBuffers = 1;
+        } else {
+            expectedWriteBuffers =
+                    Math.min(EXPECTED_WRITE_BATCH_SIZE, NUM_WRITE_BUFFER_BYTES / networkBufferSize);
+        }
+
+        int numBuffersForWrite = Math.min(numRequiredBuffer / 2, expectedWriteBuffers);
+        numBuffersForSort = numRequiredBuffer - numBuffersForWrite;
 
         try {
-            for (int i = 0; i < numWriteBuffers; ++i) {
+            for (int i = 0; i < numBuffersForWrite; ++i) {
                 MemorySegment segment = bufferPool.requestMemorySegmentBlocking();
                 writeSegments.add(segment);
             }
@@ -204,7 +224,7 @@ public class SortMergeResultPartition extends ResultPartition {
                 "Sort-merge partition {} initialized, num sort buffers: {}, num write buffers: {}.",
                 getPartitionId(),
                 numBuffersForSort,
-                numWriteBuffers);
+                numBuffersForWrite);
     }
 
     @Override
@@ -259,105 +279,112 @@ public class SortMergeResultPartition extends ResultPartition {
             throws IOException {
         checkInProduceState();
 
-        SortBuffer sortBuffer = isBroadcast ? getBroadcastSortBuffer() : getUnicastSortBuffer();
-        if (sortBuffer.append(record, targetSubpartition, dataType)) {
+        DataBuffer dataBuffer = isBroadcast ? getBroadcastDataBuffer() : getUnicastDataBuffer();
+        if (!dataBuffer.append(record, targetSubpartition, dataType)) {
             return;
         }
 
-        if (!sortBuffer.hasRemaining()) {
-            // the record can not be appended to the free sort buffer because it is too large
-            sortBuffer.finish();
-            sortBuffer.release();
+        if (!dataBuffer.hasRemaining()) {
+            dataBuffer.reset();
             writeLargeRecord(record, targetSubpartition, dataType, isBroadcast);
             return;
         }
 
-        flushSortBuffer(sortBuffer, isBroadcast);
-        emit(record, targetSubpartition, dataType, isBroadcast);
-    }
-
-    private void releaseSortBuffer(SortBuffer sortBuffer) {
-        if (sortBuffer != null) {
-            sortBuffer.release();
+        flushDataBuffer(dataBuffer, isBroadcast);
+        dataBuffer.reset();
+        if (record.hasRemaining()) {
+            emit(record, targetSubpartition, dataType, isBroadcast);
         }
     }
 
-    private SortBuffer getUnicastSortBuffer() throws IOException {
-        flushBroadcastSortBuffer();
-
-        if (unicastSortBuffer != null && !unicastSortBuffer.isFinished()) {
-            return unicastSortBuffer;
+    private void releaseDataBuffer(DataBuffer dataBuffer) {
+        if (dataBuffer != null) {
+            dataBuffer.release();
         }
-
-        unicastSortBuffer =
-                new PartitionSortedBuffer(
-                        bufferPool,
-                        numSubpartitions,
-                        networkBufferSize,
-                        numBuffersForSort,
-                        subpartitionOrder);
-        return unicastSortBuffer;
     }
 
-    private SortBuffer getBroadcastSortBuffer() throws IOException {
-        flushUnicastSortBuffer();
+    private DataBuffer getUnicastDataBuffer() throws IOException {
+        flushBroadcastDataBuffer();
 
-        if (broadcastSortBuffer != null && !broadcastSortBuffer.isFinished()) {
-            return broadcastSortBuffer;
+        if (unicastDataBuffer != null && !unicastDataBuffer.isFinished()) {
+            return unicastDataBuffer;
         }
 
-        broadcastSortBuffer =
-                new PartitionSortedBuffer(
-                        bufferPool,
-                        numSubpartitions,
-                        networkBufferSize,
-                        numBuffersForSort,
-                        subpartitionOrder);
-        return broadcastSortBuffer;
+        unicastDataBuffer = createNewDataBuffer();
+        return unicastDataBuffer;
     }
 
-    private void flushSortBuffer(SortBuffer sortBuffer, boolean isBroadcast) throws IOException {
-        if (sortBuffer == null || sortBuffer.isReleased()) {
+    private DataBuffer getBroadcastDataBuffer() throws IOException {
+        flushUnicastDataBuffer();
+
+        if (broadcastDataBuffer != null && !broadcastDataBuffer.isFinished()) {
+            return broadcastDataBuffer;
+        }
+
+        broadcastDataBuffer = createNewDataBuffer();
+        return broadcastDataBuffer;
+    }
+
+    private DataBuffer createNewDataBuffer() {
+        if (useHashBuffer) {
+            return new HashBasedDataBuffer(
+                    bufferPool, numSubpartitions, numBuffersForSort, subpartitionOrder);
+        } else {
+            return new SortBasedDataBuffer(
+                    bufferPool,
+                    numSubpartitions,
+                    networkBufferSize,
+                    numBuffersForSort,
+                    subpartitionOrder);
+        }
+    }
+
+    private void flushDataBuffer(DataBuffer dataBuffer, boolean isBroadcast) throws IOException {
+        if (dataBuffer == null || dataBuffer.isReleased() || !dataBuffer.hasRemaining()) {
             return;
         }
-        sortBuffer.finish();
 
-        if (sortBuffer.hasRemaining()) {
-            fileWriter.startNewRegion(isBroadcast);
+        Queue<MemorySegment> segments = new ArrayDeque<>(writeSegments);
+        int numBuffersToWrite =
+                useHashBuffer
+                        ? EXPECTED_WRITE_BATCH_SIZE
+                        : Math.min(EXPECTED_WRITE_BATCH_SIZE, segments.size());
+        List<BufferWithChannel> toWrite = new ArrayList<>(numBuffersToWrite);
 
-            List<BufferWithChannel> toWrite = new ArrayList<>();
-            Queue<MemorySegment> segments = getWriteSegments();
-
-            while (sortBuffer.hasRemaining()) {
-                if (segments.isEmpty()) {
-                    fileWriter.writeBuffers(toWrite);
-                    toWrite.clear();
-                    segments = getWriteSegments();
-                }
-
-                BufferWithChannel bufferWithChannel =
-                        sortBuffer.copyIntoSegment(checkNotNull(segments.poll()));
-                updateStatistics(bufferWithChannel.getBuffer(), isBroadcast);
-                toWrite.add(compressBufferIfPossible(bufferWithChannel));
+        fileWriter.startNewRegion(isBroadcast);
+        do {
+            if (toWrite.size() >= numBuffersToWrite) {
+                writeBuffers(toWrite);
+                segments = new ArrayDeque<>(writeSegments);
             }
 
-            fileWriter.writeBuffers(toWrite);
+            BufferWithChannel bufferWithChannel = dataBuffer.getNextBuffer(segments.poll());
+            if (bufferWithChannel == null) {
+                writeBuffers(toWrite);
+                break;
+            }
+
+            updateStatistics(bufferWithChannel.getBuffer(), isBroadcast);
+            toWrite.add(compressBufferIfPossible(bufferWithChannel));
+        } while (true);
+    }
+
+    private void flushBroadcastDataBuffer() throws IOException {
+        if (broadcastDataBuffer != null) {
+            broadcastDataBuffer.finish();
+            flushDataBuffer(broadcastDataBuffer, true);
+            broadcastDataBuffer.release();
+            broadcastDataBuffer = null;
         }
-
-        releaseSortBuffer(sortBuffer);
     }
 
-    private void flushBroadcastSortBuffer() throws IOException {
-        flushSortBuffer(broadcastSortBuffer, true);
-    }
-
-    private void flushUnicastSortBuffer() throws IOException {
-        flushSortBuffer(unicastSortBuffer, false);
-    }
-
-    private Queue<MemorySegment> getWriteSegments() {
-        checkState(!writeSegments.isEmpty(), "Task has been canceled.");
-        return new ArrayDeque<>(writeSegments);
+    private void flushUnicastDataBuffer() throws IOException {
+        if (unicastDataBuffer != null) {
+            unicastDataBuffer.finish();
+            flushDataBuffer(unicastDataBuffer, false);
+            unicastDataBuffer.release();
+            unicastDataBuffer = null;
+        }
     }
 
     private BufferWithChannel compressBufferIfPossible(BufferWithChannel bufferWithChannel) {
@@ -383,16 +410,19 @@ public class SortMergeResultPartition extends ResultPartition {
     private void writeLargeRecord(
             ByteBuffer record, int targetSubpartition, DataType dataType, boolean isBroadcast)
             throws IOException {
+        // for the hash-based data buffer implementation, a large record will be appended to the
+        // data buffer directly and spilled to multiple data regions
+        checkState(!useHashBuffer, "No buffers available for writing.");
         fileWriter.startNewRegion(isBroadcast);
 
         List<BufferWithChannel> toWrite = new ArrayList<>();
-        Queue<MemorySegment> segments = getWriteSegments();
+        Queue<MemorySegment> segments = new ArrayDeque<>(writeSegments);
 
         while (record.hasRemaining()) {
             if (segments.isEmpty()) {
                 fileWriter.writeBuffers(toWrite);
                 toWrite.clear();
-                segments = getWriteSegments();
+                segments = new ArrayDeque<>(writeSegments);
             }
 
             int toCopy = Math.min(record.remaining(), networkBufferSize);
@@ -408,6 +438,12 @@ public class SortMergeResultPartition extends ResultPartition {
         fileWriter.writeBuffers(toWrite);
     }
 
+    private void writeBuffers(List<BufferWithChannel> buffers) throws IOException {
+        fileWriter.writeBuffers(buffers);
+        buffers.forEach(buffer -> buffer.getBuffer().recycleBuffer());
+        buffers.clear();
+    }
+
     @Override
     public void notifyEndOfData(StopMode mode) throws IOException {
         if (!hasNotifiedEndOfUserRecords) {
@@ -420,9 +456,9 @@ public class SortMergeResultPartition extends ResultPartition {
     public void finish() throws IOException {
         broadcastEvent(EndOfPartitionEvent.INSTANCE, false);
         checkState(
-                unicastSortBuffer == null || unicastSortBuffer.isReleased(),
+                unicastDataBuffer == null,
                 "The unicast sort buffer should be either null or released.");
-        flushBroadcastSortBuffer();
+        flushBroadcastDataBuffer();
 
         synchronized (lock) {
             checkState(!isReleased(), "Result partition is already released.");
@@ -447,8 +483,8 @@ public class SortMergeResultPartition extends ResultPartition {
         releaseWriteBuffers();
         // the close method will be always called by the task thread, so there is need to make
         // the sort buffer fields volatile and visible to the cancel thread intermediately
-        releaseSortBuffer(unicastSortBuffer);
-        releaseSortBuffer(broadcastSortBuffer);
+        releaseDataBuffer(unicastDataBuffer);
+        releaseDataBuffer(broadcastDataBuffer);
         super.close();
 
         IOUtils.closeQuietly(fileWriter);
@@ -475,8 +511,8 @@ public class SortMergeResultPartition extends ResultPartition {
     @Override
     public void flushAll() {
         try {
-            flushUnicastSortBuffer();
-            flushBroadcastSortBuffer();
+            flushUnicastDataBuffer();
+            flushBroadcastDataBuffer();
         } catch (IOException e) {
             LOG.error("Failed to flush the current sort buffer.", e);
         }
@@ -485,8 +521,8 @@ public class SortMergeResultPartition extends ResultPartition {
     @Override
     public void flush(int subpartitionIndex) {
         try {
-            flushUnicastSortBuffer();
-            flushBroadcastSortBuffer();
+            flushUnicastDataBuffer();
+            flushBroadcastDataBuffer();
         } catch (IOException e) {
             LOG.error("Failed to flush the current sort buffer.", e);
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartitionedFileWriteReadTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartitionedFileWriteReadTest.java
@@ -90,8 +90,7 @@ public class PartitionedFileWriteReadTest {
                 }
             }
 
-            int[] writeOrder =
-                    PartitionSortedBufferTest.getRandomSubpartitionOrder(numSubpartitions);
+            int[] writeOrder = DataBufferTest.getRandomSubpartitionOrder(numSubpartitions);
             for (int index = 0; index < numSubpartitions; ++index) {
                 int subpartition = writeOrder[index];
                 fileWriter.writeBuffers(regionBuffers[subpartition]);


### PR DESCRIPTION
## What is the purpose of the change

Currently, for result partition of sort-shuffle, there is extra record copy overhead Introduced by clustering records by subpartition index. For small records, this overhead can cause even 20% performance regression. This ticket aims to solve the problem.

In fact, the hash-based implementation is a nature way to achieve the goal of sorting records by partition index. However, it incurs some serious weaknesses. For example, when there is no enough buffers or there is data skew, it can waste buffers and influence compression efficiency which can cause performance regression.

This ticket tries to solve the issue by dynamically switching between the two implementations, that is, if there are enough buffers, the hash-based implementation will be used and if there is no enough buffers, the sort-based implementation will be used.

## Brief change log

  - Dynamically switching between the two implementations, that is, if there are enough buffers, the hash-based implementation will be used and if there is no enough buffers, the sort-based implementation will be used.


## Verifying this change

This change added tests and existing tests can also help to verify the change.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
