### PR TITLE
[FLINK-25885] Suppress error reporting for ResourceManagerServiceImpl.deregisterApplication

### DIFF
--- a/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActor.java
+++ b/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActor.java
@@ -168,13 +168,13 @@ class AkkaRpcActor<T extends RpcEndpoint & RpcGateway> extends AbstractActor {
             log.info(
                     "The rpc endpoint {} has not been started yet. Discarding message {} until processing is started.",
                     rpcEndpoint.getClass().getName(),
-                    message.getClass().getName());
+                    message);
 
             sendErrorIfSender(
                     new AkkaRpcException(
                             String.format(
-                                    "Discard message, because the rpc endpoint %s has not been started yet.",
-                                    rpcEndpoint.getAddress())));
+                                    "Discard message %s, because the rpc endpoint %s has not been started yet.",
+                                    message, rpcEndpoint.getAddress())));
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/DispatcherResourceManagerComponent.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/DispatcherResourceManagerComponent.java
@@ -128,7 +128,17 @@ public class DispatcherResourceManagerComponent implements AutoCloseableAsync {
     public CompletableFuture<Void> stopApplication(
             final ApplicationStatus applicationStatus, final @Nullable String diagnostics) {
         return internalShutdown(
-                () -> resourceManagerService.deregisterApplication(applicationStatus, diagnostics));
+                () ->
+                        resourceManagerService
+                                .deregisterApplication(applicationStatus, diagnostics)
+                                // suppress deregister exception because of FLINK-25893
+                                .exceptionally(
+                                        exception -> {
+                                            LOG.warn(
+                                                    "Could not properly deregister the application.",
+                                                    exception);
+                                            return null;
+                                        }));
     }
 
     /**


### PR DESCRIPTION
This commit suppresses the error reporting for ResourceManagerServiceImpl.deregisterApplication
in order to harden the ClusterEntrypointTest.testWorkingDirectoryIsDeletedIfApplicationCompletes.
This is a temporary fix until FLINK-25893 has been fixed.