### PR TITLE
[FLINK-25479][rpc] Serialize TaskStateSnapshot when sending to JM from TM

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorGateway.java
@@ -22,6 +22,9 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.messages.checkpoint.DeclineCheckpoint;
 import org.apache.flink.runtime.rpc.RpcGateway;
+import org.apache.flink.util.SerializedValue;
+
+import javax.annotation.Nullable;
 
 /** RPC Gateway interface for messages to the CheckpointCoordinator. */
 public interface CheckpointCoordinatorGateway extends RpcGateway {
@@ -31,7 +34,7 @@ public interface CheckpointCoordinatorGateway extends RpcGateway {
             final ExecutionAttemptID executionAttemptID,
             final long checkpointId,
             final CheckpointMetrics checkpointMetrics,
-            final TaskStateSnapshot subtaskState);
+            @Nullable final SerializedValue<TaskStateSnapshot> subtaskState);
 
     void declineCheckpoint(DeclineCheckpoint declineCheckpoint);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/TaskStateSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/TaskStateSnapshot.java
@@ -22,13 +22,16 @@ import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.state.CompositeStateHandle;
 import org.apache.flink.runtime.state.SharedStateRegistry;
 import org.apache.flink.runtime.state.StateUtil;
+import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.SerializedValue;
 
 import org.apache.flink.shaded.guava30.com.google.common.collect.Iterators;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -230,5 +233,25 @@ public class TaskStateSnapshot implements CompositeStateHandle {
                         .filter(mapping -> !mapping.equals(NO_RESCALE))
                         .iterator(),
                 NO_RESCALE);
+    }
+
+    @Nullable
+    public static SerializedValue<TaskStateSnapshot> serializeTaskStateSnapshot(
+            TaskStateSnapshot subtaskState) {
+        try {
+            return subtaskState == null ? null : new SerializedValue<>(subtaskState);
+        } catch (IOException e) {
+            throw new FlinkRuntimeException(e);
+        }
+    }
+
+    @Nullable
+    public static TaskStateSnapshot deserializeTaskStateSnapshot(
+            SerializedValue<TaskStateSnapshot> subtaskState, ClassLoader classLoader) {
+        try {
+            return subtaskState == null ? null : subtaskState.deserializeValue(classLoader);
+        } catch (IOException | ClassNotFoundException e) {
+            throw new FlinkRuntimeException(e);
+        }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -114,6 +114,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.runtime.checkpoint.TaskStateSnapshot.deserializeTaskStateSnapshot;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -521,10 +522,13 @@ public class JobMaster extends PermanentlyFencedRpcEndpoint<JobMasterId>
             final ExecutionAttemptID executionAttemptID,
             final long checkpointId,
             final CheckpointMetrics checkpointMetrics,
-            final TaskStateSnapshot checkpointState) {
-
+            @Nullable final SerializedValue<TaskStateSnapshot> checkpointState) {
         schedulerNG.acknowledgeCheckpoint(
-                jobID, executionAttemptID, checkpointId, checkpointMetrics, checkpointState);
+                jobID,
+                executionAttemptID,
+                checkpointId,
+                checkpointMetrics,
+                deserializeTaskStateSnapshot(checkpointState, getClass().getClassLoader()));
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/SequenceNumber.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/SequenceNumber.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.state.changelog;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.util.Preconditions;
 
+import java.io.Serializable;
 import java.util.Objects;
 
 import static org.apache.flink.util.Preconditions.checkState;
@@ -30,12 +31,14 @@ import static org.apache.flink.util.Preconditions.checkState;
  * StateChangelogStorage} as an optimization.
  */
 @Internal
-public interface SequenceNumber extends Comparable<SequenceNumber> {
+public interface SequenceNumber extends Comparable<SequenceNumber>, Serializable {
 
     SequenceNumber next();
 
     /** Generic {@link SequenceNumber}. */
     final class GenericSequenceNumber implements SequenceNumber {
+        private static final long serialVersionUID = 1L;
+
         public final long number;
 
         GenericSequenceNumber(long number) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChange.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChange.java
@@ -20,9 +20,13 @@ package org.apache.flink.runtime.state.changelog;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.util.Preconditions;
 
+import java.io.Serializable;
+
 /** Change of state of a keyed operator. Used for generic incremental checkpoints. */
 @Internal
-public class StateChange {
+public class StateChange implements Serializable {
+
+    private static final long serialVersionUID = 1L;
 
     private final int keyGroup;
     private final byte[] change;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/rpc/RpcCheckpointResponder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/rpc/RpcCheckpointResponder.java
@@ -28,6 +28,8 @@ import org.apache.flink.runtime.messages.checkpoint.DeclineCheckpoint;
 import org.apache.flink.runtime.taskmanager.CheckpointResponder;
 import org.apache.flink.util.Preconditions;
 
+import static org.apache.flink.runtime.checkpoint.TaskStateSnapshot.serializeTaskStateSnapshot;
+
 public class RpcCheckpointResponder implements CheckpointResponder {
 
     private final CheckpointCoordinatorGateway checkpointCoordinatorGateway;
@@ -44,9 +46,12 @@ public class RpcCheckpointResponder implements CheckpointResponder {
             long checkpointId,
             CheckpointMetrics checkpointMetrics,
             TaskStateSnapshot subtaskState) {
-
         checkpointCoordinatorGateway.acknowledgeCheckpoint(
-                jobID, executionAttemptID, checkpointId, checkpointMetrics, subtaskState);
+                jobID,
+                executionAttemptID,
+                checkpointId,
+                checkpointMetrics,
+                serializeTaskStateSnapshot(subtaskState));
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/JobMasterTester.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/JobMasterTester.java
@@ -62,6 +62,8 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.runtime.checkpoint.TaskStateSnapshot.serializeTaskStateSnapshot;
+
 /**
  * A testing utility, that simulates the desired interactions with {@link JobMasterGateway} RPC.
  * This is useful for light-weight e2e tests, eg. simulating specific fail-over scenario.
@@ -227,7 +229,8 @@ public class JobMasterTester implements Closeable {
                                     executionAttemptId,
                                     checkpointId,
                                     new CheckpointMetrics(),
-                                    createNonEmptyStateSnapshot(taskInformation));
+                                    serializeTaskStateSnapshot(
+                                            createNonEmptyStateSnapshot(taskInformation)));
                             return CompletableFuture.completedFuture(Acknowledge.get());
                         });
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGateway.java
@@ -70,6 +70,8 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import static org.apache.flink.runtime.checkpoint.TaskStateSnapshot.deserializeTaskStateSnapshot;
+
 /** {@link JobMasterGateway} implementation for testing purposes. */
 public class TestingJobMasterGateway implements JobMasterGateway {
 
@@ -436,10 +438,14 @@ public class TestingJobMasterGateway implements JobMasterGateway {
             ExecutionAttemptID executionAttemptID,
             long checkpointId,
             CheckpointMetrics checkpointMetrics,
-            TaskStateSnapshot subtaskState) {
+            SerializedValue<TaskStateSnapshot> subtaskState) {
         acknowledgeCheckpointConsumer.accept(
                 Tuple5.of(
-                        jobID, executionAttemptID, checkpointId, checkpointMetrics, subtaskState));
+                        jobID,
+                        executionAttemptID,
+                        checkpointId,
+                        checkpointMetrics,
+                        deserializeTaskStateSnapshot(subtaskState, getClass().getClassLoader())));
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockKeyedStateBackend.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockKeyedStateBackend.java
@@ -53,6 +53,7 @@ import org.apache.flink.util.FlinkRuntimeException;
 
 import javax.annotation.Nonnull;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -66,10 +67,9 @@ import java.util.stream.Stream;
 /** State backend which produces in memory mock state objects. */
 public class MockKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 
-    /** Whether to create empty snapshot ({@link MockKeyedStateHandle} isn't recognized by JM). */
-    private final boolean emptySnapshot;
-
     private long lastCompletedCheckpointID;
+
+    private final MockSnapshotSupplier snapshotSupplier;
 
     private interface StateFactory {
         <N, SV, S extends State, IS extends S> IS createInternalState(
@@ -111,7 +111,7 @@ public class MockKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
             Map<String, StateSnapshotTransformer<Object>> stateSnapshotFilters,
             CloseableRegistry cancelStreamRegistry,
             InternalKeyContext<K> keyContext,
-            boolean emptySnapshot) {
+            MockSnapshotSupplier snapshotSupplier) {
         super(
                 kvStateRegistry,
                 keySerializer,
@@ -123,7 +123,7 @@ public class MockKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
                 keyContext);
         this.stateValues = stateValues;
         this.stateSnapshotFilters = stateSnapshotFilters;
-        this.emptySnapshot = emptySnapshot;
+        this.snapshotSupplier = snapshotSupplier;
     }
 
     @Override
@@ -226,13 +226,7 @@ public class MockKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
             long timestamp,
             @Nonnull CheckpointStreamFactory streamFactory,
             @Nonnull CheckpointOptions checkpointOptions) {
-        return new FutureTask<>(
-                () ->
-                        emptySnapshot
-                                ? SnapshotResult.empty()
-                                : SnapshotResult.of(
-                                        new MockKeyedStateHandle<>(
-                                                copy(stateValues, stateSnapshotFilters))));
+        return new FutureTask<>(() -> snapshotSupplier.snapshot(stateValues, stateSnapshotFilters));
     }
 
     @Nonnull
@@ -342,5 +336,37 @@ public class MockKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
         public KeyedStateHandle getIntersection(KeyGroupRange keyGroupRange) {
             throw new UnsupportedOperationException();
         }
+    }
+
+    public interface MockSnapshotSupplier extends Serializable {
+        MockSnapshotSupplier EMPTY =
+                new MockSnapshotSupplier() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public <K> SnapshotResult<KeyedStateHandle> snapshot(
+                            Map<String, Map<K, Map<Object, Object>>> stateValues,
+                            Map<String, StateSnapshotTransformer<Object>> stateSnapshotFilters) {
+                        return SnapshotResult.empty();
+                    }
+                };
+
+        MockSnapshotSupplier DEFAULT =
+                new MockSnapshotSupplier() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public <K> SnapshotResult<KeyedStateHandle> snapshot(
+                            Map<String, Map<K, Map<Object, Object>>> stateValues,
+                            Map<String, StateSnapshotTransformer<Object>> stateSnapshotFilters) {
+                        return SnapshotResult.of(
+                                new MockKeyedStateHandle<>(
+                                        copy(stateValues, stateSnapshotFilters)));
+                    }
+                };
+
+        <K> SnapshotResult<KeyedStateHandle> snapshot(
+                Map<String, Map<K, Map<Object, Object>>> stateValues,
+                Map<String, StateSnapshotTransformer<Object>> stateSnapshotFilters);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockKeyedStateBackendBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockKeyedStateBackendBuilder.java
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.state.StreamCompressionDecorator;
 import org.apache.flink.runtime.state.heap.InternalKeyContextImpl;
 import org.apache.flink.runtime.state.metrics.LatencyTrackingStateConfig;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
+import org.apache.flink.runtime.state.ttl.mock.MockKeyedStateBackend.MockSnapshotSupplier;
 
 import javax.annotation.Nonnull;
 
@@ -44,7 +45,7 @@ import java.util.Map;
  */
 public class MockKeyedStateBackendBuilder<K> extends AbstractKeyedStateBackendBuilder<K> {
 
-    private final boolean emptySnapshot;
+    private final MockSnapshotSupplier snapshotSupplier;
 
     public MockKeyedStateBackendBuilder(
             TaskKvStateRegistry kvStateRegistry,
@@ -58,7 +59,7 @@ public class MockKeyedStateBackendBuilder<K> extends AbstractKeyedStateBackendBu
             @Nonnull Collection<KeyedStateHandle> stateHandles,
             StreamCompressionDecorator keyGroupCompressionDecorator,
             CloseableRegistry cancelStreamRegistry,
-            boolean emptySnapshot) {
+            MockSnapshotSupplier snapshotSupplier) {
         super(
                 kvStateRegistry,
                 keySerializer,
@@ -71,7 +72,7 @@ public class MockKeyedStateBackendBuilder<K> extends AbstractKeyedStateBackendBu
                 stateHandles,
                 keyGroupCompressionDecorator,
                 cancelStreamRegistry);
-        this.emptySnapshot = emptySnapshot;
+        this.snapshotSupplier = snapshotSupplier;
     }
 
     @Override
@@ -92,6 +93,6 @@ public class MockKeyedStateBackendBuilder<K> extends AbstractKeyedStateBackendBu
                 stateSnapshotFilters,
                 cancelStreamRegistry,
                 new InternalKeyContextImpl<>(keyGroupRange, numberOfKeyGroups),
-                emptySnapshot);
+                snapshotSupplier);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockStateBackend.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockStateBackend.java
@@ -42,6 +42,7 @@ import org.apache.flink.runtime.state.SnapshotStrategy;
 import org.apache.flink.runtime.state.SnapshotStrategyRunner;
 import org.apache.flink.runtime.state.metrics.LatencyTrackingStateConfig;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
+import org.apache.flink.runtime.state.ttl.mock.MockKeyedStateBackend.MockSnapshotSupplier;
 
 import javax.annotation.Nonnull;
 
@@ -51,14 +52,14 @@ import java.util.HashMap;
 /** mack state backend. */
 public class MockStateBackend extends AbstractStateBackend {
     private static final long serialVersionUID = 995676510267499393L;
-    private final boolean emptySnapshot;
+    private MockSnapshotSupplier snapshotSupplier;
 
     public MockStateBackend() {
-        this(false);
+        this(MockSnapshotSupplier.DEFAULT);
     }
 
-    public MockStateBackend(boolean emptySnapshot) {
-        this.emptySnapshot = emptySnapshot;
+    public MockStateBackend(MockSnapshotSupplier snapshotSupplier) {
+        this.snapshotSupplier = snapshotSupplier;
     }
 
     @Override
@@ -86,7 +87,7 @@ public class MockStateBackend extends AbstractStateBackend {
                         stateHandles,
                         AbstractStateBackend.getCompressionDecorator(env.getExecutionConfig()),
                         cancelStreamRegistry,
-                        emptySnapshot)
+                        snapshotSupplier)
                 .build();
     }
 

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackendTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackendTest.java
@@ -34,6 +34,7 @@ import org.apache.flink.runtime.state.memory.MemCheckpointStreamFactory;
 import org.apache.flink.runtime.state.metrics.LatencyTrackingStateConfig;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 import org.apache.flink.runtime.state.ttl.mock.MockKeyedStateBackend;
+import org.apache.flink.runtime.state.ttl.mock.MockKeyedStateBackend.MockSnapshotSupplier;
 import org.apache.flink.runtime.state.ttl.mock.MockKeyedStateBackendBuilder;
 import org.apache.flink.state.changelog.ChangelogStateBackendTestUtils.DummyCheckpointingStorageAccess;
 
@@ -96,7 +97,7 @@ public class ChangelogKeyedStateBackendTest {
                         emptyList(),
                         UncompressedStreamCompressionDecorator.INSTANCE,
                         new CloseableRegistry(),
-                        true)
+                        MockSnapshotSupplier.EMPTY)
                 .build();
     }
 

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/StateHandleReuseITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/StateHandleReuseITCase.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.checkpointing;
+
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.runtime.operators.lifecycle.TestJobExecutor;
+import org.apache.flink.runtime.operators.lifecycle.TestJobWithDescription;
+import org.apache.flink.runtime.operators.lifecycle.event.CheckpointCompletedEvent;
+import org.apache.flink.runtime.operators.lifecycle.event.CheckpointStartedEvent;
+import org.apache.flink.runtime.operators.lifecycle.graph.TestJobBuilders;
+import org.apache.flink.runtime.state.IncrementalRemoteKeyedStateHandle;
+import org.apache.flink.runtime.state.KeyedStateHandle;
+import org.apache.flink.runtime.state.SnapshotResult;
+import org.apache.flink.runtime.state.StateSnapshotTransformer;
+import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
+import org.apache.flink.runtime.state.ttl.mock.MockKeyedStateBackend.MockSnapshotSupplier;
+import org.apache.flink.runtime.state.ttl.mock.MockStateBackend;
+import org.apache.flink.test.util.AbstractTestBase;
+import org.apache.flink.testutils.junit.SharedObjects;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static java.util.Collections.emptyMap;
+import static java.util.UUID.randomUUID;
+import static org.apache.flink.runtime.operators.lifecycle.command.TestCommand.FINISH_SOURCES;
+import static org.apache.flink.runtime.operators.lifecycle.command.TestCommandDispatcher.TestCommandScope.ALL_SUBTASKS;
+import static org.apache.flink.runtime.state.KeyGroupRange.EMPTY_KEY_GROUP_RANGE;
+
+/**
+ * Verifies that using the same {@link KeyedStateHandle} object is possible for {@link
+ * org.apache.flink.runtime.state.KeyedStateBackend backends}. This relies on (de)serializing
+ * handles while sending via RPC. Without it, some validation might fail in {@link
+ * org.apache.flink.runtime.checkpoint.CheckpointCoordinator} which doesn't expect to receive the
+ * same object.
+ */
+public class StateHandleReuseITCase extends AbstractTestBase {
+    @Rule public final SharedObjects sharedObjects = SharedObjects.create();
+
+    @Test
+    public void runTest() throws Exception {
+        TestJobExecutor.execute(buildJob(), miniClusterResource)
+                // register once: should succeed
+                .waitForEvent(CheckpointCompletedEvent.class)
+                // register again: might fail without serialization
+                .waitForEvent(CheckpointStartedEvent.class)
+                .waitForEvent(CheckpointCompletedEvent.class)
+                .sendBroadcastCommand(FINISH_SOURCES, ALL_SUBTASKS)
+                .waitForTermination()
+                .assertFinishedSuccessfully();
+    }
+
+    private TestJobWithDescription buildJob() throws Exception {
+        return TestJobBuilders.COMPLEX_GRAPH_BUILDER.build(
+                sharedObjects,
+                cfg -> {},
+                env -> {
+                    env.setParallelism(1);
+                    env.enableCheckpointing(10);
+                    env.setRestartStrategy(RestartStrategies.noRestart());
+                    env.setStateBackend(new MockStateBackend(new SingleHandleSnapshotSupplier()));
+                    // changelog backend doesn't work with the mock backend
+                    env.enableChangelogStateBackend(false);
+                });
+    }
+
+    /** {@link MockSnapshotSupplier} that always sends the same handle (object). */
+    private static class SingleHandleSnapshotSupplier implements MockSnapshotSupplier {
+        private static final long serialVersionUID = 1L;
+        private static final IncrementalRemoteKeyedStateHandle handle =
+                new IncrementalRemoteKeyedStateHandle(
+                        randomUUID(),
+                        EMPTY_KEY_GROUP_RANGE,
+                        1L,
+                        emptyMap(),
+                        emptyMap(),
+                        new ByteStreamStateHandle("meta", new byte[] {0}),
+                        0L);
+
+        @Override
+        public <K> SnapshotResult<KeyedStateHandle> snapshot(
+                Map<String, Map<K, Map<Object, Object>>> stateValues,
+                Map<String, StateSnapshotTransformer<Object>> stateSnapshotFilters) {
+            return SnapshotResult.of(handle);
+        }
+    }
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointFailureHandlingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointFailureHandlingITCase.java
@@ -35,6 +35,7 @@ import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
 import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.filesystem.FsCheckpointStreamFactory.FsCheckpointStateOutputStream;
 import org.apache.flink.runtime.state.storage.JobManagerCheckpointStorage;
+import org.apache.flink.runtime.state.ttl.mock.MockKeyedStateBackend.MockSnapshotSupplier;
 import org.apache.flink.runtime.state.ttl.mock.MockStateBackend;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.streaming.api.CheckpointingMode;
@@ -120,7 +121,7 @@ public class UnalignedCheckpointFailureHandlingITCase {
 
         // use non-snapshotting backend to test channel state persistence integration with
         // checkpoint storage
-        env.setStateBackend(new MockStateBackend(true));
+        env.setStateBackend(new MockStateBackend(MockSnapshotSupplier.EMPTY));
 
         env.getCheckpointConfig().enableUnalignedCheckpoints();
 


### PR DESCRIPTION
## What is the purpose of the change

```
CheckpointCoordinator doesn't expect to receive the same object more than once:
in production environment, state handles are (de)serialized while sending via RPC.

However, in tests, local RPC may be used, without (de)serialization. This causes
test failures when using state backends which re-use objects (e.g. materialized
state of ChangelogStateBackend).
Using the same KeyedStateHandle *object* should be allowed for backends.

This change makes RpcCheckpointResponder serialize TaskStateSnapshot when
sending to JM from TM.
```

## Verifying this change

Added `StateHandleReuseITCase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
