### PR TITLE
[FLINK-25428][table-common][table-planner] Expose string casting for map, multiset, structured, row and raw

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/CollectionUtil.java
+++ b/flink-core/src/main/java/org/apache/flink/util/CollectionUtil.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.Internal;
 
 import javax.annotation.Nullable;
 
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -113,5 +114,23 @@ public final class CollectionUtil {
         final ArrayList<E> list = new ArrayList<>();
         iterator.forEachRemaining(list::add);
         return list;
+    }
+
+    /** Returns an immutable {@link Map.Entry}. */
+    public static <K, V> Map.Entry<K, V> entry(K k, V v) {
+        return new AbstractMap.SimpleImmutableEntry<>(k, v);
+    }
+
+    /** Returns an immutable {@link Map} from the provided entries. */
+    @SafeVarargs
+    public static <K, V> Map<K, V> map(Map.Entry<K, V>... entries) {
+        if (entries == null) {
+            return Collections.emptyMap();
+        }
+        Map<K, V> map = new HashMap<>();
+        for (Map.Entry<K, V> entry : entries) {
+            map.put(entry.getKey(), entry.getValue());
+        }
+        return Collections.unmodifiableMap(map);
     }
 }

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeCastsTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeCastsTest.java
@@ -44,82 +44,78 @@ import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.table.types.logical.YearMonthIntervalType;
 import org.apache.flink.table.types.logical.utils.LogicalTypeCasts;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.runners.Parameterized.Parameters;
 
 import java.util.Arrays;
-import java.util.List;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link LogicalTypeCasts}. */
-@RunWith(Parameterized.class)
-public class LogicalTypeCastsTest {
+@Execution(ExecutionMode.CONCURRENT)
+class LogicalTypeCastsTest {
 
     @Parameters(name = "{index}: [From: {0}, To: {1}, Implicit: {2}, Explicit: {3}]")
-    public static List<Object[]> testData() {
-        return Arrays.asList(
-                new Object[][] {
-                    {new SmallIntType(), new BigIntType(), true, true},
+    public static Stream<Arguments> testData() {
+        return Stream.of(
+                Arguments.of(new SmallIntType(), new BigIntType(), true, true),
 
-                    // nullability does not match
-                    {new SmallIntType(false), new SmallIntType(), true, true},
-                    {new SmallIntType(), new SmallIntType(false), false, true},
-                    {
+                // nullability does not match
+                Arguments.of(new SmallIntType(false), new SmallIntType(), true, true),
+                Arguments.of(new SmallIntType(), new SmallIntType(false), false, true),
+                Arguments.of(
                         new YearMonthIntervalType(YearMonthIntervalType.YearMonthResolution.YEAR),
                         new SmallIntType(),
                         true,
-                        true
-                    },
+                        true),
 
-                    // not an interval with single field
-                    {
+                // not an interval with single field
+                Arguments.of(
                         new YearMonthIntervalType(
                                 YearMonthIntervalType.YearMonthResolution.YEAR_TO_MONTH),
                         new SmallIntType(),
                         false,
-                        false
-                    },
-                    {new IntType(), new DecimalType(5, 5), true, true},
+                        false),
+                Arguments.of(new IntType(), new DecimalType(5, 5), true, true),
 
-                    // loss of precision
-                    {new FloatType(), new IntType(), false, true},
-                    {new VarCharType(Integer.MAX_VALUE), new FloatType(), false, true},
-                    {new FloatType(), new VarCharType(Integer.MAX_VALUE), false, true},
-                    {new DecimalType(3, 2), new VarCharType(Integer.MAX_VALUE), false, true},
-                    {
+                // loss of precision
+                Arguments.of(new FloatType(), new IntType(), false, true),
+                Arguments.of(new VarCharType(Integer.MAX_VALUE), new FloatType(), false, true),
+                Arguments.of(new FloatType(), new VarCharType(Integer.MAX_VALUE), false, true),
+                Arguments.of(
+                        new DecimalType(3, 2), new VarCharType(Integer.MAX_VALUE), false, true),
+                Arguments.of(
                         new TypeInformationRawType<>(Types.GENERIC(LogicalTypesTest.class)),
                         new TypeInformationRawType<>(Types.GENERIC(LogicalTypesTest.class)),
                         true,
-                        true
-                    },
-                    {
+                        true),
+                Arguments.of(
                         new TypeInformationRawType<>(Types.GENERIC(LogicalTypesTest.class)),
                         new TypeInformationRawType<>(Types.GENERIC(Object.class)),
                         false,
-                        false
-                    },
-                    {new NullType(), new IntType(), true, true},
-                    {
+                        false),
+                Arguments.of(new NullType(), new IntType(), true, true),
+                Arguments.of(
                         new NullType(),
                         new RowType(
                                 Arrays.asList(
                                         new RowField("f1", new IntType()),
                                         new RowField("f2", new IntType()))),
                         true,
-                        true
-                    },
-                    {new ArrayType(new IntType()), new ArrayType(new BigIntType()), true, true},
-                    {
+                        true),
+                Arguments.of(
+                        new ArrayType(new IntType()), new ArrayType(new BigIntType()), true, true),
+                Arguments.of(
                         new ArrayType(new IntType()),
                         new ArrayType(new VarCharType(Integer.MAX_VALUE)),
                         false,
-                        true
-                    },
-                    {
+                        true),
+                Arguments.of(
                         new RowType(
                                 Arrays.asList(
                                         new RowField("f1", new IntType()),
@@ -129,9 +125,8 @@ public class LogicalTypeCastsTest {
                                         new RowField("f1", new IntType()),
                                         new RowField("f2", new BigIntType()))),
                         true,
-                        true
-                    },
-                    {
+                        true),
+                Arguments.of(
                         new RowType(
                                 Arrays.asList(
                                         new RowField("f1", new IntType(), "description"),
@@ -141,9 +136,8 @@ public class LogicalTypeCastsTest {
                                         new RowField("f1", new IntType()),
                                         new RowField("f2", new BigIntType()))),
                         true,
-                        true
-                    },
-                    {
+                        true),
+                Arguments.of(
                         new RowType(
                                 Arrays.asList(
                                         new RowField("f1", new IntType()),
@@ -153,32 +147,33 @@ public class LogicalTypeCastsTest {
                                         new RowField("f1", new IntType()),
                                         new RowField("f2", new BooleanType()))),
                         false,
-                        true
-                    },
-                    {
+                        true),
+                Arguments.of(
                         new RowType(
                                 Arrays.asList(
                                         new RowField("f1", new IntType()),
                                         new RowField("f2", new IntType()))),
                         new VarCharType(Integer.MAX_VALUE),
                         false,
-                        false
-                    },
+                        true),
 
-                    // timestamp type and timestamp_ltz type
-                    {new TimestampType(9), new TimestampType(9), true, true},
-                    {new LocalZonedTimestampType(9), new LocalZonedTimestampType(9), true, true},
-                    {new TimestampType(3), new LocalZonedTimestampType(3), true, true},
-                    {new LocalZonedTimestampType(3), new TimestampType(3), true, true},
-                    {new TimestampType(3), new LocalZonedTimestampType(6), true, true},
-                    {new LocalZonedTimestampType(3), new TimestampType(6), true, true},
-                    {new TimestampType(false, 3), new LocalZonedTimestampType(6), true, true},
-                    {new LocalZonedTimestampType(false, 3), new TimestampType(6), true, true},
-                    {new TimestampType(6), new LocalZonedTimestampType(3), true, true},
-                    {new LocalZonedTimestampType(6), new TimestampType(3), true, true},
+                // timestamp type and timestamp_ltz type
+                Arguments.of(new TimestampType(9), new TimestampType(9), true, true),
+                Arguments.of(
+                        new LocalZonedTimestampType(9), new LocalZonedTimestampType(9), true, true),
+                Arguments.of(new TimestampType(3), new LocalZonedTimestampType(3), true, true),
+                Arguments.of(new LocalZonedTimestampType(3), new TimestampType(3), true, true),
+                Arguments.of(new TimestampType(3), new LocalZonedTimestampType(6), true, true),
+                Arguments.of(new LocalZonedTimestampType(3), new TimestampType(6), true, true),
+                Arguments.of(
+                        new TimestampType(false, 3), new LocalZonedTimestampType(6), true, true),
+                Arguments.of(
+                        new LocalZonedTimestampType(false, 3), new TimestampType(6), true, true),
+                Arguments.of(new TimestampType(6), new LocalZonedTimestampType(3), true, true),
+                Arguments.of(new LocalZonedTimestampType(6), new TimestampType(3), true, true),
 
-                    // row and structured type
-                    {
+                // row and structured type
+                Arguments.of(
                         new RowType(
                                 Arrays.asList(
                                         new RowField("f1", new TimestampType()),
@@ -190,9 +185,8 @@ public class LogicalTypeCastsTest {
                                                 new StructuredAttribute("f2", new IntType())))
                                 .build(),
                         true,
-                        true
-                    },
-                    {
+                        true),
+                Arguments.of(
                         new RowType(
                                 Arrays.asList(
                                         new RowField("f1", new TimestampType()),
@@ -204,9 +198,8 @@ public class LogicalTypeCastsTest {
                                                 new StructuredAttribute("diff", new IntType())))
                                 .build(),
                         true,
-                        true
-                    },
-                    {
+                        true),
+                Arguments.of(
                         new RowType(
                                 Arrays.asList(
                                         new RowField("f1", new TimestampType()),
@@ -218,11 +211,10 @@ public class LogicalTypeCastsTest {
                                                 new StructuredAttribute("diff", new TinyIntType())))
                                 .build(),
                         false,
-                        true
-                    },
+                        true),
 
-                    // test slightly different children of anonymous structured types
-                    {
+                // test slightly different children of anonymous structured types
+                Arguments.of(
                         StructuredType.newBuilder(Void.class)
                                 .attributes(
                                         Arrays.asList(
@@ -238,9 +230,8 @@ public class LogicalTypeCastsTest {
                                                         "diff", new TinyIntType(true))))
                                 .build(),
                         true,
-                        true
-                    },
-                    {
+                        true),
+                Arguments.of(
                         StructuredType.newBuilder(Void.class)
                                 .attributes(
                                         Arrays.asList(
@@ -254,39 +245,28 @@ public class LogicalTypeCastsTest {
                                                 new StructuredAttribute("diff", new TinyIntType())))
                                 .build(),
                         false,
-                        true
-                    },
+                        true),
 
-                    // raw to binary
-                    {
+                // raw to binary
+                Arguments.of(
                         new RawType(Integer.class, IntSerializer.INSTANCE),
                         new BinaryType(),
                         false,
-                        true
-                    },
-                });
+                        true));
     }
 
-    @Parameter public LogicalType sourceType;
-
-    @Parameter(1)
-    public LogicalType targetType;
-
-    @Parameter(2)
-    public boolean supportsImplicit;
-
-    @Parameter(3)
-    public boolean supportsExplicit;
-
-    @Test
-    public void testImplicitCasting() {
+    @ParameterizedTest(name = "{index}: [From: {0}, To: {1}, Implicit: {2}, Explicit: {3}]")
+    @MethodSource("testData")
+    void test(
+            LogicalType sourceType,
+            LogicalType targetType,
+            boolean supportsImplicit,
+            boolean supportsExplicit) {
         assertThat(LogicalTypeCasts.supportsImplicitCast(sourceType, targetType))
+                .as("Supports implicit casting")
                 .isEqualTo(supportsImplicit);
-    }
-
-    @Test
-    public void testExplicitCasting() {
         assertThat(LogicalTypeCasts.supportsExplicitCast(sourceType, targetType))
+                .as("Supports explicit casting")
                 .isEqualTo(supportsExplicit);
     }
 }

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeCastsTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeCastsTest.java
@@ -49,7 +49,6 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.runners.Parameterized.Parameters;
 
 import java.util.Arrays;
 import java.util.stream.Stream;
@@ -60,7 +59,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Execution(ExecutionMode.CONCURRENT)
 class LogicalTypeCastsTest {
 
-    @Parameters(name = "{index}: [From: {0}, To: {1}, Implicit: {2}, Explicit: {3}]")
     public static Stream<Arguments> testData() {
         return Stream.of(
                 Arguments.of(new SmallIntType(), new BigIntType(), true, true),
@@ -249,8 +247,14 @@ class LogicalTypeCastsTest {
 
                 // raw to binary
                 Arguments.of(
-                        new RawType(Integer.class, IntSerializer.INSTANCE),
+                        new RawType<>(Integer.class, IntSerializer.INSTANCE),
                         new BinaryType(),
+                        false,
+                        true),
+                // raw to binary
+                Arguments.of(
+                        new RawType<>(Integer.class, IntSerializer.INSTANCE),
+                        VarCharType.STRING_TYPE,
                         false,
                         true));
     }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/calcite/sql/fun/SqlCastFunction.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/calcite/sql/fun/SqlCastFunction.java
@@ -1,0 +1,213 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql.fun;
+
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeFamily;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.utils.LogicalTypeCasts;
+
+import com.google.common.collect.ImmutableSetMultimap;
+import com.google.common.collect.SetMultimap;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFamily;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlCallBinding;
+import org.apache.calcite.sql.SqlDynamicParam;
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlIntervalQualifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperandCountRange;
+import org.apache.calcite.sql.SqlOperatorBinding;
+import org.apache.calcite.sql.SqlSyntax;
+import org.apache.calcite.sql.SqlUtil;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.type.InferTypes;
+import org.apache.calcite.sql.type.SqlOperandCountRanges;
+import org.apache.calcite.sql.type.SqlTypeFamily;
+import org.apache.calcite.sql.type.SqlTypeUtil;
+import org.apache.calcite.sql.validate.SqlMonotonicity;
+import org.apache.calcite.sql.validate.SqlValidatorImpl;
+
+import java.text.Collator;
+import java.util.Objects;
+
+import static org.apache.calcite.util.Static.RESOURCE;
+
+/**
+ * SqlCastFunction. Note that the std functions are really singleton objects, because they always
+ * get fetched via the StdOperatorTable. So you can't store any local info in the class and hence
+ * the return type data is maintained in operand[1] through the validation phase.
+ *
+ * <p>Can be used for both {@link SqlCall} and {@link org.apache.calcite.rex.RexCall}. Note that the
+ * {@code SqlCall} has two operands (expression and type), while the {@code RexCall} has one operand
+ * (expression) and the type is obtained from {@link org.apache.calcite.rex.RexNode#getType()}.
+ *
+ * <p>The class was copied over because of CALCITE-XXXX, in order to workaround the method {@link
+ * SqlTypeUtil#canCastFrom(RelDataType, RelDataType, boolean)}. Line 141 in {@link
+ * #checkOperandTypes(SqlCallBinding, boolean)} and new method {@link #canCastFrom(RelDataType,
+ * RelDataType)}.
+ *
+ * @see SqlCastOperator
+ */
+public class SqlCastFunction extends SqlFunction {
+    // ~ Instance fields --------------------------------------------------------
+
+    /** Map of all casts that do not preserve monotonicity. */
+    private final SetMultimap<SqlTypeFamily, SqlTypeFamily> nonMonotonicCasts =
+            ImmutableSetMultimap.<SqlTypeFamily, SqlTypeFamily>builder()
+                    .put(SqlTypeFamily.EXACT_NUMERIC, SqlTypeFamily.CHARACTER)
+                    .put(SqlTypeFamily.NUMERIC, SqlTypeFamily.CHARACTER)
+                    .put(SqlTypeFamily.APPROXIMATE_NUMERIC, SqlTypeFamily.CHARACTER)
+                    .put(SqlTypeFamily.DATETIME_INTERVAL, SqlTypeFamily.CHARACTER)
+                    .put(SqlTypeFamily.CHARACTER, SqlTypeFamily.EXACT_NUMERIC)
+                    .put(SqlTypeFamily.CHARACTER, SqlTypeFamily.NUMERIC)
+                    .put(SqlTypeFamily.CHARACTER, SqlTypeFamily.APPROXIMATE_NUMERIC)
+                    .put(SqlTypeFamily.CHARACTER, SqlTypeFamily.DATETIME_INTERVAL)
+                    .put(SqlTypeFamily.DATETIME, SqlTypeFamily.TIME)
+                    .put(SqlTypeFamily.TIMESTAMP, SqlTypeFamily.TIME)
+                    .put(SqlTypeFamily.TIME, SqlTypeFamily.DATETIME)
+                    .put(SqlTypeFamily.TIME, SqlTypeFamily.TIMESTAMP)
+                    .build();
+
+    // ~ Constructors -----------------------------------------------------------
+
+    public SqlCastFunction() {
+        super("CAST", SqlKind.CAST, null, InferTypes.FIRST_KNOWN, null, SqlFunctionCategory.SYSTEM);
+    }
+
+    // ~ Methods ----------------------------------------------------------------
+
+    public RelDataType inferReturnType(SqlOperatorBinding opBinding) {
+        assert opBinding.getOperandCount() == 2;
+        RelDataType ret = opBinding.getOperandType(1);
+        RelDataType firstType = opBinding.getOperandType(0);
+        ret = opBinding.getTypeFactory().createTypeWithNullability(ret, firstType.isNullable());
+        if (opBinding instanceof SqlCallBinding) {
+            SqlCallBinding callBinding = (SqlCallBinding) opBinding;
+            SqlNode operand0 = callBinding.operand(0);
+
+            // dynamic parameters and null constants need their types assigned
+            // to them using the type they are casted to.
+            if (((operand0 instanceof SqlLiteral) && (((SqlLiteral) operand0).getValue() == null))
+                    || (operand0 instanceof SqlDynamicParam)) {
+                final SqlValidatorImpl validator = (SqlValidatorImpl) callBinding.getValidator();
+                validator.setValidatedNodeType(operand0, ret);
+            }
+        }
+        return ret;
+    }
+
+    public String getSignatureTemplate(final int operandsCount) {
+        assert operandsCount == 2;
+        return "{0}({1} AS {2})";
+    }
+
+    public SqlOperandCountRange getOperandCountRange() {
+        return SqlOperandCountRanges.of(2);
+    }
+
+    /**
+     * Makes sure that the number and types of arguments are allowable. Operators (such as "ROW" and
+     * "AS") which do not check their arguments can override this method.
+     */
+    public boolean checkOperandTypes(SqlCallBinding callBinding, boolean throwOnFailure) {
+        final SqlNode left = callBinding.operand(0);
+        final SqlNode right = callBinding.operand(1);
+        if (SqlUtil.isNullLiteral(left, false) || left instanceof SqlDynamicParam) {
+            return true;
+        }
+        RelDataType validatedNodeType = callBinding.getValidator().getValidatedNodeType(left);
+        RelDataType returnType = SqlTypeUtil.deriveType(callBinding, right);
+        if (!canCastFrom(returnType, validatedNodeType)) {
+            if (throwOnFailure) {
+                throw callBinding.newError(
+                        RESOURCE.cannotCastValue(
+                                validatedNodeType.toString(), returnType.toString()));
+            }
+            return false;
+        }
+        if (SqlTypeUtil.areCharacterSetsMismatched(validatedNodeType, returnType)) {
+            if (throwOnFailure) {
+                // Include full type string to indicate character
+                // set mismatch.
+                throw callBinding.newError(
+                        RESOURCE.cannotCastValue(
+                                validatedNodeType.getFullTypeString(),
+                                returnType.getFullTypeString()));
+            }
+            return false;
+        }
+        return true;
+    }
+
+    private boolean canCastFrom(RelDataType toType, RelDataType fromType) {
+        LogicalType from = FlinkTypeFactory.toLogicalType(fromType);
+        if (from.is(LogicalTypeFamily.CONSTRUCTED)
+                || from.is(LogicalTypeRoot.RAW)
+                || from.is(LogicalTypeRoot.STRUCTURED_TYPE)) {
+            return LogicalTypeCasts.supportsExplicitCast(
+                    from, FlinkTypeFactory.toLogicalType(toType));
+        }
+        return SqlTypeUtil.canCastFrom(toType, fromType, true);
+    }
+
+    public SqlSyntax getSyntax() {
+        return SqlSyntax.SPECIAL;
+    }
+
+    public void unparse(SqlWriter writer, SqlCall call, int leftPrec, int rightPrec) {
+        assert call.operandCount() == 2;
+        final SqlWriter.Frame frame = writer.startFunCall(getName());
+        call.operand(0).unparse(writer, 0, 0);
+        writer.sep("AS");
+        if (call.operand(1) instanceof SqlIntervalQualifier) {
+            writer.sep("INTERVAL");
+        }
+        call.operand(1).unparse(writer, 0, 0);
+        writer.endFunCall(frame);
+    }
+
+    @Override
+    public SqlMonotonicity getMonotonicity(SqlOperatorBinding call) {
+        final RelDataType castFromType = call.getOperandType(0);
+        final RelDataTypeFamily castFromFamily = castFromType.getFamily();
+        final Collator castFromCollator =
+                castFromType.getCollation() == null
+                        ? null
+                        : castFromType.getCollation().getCollator();
+        final RelDataType castToType = call.getOperandType(1);
+        final RelDataTypeFamily castToFamily = castToType.getFamily();
+        final Collator castToCollator =
+                castToType.getCollation() == null ? null : castToType.getCollation().getCollator();
+        if (!Objects.equals(castFromCollator, castToCollator)) {
+            // Cast between types compared with different collators: not monotonic.
+            return SqlMonotonicity.NOT_MONOTONIC;
+        } else if (castFromFamily instanceof SqlTypeFamily
+                && castToFamily instanceof SqlTypeFamily
+                && nonMonotonicCasts.containsEntry(castFromFamily, castToFamily)) {
+            return SqlMonotonicity.NOT_MONOTONIC;
+        } else {
+            return call.getOperandMonotonicity(0);
+        }
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/calcite/sql/fun/SqlCastFunction.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/calcite/sql/fun/SqlCastFunction.java
@@ -60,7 +60,7 @@ import static org.apache.calcite.util.Static.RESOURCE;
  * {@code SqlCall} has two operands (expression and type), while the {@code RexCall} has one operand
  * (expression) and the type is obtained from {@link org.apache.calcite.rex.RexNode#getType()}.
  *
- * <p>The class was copied over because of CALCITE-XXXX, in order to workaround the method {@link
+ * <p>The class was copied over because of CALCITE-5017, in order to workaround the method {@link
  * SqlTypeUtil#canCastFrom(RelDataType, RelDataType, boolean)}. Line 141 in {@link
  * #checkOperandTypes(SqlCallBinding, boolean)} and new method {@link #canCastFrom(RelDataType,
  * RelDataType)}.

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
@@ -28,6 +28,7 @@ import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.LogicalTypeFamily;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.utils.LogicalTypeCasts;
 import org.apache.flink.types.Row;
 
 import org.junit.runners.Parameterized;
@@ -61,6 +62,7 @@ import static org.apache.flink.table.api.DataTypes.DATE;
 import static org.apache.flink.table.api.DataTypes.DAY;
 import static org.apache.flink.table.api.DataTypes.DECIMAL;
 import static org.apache.flink.table.api.DataTypes.DOUBLE;
+import static org.apache.flink.table.api.DataTypes.FIELD;
 import static org.apache.flink.table.api.DataTypes.FLOAT;
 import static org.apache.flink.table.api.DataTypes.INT;
 import static org.apache.flink.table.api.DataTypes.INTERVAL;
@@ -79,6 +81,7 @@ import static org.apache.flink.table.api.DataTypes.VARCHAR;
 import static org.apache.flink.table.api.DataTypes.YEAR;
 import static org.apache.flink.table.api.Expressions.$;
 import static org.apache.flink.table.api.config.ExecutionConfigOptions.LegacyCastBehaviour;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link BuiltInFunctionDefinitions#CAST}. */
 public class CastFunctionITCase extends BuiltInFunctionTestBase {
@@ -127,6 +130,7 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
     public static List<TestSpec> testData() {
         final List<TestSpec> specs = new ArrayList<>();
         specs.addAll(allTypesBasic());
+        specs.addAll(toStringCasts());
         specs.addAll(decimalCasts());
         specs.addAll(numericBounds());
         specs.addAll(constructedTypes());
@@ -135,126 +139,6 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
 
     public static List<TestSpec> allTypesBasic() {
         return Arrays.asList(
-                CastTestSpecBuilder.testCastTo(CHAR(3))
-                        .fromCase(CHAR(5), null, null)
-                        .fromCase(CHAR(3), "foo", "foo")
-                        .fromCase(VARCHAR(3), "foo", "foo")
-                        .fromCase(VARCHAR(5), "foo", "foo")
-                        .fromCase(STRING(), "abcdef", "abc")
-                        .fromCase(DATE(), DEFAULT_DATE, "202")
-                        .build(),
-                CastTestSpecBuilder.testCastTo(CHAR(5))
-                        .fromCase(CHAR(5), null, null)
-                        .fromCase(CHAR(3), "foo", "foo  ")
-                        .build(),
-                CastTestSpecBuilder.testCastTo(VARCHAR(3))
-                        .fromCase(VARCHAR(5), null, null)
-                        .fromCase(CHAR(3), "foo", "foo")
-                        .fromCase(CHAR(4), "foo", "foo")
-                        .fromCase(VARCHAR(3), "foo", "foo")
-                        .fromCase(VARCHAR(5), "foo", "foo")
-                        .fromCase(STRING(), "abcdef", "abc")
-                        .build(),
-                CastTestSpecBuilder.testCastTo(STRING())
-                        .fromCase(STRING(), null, null)
-                        .fromCase(CHAR(3), "foo", "foo")
-                        .fromCase(CHAR(5), "foo", "foo  ")
-                        .fromCase(VARCHAR(5), "Flink", "Flink")
-                        .fromCase(VARCHAR(10), "Flink", "Flink")
-                        .fromCase(STRING(), "Apache Flink", "Apache Flink")
-                        .fromCase(STRING(), null, null)
-                        .fromCase(BOOLEAN(), true, "TRUE")
-                        .fromCase(BINARY(2), DEFAULT_BINARY, "0001")
-                        .fromCase(BINARY(3), DEFAULT_BINARY, "000100")
-                        .fromCase(VARBINARY(3), DEFAULT_VARBINARY, "000102")
-                        .fromCase(VARBINARY(5), DEFAULT_VARBINARY, "000102")
-                        .fromCase(BYTES(), DEFAULT_BYTES, "0001020304")
-                        .fromCase(DECIMAL(4, 3), 9.87, "9.870")
-                        .fromCase(DECIMAL(10, 5), 1, "1.00000")
-                        .fromCase(
-                                TINYINT(),
-                                DEFAULT_POSITIVE_TINY_INT,
-                                String.valueOf(DEFAULT_POSITIVE_TINY_INT))
-                        .fromCase(
-                                TINYINT(),
-                                DEFAULT_NEGATIVE_TINY_INT,
-                                String.valueOf(DEFAULT_NEGATIVE_TINY_INT))
-                        .fromCase(
-                                SMALLINT(),
-                                DEFAULT_POSITIVE_SMALL_INT,
-                                String.valueOf(DEFAULT_POSITIVE_SMALL_INT))
-                        .fromCase(
-                                SMALLINT(),
-                                DEFAULT_NEGATIVE_SMALL_INT,
-                                String.valueOf(DEFAULT_NEGATIVE_SMALL_INT))
-                        .fromCase(INT(), DEFAULT_POSITIVE_INT, String.valueOf(DEFAULT_POSITIVE_INT))
-                        .fromCase(INT(), DEFAULT_NEGATIVE_INT, String.valueOf(DEFAULT_NEGATIVE_INT))
-                        .fromCase(
-                                BIGINT(),
-                                DEFAULT_POSITIVE_BIGINT,
-                                String.valueOf(DEFAULT_POSITIVE_BIGINT))
-                        .fromCase(
-                                BIGINT(),
-                                DEFAULT_NEGATIVE_BIGINT,
-                                String.valueOf(DEFAULT_NEGATIVE_BIGINT))
-                        .fromCase(
-                                FLOAT(),
-                                DEFAULT_POSITIVE_FLOAT,
-                                String.valueOf(DEFAULT_POSITIVE_FLOAT))
-                        .fromCase(
-                                FLOAT(),
-                                DEFAULT_NEGATIVE_FLOAT,
-                                String.valueOf(DEFAULT_NEGATIVE_FLOAT))
-                        .fromCase(
-                                DOUBLE(),
-                                DEFAULT_POSITIVE_DOUBLE,
-                                String.valueOf(DEFAULT_POSITIVE_DOUBLE))
-                        .fromCase(
-                                DOUBLE(),
-                                DEFAULT_NEGATIVE_DOUBLE,
-                                String.valueOf(DEFAULT_NEGATIVE_DOUBLE))
-                        .fromCase(DATE(), DEFAULT_DATE, "2021-09-24")
-                        // https://issues.apache.org/jira/browse/FLINK-17224 Currently, fractional
-                        // seconds are lost
-                        .fromCase(TIME(5), DEFAULT_TIME, "12:34:56")
-                        .fromCase(TIMESTAMP(), DEFAULT_TIMESTAMP, "2021-09-24 12:34:56.123456")
-                        .fromCase(TIMESTAMP(9), DEFAULT_TIMESTAMP, "2021-09-24 12:34:56.123456700")
-                        .fromCase(TIMESTAMP(4), DEFAULT_TIMESTAMP, "2021-09-24 12:34:56.1234")
-                        .fromCase(
-                                TIMESTAMP(3),
-                                LocalDateTime.parse("2021-09-24T12:34:56.1"),
-                                "2021-09-24 12:34:56.100")
-                        .fromCase(TIMESTAMP(4).nullable(), null, null)
-
-                        // https://issues.apache.org/jira/browse/FLINK-20869
-                        // TIMESTAMP_WITH_TIME_ZONE
-
-                        .fromCase(
-                                TIMESTAMP_LTZ(5),
-                                DEFAULT_TIMESTAMP_LTZ,
-                                "2021-09-25 07:54:56.12345")
-                        .fromCase(
-                                TIMESTAMP_LTZ(9),
-                                DEFAULT_TIMESTAMP_LTZ,
-                                "2021-09-25 07:54:56.123456700")
-                        .fromCase(
-                                TIMESTAMP_LTZ(3),
-                                fromLocalTZ("2021-09-24T22:34:56.1"),
-                                "2021-09-25 07:54:56.100")
-                        .fromCase(INTERVAL(YEAR()), 84, "+7-00")
-                        .fromCase(INTERVAL(MONTH()), 5, "+0-05")
-                        .fromCase(INTERVAL(MONTH()), 123, "+10-03")
-                        .fromCase(INTERVAL(MONTH()), 12334, "+1027-10")
-                        .fromCase(INTERVAL(DAY()), 10, "+0 00:00:00.010")
-                        .fromCase(INTERVAL(DAY()), 123456789L, "+1 10:17:36.789")
-                        .fromCase(INTERVAL(DAY()), Duration.ofHours(36), "+1 12:00:00.000")
-                        // https://issues.apache.org/jira/browse/FLINK-21456 Not supported currently
-                        .failValidation(ARRAY(INT()), DEFAULT_ARRAY)
-                        // MULTISET
-                        // MAP
-                        // ROW
-                        // RAW
-                        .build(),
                 CastTestSpecBuilder.testCastTo(BOOLEAN())
                         .fromCase(BOOLEAN(), null, null)
                         .failRuntime(CHAR(3), "foo", TableException.class)
@@ -1079,6 +963,135 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                 );
     }
 
+    public static List<TestSpec> toStringCasts() {
+        return Arrays.asList(
+                CastTestSpecBuilder.testCastTo(CHAR(3))
+                        .fromCase(CHAR(5), null, null)
+                        .fromCase(CHAR(3), "foo", "foo")
+                        .fromCase(VARCHAR(3), "foo", "foo")
+                        .fromCase(VARCHAR(5), "foo", "foo")
+                        .fromCase(STRING(), "abcdef", "abc")
+                        .fromCase(DATE(), DEFAULT_DATE, "202")
+                        .build(),
+                CastTestSpecBuilder.testCastTo(CHAR(5))
+                        .fromCase(CHAR(5), null, null)
+                        .fromCase(CHAR(3), "foo", "foo  ")
+                        .build(),
+                CastTestSpecBuilder.testCastTo(VARCHAR(3))
+                        .fromCase(VARCHAR(5), null, null)
+                        .fromCase(CHAR(3), "foo", "foo")
+                        .fromCase(CHAR(4), "foo", "foo")
+                        .fromCase(VARCHAR(3), "foo", "foo")
+                        .fromCase(VARCHAR(5), "foo", "foo")
+                        .fromCase(STRING(), "abcdef", "abc")
+                        .build(),
+                CastTestSpecBuilder.testCastTo(STRING())
+                        .fromCase(STRING(), null, null)
+                        .fromCase(CHAR(3), "foo", "foo")
+                        .fromCase(CHAR(5), "foo", "foo  ")
+                        .fromCase(VARCHAR(5), "Flink", "Flink")
+                        .fromCase(VARCHAR(10), "Flink", "Flink")
+                        .fromCase(STRING(), "Apache Flink", "Apache Flink")
+                        .fromCase(STRING(), null, null)
+                        .fromCase(BOOLEAN(), true, "TRUE")
+                        .fromCase(BINARY(2), DEFAULT_BINARY, "0001")
+                        .fromCase(BINARY(3), DEFAULT_BINARY, "000100")
+                        .fromCase(VARBINARY(3), DEFAULT_VARBINARY, "000102")
+                        .fromCase(VARBINARY(5), DEFAULT_VARBINARY, "000102")
+                        .fromCase(BYTES(), DEFAULT_BYTES, "0001020304")
+                        .fromCase(DECIMAL(4, 3), 9.87, "9.870")
+                        .fromCase(DECIMAL(10, 5), 1, "1.00000")
+                        .fromCase(
+                                TINYINT(),
+                                DEFAULT_POSITIVE_TINY_INT,
+                                String.valueOf(DEFAULT_POSITIVE_TINY_INT))
+                        .fromCase(
+                                TINYINT(),
+                                DEFAULT_NEGATIVE_TINY_INT,
+                                String.valueOf(DEFAULT_NEGATIVE_TINY_INT))
+                        .fromCase(
+                                SMALLINT(),
+                                DEFAULT_POSITIVE_SMALL_INT,
+                                String.valueOf(DEFAULT_POSITIVE_SMALL_INT))
+                        .fromCase(
+                                SMALLINT(),
+                                DEFAULT_NEGATIVE_SMALL_INT,
+                                String.valueOf(DEFAULT_NEGATIVE_SMALL_INT))
+                        .fromCase(INT(), DEFAULT_POSITIVE_INT, String.valueOf(DEFAULT_POSITIVE_INT))
+                        .fromCase(INT(), DEFAULT_NEGATIVE_INT, String.valueOf(DEFAULT_NEGATIVE_INT))
+                        .fromCase(
+                                BIGINT(),
+                                DEFAULT_POSITIVE_BIGINT,
+                                String.valueOf(DEFAULT_POSITIVE_BIGINT))
+                        .fromCase(
+                                BIGINT(),
+                                DEFAULT_NEGATIVE_BIGINT,
+                                String.valueOf(DEFAULT_NEGATIVE_BIGINT))
+                        .fromCase(
+                                FLOAT(),
+                                DEFAULT_POSITIVE_FLOAT,
+                                String.valueOf(DEFAULT_POSITIVE_FLOAT))
+                        .fromCase(
+                                FLOAT(),
+                                DEFAULT_NEGATIVE_FLOAT,
+                                String.valueOf(DEFAULT_NEGATIVE_FLOAT))
+                        .fromCase(
+                                DOUBLE(),
+                                DEFAULT_POSITIVE_DOUBLE,
+                                String.valueOf(DEFAULT_POSITIVE_DOUBLE))
+                        .fromCase(
+                                DOUBLE(),
+                                DEFAULT_NEGATIVE_DOUBLE,
+                                String.valueOf(DEFAULT_NEGATIVE_DOUBLE))
+                        .fromCase(DATE(), DEFAULT_DATE, "2021-09-24")
+                        // https://issues.apache.org/jira/browse/FLINK-17224 Currently, fractional
+                        // seconds are lost
+                        .fromCase(TIME(5), DEFAULT_TIME, "12:34:56")
+                        .fromCase(TIMESTAMP(), DEFAULT_TIMESTAMP, "2021-09-24 12:34:56.123456")
+                        .fromCase(TIMESTAMP(9), DEFAULT_TIMESTAMP, "2021-09-24 12:34:56.123456700")
+                        .fromCase(TIMESTAMP(4), DEFAULT_TIMESTAMP, "2021-09-24 12:34:56.1234")
+                        .fromCase(
+                                TIMESTAMP(3),
+                                LocalDateTime.parse("2021-09-24T12:34:56.1"),
+                                "2021-09-24 12:34:56.100")
+                        .fromCase(TIMESTAMP(4).nullable(), null, null)
+
+                        // https://issues.apache.org/jira/browse/FLINK-20869
+                        // TIMESTAMP_WITH_TIME_ZONE
+
+                        .fromCase(
+                                TIMESTAMP_LTZ(5),
+                                DEFAULT_TIMESTAMP_LTZ,
+                                "2021-09-25 07:54:56.12345")
+                        .fromCase(
+                                TIMESTAMP_LTZ(9),
+                                DEFAULT_TIMESTAMP_LTZ,
+                                "2021-09-25 07:54:56.123456700")
+                        .fromCase(
+                                TIMESTAMP_LTZ(3),
+                                fromLocalTZ("2021-09-24T22:34:56.1"),
+                                "2021-09-25 07:54:56.100")
+                        .fromCase(INTERVAL(YEAR()), 84, "+7-00")
+                        .fromCase(INTERVAL(MONTH()), 5, "+0-05")
+                        .fromCase(INTERVAL(MONTH()), 123, "+10-03")
+                        .fromCase(INTERVAL(MONTH()), 12334, "+1027-10")
+                        .fromCase(INTERVAL(DAY()), 10, "+0 00:00:00.010")
+                        .fromCase(INTERVAL(DAY()), 123456789L, "+1 10:17:36.789")
+                        .fromCase(INTERVAL(DAY()), Duration.ofHours(36), "+1 12:00:00.000")
+                        .fromCase(ARRAY(INT().nullable()), new Integer[] {null, 456}, "[NULL, 456]")
+                        .fromCase(
+                                MAP(STRING(), INTERVAL(MONTH()).nullable()),
+                                map(entry("a", -123), entry("b", null)),
+                                "{a=-10-03, b=NULL}")
+                        .fromCase(
+                                ROW(FIELD("f0", INT().nullable()), FIELD("f1", STRING())),
+                                Row.of(null, "abc"),
+                                "(NULL, abc)")
+                        // MULTISET, RAW and STRUCTURED are tested in CastFunctionMiscITCase,
+                        // because we need to work around the limitations of fromValues
+                        .build());
+    }
+
     public static List<TestSpec> decimalCasts() {
         return Collections.singletonList(
                 CastTestSpecBuilder.testCastTo(DECIMAL(8, 4))
@@ -1237,6 +1250,11 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
             this.columnTypes.add(dataType);
             this.columnData.add(src);
             this.expectedValues.add(target);
+            assertThat(
+                            LogicalTypeCasts.supportsExplicitCast(
+                                    dataType.getLogicalType(), targetType.getLogicalType()))
+                    .as("Should support explicit casting")
+                    .isTrue();
             return this;
         }
 
@@ -1360,12 +1378,12 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
         return srcType.is(LogicalTypeFamily.TIMESTAMP) && trgType.is(LogicalTypeFamily.NUMERIC);
     }
 
-    private static <K, V> Map.Entry<K, V> entry(K k, V v) {
+    static <K, V> Map.Entry<K, V> entry(K k, V v) {
         return new AbstractMap.SimpleImmutableEntry<>(k, v);
     }
 
     @SafeVarargs
-    private static <K, V> Map<K, V> map(Map.Entry<K, V>... entries) {
+    static <K, V> Map<K, V> map(Map.Entry<K, V>... entries) {
         if (entries == null) {
             return Collections.emptyMap();
         }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
@@ -44,13 +44,10 @@ import java.time.LocalTime;
 import java.time.Period;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
-import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import static org.apache.flink.table.api.DataTypes.ARRAY;
 import static org.apache.flink.table.api.DataTypes.BIGINT;
@@ -81,6 +78,8 @@ import static org.apache.flink.table.api.DataTypes.VARCHAR;
 import static org.apache.flink.table.api.DataTypes.YEAR;
 import static org.apache.flink.table.api.Expressions.$;
 import static org.apache.flink.table.api.config.ExecutionConfigOptions.LegacyCastBehaviour;
+import static org.apache.flink.util.CollectionUtil.entry;
+import static org.apache.flink.util.CollectionUtil.map;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link BuiltInFunctionDefinitions#CAST}. */
@@ -1376,21 +1375,5 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
 
     private static boolean isTimestampToNumeric(LogicalType srcType, LogicalType trgType) {
         return srcType.is(LogicalTypeFamily.TIMESTAMP) && trgType.is(LogicalTypeFamily.NUMERIC);
-    }
-
-    static <K, V> Map.Entry<K, V> entry(K k, V v) {
-        return new AbstractMap.SimpleImmutableEntry<>(k, v);
-    }
-
-    @SafeVarargs
-    static <K, V> Map<K, V> map(Map.Entry<K, V>... entries) {
-        if (entries == null) {
-            return Collections.emptyMap();
-        }
-        Map<K, V> map = new HashMap<>();
-        for (Map.Entry<K, V> entry : entries) {
-            map.put(entry.getKey(), entry.getValue());
-        }
-        return map;
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionMiscITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionMiscITCase.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.planner.functions;
 
+import org.apache.flink.api.common.typeutils.base.LocalDateTimeSerializer;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.annotation.DataTypeHint;
 import org.apache.flink.table.api.DataTypes;
@@ -29,6 +30,7 @@ import org.apache.flink.types.Row;
 import org.junit.runners.Parameterized;
 
 import java.nio.ByteBuffer;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.Arrays;
 import java.util.List;
@@ -39,6 +41,7 @@ import static org.apache.flink.table.api.DataTypes.BOOLEAN;
 import static org.apache.flink.table.api.DataTypes.BYTES;
 import static org.apache.flink.table.api.DataTypes.FIELD;
 import static org.apache.flink.table.api.DataTypes.INT;
+import static org.apache.flink.table.api.DataTypes.MAP;
 import static org.apache.flink.table.api.DataTypes.ROW;
 import static org.apache.flink.table.api.DataTypes.STRING;
 import static org.apache.flink.table.api.DataTypes.TIME;
@@ -47,6 +50,8 @@ import static org.apache.flink.table.api.DataTypes.VARBINARY;
 import static org.apache.flink.table.api.Expressions.$;
 import static org.apache.flink.table.api.Expressions.call;
 import static org.apache.flink.table.api.Expressions.row;
+import static org.apache.flink.table.planner.functions.CastFunctionITCase.entry;
+import static org.apache.flink.table.planner.functions.CastFunctionITCase.map;
 
 /** Tests for {@link BuiltInFunctionDefinitions#CAST} regarding {@link DataTypes#ROW}. */
 public class CastFunctionMiscITCase extends BuiltInFunctionTestBase {
@@ -210,6 +215,33 @@ public class CastFunctionMiscITCase extends BuiltInFunctionTestBase {
                                 "CAST(CAST(x'68656C6C6F2063617374' AS BINARY(10)) AS VARCHAR)",
                                 "68656c6c6f2063617374",
                                 STRING().notNull()),
+                // Test cases that can't be added to CastFunctionITCase because they need to
+                // workaround the limitations of fromValues
+                TestSpec.forFunction(BuiltInFunctionDefinitions.CAST, "cast STRUCTURED to STRING")
+                        .onFieldsWithData(123456, "Flink")
+                        .andDataTypes(INT(), STRING())
+                        .withFunction(StructuredTypeConstructor.class)
+                        .testTableApiResult(
+                                call("StructuredTypeConstructor", row($("f0"), $("f1")))
+                                        .cast(STRING()),
+                                "(i=123456, s=Flink)",
+                                STRING()),
+                TestSpec.forFunction(BuiltInFunctionDefinitions.CAST, "cast MULTISET to STRING")
+                        .onFieldsWithData(map(entry("a", 1), entry("b", 1)))
+                        .andDataTypes(MAP(STRING(), INT()))
+                        .withFunction(JsonFunctionsITCase.CreateMultiset.class)
+                        .testTableApiResult(
+                                call("CreateMultiset", $("f0")).cast(STRING()),
+                                "{a=1, b=1}",
+                                STRING()),
+                TestSpec.forFunction(BuiltInFunctionDefinitions.CAST, "cast RAW to STRING")
+                        .onFieldsWithData("2020-11-11T18:08:01.123")
+                        .andDataTypes(STRING())
+                        .withFunction(LocalDateTimeToRaw.class)
+                        .testTableApiResult(
+                                call("LocalDateTimeToRaw", $("f0")).cast(STRING()),
+                                "2020-11-11T18:08:01.123",
+                                STRING()),
                 TestSpec.forFunction(
                                 BuiltInFunctionDefinitions.TRY_CAST, "try cast from STRING to TIME")
                         .onFieldsWithData("Flink", "12:34:56")
@@ -311,6 +343,17 @@ public class CastFunctionMiscITCase extends BuiltInFunctionTestBase {
                 b.putChar(c);
             }
             return b.array();
+        }
+    }
+
+    /** Test Raw with custom class. */
+    public static class LocalDateTimeToRaw extends ScalarFunction {
+
+        public @DataTypeHint(
+                value = "RAW",
+                bridgedTo = LocalDateTime.class,
+                rawSerializer = LocalDateTimeSerializer.class) LocalDateTime eval(String str) {
+            return LocalDateTime.parse(str);
         }
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionMiscITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionMiscITCase.java
@@ -227,12 +227,12 @@ public class CastFunctionMiscITCase extends BuiltInFunctionTestBase {
                                 "(i=123456, s=Flink)",
                                 STRING()),
                 TestSpec.forFunction(BuiltInFunctionDefinitions.CAST, "cast MULTISET to STRING")
-                        .onFieldsWithData(map(entry("a", 1), entry("b", 1)))
+                        .onFieldsWithData(map(entry("a", 1), entry("b", 2)))
                         .andDataTypes(MAP(STRING(), INT()))
                         .withFunction(JsonFunctionsITCase.CreateMultiset.class)
                         .testTableApiResult(
                                 call("CreateMultiset", $("f0")).cast(STRING()),
-                                "{a=1, b=1}",
+                                "{a=1, b=2}",
                                 STRING()),
                 TestSpec.forFunction(BuiltInFunctionDefinitions.CAST, "cast RAW to STRING")
                         .onFieldsWithData("2020-11-11T18:08:01.123")

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionMiscITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionMiscITCase.java
@@ -215,8 +215,6 @@ public class CastFunctionMiscITCase extends BuiltInFunctionTestBase {
                                 "CAST(CAST(x'68656C6C6F2063617374' AS BINARY(10)) AS VARCHAR)",
                                 "68656c6c6f2063617374",
                                 STRING().notNull()),
-                // Test cases that can't be added to CastFunctionITCase because they need to
-                // workaround the limitations of fromValues
                 TestSpec.forFunction(BuiltInFunctionDefinitions.CAST, "cast STRUCTURED to STRING")
                         .onFieldsWithData(123456, "Flink")
                         .andDataTypes(INT(), STRING())

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionMiscITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionMiscITCase.java
@@ -50,8 +50,8 @@ import static org.apache.flink.table.api.DataTypes.VARBINARY;
 import static org.apache.flink.table.api.Expressions.$;
 import static org.apache.flink.table.api.Expressions.call;
 import static org.apache.flink.table.api.Expressions.row;
-import static org.apache.flink.table.planner.functions.CastFunctionITCase.entry;
-import static org.apache.flink.table.planner.functions.CastFunctionITCase.map;
+import static org.apache.flink.util.CollectionUtil.entry;
+import static org.apache.flink.util.CollectionUtil.map;
 
 /** Tests for {@link BuiltInFunctionDefinitions#CAST} regarding {@link DataTypes#ROW}. */
 public class CastFunctionMiscITCase extends BuiltInFunctionTestBase {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/casting/CastRulesTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/casting/CastRulesTest.java
@@ -39,6 +39,8 @@ import org.apache.flink.table.utils.DateTimeUtils;
 
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.TestFactory;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 import java.math.BigDecimal;
 import java.time.Duration;
@@ -98,6 +100,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * This class runs unit tests of {@link CastRule} implementations. For IT test cases, check out the
  * {@link CastFunctionITCase}
  */
+@Execution(ExecutionMode.CONCURRENT)
 class CastRulesTest {
 
     private static final ZoneId CET = ZoneId.of("CET");


### PR DESCRIPTION
## What is the purpose of the change

The goal of this PR is to allow performing casting to string of complex types, that is: ARRAY, ROW, STRUCTURED, MAP, MULTISET and RAW

## Brief change log

* Support the missing combinations in `LogicalTypeCasts`.
* Add patched `SqlCastFunction` from Calcite. This is required as calcite extension point for casting rules (see `SqlTypeCoercionRule`) is limited to atomic types. For constructed types, the logic is still hardcoded in `SqlTypeUtil`. So we replace the Calcite's `SqlCastFunction` to plug in our special cast checking logic for constructed, raw and structured.
* Add test cases

## Verifying this change

Added test cases

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? not documented
