### PR TITLE
[FLINK-25836][python] Fix the unstable test test_keyed_process_function_with_state in PyFlink

### DIFF
--- a/flink-python/pyflink/datastream/tests/test_data_stream.py
+++ b/flink-python/pyflink/datastream/tests/test_data_stream.py
@@ -638,9 +638,9 @@ class DataStreamTests(object):
                 self.value_state.update(value[0])
                 current_list = [_ for _ in self.list_state.get()]
                 self.list_state.add(value[0])
-                map_entries_string = []
-                for k, v in self.map_state.items():
-                    map_entries_string.append(str(k) + ': ' + str(v))
+                map_entries = {k: v for k, v in self.map_state.items()}
+                keys = sorted(map_entries.keys())
+                map_entries_string = [str(k) + ': ' + str(map_entries[k]) for k in keys]
                 map_entries_string = '{' + ', '.join(map_entries_string) + '}'
                 self.map_state.put(value[0], value[1])
                 current_key = ctx.get_current_key()


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will fix the unstable test test_keyed_process_function_with_state in PyFlink*


## Verifying this change

This change added tests and can be verified as follows:

  - *`test_keyed_process_function_with_state`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
