### PR TITLE
[FLINK-25835][Runtime]Adding Task Initialization Logs

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/FinishedOperatorChain.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/FinishedOperatorChain.java
@@ -74,7 +74,7 @@ public class FinishedOperatorChain<OUT, OP extends StreamOperator<OUT>>
 
     @Override
     public void initializeStateAndOpenOperators(
-            StreamTaskStateInitializer streamTaskStateInitializer) {}
+            StreamTaskStateInitializer streamTaskStateInitializer, String taskName) {}
 
     @Override
     public void finishOperators(StreamTaskActionExecutor actionExecutor, StopMode stopMode)

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
@@ -296,12 +296,13 @@ public abstract class OperatorChain<OUT, OP extends StreamOperator<OUT>>
      * #finishOperators(StreamTaskActionExecutor, StopMode)}).
      */
     public abstract void initializeStateAndOpenOperators(
-            StreamTaskStateInitializer streamTaskStateInitializer) throws Exception;
+            StreamTaskStateInitializer streamTaskStateInitializer, String taskName)
+            throws Exception;
 
     /**
      * Closes all operators in a chain effect way. Closing happens from <b>heads to tail</b>
      * operator in the chain, contrary to {@link StreamOperator#open()} which happens <b>tail to
-     * heads</b> (see {@link #initializeStateAndOpenOperators(StreamTaskStateInitializer)}).
+     * heads</b> (see {@link #initializeStateAndOpenOperators(StreamTaskStateInitializer, String)}).
      */
     public abstract void finishOperators(StreamTaskActionExecutor actionExecutor, StopMode stopMode)
             throws Exception;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/RegularOperatorChain.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/RegularOperatorChain.java
@@ -100,11 +100,14 @@ public class RegularOperatorChain<OUT, OP extends StreamOperator<OUT>>
 
     @Override
     public void initializeStateAndOpenOperators(
-            StreamTaskStateInitializer streamTaskStateInitializer) throws Exception {
+            StreamTaskStateInitializer streamTaskStateInitializer, String taskName)
+            throws Exception {
         for (StreamOperatorWrapper<?, ?> operatorWrapper : getAllOperators(true)) {
             StreamOperator<?> operator = operatorWrapper.getStreamOperator();
+            LOG.debug("Initializing {} {} state and open.", taskName, operator.getOperatorID());
             operator.initializeState(streamTaskStateInitializer);
             operator.open();
+            LOG.debug("Complete {} {} initialization.", taskName, operator.getOperatorID());
         }
     }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -647,7 +647,8 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
             return;
         }
         closedOperators = false;
-        LOG.debug("Initializing {}.", getName());
+        LOG.info("Initializing {}.", getName());
+        long startTime = System.currentTimeMillis();
 
         operatorChain =
                 getEnvironment().getTaskStateManager().isTaskDeployedAsFinished()
@@ -685,7 +686,10 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
         // we recovered all the gates, we can close the channel IO executor as it is no longer
         // needed
         channelIOExecutor.shutdown();
-
+        LOG.info(
+                "{} completion initialization, takes {}ms.",
+                getName(),
+                (System.currentTimeMillis() - startTime));
         isRunning = true;
     }
 
@@ -695,7 +699,8 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
         reader.readOutputData(
                 getEnvironment().getAllWriters(), !configuration.isGraphContainingLoops());
 
-        operatorChain.initializeStateAndOpenOperators(createStreamTaskStateInitializer());
+        operatorChain.initializeStateAndOpenOperators(
+                createStreamTaskStateInitializer(), getName());
 
         IndexedInputGate[] inputGates = getEnvironment().getAllInputGates();
         channelIOExecutor.execute(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamOperatorChainingTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamOperatorChainingTest.java
@@ -137,7 +137,7 @@ public class StreamOperatorChainingTest {
 
             headOperator.setup(mockTask, streamConfig, operatorChain.getMainOperatorOutput());
 
-            operatorChain.initializeStateAndOpenOperators(null);
+            operatorChain.initializeStateAndOpenOperators(null, "testMultiChaining");
 
             headOperator.processElement(new StreamRecord<>(1));
             headOperator.processElement(new StreamRecord<>(2));
@@ -263,7 +263,7 @@ public class StreamOperatorChainingTest {
 
             headOperator.setup(mockTask, streamConfig, operatorChain.getMainOperatorOutput());
 
-            operatorChain.initializeStateAndOpenOperators(null);
+            operatorChain.initializeStateAndOpenOperators(null, "testMultiChainingWithSplit");
 
             headOperator.processElement(new StreamRecord<>(1));
             headOperator.processElement(new StreamRecord<>(2));
@@ -302,7 +302,8 @@ public class StreamOperatorChainingTest {
 
         @Override
         public void initializeStateAndOpenOperators(
-                StreamTaskStateInitializer streamTaskStateInitializer) throws Exception {
+                StreamTaskStateInitializer streamTaskStateInitializer, String taskName)
+                throws Exception {
             for (StreamOperatorWrapper<?, ?> operatorWrapper : getAllOperators(true)) {
                 StreamOperator<?> operator = operatorWrapper.getStreamOperator();
                 operator.open();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorTest.java
@@ -275,7 +275,8 @@ public class SubtaskCheckpointCoordinatorTest {
                     operatorChain(streamMap);
             StreamTaskStateInitializerImpl stateInitializer =
                     new StreamTaskStateInitializerImpl(mockEnvironment, new TestStateBackend());
-            operatorChain.initializeStateAndOpenOperators(stateInitializer);
+            operatorChain.initializeStateAndOpenOperators(
+                    stateInitializer, "testNotifyCheckpointSubsumed");
 
             long checkpointId = 42L;
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
