### PR TITLE
[FLINK-25852][Connectors] Annotate SourceFunction and SinkFunction as deprecated

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/SinkFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/SinkFunction.java
@@ -27,7 +27,9 @@ import java.io.Serializable;
  * Interface for implementing user defined sink functionality.
  *
  * @param <IN> Input type parameter.
+ * @deprecated You should use {@link org.apache.flink.api.connector.sink2} instead.
  */
+@Deprecated
 @Public
 public interface SinkFunction<IN> extends Function, Serializable {
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/SourceFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/SourceFunction.java
@@ -94,7 +94,9 @@ import java.io.Serializable;
  * SourceContext#emitWatermark(Watermark)}.
  *
  * @param <T> The type of the elements produced by this source.
+ * @deprecated You should use {@link org.apache.flink.api.connector.source} instead.
  */
+@Deprecated
 @Public
 public interface SourceFunction<T> extends Function, Serializable {
 


### PR DESCRIPTION
## What is the purpose of the change

* The SourceFunction and SinkFunction should not be used by connectors anymore, who should be using the new Source API (See [FLIP-27](https://cwiki.apache.org/confluence/display/FLINK/FLIP-27%3A+Refactor+Source+Interface) + [Sources documentation](https://nightlies.apache.org/flink/flink-docs-master/docs/dev/datastream/sources/)) and/or Sink API (See [FLIP-143](https://cwiki.apache.org/confluence/display/FLINK/FLIP-143%3A+Unified+Sink+API) or [FLIP-171](https://cwiki.apache.org/confluence/display/FLINK/FLIP-171%3A+Async+Sink)).

## Brief change log

* Added annotations to deprecate classes

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes 
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no 
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? JavaDocs
