### PR TITLE
[FLINK-25432] Introduces ResourceCleaner to be used in the Dispatcher

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesCheckpointRecoveryFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesCheckpointRecoveryFactory.java
@@ -80,7 +80,6 @@ public class KubernetesCheckpointRecoveryFactory implements CheckpointRecoveryFa
     public CompletedCheckpointStore createRecoveredCompletedCheckpointStore(
             JobID jobID,
             int maxNumberOfCheckpointsToRetain,
-            ClassLoader userClassLoader,
             SharedStateRegistryFactory sharedStateRegistryFactory,
             Executor ioExecutor)
             throws Exception {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
@@ -25,18 +25,23 @@ import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.SecurityOptions;
+import org.apache.flink.runtime.dispatcher.cleanup.GloballyCleanableResource;
+import org.apache.flink.runtime.dispatcher.cleanup.LocallyCleanableResource;
 import org.apache.flink.runtime.net.SSLUtils;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FileUtils;
 import org.apache.flink.util.NetUtils;
 import org.apache.flink.util.Reference;
 import org.apache.flink.util.ShutdownHookUtil;
+import org.apache.flink.util.concurrent.FutureUtils;
 import org.apache.flink.util.function.FunctionUtils;
+import org.apache.flink.util.function.ThrowingRunnable;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
 import javax.net.ServerSocketFactory;
 
 import java.io.File;
@@ -55,8 +60,12 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.Timer;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -74,7 +83,12 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * the directory structure to store the BLOBs or temporarily cache them.
  */
 public class BlobServer extends Thread
-        implements BlobService, BlobWriter, PermanentBlobService, TransientBlobService {
+        implements BlobService,
+                BlobWriter,
+                PermanentBlobService,
+                TransientBlobService,
+                LocallyCleanableResource,
+                GloballyCleanableResource {
 
     /** The log object used for debugging. */
     private static final Logger LOG = LoggerFactory.getLogger(BlobServer.class);
@@ -861,61 +875,99 @@ public class BlobServer extends Thread
     }
 
     /**
-     * Removes all BLOBs from local and HA store belonging to the given job ID.
+     * Deletes locally stored artifacts for the job represented by the given {@link JobID}. This
+     * doesn't touch the job's entry in the {@link BlobStore} to enable recovering.
      *
-     * @param jobId ID of the job this blob belongs to
-     * @param cleanupBlobStoreFiles True if the corresponding blob store files shall be cleaned up
-     *     as well. Otherwise false.
-     * @return <tt>true</tt> if the job directory is successfully deleted or non-existing;
-     *     <tt>false</tt> otherwise
+     * @param jobId The {@code JobID} of the job that is subject to cleanup.
      */
-    public boolean cleanupJob(JobID jobId, boolean cleanupBlobStoreFiles) {
+    @Override
+    public CompletableFuture<Void> localCleanupAsync(JobID jobId, Executor cleanupExecutor) {
         checkNotNull(jobId);
 
+        return runAsyncWithWriteLock(() -> internalLocalCleanup(jobId), cleanupExecutor);
+    }
+
+    @GuardedBy("readWriteLock")
+    private void internalLocalCleanup(JobID jobId) throws IOException {
         final File jobDir =
                 new File(
                         BlobUtils.getStorageLocationPath(
                                 storageDir.deref().getAbsolutePath(), jobId));
+        FileUtils.deleteDirectory(jobDir);
 
-        readWriteLock.writeLock().lock();
-
-        try {
-            // delete locally
-            boolean deletedLocally = false;
-            try {
-                FileUtils.deleteDirectory(jobDir);
-
-                // NOTE on why blobExpiryTimes are not cleaned up:
-                //       Instead of going through blobExpiryTimes, keep lingering entries - they
-                //       will be cleaned up by the timer task which tolerates non-existing files
-                //       If inserted again with the same IDs (via put()), the TTL will be updated
-                //       again.
-
-                deletedLocally = true;
-            } catch (IOException e) {
-                LOG.warn(
-                        "Failed to locally delete BLOB storage directory at "
-                                + jobDir.getAbsolutePath(),
-                        e);
-            }
-
-            // delete in HA blob store files
-            final boolean deletedHA = !cleanupBlobStoreFiles || blobStore.deleteAll(jobId);
-
-            return deletedLocally && deletedHA;
-        } finally {
-            readWriteLock.writeLock().unlock();
-        }
+        // NOTE on why blobExpiryTimes are not cleaned up: Instead of going through
+        // blobExpiryTimes, keep lingering entries. They will be cleaned up by the timer
+        // task which tolerate non-existing files. If inserted again with the same IDs
+        // (via put()), the TTL will be updated again.
     }
 
-    public void retainJobs(Collection<JobID> jobsToRetain) throws IOException {
+    /**
+     * Removes all BLOBs from local and HA store belonging to the given {@link JobID}.
+     *
+     * @param jobId ID of the job this blob belongs to
+     */
+    @Override
+    public CompletableFuture<Void> globalCleanupAsync(JobID jobId, Executor executor) {
+        checkNotNull(jobId);
+
+        return runAsyncWithWriteLock(
+                () -> {
+                    IOException exception = null;
+
+                    try {
+                        internalLocalCleanup(jobId);
+                    } catch (IOException e) {
+                        exception = e;
+                    }
+
+                    if (!blobStore.deleteAll(jobId)) {
+                        exception =
+                                ExceptionUtils.firstOrSuppressed(
+                                        new IOException(
+                                                "Error while cleaning up the BlobStore for job "
+                                                        + jobId),
+                                        exception);
+                    }
+
+                    if (exception != null) {
+                        throw new IOException(exception);
+                    }
+                },
+                executor);
+    }
+
+    private CompletableFuture<Void> runAsyncWithWriteLock(
+            ThrowingRunnable<IOException> runnable, Executor executor) {
+        return CompletableFuture.runAsync(
+                () -> {
+                    readWriteLock.writeLock().lock();
+                    try {
+                        runnable.run();
+                    } catch (IOException e) {
+                        throw new CompletionException(e);
+                    } finally {
+                        readWriteLock.writeLock().unlock();
+                    }
+                },
+                executor);
+    }
+
+    public void retainJobs(Collection<JobID> jobsToRetain, Executor ioExecutor) throws IOException {
         if (storageDir.deref().exists()) {
             final Set<JobID> jobsToRemove = BlobUtils.listExistingJobs(storageDir.deref().toPath());
 
             jobsToRemove.removeAll(jobsToRetain);
 
+            final Collection<CompletableFuture<Void>> cleanupResultFutures =
+                    new ArrayList<>(jobsToRemove.size());
             for (JobID jobToRemove : jobsToRemove) {
-                cleanupJob(jobToRemove, true);
+                cleanupResultFutures.add(globalCleanupAsync(jobToRemove, ioExecutor));
+            }
+
+            try {
+                FutureUtils.completeAll(cleanupResultFutures).get();
+            } catch (InterruptedException | ExecutionException e) {
+                ExceptionUtils.rethrowIOException(e);
             }
         }
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/FileSystemBlobStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/FileSystemBlobStore.java
@@ -158,7 +158,13 @@ public class FileSystemBlobStore implements BlobStoreService {
 
             Path path = new Path(blobPath);
 
-            boolean result = fileSystem.delete(path, true);
+            boolean result = true;
+            if (fileSystem.exists(path)) {
+                result = fileSystem.delete(path, true);
+            } else {
+                LOG.debug(
+                        "The given path {} is not present anymore. No deletion is required.", path);
+            }
 
             // send a call to delete the directory containing the file. This will
             // fail (and be ignored) when some files still exist.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointRecoveryFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointRecoveryFactory.java
@@ -34,7 +34,6 @@ public interface CheckpointRecoveryFactory {
      *
      * @param jobId Job ID to recover checkpoints for
      * @param maxNumberOfCheckpointsToRetain Maximum number of checkpoints to retain
-     * @param userClassLoader User code class loader of the job
      * @param sharedStateRegistryFactory Simple factory to produce {@link SharedStateRegistry}
      *     objects.
      * @param ioExecutor Executor used to run (async) deletes.
@@ -43,7 +42,6 @@ public interface CheckpointRecoveryFactory {
     CompletedCheckpointStore createRecoveredCompletedCheckpointStore(
             JobID jobId,
             int maxNumberOfCheckpointsToRetain,
-            ClassLoader userClassLoader,
             SharedStateRegistryFactory sharedStateRegistryFactory,
             Executor ioExecutor)
             throws Exception;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PerJobCheckpointRecoveryFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PerJobCheckpointRecoveryFactory.java
@@ -74,7 +74,6 @@ public class PerJobCheckpointRecoveryFactory<T extends CompletedCheckpointStore>
     public CompletedCheckpointStore createRecoveredCompletedCheckpointStore(
             JobID jobId,
             int maxNumberOfCheckpointsToRetain,
-            ClassLoader userClassLoader,
             SharedStateRegistryFactory sharedStateRegistryFactory,
             Executor ioExecutor) {
         return store.compute(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StandaloneCheckpointRecoveryFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StandaloneCheckpointRecoveryFactory.java
@@ -31,7 +31,6 @@ public class StandaloneCheckpointRecoveryFactory implements CheckpointRecoveryFa
     public CompletedCheckpointStore createRecoveredCompletedCheckpointStore(
             JobID jobId,
             int maxNumberOfCheckpointsToRetain,
-            ClassLoader userClassLoader,
             SharedStateRegistryFactory sharedStateRegistryFactory,
             Executor ioExecutor)
             throws Exception {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/ZooKeeperCheckpointRecoveryFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/ZooKeeperCheckpointRecoveryFactory.java
@@ -50,7 +50,6 @@ public class ZooKeeperCheckpointRecoveryFactory implements CheckpointRecoveryFac
     public CompletedCheckpointStore createRecoveredCompletedCheckpointStore(
             JobID jobId,
             int maxNumberOfCheckpointsToRetain,
-            ClassLoader userClassLoader,
             SharedStateRegistryFactory sharedStateRegistryFactory,
             Executor ioExecutor)
             throws Exception {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DefaultJobManagerRunnerRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DefaultJobManagerRunnerRegistry.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.jobmaster.JobManagerRunner;
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.concurrent.FutureUtils;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+/**
+ * {@code DefaultJobManagerRunnerRegistry} is the default implementation of the {@link
+ * JobManagerRunnerRegistry} interface. All methods of this class are expected to be called from
+ * within the main thread.
+ */
+public class DefaultJobManagerRunnerRegistry implements JobManagerRunnerRegistry {
+
+    @VisibleForTesting final Map<JobID, JobManagerRunner> jobManagerRunners;
+    private final ComponentMainThreadExecutor mainThreadExecutor;
+
+    public DefaultJobManagerRunnerRegistry(
+            int initialCapacity, ComponentMainThreadExecutor mainThreadExecutor) {
+        Preconditions.checkArgument(initialCapacity > 0);
+        jobManagerRunners = new HashMap<>(initialCapacity);
+        this.mainThreadExecutor = mainThreadExecutor;
+    }
+
+    @Override
+    public boolean isRegistered(JobID jobId) {
+        return jobManagerRunners.containsKey(jobId);
+    }
+
+    @Override
+    public void register(JobManagerRunner jobManagerRunner) {
+        mainThreadExecutor.assertRunningInMainThread();
+        Preconditions.checkArgument(
+                !isRegistered(jobManagerRunner.getJobID()),
+                "A job with the ID %s is already registered.",
+                jobManagerRunner.getJobID());
+        this.jobManagerRunners.put(jobManagerRunner.getJobID(), jobManagerRunner);
+    }
+
+    @Override
+    public JobManagerRunner get(JobID jobId) {
+        assertJobRegistered(jobId);
+        return this.jobManagerRunners.get(jobId);
+    }
+
+    @Override
+    public int size() {
+        return this.jobManagerRunners.size();
+    }
+
+    @Override
+    public Set<JobID> getRunningJobIds() {
+        return new HashSet<>(this.jobManagerRunners.keySet());
+    }
+
+    @Override
+    public Collection<JobManagerRunner> getJobManagerRunners() {
+        return new ArrayList<>(this.jobManagerRunners.values());
+    }
+
+    @Override
+    public CompletableFuture<Void> globalCleanupAsync(JobID jobId, Executor unusedExecutor) {
+        return cleanup(jobId);
+    }
+
+    @Override
+    public CompletableFuture<Void> localCleanupAsync(JobID jobId, Executor unusedExecutor) {
+        return cleanup(jobId);
+    }
+
+    private CompletableFuture<Void> cleanup(JobID jobId) {
+        mainThreadExecutor.assertRunningInMainThread();
+        if (isRegistered(jobId)) {
+            try {
+                unregister(jobId).close();
+            } catch (Exception e) {
+                return FutureUtils.completedExceptionally(e);
+            }
+        }
+
+        return FutureUtils.completedVoidFuture();
+    }
+
+    @Override
+    public JobManagerRunner unregister(JobID jobId) {
+        mainThreadExecutor.assertRunningInMainThread();
+        assertJobRegistered(jobId);
+        return this.jobManagerRunners.remove(jobId);
+    }
+
+    private void assertJobRegistered(JobID jobId) {
+        if (!isRegistered(jobId)) {
+            throw new NoSuchElementException(
+                    "There is no running job registered for the job ID " + jobId);
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -902,7 +902,15 @@ public abstract class Dispatcher extends PermanentlyFencedRpcEndpoint<Dispatcher
     }
 
     private void cleanUpRemainingJobData(JobID jobId, boolean jobGraphRemoved) {
-        jobManagerMetricGroup.removeJob(jobId);
+        try {
+            jobManagerMetricGroup.globalCleanup(jobId);
+        } catch (Exception e) {
+            log.warn(
+                    "Could not properly clean data for job {} stored in JobManager metric group",
+                    jobId,
+                    e);
+        }
+
         if (jobGraphRemoved) {
             try {
                 highAvailabilityServices.globalCleanup(jobId);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -497,17 +497,13 @@ public abstract class Dispatcher extends PermanentlyFencedRpcEndpoint<Dispatcher
 
     private CleanupJobState handleJobManagerRunnerResult(
             JobManagerRunnerResult jobManagerRunnerResult, ExecutionType executionType) {
-        if (jobManagerRunnerResult.isInitializationFailure()) {
-            if (executionType == ExecutionType.RECOVERY) {
-                return jobManagerRunnerFailed(
-                        jobManagerRunnerResult.getExecutionGraphInfo().getJobId(),
-                        jobManagerRunnerResult.getInitializationFailure());
-            } else {
-                return jobReachedTerminalState(jobManagerRunnerResult.getExecutionGraphInfo());
-            }
-        } else {
-            return jobReachedTerminalState(jobManagerRunnerResult.getExecutionGraphInfo());
+        if (jobManagerRunnerResult.isInitializationFailure()
+                && executionType == ExecutionType.RECOVERY) {
+            return jobManagerRunnerFailed(
+                    jobManagerRunnerResult.getExecutionGraphInfo().getJobId(),
+                    jobManagerRunnerResult.getInitializationFailure());
         }
+        return jobReachedTerminalState(jobManagerRunnerResult.getExecutionGraphInfo());
     }
 
     enum CleanupJobState {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -882,7 +882,7 @@ public abstract class Dispatcher extends PermanentlyFencedRpcEndpoint<Dispatcher
     private boolean cleanUpJobGraph(JobID jobId, boolean cleanupHA) {
         if (cleanupHA) {
             try {
-                jobGraphWriter.removeJobGraph(jobId);
+                jobGraphWriter.globalCleanup(jobId);
                 return true;
             } catch (Exception e) {
                 log.warn(
@@ -893,7 +893,7 @@ public abstract class Dispatcher extends PermanentlyFencedRpcEndpoint<Dispatcher
             }
         }
         try {
-            jobGraphWriter.releaseJobGraph(jobId);
+            jobGraphWriter.localCleanup(jobId);
         } catch (Exception e) {
             log.warn("Could not properly release job {} from submitted job graph store.", jobId, e);
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -905,7 +905,7 @@ public abstract class Dispatcher extends PermanentlyFencedRpcEndpoint<Dispatcher
         jobManagerMetricGroup.removeJob(jobId);
         if (jobGraphRemoved) {
             try {
-                highAvailabilityServices.cleanupJobData(jobId);
+                highAvailabilityServices.globalCleanup(jobId);
             } catch (Exception e) {
                 log.warn(
                         "Could not properly clean data for job {} stored by ha services", jobId, e);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/JobManagerRunnerRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/JobManagerRunnerRegistry.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.dispatcher.cleanup.GloballyCleanableResource;
+import org.apache.flink.runtime.dispatcher.cleanup.LocallyCleanableResource;
+import org.apache.flink.runtime.jobmaster.JobManagerRunner;
+
+import java.util.Collection;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+/** {@code JobManagerRunner} collects running jobs represented by {@link JobManagerRunner}. */
+public interface JobManagerRunnerRegistry
+        extends LocallyCleanableResource, GloballyCleanableResource {
+
+    /**
+     * Checks whether a {@link JobManagerRunner} is registered under the given {@link JobID}.
+     *
+     * @param jobId The {@code JobID} to check.
+     * @return {@code true}, if a {@code JobManagerRunner} is registered; {@code false} otherwise.
+     */
+    boolean isRegistered(JobID jobId);
+
+    /** Registers the given {@link JobManagerRunner} instance. */
+    void register(JobManagerRunner jobManagerRunner);
+
+    /**
+     * Returns the {@link JobManagerRunner} for the given {@code JobID}.
+     *
+     * @throws NoSuchElementException if the passed {@code JobID} does not belong to a registered
+     *     {@code JobManagerRunner}.
+     * @see #isRegistered(JobID)
+     */
+    JobManagerRunner get(JobID jobId);
+
+    /** Returns the number of {@link JobManagerRunner} instances currently being registered. */
+    int size();
+
+    /** Returns {@link JobID} instances of registered {@link JobManagerRunner} instances. */
+    Set<JobID> getRunningJobIds();
+
+    /** Returns the registered {@link JobManagerRunner} instances. */
+    Collection<JobManagerRunner> getJobManagerRunners();
+
+    /**
+     * Unregistered the {@link JobManagerRunner} with the given {@code JobID}. {@code null} is
+     * returned if there's no {@code JobManagerRunner} registered for the given {@link JobID}.
+     */
+    JobManagerRunner unregister(JobID jobId);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/SingleJobJobGraphStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/SingleJobJobGraphStore.java
@@ -65,16 +65,6 @@ public class SingleJobJobGraphStore implements JobGraphStore {
     }
 
     @Override
-    public void removeJobGraph(JobID jobId) {
-        // ignore
-    }
-
-    @Override
-    public void releaseJobGraph(JobID jobId) {
-        // ignore
-    }
-
-    @Override
     public Collection<JobID> getJobIds() {
         return Collections.singleton(jobGraph.getJobID());
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/DefaultResourceCleaner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/DefaultResourceCleaner.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher.cleanup;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.util.concurrent.FutureUtils;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.stream.Collectors;
+
+/** {@code DefaultResourceCleaner} is the default implementation of {@link ResourceCleaner}. */
+public class DefaultResourceCleaner<T> implements ResourceCleaner {
+
+    private final ComponentMainThreadExecutor mainThreadExecutor;
+    private final Executor cleanupExecutor;
+    private final CleanupFn<T> cleanupFn;
+
+    private final Collection<T> prioritizedCleanup;
+    private final Collection<T> regularCleanup;
+
+    public static Builder<LocallyCleanableResource> forLocallyCleanableResources(
+            ComponentMainThreadExecutor mainThreadExecutor, Executor cleanupExecutor) {
+        return forCleanableResources(
+                mainThreadExecutor, cleanupExecutor, LocallyCleanableResource::localCleanupAsync);
+    }
+
+    public static Builder<GloballyCleanableResource> forGloballyCleanableResources(
+            ComponentMainThreadExecutor mainThreadExecutor, Executor cleanupExecutor) {
+        return forCleanableResources(
+                mainThreadExecutor, cleanupExecutor, GloballyCleanableResource::globalCleanupAsync);
+    }
+
+    @VisibleForTesting
+    static <T> Builder<T> forCleanableResources(
+            ComponentMainThreadExecutor mainThreadExecutor,
+            Executor cleanupExecutor,
+            CleanupFn<T> cleanupFunction) {
+        return new Builder<>(mainThreadExecutor, cleanupExecutor, cleanupFunction);
+    }
+
+    @VisibleForTesting
+    @FunctionalInterface
+    interface CleanupFn<T> {
+        CompletableFuture<Void> cleanupAsync(T resource, JobID jobId, Executor cleanupExecutor);
+    }
+
+    /**
+     * {@code Builder} for creating {@code DefaultResourceCleaner} instances.
+     *
+     * @param <T> The functional interface that's being translated into the internally used {@link
+     *     CleanupFn}.
+     */
+    public static class Builder<T> {
+
+        private final ComponentMainThreadExecutor mainThreadExecutor;
+        private final Executor cleanupExecutor;
+        private final CleanupFn<T> cleanupFn;
+
+        private final Collection<T> prioritizedCleanup = new ArrayList<>();
+        private final Collection<T> regularCleanup = new ArrayList<>();
+
+        private Builder(
+                ComponentMainThreadExecutor mainThreadExecutor,
+                Executor cleanupExecutor,
+                CleanupFn<T> cleanupFn) {
+            this.mainThreadExecutor = mainThreadExecutor;
+            this.cleanupExecutor = cleanupExecutor;
+            this.cleanupFn = cleanupFn;
+        }
+
+        public Builder<T> withPrioritizedCleanup(T prioritizedCleanup) {
+            this.prioritizedCleanup.add(prioritizedCleanup);
+            return this;
+        }
+
+        public Builder<T> withRegularCleanup(T regularCleanup) {
+            this.regularCleanup.add(regularCleanup);
+            return this;
+        }
+
+        public DefaultResourceCleaner<T> build() {
+            return new DefaultResourceCleaner<>(
+                    mainThreadExecutor,
+                    cleanupExecutor,
+                    cleanupFn,
+                    prioritizedCleanup,
+                    regularCleanup);
+        }
+    }
+
+    private DefaultResourceCleaner(
+            ComponentMainThreadExecutor mainThreadExecutor,
+            Executor cleanupExecutor,
+            CleanupFn<T> cleanupFn,
+            Collection<T> prioritizedCleanup,
+            Collection<T> regularCleanup) {
+        this.mainThreadExecutor = mainThreadExecutor;
+        this.cleanupExecutor = cleanupExecutor;
+        this.cleanupFn = cleanupFn;
+        this.prioritizedCleanup = prioritizedCleanup;
+        this.regularCleanup = regularCleanup;
+    }
+
+    @Override
+    public CompletableFuture<Void> cleanupAsync(JobID jobId) {
+        mainThreadExecutor.assertRunningInMainThread();
+        CompletableFuture<Void> cleanupFuture = FutureUtils.completedVoidFuture();
+        for (T cleanup : prioritizedCleanup) {
+            cleanupFuture =
+                    cleanupFuture.thenCompose(
+                            ignoredValue ->
+                                    cleanupFn.cleanupAsync(cleanup, jobId, cleanupExecutor));
+        }
+        return cleanupFuture.thenCompose(
+                ignoredValue ->
+                        FutureUtils.completeAll(
+                                regularCleanup.stream()
+                                        .map(
+                                                cleanup ->
+                                                        cleanupFn.cleanupAsync(
+                                                                cleanup, jobId, cleanupExecutor))
+                                        .collect(Collectors.toList())));
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/DispatcherResourceCleanerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/DispatcherResourceCleanerFactory.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher.cleanup;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.runtime.blob.BlobServer;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.dispatcher.DispatcherServices;
+import org.apache.flink.runtime.dispatcher.JobManagerRunnerRegistry;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.jobmanager.JobGraphWriter;
+import org.apache.flink.runtime.metrics.groups.JobManagerMetricGroup;
+import org.apache.flink.util.Preconditions;
+
+import java.util.concurrent.Executor;
+
+/**
+ * {@code DispatcherResourceCleanerFactory} instantiates {@link ResourceCleaner} instances that
+ * clean cleanable resources from the {@link org.apache.flink.runtime.dispatcher.Dispatcher}.
+ *
+ * <p>We need to handle the {@link JobManagerRunnerRegistry} differently due to a dependency between
+ * closing the {@link org.apache.flink.runtime.jobmaster.JobManagerRunner} and the {@link
+ * HighAvailabilityServices}. This is fixed in {@code FLINK-24038} using a feature flag to
+ * enable/disable single leader election for all the {@code JobManager} components. We can remove
+ * the priority cleanup logic after removing the per-component leader election.
+ */
+public class DispatcherResourceCleanerFactory implements ResourceCleanerFactory {
+
+    private final Executor cleanupExecutor;
+    private final JobManagerRunnerRegistry jobManagerRunnerRegistry;
+    private final JobGraphWriter jobGraphWriter;
+    private final BlobServer blobServer;
+    private final HighAvailabilityServices highAvailabilityServices;
+    private final JobManagerMetricGroup jobManagerMetricGroup;
+
+    public DispatcherResourceCleanerFactory(
+            JobManagerRunnerRegistry jobManagerRunnerRegistry,
+            DispatcherServices dispatcherServices) {
+        this(
+                dispatcherServices.getIoExecutor(),
+                jobManagerRunnerRegistry,
+                dispatcherServices.getJobGraphWriter(),
+                dispatcherServices.getBlobServer(),
+                dispatcherServices.getHighAvailabilityServices(),
+                dispatcherServices.getJobManagerMetricGroup());
+    }
+
+    @VisibleForTesting
+    DispatcherResourceCleanerFactory(
+            Executor cleanupExecutor,
+            JobManagerRunnerRegistry jobManagerRunnerRegistry,
+            JobGraphWriter jobGraphWriter,
+            BlobServer blobServer,
+            HighAvailabilityServices highAvailabilityServices,
+            JobManagerMetricGroup jobManagerMetricGroup) {
+        this.cleanupExecutor = Preconditions.checkNotNull(cleanupExecutor);
+        this.jobManagerRunnerRegistry = Preconditions.checkNotNull(jobManagerRunnerRegistry);
+        this.jobGraphWriter = Preconditions.checkNotNull(jobGraphWriter);
+        this.blobServer = Preconditions.checkNotNull(blobServer);
+        this.highAvailabilityServices = Preconditions.checkNotNull(highAvailabilityServices);
+        this.jobManagerMetricGroup = Preconditions.checkNotNull(jobManagerMetricGroup);
+    }
+
+    @Override
+    public ResourceCleaner createLocalResourceCleaner(
+            ComponentMainThreadExecutor mainThreadExecutor) {
+        return DefaultResourceCleaner.forLocallyCleanableResources(
+                        mainThreadExecutor, cleanupExecutor)
+                .withPrioritizedCleanup(jobManagerRunnerRegistry)
+                .withRegularCleanup(jobGraphWriter)
+                .withRegularCleanup(blobServer)
+                .withRegularCleanup(jobManagerMetricGroup)
+                .build();
+    }
+
+    @Override
+    public ResourceCleaner createGlobalResourceCleaner(
+            ComponentMainThreadExecutor mainThreadExecutor) {
+
+        return DefaultResourceCleaner.forGloballyCleanableResources(
+                        mainThreadExecutor, cleanupExecutor)
+                .withPrioritizedCleanup(jobManagerRunnerRegistry)
+                .withRegularCleanup(jobGraphWriter)
+                .withRegularCleanup(blobServer)
+                .withRegularCleanup(highAvailabilityServices)
+                .build();
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/GloballyCleanableResource.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/GloballyCleanableResource.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher.cleanup;
+
+import org.apache.flink.api.common.JobID;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+/**
+ * {@code GloballyCleanableResource} is supposed to be used by any class that provides artifacts for
+ * a given job that can be cleaned up globally. Globally available artifacts should survive a
+ * JobManager failover and are, in contrast to {@link GloballyCleanableResource}, only cleaned up
+ * after the corresponding job reached a globally-terminal state.
+ *
+ * @see org.apache.flink.api.common.JobStatus
+ */
+@FunctionalInterface
+public interface GloballyCleanableResource {
+
+    /**
+     * {@code globalCleanupAsync} is expected to be called from the main thread. Heavy IO tasks
+     * should be outsourced into the passed {@code cleanupExecutor}. Thread-safety must be ensured.
+     *
+     * @param jobId The {@link JobID} of the job for which the local data should be cleaned up.
+     * @param cleanupExecutor The fallback executor for IO-heavy operations.
+     * @return The cleanup result future.
+     */
+    CompletableFuture<Void> globalCleanupAsync(JobID jobId, Executor cleanupExecutor);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/LocallyCleanableResource.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/LocallyCleanableResource.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher.cleanup;
+
+import org.apache.flink.api.common.JobID;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+/**
+ * {@code LocallyCleanableResource} is supposed to be used by any class that provides artifacts for
+ * a given job that can be cleaned up locally. Artifacts considered to be local are located on the
+ * JobManager instance itself and won't survive a failover scenario. These artifacts are, in
+ * contrast to {@link GloballyCleanableResource} artifacts, going to be cleaned up even after the
+ * job reaches a locally-terminated state.
+ *
+ * @see org.apache.flink.api.common.JobStatus
+ */
+@FunctionalInterface
+public interface LocallyCleanableResource {
+
+    /**
+     * {@code localCleanupAsync} is expected to be called from the main thread. Heavy IO tasks
+     * should be outsourced into the passed {@code cleanupExecutor}. Thread-safety must be ensured.
+     *
+     * @param jobId The {@link JobID} of the job for which the local data should be cleaned up.
+     * @param cleanupExecutor The fallback executor for IO-heavy operations.
+     * @return The cleanup result future.
+     */
+    CompletableFuture<Void> localCleanupAsync(JobID jobId, Executor cleanupExecutor);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/ResourceCleaner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/ResourceCleaner.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher.cleanup;
+
+import org.apache.flink.api.common.JobID;
+
+import java.util.concurrent.CompletableFuture;
+
+/** {@code ResourceCleaner} executes instances on the given {@code JobID}. */
+@FunctionalInterface
+public interface ResourceCleaner {
+
+    /**
+     * Cleans job-related data from resources asynchronously.
+     *
+     * @param jobId The {@link JobID} referring to the job for which the data shall be cleaned up.
+     * @return the cleanup result future.
+     */
+    CompletableFuture<Void> cleanupAsync(JobID jobId);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/ResourceCleanerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/ResourceCleanerFactory.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher.cleanup;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+
+import java.util.concurrent.Executor;
+
+/**
+ * {@code ResourceCleanerFactory} provides methods to create {@link ResourceCleaner} for local and
+ * global cleanup.
+ *
+ * @see GloballyCleanableResource
+ * @see LocallyCleanableResource
+ */
+public interface ResourceCleanerFactory {
+
+    /**
+     * Creates {@link ResourceCleaner} that initiates {@link
+     * LocallyCleanableResource#localCleanupAsync(JobID, Executor)} calls.
+     *
+     * @param mainThreadExecutor Used for validating that the {@link
+     *     LocallyCleanableResource#localCleanupAsync(JobID, Executor)} is called from the main
+     *     thread.
+     */
+    ResourceCleaner createLocalResourceCleaner(ComponentMainThreadExecutor mainThreadExecutor);
+
+    /**
+     * Creates {@link ResourceCleaner} that initiates {@link
+     * GloballyCleanableResource#globalCleanupAsync(JobID, Executor)} calls.
+     *
+     * @param mainThreadExecutor Used for validating that the {@link
+     *     GloballyCleanableResource#globalCleanupAsync(JobID, Executor)} is called from the main
+     *     thread.
+     */
+    ResourceCleaner createGlobalResourceCleaner(ComponentMainThreadExecutor mainThreadExecutor);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServices.java
@@ -21,12 +21,16 @@ package org.apache.flink.runtime.highavailability;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.blob.BlobStore;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
+import org.apache.flink.runtime.dispatcher.cleanup.GloballyCleanableResource;
 import org.apache.flink.runtime.jobmanager.JobGraphStore;
 import org.apache.flink.runtime.leaderelection.LeaderElectionService;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
+import org.apache.flink.util.concurrent.FutureUtils;
 
 import java.io.IOException;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 
 /**
  * The HighAvailabilityServices give access to all services needed for a highly-available setup. In
@@ -43,7 +47,8 @@ import java.util.UUID;
  *   <li>Naming of RPC endpoints
  * </ul>
  */
-public interface HighAvailabilityServices extends ClientHighAvailabilityServices {
+public interface HighAvailabilityServices
+        extends ClientHighAvailabilityServices, GloballyCleanableResource {
 
     // ------------------------------------------------------------------------
     //  Constants
@@ -239,11 +244,8 @@ public interface HighAvailabilityServices extends ClientHighAvailabilityServices
      */
     void closeAndCleanupAllData() throws Exception;
 
-    /**
-     * Deletes all data for specified job stored by these services in external stores.
-     *
-     * @param jobID The identifier of the job to cleanup.
-     * @throws Exception Thrown, if an exception occurred while cleaning data stored by them.
-     */
-    default void cleanupJobData(JobID jobID) throws Exception {}
+    @Override
+    default CompletableFuture<Void> globalCleanupAsync(JobID jobId, Executor executor) {
+        return FutureUtils.completedVoidFuture();
+    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/JobGraphWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/JobGraphWriter.java
@@ -19,10 +19,16 @@
 package org.apache.flink.runtime.jobmanager;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.dispatcher.cleanup.GloballyCleanableResource;
+import org.apache.flink.runtime.dispatcher.cleanup.LocallyCleanableResource;
 import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.util.concurrent.FutureUtils;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 
 /** Allows to store and remove job graphs. */
-public interface JobGraphWriter {
+public interface JobGraphWriter extends LocallyCleanableResource, GloballyCleanableResource {
     /**
      * Adds the {@link JobGraph} instance.
      *
@@ -30,17 +36,13 @@ public interface JobGraphWriter {
      */
     void putJobGraph(JobGraph jobGraph) throws Exception;
 
-    /** Removes the {@link JobGraph} with the given {@link JobID} if it exists. */
-    void removeJobGraph(JobID jobId) throws Exception;
+    @Override
+    default CompletableFuture<Void> localCleanupAsync(JobID jobId, Executor executor) {
+        return FutureUtils.completedVoidFuture();
+    }
 
-    /**
-     * Releases the locks on the specified {@link JobGraph}.
-     *
-     * <p>Releasing the locks allows that another instance can delete the job from the {@link
-     * JobGraphStore}.
-     *
-     * @param jobId specifying the job to release the locks for
-     * @throws Exception if the locks cannot be released
-     */
-    void releaseJobGraph(JobID jobId) throws Exception;
+    @Override
+    default CompletableFuture<Void> globalCleanupAsync(JobID jobId, Executor executor) {
+        return FutureUtils.completedVoidFuture();
+    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/StandaloneJobGraphStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/StandaloneJobGraphStore.java
@@ -48,16 +48,6 @@ public class StandaloneJobGraphStore implements JobGraphStore {
     }
 
     @Override
-    public void removeJobGraph(JobID jobId) {
-        // Nothing to do
-    }
-
-    @Override
-    public void releaseJobGraph(JobID jobId) {
-        // nothing to do
-    }
-
-    @Override
     public Collection<JobID> getJobIds() {
         return Collections.emptyList();
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/ThrowingJobGraphWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/ThrowingJobGraphWriter.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.jobmanager;
 
-import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 
 /** {@link JobGraphWriter} implementation which does not allow to store {@link JobGraph}. */
@@ -29,10 +28,4 @@ public enum ThrowingJobGraphWriter implements JobGraphWriter {
     public void putJobGraph(JobGraph jobGraph) {
         throw new UnsupportedOperationException("Cannot store job graphs.");
     }
-
-    @Override
-    public void removeJobGraph(JobID jobId) {}
-
-    @Override
-    public void releaseJobGraph(JobID jobId) {}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
@@ -193,7 +193,6 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
                 jobGraph,
                 ioExecutor,
                 jobMasterConfiguration,
-                userCodeLoader,
                 checkpointsCleaner,
                 checkpointRecoveryFactory,
                 jobManagerJobMetricGroup,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -168,7 +168,6 @@ public abstract class SchedulerBase implements SchedulerNG, CheckpointScheduling
             final JobGraph jobGraph,
             final Executor ioExecutor,
             final Configuration jobMasterConfiguration,
-            final ClassLoader userCodeLoader,
             final CheckpointsCleaner checkpointsCleaner,
             final CheckpointRecoveryFactory checkpointRecoveryFactory,
             final JobManagerJobMetricGroup jobManagerJobMetricGroup,
@@ -193,7 +192,6 @@ public abstract class SchedulerBase implements SchedulerNG, CheckpointScheduling
                 SchedulerUtils.createCompletedCheckpointStoreIfCheckpointingIsEnabled(
                         jobGraph,
                         jobMasterConfiguration,
-                        userCodeLoader,
                         checkNotNull(checkpointRecoveryFactory),
                         ioExecutor,
                         log);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerUtils.java
@@ -47,7 +47,6 @@ public final class SchedulerUtils {
     public static CompletedCheckpointStore createCompletedCheckpointStoreIfCheckpointingIsEnabled(
             JobGraph jobGraph,
             Configuration configuration,
-            ClassLoader userCodeLoader,
             CheckpointRecoveryFactory checkpointRecoveryFactory,
             Executor ioExecutor,
             Logger log)
@@ -56,12 +55,7 @@ public final class SchedulerUtils {
         if (DefaultExecutionGraphBuilder.isCheckpointingEnabled(jobGraph)) {
             try {
                 return createCompletedCheckpointStore(
-                        configuration,
-                        userCodeLoader,
-                        checkpointRecoveryFactory,
-                        ioExecutor,
-                        log,
-                        jobId);
+                        configuration, checkpointRecoveryFactory, ioExecutor, log, jobId);
             } catch (Exception e) {
                 throw new JobExecutionException(
                         jobId,
@@ -76,7 +70,6 @@ public final class SchedulerUtils {
     @VisibleForTesting
     static CompletedCheckpointStore createCompletedCheckpointStore(
             Configuration jobManagerConfig,
-            ClassLoader classLoader,
             CheckpointRecoveryFactory recoveryFactory,
             Executor ioExecutor,
             Logger log,
@@ -101,7 +94,6 @@ public final class SchedulerUtils {
         return recoveryFactory.createRecoveredCompletedCheckpointStore(
                 jobId,
                 maxNumberOfCheckpointsToRetain,
-                classLoader,
                 SharedStateRegistry.DEFAULT_FACTORY,
                 ioExecutor);
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
@@ -246,12 +246,7 @@ public class AdaptiveScheduler
         this.checkpointsCleaner = checkpointsCleaner;
         this.completedCheckpointStore =
                 SchedulerUtils.createCompletedCheckpointStoreIfCheckpointingIsEnabled(
-                        jobGraph,
-                        configuration,
-                        userCodeClassLoader,
-                        checkpointRecoveryFactory,
-                        ioExecutor,
-                        LOG);
+                        jobGraph, configuration, checkpointRecoveryFactory, ioExecutor, LOG);
         this.checkpointIdCounter =
                 SchedulerUtils.createCheckpointIDCounterIfCheckpointingIsEnabled(
                         jobGraph, checkpointRecoveryFactory);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerRecoveryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerRecoveryTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
 import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.concurrent.Executors;
 
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -89,7 +90,7 @@ public class BlobServerRecoveryTest extends TestLogger {
      */
     public static void testBlobServerRecovery(
             final Configuration config, final BlobStore blobStore, final File blobStorage)
-            throws IOException {
+            throws Exception {
         final String clusterId = config.getString(HighAvailabilityOptions.HA_CLUSTER_ID);
         String storagePath =
                 config.getString(HighAvailabilityOptions.HA_STORAGE_PATH) + "/" + clusterId;
@@ -141,8 +142,8 @@ public class BlobServerRecoveryTest extends TestLogger {
             verifyDeleted(cache1, jobId[0], nonHAKey);
 
             // Remove again
-            server1.cleanupJob(jobId[0], true);
-            server1.cleanupJob(jobId[1], true);
+            server1.globalCleanupAsync(jobId[0], Executors.directExecutor()).join();
+            server1.globalCleanupAsync(jobId[1], Executors.directExecutor()).join();
 
             // Verify everything is clean
             assertTrue("HA storage directory does not exist", fs.exists(new Path(storagePath)));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/FileSystemBlobStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/FileSystemBlobStoreTest.java
@@ -22,25 +22,254 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.core.fs.FSDataOutputStream;
 import org.apache.flink.core.fs.local.LocalDataOutputStream;
 import org.apache.flink.runtime.state.filesystem.TestFs;
+import org.apache.flink.testutils.TestFileSystem;
+import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.TestLoggerExtension;
 import org.apache.flink.util.function.FunctionWithException;
 
 import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.io.BufferedWriter;
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileWriter;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.MessageDigest;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for the {@link FileSystemBlobStore}. */
 @ExtendWith(TestLoggerExtension.class)
 class FileSystemBlobStoreTest {
+
+    private FileSystemBlobStore testInstance;
+    private Path storagePath;
+
+    @BeforeEach
+    public void createTestInstance(@TempDir Path storagePath) throws IOException {
+        this.testInstance = new FileSystemBlobStore(new TestFileSystem(), storagePath.toString());
+        this.storagePath = storagePath;
+    }
+
+    @AfterEach
+    public void finalizeTestInstance() throws IOException {
+        testInstance.close();
+    }
+
+    @Test
+    public void testSuccessfulPut() throws IOException {
+        final Path temporaryFile = createTemporaryFileWithContent("put");
+
+        final JobID jobId = new JobID();
+        final BlobKey blobKey = createPermanentBlobKeyFromFile(temporaryFile);
+        assertThat(getBlobDirectoryPath()).isEmptyDirectory();
+
+        final boolean successfullyWritten =
+                testInstance.put(temporaryFile.toFile(), jobId, blobKey);
+        assertThat(successfullyWritten).isTrue();
+
+        assertThat(getPath(jobId)).isDirectory().exists();
+        assertThat(getPath(jobId, blobKey)).isNotEmptyFile().hasSameTextualContentAs(temporaryFile);
+    }
+
+    @Test
+    public void testMissingFilePut() throws IOException {
+        assertThatThrownBy(
+                        () ->
+                                testInstance.put(
+                                        new File("/not/existing/file"),
+                                        new JobID(),
+                                        new PermanentBlobKey()))
+                .isInstanceOf(FileNotFoundException.class);
+    }
+
+    @Test
+    public void testSuccessfulGet() throws IOException {
+        final Path temporaryFile = createTemporaryFileWithContent("get");
+        final JobID jobId = new JobID();
+        final BlobKey blobKey = createPermanentBlobKeyFromFile(temporaryFile);
+
+        assertThat(testInstance.put(temporaryFile.toFile(), jobId, blobKey)).isTrue();
+
+        final Path targetFile = Files.createTempFile("filesystemblobstoretest-get-target-", "");
+        assertThat(targetFile).isEmptyFile();
+        final boolean successfullyGet = testInstance.get(jobId, blobKey, targetFile.toFile());
+        assertThat(successfullyGet).isTrue();
+
+        assertThat(targetFile).hasSameTextualContentAs(temporaryFile);
+    }
+
+    @Test
+    public void testGetWithWrongJobId() throws IOException {
+        final Path temporaryFile = createTemporaryFileWithContent("get");
+        final BlobKey blobKey = createPermanentBlobKeyFromFile(temporaryFile);
+
+        assertThat(testInstance.put(temporaryFile.toFile(), new JobID(), blobKey)).isTrue();
+
+        assertThatThrownBy(
+                        () ->
+                                testInstance.get(
+                                        new JobID(),
+                                        blobKey,
+                                        Files.createTempFile(
+                                                        "filesystemblobstoretest-get-with-wrong-jobid-",
+                                                        "")
+                                                .toFile()))
+                .isInstanceOf(FileNotFoundException.class);
+    }
+
+    @Test
+    public void testGetWithWrongBlobKey() throws IOException {
+        final Path temporaryFile = createTemporaryFileWithContent("get");
+
+        final JobID jobId = new JobID();
+        assertThat(testInstance.put(temporaryFile.toFile(), jobId, new PermanentBlobKey()))
+                .isTrue();
+
+        assertThatThrownBy(
+                        () ->
+                                testInstance.get(
+                                        jobId,
+                                        new PermanentBlobKey(),
+                                        Files.createTempFile(
+                                                        "filesystemblobstoretest-get-with-wrong-blobkey-",
+                                                        "")
+                                                .toFile()))
+                .isInstanceOf(FileNotFoundException.class);
+    }
+
+    @Test
+    public void testSuccessfulDeleteOnlyBlob() throws IOException {
+        final Path temporaryFile = createTemporaryFileWithContent("delete");
+        final JobID jobId = new JobID();
+        final BlobKey blobKey = createPermanentBlobKeyFromFile(temporaryFile);
+
+        assertThat(testInstance.put(temporaryFile.toFile(), jobId, blobKey)).isTrue();
+
+        assertThat(getPath(jobId)).isDirectory().exists();
+        assertThat(getPath(jobId, blobKey)).isNotEmptyFile();
+
+        final boolean successfullyDeleted = testInstance.delete(jobId, blobKey);
+
+        assertThat(successfullyDeleted).isTrue();
+        assertThat(getPath(jobId)).doesNotExist();
+    }
+
+    @Test
+    public void testSuccessfulDeleteBlob() throws IOException {
+        final Path temporaryFile = createTemporaryFileWithContent("delete");
+        final JobID jobId = new JobID();
+        final BlobKey blobKey = createPermanentBlobKeyFromFile(temporaryFile);
+        final BlobKey otherBlobKey = new PermanentBlobKey();
+
+        assertThat(testInstance.put(temporaryFile.toFile(), jobId, blobKey)).isTrue();
+        // create another artifact to omit deleting the directory
+        assertThat(testInstance.put(temporaryFile.toFile(), jobId, otherBlobKey)).isTrue();
+
+        assertThat(getPath(jobId)).isDirectory().exists();
+        assertThat(getPath(jobId, blobKey)).isNotEmptyFile();
+        assertThat(getPath(jobId, otherBlobKey)).isNotEmptyFile();
+
+        final boolean successfullyDeleted = testInstance.delete(jobId, blobKey);
+
+        assertThat(successfullyDeleted).isTrue();
+        assertThat(getPath(jobId, otherBlobKey)).exists();
+    }
+
+    @Test
+    public void testDeleteWithNotExistingJobId() {
+        assertThat(testInstance.delete(new JobID(), new PermanentBlobKey())).isTrue();
+    }
+
+    @Test
+    public void testDeleteWithNotExistingBlobKey() throws IOException {
+        final Path temporaryFile = createTemporaryFileWithContent("delete");
+        final JobID jobId = new JobID();
+        final BlobKey blobKey = createPermanentBlobKeyFromFile(temporaryFile);
+
+        assertThat(testInstance.put(temporaryFile.toFile(), jobId, blobKey)).isTrue();
+        assertThat(testInstance.delete(jobId, new PermanentBlobKey())).isTrue();
+        assertThat(getPath(jobId, blobKey)).exists();
+    }
+
+    @Test
+    public void testDeleteAll() throws IOException {
+        final Path temporaryFile = createTemporaryFileWithContent("delete");
+        final JobID jobId = new JobID();
+
+        assertThat(testInstance.put(temporaryFile.toFile(), jobId, new PermanentBlobKey()))
+                .isTrue();
+        assertThat(testInstance.put(temporaryFile.toFile(), jobId, new PermanentBlobKey()))
+                .isTrue();
+
+        assertThat(getPath(jobId)).isDirectory().exists();
+        assertThat(getPath(jobId).toFile().listFiles()).hasSize(2);
+
+        assertThat(testInstance.deleteAll(jobId)).isTrue();
+        assertThat(getPath(jobId)).doesNotExist();
+    }
+
+    @Test
+    public void testDeleteAllWithNotExistingJobId() {
+        final JobID jobId = new JobID();
+        assertThat(testInstance.deleteAll(jobId)).isTrue();
+        assertThat(getPath(jobId)).doesNotExist();
+    }
+
+    private Path createTemporaryFileWithContent(String operationLabel) throws IOException {
+        final String actualContent =
+                String.format("Content for testing the %s operation", operationLabel);
+        final Path temporaryFile =
+                Files.createTempFile(
+                        String.format("filesystemblobstoretest-%s-", operationLabel), "");
+        try (BufferedWriter writer =
+                new BufferedWriter(new FileWriter(temporaryFile.toAbsolutePath().toString()))) {
+            writer.write(actualContent);
+        }
+
+        return temporaryFile;
+    }
+
+    private Path getBlobDirectoryPath() {
+        return storagePath.resolve(FileSystemBlobStore.BLOB_PATH_NAME);
+    }
+
+    private Path getPath(JobID jobId) {
+        return getBlobDirectoryPath().resolve(String.format("job_%s", jobId));
+    }
+
+    private Path getPath(JobID jobId, BlobKey blobKey) {
+        return getPath(jobId).resolve(String.format("blob_%s", blobKey));
+    }
+
+    private BlobKey createPermanentBlobKeyFromFile(Path path) throws IOException {
+        Preconditions.checkArgument(!Files.isDirectory(path));
+        Preconditions.checkArgument(Files.exists(path));
+
+        MessageDigest md = BlobUtils.createMessageDigest();
+        try (InputStream is = new FileInputStream(path.toFile())) {
+            final byte[] buf = new byte[1024];
+            int bytesRead = is.read(buf);
+            while (bytesRead >= 0) {
+                md.update(buf, 0, bytesRead);
+                bytesRead = is.read(buf);
+            }
+
+            return BlobKey.createKey(BlobKey.BlobType.PERMANENT_BLOB, md.digest());
+        }
+    }
 
     @Test
     public void fileSystemBlobStoreCallsSyncOnPut(@TempDir Path storageDirectory)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PerJobCheckpointRecoveryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PerJobCheckpointRecoveryTest.java
@@ -40,15 +40,12 @@ public class PerJobCheckpointRecoveryTest extends TestLogger {
         final CheckpointRecoveryFactory factory =
                 PerJobCheckpointRecoveryFactory.withoutCheckpointStoreRecovery(
                         maxCheckpoints -> store);
-        final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-
         final JobID firstJobId = new JobID();
         assertSame(
                 store,
                 factory.createRecoveredCompletedCheckpointStore(
                         firstJobId,
                         1,
-                        classLoader,
                         SharedStateRegistry.DEFAULT_FACTORY,
                         Executors.directExecutor()));
         assertThrows(
@@ -57,7 +54,6 @@ public class PerJobCheckpointRecoveryTest extends TestLogger {
                         factory.createRecoveredCompletedCheckpointStore(
                                 firstJobId,
                                 1,
-                                classLoader,
                                 SharedStateRegistry.DEFAULT_FACTORY,
                                 Executors.directExecutor()));
 
@@ -67,7 +63,6 @@ public class PerJobCheckpointRecoveryTest extends TestLogger {
                 factory.createRecoveredCompletedCheckpointStore(
                         secondJobId,
                         1,
-                        classLoader,
                         SharedStateRegistry.DEFAULT_FACTORY,
                         Executors.directExecutor()));
         assertThrows(
@@ -76,7 +71,6 @@ public class PerJobCheckpointRecoveryTest extends TestLogger {
                         factory.createRecoveredCompletedCheckpointStore(
                                 secondJobId,
                                 1,
-                                classLoader,
                                 SharedStateRegistry.DEFAULT_FACTORY,
                                 Executors.directExecutor()));
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/TestingCheckpointRecoveryFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/TestingCheckpointRecoveryFactory.java
@@ -38,7 +38,6 @@ public class TestingCheckpointRecoveryFactory implements CheckpointRecoveryFacto
     public CompletedCheckpointStore createRecoveredCompletedCheckpointStore(
             JobID jobId,
             int maxNumberOfCheckpointsToRetain,
-            ClassLoader userClassLoader,
             SharedStateRegistryFactory sharedStateRegistryFactory,
             Executor ioExecutor) {
         return store;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DefaultJobManagerRunnerRegistryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DefaultJobManagerRunnerRegistryTest.java
@@ -1,0 +1,230 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.core.testutils.FlinkAssertions;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
+import org.apache.flink.runtime.jobmaster.JobManagerRunner;
+import org.apache.flink.runtime.jobmaster.TestingJobManagerRunner;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.concurrent.Executors;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.NoSuchElementException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * {@code DefaultJobManagerRunnerRegistryTest} tests the functionality of {@link
+ * DefaultJobManagerRunnerRegistry}.
+ */
+public class DefaultJobManagerRunnerRegistryTest {
+
+    private JobManagerRunnerRegistry testInstance;
+
+    @BeforeEach
+    public void setup() {
+        testInstance =
+                new DefaultJobManagerRunnerRegistry(
+                        4, ComponentMainThreadExecutorServiceAdapter.forMainThread());
+    }
+
+    @Test
+    public void testIsRegistered() {
+        final JobID jobId = new JobID();
+        testInstance.register(TestingJobManagerRunner.newBuilder().setJobId(jobId).build());
+        assertThat(testInstance.isRegistered(jobId)).isTrue();
+    }
+
+    @Test
+    public void testIsNotRegistered() {
+        assertThat(testInstance.isRegistered(new JobID())).isFalse();
+    }
+
+    @Test
+    public void testRegister() {
+        final JobID jobId = new JobID();
+        testInstance.register(TestingJobManagerRunner.newBuilder().setJobId(jobId).build());
+        assertThat(testInstance.isRegistered(jobId)).isTrue();
+    }
+
+    @Test
+    public void testRegisteringTwiceCausesFailure() {
+        final JobID jobId = new JobID();
+        testInstance.register(TestingJobManagerRunner.newBuilder().setJobId(jobId).build());
+        assertThat(testInstance.isRegistered(jobId)).isTrue();
+
+        assertThatThrownBy(
+                        () ->
+                                testInstance.register(
+                                        TestingJobManagerRunner.newBuilder()
+                                                .setJobId(jobId)
+                                                .build()))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void testGet() {
+        final JobID jobId = new JobID();
+        final JobManagerRunner jobManagerRunner =
+                TestingJobManagerRunner.newBuilder().setJobId(jobId).build();
+        testInstance.register(jobManagerRunner);
+
+        assertThat(testInstance.get(jobId)).isEqualTo(jobManagerRunner);
+    }
+
+    @Test
+    public void testGetOnNonExistingJobManagerRunner() {
+        assertThatThrownBy(() -> testInstance.get(new JobID()))
+                .isInstanceOf(NoSuchElementException.class);
+    }
+
+    @Test
+    public void size() {
+        assertThat(testInstance.size()).isEqualTo(0);
+        testInstance.register(TestingJobManagerRunner.newBuilder().build());
+        assertThat(testInstance.size()).isEqualTo(1);
+        testInstance.register(TestingJobManagerRunner.newBuilder().build());
+        assertThat(testInstance.size()).isEqualTo(2);
+    }
+
+    @Test
+    public void testGetRunningJobIds() {
+        assertThat(testInstance.getRunningJobIds()).isEmpty();
+
+        final JobID jobId0 = new JobID();
+        final JobID jobId1 = new JobID();
+        testInstance.register(TestingJobManagerRunner.newBuilder().setJobId(jobId0).build());
+        testInstance.register(TestingJobManagerRunner.newBuilder().setJobId(jobId1).build());
+
+        assertThat(testInstance.getRunningJobIds()).containsExactlyInAnyOrder(jobId0, jobId1);
+    }
+
+    @Test
+    public void testGetJobManagerRunners() {
+        assertThat(testInstance.getJobManagerRunners()).isEmpty();
+
+        final JobManagerRunner jobManagerRunner0 = TestingJobManagerRunner.newBuilder().build();
+        final JobManagerRunner jobManagerRunner1 = TestingJobManagerRunner.newBuilder().build();
+        testInstance.register(jobManagerRunner0);
+        testInstance.register(jobManagerRunner1);
+
+        assertThat(testInstance.getJobManagerRunners())
+                .containsExactlyInAnyOrder(jobManagerRunner0, jobManagerRunner1);
+    }
+
+    @Test
+    public void testSuccessfulLocalCleanup() throws Throwable {
+        final TestingJobManagerRunner jobManagerRunner = registerTestingJobManagerRunner();
+
+        assertThat(
+                        testInstance.localCleanupAsync(
+                                jobManagerRunner.getJobID(), Executors.directExecutor()))
+                .isCompleted();
+        assertThat(testInstance.isRegistered(jobManagerRunner.getJobID())).isFalse();
+        assertThat(jobManagerRunner.getTerminationFuture()).isCompleted();
+    }
+
+    @Test
+    public void testFailingLocalCleanup() {
+        final TestingJobManagerRunner jobManagerRunner = registerTestingJobManagerRunner();
+
+        assertThat(testInstance.isRegistered(jobManagerRunner.getJobID())).isTrue();
+        assertThat(jobManagerRunner.getTerminationFuture()).isNotDone();
+
+        final RuntimeException expectedException = new RuntimeException("Expected exception");
+        jobManagerRunner.completeTerminationFutureExceptionally(expectedException);
+
+        assertThat(
+                        testInstance.localCleanupAsync(
+                                jobManagerRunner.getJobID(), Executors.directExecutor()))
+                .failsWithin(Duration.ZERO)
+                .withThrowableOfType(ExecutionException.class)
+                .extracting(FlinkAssertions::chainOfCauses, FlinkAssertions.STREAM_THROWABLE)
+                .hasExactlyElementsOfTypes(
+                        ExecutionException.class,
+                        FlinkException.class,
+                        expectedException.getClass())
+                .last()
+                .isEqualTo(expectedException);
+        assertThat(testInstance.isRegistered(jobManagerRunner.getJobID())).isFalse();
+    }
+
+    @Test
+    public void testSuccessfulLocalCleanupAsync() throws Exception {
+        final TestingJobManagerRunner jobManagerRunner = registerTestingJobManagerRunner();
+
+        final CompletableFuture<Void> cleanupResult =
+                testInstance.localCleanupAsync(
+                        jobManagerRunner.getJobID(), Executors.directExecutor());
+        assertThat(testInstance.isRegistered(jobManagerRunner.getJobID())).isFalse();
+        assertThat(cleanupResult).isCompleted();
+    }
+
+    @Test
+    public void testFailingLocalCleanupAsync() throws Exception {
+        final TestingJobManagerRunner jobManagerRunner = registerTestingJobManagerRunner();
+
+        assertThat(testInstance.isRegistered(jobManagerRunner.getJobID())).isTrue();
+        assertThat(jobManagerRunner.getTerminationFuture()).isNotDone();
+
+        final RuntimeException expectedException = new RuntimeException("Expected exception");
+        jobManagerRunner.completeTerminationFutureExceptionally(expectedException);
+
+        final CompletableFuture<Void> cleanupResult =
+                testInstance.localCleanupAsync(
+                        jobManagerRunner.getJobID(), Executors.directExecutor());
+        assertThat(testInstance.isRegistered(jobManagerRunner.getJobID())).isFalse();
+        assertThat(cleanupResult)
+                .isCompletedExceptionally()
+                .failsWithin(Duration.ZERO)
+                .withThrowableOfType(ExecutionException.class)
+                .extracting(FlinkAssertions::chainOfCauses, FlinkAssertions.STREAM_THROWABLE)
+                .hasExactlyElementsOfTypes(
+                        ExecutionException.class,
+                        FlinkException.class,
+                        expectedException.getClass())
+                .last()
+                .isEqualTo(expectedException);
+    }
+
+    private TestingJobManagerRunner registerTestingJobManagerRunner() {
+        final TestingJobManagerRunner jobManagerRunner =
+                TestingJobManagerRunner.newBuilder().build();
+        testInstance.register(jobManagerRunner);
+
+        assertThat(testInstance.isRegistered(jobManagerRunner.getJobID())).isTrue();
+        assertThat(jobManagerRunner.getTerminationFuture()).isNotDone();
+
+        return jobManagerRunner;
+    }
+
+    @Test
+    public void testLocalCleanupAsyncOnUnknownJobId() {
+        assertThat(testInstance.localCleanupAsync(new JobID(), Executors.directExecutor()))
+                .isCompleted();
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherFailoverITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherFailoverITCase.java
@@ -39,6 +39,7 @@ import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
 import org.apache.flink.runtime.testutils.TestingJobGraphStore;
 import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.concurrent.FutureUtils;
 
 import org.junit.After;
 import org.junit.Before;
@@ -112,8 +113,8 @@ public class DispatcherFailoverITCase extends AbstractDispatcherTest {
         final Error jobGraphRemovalError = new Error("Unable to remove job graph.");
         final TestingJobGraphStore jobGraphStore =
                 TestingJobGraphStore.newBuilder()
-                        .setRemoveJobGraphConsumer(
-                                graph -> {
+                        .setGlobalCleanupFunction(
+                                (ignoredJobId, ignoredExecutor) -> {
                                     throw jobGraphRemovalError;
                                 })
                         .build();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherResourceCleanupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherResourceCleanupTest.java
@@ -87,9 +87,11 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.BiFunction;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -136,7 +138,8 @@ public class DispatcherResourceCleanupTest extends TestLogger {
 
     private CompletableFuture<BlobKey> storedHABlobFuture;
     private CompletableFuture<JobID> deleteAllHABlobsFuture;
-    private CompletableFuture<JobID> cleanupJobFuture;
+    private CompletableFuture<JobID> localCleanupFuture;
+    private CompletableFuture<JobID> globalCleanupFuture;
     private CompletableFuture<JobID> cleanupJobHADataFuture;
     private JobGraphWriter jobGraphWriter = NoOpJobGraphWriter.INSTANCE;
 
@@ -169,14 +172,22 @@ public class DispatcherResourceCleanupTest extends TestLogger {
                         .setDeleteAllFunction(deleteAllHABlobsFuture::complete)
                         .createTestingBlobStore();
 
-        cleanupJobFuture = new CompletableFuture<>();
+        globalCleanupFuture = new CompletableFuture<>();
+        localCleanupFuture = new CompletableFuture<>();
 
         blobServer =
                 new TestingBlobServer(
                         configuration,
                         temporaryFolder.newFolder(),
                         testingBlobStore,
-                        cleanupJobFuture);
+                        (jobId, ignoredExecutor) -> {
+                            globalCleanupFuture.complete(jobId);
+                            return FutureUtils.completedVoidFuture();
+                        },
+                        (jobId, ignoredExecutor) -> {
+                            localCleanupFuture.complete(jobId);
+                            return FutureUtils.completedVoidFuture();
+                        });
     }
 
     private TestingJobManagerRunnerFactory startDispatcherAndSubmitJob() throws Exception {
@@ -254,8 +265,8 @@ public class DispatcherResourceCleanupTest extends TestLogger {
     }
 
     private void assertThatHABlobsHaveBeenRemoved()
-            throws InterruptedException, ExecutionException {
-        assertThat(cleanupJobFuture.get(), equalTo(jobId));
+            throws InterruptedException, ExecutionException, TimeoutException {
+        assertGlobalCleanupTriggered(jobId);
 
         // verify that we also cleared the BlobStore
         assertThat(deleteAllHABlobsFuture.get(), equalTo(jobId));
@@ -294,8 +305,7 @@ public class DispatcherResourceCleanupTest extends TestLogger {
                 jobManagerRunnerFactory.takeCreatedJobManagerRunner();
         suspendJob(testingJobManagerRunner);
 
-        assertThat(cleanupJobFuture.get(), equalTo(jobId));
-
+        assertLocalCleanupTriggered(jobId);
         assertThat(blobFile.exists(), is(false));
 
         // verify that we did not clear the BlobStore
@@ -331,8 +341,7 @@ public class DispatcherResourceCleanupTest extends TestLogger {
 
         dispatcher.closeAsync().get();
 
-        assertThat(cleanupJobFuture.get(), equalTo(jobId));
-
+        assertLocalCleanupTriggered(jobId);
         assertThat(blobFile.exists(), is(false));
 
         // verify that we did not clear the BlobStore
@@ -375,7 +384,7 @@ public class DispatcherResourceCleanupTest extends TestLogger {
         // check that no exceptions have been thrown
         dispatcherTerminationFuture.get();
 
-        assertThat(cleanupJobFuture.get(), is(jobId));
+        assertGlobalCleanupTriggered(jobId);
         assertThat(deleteAllHABlobsFuture.get(), is(jobId));
     }
 
@@ -468,7 +477,7 @@ public class DispatcherResourceCleanupTest extends TestLogger {
                         is(true));
             }
 
-            assertThatHABlobsHaveNotBeenRemoved();
+            assertThatNoCleanupWasTriggered();
         } finally {
             finishJob(testingJobManagerRunnerFactoryNG.takeCreatedJobManagerRunner());
         }
@@ -519,8 +528,9 @@ public class DispatcherResourceCleanupTest extends TestLogger {
                                 .build()));
     }
 
-    private void assertThatHABlobsHaveNotBeenRemoved() {
-        assertThat(cleanupJobFuture.isDone(), is(false));
+    private void assertThatNoCleanupWasTriggered() {
+        assertThat(globalCleanupFuture.isDone(), is(false));
+        assertThat(localCleanupFuture.isDone(), is(false));
         assertThat(deleteAllHABlobsFuture.isDone(), is(false));
         assertThat(blobFile.exists(), is(true));
     }
@@ -640,7 +650,7 @@ public class DispatcherResourceCleanupTest extends TestLogger {
                 jobManagerRunnerFactory.takeCreatedJobManagerRunner();
         testingJobManagerRunner.completeResultFuture(new ExecutionGraphInfo(executionGraph));
 
-        assertThat(cleanupJobFuture.get(), equalTo(jobId));
+        assertLocalCleanupTriggered(jobId);
         assertThat(deleteAllHABlobsFuture.isDone(), is(false));
     }
 
@@ -659,8 +669,20 @@ public class DispatcherResourceCleanupTest extends TestLogger {
                 jobManagerRunnerFactory.takeCreatedJobManagerRunner();
         testingJobManagerRunner.completeResultFuture(new ExecutionGraphInfo(executionGraph));
 
-        assertThat(cleanupJobFuture.get(), equalTo(jobId));
+        assertGlobalCleanupTriggered(jobId);
         assertThat(deleteAllHABlobsFuture.get(), equalTo(jobId));
+    }
+
+    private void assertLocalCleanupTriggered(JobID jobId)
+            throws ExecutionException, InterruptedException, TimeoutException {
+        assertThat(localCleanupFuture.get(100, TimeUnit.MILLISECONDS), equalTo(jobId));
+        assertThat(globalCleanupFuture.isDone(), is(false));
+    }
+
+    private void assertGlobalCleanupTriggered(JobID jobId)
+            throws ExecutionException, InterruptedException, TimeoutException {
+        assertThat(localCleanupFuture.get(100, TimeUnit.MILLISECONDS), equalTo(jobId));
+        assertThat(globalCleanupFuture.get(100, TimeUnit.MILLISECONDS), equalTo(jobId));
     }
 
     @Test
@@ -738,14 +760,18 @@ public class DispatcherResourceCleanupTest extends TestLogger {
 
     private static final class TestingBlobServer extends BlobServer {
 
-        private final CompletableFuture<JobID> cleanupJobFuture;
+        private final BiFunction<JobID, Executor, CompletableFuture<Void>> globalCleanupFunction;
+        private final BiFunction<JobID, Executor, CompletableFuture<Void>> localCleanupFunction;
 
         /**
          * Instantiates a new BLOB server and binds it to a free network port.
          *
          * @param config Configuration to be used to instantiate the BlobServer
          * @param blobStore BlobStore to store blobs persistently
-         * @param cleanupJobFuture
+         * @param globalCleanupFunction The function called along the actual {@link
+         *     #globalCleanupAsync(JobID, Executor)} call.
+         * @param localCleanupFunction The function called along the actual {@link
+         *     #localCleanupAsync(JobID, Executor)} call.
          * @throws IOException thrown if the BLOB server cannot bind to a free network port or if
          *     the (local or distributed) file storage cannot be created or is not usable
          */
@@ -753,17 +779,24 @@ public class DispatcherResourceCleanupTest extends TestLogger {
                 Configuration config,
                 File storageDirectory,
                 BlobStore blobStore,
-                CompletableFuture<JobID> cleanupJobFuture)
+                BiFunction<JobID, Executor, CompletableFuture<Void>> globalCleanupFunction,
+                BiFunction<JobID, Executor, CompletableFuture<Void>> localCleanupFunction)
                 throws IOException {
             super(config, storageDirectory, blobStore);
-            this.cleanupJobFuture = cleanupJobFuture;
+            this.globalCleanupFunction = globalCleanupFunction;
+            this.localCleanupFunction = localCleanupFunction;
         }
 
         @Override
-        public boolean cleanupJob(JobID jobId, boolean cleanupBlobStoreFiles) {
-            final boolean result = super.cleanupJob(jobId, cleanupBlobStoreFiles);
-            cleanupJobFuture.complete(jobId);
-            return result;
+        public CompletableFuture<Void> globalCleanupAsync(JobID jobId, Executor executor) {
+            return super.globalCleanupAsync(jobId, executor)
+                    .thenCompose(ignored -> globalCleanupFunction.apply(jobId, executor));
+        }
+
+        @Override
+        public CompletableFuture<Void> localCleanupAsync(JobID jobId, Executor executor) {
+            return super.localCleanupAsync(jobId, executor)
+                    .thenCompose(ignored -> localCleanupFunction.apply(jobId, executor));
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherResourceCleanupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherResourceCleanupTest.java
@@ -620,7 +620,7 @@ public class DispatcherResourceCleanupTest extends TestLogger {
     public void testHABlobsAreNotRemovedIfHAJobGraphRemovalFails() throws Exception {
         jobGraphWriter =
                 TestingJobGraphStore.newBuilder()
-                        .setRemoveJobGraphConsumer(
+                        .setGlobalCleanupConsumer(
                                 ignored -> {
                                     throw new Exception("Failed to Remove future");
                                 })

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherResourceCleanupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherResourceCleanupTest.java
@@ -160,7 +160,7 @@ public class DispatcherResourceCleanupTest extends TestLogger {
         jobResultStore = new SingleJobResultStore(jobId, clearedJobLatch);
         highAvailabilityServices.setJobResultStore(jobResultStore);
         cleanupJobHADataFuture = new CompletableFuture<>();
-        highAvailabilityServices.setCleanupJobDataFuture(cleanupJobHADataFuture);
+        highAvailabilityServices.setGlobalCleanupFuture(cleanupJobHADataFuture);
 
         storedHABlobFuture = new CompletableFuture<>();
         deleteAllHABlobsFuture = new CompletableFuture<>();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -93,7 +93,6 @@ import org.apache.flink.util.function.ThrowingRunnable;
 
 import org.assertj.core.api.Assertions;
 import org.hamcrest.Matchers;
-import org.hamcrest.collection.IsIterableContainingInAnyOrder;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -133,6 +132,7 @@ import static org.apache.flink.core.testutils.FlinkMatchers.containsMessage;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -791,7 +791,7 @@ public class DispatcherTest extends AbstractDispatcherTest {
             // make sure we've cleaned up in correct order (including HA)
             assertThat(
                     new ArrayList<>(cleanUpEvents),
-                    equalTo(Arrays.asList(CLEANUP_JOB_GRAPH_REMOVE, CLEANUP_HA_SERVICES)));
+                    containsInAnyOrder(CLEANUP_JOB_GRAPH_REMOVE, CLEANUP_HA_SERVICES));
         }
 
         // don't fail this time
@@ -1184,7 +1184,7 @@ public class DispatcherTest extends AbstractDispatcherTest {
                                         assertThat(
                                                 "All cleanup tasks should have been finished before marking the job as clean.",
                                                 cleanUpEvents,
-                                                IsIterableContainingInAnyOrder.containsInAnyOrder(
+                                                containsInAnyOrder(
                                                         CLEANUP_HA_SERVICES,
                                                         CLEANUP_JOB_GRAPH_REMOVE,
                                                         CLEANUP_JOB_MANAGER_RUNNER)))

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -746,7 +746,7 @@ public class DispatcherTest extends AbstractDispatcherTest {
 
         // Track cleanup - ha-services
         final CompletableFuture<JobID> cleanupJobData = new CompletableFuture<>();
-        haServices.setCleanupJobDataFuture(cleanupJobData);
+        haServices.setGlobalCleanupFuture(cleanupJobData);
         cleanupJobData.thenAccept(jobId -> cleanUpEvents.add(CLEANUP_HA_SERVICES));
 
         // Track cleanup - job-graph
@@ -1156,7 +1156,7 @@ public class DispatcherTest extends AbstractDispatcherTest {
 
         // Track cleanup - ha-services
         final CompletableFuture<JobID> cleanupJobData = new CompletableFuture<>();
-        haServices.setCleanupJobDataFuture(cleanupJobData);
+        haServices.setGlobalCleanupFuture(cleanupJobData);
         cleanupJobData.thenAccept(jobId -> cleanUpEvents.add(CLEANUP_HA_SERVICES));
 
         // Track cleanup - job-graph

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/NoOpJobGraphWriter.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/NoOpJobGraphWriter.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.dispatcher;
 
-import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmanager.JobGraphWriter;
 
@@ -28,10 +27,4 @@ public enum NoOpJobGraphWriter implements JobGraphWriter {
 
     @Override
     public void putJobGraph(JobGraph jobGraph) throws Exception {}
-
-    @Override
-    public void removeJobGraph(JobID jobId) throws Exception {}
-
-    @Override
-    public void releaseJobGraph(JobID jobId) throws Exception {}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/TestingJobManagerRunnerRegistry.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/TestingJobManagerRunnerRegistry.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.jobmaster.JobManagerRunner;
+import org.apache.flink.util.concurrent.FutureUtils;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * {@code TestingJobManagerRunnerRegistry} is a test implementation of {@link
+ * JobManagerRunnerRegistry}.
+ */
+public class TestingJobManagerRunnerRegistry implements JobManagerRunnerRegistry {
+
+    private final Function<JobID, Boolean> isRegisteredFunction;
+    private final Consumer<JobManagerRunner> registerConsumer;
+    private final Function<JobID, JobManagerRunner> getFunction;
+    private final Supplier<Integer> sizeSupplier;
+    private final Supplier<Set<JobID>> getRunningJobIdsSupplier;
+    private final Supplier<Collection<JobManagerRunner>> getJobManagerRunnersSupplier;
+    private final Function<JobID, JobManagerRunner> unregisterFunction;
+    private final BiFunction<JobID, Executor, CompletableFuture<Void>> localCleanupAsyncFunction;
+    private final BiFunction<JobID, Executor, CompletableFuture<Void>> globalCleanupAsyncFunction;
+
+    private TestingJobManagerRunnerRegistry(
+            Function<JobID, Boolean> isRegisteredFunction,
+            Consumer<JobManagerRunner> registerConsumer,
+            Function<JobID, JobManagerRunner> getFunction,
+            Supplier<Integer> sizeSupplier,
+            Supplier<Set<JobID>> getRunningJobIdsSupplier,
+            Supplier<Collection<JobManagerRunner>> getJobManagerRunnersSupplier,
+            Function<JobID, JobManagerRunner> unregisterFunction,
+            BiFunction<JobID, Executor, CompletableFuture<Void>> localCleanupAsyncFunction,
+            BiFunction<JobID, Executor, CompletableFuture<Void>> globalCleanupAsyncFunction) {
+        this.isRegisteredFunction = isRegisteredFunction;
+        this.registerConsumer = registerConsumer;
+        this.getFunction = getFunction;
+        this.sizeSupplier = sizeSupplier;
+        this.getRunningJobIdsSupplier = getRunningJobIdsSupplier;
+        this.getJobManagerRunnersSupplier = getJobManagerRunnersSupplier;
+        this.unregisterFunction = unregisterFunction;
+        this.localCleanupAsyncFunction = localCleanupAsyncFunction;
+        this.globalCleanupAsyncFunction = globalCleanupAsyncFunction;
+    }
+
+    @Override
+    public boolean isRegistered(JobID jobId) {
+        return isRegisteredFunction.apply(jobId);
+    }
+
+    @Override
+    public void register(JobManagerRunner jobManagerRunner) {
+        registerConsumer.accept(jobManagerRunner);
+    }
+
+    @Override
+    public JobManagerRunner get(JobID jobId) {
+        return getFunction.apply(jobId);
+    }
+
+    @Override
+    public int size() {
+        return sizeSupplier.get();
+    }
+
+    @Override
+    public Set<JobID> getRunningJobIds() {
+        return getRunningJobIdsSupplier.get();
+    }
+
+    @Override
+    public Collection<JobManagerRunner> getJobManagerRunners() {
+        return getJobManagerRunnersSupplier.get();
+    }
+
+    @Override
+    public JobManagerRunner unregister(JobID jobId) {
+        return unregisterFunction.apply(jobId);
+    }
+
+    @Override
+    public CompletableFuture<Void> localCleanupAsync(JobID jobId, Executor executor) {
+        return localCleanupAsyncFunction.apply(jobId, executor);
+    }
+
+    @Override
+    public CompletableFuture<Void> globalCleanupAsync(JobID jobId, Executor executor) {
+        return globalCleanupAsyncFunction.apply(jobId, executor);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /** {@code Builder} for creating {@code TestingJobManagerRunnerRegistry} instances. */
+    public static class Builder {
+
+        private Function<JobID, Boolean> isRegisteredFunction = ignoredJobId -> true;
+        private Consumer<JobManagerRunner> registerConsumer = ignoredRunner -> {};
+        private Function<JobID, JobManagerRunner> getFunction = ignoredJobId -> null;
+        private Supplier<Integer> sizeSupplier = () -> 0;
+        private Supplier<Set<JobID>> getRunningJobIdsSupplier = Collections::emptySet;
+        private Supplier<Collection<JobManagerRunner>> getJobManagerRunnersSupplier =
+                Collections::emptyList;
+        private Function<JobID, JobManagerRunner> unregisterFunction = ignoredJobId -> null;
+        private BiFunction<JobID, Executor, CompletableFuture<Void>> localCleanupAsyncFunction =
+                (ignoredJobId, ignoredExecutor) -> FutureUtils.completedVoidFuture();
+        private BiFunction<JobID, Executor, CompletableFuture<Void>> globalCleanupAsyncFunction =
+                (ignoredJobId, ignoredExecutor) -> FutureUtils.completedVoidFuture();
+
+        public Builder withIsRegisteredFunction(Function<JobID, Boolean> isRegisteredFunction) {
+            this.isRegisteredFunction = isRegisteredFunction;
+            return this;
+        }
+
+        public Builder withRegisterConsumer(Consumer<JobManagerRunner> registerConsumer) {
+            this.registerConsumer = registerConsumer;
+            return this;
+        }
+
+        public Builder withGetFunction(Function<JobID, JobManagerRunner> getFunction) {
+            this.getFunction = getFunction;
+            return this;
+        }
+
+        public Builder withSizeSupplier(Supplier<Integer> sizeSupplier) {
+            this.sizeSupplier = sizeSupplier;
+            return this;
+        }
+
+        public Builder withGetRunningJobIdsSupplier(Supplier<Set<JobID>> getRunningJobIdsSupplier) {
+            this.getRunningJobIdsSupplier = getRunningJobIdsSupplier;
+            return this;
+        }
+
+        public Builder withGetJobManagerRunnersSupplier(
+                Supplier<Collection<JobManagerRunner>> getJobManagerRunnersSupplier) {
+            this.getJobManagerRunnersSupplier = getJobManagerRunnersSupplier;
+            return this;
+        }
+
+        public Builder withUnregisterFunction(
+                Function<JobID, JobManagerRunner> unregisterFunction) {
+            this.unregisterFunction = unregisterFunction;
+            return this;
+        }
+
+        public Builder withLocalCleanupAsyncFunction(
+                BiFunction<JobID, Executor, CompletableFuture<Void>> localCleanupAsyncFunction) {
+            this.localCleanupAsyncFunction = localCleanupAsyncFunction;
+            return this;
+        }
+
+        public Builder withGlobalCleanupAsyncFunction(
+                BiFunction<JobID, Executor, CompletableFuture<Void>> globalCleanupAsyncFunction) {
+            this.globalCleanupAsyncFunction = globalCleanupAsyncFunction;
+            return this;
+        }
+
+        public TestingJobManagerRunnerRegistry build() {
+            return new TestingJobManagerRunnerRegistry(
+                    isRegisteredFunction,
+                    registerConsumer,
+                    getFunction,
+                    sizeSupplier,
+                    getRunningJobIdsSupplier,
+                    getJobManagerRunnersSupplier,
+                    unregisterFunction,
+                    localCleanupAsyncFunction,
+                    globalCleanupAsyncFunction);
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/cleanup/DefaultResourceCleanerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/cleanup/DefaultResourceCleanerTest.java
@@ -1,0 +1,235 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher.cleanup;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.concurrent.Executors;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** {@code DefaultResourceCleanerTest} tests {@link DefaultResourceCleaner}. */
+public class DefaultResourceCleanerTest {
+
+    private static final Executor EXECUTOR = Executors.directExecutor();
+    private static final JobID JOB_ID = new JobID();
+
+    private DefaultResourceCleaner<CleanupCallback> testInstance;
+    private CleanupCallback cleanup0;
+    private CleanupCallback cleanup1;
+
+    @BeforeEach
+    public void setup() {
+        cleanup0 = CleanupCallback.withoutCompletionOnCleanup();
+        cleanup1 = CleanupCallback.withoutCompletionOnCleanup();
+
+        testInstance =
+                createTestInstanceBuilder()
+                        .withRegularCleanup(cleanup0)
+                        .withRegularCleanup(cleanup1)
+                        .build();
+    }
+
+    @Test
+    public void testSuccessfulConcurrentCleanup() {
+        CompletableFuture<Void> cleanupResult = testInstance.cleanupAsync(JOB_ID);
+
+        assertThat(cleanupResult).isNotCompleted();
+        assertThat(cleanup0).extracting(CleanupCallback::getProcessedJobId).isEqualTo(JOB_ID);
+        assertThat(cleanup1).extracting(CleanupCallback::getProcessedJobId).isEqualTo(JOB_ID);
+
+        cleanup0.completeCleanup();
+        assertThat(cleanupResult).isNotCompleted();
+
+        cleanup1.completeCleanup();
+        assertThat(cleanupResult).isCompleted();
+    }
+
+    @Test
+    public void testConcurrentCleanupWithExceptionFirst() {
+        CompletableFuture<Void> cleanupResult = testInstance.cleanupAsync(JOB_ID);
+
+        assertThat(cleanupResult).isNotCompleted();
+        assertThat(cleanup0).extracting(CleanupCallback::getProcessedJobId).isEqualTo(JOB_ID);
+        assertThat(cleanup1).extracting(CleanupCallback::getProcessedJobId).isEqualTo(JOB_ID);
+
+        final RuntimeException expectedException = new RuntimeException("Expected exception");
+        cleanup0.completeCleanupExceptionally(expectedException);
+        assertThat(cleanupResult).isNotCompleted();
+
+        cleanup1.completeCleanup();
+        assertThat(cleanupResult)
+                .failsWithin(Duration.ZERO)
+                .withThrowableOfType(ExecutionException.class)
+                .withCause(expectedException);
+    }
+
+    @Test
+    public void testConcurrentCleanupWithExceptionSecond() {
+        CompletableFuture<Void> cleanupResult = testInstance.cleanupAsync(JOB_ID);
+
+        assertThat(cleanupResult).isNotCompleted();
+        assertThat(cleanup0).extracting(CleanupCallback::getProcessedJobId).isEqualTo(JOB_ID);
+        assertThat(cleanup1).extracting(CleanupCallback::getProcessedJobId).isEqualTo(JOB_ID);
+
+        cleanup0.completeCleanup();
+        assertThat(cleanupResult).isNotCompleted();
+
+        final RuntimeException expectedException = new RuntimeException("Expected exception");
+        cleanup1.completeCleanupExceptionally(expectedException);
+        assertThat(cleanupResult)
+                .failsWithin(Duration.ZERO)
+                .withThrowableOfType(ExecutionException.class)
+                .withCause(expectedException);
+    }
+
+    @Test
+    public void testHighestPriorityCleanupBlocksAllOtherCleanups() {
+        final CleanupCallback highPriorityCleanup = CleanupCallback.withoutCompletionOnCleanup();
+        final CleanupCallback lowerThanHighPriorityCleanup =
+                CleanupCallback.withCompletionOnCleanup();
+        final CleanupCallback noPriorityCleanup0 = CleanupCallback.withCompletionOnCleanup();
+        final CleanupCallback noPriorityCleanup1 = CleanupCallback.withCompletionOnCleanup();
+
+        final DefaultResourceCleaner<CleanupCallback> testInstance =
+                createTestInstanceBuilder()
+                        .withPrioritizedCleanup(highPriorityCleanup)
+                        .withPrioritizedCleanup(lowerThanHighPriorityCleanup)
+                        .withRegularCleanup(noPriorityCleanup0)
+                        .withRegularCleanup(noPriorityCleanup1)
+                        .build();
+
+        final CompletableFuture<Void> overallCleanupResult = testInstance.cleanupAsync(JOB_ID);
+
+        assertThat(highPriorityCleanup.isDone()).isFalse();
+        assertThat(lowerThanHighPriorityCleanup.isDone()).isFalse();
+        assertThat(noPriorityCleanup0.isDone()).isFalse();
+        assertThat(noPriorityCleanup1.isDone()).isFalse();
+
+        assertThat(overallCleanupResult.isDone()).isFalse();
+
+        highPriorityCleanup.completeCleanup();
+
+        assertThat(overallCleanupResult).succeedsWithin(Duration.ofMillis(100));
+
+        assertThat(highPriorityCleanup.isDone()).isTrue();
+        assertThat(lowerThanHighPriorityCleanup.isDone()).isTrue();
+        assertThat(noPriorityCleanup0.isDone()).isTrue();
+        assertThat(noPriorityCleanup1.isDone()).isTrue();
+    }
+
+    @Test
+    public void testMediumPriorityCleanupBlocksAllLowerPrioritizedCleanups() {
+        final CleanupCallback highPriorityCleanup = CleanupCallback.withCompletionOnCleanup();
+        final CleanupCallback lowerThanHighPriorityCleanup =
+                CleanupCallback.withoutCompletionOnCleanup();
+        final CleanupCallback noPriorityCleanup0 = CleanupCallback.withCompletionOnCleanup();
+        final CleanupCallback noPriorityCleanup1 = CleanupCallback.withCompletionOnCleanup();
+
+        final DefaultResourceCleaner<CleanupCallback> testInstance =
+                createTestInstanceBuilder()
+                        .withPrioritizedCleanup(highPriorityCleanup)
+                        .withPrioritizedCleanup(lowerThanHighPriorityCleanup)
+                        .withRegularCleanup(noPriorityCleanup0)
+                        .withRegularCleanup(noPriorityCleanup1)
+                        .build();
+
+        assertThat(highPriorityCleanup.isDone()).isFalse();
+
+        final CompletableFuture<Void> overallCleanupResult = testInstance.cleanupAsync(JOB_ID);
+
+        assertThat(highPriorityCleanup.isDone()).isTrue();
+        assertThat(lowerThanHighPriorityCleanup.isDone()).isFalse();
+        assertThat(noPriorityCleanup0.isDone()).isFalse();
+        assertThat(noPriorityCleanup1.isDone()).isFalse();
+
+        assertThat(overallCleanupResult.isDone()).isFalse();
+
+        lowerThanHighPriorityCleanup.completeCleanup();
+
+        assertThat(overallCleanupResult).succeedsWithin(Duration.ofMillis(100));
+
+        assertThat(highPriorityCleanup.isDone()).isTrue();
+        assertThat(lowerThanHighPriorityCleanup.isDone()).isTrue();
+        assertThat(noPriorityCleanup0.isDone()).isTrue();
+        assertThat(noPriorityCleanup1.isDone()).isTrue();
+    }
+
+    private static DefaultResourceCleaner.Builder<CleanupCallback> createTestInstanceBuilder() {
+        return DefaultResourceCleaner.forCleanableResources(
+                ComponentMainThreadExecutorServiceAdapter.forMainThread(),
+                EXECUTOR,
+                CleanupCallback::cleanup);
+    }
+
+    private static class CleanupCallback {
+
+        private final CompletableFuture<Void> resultFuture = new CompletableFuture<>();
+        private JobID jobId;
+
+        private final Consumer<CompletableFuture<Void>> internalFunction;
+
+        public static CleanupCallback withCompletionOnCleanup() {
+            return new CleanupCallback(resultFuture -> resultFuture.complete(null));
+        }
+
+        public static CleanupCallback withoutCompletionOnCleanup() {
+            return new CleanupCallback(ignoredResultFuture -> {});
+        }
+
+        private CleanupCallback(Consumer<CompletableFuture<Void>> internalFunction) {
+            this.internalFunction = internalFunction;
+        }
+
+        public CompletableFuture<Void> cleanup(JobID jobId, Executor executor) {
+            Preconditions.checkState(this.jobId == null);
+            this.jobId = jobId;
+
+            internalFunction.accept(resultFuture);
+
+            return resultFuture;
+        }
+
+        public boolean isDone() {
+            return resultFuture.isDone();
+        }
+
+        public JobID getProcessedJobId() {
+            return jobId;
+        }
+
+        public void completeCleanup() {
+            this.resultFuture.complete(null);
+        }
+
+        public void completeCleanupExceptionally(Throwable expectedException) {
+            this.resultFuture.completeExceptionally(expectedException);
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/cleanup/DispatcherResourceCleanerFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/cleanup/DispatcherResourceCleanerFactoryTest.java
@@ -1,0 +1,269 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher.cleanup;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.blob.BlobServer;
+import org.apache.flink.runtime.blob.TestingBlobStoreBuilder;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
+import org.apache.flink.runtime.dispatcher.JobManagerRunnerRegistry;
+import org.apache.flink.runtime.dispatcher.TestingJobManagerRunnerRegistry;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
+import org.apache.flink.runtime.jobmanager.JobGraphWriter;
+import org.apache.flink.runtime.metrics.MetricRegistry;
+import org.apache.flink.runtime.metrics.groups.JobManagerMetricGroup;
+import org.apache.flink.runtime.metrics.util.TestingMetricRegistry;
+import org.apache.flink.runtime.testutils.TestingJobGraphStore;
+import org.apache.flink.util.concurrent.Executors;
+import org.apache.flink.util.concurrent.FutureUtils;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeoutException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * {@code DispatcherResourceCleanerFactoryTest} verifies that the resources are properly cleaned up
+ * for both, the {@link GloballyCleanableResource} and {@link LocallyCleanableResource} of the
+ * {@link org.apache.flink.runtime.dispatcher.Dispatcher}.
+ */
+public class DispatcherResourceCleanerFactoryTest {
+
+    private static final JobID JOB_ID = new JobID();
+
+    private CleanableBlobServer blobServer;
+
+    private CompletableFuture<JobID> jobManagerRunnerRegistryLocalCleanupFuture;
+    private CompletableFuture<Void> jobManagerRunnerRegistryLocalCleanupResultFuture;
+    private CompletableFuture<JobID> jobManagerRunnerRegistryGlobalCleanupFuture;
+    private CompletableFuture<Void> jobManagerRunnerRegistryGlobalCleanupResultFuture;
+
+    private CompletableFuture<JobID> jobGraphWriterLocalCleanupFuture;
+    private CompletableFuture<JobID> jobGraphWriterGlobalCleanupFuture;
+
+    private CompletableFuture<JobID> highAvailabilityServicesGlobalCleanupFuture;
+    private JobManagerMetricGroup jobManagerMetricGroup;
+
+    private DispatcherResourceCleanerFactory testInstance;
+
+    @BeforeEach
+    public void setup() throws Exception {
+        blobServer = new CleanableBlobServer();
+
+        MetricRegistry metricRegistry = TestingMetricRegistry.builder().build();
+        jobManagerMetricGroup =
+                JobManagerMetricGroup.createJobManagerMetricGroup(
+                        metricRegistry, "ignored hostname");
+        jobManagerMetricGroup.addJob(JOB_ID, "ignored job name");
+
+        testInstance =
+                new DispatcherResourceCleanerFactory(
+                        Executors.directExecutor(),
+                        createJobManagerRunnerRegistry(),
+                        createJobGraphWriter(),
+                        blobServer,
+                        createHighAvailabilityServices(),
+                        jobManagerMetricGroup);
+    }
+
+    private JobManagerRunnerRegistry createJobManagerRunnerRegistry() {
+        jobManagerRunnerRegistryLocalCleanupFuture = new CompletableFuture<>();
+        jobManagerRunnerRegistryLocalCleanupResultFuture = new CompletableFuture<>();
+
+        jobManagerRunnerRegistryGlobalCleanupFuture = new CompletableFuture<>();
+        jobManagerRunnerRegistryGlobalCleanupResultFuture = new CompletableFuture<>();
+
+        return TestingJobManagerRunnerRegistry.builder()
+                .withLocalCleanupAsyncFunction(
+                        (jobId, executor) -> {
+                            jobManagerRunnerRegistryLocalCleanupFuture.complete(jobId);
+                            return jobManagerRunnerRegistryLocalCleanupResultFuture;
+                        })
+                .withGlobalCleanupAsyncFunction(
+                        (jobId, executor) -> {
+                            jobManagerRunnerRegistryGlobalCleanupFuture.complete(jobId);
+                            return jobManagerRunnerRegistryGlobalCleanupResultFuture;
+                        })
+                .build();
+    }
+
+    private JobGraphWriter createJobGraphWriter() throws Exception {
+        jobGraphWriterLocalCleanupFuture = new CompletableFuture<>();
+        jobGraphWriterGlobalCleanupFuture = new CompletableFuture<>();
+        final TestingJobGraphStore jobGraphStore =
+                TestingJobGraphStore.newBuilder()
+                        .setGlobalCleanupFunction(
+                                (jobId, executor) -> {
+                                    jobGraphWriterGlobalCleanupFuture.complete(jobId);
+                                    return FutureUtils.completedVoidFuture();
+                                })
+                        .setLocalCleanupFunction(
+                                (jobId, ignoredExecutor) -> {
+                                    jobGraphWriterLocalCleanupFuture.complete(jobId);
+                                    return FutureUtils.completedVoidFuture();
+                                })
+                        .build();
+        jobGraphStore.start(null);
+
+        return jobGraphStore;
+    }
+
+    private HighAvailabilityServices createHighAvailabilityServices() {
+        highAvailabilityServicesGlobalCleanupFuture = new CompletableFuture<>();
+        final TestingHighAvailabilityServices haServices = new TestingHighAvailabilityServices();
+        haServices.setGlobalCleanupFuture(highAvailabilityServicesGlobalCleanupFuture);
+        return haServices;
+    }
+
+    @Test
+    public void testLocalResourceCleaning() {
+        assertGlobalCleanupNotTriggered();
+        assertLocalCleanupNotTriggered();
+
+        final CompletableFuture<Void> cleanupResultFuture =
+                testInstance
+                        .createLocalResourceCleaner(
+                                ComponentMainThreadExecutorServiceAdapter.forMainThread())
+                        .cleanupAsync(JOB_ID);
+
+        assertGlobalCleanupNotTriggered();
+        assertLocalCleanupTriggeredWaitingForJobManagerRunnerRegistry();
+
+        assertThat(cleanupResultFuture).isNotCompleted();
+
+        jobManagerRunnerRegistryLocalCleanupResultFuture.complete(null);
+
+        assertGlobalCleanupNotTriggered();
+        assertLocalCleanupTriggered();
+
+        assertThat(cleanupResultFuture).isCompleted();
+    }
+
+    @Test
+    public void testGlobalResourceCleaning()
+            throws ExecutionException, InterruptedException, TimeoutException {
+        assertGlobalCleanupNotTriggered();
+        assertLocalCleanupNotTriggered();
+
+        final CompletableFuture<Void> cleanupResultFuture =
+                testInstance
+                        .createGlobalResourceCleaner(
+                                ComponentMainThreadExecutorServiceAdapter.forMainThread())
+                        .cleanupAsync(JOB_ID);
+
+        assertLocalCleanupNotTriggered();
+        assertGlobalCleanupTriggeredWaitingForJobManagerRunnerRegistry();
+
+        jobManagerRunnerRegistryGlobalCleanupResultFuture.complete(null);
+
+        assertGlobalCleanupTriggered();
+        assertLocalCleanupNotTriggered();
+
+        assertThat(cleanupResultFuture).isCompleted();
+    }
+
+    private void assertLocalCleanupNotTriggered() {
+        assertThat(jobManagerRunnerRegistryLocalCleanupFuture).isNotDone();
+        assertThat(jobGraphWriterLocalCleanupFuture).isNotDone();
+        assertThat(blobServer.getLocalCleanupFuture()).isNotDone();
+        assertThat(jobManagerMetricGroup.numRegisteredJobMetricGroups()).isEqualTo(1);
+    }
+
+    private void assertLocalCleanupTriggeredWaitingForJobManagerRunnerRegistry() {
+        assertThat(jobManagerRunnerRegistryLocalCleanupFuture).isCompleted();
+
+        // the JobManagerRunnerRegistry needs to be cleaned up first
+        assertThat(jobGraphWriterLocalCleanupFuture).isNotDone();
+        assertThat(blobServer.getLocalCleanupFuture()).isNotDone();
+        assertThat(jobManagerMetricGroup.numRegisteredJobMetricGroups()).isEqualTo(1);
+    }
+
+    private void assertGlobalCleanupNotTriggered() {
+        assertThat(jobGraphWriterGlobalCleanupFuture).isNotDone();
+        assertThat(blobServer.getGlobalCleanupFuture()).isNotDone();
+        assertThat(highAvailabilityServicesGlobalCleanupFuture).isNotDone();
+    }
+
+    private void assertGlobalCleanupTriggeredWaitingForJobManagerRunnerRegistry() {
+        assertThat(jobManagerRunnerRegistryGlobalCleanupFuture).isCompleted();
+
+        // the JobManagerRunnerRegistry needs to be cleaned up first
+        assertThat(jobGraphWriterGlobalCleanupFuture).isNotDone();
+        assertThat(blobServer.getGlobalCleanupFuture()).isNotDone();
+        assertThat(highAvailabilityServicesGlobalCleanupFuture).isNotDone();
+    }
+
+    private void assertLocalCleanupTriggered() {
+        assertThat(jobManagerRunnerRegistryLocalCleanupFuture).isCompleted();
+        assertThat(jobGraphWriterLocalCleanupFuture).isCompleted();
+        assertThat(blobServer.getLocalCleanupFuture()).isCompleted();
+        assertThat(jobManagerMetricGroup.numRegisteredJobMetricGroups()).isEqualTo(0);
+    }
+
+    private void assertGlobalCleanupTriggered() {
+        assertThat(jobManagerRunnerRegistryGlobalCleanupFuture).isCompleted();
+        assertThat(jobGraphWriterGlobalCleanupFuture).isCompleted();
+        assertThat(blobServer.getGlobalCleanupFuture()).isCompleted();
+        assertThat(highAvailabilityServicesGlobalCleanupFuture).isCompleted();
+    }
+
+    private static class CleanableBlobServer extends BlobServer {
+
+        private final CompletableFuture<JobID> localCleanupFuture = new CompletableFuture<>();
+        private final CompletableFuture<JobID> globalCleanupFuture = new CompletableFuture<>();
+
+        public CleanableBlobServer() throws IOException {
+            super(
+                    new Configuration(),
+                    new File("non-existent-file"),
+                    new TestingBlobStoreBuilder().createTestingBlobStore());
+        }
+
+        @Override
+        public CompletableFuture<Void> localCleanupAsync(JobID jobId, Executor ignoredExecutor) {
+            localCleanupFuture.complete(jobId);
+
+            return FutureUtils.completedVoidFuture();
+        }
+
+        @Override
+        public CompletableFuture<Void> globalCleanupAsync(JobID jobId, Executor ignoredExecutor) {
+            globalCleanupFuture.complete(jobId);
+
+            return FutureUtils.completedVoidFuture();
+        }
+
+        public CompletableFuture<JobID> getLocalCleanupFuture() {
+            return localCleanupFuture;
+        }
+
+        public CompletableFuture<JobID> getGlobalCleanupFuture() {
+            return globalCleanupFuture;
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/SessionDispatcherLeaderProcessTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/SessionDispatcherLeaderProcessTest.java
@@ -422,6 +422,7 @@ public class SessionDispatcherLeaderProcessTest {
         dispatcherServiceFactory =
                 createFactoryBasedOnGenericSupplier(() -> testingDispatcherService);
 
+        final ExecutorService executorService = Executors.newSingleThreadExecutor();
         try (final SessionDispatcherLeaderProcess dispatcherLeaderProcess =
                 createDispatcherLeaderProcess()) {
             dispatcherLeaderProcess.start();
@@ -430,10 +431,12 @@ public class SessionDispatcherLeaderProcessTest {
             dispatcherLeaderProcess.getDispatcherGateway().get();
 
             // now remove the Job from the JobGraphStore and notify the dispatcher service
-            jobGraphStore.removeJobGraph(JOB_GRAPH.getJobID());
+            jobGraphStore.globalCleanupAsync(JOB_GRAPH.getJobID(), executorService).join();
             dispatcherLeaderProcess.onRemovedJobGraph(JOB_GRAPH.getJobID());
 
             assertThat(terminateJobFuture.get()).isEqualTo(JOB_GRAPH.getJobID());
+        } finally {
+            assertThat(executorService.shutdownNow()).isEmpty();
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheRecoveryITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheRecoveryITCase.java
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.blob.PermanentBlobKey;
 import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
 import org.apache.flink.util.TestLogger;
 
+import org.hamcrest.collection.IsEmptyCollection;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -41,7 +42,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Random;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -70,6 +74,7 @@ public class BlobLibraryCacheRecoveryITCase extends TestLogger {
                 temporaryFolder.newFolder().getAbsolutePath());
         config.setLong(BlobServerOptions.CLEANUP_INTERVAL, 3_600L);
 
+        final ExecutorService executorService = Executors.newSingleThreadExecutor();
         try {
             blobStoreService = BlobUtils.createBlobStoreFromConfig(config);
 
@@ -160,7 +165,7 @@ public class BlobLibraryCacheRecoveryITCase extends TestLogger {
             }
 
             // Remove blobs again
-            server[1].cleanupJob(jobId, true);
+            server[1].globalCleanupAsync(jobId, executorService).join();
 
             // Verify everything is clean below recoveryDir/<cluster_id>
             final String clusterId = config.getString(HighAvailabilityOptions.HA_CLUSTER_ID);
@@ -173,6 +178,8 @@ public class BlobLibraryCacheRecoveryITCase extends TestLogger {
                     0,
                     recoveryFiles.length);
         } finally {
+            assertThat(executorService.shutdownNow(), IsEmptyCollection.empty());
+
             for (BlobLibraryCacheManager s : libServer) {
                 if (s != null) {
                     s.shutdown();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/AbstractHaServicesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/AbstractHaServicesTest.java
@@ -31,6 +31,7 @@ import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.concurrent.Executors;
 import org.apache.flink.util.function.RunnableWithException;
+import org.apache.flink.util.function.ThrowingConsumer;
 
 import org.junit.Test;
 
@@ -40,7 +41,6 @@ import java.util.ArrayDeque;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
-import java.util.function.Consumer;
 
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
@@ -130,7 +130,7 @@ public class AbstractHaServicesTest extends TestLogger {
                         () -> {},
                         jobCleanupFuture::complete);
 
-        haServices.cleanupJobData(jobID);
+        haServices.globalCleanupAsync(jobID, Executors.directExecutor()).join();
         JobID jobIDCleaned = jobCleanupFuture.get();
         assertThat(jobIDCleaned, is(jobID));
     }
@@ -185,7 +185,7 @@ public class AbstractHaServicesTest extends TestLogger {
 
         private final Queue<? super CloseOperations> closeOperations;
         private final RunnableWithException internalCleanupRunnable;
-        private final Consumer<JobID> internalJobCleanupConsumer;
+        private final ThrowingConsumer<JobID, Exception> internalJobCleanupConsumer;
 
         private TestingHaServices(
                 Configuration config,
@@ -193,7 +193,7 @@ public class AbstractHaServicesTest extends TestLogger {
                 BlobStoreService blobStoreService,
                 Queue<? super CloseOperations> closeOperations,
                 RunnableWithException internalCleanupRunnable,
-                Consumer<JobID> internalJobCleanupConsumer) {
+                ThrowingConsumer<JobID, Exception> internalJobCleanupConsumer) {
             super(
                     config,
                     ioExecutor,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/zookeeper/ZooKeeperHaServicesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/zookeeper/ZooKeeperHaServicesTest.java
@@ -173,7 +173,7 @@ public class ZooKeeperHaServicesTest extends TestLogger {
                 haServices -> {
                     final List<String> childrenBefore = client.getChildren().forPath(path);
 
-                    haServices.cleanupJobData(jobID);
+                    haServices.globalCleanupAsync(jobID, Executors.directExecutor()).join();
 
                     final List<String> childrenAfter = client.getChildren().forPath(path);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/StandaloneJobGraphStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/StandaloneJobGraphStoreTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.jobmanager;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobGraphTestUtils;
+import org.apache.flink.util.concurrent.Executors;
 
 import org.junit.Test;
 
@@ -31,7 +32,7 @@ public class StandaloneJobGraphStoreTest {
 
     /** Tests that all operations work and don't change the state. */
     @Test
-    public void testNoOps() {
+    public void testNoOps() throws Exception {
         StandaloneJobGraphStore jobGraphs = new StandaloneJobGraphStore();
 
         JobGraph jobGraph = JobGraphTestUtils.emptyJobGraph();
@@ -41,7 +42,7 @@ public class StandaloneJobGraphStoreTest {
         jobGraphs.putJobGraph(jobGraph);
         assertEquals(0, jobGraphs.getJobIds().size());
 
-        jobGraphs.removeJobGraph(jobGraph.getJobID());
+        jobGraphs.globalCleanupAsync(jobGraph.getJobID(), Executors.directExecutor()).join();
         assertEquals(0, jobGraphs.getJobIds().size());
 
         assertNull(jobGraphs.recoverJobGraph(new JobID()));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/ZooKeeperJobGraphsStoreITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/ZooKeeperJobGraphsStoreITCase.java
@@ -32,6 +32,7 @@ import org.apache.flink.runtime.zookeeper.ZooKeeperStateHandleStore;
 import org.apache.flink.runtime.zookeeper.ZooKeeperTestEnvironment;
 import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.concurrent.Executors;
 
 import org.apache.flink.shaded.curator5.org.apache.curator.framework.CuratorFramework;
 import org.apache.flink.shaded.curator5.org.apache.curator.framework.recipes.cache.PathChildrenCache;
@@ -130,7 +131,7 @@ public class ZooKeeperJobGraphsStoreITCase extends TestLogger {
             verifyJobGraphs(jobGraph, jobGraphs.recoverJobGraph(jobId));
 
             // Remove
-            jobGraphs.removeJobGraph(jobGraph.getJobID());
+            jobGraphs.globalCleanupAsync(jobGraph.getJobID(), Executors.directExecutor()).join();
 
             // Empty state
             assertEquals(0, jobGraphs.getJobIds().size());
@@ -140,7 +141,7 @@ public class ZooKeeperJobGraphsStoreITCase extends TestLogger {
             verify(listener, never()).onRemovedJobGraph(any(JobID.class));
 
             // Don't fail if called again
-            jobGraphs.removeJobGraph(jobGraph.getJobID());
+            jobGraphs.globalCleanupAsync(jobGraph.getJobID(), Executors.directExecutor()).join();
         } finally {
             jobGraphs.stop();
         }
@@ -193,7 +194,9 @@ public class ZooKeeperJobGraphsStoreITCase extends TestLogger {
 
                 verifyJobGraphs(expected.get(jobGraph.getJobID()), jobGraph);
 
-                jobGraphs.removeJobGraph(jobGraph.getJobID());
+                jobGraphs
+                        .globalCleanupAsync(jobGraph.getJobID(), Executors.directExecutor())
+                        .join();
             }
 
             // Empty state
@@ -313,7 +316,9 @@ public class ZooKeeperJobGraphsStoreITCase extends TestLogger {
         assertThat(recoveredJobGraph, is(notNullValue()));
 
         try {
-            otherSubmittedJobGraphStore.removeJobGraph(recoveredJobGraph.getJobID());
+            otherSubmittedJobGraphStore
+                    .globalCleanupAsync(recoveredJobGraph.getJobID(), Executors.directExecutor())
+                    .join();
             fail(
                     "It should not be possible to remove the JobGraph since the first store still has a lock on it.");
         } catch (Exception ignored) {
@@ -323,7 +328,9 @@ public class ZooKeeperJobGraphsStoreITCase extends TestLogger {
         submittedJobGraphStore.stop();
 
         // now we should be able to delete the job graph
-        otherSubmittedJobGraphStore.removeJobGraph(recoveredJobGraph.getJobID());
+        otherSubmittedJobGraphStore
+                .globalCleanupAsync(recoveredJobGraph.getJobID(), Executors.directExecutor())
+                .join();
 
         assertThat(
                 otherSubmittedJobGraphStore.recoverJobGraph(recoveredJobGraph.getJobID()),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestingJobManagerRunner.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestingJobManagerRunner.java
@@ -155,6 +155,10 @@ public class TestingJobManagerRunner implements JobManagerRunner {
         terminationFuture.complete(null);
     }
 
+    public void completeTerminationFutureExceptionally(Throwable expectedException) {
+        terminationFuture.completeExceptionally(expectedException);
+    }
+
     public CompletableFuture<Void> getTerminationFuture() {
         return terminationFuture;
     }
@@ -166,7 +170,7 @@ public class TestingJobManagerRunner implements JobManagerRunner {
     /** {@code Builder} for instantiating {@link TestingJobManagerRunner} instances. */
     public static class Builder {
 
-        private JobID jobId = null;
+        private JobID jobId = new JobID();
         private boolean blockingTermination = false;
         private CompletableFuture<JobMasterGateway> jobMasterGatewayFuture =
                 new CompletableFuture<>();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/JobManagerGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/JobManagerGroupTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.metrics.MetricRegistryTestUtils;
 import org.apache.flink.runtime.metrics.dump.QueryScopeInfo;
 import org.apache.flink.runtime.metrics.util.DummyCharacterFilter;
 import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.concurrent.Executors;
 
 import org.junit.Test;
 
@@ -62,12 +63,12 @@ public class JobManagerGroupTest extends TestLogger {
 
         assertEquals(2, group.numRegisteredJobMetricGroups());
 
-        group.removeJob(jid1);
+        group.localCleanupAsync(jid1, Executors.directExecutor()).join();
 
         assertTrue(jmJobGroup11.isClosed());
         assertEquals(1, group.numRegisteredJobMetricGroups());
 
-        group.removeJob(jid2);
+        group.localCleanupAsync(jid2, Executors.directExecutor()).join();
 
         assertTrue(jmJobGroup21.isClosed());
         assertEquals(0, group.numRegisteredJobMetricGroups());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SchedulerUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SchedulerUtilsTest.java
@@ -75,7 +75,6 @@ public class SchedulerUtilsTest extends TestLogger {
         final CompletedCheckpointStore completedCheckpointStore =
                 SchedulerUtils.createCompletedCheckpointStore(
                         jobManagerConfig,
-                        getClass().getClassLoader(),
                         new StandaloneCheckpointRecoveryFactory(),
                         Executors.directExecutor(),
                         log,
@@ -102,7 +101,6 @@ public class SchedulerUtilsTest extends TestLogger {
         CompletedCheckpointStore checkpointStore =
                 SchedulerUtils.createCompletedCheckpointStore(
                         new Configuration(),
-                        getClass().getClassLoader(),
                         recoveryFactory,
                         Executors.directExecutor(),
                         log,
@@ -123,7 +121,6 @@ public class SchedulerUtilsTest extends TestLogger {
             public CompletedCheckpointStore createRecoveredCompletedCheckpointStore(
                     JobID jobId,
                     int maxNumberOfCheckpointsToRetain,
-                    ClassLoader userClassLoader,
                     SharedStateRegistryFactory sharedStateRegistryFactory,
                     Executor ioExecutor) {
                 List<CompletedCheckpoint> checkpoints = singletonList(checkpoint);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/TestingJobGraphStore.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/TestingJobGraphStore.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmanager.JobGraphStore;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.concurrent.FutureUtils;
 import org.apache.flink.util.function.BiFunctionWithException;
 import org.apache.flink.util.function.FunctionWithException;
 import org.apache.flink.util.function.ThrowingConsumer;
@@ -35,6 +36,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.function.BiFunction;
 
 /** In-Memory implementation of {@link JobGraphStore} for testing purposes. */
 public class TestingJobGraphStore implements JobGraphStore {
@@ -54,9 +58,9 @@ public class TestingJobGraphStore implements JobGraphStore {
 
     private final ThrowingConsumer<JobGraph, ? extends Exception> putJobGraphConsumer;
 
-    private final ThrowingConsumer<JobID, ? extends Exception> removeJobGraphConsumer;
+    private final BiFunction<JobID, Executor, CompletableFuture<Void>> globalCleanupFunction;
 
-    private final ThrowingConsumer<JobID, ? extends Exception> releaseJobGraphConsumer;
+    private final BiFunction<JobID, Executor, CompletableFuture<Void>> localCleanupFunction;
 
     private boolean started;
 
@@ -68,16 +72,16 @@ public class TestingJobGraphStore implements JobGraphStore {
             BiFunctionWithException<JobID, Map<JobID, JobGraph>, JobGraph, ? extends Exception>
                     recoverJobGraphFunction,
             ThrowingConsumer<JobGraph, ? extends Exception> putJobGraphConsumer,
-            ThrowingConsumer<JobID, ? extends Exception> removeJobGraphConsumer,
-            ThrowingConsumer<JobID, ? extends Exception> releaseJobGraphConsumer,
+            BiFunction<JobID, Executor, CompletableFuture<Void>> globalCleanupFunction,
+            BiFunction<JobID, Executor, CompletableFuture<Void>> localCleanupFunction,
             Collection<JobGraph> initialJobGraphs) {
         this.startConsumer = startConsumer;
         this.stopRunnable = stopRunnable;
         this.jobIdsFunction = jobIdsFunction;
         this.recoverJobGraphFunction = recoverJobGraphFunction;
         this.putJobGraphConsumer = putJobGraphConsumer;
-        this.removeJobGraphConsumer = removeJobGraphConsumer;
-        this.releaseJobGraphConsumer = releaseJobGraphConsumer;
+        this.globalCleanupFunction = globalCleanupFunction;
+        this.localCleanupFunction = localCleanupFunction;
 
         for (JobGraph initialJobGraph : initialJobGraphs) {
             storedJobs.put(initialJobGraph.getJobID(), initialJobGraph);
@@ -110,16 +114,15 @@ public class TestingJobGraphStore implements JobGraphStore {
     }
 
     @Override
-    public synchronized void removeJobGraph(JobID jobId) throws Exception {
+    public synchronized CompletableFuture<Void> globalCleanupAsync(JobID jobId, Executor executor) {
         verifyIsStarted();
-        removeJobGraphConsumer.accept(jobId);
-        storedJobs.remove(jobId);
+        return globalCleanupFunction.apply(jobId, executor).thenRun(() -> storedJobs.remove(jobId));
     }
 
     @Override
-    public synchronized void releaseJobGraph(JobID jobId) throws Exception {
+    public synchronized CompletableFuture<Void> localCleanupAsync(JobID jobId, Executor executor) {
         verifyIsStarted();
-        releaseJobGraphConsumer.accept(jobId);
+        return localCleanupFunction.apply(jobId, executor);
     }
 
     @Override
@@ -156,10 +159,11 @@ public class TestingJobGraphStore implements JobGraphStore {
 
         private ThrowingConsumer<JobGraph, ? extends Exception> putJobGraphConsumer = ignored -> {};
 
-        private ThrowingConsumer<JobID, ? extends Exception> removeJobGraphConsumer = ignored -> {};
+        private BiFunction<JobID, Executor, CompletableFuture<Void>> globalCleanupFunction =
+                (ignoredJobId, ignoredExecutor) -> FutureUtils.completedVoidFuture();
 
-        private ThrowingConsumer<JobID, ? extends Exception> releaseJobGraphConsumer =
-                ignored -> {};
+        private BiFunction<JobID, Executor, CompletableFuture<Void>> localCleanupFunction =
+                (ignoredJobId, ignoredExecutor) -> FutureUtils.completedVoidFuture();
 
         private Collection<JobGraph> initialJobGraphs = Collections.emptyList();
 
@@ -198,15 +202,15 @@ public class TestingJobGraphStore implements JobGraphStore {
             return this;
         }
 
-        public Builder setRemoveJobGraphConsumer(
-                ThrowingConsumer<JobID, ? extends Exception> removeJobGraphConsumer) {
-            this.removeJobGraphConsumer = removeJobGraphConsumer;
+        public Builder setGlobalCleanupFunction(
+                BiFunction<JobID, Executor, CompletableFuture<Void>> globalCleanupFunction) {
+            this.globalCleanupFunction = globalCleanupFunction;
             return this;
         }
 
-        public Builder setReleaseJobGraphConsumer(
-                ThrowingConsumer<JobID, ? extends Exception> releaseJobGraphConsumer) {
-            this.releaseJobGraphConsumer = releaseJobGraphConsumer;
+        public Builder setLocalCleanupFunction(
+                BiFunction<JobID, Executor, CompletableFuture<Void>> localCleanupFunction) {
+            this.localCleanupFunction = localCleanupFunction;
             return this;
         }
 
@@ -228,8 +232,8 @@ public class TestingJobGraphStore implements JobGraphStore {
                             jobIdsFunction,
                             recoverJobGraphFunction,
                             putJobGraphConsumer,
-                            removeJobGraphConsumer,
-                            releaseJobGraphConsumer,
+                            globalCleanupFunction,
+                            localCleanupFunction,
                             initialJobGraphs);
 
             if (startJobGraphStore) {


### PR DESCRIPTION
Related to [FLIP-194](https://cwiki.apache.org/confluence/display/FLINK/FLIP-194%3A+Introduce+the+JobResultStore)

## What is the purpose of the change

We want to introduce a generic interface for cleaning up job-related data in the `Dispatcher`. This affects the `BlobServer`, `HighAvailabilityServices`, `JobManagerMetricsGroup` and `JobGraphStore`. The goal is to move the cleanup logic into `ResourceCleaner` and remove complexity from the `Dispatcher` implementation.

## Brief change log

* `FileSystemBlobStore` was adapted to comply to the `BlobStore` interface for deletions
* Introduced interfaces for local and global cleanup
* Refactor `BlobServer`, `HighAvailabilityServices`, `JobManagerMetricsGroup` and `JobGraphStore` to implement the new interfaces
* Introduce `JobManagerRunnerRegistry` to wrap the HashMap holding the `JobManagerRunner` instances in the `Dispatcher`. This enables us to let `JobManagerRunnerRegistry` implement the new interfaces as well and to have the `JobManagerRunner.close` method being called through the cleanup.
* Adds `ResourceCleaner` interface and related helper/test classes
* Additionally, some minor hotfixes were added.

## Verifying this change

* These changes are mostly covered by existing tests that were just refactored to match the new interfaces
* A new unit test `JobManagerRunnerRegistryTest` was added to cover the `JobManagerRunnerRegistry` implementation
* We had to adapt the `DispatcherFailoverITCase` for it to succeed in the current state. This test might need a more general refactoring in some follow-up PR.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
