### PR TITLE
[FLINK-25816][changelog] Refactor the logic of notifying materialization id to nested state backend

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockKeyedStateBackend.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockKeyedStateBackend.java
@@ -65,11 +65,13 @@ import java.util.stream.Stream;
 
 /** State backend which produces in memory mock state objects. */
 public class MockKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
+    public static final long UN_NOTIFIED_CHECKPOINT_ID = -1L;
 
     /** Whether to create empty snapshot ({@link MockKeyedStateHandle} isn't recognized by JM). */
     private final boolean emptySnapshot;
 
-    private long lastCompletedCheckpointID;
+    private long lastCompletedCheckpointID = UN_NOTIFIED_CHECKPOINT_ID;
+    private long lastAbortedCheckpointID = UN_NOTIFIED_CHECKPOINT_ID;
 
     private interface StateFactory {
         <N, SV, S extends State, IS extends S> IS createInternalState(
@@ -195,7 +197,7 @@ public class MockKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 
     @Override
     public void notifyCheckpointAborted(long checkpointId) {
-        // noop
+        lastAbortedCheckpointID = checkpointId;
     }
 
     @Override
@@ -304,6 +306,10 @@ public class MockKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 
     public long getLastCompletedCheckpointID() {
         return lastCompletedCheckpointID;
+    }
+
+    public long getLastAbortedCheckpointID() {
+        return lastAbortedCheckpointID;
     }
 
     static class MockKeyedStateHandle<K> implements KeyedStateHandle {


### PR DESCRIPTION
## What is the purpose of the change

Correct the logic of FLINK-25524, and add tests to cover this case.


## Brief change log


## Verifying this change

This change added tests and can be verified as follows:

ChangelogKeyedStateBackendTest related tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
