### PR TITLE
[FLINK-25826][table-planner] Handle symbols at a central place with serializable format

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/expressions/converter/ExpressionConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/expressions/converter/ExpressionConverter.java
@@ -39,8 +39,6 @@ import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.TimeType;
 
 import org.apache.calcite.avatica.util.ByteString;
-import org.apache.calcite.avatica.util.TimeUnit;
-import org.apache.calcite.avatica.util.TimeUnitRange;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexBuilder;
@@ -64,6 +62,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.table.planner.typeutils.SymbolUtil.commonToCalcite;
 import static org.apache.flink.table.planner.utils.TimestampStringUtils.fromLocalDateTime;
 import static org.apache.flink.table.runtime.types.LogicalTypeDataTypeConverter.fromDataTypeToLogicalType;
 
@@ -175,9 +174,9 @@ public class ExpressionConverter implements ExpressionVisitor<RexNode> {
             default:
                 value = extractValue(valueLiteral, Object.class);
                 if (value instanceof TimePointUnit) {
-                    value = timePointUnitToTimeUnit((TimePointUnit) value);
+                    value = commonToCalcite((TimePointUnit) value);
                 } else if (value instanceof TimeIntervalUnit) {
-                    value = intervalUnitToUnitRange((TimeIntervalUnit) value);
+                    value = commonToCalcite((TimeIntervalUnit) value);
                 }
                 break;
         }
@@ -262,70 +261,6 @@ public class ExpressionConverter implements ExpressionVisitor<RexNode> {
                 return dataTypeFactory;
             }
         };
-    }
-
-    private static TimeUnit timePointUnitToTimeUnit(TimePointUnit unit) {
-        switch (unit) {
-            case YEAR:
-                return TimeUnit.YEAR;
-            case MONTH:
-                return TimeUnit.MONTH;
-            case DAY:
-                return TimeUnit.DAY;
-            case HOUR:
-                return TimeUnit.HOUR;
-            case MINUTE:
-                return TimeUnit.MINUTE;
-            case SECOND:
-                return TimeUnit.SECOND;
-            case QUARTER:
-                return TimeUnit.QUARTER;
-            case WEEK:
-                return TimeUnit.WEEK;
-            case MILLISECOND:
-                return TimeUnit.MILLISECOND;
-            case MICROSECOND:
-                return TimeUnit.MICROSECOND;
-            default:
-                throw new UnsupportedOperationException("TimePointUnit is: " + unit);
-        }
-    }
-
-    private static TimeUnitRange intervalUnitToUnitRange(TimeIntervalUnit intervalUnit) {
-        switch (intervalUnit) {
-            case YEAR:
-                return TimeUnitRange.YEAR;
-            case YEAR_TO_MONTH:
-                return TimeUnitRange.YEAR_TO_MONTH;
-            case QUARTER:
-                return TimeUnitRange.QUARTER;
-            case MONTH:
-                return TimeUnitRange.MONTH;
-            case WEEK:
-                return TimeUnitRange.WEEK;
-            case DAY:
-                return TimeUnitRange.DAY;
-            case DAY_TO_HOUR:
-                return TimeUnitRange.DAY_TO_HOUR;
-            case DAY_TO_MINUTE:
-                return TimeUnitRange.DAY_TO_MINUTE;
-            case DAY_TO_SECOND:
-                return TimeUnitRange.DAY_TO_SECOND;
-            case HOUR:
-                return TimeUnitRange.HOUR;
-            case SECOND:
-                return TimeUnitRange.SECOND;
-            case HOUR_TO_MINUTE:
-                return TimeUnitRange.HOUR_TO_MINUTE;
-            case HOUR_TO_SECOND:
-                return TimeUnitRange.HOUR_TO_SECOND;
-            case MINUTE:
-                return TimeUnitRange.MINUTE;
-            case MINUTE_TO_SECOND:
-                return TimeUnitRange.MINUTE_TO_SECOND;
-            default:
-                throw new UnsupportedOperationException("TimeIntervalUnit is: " + intervalUnit);
-        }
     }
 
     /**

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/expressions/converter/converters/JsonConverterUtil.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/expressions/converter/converters/JsonConverterUtil.java
@@ -23,6 +23,7 @@ import org.apache.flink.table.api.JsonOnNull;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.expressions.CallExpression;
 import org.apache.flink.table.expressions.ValueLiteralExpression;
+import org.apache.flink.table.planner.typeutils.SymbolUtil;
 
 import org.apache.calcite.sql.SqlJsonConstructorNullClause;
 
@@ -33,19 +34,9 @@ class JsonConverterUtil {
             CallExpression call, int argumentIdx) {
         return ((ValueLiteralExpression) call.getChildren().get(argumentIdx))
                 .getValueAs(JsonOnNull.class)
-                .map(JsonConverterUtil::convertOnNull)
+                .map(SymbolUtil::commonToCalcite)
+                .map(SqlJsonConstructorNullClause.class::cast)
                 .orElseThrow(() -> new TableException("Missing argument for ON NULL."));
-    }
-
-    private static SqlJsonConstructorNullClause convertOnNull(JsonOnNull onNull) {
-        switch (onNull) {
-            case NULL:
-                return SqlJsonConstructorNullClause.NULL_ON_NULL;
-            case ABSENT:
-                return SqlJsonConstructorNullClause.ABSENT_ON_NULL;
-            default:
-                throw new TableException("Unknown ON NULL behavior: " + onNull);
-        }
     }
 
     private JsonConverterUtil() {}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/expressions/converter/converters/JsonExistsConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/expressions/converter/converters/JsonExistsConverter.java
@@ -20,15 +20,14 @@ package org.apache.flink.table.planner.expressions.converter.converters;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.api.JsonExistsOnError;
-import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.expressions.CallExpression;
 import org.apache.flink.table.expressions.ValueLiteralExpression;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 import org.apache.flink.table.planner.expressions.converter.CallExpressionConvertRule;
 import org.apache.flink.table.planner.functions.sql.FlinkSqlOperatorTable;
+import org.apache.flink.table.planner.typeutils.SymbolUtil;
 
 import org.apache.calcite.rex.RexNode;
-import org.apache.calcite.sql.SqlJsonExistsErrorBehavior;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -47,7 +46,7 @@ class JsonExistsConverter extends CustomizedConverter {
         if (call.getChildren().size() >= 3) {
             ((ValueLiteralExpression) call.getChildren().get(2))
                     .getValueAs(JsonExistsOnError.class)
-                    .map(this::convertErrorBehavior)
+                    .map(SymbolUtil::commonToCalcite)
                     .ifPresent(
                             onErrorBehavior ->
                                     operands.add(
@@ -57,20 +56,5 @@ class JsonExistsConverter extends CustomizedConverter {
         }
 
         return context.getRelBuilder().call(FlinkSqlOperatorTable.JSON_EXISTS, operands);
-    }
-
-    private SqlJsonExistsErrorBehavior convertErrorBehavior(JsonExistsOnError onError) {
-        switch (onError) {
-            case TRUE:
-                return SqlJsonExistsErrorBehavior.TRUE;
-            case FALSE:
-                return SqlJsonExistsErrorBehavior.FALSE;
-            case UNKNOWN:
-                return SqlJsonExistsErrorBehavior.UNKNOWN;
-            case ERROR:
-                return SqlJsonExistsErrorBehavior.ERROR;
-            default:
-                throw new TableException("Unknown ON ERROR behavior: " + onError);
-        }
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RexNodeJsonSerializer.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RexNodeJsonSerializer.java
@@ -24,6 +24,7 @@ import org.apache.flink.table.functions.FunctionDefinition;
 import org.apache.flink.table.functions.FunctionKind;
 import org.apache.flink.table.planner.functions.bridging.BridgingSqlFunction;
 import org.apache.flink.table.planner.functions.utils.ScalarSqlFunction;
+import org.apache.flink.table.planner.typeutils.SymbolUtil.SerializableSymbol;
 import org.apache.flink.table.utils.EncodingUtils;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonGenerator;
@@ -46,6 +47,8 @@ import org.apache.calcite.util.Sarg;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+
+import static org.apache.flink.table.planner.typeutils.SymbolUtil.calciteToSerializable;
 
 /**
  * JSON serializer for {@link RexNode}. refer to {@link RexNodeJsonDeserializer} for deserializer.
@@ -237,8 +240,9 @@ public class RexNodeJsonSerializer extends StdSerializer<RexNode> {
                 gen.writeNumberField(FIELD_NAME_VALUE, ((BigDecimal) value).longValue());
                 break;
             case SYMBOL:
-                gen.writeStringField(FIELD_NAME_VALUE, ((Enum<?>) value).name());
-                gen.writeStringField(FIELD_NAME_CLASS, value.getClass().getName());
+                final SerializableSymbol symbol = calciteToSerializable((Enum<?>) value);
+                gen.writeStringField(FIELD_NAME_VALUE, symbol.getValue());
+                gen.writeStringField(FIELD_NAME_CLASS, symbol.getKind());
                 break;
             case SARG:
                 serialize((Sarg<?>) value, elementTypeName, gen, serializerProvider);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/typeutils/SymbolUtil.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/typeutils/SymbolUtil.java
@@ -1,0 +1,575 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.typeutils;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.JsonExistsOnError;
+import org.apache.flink.table.api.JsonOnNull;
+import org.apache.flink.table.api.JsonQueryOnEmptyOrError;
+import org.apache.flink.table.api.JsonQueryWrapper;
+import org.apache.flink.table.api.JsonValueOnEmptyOrError;
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.expressions.TableSymbol;
+import org.apache.flink.table.expressions.TimeIntervalUnit;
+import org.apache.flink.table.expressions.TimePointUnit;
+import org.apache.flink.table.utils.DateTimeUtils;
+
+import org.apache.calcite.avatica.util.TimeUnit;
+import org.apache.calcite.avatica.util.TimeUnitRange;
+import org.apache.calcite.sql.SqlJsonConstructorNullClause;
+import org.apache.calcite.sql.SqlJsonEmptyOrError;
+import org.apache.calcite.sql.SqlJsonExistsErrorBehavior;
+import org.apache.calcite.sql.SqlJsonQueryEmptyOrErrorBehavior;
+import org.apache.calcite.sql.SqlJsonQueryWrapperBehavior;
+import org.apache.calcite.sql.SqlJsonValueEmptyOrErrorBehavior;
+import org.apache.calcite.sql.SqlMatchRecognize;
+import org.apache.calcite.sql.fun.SqlTrimFunction;
+
+import javax.annotation.Nullable;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Utilities to map between symbols from both Calcite and Flink. It also defines a {@link
+ * SerializableSymbol} format independent of concrete implementation classes.
+ */
+@Internal
+public final class SymbolUtil {
+
+    private static final Map<SerializableSymbol, Enum<?>> serializableToCalcite = new HashMap<>();
+    private static final Map<Enum<?>, SerializableSymbol> calciteToSerializable = new HashMap<>();
+    private static final Map<Enum<?>, Enum<?>> calciteToCommon = new HashMap<>();
+    private static final Map<Enum<?>, Enum<?>> commonToCalcite = new HashMap<>();
+    private static final Map<Enum<?>, Enum<?>> calciteToInternalCommon = new HashMap<>();
+    private static final Map<Enum<?>, Enum<?>> internalCommonToCalcite = new HashMap<>();
+
+    static {
+        // TRIM
+        addSymbolMapping(null, null, SqlTrimFunction.Flag.BOTH, "TRIM", "BOTH");
+        addSymbolMapping(null, null, SqlTrimFunction.Flag.LEADING, "TRIM", "LEADING");
+        addSymbolMapping(null, null, SqlTrimFunction.Flag.TRAILING, "TRIM", "TRAILING");
+
+        // JSON_EXISTS_ON_ERROR
+        addSymbolMapping(
+                JsonExistsOnError.TRUE,
+                null,
+                SqlJsonExistsErrorBehavior.TRUE,
+                "JSON_EXISTS_ON_ERROR",
+                "TRUE");
+        addSymbolMapping(
+                JsonExistsOnError.FALSE,
+                null,
+                SqlJsonExistsErrorBehavior.FALSE,
+                "JSON_EXISTS_ON_ERROR",
+                "FALSE");
+        addSymbolMapping(
+                JsonExistsOnError.UNKNOWN,
+                null,
+                SqlJsonExistsErrorBehavior.UNKNOWN,
+                "JSON_EXISTS_ON_ERROR",
+                "UNKNOWN");
+        addSymbolMapping(
+                JsonExistsOnError.ERROR,
+                null,
+                SqlJsonExistsErrorBehavior.ERROR,
+                "JSON_EXISTS_ON_ERROR",
+                "ERROR");
+
+        // JSON_VALUE_ON_EMPTY_OR_ERROR
+        addSymbolMapping(
+                JsonValueOnEmptyOrError.ERROR,
+                null,
+                SqlJsonValueEmptyOrErrorBehavior.ERROR,
+                "JSON_VALUE_ON_EMPTY_OR_ERROR",
+                "ERROR");
+        addSymbolMapping(
+                JsonValueOnEmptyOrError.NULL,
+                null,
+                SqlJsonValueEmptyOrErrorBehavior.NULL,
+                "JSON_VALUE_ON_EMPTY_OR_ERROR",
+                "NULL");
+        addSymbolMapping(
+                JsonValueOnEmptyOrError.DEFAULT,
+                null,
+                SqlJsonValueEmptyOrErrorBehavior.DEFAULT,
+                "JSON_VALUE_ON_EMPTY_OR_ERROR",
+                "DEFAULT");
+
+        // JSON_QUERY_WRAPPER
+        addSymbolMapping(
+                JsonQueryWrapper.WITHOUT_ARRAY,
+                null,
+                SqlJsonQueryWrapperBehavior.WITHOUT_ARRAY,
+                "JSON_QUERY_WRAPPER",
+                "WITHOUT_ARRAY");
+        addSymbolMapping(
+                JsonQueryWrapper.CONDITIONAL_ARRAY,
+                null,
+                SqlJsonQueryWrapperBehavior.WITH_CONDITIONAL_ARRAY,
+                "JSON_QUERY_WRAPPER",
+                "CONDITIONAL_ARRAY");
+        addSymbolMapping(
+                JsonQueryWrapper.UNCONDITIONAL_ARRAY,
+                null,
+                SqlJsonQueryWrapperBehavior.WITH_UNCONDITIONAL_ARRAY,
+                "JSON_QUERY_WRAPPER",
+                "WITH_UNCONDITIONAL_ARRAY");
+
+        // JSON_QUERY_ON_EMPTY_OR_ERROR
+        addSymbolMapping(
+                JsonQueryOnEmptyOrError.ERROR,
+                null,
+                SqlJsonQueryEmptyOrErrorBehavior.ERROR,
+                "JSON_QUERY_ON_EMPTY_OR_ERROR",
+                "ERROR");
+        addSymbolMapping(
+                JsonQueryOnEmptyOrError.NULL,
+                null,
+                SqlJsonQueryEmptyOrErrorBehavior.NULL,
+                "JSON_QUERY_ON_EMPTY_OR_ERROR",
+                "NULL");
+        addSymbolMapping(
+                JsonQueryOnEmptyOrError.EMPTY_ARRAY,
+                null,
+                SqlJsonQueryEmptyOrErrorBehavior.EMPTY_ARRAY,
+                "JSON_QUERY_ON_EMPTY_OR_ERROR",
+                "EMPTY_ARRAY");
+        addSymbolMapping(
+                JsonQueryOnEmptyOrError.EMPTY_OBJECT,
+                null,
+                SqlJsonQueryEmptyOrErrorBehavior.EMPTY_OBJECT,
+                "JSON_QUERY_ON_EMPTY_OR_ERROR",
+                "EMPTY_OBJECT");
+
+        // JSON_ON_NULL
+        addSymbolMapping(
+                JsonOnNull.NULL,
+                null,
+                SqlJsonConstructorNullClause.NULL_ON_NULL,
+                "JSON_ON_NULL",
+                "NULL");
+        addSymbolMapping(
+                JsonOnNull.ABSENT,
+                null,
+                SqlJsonConstructorNullClause.ABSENT_ON_NULL,
+                "JSON_ON_NULL",
+                "ABSENT");
+
+        // JSON_EMPTY_OR_ERROR
+        addSymbolMapping(null, null, SqlJsonEmptyOrError.EMPTY, "JSON_EMPTY_OR_ERROR", "EMPTY");
+        addSymbolMapping(null, null, SqlJsonEmptyOrError.ERROR, "JSON_EMPTY_OR_ERROR", "ERROR");
+
+        // TIME_UNIT_RANGE
+        addSymbolMapping(
+                TimeIntervalUnit.YEAR,
+                DateTimeUtils.TimeUnitRange.YEAR,
+                TimeUnitRange.YEAR,
+                "TIME_UNIT_RANGE",
+                "YEAR");
+        addSymbolMapping(
+                TimeIntervalUnit.YEAR_TO_MONTH,
+                DateTimeUtils.TimeUnitRange.YEAR_TO_MONTH,
+                TimeUnitRange.YEAR_TO_MONTH,
+                "TIME_UNIT_RANGE",
+                "YEAR_TO_MONTH");
+        addSymbolMapping(
+                TimeIntervalUnit.MONTH,
+                DateTimeUtils.TimeUnitRange.MONTH,
+                TimeUnitRange.MONTH,
+                "TIME_UNIT_RANGE",
+                "MONTH");
+        addSymbolMapping(
+                TimeIntervalUnit.DAY,
+                DateTimeUtils.TimeUnitRange.DAY,
+                TimeUnitRange.DAY,
+                "TIME_UNIT_RANGE",
+                "DAY");
+        addSymbolMapping(
+                TimeIntervalUnit.DAY_TO_HOUR,
+                DateTimeUtils.TimeUnitRange.DAY_TO_HOUR,
+                TimeUnitRange.DAY_TO_HOUR,
+                "TIME_UNIT_RANGE",
+                "DAY_TO_HOUR");
+        addSymbolMapping(
+                TimeIntervalUnit.DAY_TO_MINUTE,
+                DateTimeUtils.TimeUnitRange.DAY_TO_MINUTE,
+                TimeUnitRange.DAY_TO_MINUTE,
+                "TIME_UNIT_RANGE",
+                "DAY_TO_MINUTE");
+        addSymbolMapping(
+                TimeIntervalUnit.DAY_TO_SECOND,
+                DateTimeUtils.TimeUnitRange.DAY_TO_SECOND,
+                TimeUnitRange.DAY_TO_SECOND,
+                "TIME_UNIT_RANGE",
+                "DAY_TO_SECOND");
+        addSymbolMapping(
+                TimeIntervalUnit.HOUR,
+                DateTimeUtils.TimeUnitRange.HOUR,
+                TimeUnitRange.HOUR,
+                "TIME_UNIT_RANGE",
+                "HOUR");
+        addSymbolMapping(
+                TimeIntervalUnit.HOUR_TO_MINUTE,
+                DateTimeUtils.TimeUnitRange.HOUR_TO_MINUTE,
+                TimeUnitRange.HOUR_TO_MINUTE,
+                "TIME_UNIT_RANGE",
+                "HOUR_TO_MINUTE");
+        addSymbolMapping(
+                TimeIntervalUnit.HOUR_TO_SECOND,
+                DateTimeUtils.TimeUnitRange.HOUR_TO_SECOND,
+                TimeUnitRange.HOUR_TO_SECOND,
+                "TIME_UNIT_RANGE",
+                "HOUR_TO_SECOND");
+        addSymbolMapping(
+                TimeIntervalUnit.MINUTE,
+                DateTimeUtils.TimeUnitRange.MINUTE,
+                TimeUnitRange.MINUTE,
+                "TIME_UNIT_RANGE",
+                "MINUTE");
+        addSymbolMapping(
+                TimeIntervalUnit.MINUTE_TO_SECOND,
+                DateTimeUtils.TimeUnitRange.MINUTE_TO_SECOND,
+                TimeUnitRange.MINUTE_TO_SECOND,
+                "TIME_UNIT_RANGE",
+                "MINUTE_TO_SECOND");
+        addSymbolMapping(
+                TimeIntervalUnit.SECOND,
+                DateTimeUtils.TimeUnitRange.SECOND,
+                TimeUnitRange.SECOND,
+                "TIME_UNIT_RANGE",
+                "SECOND");
+        addSymbolMapping(
+                TimeIntervalUnit.QUARTER,
+                DateTimeUtils.TimeUnitRange.QUARTER,
+                TimeUnitRange.QUARTER,
+                "TIME_UNIT_RANGE",
+                "QUARTER");
+        addSymbolMapping(
+                null,
+                DateTimeUtils.TimeUnitRange.ISOYEAR,
+                TimeUnitRange.ISOYEAR,
+                "TIME_UNIT_RANGE",
+                "ISOYEAR");
+        addSymbolMapping(
+                TimeIntervalUnit.WEEK,
+                DateTimeUtils.TimeUnitRange.WEEK,
+                TimeUnitRange.WEEK,
+                "TIME_UNIT_RANGE",
+                "WEEK");
+        addSymbolMapping(
+                null,
+                DateTimeUtils.TimeUnitRange.MILLISECOND,
+                TimeUnitRange.MILLISECOND,
+                "TIME_UNIT_RANGE",
+                "MILLISECOND");
+        addSymbolMapping(
+                null,
+                DateTimeUtils.TimeUnitRange.MICROSECOND,
+                TimeUnitRange.MICROSECOND,
+                "TIME_UNIT_RANGE",
+                "MICROSECOND");
+        addSymbolMapping(
+                null,
+                DateTimeUtils.TimeUnitRange.NANOSECOND,
+                TimeUnitRange.NANOSECOND,
+                "TIME_UNIT_RANGE",
+                "NANOSECOND");
+        addSymbolMapping(
+                null, DateTimeUtils.TimeUnitRange.DOW, TimeUnitRange.DOW, "TIME_UNIT_RANGE", "DOW");
+        addSymbolMapping(
+                null,
+                DateTimeUtils.TimeUnitRange.ISODOW,
+                TimeUnitRange.ISODOW,
+                "TIME_UNIT_RANGE",
+                "ISODOW");
+        addSymbolMapping(
+                null, DateTimeUtils.TimeUnitRange.DOY, TimeUnitRange.DOY, "TIME_UNIT_RANGE", "DOY");
+        addSymbolMapping(
+                null,
+                DateTimeUtils.TimeUnitRange.EPOCH,
+                TimeUnitRange.EPOCH,
+                "TIME_UNIT_RANGE",
+                "EPOCH");
+        addSymbolMapping(
+                null,
+                DateTimeUtils.TimeUnitRange.DECADE,
+                TimeUnitRange.DECADE,
+                "TIME_UNIT_RANGE",
+                "DECADE");
+        addSymbolMapping(
+                null,
+                DateTimeUtils.TimeUnitRange.CENTURY,
+                TimeUnitRange.CENTURY,
+                "TIME_UNIT_RANGE",
+                "CENTURY");
+        addSymbolMapping(
+                null,
+                DateTimeUtils.TimeUnitRange.MILLENNIUM,
+                TimeUnitRange.MILLENNIUM,
+                "TIME_UNIT_RANGE",
+                "MILLENNIUM");
+
+        // TIME_UNIT
+        addSymbolMapping(
+                TimePointUnit.YEAR,
+                DateTimeUtils.TimeUnit.YEAR,
+                TimeUnit.YEAR,
+                "TIME_UNIT",
+                "YEAR");
+        addSymbolMapping(
+                TimePointUnit.MONTH,
+                DateTimeUtils.TimeUnit.MONTH,
+                TimeUnit.MONTH,
+                "TIME_UNIT",
+                "MONTH");
+        addSymbolMapping(
+                TimePointUnit.DAY, DateTimeUtils.TimeUnit.DAY, TimeUnit.DAY, "TIME_UNIT", "DAY");
+        addSymbolMapping(
+                TimePointUnit.HOUR,
+                DateTimeUtils.TimeUnit.HOUR,
+                TimeUnit.HOUR,
+                "TIME_UNIT",
+                "HOUR");
+        addSymbolMapping(
+                TimePointUnit.MINUTE,
+                DateTimeUtils.TimeUnit.MINUTE,
+                TimeUnit.MINUTE,
+                "TIME_UNIT",
+                "MINUTE");
+        addSymbolMapping(
+                TimePointUnit.SECOND,
+                DateTimeUtils.TimeUnit.SECOND,
+                TimeUnit.SECOND,
+                "TIME_UNIT",
+                "SECOND");
+        addSymbolMapping(
+                TimePointUnit.QUARTER,
+                DateTimeUtils.TimeUnit.QUARTER,
+                TimeUnit.QUARTER,
+                "TIME_UNIT",
+                "QUARTER");
+        addSymbolMapping(
+                TimePointUnit.WEEK,
+                DateTimeUtils.TimeUnit.WEEK,
+                TimeUnit.WEEK,
+                "TIME_UNIT",
+                "WEEK");
+        addSymbolMapping(
+                TimePointUnit.MILLISECOND,
+                DateTimeUtils.TimeUnit.MILLISECOND,
+                TimeUnit.MILLISECOND,
+                "TIME_UNIT",
+                "MILLISECOND");
+        addSymbolMapping(
+                TimePointUnit.MICROSECOND,
+                DateTimeUtils.TimeUnit.MICROSECOND,
+                TimeUnit.MICROSECOND,
+                "TIME_UNIT",
+                "MICROSECOND");
+        addSymbolMapping(null, DateTimeUtils.TimeUnit.DOW, TimeUnit.DOW, "TIME_UNIT", "DOW");
+        addSymbolMapping(null, DateTimeUtils.TimeUnit.DOY, TimeUnit.DOY, "TIME_UNIT", "DOY");
+        addSymbolMapping(null, DateTimeUtils.TimeUnit.EPOCH, TimeUnit.EPOCH, "TIME_UNIT", "EPOCH");
+        addSymbolMapping(
+                null, DateTimeUtils.TimeUnit.DECADE, TimeUnit.DECADE, "TIME_UNIT", "DECADE");
+        addSymbolMapping(
+                null, DateTimeUtils.TimeUnit.CENTURY, TimeUnit.CENTURY, "TIME_UNIT", "CENTURY");
+        addSymbolMapping(
+                null,
+                DateTimeUtils.TimeUnit.MILLENNIUM,
+                TimeUnit.MILLENNIUM,
+                "TIME_UNIT",
+                "MILLENNIUM");
+
+        // MATCH_RECOGNIZE_AFTER_OPTION
+        addSymbolMapping(
+                null,
+                null,
+                SqlMatchRecognize.AfterOption.SKIP_TO_NEXT_ROW,
+                "MATCH_RECOGNIZE_AFTER_OPTION",
+                "SKIP_TO_NEXT_ROW");
+        addSymbolMapping(
+                null,
+                null,
+                SqlMatchRecognize.AfterOption.SKIP_PAST_LAST_ROW,
+                "MATCH_RECOGNIZE_AFTER_OPTION",
+                "SKIP_PAST_LAST_ROW");
+    }
+
+    /**
+     * Converts from a common to a Calcite symbol. The common symbol can be a publicly exposed one
+     * such as {@link TimeIntervalUnit} or internal one such as {@link DateTimeUtils.TimeUnitRange}.
+     */
+    public static Enum<?> commonToCalcite(Enum<?> commonSymbol) {
+        checkCommonSymbol(commonSymbol);
+        Enum<?> calciteSymbol = commonToCalcite.get(commonSymbol);
+        if (calciteSymbol == null) {
+            calciteSymbol = internalCommonToCalcite.get(commonSymbol);
+            if (calciteSymbol == null) {
+                throw new UnsupportedOperationException(
+                        String.format("Cannot map '%s' to an internal symbol.", commonSymbol));
+            }
+        }
+        return calciteSymbol;
+    }
+
+    /**
+     * Converts from Calcite to a common symbol. The common symbol can be a publicly exposed one
+     * such as {@link TimeIntervalUnit} or internal one such as {@link DateTimeUtils.TimeUnitRange}.
+     * Since the common symbol is optional, the input is returned as a fallback.
+     */
+    public static Enum<?> calciteToCommon(Enum<?> calciteSymbol, boolean preferInternal) {
+        checkCalciteSymbol(calciteSymbol);
+        Enum<?> internalCommonSymbol =
+                preferInternal ? calciteToInternalCommon.get(calciteSymbol) : null;
+        if (internalCommonSymbol == null) {
+            internalCommonSymbol = calciteToCommon.get(calciteSymbol);
+            if (internalCommonSymbol == null) {
+                // for cases that have no common representation
+                // e.g. TRIM
+                return calciteSymbol;
+            }
+        }
+        return internalCommonSymbol;
+    }
+
+    public static SerializableSymbol calciteToSerializable(Enum<?> calciteSymbol) {
+        final SerializableSymbol serializableSymbol = calciteToSerializable.get(calciteSymbol);
+        if (serializableSymbol == null) {
+            throw new TableException(
+                    String.format(
+                            "Symbol class '%s' has no serializable representation.",
+                            calciteSymbol.getClass().getName()));
+        }
+        return serializableSymbol;
+    }
+
+    public static Enum<?> serializableToCalcite(SerializableSymbol serializableSymbol) {
+        final Enum<?> calciteSymbol = serializableToCalcite.get(serializableSymbol);
+        if (calciteSymbol == null) {
+            throw new TableException(
+                    String.format(
+                            "Cannot find a corresponding symbol class for '%s'.",
+                            serializableSymbol));
+        }
+        return calciteSymbol;
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // SerializableSymbol
+    // --------------------------------------------------------------------------------------------
+
+    /** Serializable representation of a symbol that can be used for persistence. */
+    public static class SerializableSymbol {
+        private final String kind;
+        private final String value;
+
+        private SerializableSymbol(String kind, String value) {
+            this.kind = kind;
+            this.value = value;
+        }
+
+        public static SerializableSymbol of(String kind, String value) {
+            return new SerializableSymbol(kind, value);
+        }
+
+        public String getKind() {
+            return kind;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            SerializableSymbol that = (SerializableSymbol) o;
+            return kind.equals(that.kind) && value.equals(that.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(kind, value);
+        }
+
+        @Override
+        public String toString() {
+            return kind + '.' + value;
+        }
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Helper methods
+    // --------------------------------------------------------------------------------------------
+
+    private static void addSymbolMapping(
+            @Nullable TableSymbol commonSymbol,
+            @Nullable Enum<?> commonInternalSymbol,
+            Enum<?> calciteSymbol,
+            String serializableKind,
+            String serializableValue) {
+        checkNotNull(calciteSymbol, "Calcite symbol must not be null.");
+        checkNotNull(serializableKind, "Serializable kind must not be null.");
+        checkNotNull(serializableValue, "Serializable value must not be null.");
+        final SerializableSymbol serializableSymbol =
+                SerializableSymbol.of(serializableKind, serializableValue);
+        checkCalciteSymbol(calciteSymbol);
+        serializableToCalcite.put(serializableSymbol, calciteSymbol);
+        calciteToSerializable.put(calciteSymbol, serializableSymbol);
+        if (commonSymbol != null) {
+            final Enum<?> commonSymbolEnum = (Enum<?>) commonSymbol;
+            checkCommonSymbol(commonSymbolEnum);
+            calciteToCommon.put(calciteSymbol, commonSymbolEnum);
+            commonToCalcite.put(commonSymbolEnum, calciteSymbol);
+        }
+        if (commonInternalSymbol != null) {
+            checkCommonSymbol(commonInternalSymbol);
+            calciteToInternalCommon.put(calciteSymbol, commonInternalSymbol);
+            internalCommonToCalcite.put(commonInternalSymbol, calciteSymbol);
+        }
+    }
+
+    private static void checkCalciteSymbol(Enum<?> calciteSymbol) {
+        checkArgument(
+                calciteSymbol.getClass().getName().startsWith("org.apache.calcite."),
+                "Class '%s' is not a Calcite symbol.",
+                calciteSymbol);
+    }
+
+    private static void checkCommonSymbol(Enum<?> commonInternalSymbol) {
+        checkArgument(
+                commonInternalSymbol.getClass().getName().startsWith("org.apache.flink.table."),
+                "Class '%s' is not a Flink symbol.",
+                commonInternalSymbol);
+    }
+
+    private SymbolUtil() {
+        // no instantiation
+    }
+}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
@@ -20,7 +20,6 @@ package org.apache.flink.table.planner.codegen
 
 import org.apache.flink.api.common.ExecutionConfig
 import org.apache.flink.api.common.typeinfo.{AtomicType => AtomicTypeInfo}
-import org.apache.flink.table.api.{JsonExistsOnError, JsonQueryOnEmptyOrError, JsonQueryWrapper}
 import org.apache.flink.table.data._
 import org.apache.flink.table.data.binary.BinaryRowData
 import org.apache.flink.table.data.utils.JoinedRowData
@@ -30,6 +29,7 @@ import org.apache.flink.table.planner.codegen.GeneratedExpression.{ALWAYS_NULL, 
 import org.apache.flink.table.planner.codegen.calls.CurrentTimePointCallGen
 import org.apache.flink.table.planner.plan.nodes.exec.spec.SortSpec
 import org.apache.flink.table.planner.plan.utils.SortUtil
+import org.apache.flink.table.planner.typeutils.SymbolUtil.calciteToCommon
 import org.apache.flink.table.planner.utils.TimestampStringUtils.toLocalDateTime
 import org.apache.flink.table.runtime.typeutils.TypeCheckUtils.{isCharacterString, isReference, isTemporal}
 import org.apache.flink.table.types.logical.LogicalTypeRoot._
@@ -37,7 +37,6 @@ import org.apache.flink.table.types.logical._
 import org.apache.flink.table.types.logical.utils.LogicalTypeChecks.{getFieldCount, getFieldTypes}
 
 import org.apache.calcite.avatica.util.ByteString
-import org.apache.calcite.sql.{SqlJsonExistsErrorBehavior, SqlJsonQueryEmptyOrErrorBehavior, SqlJsonQueryWrapperBehavior}
 import org.apache.calcite.util.TimestampString
 import org.apache.commons.lang3.StringEscapeUtils
 
@@ -445,27 +444,7 @@ object GenerateUtils {
   }
 
   def generateSymbol(value: Enum[_]): GeneratedExpression = {
-    // Make sure to convert calcite enum types to flink types
-    val convertedValue = value match {
-      case tu: org.apache.calcite.avatica.util.TimeUnit =>
-        org.apache.flink.table.utils.DateTimeUtils.TimeUnit.valueOf(tu.name())
-      case tur: org.apache.calcite.avatica.util.TimeUnitRange =>
-        org.apache.flink.table.utils.DateTimeUtils.TimeUnitRange.valueOf(tur.name())
-      case jeeb: SqlJsonExistsErrorBehavior =>
-        JsonExistsOnError.valueOf(jeeb.name())
-      case jqeeb: SqlJsonQueryEmptyOrErrorBehavior =>
-        JsonQueryOnEmptyOrError.valueOf(jqeeb.name())
-      case jqwb: SqlJsonQueryWrapperBehavior => jqwb match {
-        case SqlJsonQueryWrapperBehavior.WITHOUT_ARRAY =>
-          JsonQueryWrapper.WITHOUT_ARRAY
-        case SqlJsonQueryWrapperBehavior.WITH_CONDITIONAL_ARRAY =>
-          JsonQueryWrapper.CONDITIONAL_ARRAY
-        case SqlJsonQueryWrapperBehavior.WITH_UNCONDITIONAL_ARRAY =>
-          JsonQueryWrapper.UNCONDITIONAL_ARRAY
-      }
-      case _ => value
-    }
-
+    val convertedValue = calciteToCommon(value, true)
     GeneratedExpression(
       qualifyEnum(convertedValue),
       NEVER_NULL,

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/JsonGenerateUtils.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/JsonGenerateUtils.scala
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.planner.codegen
 
-import org.apache.flink.table.api.DataTypes
+import org.apache.flink.table.api.{DataTypes, JsonOnNull}
 import org.apache.flink.table.planner.codegen.CodeGenUtils.{className, newName, rowFieldReadAccess, typeTerm}
 import org.apache.flink.table.planner.functions.sql.FlinkSqlOperatorTable.{JSON_ARRAY, JSON_OBJECT}
 import org.apache.flink.table.planner.utils.JavaScalaConversionUtil.toScala
@@ -33,7 +33,6 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.{Arr
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.util.RawValue
 
 import org.apache.calcite.rex.{RexCall, RexNode}
-import org.apache.calcite.sql.SqlJsonConstructorNullClause
 
 import java.time.format.DateTimeFormatter
 
@@ -134,12 +133,12 @@ object JsonGenerateUtils {
        |""".stripMargin
   }
 
-  /** Convert the operand to [[SqlJsonConstructorNullClause]]. */
-  def getOnNullBehavior(operand: GeneratedExpression): SqlJsonConstructorNullClause = {
+  /** Convert the operand to [[JsonOnNull]]. */
+  def getOnNullBehavior(operand: GeneratedExpression): JsonOnNull = {
     operand.literalValue match {
-      case Some(onNull: SqlJsonConstructorNullClause) => onNull
+      case Some(onNull: JsonOnNull) => onNull
       case _ => throw new CodeGenException(s"Expected operand to be of type"
-        + s"'${typeTerm(classOf[SqlJsonConstructorNullClause])}''")
+        + s"'${typeTerm(classOf[JsonOnNull])}''")
     }
   }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/JsonArrayCallGen.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/JsonArrayCallGen.scala
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.planner.codegen.calls
 
+import org.apache.flink.table.api.JsonOnNull
 import org.apache.flink.table.planner.codegen.CodeGenUtils.{BINARY_STRING, className, newName, primitiveTypeTermForType}
 import org.apache.flink.table.planner.codegen.JsonGenerateUtils.{createNodeTerm, getOnNullBehavior}
 import org.apache.flink.table.planner.codegen.{CodeGeneratorContext, GeneratedExpression}
@@ -27,7 +28,6 @@ import org.apache.flink.table.types.logical.LogicalType
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.{ArrayNode, NullNode}
 
 import org.apache.calcite.rex.RexCall
-import org.apache.calcite.sql.SqlJsonConstructorNullClause.{ABSENT_ON_NULL, NULL_ON_NULL}
 
 /** [[CallGenerator]] for `JSON_ARRAY`. */
 class JsonArrayCallGen(call: RexCall) extends CallGenerator {
@@ -50,7 +50,7 @@ class JsonArrayCallGen(call: RexCall) extends CallGenerator {
         val elementTerm = createNodeTerm(ctx, elementExpr, call.operands.get(elementIdx))
 
         onNull match {
-          case NULL_ON_NULL =>
+          case JsonOnNull.NULL =>
             s"""
                |if (${elementExpr.nullTerm}) {
                |    $nodeTerm.add($nullNodeTerm);
@@ -58,7 +58,7 @@ class JsonArrayCallGen(call: RexCall) extends CallGenerator {
                |    $nodeTerm.add($elementTerm);
                |}
                |""".stripMargin
-          case ABSENT_ON_NULL =>
+          case JsonOnNull.ABSENT =>
             s"""
                |if (!${elementExpr.nullTerm}) {
                |    $nodeTerm.add($elementTerm);

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/JsonObjectCallGen.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/JsonObjectCallGen.scala
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.planner.codegen.calls
 
+import org.apache.flink.table.api.JsonOnNull
 import org.apache.flink.table.planner.codegen.CodeGenUtils._
 import org.apache.flink.table.planner.codegen.JsonGenerateUtils.{createNodeTerm, getOnNullBehavior}
 import org.apache.flink.table.planner.codegen.{CodeGeneratorContext, GeneratedExpression}
@@ -27,7 +28,6 @@ import org.apache.flink.table.types.logical.LogicalType
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.{NullNode, ObjectNode}
 
 import org.apache.calcite.rex.RexCall
-import org.apache.calcite.sql.SqlJsonConstructorNullClause.{ABSENT_ON_NULL, NULL_ON_NULL}
 
 /**
  * [[CallGenerator]] for `JSON_OBJECT`.
@@ -60,7 +60,7 @@ class JsonObjectCallGen(call: RexCall) extends CallGenerator {
         val valueTerm = createNodeTerm(ctx, valueExpr, call.operands.get(valueIdx))
 
         onNull match {
-          case NULL_ON_NULL =>
+          case JsonOnNull.NULL =>
             s"""
                |if (${valueExpr.nullTerm}) {
                |    $nodeTerm.set(${keyExpr.resultTerm}.toString(), $nullNodeTerm);
@@ -68,7 +68,7 @@ class JsonObjectCallGen(call: RexCall) extends CallGenerator {
                |    $nodeTerm.set(${keyExpr.resultTerm}.toString(), $valueTerm);
                |}
                |""".stripMargin
-          case ABSENT_ON_NULL =>
+          case JsonOnNull.ABSENT =>
             s"""
                |if (!${valueExpr.nullTerm}) {
                |    $nodeTerm.set(${keyExpr.resultTerm}.toString(), $valueTerm);

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/typeutils/SymbolUtilTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/typeutils/SymbolUtilTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.typeutils;
+
+import org.apache.flink.table.expressions.TimeIntervalUnit;
+import org.apache.flink.table.planner.typeutils.SymbolUtil.SerializableSymbol;
+import org.apache.flink.table.utils.DateTimeUtils;
+
+import org.apache.calcite.avatica.util.TimeUnitRange;
+import org.apache.calcite.sql.SqlJsonQueryEmptyOrErrorBehavior;
+import org.apache.calcite.sql.fun.SqlTrimFunction;
+import org.junit.Test;
+
+import static org.apache.flink.table.planner.typeutils.SymbolUtil.calciteToCommon;
+import static org.apache.flink.table.planner.typeutils.SymbolUtil.calciteToSerializable;
+import static org.apache.flink.table.planner.typeutils.SymbolUtil.commonToCalcite;
+import static org.apache.flink.table.planner.typeutils.SymbolUtil.serializableToCalcite;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link SymbolUtil}. */
+public class SymbolUtilTest {
+
+    @Test
+    public void testCalciteToSerializable() {
+        final SerializableSymbol trimString = SerializableSymbol.of("TRIM", "LEADING");
+        assertThat(calciteToSerializable(SqlTrimFunction.Flag.LEADING)).isEqualTo(trimString);
+        assertThat(SymbolUtil.serializableToCalcite(trimString))
+                .isEqualTo(SqlTrimFunction.Flag.LEADING);
+
+        final SerializableSymbol emptyOrErrorString =
+                SerializableSymbol.of("JSON_QUERY_ON_EMPTY_OR_ERROR", "EMPTY_OBJECT");
+        assertThat(calciteToSerializable(SqlJsonQueryEmptyOrErrorBehavior.EMPTY_OBJECT))
+                .isEqualTo(emptyOrErrorString);
+        assertThat(serializableToCalcite(emptyOrErrorString))
+                .isEqualTo(SqlJsonQueryEmptyOrErrorBehavior.EMPTY_OBJECT);
+    }
+
+    @Test
+    public void testCommonToCalcite() {
+        // public symbol
+        assertThat(commonToCalcite(TimeIntervalUnit.QUARTER)).isEqualTo(TimeUnitRange.QUARTER);
+        assertThat(calciteToCommon(TimeUnitRange.QUARTER, false))
+                .isEqualTo(TimeIntervalUnit.QUARTER);
+
+        // internal symbol
+        assertThat(commonToCalcite(DateTimeUtils.TimeUnitRange.QUARTER))
+                .isEqualTo(TimeUnitRange.QUARTER);
+        assertThat(calciteToCommon(TimeUnitRange.QUARTER, true))
+                .isEqualTo(DateTimeUtils.TimeUnitRange.QUARTER);
+    }
+}

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/MatchRecognizeJsonPlanTest_jsonplan/testMatch.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/MatchRecognizeJsonPlanTest_jsonplan/testMatch.out
@@ -284,7 +284,7 @@
       "after" : {
         "kind" : "LITERAL",
         "value" : "SKIP_TO_NEXT_ROW",
-        "class" : "org.apache.calcite.sql.SqlMatchRecognize$AfterOption",
+        "class" : "MATCH_RECOGNIZE_AFTER_OPTION",
         "type" : {
           "type" : "SYMBOL",
           "nullable" : false


### PR DESCRIPTION
## What is the purpose of the change

The Table API, `table-common` and planner declare several symbols that basically describe the same thing. However, this is not straightforward and should only consistently exposed via the persisted JSON plan. This introduces a central utility to ease the handling of those symbols. Not nice but it serves the purpose.


## Brief change log

- Introduce `SymbolUtil`
- Add mapping for all symbols that end up in a plan
- Remove custom mappings at various locations


## Verifying this change

This change added tests and can be verified as follows: `SymbolUtilTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? JavaDocs
