### PR TITLE
[FLINK-25805][table-planner] Use DataType compact representation for default conversion classes

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/DataTypeJsonSerializer.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/DataTypeJsonSerializer.java
@@ -23,7 +23,6 @@ import org.apache.flink.table.api.DataTypes.Field;
 import org.apache.flink.table.types.CollectionDataType;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.KeyValueDataType;
-import org.apache.flink.table.types.utils.DataTypeUtils;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonGenerator;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.SerializerProvider;
@@ -31,7 +30,10 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ser.std.S
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
+
+import static org.apache.flink.table.types.utils.DataTypeUtils.isInternal;
 
 /**
  * JSON serializer for {@link DataType}.
@@ -43,28 +45,41 @@ public final class DataTypeJsonSerializer extends StdSerializer<DataType> {
     private static final long serialVersionUID = 1L;
 
     /*
-    Example generated JSON for a data type with external conversion classes:
+    Example generated JSON for a data type with custom conversion classes:
 
         DataTypes.ROW(
             DataTypes.STRING().toInternal(),
-            DataTypes.TIMESTAMP_LTZ().bridgedTo(Long.class))
+            DataTypes.TIMESTAMP_LTZ().bridgedTo(Long.class),
+            DataTypes.STRING())
 
         {
-           "logicalType":"ROW<`f0` VARCHAR(2147483647), `f1` TIMESTAMP(6) WITH LOCAL TIME ZONE>",
-           "conversionClass":"org.apache.flink.types.Row",
-           "fields":[
-              {
-                 "name":"f1",
-                 "conversionClass":"java.lang.Long"
-              }
-           ]
-         }
+          "logicalType": "ROW<`f0` VARCHAR(2147483647), `f1` TIMESTAMP(6) WITH LOCAL TIME ZONE, `f2` VARCHAR(2147483647)>",
+          "fields": [
+            {
+              "name": "f0",
+              "conversionClass": "org.apache.flink.table.data.StringData"
+            },
+            {
+              "name": "f1",
+              "conversionClass": "java.lang.Long"
+            }
+          ]
+        }
+
+     Example generated JSON for a data type with only default conversion classes:
+
+        DataTypes.ROW(DataTypes.STRING(), DataTypes.TIMESTAMP_LTZ())
+
+        "ROW<`f0` VARCHAR(2147483647), `f1` TIMESTAMP(6) WITH LOCAL TIME ZONE>"
 
      Example generated JSON for a data type with only internal conversion classes:
 
         DataTypes.ROW(DataTypes.STRING(), DataTypes.TIMESTAMP_LTZ()).toInternal()
 
-        "ROW<`f0` VARCHAR(2147483647), `f1` TIMESTAMP(6) WITH LOCAL TIME ZONE>"
+        {
+          "logicalType": "ROW<`f0` VARCHAR(2147483647), `f1` TIMESTAMP(6) WITH LOCAL TIME ZONE>",
+          "conversionClass": "org.apache.flink.table.data.RowData"
+        }
      */
 
     // Common fields
@@ -91,7 +106,7 @@ public final class DataTypeJsonSerializer extends StdSerializer<DataType> {
     public void serialize(
             DataType dataType, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
             throws IOException {
-        if (DataTypeUtils.isInternal(dataType, false)) {
+        if (isDefaultClassNested(dataType)) {
             serializerProvider.defaultSerializeValue(dataType.getLogicalType(), jsonGenerator);
         } else {
             jsonGenerator.writeStartObject();
@@ -104,53 +119,55 @@ public final class DataTypeJsonSerializer extends StdSerializer<DataType> {
 
     private static void serializeClass(DataType dataType, JsonGenerator jsonGenerator)
             throws IOException {
-        jsonGenerator.writeStringField(
-                FIELD_NAME_CONVERSION_CLASS, dataType.getConversionClass().getName());
+        // skip the conversion class if only nested types contain custom conversion classes
+        if (!isDefaultClass(dataType)) {
+            jsonGenerator.writeStringField(
+                    FIELD_NAME_CONVERSION_CLASS, dataType.getConversionClass().getName());
+        }
+        // internal classes only contain nested internal classes
+        if (isInternal(dataType, false)) {
+            return;
+        }
 
         switch (dataType.getLogicalType().getTypeRoot()) {
             case ARRAY:
             case MULTISET:
                 final CollectionDataType collectionDataType = (CollectionDataType) dataType;
-                serializeFieldIfNotInternal(
+                serializeFieldIfNotDefaultClass(
                         collectionDataType.getElementDataType(),
                         FIELD_NAME_ELEMENT_CLASS,
                         jsonGenerator);
                 break;
             case MAP:
                 final KeyValueDataType keyValueDataType = (KeyValueDataType) dataType;
-                serializeFieldIfNotInternal(
+                serializeFieldIfNotDefaultClass(
                         keyValueDataType.getKeyDataType(), FIELD_NAME_KEY_CLASS, jsonGenerator);
-                serializeFieldIfNotInternal(
+                serializeFieldIfNotDefaultClass(
                         keyValueDataType.getValueDataType(), FIELD_NAME_VALUE_CLASS, jsonGenerator);
                 break;
             case ROW:
             case STRUCTURED_TYPE:
-                final List<Field> externalFields =
+                final List<Field> nonDefaultFields =
                         DataType.getFields(dataType).stream()
-                                .filter(
-                                        field ->
-                                                !DataTypeUtils.isInternal(
-                                                        field.getDataType(), false))
+                                .filter(field -> !isDefaultClassNested(field.getDataType()))
                                 .collect(Collectors.toList());
-                if (externalFields.isEmpty()) {
+                if (nonDefaultFields.isEmpty()) {
                     break;
                 }
                 jsonGenerator.writeFieldName(FIELD_NAME_FIELDS);
                 jsonGenerator.writeStartArray();
-                for (Field externalField : externalFields) {
-                    if (!DataTypeUtils.isInternal(externalField.getDataType(), false)) {
-                        jsonGenerator.writeStartObject();
-                        jsonGenerator.writeStringField(
-                                FIELD_NAME_FIELD_NAME, externalField.getName());
-                        serializeClass(externalField.getDataType(), jsonGenerator);
-                        jsonGenerator.writeEndObject();
-                    }
+                for (Field nonDefaultField : nonDefaultFields) {
+                    jsonGenerator.writeStartObject();
+                    jsonGenerator.writeStringField(
+                            FIELD_NAME_FIELD_NAME, nonDefaultField.getName());
+                    serializeClass(nonDefaultField.getDataType(), jsonGenerator);
+                    jsonGenerator.writeEndObject();
                 }
                 jsonGenerator.writeEndArray();
                 break;
             case DISTINCT_TYPE:
                 final DataType sourceDataType = dataType.getChildren().get(0);
-                if (!DataTypeUtils.isInternal(sourceDataType, false)) {
+                if (!isDefaultClassNested(sourceDataType)) {
                     serializeClass(sourceDataType, jsonGenerator);
                 }
                 break;
@@ -159,13 +176,24 @@ public final class DataTypeJsonSerializer extends StdSerializer<DataType> {
         }
     }
 
-    private static void serializeFieldIfNotInternal(
+    private static void serializeFieldIfNotDefaultClass(
             DataType dataType, String fieldName, JsonGenerator jsonGenerator) throws IOException {
-        if (!DataTypeUtils.isInternal(dataType, false)) {
+        if (!isDefaultClassNested(dataType)) {
             jsonGenerator.writeFieldName(fieldName);
             jsonGenerator.writeStartObject();
             serializeClass(dataType, jsonGenerator);
             jsonGenerator.writeEndObject();
         }
+    }
+
+    private static boolean isDefaultClassNested(DataType dataType) {
+        return isDefaultClass(dataType)
+                && dataType.getChildren().stream()
+                        .allMatch(DataTypeJsonSerializer::isDefaultClassNested);
+    }
+
+    private static boolean isDefaultClass(DataType dataType) {
+        return Objects.equals(
+                dataType.getConversionClass(), dataType.getLogicalType().getDefaultConversion());
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LogicalTypeJsonDeserializer.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LogicalTypeJsonDeserializer.java
@@ -116,7 +116,7 @@ public class LogicalTypeJsonDeserializer extends StdDeserializer<LogicalType> {
         if (logicalTypeNode.isTextual()) {
             return deserializeWithCompactSerialization(logicalTypeNode.asText(), serdeContext);
         } else {
-            return deserializeWithGenericSerialization(logicalTypeNode, serdeContext);
+            return deserializeWithExtendedSerialization(logicalTypeNode, serdeContext);
         }
     }
 
@@ -127,7 +127,7 @@ public class LogicalTypeJsonDeserializer extends StdDeserializer<LogicalType> {
         return dataTypeFactory.createLogicalType(serializableString);
     }
 
-    private static LogicalType deserializeWithGenericSerialization(
+    private static LogicalType deserializeWithExtendedSerialization(
             JsonNode logicalTypeNode, SerdeContext serdeContext) {
         final LogicalType logicalType = deserializeFromRoot(logicalTypeNode, serdeContext);
         if (logicalTypeNode.has(FIELD_NAME_NULLABLE)) {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/DataTypeJsonSerdeTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/DataTypeJsonSerdeTest.java
@@ -68,7 +68,8 @@ public class DataTypeJsonSerdeTest {
                         DataTypes.FIELD("f0", DataTypes.INT().notNull().bridgedTo(int.class)),
                         DataTypes.FIELD("f1", DataTypes.BIGINT().notNull().bridgedTo(long.class)),
                         DataTypes.FIELD("f2", DataTypes.STRING())),
-                DataTypes.MAP(DataTypes.STRING().toInternal(), DataTypes.TIMESTAMP(3)));
+                DataTypes.MAP(DataTypes.STRING().toInternal(), DataTypes.TIMESTAMP(3)),
+                DataTypes.ROW(DataTypes.TIMESTAMP_LTZ(3)).toInternal());
     }
 
     // --------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/GroupAggregateJsonPlanTest_jsonplan/testDistinctAggCalls[isMiniBatchEnabled=true].out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/GroupAggregateJsonPlanTest_jsonplan/testDistinctAggCalls[isMiniBatchEnabled=true].out
@@ -208,18 +208,11 @@
           "type" : "RAW",
           "class" : "org.apache.flink.table.api.dataview.MapView",
           "externalDataType" : {
-            "logicalType" : {
-              "type" : "STRUCTURED_TYPE",
-              "implementationClass" : "org.apache.flink.table.api.dataview.MapView",
-              "attributes" : [ {
-                "name" : "map",
-                "attributeType" : "MAP<BIGINT, BIGINT NOT NULL>"
-              } ]
-            },
-            "conversionClass" : "org.apache.flink.table.api.dataview.MapView",
-            "fields" : [ {
+            "type" : "STRUCTURED_TYPE",
+            "implementationClass" : "org.apache.flink.table.api.dataview.MapView",
+            "attributes" : [ {
               "name" : "map",
-              "conversionClass" : "java.util.Map"
+              "attributeType" : "MAP<BIGINT, BIGINT NOT NULL>"
             } ]
           }
         }
@@ -229,18 +222,11 @@
           "type" : "RAW",
           "class" : "org.apache.flink.table.api.dataview.MapView",
           "externalDataType" : {
-            "logicalType" : {
-              "type" : "STRUCTURED_TYPE",
-              "implementationClass" : "org.apache.flink.table.api.dataview.MapView",
-              "attributes" : [ {
-                "name" : "map",
-                "attributeType" : "MAP<INT NOT NULL, BIGINT NOT NULL>"
-              } ]
-            },
-            "conversionClass" : "org.apache.flink.table.api.dataview.MapView",
-            "fields" : [ {
+            "type" : "STRUCTURED_TYPE",
+            "implementationClass" : "org.apache.flink.table.api.dataview.MapView",
+            "attributes" : [ {
               "name" : "map",
-              "conversionClass" : "java.util.Map"
+              "attributeType" : "MAP<INT NOT NULL, BIGINT NOT NULL>"
             } ]
           }
         }
@@ -258,10 +244,11 @@
                 "attributeType" : "MAP<VARCHAR(2147483647), BIGINT NOT NULL>"
               } ]
             },
-            "conversionClass" : "org.apache.flink.table.api.dataview.MapView",
             "fields" : [ {
               "name" : "map",
-              "conversionClass" : "java.util.Map"
+              "keyClass" : {
+                "conversionClass" : "org.apache.flink.table.data.StringData"
+              }
             } ]
           }
         }
@@ -311,18 +298,11 @@
           "type" : "RAW",
           "class" : "org.apache.flink.table.api.dataview.MapView",
           "externalDataType" : {
-            "logicalType" : {
-              "type" : "STRUCTURED_TYPE",
-              "implementationClass" : "org.apache.flink.table.api.dataview.MapView",
-              "attributes" : [ {
-                "name" : "map",
-                "attributeType" : "MAP<BIGINT, BIGINT NOT NULL>"
-              } ]
-            },
-            "conversionClass" : "org.apache.flink.table.api.dataview.MapView",
-            "fields" : [ {
+            "type" : "STRUCTURED_TYPE",
+            "implementationClass" : "org.apache.flink.table.api.dataview.MapView",
+            "attributes" : [ {
               "name" : "map",
-              "conversionClass" : "java.util.Map"
+              "attributeType" : "MAP<BIGINT, BIGINT NOT NULL>"
             } ]
           }
         }
@@ -332,18 +312,11 @@
           "type" : "RAW",
           "class" : "org.apache.flink.table.api.dataview.MapView",
           "externalDataType" : {
-            "logicalType" : {
-              "type" : "STRUCTURED_TYPE",
-              "implementationClass" : "org.apache.flink.table.api.dataview.MapView",
-              "attributes" : [ {
-                "name" : "map",
-                "attributeType" : "MAP<INT NOT NULL, BIGINT NOT NULL>"
-              } ]
-            },
-            "conversionClass" : "org.apache.flink.table.api.dataview.MapView",
-            "fields" : [ {
+            "type" : "STRUCTURED_TYPE",
+            "implementationClass" : "org.apache.flink.table.api.dataview.MapView",
+            "attributes" : [ {
               "name" : "map",
-              "conversionClass" : "java.util.Map"
+              "attributeType" : "MAP<INT NOT NULL, BIGINT NOT NULL>"
             } ]
           }
         }
@@ -361,10 +334,11 @@
                 "attributeType" : "MAP<VARCHAR(2147483647), BIGINT NOT NULL>"
               } ]
             },
-            "conversionClass" : "org.apache.flink.table.api.dataview.MapView",
             "fields" : [ {
               "name" : "map",
-              "conversionClass" : "java.util.Map"
+              "keyClass" : {
+                "conversionClass" : "org.apache.flink.table.data.StringData"
+              }
             } ]
           }
         }

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/IncrementalAggregateJsonPlanTest_jsonplan/testIncrementalAggregate.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/IncrementalAggregateJsonPlanTest_jsonplan/testIncrementalAggregate.out
@@ -146,10 +146,11 @@
                 "attributeType" : "MAP<VARCHAR(2147483647), BIGINT NOT NULL>"
               } ]
             },
-            "conversionClass" : "org.apache.flink.table.api.dataview.MapView",
             "fields" : [ {
               "name" : "map",
-              "conversionClass" : "java.util.Map"
+              "keyClass" : {
+                "conversionClass" : "org.apache.flink.table.data.StringData"
+              }
             } ]
           }
         }
@@ -192,10 +193,11 @@
                 "attributeType" : "MAP<VARCHAR(2147483647), BIGINT NOT NULL>"
               } ]
             },
-            "conversionClass" : "org.apache.flink.table.api.dataview.MapView",
             "fields" : [ {
               "name" : "map",
-              "conversionClass" : "java.util.Map"
+              "keyClass" : {
+                "conversionClass" : "org.apache.flink.table.data.StringData"
+              }
             } ]
           }
         }

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/IncrementalAggregateJsonPlanTest_jsonplan/testIncrementalAggregateWithSumCountDistinctAndRetraction.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/IncrementalAggregateJsonPlanTest_jsonplan/testIncrementalAggregateWithSumCountDistinctAndRetraction.out
@@ -272,18 +272,11 @@
           "type" : "RAW",
           "class" : "org.apache.flink.table.api.dataview.MapView",
           "externalDataType" : {
-            "logicalType" : {
-              "type" : "STRUCTURED_TYPE",
-              "implementationClass" : "org.apache.flink.table.api.dataview.MapView",
-              "attributes" : [ {
-                "name" : "map",
-                "attributeType" : "MAP<INT NOT NULL, BIGINT NOT NULL>"
-              } ]
-            },
-            "conversionClass" : "org.apache.flink.table.api.dataview.MapView",
-            "fields" : [ {
+            "type" : "STRUCTURED_TYPE",
+            "implementationClass" : "org.apache.flink.table.api.dataview.MapView",
+            "attributes" : [ {
               "name" : "map",
-              "conversionClass" : "java.util.Map"
+              "attributeType" : "MAP<INT NOT NULL, BIGINT NOT NULL>"
             } ]
           }
         }
@@ -327,18 +320,11 @@
           "type" : "RAW",
           "class" : "org.apache.flink.table.api.dataview.MapView",
           "externalDataType" : {
-            "logicalType" : {
-              "type" : "STRUCTURED_TYPE",
-              "implementationClass" : "org.apache.flink.table.api.dataview.MapView",
-              "attributes" : [ {
-                "name" : "map",
-                "attributeType" : "MAP<INT NOT NULL, BIGINT NOT NULL>"
-              } ]
-            },
-            "conversionClass" : "org.apache.flink.table.api.dataview.MapView",
-            "fields" : [ {
+            "type" : "STRUCTURED_TYPE",
+            "implementationClass" : "org.apache.flink.table.api.dataview.MapView",
+            "attributes" : [ {
               "name" : "map",
-              "conversionClass" : "java.util.Map"
+              "attributeType" : "MAP<INT NOT NULL, BIGINT NOT NULL>"
             } ]
           }
         }

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/WindowAggregateJsonPlanTest_jsonplan/testDistinctSplitEnabled.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/WindowAggregateJsonPlanTest_jsonplan/testDistinctSplitEnabled.out
@@ -295,10 +295,11 @@
                 "attributeType" : "MAP<VARCHAR(2147483647), BIGINT NOT NULL>"
               } ]
             },
-            "conversionClass" : "org.apache.flink.table.api.dataview.MapView",
             "fields" : [ {
               "name" : "map",
-              "conversionClass" : "java.util.Map"
+              "keyClass" : {
+                "conversionClass" : "org.apache.flink.table.data.StringData"
+              }
             } ]
           }
         }
@@ -350,10 +351,11 @@
                 "attributeType" : "MAP<VARCHAR(2147483647), BIGINT NOT NULL>"
               } ]
             },
-            "conversionClass" : "org.apache.flink.table.api.dataview.MapView",
             "fields" : [ {
               "name" : "map",
-              "conversionClass" : "java.util.Map"
+              "keyClass" : {
+                "conversionClass" : "org.apache.flink.table.data.StringData"
+              }
             } ]
           }
         }

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/WindowAggregateJsonPlanTest_jsonplan/testEventTimeTumbleWindow.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/WindowAggregateJsonPlanTest_jsonplan/testEventTimeTumbleWindow.out
@@ -283,13 +283,9 @@
                     "attributeType" : "ARRAY<VARCHAR(2147483647)>"
                   } ]
                 },
-                "conversionClass" : "org.apache.flink.table.api.dataview.ListView",
                 "fields" : [ {
                   "name" : "list",
-                  "conversionClass" : "java.util.List",
-                  "elementClass" : {
-                    "conversionClass" : "java.lang.String"
-                  }
+                  "conversionClass" : "java.util.List"
                 } ]
               }
             }
@@ -299,21 +295,11 @@
               "type" : "RAW",
               "class" : "org.apache.flink.table.api.dataview.MapView",
               "externalDataType" : {
-                "logicalType" : {
-                  "type" : "STRUCTURED_TYPE",
-                  "implementationClass" : "org.apache.flink.table.api.dataview.MapView",
-                  "attributes" : [ {
-                    "name" : "map",
-                    "attributeType" : "MAP<VARCHAR(2147483647), BOOLEAN>"
-                  } ]
-                },
-                "conversionClass" : "org.apache.flink.table.api.dataview.MapView",
-                "fields" : [ {
+                "type" : "STRUCTURED_TYPE",
+                "implementationClass" : "org.apache.flink.table.api.dataview.MapView",
+                "attributes" : [ {
                   "name" : "map",
-                  "conversionClass" : "java.util.Map",
-                  "keyClass" : {
-                    "conversionClass" : "java.lang.String"
-                  }
+                  "attributeType" : "MAP<VARCHAR(2147483647), BOOLEAN>"
                 } ]
               }
             }
@@ -333,10 +319,11 @@
                 "attributeType" : "MAP<VARCHAR(2147483647), BIGINT NOT NULL>"
               } ]
             },
-            "conversionClass" : "org.apache.flink.table.api.dataview.MapView",
             "fields" : [ {
               "name" : "map",
-              "conversionClass" : "java.util.Map"
+              "keyClass" : {
+                "conversionClass" : "org.apache.flink.table.data.StringData"
+              }
             } ]
           }
         }
@@ -390,13 +377,9 @@
                     "attributeType" : "ARRAY<VARCHAR(2147483647)>"
                   } ]
                 },
-                "conversionClass" : "org.apache.flink.table.api.dataview.ListView",
                 "fields" : [ {
                   "name" : "list",
-                  "conversionClass" : "java.util.List",
-                  "elementClass" : {
-                    "conversionClass" : "java.lang.String"
-                  }
+                  "conversionClass" : "java.util.List"
                 } ]
               }
             }
@@ -406,21 +389,11 @@
               "type" : "RAW",
               "class" : "org.apache.flink.table.api.dataview.MapView",
               "externalDataType" : {
-                "logicalType" : {
-                  "type" : "STRUCTURED_TYPE",
-                  "implementationClass" : "org.apache.flink.table.api.dataview.MapView",
-                  "attributes" : [ {
-                    "name" : "map",
-                    "attributeType" : "MAP<VARCHAR(2147483647), BOOLEAN>"
-                  } ]
-                },
-                "conversionClass" : "org.apache.flink.table.api.dataview.MapView",
-                "fields" : [ {
+                "type" : "STRUCTURED_TYPE",
+                "implementationClass" : "org.apache.flink.table.api.dataview.MapView",
+                "attributes" : [ {
                   "name" : "map",
-                  "conversionClass" : "java.util.Map",
-                  "keyClass" : {
-                    "conversionClass" : "java.lang.String"
-                  }
+                  "attributeType" : "MAP<VARCHAR(2147483647), BOOLEAN>"
                 } ]
               }
             }
@@ -440,10 +413,11 @@
                 "attributeType" : "MAP<VARCHAR(2147483647), BIGINT NOT NULL>"
               } ]
             },
-            "conversionClass" : "org.apache.flink.table.api.dataview.MapView",
             "fields" : [ {
               "name" : "map",
-              "conversionClass" : "java.util.Map"
+              "keyClass" : {
+                "conversionClass" : "org.apache.flink.table.data.StringData"
+              }
             } ]
           }
         }

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/WindowAggregateJsonPlanTest_jsonplan/testEventTimeTumbleWindowWithOffset.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/WindowAggregateJsonPlanTest_jsonplan/testEventTimeTumbleWindowWithOffset.out
@@ -284,13 +284,9 @@
                     "attributeType" : "ARRAY<VARCHAR(2147483647)>"
                   } ]
                 },
-                "conversionClass" : "org.apache.flink.table.api.dataview.ListView",
                 "fields" : [ {
                   "name" : "list",
-                  "conversionClass" : "java.util.List",
-                  "elementClass" : {
-                    "conversionClass" : "java.lang.String"
-                  }
+                  "conversionClass" : "java.util.List"
                 } ]
               }
             }
@@ -300,21 +296,11 @@
               "type" : "RAW",
               "class" : "org.apache.flink.table.api.dataview.MapView",
               "externalDataType" : {
-                "logicalType" : {
-                  "type" : "STRUCTURED_TYPE",
-                  "implementationClass" : "org.apache.flink.table.api.dataview.MapView",
-                  "attributes" : [ {
-                    "name" : "map",
-                    "attributeType" : "MAP<VARCHAR(2147483647), BOOLEAN>"
-                  } ]
-                },
-                "conversionClass" : "org.apache.flink.table.api.dataview.MapView",
-                "fields" : [ {
+                "type" : "STRUCTURED_TYPE",
+                "implementationClass" : "org.apache.flink.table.api.dataview.MapView",
+                "attributes" : [ {
                   "name" : "map",
-                  "conversionClass" : "java.util.Map",
-                  "keyClass" : {
-                    "conversionClass" : "java.lang.String"
-                  }
+                  "attributeType" : "MAP<VARCHAR(2147483647), BOOLEAN>"
                 } ]
               }
             }
@@ -334,10 +320,11 @@
                 "attributeType" : "MAP<VARCHAR(2147483647), BIGINT NOT NULL>"
               } ]
             },
-            "conversionClass" : "org.apache.flink.table.api.dataview.MapView",
             "fields" : [ {
               "name" : "map",
-              "conversionClass" : "java.util.Map"
+              "keyClass" : {
+                "conversionClass" : "org.apache.flink.table.data.StringData"
+              }
             } ]
           }
         }
@@ -391,13 +378,9 @@
                     "attributeType" : "ARRAY<VARCHAR(2147483647)>"
                   } ]
                 },
-                "conversionClass" : "org.apache.flink.table.api.dataview.ListView",
                 "fields" : [ {
                   "name" : "list",
-                  "conversionClass" : "java.util.List",
-                  "elementClass" : {
-                    "conversionClass" : "java.lang.String"
-                  }
+                  "conversionClass" : "java.util.List"
                 } ]
               }
             }
@@ -407,21 +390,11 @@
               "type" : "RAW",
               "class" : "org.apache.flink.table.api.dataview.MapView",
               "externalDataType" : {
-                "logicalType" : {
-                  "type" : "STRUCTURED_TYPE",
-                  "implementationClass" : "org.apache.flink.table.api.dataview.MapView",
-                  "attributes" : [ {
-                    "name" : "map",
-                    "attributeType" : "MAP<VARCHAR(2147483647), BOOLEAN>"
-                  } ]
-                },
-                "conversionClass" : "org.apache.flink.table.api.dataview.MapView",
-                "fields" : [ {
+                "type" : "STRUCTURED_TYPE",
+                "implementationClass" : "org.apache.flink.table.api.dataview.MapView",
+                "attributes" : [ {
                   "name" : "map",
-                  "conversionClass" : "java.util.Map",
-                  "keyClass" : {
-                    "conversionClass" : "java.lang.String"
-                  }
+                  "attributeType" : "MAP<VARCHAR(2147483647), BOOLEAN>"
                 } ]
               }
             }
@@ -441,10 +414,11 @@
                 "attributeType" : "MAP<VARCHAR(2147483647), BIGINT NOT NULL>"
               } ]
             },
-            "conversionClass" : "org.apache.flink.table.api.dataview.MapView",
             "fields" : [ {
               "name" : "map",
-              "conversionClass" : "java.util.Map"
+              "keyClass" : {
+                "conversionClass" : "org.apache.flink.table.data.StringData"
+              }
             } ]
           }
         }

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/WindowJoinJsonPlanTest_jsonplan/testEventTimeTumbleWindow.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/WindowJoinJsonPlanTest_jsonplan/testEventTimeTumbleWindow.out
@@ -195,10 +195,11 @@
                 "attributeType" : "MAP<VARCHAR(2147483647), BIGINT NOT NULL>"
               } ]
             },
-            "conversionClass" : "org.apache.flink.table.api.dataview.MapView",
             "fields" : [ {
               "name" : "map",
-              "conversionClass" : "java.util.Map"
+              "keyClass" : {
+                "conversionClass" : "org.apache.flink.table.data.StringData"
+              }
             } ]
           }
         }
@@ -244,10 +245,11 @@
                 "attributeType" : "MAP<VARCHAR(2147483647), BIGINT NOT NULL>"
               } ]
             },
-            "conversionClass" : "org.apache.flink.table.api.dataview.MapView",
             "fields" : [ {
               "name" : "map",
-              "conversionClass" : "java.util.Map"
+              "keyClass" : {
+                "conversionClass" : "org.apache.flink.table.data.StringData"
+              }
             } ]
           }
         }
@@ -636,10 +638,11 @@
                 "attributeType" : "MAP<VARCHAR(2147483647), BIGINT NOT NULL>"
               } ]
             },
-            "conversionClass" : "org.apache.flink.table.api.dataview.MapView",
             "fields" : [ {
               "name" : "map",
-              "conversionClass" : "java.util.Map"
+              "keyClass" : {
+                "conversionClass" : "org.apache.flink.table.data.StringData"
+              }
             } ]
           }
         }
@@ -685,10 +688,11 @@
                 "attributeType" : "MAP<VARCHAR(2147483647), BIGINT NOT NULL>"
               } ]
             },
-            "conversionClass" : "org.apache.flink.table.api.dataview.MapView",
             "fields" : [ {
               "name" : "map",
-              "conversionClass" : "java.util.Map"
+              "keyClass" : {
+                "conversionClass" : "org.apache.flink.table.data.StringData"
+              }
             } ]
           }
         }


### PR DESCRIPTION
## What is the purpose of the change

This switches to compact representation for non-default conversion classes.

## Brief change log

- Use compact representation for non-default conversion classes.
- Internal conversion classes only serialize the top-level.

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
