### PR TITLE
[FLINK-25068][Runtime/Web] Show the maximum parallelism(number of key groups) of a job in Web UI

### DIFF
--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/WebFrontendITCase.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/WebFrontendITCase.java
@@ -356,7 +356,7 @@ class WebFrontendITCase {
                                     + jid
                                     + "\",\"name\":\"Stoppable streaming test job\","
                                     + "\"execution-config\":{\"execution-mode\":\"PIPELINED\",\"restart-strategy\":\"Cluster level default restart strategy\","
-                                    + "\"job-parallelism\":1,\"object-reuse-mode\":false,\"user-config\":{}}}");
+                                    + "\"job-parallelism\":1,\"job-max-parallelism\":-1,\"object-reuse-mode\":false,\"user-config\":{}}}");
         }
 
         BlockingInvokable.reset();

--- a/flink-runtime-web/web-dashboard/src/app/components/dagre/components/node/node.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/components/dagre/components/node/node.component.html
@@ -32,6 +32,7 @@
         <xhtml:div class="detail">{{ operator }}</xhtml:div>
         <xhtml:div class="detail description">{{ description }}</xhtml:div>
         <xhtml:div class="node-label">Parallelism: {{ parallelism }}</xhtml:div>
+        <xhtml:div class="node-label">Max Parallelism: {{ maxParallelism }}</xhtml:div>
         <xhtml:div
           class="node-label metric"
           title="Maximum back pressured percentage across all subtasks"

--- a/flink-runtime-web/web-dashboard/src/app/components/dagre/components/node/node.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/components/dagre/components/node/node.component.ts
@@ -34,6 +34,7 @@ export class NodeComponent {
   operator: string | null;
   operatorStrategy: string | null;
   parallelism: number | null;
+  maxParallelism: number | null;
   lowWatermark: number | null | undefined;
   backPressuredPercentage: number | undefined = NaN;
   busyPercentage: number | undefined = NaN;
@@ -63,6 +64,7 @@ export class NodeComponent {
     this.operator = this.decodeHTML(value.operator);
     this.operatorStrategy = this.decodeHTML(value.operator_strategy);
     this.parallelism = value.parallelism;
+    this.maxParallelism = value.maxParallelism;
     this.lowWatermark = value.lowWatermark;
     if (this.isValid(value.backPressuredPercentage)) {
       this.backPressuredPercentage = value.backPressuredPercentage;

--- a/flink-runtime-web/web-dashboard/src/app/interfaces/job-detail.ts
+++ b/flink-runtime-web/web-dashboard/src/app/interfaces/job-detail.ts
@@ -122,6 +122,7 @@ interface MetricsStatus {
 export interface NodesItem {
   id: string;
   parallelism: number;
+  maxParallelism: number;
   operator: string;
   operator_strategy: string;
   description: string;

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/configuration/job-configuration.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/configuration/job-configuration.component.html
@@ -46,6 +46,16 @@
         </td>
       </tr>
       <tr>
+        <td><strong>Job max parallelism</strong></td>
+        <td>
+          {{
+            config['execution-config']['job-max-parallelism'] === -1
+              ? 'auto'
+              : config['execution-config']['job-max-parallelism']
+          }}
+        </td>
+      </tr>
+      <tr>
         <td><strong>Object reuse mode</strong></td>
         <td>{{ config['execution-config']['object-reuse-mode'] }}</td>
       </tr>

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/overview/detail/job-overview-drawer-detail.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/overview/detail/job-overview-drawer-detail.component.html
@@ -35,6 +35,10 @@
         <dt>
           {{ node.detail.parallelism }}
         </dt>
+        <dd>Max Parallelism</dd>
+        <dt>
+          {{ node.detail.maxParallelism }}
+        </dt>
         <dd>Start Time</dd>
         <dt>
           {{ node.detail['start-time'] | humanizeDate: 'yyyy-MM-dd HH:mm:ss' }}

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/overview/list/job-overview-list.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/overview/list/job-overview-list.component.html
@@ -34,6 +34,7 @@
       <th [nzSortFn]="sortWriteBytesFn" nzWidth="150px">Bytes Sent</th>
       <th [nzSortFn]="sortWriteRecordsFn" nzWidth="120px">Records Sent</th>
       <th [nzSortFn]="sortParallelismFn" nzWidth="120px">Parallelism</th>
+      <th [nzSortFn]="sortParallelismFn" nzWidth="120px">Max Parallelism</th>
       <th [nzSortFn]="sortStartTimeFn" nzWidth="150px">Start Time</th>
       <th [nzSortFn]="sortDurationFn" nzWidth="150px">Duration</th>
       <th [nzSortFn]="sortEndTimeFn" nzWidth="150px">End Time</th>
@@ -96,6 +97,7 @@
         </span>
       </td>
       <td>{{ node.parallelism }}</td>
+      <td>{{ node.maxParallelism }}</td>
       <td>{{ node.detail['start-time'] | humanizeDate: 'yyyy-MM-dd HH:mm:ss' }}</td>
       <td>{{ node.detail?.duration | humanizeDuration }}</td>
       <td>{{ node.detail['end-time'] | humanizeDate: 'yyyy-MM-dd HH:mm:ss' }}</td>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobConfigInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobConfigInfo.java
@@ -171,6 +171,7 @@ public class JobConfigInfo implements ResponseBody {
         public static final String FIELD_NAME_EXECUTION_MODE = "execution-mode";
         public static final String FIELD_NAME_RESTART_STRATEGY = "restart-strategy";
         public static final String FIELD_NAME_PARALLELISM = "job-parallelism";
+        public static final String FIELD_NAME_MAX_PARALLELISM = "job-max-parallelism";
         public static final String FIELD_NAME_OBJECT_REUSE_MODE = "object-reuse-mode";
         public static final String FIELD_NAME_GLOBAL_JOB_PARAMETERS = "user-config";
 
@@ -183,6 +184,9 @@ public class JobConfigInfo implements ResponseBody {
         @JsonProperty(FIELD_NAME_PARALLELISM)
         private final int parallelism;
 
+        @JsonProperty(FIELD_NAME_MAX_PARALLELISM)
+        private final int maxParallelism;
+
         @JsonProperty(FIELD_NAME_OBJECT_REUSE_MODE)
         private final boolean isObjectReuse;
 
@@ -194,12 +198,14 @@ public class JobConfigInfo implements ResponseBody {
                 @JsonProperty(FIELD_NAME_EXECUTION_MODE) String executionMode,
                 @JsonProperty(FIELD_NAME_RESTART_STRATEGY) String restartStrategy,
                 @JsonProperty(FIELD_NAME_PARALLELISM) int parallelism,
+                @JsonProperty(FIELD_NAME_MAX_PARALLELISM) int maxParallelism,
                 @JsonProperty(FIELD_NAME_OBJECT_REUSE_MODE) boolean isObjectReuse,
                 @JsonProperty(FIELD_NAME_GLOBAL_JOB_PARAMETERS)
                         Map<String, String> globalJobParameters) {
             this.executionMode = Preconditions.checkNotNull(executionMode);
             this.restartStrategy = Preconditions.checkNotNull(restartStrategy);
             this.parallelism = parallelism;
+            this.maxParallelism = maxParallelism;
             this.isObjectReuse = isObjectReuse;
             this.globalJobParameters = Preconditions.checkNotNull(globalJobParameters);
         }
@@ -214,6 +220,10 @@ public class JobConfigInfo implements ResponseBody {
 
         public int getParallelism() {
             return parallelism;
+        }
+
+        public int getMaxParallelism() {
+            return maxParallelism;
         }
 
         @JsonIgnore
@@ -235,6 +245,7 @@ public class JobConfigInfo implements ResponseBody {
             }
             ExecutionConfigInfo that = (ExecutionConfigInfo) o;
             return parallelism == that.parallelism
+                    && maxParallelism == that.maxParallelism
                     && isObjectReuse == that.isObjectReuse
                     && Objects.equals(executionMode, that.executionMode)
                     && Objects.equals(restartStrategy, that.restartStrategy)
@@ -247,6 +258,7 @@ public class JobConfigInfo implements ResponseBody {
                     executionMode,
                     restartStrategy,
                     parallelism,
+                    maxParallelism,
                     isObjectReuse,
                     globalJobParameters);
         }
@@ -256,6 +268,7 @@ public class JobConfigInfo implements ResponseBody {
                     archivedExecutionConfig.getExecutionMode(),
                     archivedExecutionConfig.getRestartStrategyDescription(),
                     archivedExecutionConfig.getParallelism(),
+                    archivedExecutionConfig.getMaxParallelism(),
                     archivedExecutionConfig.getObjectReuseEnabled(),
                     ConfigurationUtils.hideSensitiveValues(
                             archivedExecutionConfig.getGlobalJobParameters()));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/allocator/VertexParallelism.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/allocator/VertexParallelism.java
@@ -19,6 +19,8 @@ package org.apache.flink.runtime.scheduler.adaptive.allocator;
 
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 
+import javax.annotation.Nonnull;
+
 import java.util.Collection;
 import java.util.Map;
 
@@ -30,6 +32,13 @@ import java.util.Map;
  * SlotAllocator#tryReserveResources(VertexParallelism)}.
  */
 public interface VertexParallelism {
+    /**
+     * Returns an map with all {@link JobVertexID} and it's maxParallelism, can be empty but can't
+     * be null.
+     *
+     * @return
+     */
+    @Nonnull
     Map<JobVertexID, Integer> getMaxParallelismForVertices();
 
     int getParallelism(JobVertexID jobVertexId);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/JobConfigInfoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/JobConfigInfoTest.java
@@ -40,7 +40,7 @@ public class JobConfigInfoTest extends RestResponseMarshallingTestBase<JobConfig
 
         final JobConfigInfo.ExecutionConfigInfo executionConfigInfo =
                 new JobConfigInfo.ExecutionConfigInfo(
-                        "foobar", "always", 42, false, globalJobParameters);
+                        "foobar", "always", 42, 128, false, globalJobParameters);
         return new JobConfigInfo(new JobID(), "testJob", executionConfigInfo);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

*This pull request show the maximum parallelism(number of key groups) of a job in Web UI*


## Brief change log

  - *ExecutionConfigInfo add maxParallelism*
  - *Job detail page add maxParallelism*
  - *Job configuration page add maxParallelism*
  - *Job overview page add maxParallelism*


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*This change is already covered by existing tests, such as *(please describe tests)*.Such as `JobConfigInfoTest`.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (slightly)
  - If yes, how is the feature documented? (not applicable)
