### PR TITLE
[FLINK-25492][state/changelog] Fix materialization boundary for InMemoryStateChangelogWriter

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/inmemory/InMemoryStateChangelogWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/inmemory/InMemoryStateChangelogWriter.java
@@ -109,7 +109,7 @@ class InMemoryStateChangelogWriter implements StateChangelogWriter<InMemoryChang
                 .filter(map -> !map.isEmpty())
                 .map(SortedMap::firstKey)
                 .min(Comparator.naturalOrder())
-                .orElse(initialSequenceNumber());
+                .orElse(lastAppendedSequenceNumber().next());
     }
 
     @Override

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
@@ -374,7 +374,7 @@ public class ChangelogKeyedStateBackend<K>
         // have to split it somehow for the former option, so the latter is used.
         lastCheckpointId = checkpointId;
         lastUploadedFrom = changelogSnapshotState.lastMaterializedTo();
-        lastUploadedTo = getLastAppendedTo();
+        lastUploadedTo = stateChangelogWriter.lastAppendedSequenceNumber().next();
 
         LOG.info(
                 "snapshot of {} for checkpoint {}, change range: {}..{}",
@@ -629,7 +629,7 @@ public class ChangelogKeyedStateBackend<K>
      *     SequenceNumber} identifying the latest change in the changelog
      */
     public Optional<MaterializationRunnable> initMaterialization() throws Exception {
-        SequenceNumber upTo = getLastAppendedTo();
+        SequenceNumber upTo = stateChangelogWriter.lastAppendedSequenceNumber().next();
         SequenceNumber lastMaterializedTo = changelogSnapshotState.lastMaterializedTo();
 
         LOG.info(
@@ -675,14 +675,6 @@ public class ChangelogKeyedStateBackend<K>
 
             return Optional.empty();
         }
-    }
-
-    // TODO: Remove after fix FLINK-24436
-    //  FsStateChangelogWriter#lastAppendedSequenceNumber returns different seq number
-    //  the first time called vs called after the first time.
-    private SequenceNumber getLastAppendedTo() {
-        stateChangelogWriter.lastAppendedSequenceNumber();
-        return stateChangelogWriter.lastAppendedSequenceNumber();
     }
 
     /**

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateHashMapInMemoryTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateHashMapInMemoryTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.changelog;
+
+import org.apache.flink.runtime.state.HashMapStateBackendTest;
+import org.apache.flink.runtime.state.TestTaskStateManager;
+import org.apache.flink.runtime.state.changelog.inmemory.InMemoryStateChangelogStorage;
+
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Tests for {@link ChangelogStateBackend} using {@link InMemoryStateChangelogStorage} and
+ * delegating {@link HashMapStateBackendTest}.
+ */
+public class ChangelogDelegateHashMapInMemoryTest extends ChangelogDelegateHashMapTest {
+
+    @Rule public final TemporaryFolder temp = new TemporaryFolder();
+
+    protected TestTaskStateManager getTestTaskStateManager() {
+        return TestTaskStateManager.builder().build();
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Materialization.upTo is suppoed to be exclusive boundary. This is true for the DFS-based writer, but not for InMemory one.
This change:
- makes "exclusiveness" excplicit by adding `.next()` to `writer.lastAppendedSqn` in the Changelog backend
- makes `lastAppendedSqn` deterministic in the DFS-based writer by remembering the last returned value if needed

## Verifying this change

Added `ChangelogDelegateHashMapInMemoryTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
