### PR TITLE
[FLINK-25888] Capture time that the job spends on deploying tasks

### DIFF
--- a/docs/assets/_custom.scss
+++ b/docs/assets/_custom.scss
@@ -236,4 +236,8 @@ pre.chroma code {
 
 .markdown table tr:nth-child(2n) {
     background: white;
-} 
+}
+
+.table-inline {
+    background: white;
+}

--- a/docs/content.zh/docs/ops/metrics.md
+++ b/docs/content.zh/docs/ops/metrics.md
@@ -1105,6 +1105,46 @@ Whether these metrics are reported depends on the [metrics.job.status.enable]({{
   </tbody>
 </table>
 
+{{< hint info >}}
+<span class="label label-info">Experimental</span>
+
+While the job is in the RUNNING state the metrics in this table provide additional details on what the job is currently doing.
+Whether these metrics are reported depends on the [metrics.job.status.enable]({{< ref "docs/deployment/config" >}}#metrics-job-status-enable) setting.
+
+<table class="table table-bordered table-inline">
+  <thead>
+    <tr>
+      <th class="text-left" style="width: 18%">Scope</th>
+      <th class="text-left" style="width: 26%">Metrics</th>
+      <th class="text-left" style="width: 48%">Description</th>
+      <th class="text-left" style="width: 8%">Type</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th rowspan="3"><strong>Job (only available on JobManager)</strong></th>
+      <td>deployingState</td>
+      <td>Return 1 if the job is currently deploying* tasks, otherwise return 0.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>deployingTime</td>
+      <td>Return the time (in milliseconds) since the job has started deploying* tasks, otherwise return 0.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>deployingTimeTotal</td>
+      <td>Return how much time (in milliseconds) the job has spent deploying* tasks in total.</td>
+      <td>Gauge</td>
+    </tr>
+  </tbody>
+</table>
+
+*A job is considered to be deploying tasks when:
+* for streaming jobs, any task is in the DEPLOYING state
+* for batch jobs, if at least 1 task is in the DEPLOYING state, and there are no INITIALIZING/RUNNING tasks
+{{< /hint >}}
+
 <table class="table table-bordered">
   <thead>
     <tr>

--- a/docs/content/docs/ops/metrics.md
+++ b/docs/content/docs/ops/metrics.md
@@ -1105,6 +1105,46 @@ Whether these metrics are reported depends on the [metrics.job.status.enable]({{
   </tbody>
 </table>
 
+{{< hint info >}}
+<span class="label label-info">Experimental</span>
+
+While the job is in the RUNNING state the metrics in this table provide additional details on what the job is currently doing.
+Whether these metrics are reported depends on the [metrics.job.status.enable]({{< ref "docs/deployment/config" >}}#metrics-job-status-enable) setting.
+
+<table class="table table-bordered table-inline">
+  <thead>
+    <tr>
+      <th class="text-left" style="width: 18%">Scope</th>
+      <th class="text-left" style="width: 26%">Metrics</th>
+      <th class="text-left" style="width: 48%">Description</th>
+      <th class="text-left" style="width: 8%">Type</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th rowspan="3"><strong>Job (only available on JobManager)</strong></th>
+      <td>deployingState</td>
+      <td>Return 1 if the job is currently deploying* tasks, otherwise return 0.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>deployingTime</td>
+      <td>Return the time (in milliseconds) since the job has started deploying* tasks, otherwise return 0.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>deployingTimeTotal</td>
+      <td>Return how much time (in milliseconds) the job has spent deploying* tasks in total.</td>
+      <td>Gauge</td>
+    </tr>
+  </tbody>
+</table>
+
+*A job is considered to be deploying tasks when:
+* for streaming jobs, any task is in the DEPLOYING state
+* for batch jobs, if at least 1 task is in the DEPLOYING state, and there are no INITIALIZING/RUNNING tasks
+{{< /hint >}}
+
 <table class="table table-bordered">
   <thead>
     <tr>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraph.java
@@ -1512,8 +1512,11 @@ public class DefaultExecutionGraph implements ExecutionGraph, InternalExecutionG
 
     @Override
     public void notifyExecutionChange(
-            final Execution execution, final ExecutionState newExecutionState) {
-        executionStateUpdateListener.onStateUpdate(execution.getAttemptId(), newExecutionState);
+            final Execution execution,
+            ExecutionState previousState,
+            final ExecutionState newExecutionState) {
+        executionStateUpdateListener.onStateUpdate(
+                execution.getAttemptId(), previousState, newExecutionState);
     }
 
     private void assertRunningInJobMasterMainThread() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -1436,7 +1436,7 @@ public class Execution
             // make sure that the state transition completes normally.
             // potential errors (in listeners may not affect the main logic)
             try {
-                vertex.notifyStateTransition(this, targetState);
+                vertex.notifyStateTransition(this, currentState, targetState);
             } catch (Throwable t) {
                 LOG.error(
                         "Error while notifying execution graph of execution state transition.", t);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionStateUpdateListener.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionStateUpdateListener.java
@@ -21,5 +21,6 @@ import org.apache.flink.runtime.execution.ExecutionState;
 
 /** A listener that is called when an execution switched to a new state. */
 public interface ExecutionStateUpdateListener {
-    void onStateUpdate(ExecutionAttemptID execution, ExecutionState newState);
+    void onStateUpdate(
+            ExecutionAttemptID execution, ExecutionState previousState, ExecutionState newState);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -560,11 +560,12 @@ public class ExecutionVertex
     }
 
     /** Simply forward this notification. */
-    void notifyStateTransition(Execution execution, ExecutionState newState) {
+    void notifyStateTransition(
+            Execution execution, ExecutionState previousState, ExecutionState newState) {
         // only forward this notification if the execution is still the current execution
         // otherwise we have an outdated execution
         if (isCurrentExecution(execution)) {
-            getExecutionGraphAccessor().notifyExecutionChange(execution, newState);
+            getExecutionGraphAccessor().notifyExecutionChange(execution, previousState, newState);
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/InternalExecutionGraphAccessor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/InternalExecutionGraphAccessor.java
@@ -92,7 +92,8 @@ public interface InternalExecutionGraphAccessor {
      */
     void failGlobal(Throwable t);
 
-    void notifyExecutionChange(final Execution execution, final ExecutionState newExecutionState);
+    void notifyExecutionChange(
+            Execution execution, ExecutionState previousState, ExecutionState newExecutionState);
 
     void notifySchedulerNgAboutInternalTaskFailure(
             ExecutionAttemptID attemptId,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultExecutionGraphFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultExecutionGraphFactory.java
@@ -137,7 +137,8 @@ public class DefaultExecutionGraphFactory implements ExecutionGraphFactory {
         ExecutionDeploymentListener executionDeploymentListener =
                 new ExecutionDeploymentTrackerDeploymentListenerAdapter(executionDeploymentTracker);
         ExecutionStateUpdateListener executionStateUpdateListener =
-                (execution, newState) -> {
+                (execution, previousState, newState) -> {
+                    executionStateUpdateListener.onStateUpdate(execution, previousState, newState);
                     if (newState.isTerminal()) {
                         executionDeploymentTracker.stopTrackingDeploymentOf(execution);
                     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultExecutionGraphFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultExecutionGraphFactory.java
@@ -132,11 +132,12 @@ public class DefaultExecutionGraphFactory implements ExecutionGraphFactory {
             long initializationTimestamp,
             VertexAttemptNumberStore vertexAttemptNumberStore,
             VertexParallelismStore vertexParallelismStore,
+            ExecutionStateUpdateListener executionStateUpdateListener,
             Logger log)
             throws Exception {
         ExecutionDeploymentListener executionDeploymentListener =
                 new ExecutionDeploymentTrackerDeploymentListenerAdapter(executionDeploymentTracker);
-        ExecutionStateUpdateListener executionStateUpdateListener =
+        ExecutionStateUpdateListener combinedExecutionStateUpdateListener =
                 (execution, previousState, newState) -> {
                     executionStateUpdateListener.onStateUpdate(execution, previousState, newState);
                     if (newState.isTerminal()) {
@@ -161,7 +162,7 @@ public class DefaultExecutionGraphFactory implements ExecutionGraphFactory {
                         jobMasterPartitionTracker,
                         partitionLocationConstraint,
                         executionDeploymentListener,
-                        executionStateUpdateListener,
+                        combinedExecutionStateUpdateListener,
                         initializationTimestamp,
                         vertexAttemptNumberStore,
                         vertexParallelismStore,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionGraphFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionGraphFactory.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.checkpoint.CheckpointsCleaner;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpointStore;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptorFactory;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ExecutionStateUpdateListener;
 import org.apache.flink.runtime.executiongraph.VertexAttemptNumberStore;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 
@@ -44,6 +45,8 @@ public interface ExecutionGraphFactory {
      *     attempts of previous runs
      * @param vertexParallelismStore vertexMaxParallelismStore keeping information about the vertex
      *     max parallelism settings
+     * @param executionStateUpdateListener listener for state transitions of the individual
+     *     executions
      * @param log log to use for logging
      * @return restored {@link ExecutionGraph}
      * @throws Exception if the {@link ExecutionGraph} could not be created and restored
@@ -57,6 +60,7 @@ public interface ExecutionGraphFactory {
             long initializationTimestamp,
             VertexAttemptNumberStore vertexAttemptNumberStore,
             VertexParallelismStore vertexParallelismStore,
+            ExecutionStateUpdateListener executionStateUpdateListener,
             Logger log)
             throws Exception;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -631,8 +631,10 @@ public abstract class SchedulerBase implements SchedulerNG, CheckpointScheduling
         metrics.gauge(MetricNames.NUM_RESTARTS, numberOfRestarts);
         metrics.gauge(MetricNames.FULL_RESTARTS, numberOfRestarts);
 
-        jobStatusListenerRegistrar.accept(
-                new JobStatusMetrics(metrics, initializationTimestamp, jobStatusMetricsSettings));
+        final JobStatusMetrics jobStatusMetrics =
+                new JobStatusMetrics(initializationTimestamp, jobStatusMetricsSettings);
+        jobStatusMetrics.registerMetrics(metrics);
+        jobStatusListenerRegistrar.accept(jobStatusMetrics);
     }
 
     protected abstract void startSchedulingInternal();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
@@ -271,13 +271,16 @@ public class AdaptiveScheduler
         tmpJobStatusListeners.add(Preconditions.checkNotNull(jobStatusListener));
         tmpJobStatusListeners.add(jobStatusStore);
 
+        final MetricOptions.JobStatusMetricsSettings jobStatusMetricsSettings =
+                MetricOptions.JobStatusMetricsSettings.fromConfiguration(configuration);
+
         SchedulerBase.registerJobMetrics(
                 jobManagerJobMetricGroup,
                 jobStatusStore,
                 () -> (long) numRestarts,
                 tmpJobStatusListeners::add,
                 initializationTimestamp,
-                MetricOptions.JobStatusMetricsSettings.fromConfiguration(configuration));
+                jobStatusMetricsSettings);
 
         jobStatusListeners = Collections.unmodifiableCollection(tmpJobStatusListeners);
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
@@ -99,6 +99,7 @@ import org.apache.flink.runtime.scheduler.adaptive.allocator.SlotAllocator;
 import org.apache.flink.runtime.scheduler.adaptive.allocator.VertexParallelism;
 import org.apache.flink.runtime.scheduler.adaptive.scalingpolicy.ReactiveScaleUpController;
 import org.apache.flink.runtime.scheduler.adaptive.scalingpolicy.ScaleUpController;
+import org.apache.flink.runtime.scheduler.metrics.DeploymentStateTimeMetrics;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.util.ResourceCounter;
 import org.apache.flink.util.ExceptionUtils;
@@ -207,6 +208,8 @@ public class AdaptiveScheduler
 
     private final SchedulerExecutionMode executionMode;
 
+    private final DeploymentStateTimeMetrics deploymentTimeMetrics;
+
     public AdaptiveScheduler(
             JobGraph jobGraph,
             Configuration configuration,
@@ -274,10 +277,14 @@ public class AdaptiveScheduler
         final MetricOptions.JobStatusMetricsSettings jobStatusMetricsSettings =
                 MetricOptions.JobStatusMetricsSettings.fromConfiguration(configuration);
 
+        deploymentTimeMetrics =
+                new DeploymentStateTimeMetrics(jobGraph.getJobType(), jobStatusMetricsSettings);
+
         SchedulerBase.registerJobMetrics(
                 jobManagerJobMetricGroup,
                 jobStatusStore,
                 () -> (long) numRestarts,
+                deploymentTimeMetrics,
                 tmpJobStatusListeners::add,
                 initializationTimestamp,
                 jobStatusMetricsSettings);
@@ -1026,6 +1033,7 @@ public class AdaptiveScheduler
                 initializationTimestamp,
                 vertexAttemptNumberStore,
                 adjustedParallelismStore,
+                deploymentTimeMetrics,
                 LOG);
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/metrics/DeploymentStateTimeMetrics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/metrics/DeploymentStateTimeMetrics.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.metrics;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.configuration.MetricOptions;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.executiongraph.ExecutionStateUpdateListener;
+import org.apache.flink.runtime.jobgraph.JobType;
+import org.apache.flink.util.clock.Clock;
+import org.apache.flink.util.clock.SystemClock;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Predicate;
+
+/**
+ * Metrics that capture how long a job was deploying tasks.
+ *
+ * <p>These metrics differentiate between batch & streaming use-cases:
+ *
+ * <p>Batch: Measures from the start of the first deployment until the first task has been deployed.
+ * From that point the job is making progress.
+ *
+ * <p>Streaming: Measures from the start of the first deployment until all tasks have been deployed.
+ * From that point on checkpoints can be triggered, and thus progress be made.
+ */
+public class DeploymentStateTimeMetrics
+        implements ExecutionStateUpdateListener, StateTimeMetric, MetricsRegistrar {
+
+    private static final long NOT_STARTED = -1L;
+
+    private final Predicate<Integer> deploymentStartPredicate;
+    private final Predicate<Integer> deploymentEndPredicate;
+    private final MetricOptions.JobStatusMetricsSettings stateTimeMetricsSettings;
+    private final Clock clock;
+
+    // deployment book-keeping
+    private final Set<ExecutionAttemptID> expectedDeployments = new HashSet<>();
+    private int pendingDeployments = 0;
+    private int completedDeployments = 0;
+
+    // metrics state
+    private long deploymentStart = NOT_STARTED;
+    private long deploymentTimeTotal = 0L;
+
+    public DeploymentStateTimeMetrics(
+            JobType semantic, MetricOptions.JobStatusMetricsSettings stateTimeMetricsSettings) {
+        this(semantic, stateTimeMetricsSettings, SystemClock.getInstance());
+    }
+
+    @VisibleForTesting
+    DeploymentStateTimeMetrics(
+            JobType semantic,
+            MetricOptions.JobStatusMetricsSettings stateTimeMetricsSettings,
+            Clock clock) {
+        this.stateTimeMetricsSettings = stateTimeMetricsSettings;
+        this.clock = clock;
+
+        if (semantic == JobType.BATCH) {
+            deploymentStartPredicate = completedDeployments -> completedDeployments == 0;
+            deploymentEndPredicate = completedDeployments -> completedDeployments > 0;
+        } else {
+            deploymentStartPredicate = completedDeployments -> true;
+            deploymentEndPredicate =
+                    completedDeployments -> completedDeployments == expectedDeployments.size();
+        }
+    }
+
+    @Override
+    public long getCurrentTime() {
+        return deploymentStart == NOT_STARTED
+                ? 0L
+                : Math.max(0, clock.absoluteTimeMillis() - deploymentStart);
+    }
+
+    @Override
+    public long getTotalTime() {
+        return getCurrentTime() + deploymentTimeTotal;
+    }
+
+    @Override
+    public long getBinary() {
+        return deploymentStart == NOT_STARTED ? 0L : 1L;
+    }
+
+    @Override
+    public void registerMetrics(MetricGroup metricGroup) {
+        StateTimeMetric.register(stateTimeMetricsSettings, metricGroup, this, "deploying");
+    }
+
+    @Override
+    public void onStateUpdate(
+            ExecutionAttemptID execution, ExecutionState previousState, ExecutionState newState) {
+        switch (newState) {
+            case SCHEDULED:
+                expectedDeployments.add(execution);
+                break;
+            case DEPLOYING:
+                pendingDeployments++;
+                break;
+            case INITIALIZING:
+            case RUNNING:
+                completedDeployments++;
+                break;
+            default:
+                // the deployment started terminating
+                expectedDeployments.remove(execution);
+        }
+        switch (previousState) {
+            case DEPLOYING:
+                pendingDeployments--;
+                break;
+            case INITIALIZING:
+            case RUNNING:
+                completedDeployments--;
+                break;
+        }
+
+        if (deploymentStart == NOT_STARTED) {
+            if (pendingDeployments > 0 && deploymentStartPredicate.test(completedDeployments)) {
+                markDeploymentStart();
+            }
+        } else {
+            if (deploymentEndPredicate.test(completedDeployments)
+                    || expectedDeployments.isEmpty()) {
+                markDeploymentEnd();
+            }
+        }
+    }
+
+    private void markDeploymentStart() {
+        deploymentStart = clock.absoluteTimeMillis();
+    }
+
+    private void markDeploymentEnd() {
+        deploymentTimeTotal += Math.max(0, clock.absoluteTimeMillis() - deploymentStart);
+        deploymentStart = NOT_STARTED;
+    }
+
+    @VisibleForTesting
+    boolean hasCleanState() {
+        return expectedDeployments.isEmpty()
+                && pendingDeployments == 0
+                && completedDeployments == 0
+                && deploymentStart == NOT_STARTED;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/metrics/JobStatusMetrics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/metrics/JobStatusMetrics.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.metrics;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.configuration.MetricOptions;
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.executiongraph.JobStatusListener;
+import org.apache.flink.util.clock.Clock;
+import org.apache.flink.util.clock.SystemClock;
+
+import java.util.Locale;
+
+/** Metrics that capture the time that a job spends in each {@link JobStatus}. */
+public class JobStatusMetrics implements JobStatusListener {
+
+    private JobStatus currentStatus = JobStatus.INITIALIZING;
+    private long currentStatusTimestamp;
+    private final long[] cumulativeStatusTimes;
+
+    public JobStatusMetrics(
+            MetricGroup metricGroup,
+            long initializationTimestamp,
+            MetricOptions.JobStatusMetricsSettings jobStatusMetricsSettings) {
+
+        currentStatus = JobStatus.INITIALIZING;
+        currentStatusTimestamp = initializationTimestamp;
+        cumulativeStatusTimes = new long[JobStatus.values().length];
+
+        for (JobStatus jobStatus : JobStatus.values()) {
+            if (!jobStatus.isTerminalState() && jobStatus != JobStatus.RECONCILING) {
+
+                if (jobStatusMetricsSettings.isStateMetricsEnabled()) {
+                    metricGroup.gauge(getStateMetricName(jobStatus), createStateMetric(jobStatus));
+                }
+
+                if (jobStatusMetricsSettings.isCurrentTimeMetricsEnabled()) {
+                    metricGroup.gauge(
+                            getCurrentTimeMetricName(jobStatus),
+                            createCurrentTimeMetric(jobStatus, SystemClock.getInstance()));
+                }
+
+                if (jobStatusMetricsSettings.isTotalTimeMetricsEnabled()) {
+                    metricGroup.gauge(
+                            getTotalTimeMetricName(jobStatus),
+                            createTotalTimeMetric(jobStatus, SystemClock.getInstance()));
+                }
+            }
+        }
+    }
+
+    @VisibleForTesting
+    Gauge<Long> createStateMetric(JobStatus jobStatus) {
+        return () -> currentStatus == jobStatus ? 1L : 0L;
+    }
+
+    @VisibleForTesting
+    Gauge<Long> createCurrentTimeMetric(JobStatus jobStatus, Clock clock) {
+        return () ->
+                currentStatus == jobStatus
+                        ? Math.max(clock.absoluteTimeMillis() - currentStatusTimestamp, 0)
+                        : 0;
+    }
+
+    @VisibleForTesting
+    Gauge<Long> createTotalTimeMetric(JobStatus jobStatus, Clock clock) {
+        return () ->
+                currentStatus == jobStatus
+                        ? cumulativeStatusTimes[jobStatus.ordinal()]
+                                + Math.max(clock.absoluteTimeMillis() - currentStatusTimestamp, 0)
+                        : cumulativeStatusTimes[jobStatus.ordinal()];
+    }
+
+    @VisibleForTesting
+    static String getStateMetricName(JobStatus jobStatus) {
+        return jobStatus.name().toLowerCase(Locale.ROOT) + "State";
+    }
+
+    @VisibleForTesting
+    static String getCurrentTimeMetricName(JobStatus jobStatus) {
+        return jobStatus.name().toLowerCase(Locale.ROOT) + "Time";
+    }
+
+    @VisibleForTesting
+    static String getTotalTimeMetricName(JobStatus jobStatus) {
+        return jobStatus.name().toLowerCase(Locale.ROOT) + "TimeTotal";
+    }
+
+    @Override
+    public void jobStatusChanges(JobID jobId, JobStatus newJobStatus, long timestamp) {
+        cumulativeStatusTimes[currentStatus.ordinal()] += timestamp - currentStatusTimestamp;
+
+        currentStatus = newJobStatus;
+        currentStatusTimestamp = timestamp;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/metrics/MetricsRegistrar.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/metrics/MetricsRegistrar.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.metrics;
+
+import org.apache.flink.metrics.MetricGroup;
+
+/** A component that can register metrics. */
+public interface MetricsRegistrar {
+    void registerMetrics(MetricGroup metricGroup);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/metrics/StateTimeMetric.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/metrics/StateTimeMetric.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.metrics;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.configuration.MetricOptions;
+import org.apache.flink.metrics.MetricGroup;
+
+/** Utility to define metrics that capture the time that some component spends in a state. */
+public interface StateTimeMetric {
+
+    /**
+     * Returns the time, in milliseconds, that have elapsed since we transitioned to the targeted
+     * state. Returns 0 if we are not in the targeted state.
+     */
+    long getCurrentTime();
+
+    /** Returns the total time, in milliseconds, that we have spent in the targeted state. */
+    long getTotalTime();
+
+    /** Returns 1 if we are in the targeted state, otherwise 0. */
+    long getBinary();
+
+    static void register(
+            MetricOptions.JobStatusMetricsSettings jobStatusMetricsSettings,
+            MetricGroup metricGroup,
+            StateTimeMetric stateTimeMetric,
+            String baseName) {
+
+        if (jobStatusMetricsSettings.isStateMetricsEnabled()) {
+            metricGroup.gauge(getStateMetricName(baseName), stateTimeMetric::getBinary);
+        }
+
+        if (jobStatusMetricsSettings.isCurrentTimeMetricsEnabled()) {
+            metricGroup.gauge(getCurrentTimeMetricName(baseName), stateTimeMetric::getCurrentTime);
+        }
+
+        if (jobStatusMetricsSettings.isTotalTimeMetricsEnabled()) {
+            metricGroup.gauge(getTotalTimeMetricName(baseName), stateTimeMetric::getTotalTime);
+        }
+    }
+
+    @VisibleForTesting
+    static String getStateMetricName(String baseName) {
+        return baseName + "State";
+    }
+
+    @VisibleForTesting
+    static String getCurrentTimeMetricName(String baseName) {
+        return baseName + "Time";
+    }
+
+    @VisibleForTesting
+    static String getTotalTimeMetricName(String baseName) {
+        return baseName + "TimeTotal";
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/TestingDefaultExecutionGraphBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/TestingDefaultExecutionGraphBuilder.java
@@ -74,7 +74,8 @@ public class TestingDefaultExecutionGraphBuilder {
     private CheckpointIDCounter checkpointIdCounter = new StandaloneCheckpointIDCounter();
     private ExecutionDeploymentListener executionDeploymentListener =
             NoOpExecutionDeploymentListener.get();
-    private ExecutionStateUpdateListener executionStateUpdateListener = (execution, newState) -> {};
+    private ExecutionStateUpdateListener executionStateUpdateListener =
+            (execution, previousState, newState) -> {};
     private VertexParallelismStore vertexParallelismStore;
 
     private TestingDefaultExecutionGraphBuilder() {}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultExecutionGraphFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultExecutionGraphFactoryTest.java
@@ -77,6 +77,7 @@ public class DefaultExecutionGraphFactoryTest extends TestLogger {
                     0L,
                     new DefaultVertexAttemptNumberStore(),
                     SchedulerBase.computeVertexParallelismStore(jobGraphWithNewOperator),
+                    (execution, previousState, newState) -> {},
                     log);
             fail("Expected ExecutionGraph creation to fail because of non restored state.");
         } catch (Exception e) {
@@ -105,6 +106,7 @@ public class DefaultExecutionGraphFactoryTest extends TestLogger {
                 0L,
                 new DefaultVertexAttemptNumberStore(),
                 SchedulerBase.computeVertexParallelismStore(jobGraphWithNewOperator),
+                (execution, previousState, newState) -> {},
                 log);
 
         final CompletedCheckpoint savepoint = completedCheckpointStore.getLatestCheckpoint();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/ExecutingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/ExecutingTest.java
@@ -916,7 +916,10 @@ public class ExecutingTest extends TestLogger {
         }
 
         @Override
-        public void notifyExecutionChange(Execution execution, ExecutionState newExecutionState) {}
+        public void notifyExecutionChange(
+                Execution execution,
+                ExecutionState previousState,
+                ExecutionState newExecutionState) {}
 
         @Override
         public EdgeManager getEdgeManager() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/metrics/DeploymentStateTimeMetricsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/metrics/DeploymentStateTimeMetricsTest.java
@@ -1,0 +1,279 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.metrics;
+
+import org.apache.flink.configuration.MetricOptions;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.jobgraph.JobType;
+import org.apache.flink.util.clock.ManualClock;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.apache.flink.runtime.scheduler.metrics.StateTimeMetricTest.enable;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DeploymentStateTimeMetricsTest {
+
+    private static final MetricOptions.JobStatusMetricsSettings settings =
+            enable(
+                    MetricOptions.JobStatusMetrics.STATE,
+                    MetricOptions.JobStatusMetrics.CURRENT_TIME,
+                    MetricOptions.JobStatusMetrics.TOTAL_TIME);
+
+    @Test
+    void testInitialValues() {
+        final ManualClock clock = new ManualClock(Duration.ofMillis(5).toNanos());
+
+        final DeploymentStateTimeMetrics deploymentStateTimeMetrics =
+                new DeploymentStateTimeMetrics(JobType.BATCH, settings, clock);
+
+        assertThat(deploymentStateTimeMetrics.getCurrentTime()).isEqualTo(0L);
+        assertThat(deploymentStateTimeMetrics.getTotalTime()).isEqualTo(0L);
+        assertThat(deploymentStateTimeMetrics.getBinary()).isEqualTo(0L);
+    }
+
+    @Test
+    void testDeploymentStartsOnFirstDeploying() {
+        final DeploymentStateTimeMetrics metrics =
+                new DeploymentStateTimeMetrics(JobType.BATCH, settings);
+
+        final ExecutionAttemptID id1 = new ExecutionAttemptID();
+
+        metrics.onStateUpdate(id1, ExecutionState.CREATED, ExecutionState.SCHEDULED);
+        assertThat(metrics.getBinary()).isEqualTo(0L);
+
+        metrics.onStateUpdate(id1, ExecutionState.SCHEDULED, ExecutionState.DEPLOYING);
+        assertThat(metrics.getBinary()).isEqualTo(1L);
+    }
+
+    @Test
+    void testDeploymentStart_batch_notTriggeredIfOneDeploymentIsRunning() {
+        final DeploymentStateTimeMetrics metrics =
+                new DeploymentStateTimeMetrics(JobType.BATCH, settings);
+
+        final ExecutionAttemptID id1 = new ExecutionAttemptID();
+
+        metrics.onStateUpdate(id1, ExecutionState.CREATED, ExecutionState.SCHEDULED);
+        metrics.onStateUpdate(id1, ExecutionState.SCHEDULED, ExecutionState.DEPLOYING);
+        metrics.onStateUpdate(id1, ExecutionState.DEPLOYING, ExecutionState.INITIALIZING);
+
+        final ExecutionAttemptID id2 = new ExecutionAttemptID();
+
+        metrics.onStateUpdate(id2, ExecutionState.CREATED, ExecutionState.SCHEDULED);
+        metrics.onStateUpdate(id2, ExecutionState.SCHEDULED, ExecutionState.DEPLOYING);
+
+        assertThat(metrics.getBinary()).isEqualTo(0L);
+    }
+
+    @Test
+    void testDeploymentEnd_batch() {
+        final DeploymentStateTimeMetrics metrics =
+                new DeploymentStateTimeMetrics(JobType.BATCH, settings);
+
+        final ExecutionAttemptID id1 = new ExecutionAttemptID();
+        final ExecutionAttemptID id2 = new ExecutionAttemptID();
+
+        metrics.onStateUpdate(id1, ExecutionState.CREATED, ExecutionState.SCHEDULED);
+        metrics.onStateUpdate(id2, ExecutionState.CREATED, ExecutionState.SCHEDULED);
+
+        metrics.onStateUpdate(id1, ExecutionState.SCHEDULED, ExecutionState.DEPLOYING);
+        metrics.onStateUpdate(id2, ExecutionState.SCHEDULED, ExecutionState.DEPLOYING);
+
+        metrics.onStateUpdate(id1, ExecutionState.DEPLOYING, ExecutionState.INITIALIZING);
+        assertThat(metrics.getBinary()).isEqualTo(0L);
+    }
+
+    @Test
+    void testDeploymentEnd_streaming() {
+        final DeploymentStateTimeMetrics metrics =
+                new DeploymentStateTimeMetrics(JobType.STREAMING, settings);
+
+        final ExecutionAttemptID id1 = new ExecutionAttemptID();
+        final ExecutionAttemptID id2 = new ExecutionAttemptID();
+
+        metrics.onStateUpdate(id1, ExecutionState.CREATED, ExecutionState.SCHEDULED);
+        metrics.onStateUpdate(id2, ExecutionState.CREATED, ExecutionState.SCHEDULED);
+
+        metrics.onStateUpdate(id1, ExecutionState.SCHEDULED, ExecutionState.DEPLOYING);
+        metrics.onStateUpdate(id2, ExecutionState.SCHEDULED, ExecutionState.DEPLOYING);
+
+        metrics.onStateUpdate(id1, ExecutionState.DEPLOYING, ExecutionState.INITIALIZING);
+        assertThat(metrics.getBinary()).isEqualTo(1L);
+
+        metrics.onStateUpdate(id2, ExecutionState.DEPLOYING, ExecutionState.INITIALIZING);
+        assertThat(metrics.getBinary()).isEqualTo(0L);
+    }
+
+    @Test
+    void testDeploymentEnd_streaming_ignoresTerminalDeployments() {
+        final DeploymentStateTimeMetrics metrics =
+                new DeploymentStateTimeMetrics(JobType.STREAMING, settings);
+
+        final ExecutionAttemptID id1 = new ExecutionAttemptID();
+        final ExecutionAttemptID id2 = new ExecutionAttemptID();
+
+        metrics.onStateUpdate(id1, ExecutionState.CREATED, ExecutionState.SCHEDULED);
+        metrics.onStateUpdate(id2, ExecutionState.CREATED, ExecutionState.SCHEDULED);
+
+        metrics.onStateUpdate(id1, ExecutionState.SCHEDULED, ExecutionState.DEPLOYING);
+        metrics.onStateUpdate(id2, ExecutionState.SCHEDULED, ExecutionState.DEPLOYING);
+
+        metrics.onStateUpdate(id1, ExecutionState.DEPLOYING, ExecutionState.INITIALIZING);
+        metrics.onStateUpdate(id1, ExecutionState.INITIALIZING, ExecutionState.FINISHED);
+        assertThat(metrics.getBinary()).isEqualTo(1L);
+
+        metrics.onStateUpdate(id2, ExecutionState.DEPLOYING, ExecutionState.INITIALIZING);
+        assertThat(metrics.getBinary()).isEqualTo(0L);
+    }
+
+    @Test
+    void testGetCurrentTime() {
+        final ManualClock clock = new ManualClock(Duration.ofMillis(5).toNanos());
+
+        final DeploymentStateTimeMetrics metrics =
+                new DeploymentStateTimeMetrics(JobType.BATCH, settings, clock);
+
+        final ExecutionAttemptID id1 = new ExecutionAttemptID();
+        final ExecutionAttemptID id2 = new ExecutionAttemptID();
+
+        metrics.onStateUpdate(id1, ExecutionState.CREATED, ExecutionState.SCHEDULED);
+        metrics.onStateUpdate(id1, ExecutionState.SCHEDULED, ExecutionState.DEPLOYING);
+
+        clock.advanceTime(Duration.ofMillis(5));
+        assertThat(metrics.getCurrentTime()).isEqualTo(5L);
+    }
+
+    @Test
+    void testGetCurrentTimeResetOndDeployentEnd() {
+        final ManualClock clock = new ManualClock(Duration.ofMillis(5).toNanos());
+
+        final DeploymentStateTimeMetrics metrics =
+                new DeploymentStateTimeMetrics(JobType.BATCH, settings, clock);
+
+        final ExecutionAttemptID id1 = new ExecutionAttemptID();
+        final ExecutionAttemptID id2 = new ExecutionAttemptID();
+
+        metrics.onStateUpdate(id1, ExecutionState.CREATED, ExecutionState.SCHEDULED);
+        metrics.onStateUpdate(id1, ExecutionState.SCHEDULED, ExecutionState.DEPLOYING);
+        metrics.onStateUpdate(id1, ExecutionState.DEPLOYING, ExecutionState.INITIALIZING);
+
+        assertThat(metrics.getCurrentTime()).isEqualTo(0L);
+    }
+
+    @Test
+    void testGetCurrentTime_notResetOnSecondaryDeployment() {
+        final ManualClock clock = new ManualClock(Duration.ofMillis(5).toNanos());
+
+        final DeploymentStateTimeMetrics metrics =
+                new DeploymentStateTimeMetrics(JobType.BATCH, settings, clock);
+
+        final ExecutionAttemptID id1 = new ExecutionAttemptID();
+        final ExecutionAttemptID id2 = new ExecutionAttemptID();
+
+        metrics.onStateUpdate(id1, ExecutionState.CREATED, ExecutionState.SCHEDULED);
+        metrics.onStateUpdate(id2, ExecutionState.CREATED, ExecutionState.SCHEDULED);
+
+        metrics.onStateUpdate(id1, ExecutionState.SCHEDULED, ExecutionState.DEPLOYING);
+        clock.advanceTime(Duration.ofMillis(5));
+
+        metrics.onStateUpdate(id2, ExecutionState.SCHEDULED, ExecutionState.DEPLOYING);
+        clock.advanceTime(Duration.ofMillis(5));
+        assertThat(metrics.getCurrentTime()).isEqualTo(10L);
+    }
+
+    @Test
+    void testGetTotalTime() {
+        final ManualClock clock = new ManualClock(Duration.ofMillis(5).toNanos());
+
+        final DeploymentStateTimeMetrics metrics =
+                new DeploymentStateTimeMetrics(JobType.BATCH, settings, clock);
+
+        final ExecutionAttemptID id1 = new ExecutionAttemptID();
+
+        metrics.onStateUpdate(id1, ExecutionState.CREATED, ExecutionState.SCHEDULED);
+        metrics.onStateUpdate(id1, ExecutionState.SCHEDULED, ExecutionState.DEPLOYING);
+        clock.advanceTime(Duration.ofMillis(5));
+        metrics.onStateUpdate(id1, ExecutionState.DEPLOYING, ExecutionState.FINISHED);
+        assertThat(metrics.getTotalTime()).isEqualTo(5L);
+
+        final ExecutionAttemptID id2 = new ExecutionAttemptID();
+
+        metrics.onStateUpdate(id2, ExecutionState.CREATED, ExecutionState.SCHEDULED);
+        metrics.onStateUpdate(id2, ExecutionState.SCHEDULED, ExecutionState.DEPLOYING);
+        clock.advanceTime(Duration.ofMillis(5));
+        metrics.onStateUpdate(id2, ExecutionState.DEPLOYING, ExecutionState.FINISHED);
+        assertThat(metrics.getTotalTime()).isEqualTo(10L);
+    }
+
+    @Test
+    void testGetTotalTimeIncludesCurrentTime() {
+        final ManualClock clock = new ManualClock(Duration.ofMillis(5).toNanos());
+
+        final DeploymentStateTimeMetrics metrics =
+                new DeploymentStateTimeMetrics(JobType.BATCH, settings, clock);
+
+        final ExecutionAttemptID id1 = new ExecutionAttemptID();
+        final ExecutionAttemptID id2 = new ExecutionAttemptID();
+
+        metrics.onStateUpdate(id1, ExecutionState.CREATED, ExecutionState.SCHEDULED);
+        metrics.onStateUpdate(id1, ExecutionState.SCHEDULED, ExecutionState.DEPLOYING);
+
+        clock.advanceTime(Duration.ofMillis(5));
+        assertThat(metrics.getTotalTime()).isEqualTo(5L);
+    }
+
+    @Test
+    void testCleanStateAfterFullDeploymentCycle() {
+        final ManualClock clock = new ManualClock(Duration.ofMillis(5).toNanos());
+
+        final DeploymentStateTimeMetrics metrics =
+                new DeploymentStateTimeMetrics(JobType.BATCH, settings, clock);
+
+        final ExecutionAttemptID id1 = new ExecutionAttemptID();
+        final ExecutionAttemptID id2 = new ExecutionAttemptID();
+
+        metrics.onStateUpdate(id1, ExecutionState.CREATED, ExecutionState.SCHEDULED);
+        metrics.onStateUpdate(id1, ExecutionState.SCHEDULED, ExecutionState.DEPLOYING);
+        metrics.onStateUpdate(id1, ExecutionState.DEPLOYING, ExecutionState.INITIALIZING);
+        metrics.onStateUpdate(id1, ExecutionState.INITIALIZING, ExecutionState.RUNNING);
+        metrics.onStateUpdate(id1, ExecutionState.RUNNING, ExecutionState.CANCELING);
+        metrics.onStateUpdate(id1, ExecutionState.CANCELING, ExecutionState.CANCELED);
+
+        assertThat(metrics.hasCleanState()).isEqualTo(true);
+    }
+
+    @Test
+    void testCleanStateAfterEarlyDeploymentFailure() {
+        final ManualClock clock = new ManualClock(Duration.ofMillis(5).toNanos());
+
+        final DeploymentStateTimeMetrics metrics =
+                new DeploymentStateTimeMetrics(JobType.BATCH, settings, clock);
+
+        final ExecutionAttemptID id1 = new ExecutionAttemptID();
+        final ExecutionAttemptID id2 = new ExecutionAttemptID();
+
+        metrics.onStateUpdate(id1, ExecutionState.CREATED, ExecutionState.SCHEDULED);
+        metrics.onStateUpdate(id1, ExecutionState.SCHEDULED, ExecutionState.DEPLOYING);
+        metrics.onStateUpdate(id1, ExecutionState.DEPLOYING, ExecutionState.FAILED);
+
+        assertThat(metrics.hasCleanState()).isEqualTo(true);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/metrics/JobStatusMetricsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/metrics/JobStatusMetricsTest.java
@@ -19,24 +19,17 @@ package org.apache.flink.runtime.scheduler.metrics;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MetricOptions;
-import org.apache.flink.metrics.Gauge;
-import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.runtime.metrics.util.InterceptingOperatorMetricGroup;
 import org.apache.flink.util.clock.ManualClock;
 
 import org.junit.jupiter.api.Test;
 
-import javax.annotation.Nullable;
-
 import java.time.Duration;
-import java.util.Arrays;
-import java.util.EnumMap;
-import java.util.EnumSet;
 import java.util.Map;
-import java.util.Optional;
 
+import static org.apache.flink.runtime.scheduler.metrics.StateTimeMetricTest.enable;
+import static org.apache.flink.runtime.scheduler.metrics.StateTimeMetricTest.extractMetrics;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class JobStatusMetricsTest {
@@ -45,78 +38,75 @@ class JobStatusMetricsTest {
     void testStateMetric() {
         final JobStatusMetrics jobStatusMetrics =
                 new JobStatusMetrics(
-                        new UnregisteredMetricsGroup(),
                         0L,
                         enable(
                                 MetricOptions.JobStatusMetrics.STATE,
                                 MetricOptions.JobStatusMetrics.CURRENT_TIME,
                                 MetricOptions.JobStatusMetrics.TOTAL_TIME));
 
-        final Gauge<Long> metric = jobStatusMetrics.createStateMetric(JobStatus.RUNNING);
+        final StateTimeMetric metric = jobStatusMetrics.createTimeMetric(JobStatus.RUNNING);
 
-        assertThat(metric.getValue()).isEqualTo(0L);
+        assertThat(metric.getBinary()).isEqualTo(0L);
         jobStatusMetrics.jobStatusChanges(new JobID(), JobStatus.RUNNING, 1L);
-        assertThat(metric.getValue()).isEqualTo(1L);
+        assertThat(metric.getBinary()).isEqualTo(1L);
         jobStatusMetrics.jobStatusChanges(new JobID(), JobStatus.RESTARTING, 2L);
-        assertThat(metric.getValue()).isEqualTo(0L);
+        assertThat(metric.getBinary()).isEqualTo(0L);
     }
 
     @Test
     void testCurrentTimeMetric() {
+        final ManualClock clock = new ManualClock();
         final JobStatusMetrics jobStatusMetrics =
                 new JobStatusMetrics(
-                        new UnregisteredMetricsGroup(),
                         0L,
                         enable(
                                 MetricOptions.JobStatusMetrics.STATE,
                                 MetricOptions.JobStatusMetrics.CURRENT_TIME,
-                                MetricOptions.JobStatusMetrics.TOTAL_TIME));
+                                MetricOptions.JobStatusMetrics.TOTAL_TIME),
+                        clock);
+        final StateTimeMetric metric = jobStatusMetrics.createTimeMetric(JobStatus.RUNNING);
 
-        final ManualClock clock = new ManualClock();
-        final Gauge<Long> metric =
-                jobStatusMetrics.createCurrentTimeMetric(JobStatus.RUNNING, clock);
-
-        assertThat(metric.getValue()).isEqualTo(0L);
+        assertThat(metric.getCurrentTime()).isEqualTo(0L);
         jobStatusMetrics.jobStatusChanges(new JobID(), JobStatus.RUNNING, 1L);
         clock.advanceTime(Duration.ofMillis(11));
-        assertThat(metric.getValue()).isEqualTo(10L);
+        assertThat(metric.getCurrentTime()).isEqualTo(10L);
         jobStatusMetrics.jobStatusChanges(new JobID(), JobStatus.RESTARTING, 15L);
-        assertThat(metric.getValue()).isEqualTo(0L);
+        assertThat(metric.getCurrentTime()).isEqualTo(0L);
     }
 
     @Test
     void testTotalTimeMetric() {
+        final ManualClock clock = new ManualClock(0);
         final JobStatusMetrics jobStatusMetrics =
                 new JobStatusMetrics(
-                        new UnregisteredMetricsGroup(),
                         0L,
                         enable(
                                 MetricOptions.JobStatusMetrics.STATE,
                                 MetricOptions.JobStatusMetrics.CURRENT_TIME,
-                                MetricOptions.JobStatusMetrics.TOTAL_TIME));
+                                MetricOptions.JobStatusMetrics.TOTAL_TIME),
+                        clock);
 
-        final ManualClock clock = new ManualClock(0);
-        final Gauge<Long> metric = jobStatusMetrics.createTotalTimeMetric(JobStatus.RUNNING, clock);
+        final StateTimeMetric metric = jobStatusMetrics.createTimeMetric(JobStatus.RUNNING);
 
-        assertThat(metric.getValue()).isEqualTo(0L);
+        assertThat(metric.getTotalTime()).isEqualTo(0L);
 
         jobStatusMetrics.jobStatusChanges(
                 new JobID(), JobStatus.RUNNING, clock.absoluteTimeMillis());
 
         clock.advanceTime(Duration.ofMillis(10));
-        assertThat(metric.getValue()).isEqualTo(10L);
+        assertThat(metric.getTotalTime()).isEqualTo(10L);
 
         jobStatusMetrics.jobStatusChanges(
                 new JobID(), JobStatus.RESTARTING, clock.absoluteTimeMillis());
 
         clock.advanceTime(Duration.ofMillis(4));
-        assertThat(metric.getValue()).isEqualTo(10L);
+        assertThat(metric.getTotalTime()).isEqualTo(10L);
 
         jobStatusMetrics.jobStatusChanges(
                 new JobID(), JobStatus.RUNNING, clock.absoluteTimeMillis());
 
         clock.advanceTime(Duration.ofMillis(1));
-        assertThat(metric.getValue()).isEqualTo(11L);
+        assertThat(metric.getTotalTime()).isEqualTo(11L);
     }
 
     @Test
@@ -124,8 +114,10 @@ class JobStatusMetricsTest {
         final InterceptingOperatorMetricGroup metricGroup = new InterceptingOperatorMetricGroup();
 
         final JobStatusMetrics jobStatusMetrics =
-                new JobStatusMetrics(metricGroup, 0L, enable(MetricOptions.JobStatusMetrics.STATE));
-        final Map<JobStatus, StatusMetricSet> registeredMetrics = extractMetrics(metricGroup);
+                new JobStatusMetrics(0L, enable(MetricOptions.JobStatusMetrics.STATE));
+        jobStatusMetrics.registerMetrics(metricGroup);
+        final Map<JobStatus, StateTimeMetricTest.StatusMetricSet> registeredMetrics =
+                extractMetrics(metricGroup);
 
         for (JobStatus value : JobStatus.values()) {
             if (value.isTerminalState() || value == JobStatus.RECONCILING) {
@@ -133,117 +125,6 @@ class JobStatusMetricsTest {
             } else {
                 assertThat(registeredMetrics).containsKey(value);
             }
-        }
-    }
-
-    @Test
-    void testEnableStateMetrics() {
-        testMetricSelection(MetricOptions.JobStatusMetrics.STATE);
-    }
-
-    @Test
-    void testEnableCurrentTimeMetrics() {
-        testMetricSelection(MetricOptions.JobStatusMetrics.CURRENT_TIME);
-    }
-
-    @Test
-    void testEnableTotalTimeMetrics() {
-        testMetricSelection(MetricOptions.JobStatusMetrics.TOTAL_TIME);
-    }
-
-    @Test
-    void testEnableMultipleMetrics() {
-        testMetricSelection(
-                MetricOptions.JobStatusMetrics.CURRENT_TIME,
-                MetricOptions.JobStatusMetrics.TOTAL_TIME);
-    }
-
-    private static void testMetricSelection(MetricOptions.JobStatusMetrics... selectedMetrics) {
-        final EnumSet<MetricOptions.JobStatusMetrics> selectedMetricsSet =
-                EnumSet.noneOf(MetricOptions.JobStatusMetrics.class);
-        Arrays.stream(selectedMetrics).forEach(selectedMetricsSet::add);
-
-        final InterceptingOperatorMetricGroup metricGroup = new InterceptingOperatorMetricGroup();
-
-        final JobStatusMetrics jobStatusMetrics =
-                new JobStatusMetrics(metricGroup, 1L, enable(selectedMetrics));
-        final Map<JobStatus, StatusMetricSet> registeredMetrics = extractMetrics(metricGroup);
-
-        for (StatusMetricSet metrics : registeredMetrics.values()) {
-            assertThat(metrics.getState().isPresent())
-                    .isEqualTo(selectedMetricsSet.contains(MetricOptions.JobStatusMetrics.STATE));
-            assertThat(metrics.getCurrentTime().isPresent())
-                    .isEqualTo(
-                            selectedMetricsSet.contains(
-                                    MetricOptions.JobStatusMetrics.CURRENT_TIME));
-            assertThat(metrics.getTotalTime().isPresent())
-                    .isEqualTo(
-                            selectedMetricsSet.contains(MetricOptions.JobStatusMetrics.TOTAL_TIME));
-        }
-    }
-
-    private static MetricOptions.JobStatusMetricsSettings enable(
-            MetricOptions.JobStatusMetrics... enabledMetrics) {
-        final Configuration configuration = new Configuration();
-
-        configuration.set(MetricOptions.JOB_STATUS_METRICS, Arrays.asList(enabledMetrics));
-
-        return MetricOptions.JobStatusMetricsSettings.fromConfiguration(configuration);
-    }
-
-    private static Map<JobStatus, StatusMetricSet> extractMetrics(
-            InterceptingOperatorMetricGroup metrics) {
-        final Map<JobStatus, StatusMetricSet> extractedMetrics = new EnumMap<>(JobStatus.class);
-
-        for (JobStatus jobStatus : JobStatus.values()) {
-            final StatusMetricSet statusMetricSet =
-                    new StatusMetricSet(
-                            (Gauge<Long>)
-                                    metrics.get(JobStatusMetrics.getStateMetricName(jobStatus)),
-                            (Gauge<Long>)
-                                    metrics.get(
-                                            JobStatusMetrics.getCurrentTimeMetricName(jobStatus)),
-                            (Gauge<Long>)
-                                    metrics.get(
-                                            JobStatusMetrics.getTotalTimeMetricName(jobStatus)));
-            if (statusMetricSet.getState().isPresent()
-                    || statusMetricSet.getCurrentTime().isPresent()
-                    || statusMetricSet.getTotalTime().isPresent()) {
-                extractedMetrics.put(jobStatus, statusMetricSet);
-            }
-        }
-
-        return extractedMetrics;
-    }
-
-    private static class StatusMetricSet {
-
-        @Nullable private final Gauge<Long> state;
-        @Nullable private final Gauge<Long> currentTime;
-        @Nullable private final Gauge<Long> totalTime;
-
-        private StatusMetricSet(
-                @Nullable Gauge<Long> state,
-                @Nullable Gauge<Long> currentTime,
-                @Nullable Gauge<Long> totalTime) {
-            this.state = state;
-            this.currentTime = currentTime;
-            this.totalTime = totalTime;
-        }
-
-        @Nullable
-        public Optional<Gauge<Long>> getState() {
-            return Optional.ofNullable(state);
-        }
-
-        @Nullable
-        public Optional<Gauge<Long>> getCurrentTime() {
-            return Optional.ofNullable(currentTime);
-        }
-
-        @Nullable
-        public Optional<Gauge<Long>> getTotalTime() {
-            return Optional.ofNullable(totalTime);
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/metrics/JobStatusMetricsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/metrics/JobStatusMetricsTest.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.scheduler;
+package org.apache.flink.runtime.scheduler.metrics;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
@@ -39,12 +39,12 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class SchedulerBaseTest {
+class JobStatusMetricsTest {
 
     @Test
     void testStateMetric() {
-        final SchedulerBase.JobStatusMetrics jobStatusMetrics =
-                new SchedulerBase.JobStatusMetrics(
+        final JobStatusMetrics jobStatusMetrics =
+                new JobStatusMetrics(
                         new UnregisteredMetricsGroup(),
                         0L,
                         enable(
@@ -63,8 +63,8 @@ class SchedulerBaseTest {
 
     @Test
     void testCurrentTimeMetric() {
-        final SchedulerBase.JobStatusMetrics jobStatusMetrics =
-                new SchedulerBase.JobStatusMetrics(
+        final JobStatusMetrics jobStatusMetrics =
+                new JobStatusMetrics(
                         new UnregisteredMetricsGroup(),
                         0L,
                         enable(
@@ -86,8 +86,8 @@ class SchedulerBaseTest {
 
     @Test
     void testTotalTimeMetric() {
-        final SchedulerBase.JobStatusMetrics jobStatusMetrics =
-                new SchedulerBase.JobStatusMetrics(
+        final JobStatusMetrics jobStatusMetrics =
+                new JobStatusMetrics(
                         new UnregisteredMetricsGroup(),
                         0L,
                         enable(
@@ -123,9 +123,8 @@ class SchedulerBaseTest {
     void testStatusSelection() {
         final InterceptingOperatorMetricGroup metricGroup = new InterceptingOperatorMetricGroup();
 
-        final SchedulerBase.JobStatusMetrics jobStatusMetrics =
-                new SchedulerBase.JobStatusMetrics(
-                        metricGroup, 0L, enable(MetricOptions.JobStatusMetrics.STATE));
+        final JobStatusMetrics jobStatusMetrics =
+                new JobStatusMetrics(metricGroup, 0L, enable(MetricOptions.JobStatusMetrics.STATE));
         final Map<JobStatus, StatusMetricSet> registeredMetrics = extractMetrics(metricGroup);
 
         for (JobStatus value : JobStatus.values()) {
@@ -166,8 +165,8 @@ class SchedulerBaseTest {
 
         final InterceptingOperatorMetricGroup metricGroup = new InterceptingOperatorMetricGroup();
 
-        final SchedulerBase.JobStatusMetrics jobStatusMetrics =
-                new SchedulerBase.JobStatusMetrics(metricGroup, 1L, enable(selectedMetrics));
+        final JobStatusMetrics jobStatusMetrics =
+                new JobStatusMetrics(metricGroup, 1L, enable(selectedMetrics));
         final Map<JobStatus, StatusMetricSet> registeredMetrics = extractMetrics(metricGroup);
 
         for (StatusMetricSet metrics : registeredMetrics.values()) {
@@ -200,17 +199,13 @@ class SchedulerBaseTest {
             final StatusMetricSet statusMetricSet =
                     new StatusMetricSet(
                             (Gauge<Long>)
-                                    metrics.get(
-                                            SchedulerBase.JobStatusMetrics.getStateMetricName(
-                                                    jobStatus)),
+                                    metrics.get(JobStatusMetrics.getStateMetricName(jobStatus)),
                             (Gauge<Long>)
                                     metrics.get(
-                                            SchedulerBase.JobStatusMetrics.getCurrentTimeMetricName(
-                                                    jobStatus)),
+                                            JobStatusMetrics.getCurrentTimeMetricName(jobStatus)),
                             (Gauge<Long>)
                                     metrics.get(
-                                            SchedulerBase.JobStatusMetrics.getTotalTimeMetricName(
-                                                    jobStatus)));
+                                            JobStatusMetrics.getTotalTimeMetricName(jobStatus)));
             if (statusMetricSet.getState().isPresent()
                     || statusMetricSet.getCurrentTime().isPresent()
                     || statusMetricSet.getTotalTime().isPresent()) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/metrics/StateTimeMetricTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/metrics/StateTimeMetricTest.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.metrics;
+
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.MetricOptions;
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.runtime.metrics.util.InterceptingOperatorMetricGroup;
+
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nullable;
+
+import java.util.Arrays;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class StateTimeMetricTest {
+
+    @Test
+    void testEnableStateMetrics() {
+        testMetricSelection(MetricOptions.JobStatusMetrics.STATE);
+    }
+
+    @Test
+    void testEnableCurrentTimeMetrics() {
+        testMetricSelection(MetricOptions.JobStatusMetrics.CURRENT_TIME);
+    }
+
+    @Test
+    void testEnableTotalTimeMetrics() {
+        testMetricSelection(MetricOptions.JobStatusMetrics.TOTAL_TIME);
+    }
+
+    @Test
+    void testEnableMultipleMetrics() {
+        testMetricSelection(
+                MetricOptions.JobStatusMetrics.CURRENT_TIME,
+                MetricOptions.JobStatusMetrics.TOTAL_TIME);
+    }
+
+    private static void testMetricSelection(MetricOptions.JobStatusMetrics... selectedMetrics) {
+        final EnumSet<MetricOptions.JobStatusMetrics> selectedMetricsSet =
+                EnumSet.noneOf(MetricOptions.JobStatusMetrics.class);
+        Arrays.stream(selectedMetrics).forEach(selectedMetricsSet::add);
+
+        final InterceptingOperatorMetricGroup metricGroup = new InterceptingOperatorMetricGroup();
+
+        StateTimeMetric.register(
+                enable(selectedMetrics), metricGroup, new TestStateTimeMetric(), "test");
+        final Map<JobStatus, StatusMetricSet> registeredMetrics = extractMetrics(metricGroup);
+
+        for (StatusMetricSet metrics : registeredMetrics.values()) {
+            assertThat(metrics.getState().isPresent())
+                    .isEqualTo(selectedMetricsSet.contains(MetricOptions.JobStatusMetrics.STATE));
+            assertThat(metrics.getCurrentTime().isPresent())
+                    .isEqualTo(
+                            selectedMetricsSet.contains(
+                                    MetricOptions.JobStatusMetrics.CURRENT_TIME));
+            assertThat(metrics.getTotalTime().isPresent())
+                    .isEqualTo(
+                            selectedMetricsSet.contains(MetricOptions.JobStatusMetrics.TOTAL_TIME));
+        }
+    }
+
+    static MetricOptions.JobStatusMetricsSettings enable(
+            MetricOptions.JobStatusMetrics... enabledMetrics) {
+        final Configuration configuration = new Configuration();
+
+        configuration.set(MetricOptions.JOB_STATUS_METRICS, Arrays.asList(enabledMetrics));
+
+        return MetricOptions.JobStatusMetricsSettings.fromConfiguration(configuration);
+    }
+
+    static Map<JobStatus, StatusMetricSet> extractMetrics(InterceptingOperatorMetricGroup metrics) {
+        final Map<JobStatus, StatusMetricSet> extractedMetrics = new EnumMap<>(JobStatus.class);
+
+        for (JobStatus jobStatus : JobStatus.values()) {
+            final String baseMetricName = JobStatusMetrics.getBaseMetricName(jobStatus);
+            final StatusMetricSet statusMetricSet =
+                    new StatusMetricSet(
+                            (Gauge<Long>)
+                                    metrics.get(StateTimeMetric.getStateMetricName(baseMetricName)),
+                            (Gauge<Long>)
+                                    metrics.get(
+                                            StateTimeMetric.getCurrentTimeMetricName(
+                                                    baseMetricName)),
+                            (Gauge<Long>)
+                                    metrics.get(
+                                            StateTimeMetric.getTotalTimeMetricName(
+                                                    baseMetricName)));
+            if (statusMetricSet.getState().isPresent()
+                    || statusMetricSet.getCurrentTime().isPresent()
+                    || statusMetricSet.getTotalTime().isPresent()) {
+                extractedMetrics.put(jobStatus, statusMetricSet);
+            }
+        }
+
+        return extractedMetrics;
+    }
+
+    private static class TestStateTimeMetric implements StateTimeMetric {
+
+        @Override
+        public long getCurrentTime() {
+            return 2;
+        }
+
+        @Override
+        public long getTotalTime() {
+            return 3;
+        }
+
+        @Override
+        public long getBinary() {
+            return 1;
+        }
+    }
+
+    static class StatusMetricSet {
+
+        @Nullable private final Gauge<Long> state;
+        @Nullable private final Gauge<Long> currentTime;
+        @Nullable private final Gauge<Long> totalTime;
+
+        private StatusMetricSet(
+                @Nullable Gauge<Long> state,
+                @Nullable Gauge<Long> currentTime,
+                @Nullable Gauge<Long> totalTime) {
+            this.state = state;
+            this.currentTime = currentTime;
+            this.totalTime = totalTime;
+        }
+
+        @Nullable
+        public Optional<Gauge<Long>> getState() {
+            return Optional.ofNullable(state);
+        }
+
+        @Nullable
+        public Optional<Gauge<Long>> getCurrentTime() {
+            return Optional.ofNullable(currentTime);
+        }
+
+        @Nullable
+        public Optional<Gauge<Long>> getTotalTime() {
+            return Optional.ofNullable(totalTime);
+        }
+    }
+}


### PR DESCRIPTION
FLINK-23976 added standardized metrics for capturing how much time we spend in each JobStatus. However, certain states in practice consist of several stages; for example the RUNNING state also includes the deployment of tasks.

To get a better picture on where time is spent I propose to add new metrics that capture the deployingTime based on the execution states. This will additionally get us closer to a proper uptime metric, which ideally will be runningTime - various stage time metrics.

A job is considered to be deploying,

    for batch jobs, if no task is running and at least one task is being deployed
    for streaming jobs, if at least one task is being deployed

The semantics are different for batch/streaming jobs because they differ in terms of how they make progress. For a streaming job all tasks need to be deployed for checkpointing to make work. For batch jobs any deployed task immediately starts progressing the job.


I will add documentation later once we have agreed on the semantics.