### PR TITLE
[FLINK-25288][tests] add savepoint and metric test cases in source suite of connector testframe

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/testutils/KafkaSourceExternalContext.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/testutils/KafkaSourceExternalContext.java
@@ -71,7 +71,7 @@ public class KafkaSourceExternalContext implements DataStreamSourceExternalConte
     private final AdminClient adminClient;
     private final List<KafkaPartitionDataWriter> writers = new ArrayList<>();
 
-    KafkaSourceExternalContext(
+    protected KafkaSourceExternalContext(
             String bootstrapServers,
             SplitMappingMode splitMappingMode,
             List<URL> connectorJarPaths) {

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/FlinkContainerTestEnvironment.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/FlinkContainerTestEnvironment.java
@@ -24,7 +24,9 @@ import org.apache.flink.connector.testframe.environment.ClusterControllable;
 import org.apache.flink.connector.testframe.environment.TestEnvironment;
 import org.apache.flink.connector.testframe.environment.TestEnvironmentSettings;
 import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
+import org.apache.flink.streaming.api.environment.RemoteStreamEnvironment;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.tests.util.flink.container.FlinkContainers;
 import org.apache.flink.tests.util.flink.container.FlinkContainersBuilder;
@@ -42,7 +44,12 @@ import java.util.stream.Collectors;
 import static org.apache.flink.configuration.HeartbeatManagerOptions.HEARTBEAT_INTERVAL;
 import static org.apache.flink.configuration.HeartbeatManagerOptions.HEARTBEAT_TIMEOUT;
 import static org.apache.flink.configuration.JobManagerOptions.SLOT_REQUEST_TIMEOUT;
+import static org.apache.flink.configuration.MetricOptions.METRIC_FETCHER_UPDATE_INTERVAL;
 import static org.apache.flink.configuration.TaskManagerOptions.NUM_TASK_SLOTS;
+import static org.apache.flink.connector.testframe.utils.ConnectorTestConstants.HEARTBEAT_INTERVAL_MS;
+import static org.apache.flink.connector.testframe.utils.ConnectorTestConstants.HEARTBEAT_TIMEOUT_MS;
+import static org.apache.flink.connector.testframe.utils.ConnectorTestConstants.METRIC_FETCHER_UPDATE_INTERVAL_MS;
+import static org.apache.flink.connector.testframe.utils.ConnectorTestConstants.SLOT_REQUEST_TIMEOUT_MS;
 
 /** Test environment running job on {@link FlinkContainers}. */
 public class FlinkContainerTestEnvironment implements TestEnvironment, ClusterControllable {
@@ -65,9 +72,10 @@ public class FlinkContainerTestEnvironment implements TestEnvironment, ClusterCo
         Configuration config = new Configuration();
         config.addAll(clusterConfiguration);
         config.set(NUM_TASK_SLOTS, numSlotsPerTaskManager);
-        config.set(HEARTBEAT_INTERVAL, 1000L);
-        config.set(HEARTBEAT_TIMEOUT, 5000L);
-        config.set(SLOT_REQUEST_TIMEOUT, 10000L);
+        config.set(HEARTBEAT_INTERVAL, HEARTBEAT_INTERVAL_MS);
+        config.set(HEARTBEAT_TIMEOUT, HEARTBEAT_TIMEOUT_MS);
+        config.set(SLOT_REQUEST_TIMEOUT, SLOT_REQUEST_TIMEOUT_MS);
+        config.set(METRIC_FETCHER_UPDATE_INTERVAL, METRIC_FETCHER_UPDATE_INTERVAL_MS);
         flinkContainers =
                 FlinkContainers.builder()
                         .setNumTaskManagers(numTaskManagers)
@@ -99,6 +107,15 @@ public class FlinkContainerTestEnvironment implements TestEnvironment, ClusterCo
                 envOptions.getConnectorJarPaths().stream()
                         .map(URL::getPath)
                         .collect(Collectors.toList()));
+        if (envOptions.getSavepointRestorePath() != null) {
+            return new RemoteStreamEnvironment(
+                    flinkContainers.getJobManagerHost(),
+                    flinkContainers.getJobManagerPort(),
+                    null,
+                    jarPaths.toArray(new String[0]),
+                    null,
+                    SavepointRestoreSettings.forPath(envOptions.getSavepointRestorePath()));
+        }
         return StreamExecutionEnvironment.createRemoteEnvironment(
                 flinkContainers.getJobManagerHost(),
                 flinkContainers.getJobManagerPort(),

--- a/flink-end-to-end-tests/flink-end-to-end-tests-pulsar/src/test/java/org/apache/flink/tests/util/pulsar/common/FlinkContainerWithPulsarEnvironment.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-pulsar/src/test/java/org/apache/flink/tests/util/pulsar/common/FlinkContainerWithPulsarEnvironment.java
@@ -19,11 +19,11 @@
 package org.apache.flink.tests.util.pulsar.common;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.tests.util.TestUtils;
 import org.apache.flink.tests.util.flink.FlinkContainerTestEnvironment;
-
-import static org.apache.flink.configuration.TaskManagerOptions.TASK_OFF_HEAP_MEMORY;
 
 /** A Flink Container which would bundles pulsar connector in its classpath. */
 public class FlinkContainerWithPulsarEnvironment extends FlinkContainerTestEnvironment {
@@ -46,8 +46,16 @@ public class FlinkContainerWithPulsarEnvironment extends FlinkContainerTestEnvir
 
     protected static Configuration flinkConfiguration() {
         Configuration configuration = new Configuration();
-        // Increase the off heap memory for avoiding direct buffer memory error on Pulsar e2e tests.
-        configuration.set(TASK_OFF_HEAP_MEMORY, MemorySize.ofMebiBytes(100));
+        // Increase the off heap memory of TaskManager to avoid direct buffer memory error in Pulsar
+        // e2e tests.
+        configuration.set(TaskManagerOptions.TASK_OFF_HEAP_MEMORY, MemorySize.ofMebiBytes(100));
+
+        // Increase the jvm metaspace memory to avoid java.lang.OutOfMemoryError: Metaspace
+        configuration.set(TaskManagerOptions.TOTAL_PROCESS_MEMORY, MemorySize.ofMebiBytes(2048));
+        configuration.set(TaskManagerOptions.JVM_METASPACE, MemorySize.ofMebiBytes(512));
+        configuration.set(JobManagerOptions.TOTAL_PROCESS_MEMORY, MemorySize.ofMebiBytes(2048));
+        configuration.set(JobManagerOptions.JVM_METASPACE, MemorySize.ofMebiBytes(512));
+
         return configuration;
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/CommonTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/CommonTestUtils.java
@@ -315,8 +315,8 @@ public class CommonTestUtils {
                 deadline);
     }
 
-    public static void terminateJob(JobClient client, Duration timeout) throws Exception {
-        client.cancel().get(timeout.toMillis(), TimeUnit.MILLISECONDS);
+    public static void terminateJob(JobClient client) throws Exception {
+        client.cancel().get();
     }
 
     public static void waitForSubtasksToFinish(

--- a/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/environment/MiniClusterTestEnvironment.java
+++ b/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/environment/MiniClusterTestEnvironment.java
@@ -20,24 +20,34 @@ package org.apache.flink.connector.testframe.environment;
 
 import org.apache.flink.annotation.Experimental;
 import org.apache.flink.api.common.time.Deadline;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.runtime.highavailability.nonha.embedded.HaLeadershipControl;
 import org.apache.flink.runtime.minicluster.RpcServiceSharing;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.util.TestStreamEnvironment;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.configuration.MetricOptions.METRIC_FETCHER_UPDATE_INTERVAL;
+import static org.apache.flink.connector.testframe.utils.ConnectorTestConstants.METRIC_FETCHER_UPDATE_INTERVAL_MS;
+import static org.apache.flink.runtime.jobgraph.SavepointConfigOptions.SAVEPOINT_PATH;
 
 /** Test environment for running jobs on Flink mini-cluster. */
 @Experimental
@@ -53,9 +63,12 @@ public class MiniClusterTestEnvironment implements TestEnvironment, ClusterContr
     private boolean isStarted = false;
 
     public MiniClusterTestEnvironment() {
+        Configuration conf = new Configuration();
+        conf.set(METRIC_FETCHER_UPDATE_INTERVAL, METRIC_FETCHER_UPDATE_INTERVAL_MS);
         this.miniCluster =
                 new MiniClusterWithClientResource(
                         new MiniClusterResourceConfiguration.Builder()
+                                .setConfiguration(conf)
                                 .setNumberTaskManagers(1)
                                 .setNumberSlotsPerTaskManager(6)
                                 .setRpcServiceSharing(RpcServiceSharing.DEDICATED)
@@ -71,7 +84,18 @@ public class MiniClusterTestEnvironment implements TestEnvironment, ClusterContr
     @Override
     public StreamExecutionEnvironment createExecutionEnvironment(
             TestEnvironmentSettings envOptions) {
-        return StreamExecutionEnvironment.getExecutionEnvironment();
+        Configuration configuration = new Configuration();
+        if (envOptions.getSavepointRestorePath() != null) {
+            configuration.setString(SAVEPOINT_PATH, envOptions.getSavepointRestorePath());
+        }
+        return new TestStreamEnvironment(
+                this.miniCluster.getMiniCluster(),
+                configuration,
+                this.miniCluster.getNumberSlots(),
+                envOptions.getConnectorJarPaths().stream()
+                        .map(url -> new org.apache.flink.core.fs.Path(url.getPath()))
+                        .collect(Collectors.toList()),
+                Collections.emptyList());
     }
 
     @Override
@@ -131,12 +155,13 @@ public class MiniClusterTestEnvironment implements TestEnvironment, ClusterContr
     }
 
     @Override
-    public void tearDown() {
+    public void tearDown() throws Exception {
         if (!isStarted) {
             return;
         }
         isStarted = false;
         this.miniCluster.after();
+        deletePath(checkpointPath);
         LOG.debug("MiniCluster has been tear down");
     }
 
@@ -154,5 +179,22 @@ public class MiniClusterTestEnvironment implements TestEnvironment, ClusterContr
     @Override
     public String toString() {
         return "MiniCluster";
+    }
+
+    /** Deletes the given path recursively. */
+    public static void deletePath(Path path) throws IOException {
+        final List<File> files =
+                Files.walk(path)
+                        .filter(p -> p != path)
+                        .map(Path::toFile)
+                        .collect(Collectors.toList());
+        for (File file : files) {
+            if (file.isDirectory()) {
+                deletePath(file.toPath());
+            } else {
+                file.delete();
+            }
+        }
+        Files.deleteIfExists(path);
     }
 }

--- a/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/utils/ConnectorTestConstants.java
+++ b/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/utils/ConnectorTestConstants.java
@@ -18,10 +18,14 @@
 
 package org.apache.flink.connector.testframe.utils;
 
+import java.time.Duration;
+
 /** The default configuration values used in connector tests. */
 public class ConnectorTestConstants {
     public static final long METRIC_FETCHER_UPDATE_INTERVAL_MS = 1000L;
-    public static final long SLOT_REQUEST_TIMEOUT_MS = 10000L;
-    public static final long HEARTBEAT_TIMEOUT_MS = 5000L;
+    public static final long SLOT_REQUEST_TIMEOUT_MS = 10_000L;
+    public static final long HEARTBEAT_TIMEOUT_MS = 5_000L;
     public static final long HEARTBEAT_INTERVAL_MS = 1000L;
+    public static final Duration DEFAULT_JOB_STATUS_CHANGE_TIMEOUT = Duration.ofSeconds(30L);
+    public static final Duration DEFAULT_COLLECT_DATA_TIMEOUT = Duration.ofSeconds(120L);
 }

--- a/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/utils/ConnectorTestConstants.java
+++ b/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/utils/ConnectorTestConstants.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.testframe.utils;
+
+/** The default configuration values used in connector tests. */
+public class ConnectorTestConstants {
+    public static final long METRIC_FETCHER_UPDATE_INTERVAL_MS = 1000L;
+    public static final long SLOT_REQUEST_TIMEOUT_MS = 10000L;
+    public static final long HEARTBEAT_TIMEOUT_MS = 5000L;
+    public static final long HEARTBEAT_INTERVAL_MS = 1000L;
+}

--- a/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/utils/MetricQuerier.java
+++ b/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/utils/MetricQuerier.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.testframe.utils;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.testframe.environment.TestEnvironment;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.rest.RestClient;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.JobIDPathParameter;
+import org.apache.flink.runtime.rest.messages.JobMessageParameters;
+import org.apache.flink.runtime.rest.messages.JobVertexIdPathParameter;
+import org.apache.flink.runtime.rest.messages.MessagePathParameter;
+import org.apache.flink.runtime.rest.messages.job.JobDetailsHeaders;
+import org.apache.flink.runtime.rest.messages.job.JobDetailsInfo;
+import org.apache.flink.runtime.rest.messages.job.metrics.AggregatedMetricsResponseBody;
+import org.apache.flink.runtime.rest.messages.job.metrics.AggregatedSubtaskMetricsHeaders;
+import org.apache.flink.runtime.rest.messages.job.metrics.AggregatedSubtaskMetricsParameters;
+import org.apache.flink.runtime.rest.messages.job.metrics.MetricsFilterParameter;
+import org.apache.flink.util.ConfigurationException;
+import org.apache.flink.util.StringUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Iterator;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+/** The querier used to get job metrics by rest API. */
+public class MetricQuerier {
+    private static final Logger LOG = LoggerFactory.getLogger(MetricQuerier.class);
+    private RestClient restClient;
+
+    public MetricQuerier(Configuration configuration) throws ConfigurationException {
+        restClient = new RestClient(configuration, Executors.newCachedThreadPool());
+    }
+
+    public JobDetailsInfo getJobDetails(TestEnvironment.Endpoint endpoint, JobID jobId)
+            throws Exception {
+        String jmAddress = endpoint.getAddress();
+        int jmPort = endpoint.getPort();
+
+        final JobMessageParameters params = new JobMessageParameters();
+        params.jobPathParameter.resolve(jobId);
+
+        return restClient
+                .sendRequest(
+                        jmAddress,
+                        jmPort,
+                        JobDetailsHeaders.getInstance(),
+                        params,
+                        EmptyRequestBody.getInstance())
+                .get(30, TimeUnit.SECONDS);
+    }
+
+    public AggregatedMetricsResponseBody getMetricList(
+            TestEnvironment.Endpoint endpoint, JobID jobId, JobVertexID vertexId) throws Exception {
+        AggregatedSubtaskMetricsParameters subtaskMetricsParameters =
+                new AggregatedSubtaskMetricsParameters();
+        Iterator<MessagePathParameter<?>> pathParams =
+                subtaskMetricsParameters.getPathParameters().iterator();
+        ((JobIDPathParameter) pathParams.next()).resolve(jobId);
+        ((JobVertexIdPathParameter) pathParams.next()).resolve(vertexId);
+        return restClient
+                .sendRequest(
+                        endpoint.getAddress(),
+                        endpoint.getPort(),
+                        AggregatedSubtaskMetricsHeaders.getInstance(),
+                        subtaskMetricsParameters,
+                        EmptyRequestBody.getInstance())
+                .get(30, TimeUnit.SECONDS);
+    }
+
+    public AggregatedMetricsResponseBody getMetrics(
+            TestEnvironment.Endpoint endpoint, JobID jobId, JobVertexID vertexId, String filters)
+            throws Exception {
+        AggregatedSubtaskMetricsParameters subtaskMetricsParameters =
+                new AggregatedSubtaskMetricsParameters();
+        Iterator<MessagePathParameter<?>> pathParams =
+                subtaskMetricsParameters.getPathParameters().iterator();
+        ((JobIDPathParameter) pathParams.next()).resolve(jobId);
+        ((JobVertexIdPathParameter) pathParams.next()).resolve(vertexId);
+        MetricsFilterParameter metricFilter =
+                (MetricsFilterParameter)
+                        subtaskMetricsParameters.getQueryParameters().iterator().next();
+        metricFilter.resolveFromString(filters);
+
+        return restClient
+                .sendRequest(
+                        endpoint.getAddress(),
+                        endpoint.getPort(),
+                        AggregatedSubtaskMetricsHeaders.getInstance(),
+                        subtaskMetricsParameters,
+                        EmptyRequestBody.getInstance())
+                .get(30, TimeUnit.SECONDS);
+    }
+
+    public Double getAggregatedMetricsByRestAPI(
+            TestEnvironment.Endpoint endpoint,
+            JobID jobId,
+            String sourceOrSinkName,
+            String metricName)
+            throws Exception {
+        // get job details, including the vertex id
+        JobDetailsInfo jobDetailsInfo = getJobDetails(endpoint, jobId);
+
+        // get the vertex id for source/sink operator
+        JobDetailsInfo.JobVertexDetailsInfo vertex =
+                jobDetailsInfo.getJobVertexInfos().stream()
+                        .filter(v -> v.getName().contains(sourceOrSinkName))
+                        .findAny()
+                        .orElse(null);
+        assertThat(vertex).isNotNull();
+        JobVertexID vertexId = vertex.getJobVertexID();
+
+        // get the metric list
+        AggregatedMetricsResponseBody metricsResponseBody =
+                getMetricList(endpoint, jobId, vertexId);
+
+        // get the metric query filters
+        String queryParam =
+                metricsResponseBody.getMetrics().stream()
+                        .filter(
+                                m ->
+                                        m.getId().endsWith(metricName)
+                                                && m.getId().contains(sourceOrSinkName))
+                        .map(m -> m.getId())
+                        .collect(Collectors.joining(","));
+
+        if (StringUtils.isNullOrWhitespaceOnly(queryParam)) {
+            throw new IllegalStateException(
+                    String.format(
+                            "Cannot find metric[%s] for operator [%s].",
+                            metricName, sourceOrSinkName));
+        }
+
+        AggregatedMetricsResponseBody metricsResponse =
+                getMetrics(endpoint, jobId, vertexId, queryParam);
+        return metricsResponse.getMetrics().iterator().next().getSum();
+    }
+}


### PR DESCRIPTION

## What is the purpose of the change

This pull request adds savepoint and metric test cases in source suite of the connector testfram.

## Brief change log 

  - Add savepoint and metric test cases in the source suite of the connector testfram
  - Change the tests in the Kafka and Pulsar connector

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
