### PR TITLE
[FLINK-25653][network] Move buffer recycle in SortMergeSubpartitionReader out of lock to avoid deadlock

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartitionReadSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartitionReadSchedulerTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.io.network.partition;
 
 import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.runtime.io.disk.BatchShuffleReadBufferPool;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.util.ExceptionUtils;
@@ -37,6 +38,7 @@ import java.nio.channels.FileChannel;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.time.Duration;
+import java.util.ArrayDeque;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.PriorityQueue;
@@ -69,6 +71,12 @@ public class SortMergeResultPartitionReadSchedulerTest extends TestLogger {
 
     private PartitionedFile partitionedFile;
 
+    private PartitionedFileReader fileReader;
+
+    private FileChannel dataFileChannel;
+
+    private FileChannel indexFileChannel;
+
     private BatchShuffleReadBufferPool bufferPool;
 
     private ExecutorService executor;
@@ -90,6 +98,10 @@ public class SortMergeResultPartitionReadSchedulerTest extends TestLogger {
                         numBuffersPerSubpartition,
                         bufferSize,
                         dataBytes);
+        dataFileChannel = openFileChannel(partitionedFile.getDataFilePath());
+        indexFileChannel = openFileChannel(partitionedFile.getIndexFilePath());
+        fileReader =
+                new PartitionedFileReader(partitionedFile, 0, dataFileChannel, indexFileChannel);
         bufferPool = new BatchShuffleReadBufferPool(totalBytes, bufferSize);
         executor = Executors.newFixedThreadPool(numThreads);
         readScheduler =
@@ -98,7 +110,9 @@ public class SortMergeResultPartitionReadSchedulerTest extends TestLogger {
     }
 
     @After
-    public void after() {
+    public void after() throws Exception {
+        dataFileChannel.close();
+        indexFileChannel.close();
         partitionedFile.deleteQuietly();
         bufferPool.destroy();
         executor.shutdown();
@@ -205,6 +219,33 @@ public class SortMergeResultPartitionReadSchedulerTest extends TestLogger {
         assertAllResourcesReleased();
     }
 
+    @Test(timeout = 60000)
+    public void testNotDeadLockWhenReadAndReleaseBuffers() throws Exception {
+        SortMergeSubpartitionReader subpartitionReader =
+                new SortMergeSubpartitionReader(new NoOpBufferAvailablityListener(), fileReader);
+        Thread readAndReleaseThread =
+                new Thread(
+                        () -> {
+                            Queue<MemorySegment> segments = new ArrayDeque<>();
+                            segments.add(MemorySegmentFactory.allocateUnpooledSegment(bufferSize));
+                            try {
+                                assertTrue(fileReader.hasRemaining());
+                                subpartitionReader.readBuffers(segments, readScheduler);
+                                subpartitionReader.releaseAllResources();
+                                subpartitionReader.readBuffers(segments, readScheduler);
+                            } catch (Exception ignore) {
+                            }
+                        });
+
+        synchronized (this) {
+            readAndReleaseThread.start();
+            do {
+                Thread.sleep(100);
+            } while (!subpartitionReader.isReleased());
+        }
+        readAndReleaseThread.join();
+    }
+
     @Test
     public void testRequestBufferTimeoutAndFailed() throws Exception {
         Duration bufferRequestTimeout = Duration.ofSeconds(3);
@@ -240,13 +281,6 @@ public class SortMergeResultPartitionReadSchedulerTest extends TestLogger {
         SortMergeResultPartitionReadScheduler readScheduler =
                 new SortMergeResultPartitionReadScheduler(
                         numSubpartitions, bufferPool, executor, this, bufferRequestTimeout);
-
-        FileChannel dataFileChannel = openFileChannel(partitionedFile.getDataFilePath());
-        FileChannel indexFileChannel = openFileChannel(partitionedFile.getIndexFilePath());
-
-        PartitionedFileReader fileReader =
-                new PartitionedFileReader(partitionedFile, 0, dataFileChannel, indexFileChannel);
-
         SortMergeSubpartitionReader subpartitionReader =
                 new SortMergeSubpartitionReader(new NoOpBufferAvailablityListener(), fileReader);
 
@@ -263,8 +297,6 @@ public class SortMergeResultPartitionReadSchedulerTest extends TestLogger {
 
         bufferPool.recycle(allocatedBuffers);
         bufferPool.destroy();
-        dataFileChannel.close();
-        indexFileChannel.close();
         readScheduler.release();
     }
 


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

For the current sort-shuffle implementation, the different lock order in `SortMergeSubpartitionReader` and `SortMergeResultPartitionReadScheduler` can cause deadlock. To solve the problem, this change moves buffer recycle in `SortMergeSubpartitionReader` out of the lock.


## Brief change log

  - *Moves buffer recycle in `SortMergeSubpartitionReader` out of the lock.*

## Verifying this change

This change added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
