### PR TITLE
[FLINK-25816][state] Remove checkpoint abortion notification of notify backend

### DIFF
--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
@@ -78,13 +78,11 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.NoSuchElementException;
 import java.util.Optional;
-import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -209,19 +207,6 @@ public class ChangelogKeyedStateBackend<K>
 
     /** Checkpoint ID mapped to Materialization ID - used to notify nested backend of completion. */
     private final NavigableMap<Long, Long> materializationIdByCheckpointId = new TreeMap<>();
-    /**
-     * Materialization ID mapped to Checkpoint IDs - used to notify nested backend of abortion.
-     * Entry is removed when:
-     *
-     * <ol>
-     *   <li>some checkpoint of a Set completes (in which case {@link #keyedStateBackend} is {@link
-     *       CheckpointListener#notifyCheckpointComplete(long) notified of completion}.
-     *   <li>a newer checkpoint completes
-     *   <li>all checkpoints of a Set are aborted (in which case {@link #keyedStateBackend} is
-     *       {@link CheckpointListener#notifyCheckpointAborted(long) notified of abortion}.
-     * </ol>
-     */
-    private final Map<Long, Set<Long>> pendingMaterializationConfirmations = new HashMap<>();
 
     private long lastConfirmedMaterializationId = -1L;
 
@@ -400,15 +385,8 @@ public class ChangelogKeyedStateBackend<K>
 
         ChangelogSnapshotState changelogStateBackendStateCopy = changelogSnapshotState;
 
-        if (changelogStateBackendStateCopy.materializationID > lastConfirmedMaterializationId) {
-            materializationIdByCheckpointId.put(
-                    checkpointId, changelogStateBackendStateCopy.materializationID);
-            pendingMaterializationConfirmations
-                    .computeIfAbsent(
-                            changelogStateBackendStateCopy.materializationID,
-                            ign -> new HashSet<>())
-                    .add(checkpointId);
-        }
+        materializationIdByCheckpointId.put(
+                checkpointId, changelogStateBackendStateCopy.materializationID);
 
         return toRunnableFuture(
                 stateChangelogWriter
@@ -505,14 +483,8 @@ public class ChangelogKeyedStateBackend<K>
                 keyedStateBackend.notifyCheckpointComplete(materializationID);
                 lastConfirmedMaterializationId = materializationID;
             }
-            pendingMaterializationConfirmations.remove(materializationID);
         }
-        // there is a chance that nested backend will miss the abort notification
-        // but there is no other way to cleanup this map
-        Map<Long, Long> olderCheckpoints =
-                materializationIdByCheckpointId.headMap(checkpointId, true);
-        olderCheckpoints.values().forEach(pendingMaterializationConfirmations::remove);
-        olderCheckpoints.clear();
+        materializationIdByCheckpointId.headMap(checkpointId, true).clear();
     }
 
     @Override
@@ -524,22 +496,7 @@ public class ChangelogKeyedStateBackend<K>
             // This might change if the log ownership changes (the method won't likely be needed).
             stateChangelogWriter.reset(lastUploadedFrom, lastUploadedTo);
         }
-        Long materializationID = materializationIdByCheckpointId.remove(checkpointId);
-        if (materializationID != null) {
-            Set<Long> checkpoints = pendingMaterializationConfirmations.get(materializationID);
-            checkpoints.remove(checkpointId);
-            if (checkpoints.isEmpty()) {
-                if (materializationID < changelogSnapshotState.materializationID) {
-                    // Notification is not strictly required and will arrive only after the nested
-                    // snapshot has completed. It's also unlikely to be sent because of the
-                    // difference in checkpoint/materialization intervals. But it can still be
-                    // useful
-                    // for some backends.
-                    keyedStateBackend.notifyCheckpointAborted(materializationID);
-                }
-                pendingMaterializationConfirmations.remove(materializationID);
-            }
-        }
+        // TODO: Consider notifying nested state backend about checkpoint abortion (FLINK-25850)
     }
 
     // -------- Methods not simply delegating to wrapped state backend ---------


### PR DESCRIPTION
## What is the purpose of the change

```
The notification currently causes an exception and adds complexity.
It's also not necessary, unlikely to be delivered (because of the
difference in checkpoint/materialization intervals) and unlikely to be
utilized (it will arrive only after the nested snapshot has completed
and most likely do the same GC as in completion notification).
```

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
