### PR TITLE
[FLINK-25745] Support RocksDB incremental native savepoints 

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.executiongraph.JobStatusListener;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.jobgraph.RestoreMode;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
 import org.apache.flink.runtime.messages.Acknowledge;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -30,7 +30,6 @@ import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.executiongraph.JobStatusListener;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
-import org.apache.flink.runtime.jobgraph.RestoreMode;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
 import org.apache.flink.runtime.messages.Acknowledge;
@@ -1742,7 +1741,8 @@ public class CheckpointCoordinator {
                         checkpointLocation,
                         userClassLoader,
                         allowNonRestored,
-                        checkpointProperties);
+                        checkpointProperties,
+                        restoreSettings.getRestoreMode());
 
         // register shared state - even before adding the checkpoint to the store
         // because the latter might trigger subsumption so the ref counts must be up-to-date

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/Checkpoints.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/Checkpoints.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.checkpoint.metadata.MetadataV3Serializer;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.jobgraph.RestoreMode;
 import org.apache.flink.runtime.state.CheckpointStorage;
 import org.apache.flink.runtime.state.CheckpointStorageLoader;
 import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
@@ -123,7 +124,8 @@ public class Checkpoints {
             CompletedCheckpointStorageLocation location,
             ClassLoader classLoader,
             boolean allowNonRestoredState,
-            CheckpointProperties checkpointProperties)
+            CheckpointProperties checkpointProperties,
+            RestoreMode restoreMode)
             throws IOException {
 
         checkNotNull(jobId, "jobId");
@@ -211,7 +213,9 @@ public class Checkpoints {
                 operatorStates,
                 checkpointMetadata.getMasterStates(),
                 checkpointProperties,
-                location);
+                restoreMode == RestoreMode.CLAIM
+                        ? new ClaimModeCompletedStorageLocation(location)
+                        : location);
     }
 
     private static void throwNonRestoredStateException(
@@ -369,4 +373,37 @@ public class Checkpoints {
 
     /** This class contains only static utility methods and is not meant to be instantiated. */
     private Checkpoints() {}
+
+    private static class ClaimModeCompletedStorageLocation
+            implements CompletedCheckpointStorageLocation {
+
+        private final CompletedCheckpointStorageLocation wrapped;
+
+        private ClaimModeCompletedStorageLocation(CompletedCheckpointStorageLocation location) {
+            wrapped = location;
+        }
+
+        @Override
+        public String getExternalPointer() {
+            return wrapped.getExternalPointer();
+        }
+
+        @Override
+        public StreamStateHandle getMetadataHandle() {
+            return wrapped.getMetadataHandle();
+        }
+
+        @Override
+        public void disposeStorageLocation() throws IOException {
+            try {
+                wrapped.disposeStorageLocation();
+            } catch (Exception ex) {
+                LOG.debug(
+                        "We could not delete the storage location: {} in CLAIM restore mode. It is"
+                                + " most probably because of shared files still being used by newer"
+                                + " checkpoints",
+                        wrapped);
+            }
+        }
+    }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointMetadataLoadingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointMetadataLoadingTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.checkpoint.metadata.CheckpointMetadata;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.jobgraph.RestoreMode;
 import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
 import org.apache.flink.runtime.state.OperatorStreamStateHandle;
 import org.apache.flink.runtime.state.StreamStateHandle;
@@ -78,7 +79,8 @@ public class CheckpointMetadataLoadingTest {
                         testSavepoint,
                         cl,
                         false,
-                        CheckpointProperties.forSavepoint(false, SavepointFormatType.CANONICAL));
+                        CheckpointProperties.forSavepoint(false, SavepointFormatType.CANONICAL),
+                        RestoreMode.NO_CLAIM);
 
         assertEquals(jobId, loaded.getJobId());
         assertEquals(checkpointId, loaded.getCheckpointID());
@@ -102,7 +104,8 @@ public class CheckpointMetadataLoadingTest {
                     testSavepoint,
                     cl,
                     false,
-                    CheckpointProperties.forSavepoint(false, SavepointFormatType.CANONICAL));
+                    CheckpointProperties.forSavepoint(false, SavepointFormatType.CANONICAL),
+                    RestoreMode.NO_CLAIM);
             fail("Did not throw expected Exception");
         } catch (IllegalStateException expected) {
             assertTrue(expected.getMessage().contains("Max parallelism mismatch"));
@@ -128,7 +131,8 @@ public class CheckpointMetadataLoadingTest {
                     testSavepoint,
                     cl,
                     false,
-                    CheckpointProperties.forSavepoint(false, SavepointFormatType.CANONICAL));
+                    CheckpointProperties.forSavepoint(false, SavepointFormatType.CANONICAL),
+                    RestoreMode.NO_CLAIM);
             fail("Did not throw expected Exception");
         } catch (IllegalStateException expected) {
             assertTrue(expected.getMessage().contains("allowNonRestoredState"));
@@ -154,7 +158,8 @@ public class CheckpointMetadataLoadingTest {
                         testSavepoint,
                         cl,
                         true,
-                        CheckpointProperties.forSavepoint(false, SavepointFormatType.CANONICAL));
+                        CheckpointProperties.forSavepoint(false, SavepointFormatType.CANONICAL),
+                        RestoreMode.NO_CLAIM);
 
         assertTrue(loaded.getOperatorStates().isEmpty());
     }
@@ -183,7 +188,8 @@ public class CheckpointMetadataLoadingTest {
                     testSavepoint,
                     cl,
                     false,
-                    CheckpointProperties.forSavepoint(false, SavepointFormatType.CANONICAL));
+                    CheckpointProperties.forSavepoint(false, SavepointFormatType.CANONICAL),
+                    RestoreMode.NO_CLAIM);
             fail("Did not throw expected Exception");
         } catch (IllegalStateException expected) {
             assertTrue(expected.getMessage().contains("allowNonRestoredState"));

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateUploaderTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateUploaderTest.java
@@ -93,7 +93,10 @@ public class RocksDBStateUploaderTest extends TestLogger {
         filePaths.put(new StateHandleID("mockHandleID"), file.toPath());
         try (RocksDBStateUploader rocksDBStateUploader = new RocksDBStateUploader(5)) {
             rocksDBStateUploader.uploadFilesToCheckpointFs(
-                    filePaths, checkpointStreamFactory, new CloseableRegistry());
+                    filePaths,
+                    checkpointStreamFactory,
+                    CheckpointedStateScope.SHARED,
+                    new CloseableRegistry());
             fail();
         } catch (Exception e) {
             assertEquals(expectedException, e);
@@ -132,7 +135,10 @@ public class RocksDBStateUploaderTest extends TestLogger {
         try (RocksDBStateUploader rocksDBStateUploader = new RocksDBStateUploader(5)) {
             Map<StateHandleID, StreamStateHandle> sstFiles =
                     rocksDBStateUploader.uploadFilesToCheckpointFs(
-                            sstFilePaths, checkpointStreamFactory, new CloseableRegistry());
+                            sstFilePaths,
+                            checkpointStreamFactory,
+                            CheckpointedStateScope.SHARED,
+                            new CloseableRegistry());
 
             for (Map.Entry<StateHandleID, Path> entry : sstFilePaths.entrySet()) {
                 assertStateContentEqual(


### PR DESCRIPTION
## What is the purpose of the change

Incremental savepoints do not reuse sst files from previous checkpoints.
At this point they re-upload those files. Moreover they do not register
its files as reusable by future checkpoints. Lastly, all sst files are
created in the EXCLUSIVE scope with relative paths, which makes the
savepoint relocatable.

## Verifying this change

Added tests:
* SavepointFormatITCase

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
