### PR TITLE
[FLINK-25861] Move states of AbstractAvroBulkFormat into its reader

### DIFF
--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroBulkFormatTestUtils.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroBulkFormatTestUtils.java
@@ -30,6 +30,8 @@ import org.apache.flink.table.types.logical.RowType;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 
+import java.util.function.Function;
+
 /** Testing utils for tests related to {@link AbstractAvroBulkFormat}. */
 public class AvroBulkFormatTestUtils {
 
@@ -45,27 +47,20 @@ public class AvroBulkFormatTestUtils {
     public static class TestingAvroBulkFormat
             extends AbstractAvroBulkFormat<GenericRecord, RowData, FileSourceSplit> {
 
-        private transient GenericRecord reusedAvroRecord;
-        private transient AvroToRowDataConverters.AvroToRowDataConverter converter;
-
         protected TestingAvroBulkFormat() {
             super(AvroSchemaConverter.convertToSchema(ROW_TYPE));
         }
 
         @Override
-        protected void open(FileSourceSplit split) {
-            reusedAvroRecord = new GenericData.Record(readerSchema);
-            converter = AvroToRowDataConverters.createRowConverter(ROW_TYPE);
-        }
-
-        @Override
-        protected RowData convert(GenericRecord record) {
-            return record == null ? null : (RowData) converter.convert(record);
-        }
-
-        @Override
         protected GenericRecord createReusedAvroRecord() {
-            return reusedAvroRecord;
+            return new GenericData.Record(readerSchema);
+        }
+
+        @Override
+        protected Function<GenericRecord, RowData> createConverter() {
+            AvroToRowDataConverters.AvroToRowDataConverter converter =
+                    AvroToRowDataConverters.createRowConverter(ROW_TYPE);
+            return record -> record == null ? null : (RowData) converter.convert(record);
         }
 
         @Override


### PR DESCRIPTION
## What is the purpose of the change

FLINK-24565 ports avro format to BulkReaderFormatFactory. However the implementation leaves some states into the format factory itself. These states should be in the readers.

This PR fixes this issue.

## Brief change log

 - Move states of AbstractAvroBulkFormat into its reader

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
