### PR TITLE
[FLINK-25855] Allow JobMaster to accept excess slots when restarting the job

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPool.java
@@ -87,6 +87,21 @@ public interface DeclarativeSlotPool {
             long currentTime);
 
     /**
+     * Registers the given set of slots at the slot pool.
+     *
+     * @param slots slots to register
+     * @param taskManagerLocation taskManagerLocation is the location of the offering TaskExecutor
+     * @param taskManagerGateway taskManagerGateway is the gateway to talk to the offering
+     *     TaskExecutor
+     * @param currentTime currentTime is the time the slots are being offered
+     */
+    void registerSlots(
+            Collection<? extends SlotOffer> slots,
+            TaskManagerLocation taskManagerLocation,
+            TaskManagerGateway taskManagerGateway,
+            long currentTime);
+
+    /**
      * Returns the slot information for all free slots (slots which can be allocated from the slot
      * pool).
      *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
@@ -218,4 +218,11 @@ public interface SlotPool extends AllocatedSlotActions, AutoCloseable {
      * @return the allocated slots on the task manager
      */
     AllocatedSlotReport createAllocatedSlotReport(ResourceID taskManagerId);
+
+    /**
+     * Sets whether the underlying job is currently restarting or not.
+     *
+     * @param isJobRestarting whether the job is restarting or not
+     */
+    void setIsJobRestarting(boolean isJobRestarting);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultSchedulerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultSchedulerFactory.java
@@ -19,6 +19,7 @@
 
 package org.apache.flink.runtime.scheduler;
 
+import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
@@ -134,7 +135,14 @@ public class DefaultSchedulerFactory implements SchedulerNGFactory {
                 schedulerComponents.getAllocatorFactory(),
                 initializationTimestamp,
                 mainThreadExecutor,
-                jobStatusListener,
+                (jobId, jobStatus, timestamp) -> {
+                    if (jobStatus == JobStatus.RESTARTING) {
+                        slotPool.setIsJobRestarting(true);
+                    } else {
+                        slotPool.setIsJobRestarting(false);
+                    }
+                    jobStatusListener.jobStatusChanges(jobId, jobStatus, timestamp);
+                },
                 executionGraphFactory,
                 shuffleMaster,
                 rpcTimeout);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/SlotOffer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/SlotOffer.java
@@ -76,4 +76,16 @@ public class SlotOffer implements Serializable {
     public int hashCode() {
         return allocationId.hashCode();
     }
+
+    @Override
+    public String toString() {
+        return "SlotOffer{"
+                + "allocationId="
+                + allocationId
+                + ", slotIndex="
+                + slotIndex
+                + ", resourceProfile="
+                + resourceProfile
+                + '}';
+    }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultDeclarativeSlotPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultDeclarativeSlotPoolTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.jobmaster.slotpool;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.jobmaster.SlotInfo;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.slots.ResourceRequirement;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
@@ -63,6 +64,7 @@ import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -516,6 +518,30 @@ public class DefaultDeclarativeSlotPoolTest extends TestLogger {
 
         assertThat(acceptedSlots, is(empty()));
         assertTrue(slotPool.calculateUnfulfilledResources().isEmpty());
+    }
+
+    @Test
+    public void testRegisterSlotsAcceptsAllSlots() {
+        final DefaultDeclarativeSlotPool declarativeSlotPool = createDefaultDeclarativeSlotPool();
+        final int numberSlots = 10;
+        final Collection<SlotOffer> slots =
+                createSlotOffersForResourceRequirements(
+                        ResourceCounter.withResource(RESOURCE_PROFILE_1, numberSlots));
+
+        declarativeSlotPool.registerSlots(
+                slots,
+                new LocalTaskManagerLocation(),
+                SlotPoolTestUtils.createTaskManagerGateway(null),
+                0);
+
+        final Collection<? extends SlotInfo> allSlotsInformation =
+                declarativeSlotPool.getAllSlotsInformation();
+
+        assertThat(allSlotsInformation, hasSize(numberSlots));
+
+        for (SlotInfo slotInfo : allSlotsInformation) {
+            assertThat(slotInfo.getResourceProfile(), is(RESOURCE_PROFILE_1));
+        }
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/TestingDeclarativeSlotPool.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/TestingDeclarativeSlotPool.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.slots.ResourceRequirement;
 import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.util.ResourceCounter;
+import org.apache.flink.util.function.QuadConsumer;
 import org.apache.flink.util.function.QuadFunction;
 import org.apache.flink.util.function.TriFunction;
 
@@ -55,6 +56,10 @@ final class TestingDeclarativeSlotPool implements DeclarativeSlotPool {
                     Long,
                     Collection<SlotOffer>>
             offerSlotsFunction;
+
+    private final QuadConsumer<
+                    Collection<? extends SlotOffer>, TaskManagerLocation, TaskManagerGateway, Long>
+            registerSlotsFunction;
 
     private final Supplier<Collection<SlotInfoWithUtilization>> getFreeSlotsInformationSupplier;
 
@@ -88,6 +93,12 @@ final class TestingDeclarativeSlotPool implements DeclarativeSlotPool {
                             Long,
                             Collection<SlotOffer>>
                     offerSlotsFunction,
+            QuadConsumer<
+                            Collection<? extends SlotOffer>,
+                            TaskManagerLocation,
+                            TaskManagerGateway,
+                            Long>
+                    registerSlotsFunction,
             Supplier<Collection<SlotInfoWithUtilization>> getFreeSlotsInformationSupplier,
             Supplier<Collection<? extends SlotInfo>> getAllSlotsInformationSupplier,
             BiFunction<ResourceID, Exception, ResourceCounter> releaseSlotsFunction,
@@ -102,6 +113,7 @@ final class TestingDeclarativeSlotPool implements DeclarativeSlotPool {
         this.decreaseResourceRequirementsByConsumer = decreaseResourceRequirementsByConsumer;
         this.getResourceRequirementsSupplier = getResourceRequirementsSupplier;
         this.offerSlotsFunction = offerSlotsFunction;
+        this.registerSlotsFunction = registerSlotsFunction;
         this.getFreeSlotsInformationSupplier = getFreeSlotsInformationSupplier;
         this.getAllSlotsInformationSupplier = getAllSlotsInformationSupplier;
         this.releaseSlotsFunction = releaseSlotsFunction;
@@ -142,6 +154,15 @@ final class TestingDeclarativeSlotPool implements DeclarativeSlotPool {
             long currentTime) {
         return offerSlotsFunction.apply(
                 offers, taskManagerLocation, taskManagerGateway, currentTime);
+    }
+
+    @Override
+    public void registerSlots(
+            Collection<? extends SlotOffer> slots,
+            TaskManagerLocation taskManagerLocation,
+            TaskManagerGateway taskManagerGateway,
+            long currentTime) {
+        registerSlotsFunction.accept(slots, taskManagerLocation, taskManagerGateway, currentTime);
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/TestingDeclarativeSlotPoolBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/TestingDeclarativeSlotPoolBuilder.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.slots.ResourceRequirement;
 import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.util.ResourceCounter;
+import org.apache.flink.util.function.QuadConsumer;
 import org.apache.flink.util.function.QuadFunction;
 import org.apache.flink.util.function.TriFunction;
 
@@ -69,6 +70,9 @@ public class TestingDeclarativeSlotPoolBuilder {
     private LongConsumer returnIdleSlotsConsumer = ignored -> {};
     private Consumer<ResourceCounter> setResourceRequirementsConsumer = ignored -> {};
     private Function<AllocationID, Boolean> containsFreeSlotFunction = ignored -> false;
+    private QuadConsumer<
+                    Collection<? extends SlotOffer>, TaskManagerLocation, TaskManagerGateway, Long>
+            registerSlotsFunction = (ignoredA, ignoredB, ignoredC, ignoredD) -> {};
 
     public TestingDeclarativeSlotPoolBuilder setIncreaseResourceRequirementsByConsumer(
             Consumer<ResourceCounter> increaseResourceRequirementsByConsumer) {
@@ -103,6 +107,17 @@ public class TestingDeclarativeSlotPoolBuilder {
                             Collection<SlotOffer>>
                     offerSlotsFunction) {
         this.offerSlotsFunction = offerSlotsFunction;
+        return this;
+    }
+
+    public TestingDeclarativeSlotPoolBuilder setRegisterSlotsFunction(
+            QuadConsumer<
+                            Collection<? extends SlotOffer>,
+                            TaskManagerLocation,
+                            TaskManagerGateway,
+                            Long>
+                    registerSlotsFunction) {
+        this.registerSlotsFunction = registerSlotsFunction;
         return this;
     }
 
@@ -167,6 +182,7 @@ public class TestingDeclarativeSlotPoolBuilder {
                 decreaseResourceRequirementsByConsumer,
                 getResourceRequirementsSupplier,
                 offerSlotsFunction,
+                registerSlotsFunction,
                 getFreeSlotsInformationSupplier,
                 getAllSlotsInformationSupplier,
                 releaseSlotsFunction,


### PR DESCRIPTION
## What is the purpose of the change

This commit allows the JobMaster to accept excess slots when the job is restarting.
The way it works is that the DefaultScheduler tells the DefaultSlotPoolBridge when
the job is restarting. If during this time new slots should be offered, then the
DefaultSLotPoolBridge calls DeclarativeSlotPool.registerSlots which accepts all
slot offers. Once the job leaves the RESTARTING state, the DefaultSlotPoolBridge
will call DeclarativeSlotPool.offerSlots which only accepts those slots that are
currently required.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
