### PR TITLE
[FLINK-25847] Fix deadlock in DefaultMultipleComponentLeaderElectionService

### DIFF
--- a/flink-core/src/test/java/org/apache/flink/testutils/TestingUtils.java
+++ b/flink-core/src/test/java/org/apache/flink/testutils/TestingUtils.java
@@ -41,6 +41,12 @@ public class TestingUtils {
         return Time.milliseconds(Integer.MAX_VALUE);
     }
 
+    public static Duration infiniteDuration() {
+        // we cannot use Long.MAX_VALUE because the Duration stores it in nanosecond resolution and
+        // calculations will easily cause overflows --> 1 year should be long enough for "infinity"
+        return Duration.ofDays(365L);
+    }
+
     public static synchronized ScheduledExecutorService defaultExecutor() {
         if (sharedExecutorInstance == null || sharedExecutorInstance.isShutdown()) {
             sharedExecutorInstance = Executors.newSingleThreadScheduledExecutor();

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesMultipleComponentLeaderElectionDriver.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesMultipleComponentLeaderElectionDriver.java
@@ -105,6 +105,8 @@ public class KubernetesMultipleComponentLeaderElectionDriver
                         configMapName, new ConfigMapCallbackHandlerImpl(), watchExecutor);
 
         leaderElector.run();
+
+        LOG.debug("Starting the {} for config map {}.", getClass().getSimpleName(), configMapName);
     }
 
     @Override

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesHighAvailabilityRecoverFromSavepointITCase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesHighAvailabilityRecoverFromSavepointITCase.java
@@ -47,6 +47,7 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.apache.flink.testutils.TestingUtils;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.TestLogger;
@@ -102,12 +103,14 @@ public class KubernetesHighAvailabilityRecoverFromSavepointITCase extends TestLo
     @Test
     public void testRecoverFromSavepoint() throws Exception {
         final JobGraph jobGraph = createJobGraph();
-        clusterClient.submitJob(jobGraph).get(TIMEOUT, TimeUnit.MILLISECONDS);
+        clusterClient
+                .submitJob(jobGraph)
+                .get(TestingUtils.infiniteTime().toMilliseconds(), TimeUnit.MILLISECONDS);
 
         // Wait until all tasks running and getting a successful savepoint
         CommonTestUtils.waitUntilCondition(
                 () -> triggerSavepoint(clusterClient, jobGraph.getJobID(), savepointPath) != null,
-                Deadline.fromNow(Duration.ofMillis(TIMEOUT)),
+                Deadline.fromNow(TestingUtils.infiniteDuration()),
                 1000);
 
         // Trigger savepoint 2

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultMultipleComponentLeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultMultipleComponentLeaderElectionService.java
@@ -235,12 +235,17 @@ public class DefaultMultipleComponentLeaderElectionService
                     leaderElectionEventHandlers.get(componentId);
 
             if (leaderElectionEventHandler != null) {
-                leadershipOperationExecutor.execute(
-                        () ->
-                                leaderElectionEventHandler.onLeaderInformationChange(
-                                        leaderInformation));
+                sendLeaderInformationChange(leaderElectionEventHandler, leaderInformation);
             }
         }
+    }
+
+    @GuardedBy("lock")
+    private void sendLeaderInformationChange(
+            LeaderElectionEventHandler leaderElectionEventHandler,
+            LeaderInformation leaderInformation) {
+        leadershipOperationExecutor.execute(
+                () -> leaderElectionEventHandler.onLeaderInformationChange(leaderInformation));
     }
 
     @Override
@@ -264,13 +269,13 @@ public class DefaultMultipleComponentLeaderElectionService
                             leaderElectionEventHandlers.entrySet()) {
                 final String leaderName = leaderNameLeaderElectionEventHandlerPair.getKey();
                 if (leaderInformationByName.containsKey(leaderName)) {
-                    leaderNameLeaderElectionEventHandlerPair
-                            .getValue()
-                            .onLeaderInformationChange(leaderInformationByName.get(leaderName));
+                    sendLeaderInformationChange(
+                            leaderNameLeaderElectionEventHandlerPair.getValue(),
+                            leaderInformationByName.get(leaderName));
                 } else {
-                    leaderNameLeaderElectionEventHandlerPair
-                            .getValue()
-                            .onLeaderInformationChange(LeaderInformation.empty());
+                    sendLeaderInformationChange(
+                            leaderNameLeaderElectionEventHandlerPair.getValue(),
+                            LeaderInformation.empty());
                 }
             }
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/SessionDispatcherLeaderProcessTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/SessionDispatcherLeaderProcessTest.java
@@ -433,7 +433,7 @@ public class SessionDispatcherLeaderProcessTest {
             jobGraphStore.removeJobGraph(JOB_GRAPH.getJobID());
             dispatcherLeaderProcess.onRemovedJobGraph(JOB_GRAPH.getJobID());
 
-            assertThat(terminateJobFuture).isCompletedWithValue(JOB_GRAPH.getJobID());
+            assertThat(terminateJobFuture.get()).isEqualTo(JOB_GRAPH.getJobID());
         }
     }
 


### PR DESCRIPTION
The cause for the deadlock was that we called into the LeaderElectionEventListener
from under the lock of the DefaultMultipleComponentLeaderElectionService. That way
the lock could escape from this class. The problem has been solved by using the
leadershipOperationExecutor to call into the LeaderElectionEventListener.