### PR TITLE
[FLINK-25673] Harden AdaptiveSchedulerITCase by introducing MiniClust…

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/MiniClusterResource.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/MiniClusterResource.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.testutils;
 import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.configuration.HeartbeatManagerOptions;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.RestOptions;
@@ -29,6 +30,7 @@ import org.apache.flink.configuration.UnmodifiableConfiguration;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.minicluster.MiniCluster;
 import org.apache.flink.runtime.minicluster.MiniClusterConfiguration;
+import org.apache.flink.runtime.resourcemanager.ResourceOverview;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.concurrent.FutureUtils;
@@ -99,15 +101,29 @@ public class MiniClusterResource extends ExternalResource {
                         * miniClusterResourceConfiguration.getNumberTaskManagers();
     }
 
-    public void cancelAllJobs() {
-        try {
-            final Deadline jobCancellationDeadline =
-                    Deadline.fromNow(
-                            Duration.ofMillis(
-                                    miniClusterResourceConfiguration
-                                            .getShutdownTimeout()
-                                            .toMilliseconds()));
+    public void cancelAllJobsAndWaitUntilSlotsAreFreed() {
+        final long heartbeatTimeout =
+                miniCluster.getConfiguration().get(HeartbeatManagerOptions.HEARTBEAT_INTERVAL);
+        final long shutdownTimeout =
+                miniClusterResourceConfiguration.getShutdownTimeout().toMilliseconds();
+        Preconditions.checkState(
+                heartbeatTimeout < shutdownTimeout,
+                "Heartbeat timeout (%d) needs to be lower than the shutdown timeout (%d) in order to ensure reliable job cancellation and resource cleanup.",
+                heartbeatTimeout,
+                shutdownTimeout);
+        cancelAllJobs(true);
+    }
 
+    public void cancelAllJobs() {
+        cancelAllJobs(false);
+    }
+
+    private void cancelAllJobs(boolean waitUntilSlotsAreFreed) {
+        try {
+            final long shutdownTimeout =
+                    miniClusterResourceConfiguration.getShutdownTimeout().toMilliseconds();
+            final Deadline jobCancellationDeadline =
+                    Deadline.fromNow(Duration.ofMillis(shutdownTimeout));
             final List<CompletableFuture<Acknowledge>> jobCancellationFutures =
                     miniCluster.listJobs()
                             .get(
@@ -137,6 +153,17 @@ public class MiniClusterResource extends ExternalResource {
                         return unfinishedJobs == 0;
                     },
                     jobCancellationDeadline);
+
+            if (waitUntilSlotsAreFreed) {
+                CommonTestUtils.waitUntilCondition(
+                        () -> {
+                            final ResourceOverview resourceOverview =
+                                    miniCluster.getResourceOverview().get();
+                            return resourceOverview.getNumberRegisteredSlots()
+                                    == resourceOverview.getNumberFreeSlots();
+                        },
+                        jobCancellationDeadline);
+            }
         } catch (Exception e) {
             log.warn("Exception while shutting down remaining jobs.", e);
         }

--- a/flink-tests/src/test/java/org/apache/flink/test/scheduling/AdaptiveSchedulerITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/scheduling/AdaptiveSchedulerITCase.java
@@ -26,6 +26,7 @@ import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.configuration.ClusterOptions;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.HeartbeatManagerOptions;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
@@ -81,9 +82,9 @@ public class AdaptiveSchedulerITCase extends TestLogger {
 
     private static Configuration getConfiguration() {
         final Configuration conf = new Configuration();
-
         conf.set(JobManagerOptions.SCHEDULER, JobManagerOptions.SchedulerType.Adaptive);
-
+        conf.set(HeartbeatManagerOptions.HEARTBEAT_INTERVAL, 1_000L);
+        conf.set(HeartbeatManagerOptions.HEARTBEAT_TIMEOUT, 5_000L);
         return conf;
     }
 
@@ -103,7 +104,7 @@ public class AdaptiveSchedulerITCase extends TestLogger {
 
     @After
     public void cancelRunningJobs() {
-        MINI_CLUSTER_WITH_CLIENT_RESOURCE.cancelAllJobs();
+        MINI_CLUSTER_WITH_CLIENT_RESOURCE.cancelAllJobsAndWaitUntilSlotsAreFreed();
     }
 
     /** Tests that the adaptive scheduler can recover stateful operators. */


### PR DESCRIPTION
Fixes race conditions related to freeing of the slot resources when reusing the MiniCluster between multiple tests.

https://issues.apache.org/jira/browse/FLINK-25673