### PR TITLE
[FLINK-25728][task] Solve potential memory leaks in StreamMultipleInputProcessor

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamMultipleInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamMultipleInputProcessor.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.runtime.io;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
 import org.apache.flink.streaming.api.operators.InputSelection;
@@ -27,8 +28,7 @@ import org.apache.flink.util.ExceptionUtils;
 
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
-
-import static org.apache.flink.util.concurrent.FutureUtils.assertNoException;
+import java.util.function.Consumer;
 
 /** Input processor for {@link MultipleInputStreamOperator}. */
 @Internal
@@ -37,6 +37,8 @@ public final class StreamMultipleInputProcessor implements StreamInputProcessor 
     private final MultipleInputSelectionHandler inputSelectionHandler;
 
     private final StreamOneInputProcessor<?>[] inputProcessors;
+
+    private final MultipleInputAvailabilityHelper availabilityHelper;
     /** Always try to read from the first input. */
     private int lastReadInputIndex = 1;
 
@@ -47,6 +49,14 @@ public final class StreamMultipleInputProcessor implements StreamInputProcessor 
             StreamOneInputProcessor<?>[] inputProcessors) {
         this.inputSelectionHandler = inputSelectionHandler;
         this.inputProcessors = inputProcessors;
+        this.availabilityHelper =
+                MultipleInputAvailabilityHelper.newInstance(inputProcessors.length);
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return inputSelectionHandler.isAnyInputAvailable()
+                || inputSelectionHandler.areAllInputsFinished();
     }
 
     @Override
@@ -55,17 +65,19 @@ public final class StreamMultipleInputProcessor implements StreamInputProcessor 
                 || inputSelectionHandler.areAllInputsFinished()) {
             return AVAILABLE;
         }
-        final CompletableFuture<?> anyInputAvailable = new CompletableFuture<>();
+        /*
+         * According to the following issue. The implementation of `CompletableFuture.anyOf` in jdk8
+         * has some memory issue. This issue is fixed in jdk9.
+         * https://bugs.openjdk.java.net/browse/JDK-8160402
+         */
+        availabilityHelper.resetToUnAvailable();
         for (int i = 0; i < inputProcessors.length; i++) {
             if (!inputSelectionHandler.isInputFinished(i)
                     && inputSelectionHandler.isInputSelected(i)) {
-                assertNoException(
-                        inputProcessors[i]
-                                .getAvailableFuture()
-                                .thenRun(() -> anyInputAvailable.complete(null)));
+                availabilityHelper.anyOf(i, inputProcessors[i].getAvailableFuture());
             }
         }
-        return anyInputAvailable;
+        return availabilityHelper.getAvailableFuture();
     }
 
     @Override
@@ -154,6 +166,61 @@ public final class StreamMultipleInputProcessor implements StreamInputProcessor 
             // NetworkBuffer
             if (inputProcessor.isApproximatelyAvailable() || inputProcessor.isAvailable()) {
                 inputSelectionHandler.setAvailableInput(i);
+            }
+        }
+    }
+
+    /** Visible for testing only. Do not use out side of StreamMultipleInputProcessor. */
+    @VisibleForTesting
+    public static class MultipleInputAvailabilityHelper {
+        private final CompletableFuture<?>[] cachedAvailableFutures;
+        private final Consumer[] onCompletion;
+        private volatile CompletableFuture<?> availableFuture;
+
+        public CompletableFuture<?> getAvailableFuture() {
+            return availableFuture;
+        }
+
+        public static MultipleInputAvailabilityHelper newInstance(int inputSize) {
+            MultipleInputAvailabilityHelper obj = new MultipleInputAvailabilityHelper(inputSize);
+            return obj;
+        }
+
+        private MultipleInputAvailabilityHelper(int inputSize) {
+            this.cachedAvailableFutures = new CompletableFuture[inputSize];
+            this.onCompletion = new Consumer[inputSize];
+            availableFuture = new CompletableFuture<>();
+            for (int i = 0; i < cachedAvailableFutures.length; i++) {
+                final int inputIdx = i;
+                onCompletion[i] = (Void) -> notifyCompletion(inputIdx);
+            }
+        }
+
+        /** Reset availableFuture to fresh unavailable. */
+        public void resetToUnAvailable() {
+            if (availableFuture.isDone()) {
+                availableFuture = new CompletableFuture<>();
+            }
+        }
+
+        private void notifyCompletion(int idx) {
+            availableFuture.complete(null);
+            cachedAvailableFutures[idx] = AVAILABLE;
+        }
+
+        /**
+         * Implement `Or` logic.
+         *
+         * @param idx
+         * @param dep
+         */
+        public void anyOf(final int idx, CompletableFuture<?> dep) {
+            if (dep == AVAILABLE || dep.isDone()) {
+                cachedAvailableFutures[idx] = dep;
+                availableFuture.complete(null);
+            } else if (dep != cachedAvailableFutures[idx]) {
+                cachedAvailableFutures[idx] = dep;
+                dep.thenAccept(onCompletion[idx]);
             }
         }
     }


### PR DESCRIPTION
This is a draft PR to solve:

> Let's assume we have two inputs, one is flipping between available/unavailable status, the other is continuously unavailable. Now per each StreamMultipleInputProcessor#getAvailableFuture call, we will create one CompletableFuture<?> anyInputAvailable, referenced by TWO instances CompletableFuture$UniRun, for inputProcessors[i].getAvailableFuture() from each of the inputs. anyInputAvailable will be returned, and it will be completed by first input sooner or later, waking up SteamTask in the process. That's fine. Now the problem is that each of those anyInputAvailable instance will be in this scenario referenced forever by the second input's inputProcessors[i].getAvailableFuture(). As long as the second input is not available, we are keep building up the memory leak.

and a counter proposal to https://github.com/apache/flink/pull/18475

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
