### PR TITLE
[FLINK-25841][table] Expose plan via TableEnvironment.compilePlanSql/executePlan

### DIFF
--- a/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/TableCsvFormatITCase.java
+++ b/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/TableCsvFormatITCase.java
@@ -19,6 +19,7 @@
 package org.apache.flink.formats.csv;
 
 import org.apache.flink.formats.common.TimeFormats;
+import org.apache.flink.table.api.CompiledPlan;
 import org.apache.flink.table.planner.runtime.utils.TestData;
 import org.apache.flink.table.planner.utils.JavaScalaConversionUtil;
 import org.apache.flink.table.planner.utils.JsonPlanTestBase;
@@ -45,8 +46,9 @@ public class TableCsvFormatITCase extends JsonPlanTestBase {
         createSourceTable("MyTable", data, "a bigint", "b int not null", "c varchar");
         File sinkPath = createSinkTable("MySink", "a bigint", "c varchar");
 
-        String jsonPlan = tableEnv.getJsonPlan("insert into MySink select a, c from MyTable");
-        tableEnv.executeJsonPlan(jsonPlan).await();
+        CompiledPlan compiledPlan =
+                tableEnv.compilePlanSql("insert into MySink select a, c from MyTable");
+        tableEnv.executePlan(compiledPlan).await();
 
         assertResult(Arrays.asList("1,hi", "2,hello", "3,hello world"), sinkPath);
     }
@@ -65,8 +67,9 @@ public class TableCsvFormatITCase extends JsonPlanTestBase {
 
         File sinkPath = createSinkTable("MySink", "a bigint", "m varchar");
 
-        String jsonPlan = tableEnv.getJsonPlan("insert into MySink select a, m from MyTable");
-        tableEnv.executeJsonPlan(jsonPlan).await();
+        CompiledPlan compiledPlan =
+                tableEnv.compilePlanSql("insert into MySink select a, m from MyTable");
+        tableEnv.executePlan(compiledPlan).await();
 
         assertResult(Arrays.asList("1,Hi", "2,Hello", "3,Hello world"), sinkPath);
     }
@@ -77,9 +80,9 @@ public class TableCsvFormatITCase extends JsonPlanTestBase {
         createSourceTable("MyTable", data, "a bigint", "b int not null", "c varchar");
         File sinkPath = createSinkTable("MySink", "a bigint", "b int", "c varchar");
 
-        String jsonPlan =
-                tableEnv.getJsonPlan("insert into MySink select * from MyTable where a > 1");
-        tableEnv.executeJsonPlan(jsonPlan).await();
+        CompiledPlan compiledPlan =
+                tableEnv.compilePlanSql("insert into MySink select * from MyTable where a > 1");
+        tableEnv.executePlan(compiledPlan).await();
 
         assertResult(Arrays.asList("2,1,hello", "3,2,hello world"), sinkPath);
     }
@@ -98,9 +101,9 @@ public class TableCsvFormatITCase extends JsonPlanTestBase {
                 });
         File sinkPath = createSinkTable("MySink", "a int", "p bigint", "c varchar");
 
-        String jsonPlan =
-                tableEnv.getJsonPlan("insert into MySink select * from MyTable where p = 2");
-        tableEnv.executeJsonPlan(jsonPlan).await();
+        CompiledPlan compiledPlan =
+                tableEnv.compilePlanSql("insert into MySink select * from MyTable where p = 2");
+        tableEnv.executePlan(compiledPlan).await();
 
         assertResult(Arrays.asList("2,2,Hello", "3,2,Hello world"), sinkPath);
     }
@@ -125,9 +128,10 @@ public class TableCsvFormatITCase extends JsonPlanTestBase {
 
         File sinkPath = createSinkTable("MySink", "a int", "b bigint", "ts timestamp(3)");
 
-        String jsonPlan =
-                tableEnv.getJsonPlan("insert into MySink select a, b, ts from MyTable where b = 3");
-        tableEnv.executeJsonPlan(jsonPlan).await();
+        CompiledPlan compiledPlan =
+                tableEnv.compilePlanSql(
+                        "insert into MySink select a, b, ts from MyTable where b = 3");
+        tableEnv.executePlan(compiledPlan).await();
 
         assertResult(
                 Arrays.asList(
@@ -161,10 +165,10 @@ public class TableCsvFormatITCase extends JsonPlanTestBase {
 
         File sinkPath = createSinkTable("MySink", "a int", "ts timestamp(3)");
 
-        String jsonPlan =
-                tableEnv.getJsonPlan(
+        CompiledPlan compiledPlan =
+                tableEnv.compilePlanSql(
                         "insert into MySink select a, ts from MyTable where b = 3 and a > 4");
-        tableEnv.executeJsonPlan(jsonPlan).await();
+        tableEnv.executePlan(compiledPlan).await();
 
         assertResult(
                 Arrays.asList("5," + formatSqlTimestamp(5000L), "6," + formatSqlTimestamp(6000L)),

--- a/flink-python/pyflink/table/tests/test_environment_completeness.py
+++ b/flink-python/pyflink/table/tests/test_environment_completeness.py
@@ -39,7 +39,12 @@ class EnvironmentAPICompletenessTests(PythonAPICompletenessTestCase, PyFlinkTest
         return {
             'getCompletionHints',
             'fromValues',
-            'create'}
+            'create',
+            # See FLINK-25986
+            'loadPlan',
+            'compilePlanSql',
+            'executePlan',
+            'explainPlan'}
 
     @classmethod
     def java_method_name(cls, python_method_name):

--- a/flink-python/pyflink/table/tests/test_pandas_udaf.py
+++ b/flink-python/pyflink/table/tests/test_pandas_udaf.py
@@ -811,7 +811,7 @@ class StreamPandasUDAFITTests(PyFlinkStreamTableTestCase):
         self.t_env.create_temporary_system_function("mean_udaf", mean_udaf)
         self.t_env.create_temporary_system_function("max_add_min_udaf", max_add_min_udaf)
 
-        json_plan = self.t_env._j_tenv.getJsonPlan("""
+        json_plan = self.t_env._j_tenv.compilePlanSql("""
         insert into sink_table
             select a,
              mean_udaf(b)
@@ -823,7 +823,7 @@ class StreamPandasUDAFITTests(PyFlinkStreamTableTestCase):
             from source_table
         """)
         from py4j.java_gateway import get_method
-        get_method(self.t_env._j_tenv.executeJsonPlan(json_plan), "await")()
+        get_method(self.t_env._j_tenv.executePlan(json_plan), "await")()
 
         import glob
         lines = [line.strip() for file in glob.glob(sink_path + '/*') for line in open(file, 'r')]

--- a/flink-python/pyflink/table/tests/test_udaf.py
+++ b/flink-python/pyflink/table/tests/test_udaf.py
@@ -818,11 +818,11 @@ class StreamTableAggregateTests(PyFlinkStreamTableTestCase):
 
         self.t_env.create_temporary_function("my_sum", SumAggregateFunction())
 
-        json_plan = self.t_env._j_tenv.getJsonPlan("INSERT INTO sink_table "
-                                                   "SELECT a, my_sum(b) FROM source_table "
-                                                   "GROUP BY a")
+        json_plan = self.t_env._j_tenv.compilePlanSql("INSERT INTO sink_table "
+                                                      "SELECT a, my_sum(b) FROM source_table "
+                                                      "GROUP BY a")
         from py4j.java_gateway import get_method
-        get_method(self.t_env._j_tenv.executeJsonPlan(json_plan), "await")()
+        get_method(self.t_env._j_tenv.executePlan(json_plan), "await")()
 
     def test_execute_group_window_aggregate_from_json_plan(self):
         # create source file path
@@ -871,16 +871,18 @@ class StreamTableAggregateTests(PyFlinkStreamTableTestCase):
 
         self.t_env.create_temporary_function("my_count", CountAggregateFunction())
 
-        json_plan = self.t_env._j_tenv.getJsonPlan("INSERT INTO sink_table "
-                                                   "SELECT a, "
-                                                   "SESSION_START(rowtime, INTERVAL '30' MINUTE), "
-                                                   "SESSION_END(rowtime, INTERVAL '30' MINUTE), "
-                                                   "my_count(c) "
-                                                   "FROM source_table "
-                                                   "GROUP BY "
-                                                   "a, b, SESSION(rowtime, INTERVAL '30' MINUTE)")
+        json_plan = self.t_env._j_tenv.compilePlanSql("INSERT INTO sink_table "
+                                                      "SELECT a, "
+                                                      "SESSION_START("
+                                                      "rowtime, INTERVAL '30' MINUTE), "
+                                                      "SESSION_END(rowtime, INTERVAL '30' MINUTE), "
+                                                      "my_count(c) "
+                                                      "FROM source_table "
+                                                      "GROUP BY "
+                                                      "a, b, "
+                                                      "SESSION(rowtime, INTERVAL '30' MINUTE)")
         from py4j.java_gateway import get_method
-        get_method(self.t_env._j_tenv.executeJsonPlan(json_plan), "await")()
+        get_method(self.t_env._j_tenv.executePlan(json_plan), "await")()
 
         import glob
         lines = [line.strip() for file in glob.glob(sink_path + '/*') for line in open(file, 'r')]

--- a/flink-python/pyflink/table/tests/test_udf.py
+++ b/flink-python/pyflink/table/tests/test_udf.py
@@ -778,12 +778,12 @@ class PyFlinkStreamUserDefinedFunctionTests(UserDefinedFunctionTests,
         add_one = udf(lambda i: i + 1, result_type=DataTypes.BIGINT())
         self.t_env.create_temporary_system_function("add_one", add_one)
 
-        json_plan = self.t_env._j_tenv.getJsonPlan("INSERT INTO sink_table SELECT "
-                                                   "a, "
-                                                   "add_one(b) "
-                                                   "FROM source_table")
+        json_plan = self.t_env._j_tenv.compilePlanSql("INSERT INTO sink_table SELECT "
+                                                      "a, "
+                                                      "add_one(b) "
+                                                      "FROM source_table")
         from py4j.java_gateway import get_method
-        get_method(self.t_env._j_tenv.executeJsonPlan(json_plan), "await")()
+        get_method(self.t_env._j_tenv.executePlan(json_plan), "await")()
 
         import glob
         lines = [line.strip() for file in glob.glob(sink_path + '/*') for line in open(file, 'r')]

--- a/flink-python/pyflink/table/tests/test_udtf.py
+++ b/flink-python/pyflink/table/tests/test_udtf.py
@@ -110,13 +110,13 @@ class PyFlinkStreamUserDefinedFunctionTests(UserDefinedTableFunctionTests,
         self.t_env.create_temporary_system_function(
             "multi_emit", udtf(MultiEmit(), result_types=[DataTypes.BIGINT(), DataTypes.BIGINT()]))
 
-        json_plan = self.t_env._j_tenv.getJsonPlan("INSERT INTO sink_table "
-                                                   "SELECT a, x, y FROM source_table "
-                                                   "LEFT JOIN LATERAL TABLE(multi_emit(a, b))"
-                                                   " as T(x, y)"
-                                                   " ON TRUE")
+        json_plan = self.t_env._j_tenv.compilePlanSql("INSERT INTO sink_table "
+                                                      "SELECT a, x, y FROM source_table "
+                                                      "LEFT JOIN LATERAL TABLE(multi_emit(a, b))"
+                                                      " as T(x, y)"
+                                                      " ON TRUE")
         from py4j.java_gateway import get_method
-        get_method(self.t_env._j_tenv.executeJsonPlan(json_plan), "await")()
+        get_method(self.t_env._j_tenv.executePlan(json_plan), "await")()
 
         import glob
         lines = [line.strip() for file in glob.glob(sink_path + '/*') for line in open(file, 'r')]

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/CompiledPlan.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/CompiledPlan.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api;
+
+import org.apache.flink.annotation.Experimental;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * This interface represents a compiled plan that can be executed using {@link
+ * TableEnvironment#executePlan(CompiledPlan)}. A plan can be compiled starting from a SQL query
+ * using {@link TableEnvironment#compilePlanSql(String)} and can be loaded back from a file or a
+ * string using {@link TableEnvironment#loadPlan(PlanReference)}. A plan can be persisted using
+ * {@link #writeToFile(Path, boolean)} or by manually extracting the JSON representation with {@link
+ * #asJsonString()}.
+ */
+@Experimental
+public interface CompiledPlan {
+
+    /** Convert the plan to a JSON string representation. */
+    String asJsonString();
+
+    /** @see #writeToFile(Path) */
+    default void writeToFile(String path) throws IOException {
+        writeToFile(Paths.get(path));
+    }
+
+    /** @see #writeToFile(Path, boolean) */
+    default void writeToFile(String path, boolean ignoreIfExists) throws IOException {
+        writeToFile(Paths.get(path), ignoreIfExists);
+    }
+
+    /**
+     * Write this plan to a file using the JSON representation. This will not overwrite the file if
+     * it's already existing.
+     */
+    default void writeToFile(Path path) throws IOException {
+        writeToFile(path, true);
+    }
+
+    /** Write this plan to a file using the JSON representation. */
+    void writeToFile(Path path, boolean ignoreIfExists)
+            throws IOException, UnsupportedOperationException;
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/CompiledPlan.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/CompiledPlan.java
@@ -23,7 +23,6 @@ import org.apache.flink.annotation.Experimental;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.List;
 
 /**
  * This interface represents a compiled plan that can be executed using {@link
@@ -67,7 +66,4 @@ public interface CompiledPlan {
 
     /** Get the flink version used to compile the plan. */
     String getFlinkVersion();
-
-    /** This returns an ordered list of sink identifiers, if any. */
-    List<String> getSinkIdentifiers();
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/CompiledPlan.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/CompiledPlan.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.api;
 
 import org.apache.flink.annotation.Experimental;
+import org.apache.flink.table.api.config.TableConfigOptions;
 
 import java.io.File;
 import java.io.IOException;
@@ -26,12 +27,34 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 /**
- * This interface represents a compiled plan that can be executed using {@link
- * TableEnvironment#executePlan(CompiledPlan)}. A plan can be compiled starting from a SQL query
- * using {@link TableEnvironment#compilePlanSql(String)} and can be loaded back from a file or a
- * string using {@link TableEnvironment#loadPlan(PlanReference)}. A plan can be persisted using
- * {@link #writeToFile(Path, boolean)} or by manually extracting the JSON representation with {@link
- * #asJsonString()}.
+ * Represents a static, executable entity that has been compiled from a Table & SQL API pipeline
+ * definition.
+ *
+ * <p>Every new Flink version might introduce improved optimizer rules, more efficient operators,
+ * and other changes that impact the behavior of previously defined pipelines. In order to ensure
+ * backwards compatibility and enable stateful streaming job upgrades, compiled plans can be
+ * persisted and reloaded across Flink versions. A compiled plan encodes operators, expressions,
+ * functions, data types, and table connectors. See the website documentation for more information
+ * about provided guarantees during stateful pipeline upgrades.
+ *
+ * <p>A plan can be compiled from a SQL query using {@link TableEnvironment#compilePlanSql(String)}.
+ * It can be persisted using {@link #writeToFile(Path, boolean)} or by manually extracting the JSON
+ * representation with {@link #asJsonString()}. A plan can be loaded back from a file or a string
+ * using {@link TableEnvironment#loadPlan(PlanReference)}. Instances can be executed using {@link
+ * TableEnvironment#executePlan(CompiledPlan)}.
+ *
+ * <p>Depending on the configuration, permanent catalog metadata (such as information about tables
+ * and functions) will be persisted in the plan as well. Anonymous/inline objects will be persisted
+ * if possible or fail the compilation otherwise. Temporary objects are never part of a plan and
+ * need to be present during a restore.
+ *
+ * <p>Note: Plan restores assume a stable session context. Configuration, loaded modules and
+ * catalogs, and temporary objects must not change. Schema evolution and changes of function
+ * signatures are not supported.
+ *
+ * @see TableConfigOptions#PLAN_COMPILE_CATALOG_OBJECTS
+ * @see TableConfigOptions#PLAN_RESTORE_CATALOG_OBJECTS
+ * @see PlanReference
  */
 @Experimental
 public interface CompiledPlan {
@@ -63,19 +86,19 @@ public interface CompiledPlan {
     }
 
     /**
-     * Write this plan to a file using the JSON representation. This will not overwrite the file if
+     * Writes this plan to a file using the JSON representation. This will not overwrite the file if
      * it's already existing.
      */
     default void writeToFile(File file) throws IOException {
         writeToFile(file, true);
     }
 
-    /** Write this plan to a file using the JSON representation. */
+    /** Writes this plan to a file using the JSON representation. */
     void writeToFile(File file, boolean ignoreIfExists)
             throws IOException, UnsupportedOperationException;
 
     // --- Accessors
 
-    /** Get the flink version used to compile the plan. */
+    /** Returns the Flink version used to compile the plan. */
     String getFlinkVersion();
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/CompiledPlan.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/CompiledPlan.java
@@ -23,6 +23,7 @@ import org.apache.flink.annotation.Experimental;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 
 /**
  * This interface represents a compiled plan that can be executed using {@link
@@ -34,6 +35,8 @@ import java.nio.file.Paths;
  */
 @Experimental
 public interface CompiledPlan {
+
+    // --- Writer methods
 
     /** Convert the plan to a JSON string representation. */
     String asJsonString();
@@ -59,4 +62,12 @@ public interface CompiledPlan {
     /** Write this plan to a file using the JSON representation. */
     void writeToFile(Path path, boolean ignoreIfExists)
             throws IOException, UnsupportedOperationException;
+
+    // --- Accessors
+
+    /** Get the flink version used to compile the plan. */
+    String getFlinkVersion();
+
+    /** This returns an ordered list of sink identifiers, if any. */
+    List<String> getSinkIdentifiers();
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/CompiledPlan.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/CompiledPlan.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.api;
 
 import org.apache.flink.annotation.Experimental;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -40,26 +41,37 @@ public interface CompiledPlan {
     /** Convert the plan to a JSON string representation. */
     String asJsonString();
 
-    /** @see #writeToFile(Path) */
+    /** @see #writeToFile(File) */
     default void writeToFile(String path) throws IOException {
         writeToFile(Paths.get(path));
     }
 
-    /** @see #writeToFile(Path, boolean) */
+    /** @see #writeToFile(File, boolean) */
     default void writeToFile(String path, boolean ignoreIfExists) throws IOException {
         writeToFile(Paths.get(path), ignoreIfExists);
+    }
+
+    /** @see #writeToFile(File) */
+    default void writeToFile(Path path) throws IOException {
+        writeToFile(path.toFile());
+    }
+
+    /** @see #writeToFile(File, boolean) */
+    default void writeToFile(Path path, boolean ignoreIfExists)
+            throws IOException, UnsupportedOperationException {
+        writeToFile(path.toFile(), ignoreIfExists);
     }
 
     /**
      * Write this plan to a file using the JSON representation. This will not overwrite the file if
      * it's already existing.
      */
-    default void writeToFile(Path path) throws IOException {
-        writeToFile(path, true);
+    default void writeToFile(File file) throws IOException {
+        writeToFile(file, true);
     }
 
     /** Write this plan to a file using the JSON representation. */
-    void writeToFile(Path path, boolean ignoreIfExists)
+    void writeToFile(File file, boolean ignoreIfExists)
             throws IOException, UnsupportedOperationException;
 
     // --- Accessors

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/PlanReference.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/PlanReference.java
@@ -26,9 +26,16 @@ import java.nio.file.Paths;
 import java.util.Objects;
 
 /**
- * Pointer to a persisted plan. You can load the content of this reference into a {@link
- * CompiledPlan} using {@link TableEnvironment#loadPlan(PlanReference)} or you can directly execute
- * it with {@link TableEnvironment#executePlan(PlanReference)}.
+ * Unresolved pointer to a persisted plan.
+ *
+ * <p>A plan represents a static, executable entity that has been compiled from a Table & SQL API
+ * pipeline definition.
+ *
+ * <p>You can load the content of this reference into a {@link CompiledPlan} using {@link
+ * TableEnvironment#loadPlan(PlanReference)}, or you can directly load and execute it with {@link
+ * TableEnvironment#executePlan(PlanReference)}.
+ *
+ * @see CompiledPlan
  */
 @Experimental
 public abstract class PlanReference {

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/PlanReference.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/PlanReference.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api;
+
+import org.apache.flink.annotation.Experimental;
+
+import javax.annotation.Nullable;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Optional;
+
+/**
+ * Pointer to a persisted plan. You can load the content of this reference into a {@link
+ * CompiledPlan} using {@link TableEnvironment#loadPlan(PlanReference)} or you can directly execute
+ * it with {@link TableEnvironment#executePlan(PlanReference)}.
+ */
+@Experimental
+public final class PlanReference {
+
+    private final @Nullable File file;
+    private final @Nullable String content;
+
+    private PlanReference(@Nullable File file, @Nullable String content) {
+        this.file = file;
+        this.content = content;
+    }
+
+    /** @see #fromFile(File) */
+    public static PlanReference fromFile(String path) {
+        return fromFile(Paths.get(path).toFile());
+    }
+
+    /** @see #fromFile(File) */
+    public static PlanReference fromFile(Path path) {
+        return fromFile(path.toFile());
+    }
+
+    /** Create a reference starting from a file path. */
+    public static PlanReference fromFile(File file) {
+        return new PlanReference(file, null);
+    }
+
+    /** Create a reference starting from a JSON string. */
+    public static PlanReference fromJsonString(String jsonString) {
+        return new PlanReference(null, jsonString);
+    }
+
+    public Optional<File> getFile() {
+        return Optional.ofNullable(file);
+    }
+
+    public Optional<String> getContent() {
+        return Optional.ofNullable(content);
+    }
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/PlanReference.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/PlanReference.java
@@ -37,21 +37,25 @@ public abstract class PlanReference {
 
     /** @see #fromFile(File) */
     public static PlanReference fromFile(String path) {
+        Objects.requireNonNull(path, "Path cannot be null");
         return fromFile(Paths.get(path).toFile());
     }
 
     /** @see #fromFile(File) */
     public static PlanReference fromFile(Path path) {
+        Objects.requireNonNull(path, "Path cannot be null");
         return fromFile(path.toFile());
     }
 
     /** Create a reference starting from a file path. */
     public static PlanReference fromFile(File file) {
+        Objects.requireNonNull(file, "File cannot be null");
         return new FilePlanReference(file);
     }
 
     /** Create a reference starting from a JSON string. */
     public static PlanReference fromJsonString(String jsonString) {
+        Objects.requireNonNull(jsonString, "Json string cannot be null");
         return new ContentPlanReference(jsonString);
     }
 
@@ -60,11 +64,14 @@ public abstract class PlanReference {
      * Thread.currentThread().getContextClassLoader()} as {@link ClassLoader}.
      */
     public static PlanReference fromResource(String resourcePath) {
+        Objects.requireNonNull(resourcePath, "Resource path cannot be null");
         return fromResource(Thread.currentThread().getContextClassLoader(), resourcePath);
     }
 
     /** Create a reference from a file in the classpath. */
     public static PlanReference fromResource(ClassLoader classLoader, String resourcePath) {
+        Objects.requireNonNull(classLoader, "ClassLoader cannot be null");
+        Objects.requireNonNull(resourcePath, "Resource path cannot be null");
         return new ResourcePlanReference(classLoader, resourcePath);
     }
 
@@ -109,7 +116,7 @@ public abstract class PlanReference {
 
         private final String content;
 
-        public ContentPlanReference(String content) {
+        private ContentPlanReference(String content) {
             this.content = content;
         }
 
@@ -136,7 +143,7 @@ public abstract class PlanReference {
 
         @Override
         public String toString() {
-            return "Plan '" + content + "'";
+            return "Plan:\n" + content;
         }
     }
 
@@ -146,7 +153,7 @@ public abstract class PlanReference {
         private final ClassLoader classLoader;
         private final String resourcePath;
 
-        public ResourcePlanReference(ClassLoader classLoader, String resourcePath) {
+        private ResourcePlanReference(ClassLoader classLoader, String resourcePath) {
             this.classLoader = classLoader;
             this.resourcePath =
                     resourcePath.startsWith("/") ? resourcePath.substring(1) : resourcePath;

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
@@ -1258,22 +1258,44 @@ public interface TableEnvironment {
     // --- Plan compilation and restore
 
     /**
-     * Load a plan starting from a {@link PlanReference} into a {@link CompiledPlan}. This will
-     * parse the input reference and will validate the plan.
+     * Loads a plan from a {@link PlanReference} into a {@link CompiledPlan}.
+     *
+     * <p>Compiled plans can be persisted and reloaded across Flink versions. They describe static
+     * pipelines to ensure backwards compatibility and enable stateful streaming job upgrades. See
+     * {@link CompiledPlan} and the website documentation for more information.
+     *
+     * <p>This method will parse the input reference and will validate the plan. The returned
+     * instance can be executed via {@link #executePlan(CompiledPlan)}.
      */
     @Experimental
     CompiledPlan loadPlan(PlanReference planReference) throws IOException, TableException;
 
     /**
-     * Compile a SQL DML statement in a {@link CompiledPlan}. Only {@code INSERT INTO} is supported
-     * at the moment.
+     * Compiles a SQL DML statement into a {@link CompiledPlan}.
+     *
+     * <p>Compiled plans can be persisted and reloaded across Flink versions. They describe static
+     * pipelines to ensure backwards compatibility and enable stateful streaming job upgrades. See
+     * {@link CompiledPlan} and the website documentation for more information.
+     *
+     * <p>Note: Only {@code INSERT INTO} is supported at the moment.
+     *
+     * @see #executePlan(CompiledPlan)
+     * @see #loadPlan(PlanReference)
      */
     @Experimental
     CompiledPlan compilePlanSql(String stmt);
 
     /**
-     * Execute the provided {@link CompiledPlan}. This will eventually resume the execution if a
-     * previous savepoint is already existing for this job.
+     * Executes the provided {@link CompiledPlan}.
+     *
+     * <p>Compiled plans can be persisted and reloaded across Flink versions. They describe static
+     * pipelines to ensure backwards compatibility and enable stateful streaming job upgrades. See
+     * {@link CompiledPlan} and the website documentation for more information.
+     *
+     * <p>If a job is resumed from a savepoint, it will eventually resume the execution.
+     *
+     * @see #compilePlanSql(String)
+     * @see #loadPlan(PlanReference)
      */
     @Experimental
     TableResult executePlan(CompiledPlan plan);
@@ -1287,6 +1309,13 @@ public interface TableEnvironment {
     /**
      * Returns the AST of the specified statement and the execution plan to compute the result of
      * the given statement.
+     *
+     * <p>Compiled plans can be persisted and reloaded across Flink versions. They describe static
+     * pipelines to ensure backwards compatibility and enable stateful streaming job upgrades. See
+     * {@link CompiledPlan} and the website documentation for more information.
+     *
+     * @see #loadPlan(PlanReference)
+     * @see #compilePlanSql(String)
      */
     @Experimental
     String explainPlan(CompiledPlan compiledPlan, ExplainDetail... extraDetails);

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.api;
 
+import org.apache.flink.annotation.Experimental;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.configuration.Configuration;
@@ -34,6 +35,7 @@ import org.apache.flink.table.sinks.TableSink;
 import org.apache.flink.table.sources.TableSource;
 import org.apache.flink.table.types.AbstractDataType;
 
+import java.io.IOException;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Optional;
@@ -1252,4 +1254,52 @@ public interface TableEnvironment {
      * as one job.
      */
     StatementSet createStatementSet();
+
+    // FLIP-190 methods. They're considered experimental and might change in future versions
+
+    /**
+     * Load a plan starting from a {@link PlanReference} into a {@link CompiledPlan}. This will
+     * parse the input reference and will validate the plan.
+     *
+     * <p><b>Note:</b> This API is <b>experimental</b> and subject to change in future releases.
+     */
+    @Experimental
+    CompiledPlan loadPlan(PlanReference planReference) throws IOException, TableException;
+
+    /**
+     * Compile a SQL DML statement in a {@link CompiledPlan}. Only {@code INSERT INTO} is supported
+     * at the moment.
+     *
+     * <p><b>Note:</b> This API is <b>experimental</b> and subject to change in future releases.
+     */
+    @Experimental
+    CompiledPlan compilePlanSql(String stmt);
+
+    /**
+     * Execute the provided {@link CompiledPlan}. This will eventually resume the execution if a
+     * previous savepoint is already existing for this job.
+     *
+     * <p><b>Note:</b> This API is <b>experimental</b> and subject to change in future releases.
+     */
+    @Experimental
+    TableResult executePlan(CompiledPlan plan);
+
+    /**
+     * Shorthand for {@code tEnv.executePlan(tEnv.loadPlan(planReference))}.
+     *
+     * <p><b>Note:</b> This API is <b>experimental</b> and subject to change in future releases.
+     */
+    @Experimental
+    default TableResult executePlan(PlanReference planReference) throws IOException {
+        return executePlan(loadPlan(planReference));
+    }
+
+    /**
+     * Returns the AST of the specified statement and the execution plan to compute the result of
+     * the given statement.
+     *
+     * <p><b>Note:</b> This API is <b>experimental</b> and subject to change in future releases.
+     */
+    @Experimental
+    String explainPlan(CompiledPlan compiledPlan, ExplainDetail... extraDetails);
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
@@ -1255,13 +1255,11 @@ public interface TableEnvironment {
      */
     StatementSet createStatementSet();
 
-    // FLIP-190 methods. They're considered experimental and might change in future versions
+    // --- Plan compilation and restore
 
     /**
      * Load a plan starting from a {@link PlanReference} into a {@link CompiledPlan}. This will
      * parse the input reference and will validate the plan.
-     *
-     * <p><b>Note:</b> This API is <b>experimental</b> and subject to change in future releases.
      */
     @Experimental
     CompiledPlan loadPlan(PlanReference planReference) throws IOException, TableException;
@@ -1269,8 +1267,6 @@ public interface TableEnvironment {
     /**
      * Compile a SQL DML statement in a {@link CompiledPlan}. Only {@code INSERT INTO} is supported
      * at the moment.
-     *
-     * <p><b>Note:</b> This API is <b>experimental</b> and subject to change in future releases.
      */
     @Experimental
     CompiledPlan compilePlanSql(String stmt);
@@ -1278,17 +1274,11 @@ public interface TableEnvironment {
     /**
      * Execute the provided {@link CompiledPlan}. This will eventually resume the execution if a
      * previous savepoint is already existing for this job.
-     *
-     * <p><b>Note:</b> This API is <b>experimental</b> and subject to change in future releases.
      */
     @Experimental
     TableResult executePlan(CompiledPlan plan);
 
-    /**
-     * Shorthand for {@code tEnv.executePlan(tEnv.loadPlan(planReference))}.
-     *
-     * <p><b>Note:</b> This API is <b>experimental</b> and subject to change in future releases.
-     */
+    /** Shorthand for {@code tEnv.executePlan(tEnv.loadPlan(planReference))}. */
     @Experimental
     default TableResult executePlan(PlanReference planReference) throws IOException {
         return executePlan(loadPlan(planReference));
@@ -1297,8 +1287,6 @@ public interface TableEnvironment {
     /**
      * Returns the AST of the specified statement and the execution plan to compute the result of
      * the given statement.
-     *
-     * <p><b>Note:</b> This API is <b>experimental</b> and subject to change in future releases.
      */
     @Experimental
     String explainPlan(CompiledPlan compiledPlan, ExplainDetail... extraDetails);

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/CompiledPlanInternal.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/CompiledPlanInternal.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api.internal;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.CompiledPlan;
+
+import java.util.List;
+
+/**
+ * Internal interface of {@link CompiledPlan} containing methods used by {@link
+ * TableEnvironmentInternal} implementation.
+ */
+@Internal
+public interface CompiledPlanInternal extends CompiledPlan {
+
+    /** This returns an ordered list of sink identifiers, if any. */
+    List<String> getSinkIdentifiers();
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/StatementSetImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/StatementSetImpl.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.api.internal;
 
 import org.apache.flink.annotation.Experimental;
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.CompiledPlan;
 import org.apache.flink.table.api.ExplainDetail;
 import org.apache.flink.table.api.StatementSet;
 import org.apache.flink.table.api.Table;
@@ -142,21 +143,17 @@ public class StatementSetImpl<E extends TableEnvironmentInternal> implements Sta
     }
 
     /**
-     * Get the json plan of the all statements and Tables as a batch.
-     *
-     * <p>The json plan is the string json representation of an optimized ExecNode plan for the
-     * statements and Tables. An ExecNode plan can be serialized to json plan, and a json plan can
-     * be deserialized to an ExecNode plan.
+     * Get the {@link CompiledPlan} of the all statements and Tables as a batch.
      *
      * <p>The added statements and Tables will NOT be cleared when executing this method.
      *
-     * <p><b>NOTES</b>: This is an experimental feature now.
+     * <p><b>Note:</b> This API is <b>experimental</b> and subject to change in future releases.
      *
      * @return the string json representation of an optimized ExecNode plan for the statements and
      *     Tables.
      */
     @Experimental
-    public String getJsonPlan() {
-        return tableEnvironment.getJsonPlan(operations);
+    public CompiledPlan compilePlan() {
+        return tableEnvironment.compilePlan(operations);
     }
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -779,7 +779,7 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
         List<String> sinkIdentifierNames = new ArrayList<>();
         for (int i = 0; i < transformations.size(); ++i) {
             // TODO serialize the sink table names to json plan ?
-            sinkIdentifierNames.add("sink" + i);
+            sinkIdentifierNames.add(transformations.get(i).getName());
         }
         return executeInternal(transformations, sinkIdentifierNames);
     }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -759,7 +759,7 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
 
     @Override
     public CompiledPlan loadPlan(PlanReference planReference) throws IOException {
-        return planner.load(planReference);
+        return planner.loadPlan(planReference);
     }
 
     @Override
@@ -770,12 +770,12 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
             throw new TableException(UNSUPPORTED_QUERY_IN_COMPILE_PLAN_SQL_MSG);
         }
 
-        return planner.compile(Collections.singletonList((ModifyOperation) operations.get(0)));
+        return planner.compilePlan(Collections.singletonList((ModifyOperation) operations.get(0)));
     }
 
     @Override
     public TableResult executePlan(CompiledPlan plan) {
-        List<Transformation<?>> transformations = planner.translate(plan);
+        List<Transformation<?>> transformations = planner.translatePlan(plan);
         List<String> sinkIdentifierNames = new ArrayList<>();
         for (int i = 0; i < transformations.size(); ++i) {
             // TODO serialize the sink table names to json plan ?
@@ -786,7 +786,7 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
 
     @Override
     public CompiledPlan compilePlan(List<ModifyOperation> operations) {
-        return planner.compile(operations);
+        return planner.compilePlan(operations);
     }
 
     @Override
@@ -1898,6 +1898,6 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
 
     @Override
     public String explainPlan(CompiledPlan compiledPlan, ExplainDetail... extraDetails) {
-        return planner.explain(compiledPlan, extraDetails);
+        return planner.explainPlan(compiledPlan, extraDetails);
     }
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -775,9 +775,10 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
 
     @Override
     public TableResult executePlan(CompiledPlan plan) {
-        List<Transformation<?>> transformations = planner.translatePlan(plan);
+        CompiledPlanInternal planInternal = (CompiledPlanInternal) plan;
+        List<Transformation<?>> transformations = planner.translatePlan(planInternal);
         List<String> sinkIdentifierNames =
-                deduplicateSinkIdentifierNames(plan.getSinkIdentifiers());
+                deduplicateSinkIdentifierNames(planInternal.getSinkIdentifiers());
         return executeInternal(transformations, sinkIdentifierNames);
     }
 
@@ -1904,6 +1905,6 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
 
     @Override
     public String explainPlan(CompiledPlan compiledPlan, ExplainDetail... extraDetails) {
-        return planner.explainPlan(compiledPlan, extraDetails);
+        return planner.explainPlan((CompiledPlanInternal) compiledPlan, extraDetails);
     }
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -785,6 +785,11 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
     }
 
     @Override
+    public CompiledPlan compilePlan(List<ModifyOperation> operations) {
+        return planner.compile(operations);
+    }
+
+    @Override
     public TableResultInternal executeInternal(List<ModifyOperation> operations) {
         List<Transformation<?>> transformations = translate(operations);
         List<String> sinkIdentifierNames = extractSinkIdentifierNames(operations);
@@ -1889,44 +1894,6 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
                 tableOperation,
                 operationTreeBuilder,
                 functionCatalog.asLookup(getParser()::parseIdentifier));
-    }
-
-    @Override
-    public String getJsonPlan(String stmt) {
-        List<Operation> operations = getParser().parse(stmt);
-        if (operations.size() != 1) {
-            throw new TableException(
-                    "Unsupported SQL query! getJsonPlan() only accepts a single INSERT statement.");
-        }
-        Operation operation = operations.get(0);
-        List<ModifyOperation> modifyOperations = new ArrayList<>(1);
-        if (operation instanceof ModifyOperation) {
-            modifyOperations.add((ModifyOperation) operation);
-        } else {
-            throw new TableException("Only INSERT is supported now.");
-        }
-        return getJsonPlan(modifyOperations);
-    }
-
-    @Override
-    public String getJsonPlan(List<ModifyOperation> operations) {
-        return planner.getJsonPlan(operations);
-    }
-
-    @Override
-    public String explainJsonPlan(String jsonPlan, ExplainDetail... extraDetails) {
-        return planner.explainJsonPlan(jsonPlan, extraDetails);
-    }
-
-    @Override
-    public TableResult executeJsonPlan(String jsonPlan) {
-        List<Transformation<?>> transformations = planner.translateJsonPlan(jsonPlan);
-        List<String> sinkIdentifierNames = new ArrayList<>();
-        for (int i = 0; i < transformations.size(); ++i) {
-            // TODO serialize the sink table names to json plan ?
-            sinkIdentifierNames.add("sink" + i);
-        }
-        return executeInternal(transformations, sinkIdentifierNames);
     }
 
     @Override

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentInternal.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentInternal.java
@@ -20,8 +20,11 @@ package org.apache.flink.table.api.internal;
 
 import org.apache.flink.annotation.Experimental;
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.CompiledPlan;
 import org.apache.flink.table.api.ExplainDetail;
+import org.apache.flink.table.api.PlanReference;
 import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.catalog.CatalogManager;
 import org.apache.flink.table.delegation.Parser;
@@ -32,6 +35,7 @@ import org.apache.flink.table.operations.utils.OperationTreeBuilder;
 import org.apache.flink.table.sinks.TableSink;
 import org.apache.flink.table.sources.TableSource;
 
+import java.io.IOException;
 import java.util.List;
 
 /**
@@ -110,59 +114,45 @@ public interface TableEnvironmentInternal extends TableEnvironment {
      */
     void registerTableSinkInternal(String name, TableSink<?> configuredSink);
 
-    /**
-     * Get the json plan for the given statement.
-     *
-     * <p>The statement can only be DML.
-     *
-     * <p>The json plan is the string json representation of an optimized ExecNode plan for the
-     * given statement. An ExecNode plan can be serialized to json plan, and a json plan can be
-     * deserialized to an ExecNode plan.
-     *
-     * <p><b>NOTES</b>: This is an experimental feature now.
-     *
-     * @param stmt The SQL statement to generate json plan.
-     * @return the string json representation of an optimized ExecNode plan for the given statement.
-     */
+    /** @deprecated This has been replaced by {@link #compilePlanSql(String)}. */
     @Experimental
-    String getJsonPlan(String stmt);
+    @Deprecated
+    default String getJsonPlan(String stmt) {
+        return compilePlanSql(stmt).asJsonString();
+    }
+
+    /** @deprecated This has been replaced by {@link #compilePlan(List)}. */
+    @Experimental
+    @Deprecated
+    default String getJsonPlan(List<ModifyOperation> operations) {
+        return compilePlan(operations).asJsonString();
+    }
 
     /**
-     * Get the json plan for the given {@link ModifyOperation}s. see {@link #getJsonPlan(String)}
-     * for more info about json plan.
-     *
-     * <p><b>NOTES</b>: This is an experimental feature now.
-     *
-     * @param operations the {@link ModifyOperation}s to generate json plan.
-     * @return the string json representation of an optimized ExecNode plan for the given
-     *     operations.
+     * @deprecated This has been replaced by {@link #explainPlan(CompiledPlan, ExplainDetail...)}.
      */
     @Experimental
-    String getJsonPlan(List<ModifyOperation> operations);
+    @Deprecated
+    default String explainJsonPlan(String jsonPlan, ExplainDetail... extraDetails) {
+        return explainPlan(compilePlanSql(jsonPlan), extraDetails);
+    }
+
+    /** @deprecated This has been replaced by {@link #executePlan(PlanReference)}. */
+    @Experimental
+    @Deprecated
+    default TableResult executeJsonPlan(String jsonPlan) {
+        try {
+            return executePlan(PlanReference.fromJsonString(jsonPlan));
+        } catch (IOException e) {
+            throw new TableException("Error while trying to execute json plan", e);
+        }
+    }
 
     /**
-     * Returns the execution plan for the given json plan. A SQL statement can be converted to json
-     * plan through {@link #getJsonPlan(String)}.
+     * Compile a plan staring from a list of operations.
      *
-     * <p><b>NOTES</b>: This is an experimental feature now.
-     *
-     * @param jsonPlan The json plan to be explained.
-     * @param extraDetails The extra explain details which the explain result should include, e.g.
-     *     estimated cost, changelog mode for streaming
-     * @return the execution plan.
+     * <p><b>Note:</b> This API is <b>experimental</b> and subject to change in future releases.
      */
     @Experimental
-    String explainJsonPlan(String jsonPlan, ExplainDetail... extraDetails);
-
-    /**
-     * Execute the given json plan, and return the execution result. A SQL statement can be
-     * converted to json plan through {@link #getJsonPlan(String)}.
-     *
-     * <p><b>NOTES</b>: This is an experimental feature now.
-     *
-     * @param jsonPlan The json plan to be executed.
-     * @return the affected row count for `DML` (-1 means unknown).
-     */
-    @Experimental
-    TableResult executeJsonPlan(String jsonPlan);
+    CompiledPlan compilePlan(List<ModifyOperation> operations);
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentInternal.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentInternal.java
@@ -22,10 +22,7 @@ import org.apache.flink.annotation.Experimental;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.api.CompiledPlan;
 import org.apache.flink.table.api.ExplainDetail;
-import org.apache.flink.table.api.PlanReference;
 import org.apache.flink.table.api.TableEnvironment;
-import org.apache.flink.table.api.TableException;
-import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.catalog.CatalogManager;
 import org.apache.flink.table.delegation.Parser;
 import org.apache.flink.table.operations.ModifyOperation;
@@ -35,7 +32,6 @@ import org.apache.flink.table.operations.utils.OperationTreeBuilder;
 import org.apache.flink.table.sinks.TableSink;
 import org.apache.flink.table.sources.TableSource;
 
-import java.io.IOException;
 import java.util.List;
 
 /**
@@ -113,40 +109,6 @@ public interface TableEnvironmentInternal extends TableEnvironment {
      * @param configuredSink The configured {@link TableSink} to register.
      */
     void registerTableSinkInternal(String name, TableSink<?> configuredSink);
-
-    /** @deprecated This has been replaced by {@link #compilePlanSql(String)}. */
-    @Experimental
-    @Deprecated
-    default String getJsonPlan(String stmt) {
-        return compilePlanSql(stmt).asJsonString();
-    }
-
-    /** @deprecated This has been replaced by {@link #compilePlan(List)}. */
-    @Experimental
-    @Deprecated
-    default String getJsonPlan(List<ModifyOperation> operations) {
-        return compilePlan(operations).asJsonString();
-    }
-
-    /**
-     * @deprecated This has been replaced by {@link #explainPlan(CompiledPlan, ExplainDetail...)}.
-     */
-    @Experimental
-    @Deprecated
-    default String explainJsonPlan(String jsonPlan, ExplainDetail... extraDetails) {
-        return explainPlan(compilePlanSql(jsonPlan), extraDetails);
-    }
-
-    /** @deprecated This has been replaced by {@link #executePlan(PlanReference)}. */
-    @Experimental
-    @Deprecated
-    default TableResult executeJsonPlan(String jsonPlan) {
-        try {
-            return executePlan(PlanReference.fromJsonString(jsonPlan));
-        } catch (IOException e) {
-            throw new TableException("Error while trying to execute json plan", e);
-        }
-    }
 
     /**
      * Compile a plan staring from a list of operations.

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/delegation/Planner.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/delegation/Planner.java
@@ -21,11 +21,14 @@ package org.apache.flink.table.delegation;
 import org.apache.flink.annotation.Experimental;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.table.api.CompiledPlan;
 import org.apache.flink.table.api.ExplainDetail;
+import org.apache.flink.table.api.PlanReference;
 import org.apache.flink.table.operations.ModifyOperation;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.QueryOperation;
 
+import java.io.IOException;
 import java.util.List;
 
 /**
@@ -129,4 +132,18 @@ public interface Planner {
      */
     @Experimental
     List<Transformation<?>> translateJsonPlan(String jsonPlan);
+
+    // FLIP-190 methods
+
+    @Experimental
+    CompiledPlan load(PlanReference planReference) throws IOException;
+
+    @Experimental
+    CompiledPlan compile(List<ModifyOperation> modifyOperations);
+
+    @Experimental
+    List<Transformation<?>> translate(CompiledPlan plan);
+
+    @Experimental
+    String explain(CompiledPlan plan, ExplainDetail... extraDetails);
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/delegation/Planner.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/delegation/Planner.java
@@ -89,17 +89,17 @@ public interface Planner {
      */
     String explain(List<Operation> operations, ExplainDetail... extraDetails);
 
-    // FLIP-190 methods
+    // --- Plan compilation and restore
 
     @Experimental
-    CompiledPlan load(PlanReference planReference) throws IOException;
+    CompiledPlan loadPlan(PlanReference planReference) throws IOException;
 
     @Experimental
-    CompiledPlan compile(List<ModifyOperation> modifyOperations);
+    CompiledPlan compilePlan(List<ModifyOperation> modifyOperations);
 
     @Experimental
-    List<Transformation<?>> translate(CompiledPlan plan);
+    List<Transformation<?>> translatePlan(CompiledPlan plan);
 
     @Experimental
-    String explain(CompiledPlan plan, ExplainDetail... extraDetails);
+    String explainPlan(CompiledPlan plan, ExplainDetail... extraDetails);
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/delegation/Planner.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/delegation/Planner.java
@@ -89,50 +89,6 @@ public interface Planner {
      */
     String explain(List<Operation> operations, ExplainDetail... extraDetails);
 
-    /**
-     * Get the json plan of the given {@link ModifyOperation}s.
-     *
-     * <p>The json plan is the string json representation of an optimized ExecNode plan for the
-     * given statement. An ExecNode plan can be serialized to json plan, and a json plan can be
-     * deserialized to an ExecNode plan.
-     *
-     * <p><b>NOTES:</b>: This is an experimental feature now.
-     *
-     * @param modifyOperations the {@link ModifyOperation}s to generate json plan.
-     * @return the string json representation of an optimized ExecNode plan for the given
-     *     operations.
-     */
-    @Experimental
-    String getJsonPlan(List<ModifyOperation> modifyOperations);
-
-    /**
-     * Returns the execution plan for the given json plan.
-     *
-     * <p><b>NOTES:</b>: This is an experimental feature now.
-     *
-     * @param jsonPlan The json plan to be explained.
-     * @param extraDetails The extra explain details which the explain result should include, e.g.
-     *     estimated cost, changelog mode for streaming
-     * @return the execution plan.
-     */
-    @Experimental
-    String explainJsonPlan(String jsonPlan, ExplainDetail... extraDetails);
-
-    /**
-     * Converts a json plan into a set of runnable {@link Transformation}s.
-     *
-     * <p>The json plan is the string json representation of an optimized ExecNode plan for the
-     * given statement. An ExecNode plan can be serialized to json plan, and a json plan can be
-     * deserialized to an ExecNode plan.
-     *
-     * <p><b>NOTES:</b>: This is an experimental feature now.
-     *
-     * @param jsonPlan The json plan to be translated.
-     * @return list of corresponding {@link Transformation}s.
-     */
-    @Experimental
-    List<Transformation<?>> translateJsonPlan(String jsonPlan);
-
     // FLIP-190 methods
 
     @Experimental

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/delegation/Planner.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/delegation/Planner.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.table.api.CompiledPlan;
 import org.apache.flink.table.api.ExplainDetail;
 import org.apache.flink.table.api.PlanReference;
+import org.apache.flink.table.api.internal.CompiledPlanInternal;
 import org.apache.flink.table.operations.ModifyOperation;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.QueryOperation;
@@ -95,11 +96,11 @@ public interface Planner {
     CompiledPlan loadPlan(PlanReference planReference) throws IOException;
 
     @Experimental
-    CompiledPlan compilePlan(List<ModifyOperation> modifyOperations);
+    CompiledPlanInternal compilePlan(List<ModifyOperation> modifyOperations);
 
     @Experimental
-    List<Transformation<?>> translatePlan(CompiledPlan plan);
+    List<Transformation<?>> translatePlan(CompiledPlanInternal plan);
 
     @Experimental
-    String explainPlan(CompiledPlan plan, ExplainDetail... extraDetails);
+    String explainPlan(CompiledPlanInternal plan, ExplainDetail... extraDetails);
 }

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/utils/PlannerMock.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/utils/PlannerMock.java
@@ -49,22 +49,22 @@ public class PlannerMock implements Planner {
     }
 
     @Override
-    public CompiledPlan load(PlanReference planReference) throws IOException {
+    public CompiledPlan loadPlan(PlanReference planReference) throws IOException {
         return null;
     }
 
     @Override
-    public CompiledPlan compile(List<ModifyOperation> modifyOperations) {
+    public CompiledPlan compilePlan(List<ModifyOperation> modifyOperations) {
         return null;
     }
 
     @Override
-    public List<Transformation<?>> translate(CompiledPlan plan) {
+    public List<Transformation<?>> translatePlan(CompiledPlan plan) {
         return null;
     }
 
     @Override
-    public String explain(CompiledPlan plan, ExplainDetail... extraDetails) {
+    public String explainPlan(CompiledPlan plan, ExplainDetail... extraDetails) {
         return null;
     }
 }

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/utils/PlannerMock.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/utils/PlannerMock.java
@@ -19,12 +19,15 @@
 package org.apache.flink.table.utils;
 
 import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.table.api.CompiledPlan;
 import org.apache.flink.table.api.ExplainDetail;
+import org.apache.flink.table.api.PlanReference;
 import org.apache.flink.table.delegation.Parser;
 import org.apache.flink.table.delegation.Planner;
 import org.apache.flink.table.operations.ModifyOperation;
 import org.apache.flink.table.operations.Operation;
 
+import java.io.IOException;
 import java.util.List;
 
 /** Mocking {@link Planner} for tests. */
@@ -57,6 +60,26 @@ public class PlannerMock implements Planner {
 
     @Override
     public List<Transformation<?>> translateJsonPlan(String jsonPlan) {
+        return null;
+    }
+
+    @Override
+    public CompiledPlan load(PlanReference planReference) throws IOException {
+        return null;
+    }
+
+    @Override
+    public CompiledPlan compile(List<ModifyOperation> modifyOperations) {
+        return null;
+    }
+
+    @Override
+    public List<Transformation<?>> translate(CompiledPlan plan) {
+        return null;
+    }
+
+    @Override
+    public String explain(CompiledPlan plan, ExplainDetail... extraDetails) {
         return null;
     }
 }

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/utils/PlannerMock.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/utils/PlannerMock.java
@@ -49,21 +49,6 @@ public class PlannerMock implements Planner {
     }
 
     @Override
-    public String getJsonPlan(List<ModifyOperation> modifyOperations) {
-        return null;
-    }
-
-    @Override
-    public String explainJsonPlan(String jsonPlan, ExplainDetail... extraDetails) {
-        return null;
-    }
-
-    @Override
-    public List<Transformation<?>> translateJsonPlan(String jsonPlan) {
-        return null;
-    }
-
-    @Override
     public CompiledPlan load(PlanReference planReference) throws IOException {
         return null;
     }

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/utils/PlannerMock.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/utils/PlannerMock.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.table.api.CompiledPlan;
 import org.apache.flink.table.api.ExplainDetail;
 import org.apache.flink.table.api.PlanReference;
+import org.apache.flink.table.api.internal.CompiledPlanInternal;
 import org.apache.flink.table.delegation.Parser;
 import org.apache.flink.table.delegation.Planner;
 import org.apache.flink.table.operations.ModifyOperation;
@@ -54,17 +55,17 @@ public class PlannerMock implements Planner {
     }
 
     @Override
-    public CompiledPlan compilePlan(List<ModifyOperation> modifyOperations) {
+    public CompiledPlanInternal compilePlan(List<ModifyOperation> modifyOperations) {
         return null;
     }
 
     @Override
-    public List<Transformation<?>> translatePlan(CompiledPlan plan) {
+    public List<Transformation<?>> translatePlan(CompiledPlanInternal plan) {
         return null;
     }
 
     @Override
-    public String explainPlan(CompiledPlan plan, ExplainDetail... extraDetails) {
+    public String explainPlan(CompiledPlanInternal plan, ExplainDetail... extraDetails) {
         return null;
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/JsonPlanGraph.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/JsonPlanGraph.java
@@ -162,6 +162,6 @@ class JsonPlanGraph {
                 rootNodes.add(node);
             }
         }
-        return new ExecNodeGraph(rootNodes);
+        return new ExecNodeGraph(flinkVersion, rootNodes);
     }
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/BatchPlanner.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/BatchPlanner.scala
@@ -23,7 +23,7 @@ import org.apache.flink.api.dag.Transformation
 import org.apache.flink.configuration.ExecutionOptions
 import org.apache.flink.streaming.api.graph.StreamGraph
 import org.apache.flink.table.api.config.OptimizerConfigOptions
-import org.apache.flink.table.api.{ExplainDetail, TableConfig, TableException}
+import org.apache.flink.table.api.{CompiledPlan, ExplainDetail, TableConfig, TableException}
 import org.apache.flink.table.catalog.{CatalogManager, FunctionCatalog, ObjectIdentifier}
 import org.apache.flink.table.delegation.Executor
 import org.apache.flink.table.module.ModuleManager
@@ -136,9 +136,21 @@ class BatchPlanner(
     new BatchPlanner(executor, config, moduleManager, functionCatalog, catalogManager)
   }
 
-  override def explainJsonPlan(jsonPlan: String, extraDetails: ExplainDetail*): String = {
-    throw new TableException("This method is not supported for batch planner now.")
-  }
+  override def explainJsonPlan(jsonPlan: String, extraDetails: ExplainDetail*): String =
+    throw new UnsupportedOperationException(
+      "The batch planner doesn't support the persisted plan feature.")
+
+  override def compile(modifyOperations: util.List[ModifyOperation]): CompiledPlan =
+    throw new UnsupportedOperationException(
+      "The batch planner doesn't support the persisted plan feature.")
+
+  override def translate(plan: CompiledPlan): util.List[Transformation[_]] =
+    throw new UnsupportedOperationException(
+      "The batch planner doesn't support the persisted plan feature.")
+
+  override def explain(plan: CompiledPlan, extraDetails: ExplainDetail*): String =
+    throw new UnsupportedOperationException(
+      "The batch planner doesn't support the persisted plan feature.")
 
   override def validateAndOverrideConfiguration(): Unit = {
     super.validateAndOverrideConfiguration()

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/BatchPlanner.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/BatchPlanner.scala
@@ -21,14 +21,12 @@ package org.apache.flink.table.planner.delegation
 import org.apache.flink.api.common.RuntimeExecutionMode
 import org.apache.flink.api.dag.Transformation
 import org.apache.flink.configuration.ExecutionOptions
-import org.apache.flink.streaming.api.graph.StreamGraph
 import org.apache.flink.table.api.config.OptimizerConfigOptions
 import org.apache.flink.table.api.{CompiledPlan, ExplainDetail, TableConfig, TableException}
-import org.apache.flink.table.catalog.{CatalogManager, FunctionCatalog, ObjectIdentifier}
+import org.apache.flink.table.catalog.{CatalogManager, FunctionCatalog}
 import org.apache.flink.table.delegation.Executor
 import org.apache.flink.table.module.ModuleManager
-import org.apache.flink.table.operations.{ModifyOperation, Operation, QueryOperation, SinkModifyOperation}
-import org.apache.flink.table.planner.operations.PlannerQueryOperation
+import org.apache.flink.table.operations.{ModifyOperation, Operation}
 import org.apache.flink.table.planner.plan.`trait`.FlinkRelDistributionTraitDef
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeGraph
 import org.apache.flink.table.planner.plan.nodes.exec.batch.BatchExecNode
@@ -40,7 +38,6 @@ import org.apache.flink.table.planner.utils.DummyStreamExecutionEnvironment
 
 import org.apache.calcite.plan.{ConventionTraitDef, RelTrait, RelTraitDef}
 import org.apache.calcite.rel.RelCollationTraitDef
-import org.apache.calcite.rel.logical.LogicalTableModify
 import org.apache.calcite.sql.SqlExplainLevel
 
 import java.util
@@ -135,10 +132,6 @@ class BatchPlanner(
     val executor = new DefaultExecutor(dummyExecEnv)
     new BatchPlanner(executor, config, moduleManager, functionCatalog, catalogManager)
   }
-
-  override def explainJsonPlan(jsonPlan: String, extraDetails: ExplainDetail*): String =
-    throw new UnsupportedOperationException(
-      "The batch planner doesn't support the persisted plan feature.")
 
   override def compile(modifyOperations: util.List[ModifyOperation]): CompiledPlan =
     throw new UnsupportedOperationException(

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/BatchPlanner.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/BatchPlanner.scala
@@ -133,15 +133,15 @@ class BatchPlanner(
     new BatchPlanner(executor, config, moduleManager, functionCatalog, catalogManager)
   }
 
-  override def compile(modifyOperations: util.List[ModifyOperation]): CompiledPlan =
+  override def compilePlan(modifyOperations: util.List[ModifyOperation]): CompiledPlan =
     throw new UnsupportedOperationException(
       "The batch planner doesn't support the persisted plan feature.")
 
-  override def translate(plan: CompiledPlan): util.List[Transformation[_]] =
+  override def translatePlan(plan: CompiledPlan): util.List[Transformation[_]] =
     throw new UnsupportedOperationException(
       "The batch planner doesn't support the persisted plan feature.")
 
-  override def explain(plan: CompiledPlan, extraDetails: ExplainDetail*): String =
+  override def explainPlan(plan: CompiledPlan, extraDetails: ExplainDetail*): String =
     throw new UnsupportedOperationException(
       "The batch planner doesn't support the persisted plan feature.")
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/BatchPlanner.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/BatchPlanner.scala
@@ -22,7 +22,8 @@ import org.apache.flink.api.common.RuntimeExecutionMode
 import org.apache.flink.api.dag.Transformation
 import org.apache.flink.configuration.ExecutionOptions
 import org.apache.flink.table.api.config.OptimizerConfigOptions
-import org.apache.flink.table.api.{CompiledPlan, ExplainDetail, TableConfig, TableException}
+import org.apache.flink.table.api.internal.CompiledPlanInternal
+import org.apache.flink.table.api.{ExplainDetail, TableConfig, TableException}
 import org.apache.flink.table.catalog.{CatalogManager, FunctionCatalog}
 import org.apache.flink.table.delegation.Executor
 import org.apache.flink.table.module.ModuleManager
@@ -133,15 +134,15 @@ class BatchPlanner(
     new BatchPlanner(executor, config, moduleManager, functionCatalog, catalogManager)
   }
 
-  override def compilePlan(modifyOperations: util.List[ModifyOperation]): CompiledPlan =
+  override def compilePlan(modifyOperations: util.List[ModifyOperation]): CompiledPlanInternal =
     throw new UnsupportedOperationException(
       "The batch planner doesn't support the persisted plan feature.")
 
-  override def translatePlan(plan: CompiledPlan): util.List[Transformation[_]] =
+  override def translatePlan(plan: CompiledPlanInternal): util.List[Transformation[_]] =
     throw new UnsupportedOperationException(
       "The batch planner doesn't support the persisted plan feature.")
 
-  override def explainPlan(plan: CompiledPlan, extraDetails: ExplainDetail*): String =
+  override def explainPlan(plan: CompiledPlanInternal, extraDetails: ExplainDetail*): String =
     throw new UnsupportedOperationException(
       "The batch planner doesn't support the persisted plan feature.")
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
@@ -23,10 +23,10 @@ import org.apache.flink.api.dag.Transformation
 import org.apache.flink.configuration.ReadableConfig
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.apache.flink.streaming.api.graph.StreamGraph
-import org.apache.flink.table.api.config.{ExecutionConfigOptions, TableConfigOptions}
 import org.apache.flink.table.api._
-import org.apache.flink.table.catalog._
+import org.apache.flink.table.api.config.{ExecutionConfigOptions, TableConfigOptions}
 import org.apache.flink.table.catalog.ManagedTableListener.isManagedTable
+import org.apache.flink.table.catalog._
 import org.apache.flink.table.connector.sink.DynamicTableSink
 import org.apache.flink.table.delegation.{Executor, Parser, Planner}
 import org.apache.flink.table.descriptors.{ConnectorDescriptorValidator, DescriptorProperties}
@@ -482,34 +482,6 @@ abstract class PlannerBase(
       }
 
     new ExecNodeGraphCompiledPlan(ctx, execNodeGraph)
-  }
-
-  override def getJsonPlan(modifyOperations: util.List[ModifyOperation]): String = {
-    if (!isStreamingMode) {
-      throw new TableException("Only streaming mode is supported now.")
-    }
-    validateAndOverrideConfiguration()
-    val relNodes = modifyOperations.map(translateToRel)
-    val optimizedRelNodes = optimize(relNodes)
-    val execGraph = translateToExecNodeGraph(optimizedRelNodes)
-    val jsonPlan = JsonSerdeUtil
-      .createObjectWriter(createSerdeContext)
-      .writeValueAsString(execGraph)
-    cleanupInternalConfigurations()
-    jsonPlan
-  }
-
-  override def translateJsonPlan(jsonPlan: String): util.List[Transformation[_]] = {
-    if (!isStreamingMode) {
-      throw new TableException("Only streaming mode is supported now.")
-    }
-    validateAndOverrideConfiguration()
-    val execGraph = JsonSerdeUtil
-      .createObjectReader(createSerdeContext)
-      .readValue(jsonPlan, classOf[ExecNodeGraph])
-    val transformations = translateToPlan(execGraph)
-    cleanupInternalConfigurations()
-    transformations
   }
 
   protected def createSerdeContext: SerdeContext = {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
@@ -471,7 +471,7 @@ abstract class PlannerBase(
     }
   }
 
-  override def load(planReference: PlanReference): CompiledPlan = {
+  override def loadPlan(planReference: PlanReference): CompiledPlan = {
     val ctx = createSerdeContext
     val objectReader: ObjectReader = JsonSerdeUtil.createObjectReader(ctx)
     val execNodeGraph = planReference match {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
@@ -26,6 +26,7 @@ import org.apache.flink.streaming.api.graph.StreamGraph
 import org.apache.flink.table.api.PlanReference.{ContentPlanReference, FilePlanReference, ResourcePlanReference}
 import org.apache.flink.table.api._
 import org.apache.flink.table.api.config.{ExecutionConfigOptions, TableConfigOptions}
+import org.apache.flink.table.api.internal.CompiledPlanInternal
 import org.apache.flink.table.catalog.ManagedTableListener.isManagedTable
 import org.apache.flink.table.catalog._
 import org.apache.flink.table.connector.sink.DynamicTableSink
@@ -471,7 +472,7 @@ abstract class PlannerBase(
     }
   }
 
-  override def loadPlan(planReference: PlanReference): CompiledPlan = {
+  override def loadPlan(planReference: PlanReference): CompiledPlanInternal = {
     val ctx = createSerdeContext
     val objectReader: ObjectReader = JsonSerdeUtil.createObjectReader(ctx)
     val execNodeGraph = planReference match {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/StreamPlanner.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/StreamPlanner.scala
@@ -128,7 +128,7 @@ class StreamPlanner(
     new StreamPlanner(executor, config, moduleManager, functionCatalog, catalogManager)
   }
 
-  override def compile(modifyOperations: util.List[ModifyOperation]): CompiledPlan = {
+  override def compilePlan(modifyOperations: util.List[ModifyOperation]): CompiledPlan = {
     validateAndOverrideConfiguration()
     val relNodes = modifyOperations.map(translateToRel)
     val optimizedRelNodes = optimize(relNodes)
@@ -138,7 +138,7 @@ class StreamPlanner(
     new ExecNodeGraphCompiledPlan(createSerdeContext, execGraph)
   }
 
-  override def translate(plan: CompiledPlan): util.List[Transformation[_]] = {
+  override def translatePlan(plan: CompiledPlan): util.List[Transformation[_]] = {
     validateAndOverrideConfiguration()
     val execGraph = plan.asInstanceOf[ExecNodeGraphCompiledPlan].getExecNodeGraph
     val transformations = translateToPlan(execGraph)
@@ -146,7 +146,7 @@ class StreamPlanner(
     transformations
   }
 
-  override def explain(plan: CompiledPlan, extraDetails: ExplainDetail*): String = {
+  override def explainPlan(plan: CompiledPlan, extraDetails: ExplainDetail*): String = {
     validateAndOverrideConfiguration()
     val execGraph = plan.asInstanceOf[ExecNodeGraphCompiledPlan].getExecNodeGraph
     val transformations = translateToPlan(execGraph)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/StreamPlanner.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/StreamPlanner.scala
@@ -22,17 +22,15 @@ import org.apache.flink.api.common.RuntimeExecutionMode
 import org.apache.flink.api.dag.Transformation
 import org.apache.flink.configuration.ExecutionOptions
 import org.apache.flink.streaming.api.graph.StreamGraph
-import org.apache.flink.table.api.{CompiledPlan, ExplainDetail, PlanReference, TableConfig, TableException}
-import org.apache.flink.table.catalog.{CatalogManager, FunctionCatalog, ObjectIdentifier}
+import org.apache.flink.table.api.{CompiledPlan, ExplainDetail, TableConfig, TableException}
+import org.apache.flink.table.catalog.{CatalogManager, FunctionCatalog}
 import org.apache.flink.table.delegation.Executor
 import org.apache.flink.table.module.ModuleManager
-import org.apache.flink.table.operations.{ModifyOperation, Operation, QueryOperation, SinkModifyOperation}
-import org.apache.flink.table.planner.operations.PlannerQueryOperation
+import org.apache.flink.table.operations.{ModifyOperation, Operation}
 import org.apache.flink.table.planner.plan.ExecNodeGraphCompiledPlan
 import org.apache.flink.table.planner.plan.`trait`._
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeGraph
 import org.apache.flink.table.planner.plan.nodes.exec.processor.ExecNodeGraphProcessor
-import org.apache.flink.table.planner.plan.nodes.exec.serde.ExecNodeGraphJsonPlanGenerator
 import org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecNode
 import org.apache.flink.table.planner.plan.nodes.exec.utils.ExecNodePlanDumper
 import org.apache.flink.table.planner.plan.optimize.{Optimizer, StreamCommonSubGraphBasedOptimizer}
@@ -40,7 +38,6 @@ import org.apache.flink.table.planner.plan.utils.FlinkRelOptUtil
 import org.apache.flink.table.planner.utils.DummyStreamExecutionEnvironment
 
 import org.apache.calcite.plan.{ConventionTraitDef, RelTrait, RelTraitDef}
-import org.apache.calcite.rel.logical.LogicalTableModify
 import org.apache.calcite.sql.SqlExplainLevel
 
 import java.util
@@ -129,31 +126,6 @@ class StreamPlanner(
     val dummyExecEnv = new DummyStreamExecutionEnvironment(getExecEnv)
     val executor = new DefaultExecutor(dummyExecEnv)
     new StreamPlanner(executor, config, moduleManager, functionCatalog, catalogManager)
-  }
-
-  override def explainJsonPlan(jsonPlan: String, extraDetails: ExplainDetail*): String = {
-    validateAndOverrideConfiguration()
-    val execGraph = ExecNodeGraphJsonPlanGenerator.read(
-      PlanReference.fromJsonString(jsonPlan), createSerdeContext)
-    val transformations = translateToPlan(execGraph)
-    cleanupInternalConfigurations()
-
-    val streamGraph = executor.createPipeline(transformations, config.getConfiguration, null)
-      .asInstanceOf[StreamGraph]
-
-    val sb = new StringBuilder
-    sb.append("== Optimized Execution Plan ==")
-    sb.append(System.lineSeparator)
-    sb.append(ExecNodePlanDumper.dagToString(execGraph))
-
-    if (extraDetails.contains(ExplainDetail.JSON_EXECUTION_PLAN)) {
-      sb.append(System.lineSeparator)
-      sb.append("== Physical Execution Plan ==")
-      sb.append(System.lineSeparator)
-      sb.append(streamGraph.getStreamingPlanAsJSON)
-    }
-
-    sb.toString()
   }
 
   override def compile(modifyOperations: util.List[ModifyOperation]): CompiledPlan = {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/StreamPlanner.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/StreamPlanner.scala
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.RuntimeExecutionMode
 import org.apache.flink.api.dag.Transformation
 import org.apache.flink.configuration.ExecutionOptions
 import org.apache.flink.streaming.api.graph.StreamGraph
+import org.apache.flink.table.api.internal.CompiledPlanInternal
 import org.apache.flink.table.api.{CompiledPlan, ExplainDetail, TableConfig, TableException}
 import org.apache.flink.table.catalog.{CatalogManager, FunctionCatalog}
 import org.apache.flink.table.delegation.Executor
@@ -128,7 +129,7 @@ class StreamPlanner(
     new StreamPlanner(executor, config, moduleManager, functionCatalog, catalogManager)
   }
 
-  override def compilePlan(modifyOperations: util.List[ModifyOperation]): CompiledPlan = {
+  override def compilePlan(modifyOperations: util.List[ModifyOperation]): CompiledPlanInternal = {
     validateAndOverrideConfiguration()
     val relNodes = modifyOperations.map(translateToRel)
     val optimizedRelNodes = optimize(relNodes)
@@ -138,7 +139,7 @@ class StreamPlanner(
     new ExecNodeGraphCompiledPlan(createSerdeContext, execGraph)
   }
 
-  override def translatePlan(plan: CompiledPlan): util.List[Transformation[_]] = {
+  override def translatePlan(plan: CompiledPlanInternal): util.List[Transformation[_]] = {
     validateAndOverrideConfiguration()
     val execGraph = plan.asInstanceOf[ExecNodeGraphCompiledPlan].getExecNodeGraph
     val transformations = translateToPlan(execGraph)
@@ -146,7 +147,7 @@ class StreamPlanner(
     transformations
   }
 
-  override def explainPlan(plan: CompiledPlan, extraDetails: ExplainDetail*): String = {
+  override def explainPlan(plan: CompiledPlanInternal, extraDetails: ExplainDetail*): String = {
     validateAndOverrideConfiguration()
     val execGraph = plan.asInstanceOf[ExecNodeGraphCompiledPlan].getExecNodeGraph
     val transformations = translateToPlan(execGraph)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/ExecNodeGraphCompiledPlan.java
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/ExecNodeGraphCompiledPlan.java
@@ -62,9 +62,8 @@ public class ExecNodeGraphCompiledPlan implements CompiledPlanInternal {
     }
 
     @Override
-    public void writeToFile(java.nio.file.Path path, boolean ignoreIfExists)
+    public void writeToFile(File file, boolean ignoreIfExists)
             throws IOException, UnsupportedOperationException {
-        File file = new File(path.toUri());
         if (ignoreIfExists && file.exists()) {
             return;
         }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/ExecNodeGraphCompiledPlan.java
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/ExecNodeGraphCompiledPlan.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.CompiledPlan;
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeGraph;
+import org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeUtil;
+import org.apache.flink.table.planner.plan.nodes.exec.serde.SerdeContext;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+/** Implementation of {@link CompiledPlan} backed by an {@link ExecNodeGraph}. */
+@Internal
+public class ExecNodeGraphCompiledPlan implements CompiledPlan {
+
+    private final SerdeContext serdeContext;
+    private final ExecNodeGraph execNodeGraph;
+
+    public ExecNodeGraphCompiledPlan(SerdeContext serdeContext, ExecNodeGraph execNodeGraph) {
+        this.serdeContext = serdeContext;
+        this.execNodeGraph = execNodeGraph;
+    }
+
+    public ExecNodeGraph getExecNodeGraph() {
+        return execNodeGraph;
+    }
+
+    @Override
+    public String asJsonString() {
+        try {
+            return JsonSerdeUtil.createObjectWriter(serdeContext).writeValueAsString(execNodeGraph);
+        } catch (JsonProcessingException e) {
+            throw new TableException("Cannot convert the plan into a string", e);
+        }
+    }
+
+    @Override
+    public void writeToFile(java.nio.file.Path path, boolean ignoreIfExists)
+            throws IOException, UnsupportedOperationException {
+        File file = new File(path.toUri());
+        if (ignoreIfExists && file.exists()) {
+            return;
+        }
+        JsonSerdeUtil.createObjectWriter(serdeContext)
+                .writeValue(new FileWriter(file, false), execNodeGraph);
+    }
+}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/ExecNodeGraphCompiledPlan.java
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/ExecNodeGraphCompiledPlan.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.planner.plan;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.api.CompiledPlan;
 import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.api.internal.CompiledPlanInternal;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeGraph;
 import org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeUtil;
@@ -37,7 +38,7 @@ import java.util.stream.Collectors;
 
 /** Implementation of {@link CompiledPlan} backed by an {@link ExecNodeGraph}. */
 @Internal
-public class ExecNodeGraphCompiledPlan implements CompiledPlan {
+public class ExecNodeGraphCompiledPlan implements CompiledPlanInternal {
 
     private final SerdeContext serdeContext;
     private final ExecNodeGraph execNodeGraph;

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/api/internal/StatementSetImplTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/api/internal/StatementSetImplTest.java
@@ -65,7 +65,7 @@ public class StatementSetImplTest {
 
         StatementSetImpl stmtSet = (StatementSetImpl) tableEnv.createStatementSet();
         stmtSet.addInsertSql("INSERT INTO MySink SELECT * FROM MyTable");
-        String jsonPlan = stmtSet.getJsonPlan();
+        String jsonPlan = stmtSet.compilePlan().asJsonString();
         String actual = TableTestUtil.readFromResource("/jsonplan/testGetJsonPlan.out");
         assertEquals(
                 TableTestUtil.replaceExecNodeId(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/api/internal/TableEnvironmentInternalTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/api/internal/TableEnvironmentInternalTest.java
@@ -18,10 +18,10 @@
 
 package org.apache.flink.table.api.internal;
 
+import org.apache.flink.table.api.CompiledPlan;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.ExplainDetail;
 import org.apache.flink.table.api.TableEnvironment;
-import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.planner.utils.JsonPlanTestBase;
 import org.apache.flink.table.planner.utils.TableTestUtil;
 
@@ -33,7 +33,8 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test for {@link TableEnvironmentInternal}. */
 public class TableEnvironmentInternalTest extends JsonPlanTestBase {
@@ -64,38 +65,43 @@ public class TableEnvironmentInternalTest extends JsonPlanTestBase {
     }
 
     @Test
-    public void testGetJsonPlan() throws IOException {
-        String jsonPlan = tableEnv.getJsonPlan("insert into MySink select * from MyTable");
+    public void testCompilePlanSql() throws IOException {
+        CompiledPlan compiledPlan =
+                tableEnv.compilePlanSql("insert into MySink select * from MyTable");
         String expected = TableTestUtil.readFromResource("/jsonplan/testGetJsonPlan.out");
-        assertEquals(
-                TableTestUtil.replaceExecNodeId(
-                        TableTestUtil.replaceFlinkVersion(
-                                TableTestUtil.getFormattedJson(expected))),
-                TableTestUtil.replaceExecNodeId(
-                        TableTestUtil.replaceFlinkVersion(
-                                TableTestUtil.getFormattedJson(jsonPlan))));
+        assertThat(
+                        TableTestUtil.replaceExecNodeId(
+                                TableTestUtil.replaceFlinkVersion(
+                                        TableTestUtil.getFormattedJson(
+                                                compiledPlan.asJsonString()))))
+                .isEqualTo(
+                        TableTestUtil.replaceExecNodeId(
+                                TableTestUtil.replaceFlinkVersion(
+                                        TableTestUtil.getFormattedJson(expected))));
     }
 
     @Test
-    public void testExecuteJsonPlan() throws Exception {
+    public void testExecutePlan() throws Exception {
         List<String> data = Arrays.asList("1,1,hi", "2,1,hello", "3,2,hello world");
         createTestCsvSourceTable("src", data, "a bigint", "b int", "c varchar");
         File sinkPath = createTestCsvSinkTable("sink", "a bigint", "b int", "c varchar");
 
-        String jsonPlan = tableEnv.getJsonPlan("insert into sink select * from src");
-        tableEnv.executeJsonPlan(jsonPlan).await();
+        CompiledPlan plan = tableEnv.compilePlanSql("insert into sink select * from src");
+        tableEnv.executePlan(plan).await();
 
         assertResult(data, sinkPath);
     }
 
     @Test
-    public void testExplainJsonPlan() {
-        String jsonPlan = TableTestUtil.readFromResource("/jsonplan/testGetJsonPlan.out");
-        String actual = tableEnv.explainJsonPlan(jsonPlan, ExplainDetail.JSON_EXECUTION_PLAN);
+    public void testExplainPlan() throws IOException {
+        String actual =
+                tableEnv.explainPlan(
+                        tableEnv.loadPlan(
+                                planReferenceFromClasspath("/jsonplan/testGetJsonPlan.out")),
+                        ExplainDetail.JSON_EXECUTION_PLAN);
         String expected = TableTestUtil.readFromResource("/explain/testExplainJsonPlan.out");
-        assertEquals(
-                expected,
-                TableTestUtil.replaceNodeIdInOperator(TableTestUtil.replaceStreamNodeId(actual)));
+        assertThat(TableTestUtil.replaceNodeIdInOperator(TableTestUtil.replaceStreamNodeId(actual)))
+                .isEqualTo(expected);
     }
 
     @Test
@@ -120,8 +126,8 @@ public class TableEnvironmentInternalTest extends JsonPlanTestBase {
                         + "  'table-sink-class' = 'DEFAULT')";
         tableEnv.executeSql(sinkTableDdl);
 
-        exception.expect(TableException.class);
-        exception.expectMessage("Only streaming mode is supported now");
-        tableEnv.getJsonPlan("insert into sink select * from src");
+        assertThatThrownBy(() -> tableEnv.compilePlanSql("insert into sink select * from src"))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessage("The batch planner doesn't support the persisted plan feature.");
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/api/internal/TableEnvironmentInternalTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/api/internal/TableEnvironmentInternalTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.api.internal;
 import org.apache.flink.table.api.CompiledPlan;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.ExplainDetail;
+import org.apache.flink.table.api.PlanReference;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.planner.utils.JsonPlanTestBase;
 import org.apache.flink.table.planner.utils.TableTestUtil;
@@ -97,7 +98,7 @@ public class TableEnvironmentInternalTest extends JsonPlanTestBase {
         String actual =
                 tableEnv.explainPlan(
                         tableEnv.loadPlan(
-                                planReferenceFromClasspath("/jsonplan/testGetJsonPlan.out")),
+                                PlanReference.fromClasspath("/jsonplan/testGetJsonPlan.out")),
                         ExplainDetail.JSON_EXECUTION_PLAN);
         String expected = TableTestUtil.readFromResource("/explain/testExplainJsonPlan.out");
         assertThat(TableTestUtil.replaceNodeIdInOperator(TableTestUtil.replaceStreamNodeId(actual)))

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/api/internal/TableEnvironmentInternalTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/api/internal/TableEnvironmentInternalTest.java
@@ -98,7 +98,7 @@ public class TableEnvironmentInternalTest extends JsonPlanTestBase {
         String actual =
                 tableEnv.explainPlan(
                         tableEnv.loadPlan(
-                                PlanReference.fromClasspath("/jsonplan/testGetJsonPlan.out")),
+                                PlanReference.fromResource("/jsonplan/testGetJsonPlan.out")),
                         ExplainDetail.JSON_EXECUTION_PLAN);
         String expected = TableTestUtil.readFromResource("/explain/testExplainJsonPlan.out");
         assertThat(TableTestUtil.replaceNodeIdInOperator(TableTestUtil.replaceStreamNodeId(actual)))

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/ChangelogSourceJsonPlanITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/ChangelogSourceJsonPlanITCase.java
@@ -45,7 +45,7 @@ public class ChangelogSourceJsonPlanITCase extends JsonPlanTestBase {
                 "balance2 DECIMAL(18,2)");
 
         String dml = "INSERT INTO user_sink SELECT * FROM users";
-        executeSqlWithJsonPlanVerified(dml).await();
+        compileSqlAndExecutePlan(dml).await();
 
         List<String> expected =
                 Arrays.asList(
@@ -67,7 +67,7 @@ public class ChangelogSourceJsonPlanITCase extends JsonPlanTestBase {
                 "balance2 DECIMAL(18,2)");
 
         String dml = "INSERT INTO user_sink SELECT * FROM users";
-        executeSqlWithJsonPlanVerified(dml).await();
+        compileSqlAndExecutePlan(dml).await();
 
         List<String> expected =
                 Arrays.asList(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/CorrelateJsonPlanITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/CorrelateJsonPlanITCase.java
@@ -49,7 +49,7 @@ public class CorrelateJsonPlanITCase extends JsonPlanTestBase {
         createTestValuesSinkTable("MySink", "a STRING", "b STRING");
         String query =
                 "insert into MySink SELECT a, v FROM MyTable, lateral table(STRING_SPLIT(a, ',')) as T(v)";
-        executeSqlWithJsonPlanVerified(query).await();
+        compileSqlAndExecutePlan(query).await();
         List<String> expected = Arrays.asList("+I[1,1,hi, 1]", "+I[1,1,hi, 1]", "+I[1,1,hi, hi]");
         assertResult(expected, TestValuesTableFactory.getResults("MySink"));
     }
@@ -62,7 +62,7 @@ public class CorrelateJsonPlanITCase extends JsonPlanTestBase {
         createTestValuesSinkTable("MySink", "a STRING", "b STRING");
         String query =
                 "insert into MySink SELECT a, v FROM MyTable, lateral table(STRING_SPLIT(a, ',')) as T(v)";
-        executeSqlWithJsonPlanVerified(query).await();
+        compileSqlAndExecutePlan(query).await();
         List<String> expected = Arrays.asList("+I[1,1,hi, 1]", "+I[1,1,hi, 1]", "+I[1,1,hi, hi]");
         assertResult(expected, TestValuesTableFactory.getResults("MySink"));
     }
@@ -75,7 +75,7 @@ public class CorrelateJsonPlanITCase extends JsonPlanTestBase {
         createTestValuesSinkTable("MySink", "a STRING", "b STRING");
         String query =
                 "insert into MySink SELECT a, v FROM MyTable, lateral table(STRING_SPLIT(a, ',')) as T(v)";
-        executeSqlWithJsonPlanVerified(query).await();
+        compileSqlAndExecutePlan(query).await();
         List<String> expected = Arrays.asList("+I[1,1,hi, 1]", "+I[1,1,hi, 1]", "+I[1,1,hi, hi]");
         assertResult(expected, TestValuesTableFactory.getResults("MySink"));
     }
@@ -88,7 +88,7 @@ public class CorrelateJsonPlanITCase extends JsonPlanTestBase {
         createTestValuesSinkTable("MySink", "a STRING", "b STRING");
         String query =
                 "insert into MySink SELECT a, v FROM MyTable, lateral table(STRING_SPLIT(a, ',')) as T(v)";
-        executeSqlWithJsonPlanVerified(query).await();
+        compileSqlAndExecutePlan(query).await();
         List<String> expected = Arrays.asList("+I[1,1,hi, 1]", "+I[1,1,hi, 1]", "+I[1,1,hi, hi]");
         assertResult(expected, TestValuesTableFactory.getResults("MySink"));
     }
@@ -100,7 +100,7 @@ public class CorrelateJsonPlanITCase extends JsonPlanTestBase {
         createTestValuesSinkTable("MySink", "a STRING", "b STRING");
         String query =
                 "insert into MySink SELECT a, v FROM MyTable, lateral table(STRING_SPLIT(a, ',')) as T(v) where cast(v as int) > 0";
-        executeSqlWithJsonPlanVerified(query).await();
+        compileSqlAndExecutePlan(query).await();
         List<String> expected = Arrays.asList("+I[1,1,hi, 1]", "+I[1,1,hi, 1]");
         assertResult(expected, TestValuesTableFactory.getResults("MySink"));
     }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/DeduplicationJsonPlanITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/DeduplicationJsonPlanITCase.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.planner.runtime.stream.jsonplan;
 
+import org.apache.flink.table.api.CompiledPlan;
 import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.flink.table.planner.factories.TestValuesTableFactory;
 import org.apache.flink.table.planner.utils.JsonPlanTestBase;
@@ -58,8 +59,8 @@ public class DeduplicationJsonPlanITCase extends JsonPlanTestBase {
                 "order_time bigint",
                 "primary key(product) not enforced");
 
-        String jsonPlan =
-                tableEnv.getJsonPlan(
+        CompiledPlan compiledPlan =
+                tableEnv.compilePlanSql(
                         "insert into MySink "
                                 + "select order_id, user, product, order_time \n"
                                 + "FROM (\n"
@@ -70,7 +71,7 @@ public class DeduplicationJsonPlanITCase extends JsonPlanTestBase {
         tableEnv.getConfig()
                 .getConfiguration()
                 .setInteger(ExecutionConfigOptions.TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM, 1);
-        tableEnv.executeJsonPlan(jsonPlan).await();
+        tableEnv.executePlan(compiledPlan).await();
 
         assertResult(
                 Arrays.asList("+I[1, terry, pen, 1000]", "+I[4, bob, apple, 4000]"),

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/ExpandJsonPlanITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/ExpandJsonPlanITCase.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.planner.runtime.stream.jsonplan;
 
+import org.apache.flink.table.api.CompiledPlan;
 import org.apache.flink.table.api.config.OptimizerConfigOptions;
 import org.apache.flink.table.planner.factories.TestValuesTableFactory;
 import org.apache.flink.table.planner.plan.rules.physical.stream.IncrementalAggregateRule;
@@ -56,13 +57,13 @@ public class ExpandJsonPlanITCase extends JsonPlanTestBase {
                 "c varchar");
         createTestNonInsertOnlyValuesSinkTable(
                 "MySink", "b bigint", "a bigint", "c varchar", "primary key (b) not enforced");
-        String jsonPlan =
-                tableEnv.getJsonPlan(
+        CompiledPlan compiledPlan =
+                tableEnv.compilePlanSql(
                         "insert into MySink select b, "
                                 + "count(distinct a) as a, "
                                 + "max(c) as c "
                                 + "from MyTable group by b");
-        tableEnv.executeJsonPlan(jsonPlan).await();
+        tableEnv.executePlan(compiledPlan).await();
 
         List<String> result = TestValuesTableFactory.getResults("MySink");
         assertResult(Arrays.asList("+I[1, 1, Hi]", "+I[2, 2, Hello world]"), result);

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/GroupAggregateJsonPlanITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/GroupAggregateJsonPlanITCase.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.planner.runtime.stream.jsonplan;
 
+import org.apache.flink.table.api.CompiledPlan;
 import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.flink.table.planner.factories.TestValuesTableFactory;
 import org.apache.flink.table.planner.plan.utils.JavaUserDefinedAggFunctions;
@@ -85,14 +86,14 @@ public class GroupAggregateJsonPlanITCase extends JsonPlanTestBase {
                 "avg_a double",
                 "min_c varchar",
                 "primary key (b) not enforced");
-        String jsonPlan =
-                tableEnv.getJsonPlan(
+        CompiledPlan compiledPlan =
+                tableEnv.compilePlanSql(
                         "insert into MySink select b, "
                                 + "count(*) as cnt, "
                                 + "avg(a) filter (where a > 1) as avg_a, "
                                 + "min(c) as min_c "
                                 + "from MyTable group by b");
-        tableEnv.executeJsonPlan(jsonPlan).await();
+        tableEnv.executePlan(compiledPlan).await();
 
         List<String> result = TestValuesTableFactory.getResults("MySink");
         assertResult(Arrays.asList("+I[1, 1, null, Hi]", "+I[2, 2, 2.0, Hello]"), result);
@@ -118,8 +119,8 @@ public class GroupAggregateJsonPlanITCase extends JsonPlanTestBase {
                 "avg_b double",
                 "cnt_d bigint",
                 "primary key (e) not enforced");
-        String jsonPlan =
-                tableEnv.getJsonPlan(
+        CompiledPlan compiledPlan =
+                tableEnv.compilePlanSql(
                         "insert into MySink select e, "
                                 + "count(distinct a) filter (where b > 10) as cnt_a1, "
                                 + "count(distinct a) as cnt_a2, "
@@ -128,7 +129,7 @@ public class GroupAggregateJsonPlanITCase extends JsonPlanTestBase {
                                 + "avg(b) as avg_b, "
                                 + "count(distinct d) as concat_d "
                                 + "from MyTable group by e");
-        tableEnv.executeJsonPlan(jsonPlan).await();
+        tableEnv.executePlan(compiledPlan).await();
 
         List<String> result = TestValuesTableFactory.getResults("MySink");
         assertResult(
@@ -161,15 +162,15 @@ public class GroupAggregateJsonPlanITCase extends JsonPlanTestBase {
                 "s3 bigint",
                 "primary key (d) not enforced");
 
-        String jsonPlan =
-                tableEnv.getJsonPlan(
+        CompiledPlan compiledPlan =
+                tableEnv.compilePlanSql(
                         "insert into MySink select "
                                 + "e, "
                                 + "my_sum1(c, 10) as s1, "
                                 + "my_sum2(5, c) as s2, "
                                 + "my_avg(e, a) as s3 "
                                 + "from MyTable group by e");
-        tableEnv.executeJsonPlan(jsonPlan).await();
+        tableEnv.executePlan(compiledPlan).await();
 
         List<String> result = TestValuesTableFactory.getResults("MySink");
         assertResult(
@@ -193,14 +194,14 @@ public class GroupAggregateJsonPlanITCase extends JsonPlanTestBase {
         createTestNonInsertOnlyValuesSinkTable(
                 "MySink", "d bigint", "s1 bigint", "c1 varchar", "primary key (d) not enforced");
 
-        String jsonPlan =
-                tableEnv.getJsonPlan(
+        CompiledPlan compiledPlan =
+                tableEnv.compilePlanSql(
                         "insert into MySink select "
                                 + "e, "
                                 + "my_avg(e, a) as s1, "
                                 + "my_concat_agg(d) as c1 "
                                 + "from MyTable group by e");
-        tableEnv.executeJsonPlan(jsonPlan).await();
+        tableEnv.executePlan(compiledPlan).await();
 
         List<String> result = TestValuesTableFactory.getResults("MySink");
         assertResult(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/GroupWindowAggregateJsonITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/GroupWindowAggregateJsonITCase.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.planner.runtime.stream.jsonplan;
 
+import org.apache.flink.table.api.CompiledPlan;
 import org.apache.flink.table.planner.factories.TestValuesTableFactory;
 import org.apache.flink.table.planner.runtime.utils.TestData;
 import org.apache.flink.table.planner.utils.JavaScalaConversionUtil;
@@ -68,8 +69,8 @@ public class GroupWindowAggregateJsonITCase extends JsonPlanTestBase {
                 "cnt BIGINT",
                 "sum_int INT",
                 "distinct_cnt BIGINT");
-        String jsonPlan =
-                tableEnv.getJsonPlan(
+        CompiledPlan compiledPlan =
+                tableEnv.compilePlanSql(
                         "insert into MySink select\n"
                                 + "  name,\n"
                                 + "  TUMBLE_START(rowtime, INTERVAL '5' SECOND) as window_start,\n"
@@ -79,7 +80,7 @@ public class GroupWindowAggregateJsonITCase extends JsonPlanTestBase {
                                 + "  COUNT(DISTINCT `string`)\n"
                                 + "FROM MyTable\n"
                                 + "GROUP BY name, TUMBLE(rowtime, INTERVAL '5' SECOND)");
-        tableEnv.executeJsonPlan(jsonPlan).await();
+        tableEnv.executePlan(compiledPlan).await();
 
         List<String> result = TestValuesTableFactory.getResults("MySink");
         assertResult(
@@ -96,14 +97,14 @@ public class GroupWindowAggregateJsonITCase extends JsonPlanTestBase {
     @Test
     public void testEventTimeHopWindow() throws Exception {
         createTestValuesSinkTable("MySink", "name STRING", "cnt BIGINT");
-        String jsonPlan =
-                tableEnv.getJsonPlan(
+        CompiledPlan compiledPlan =
+                tableEnv.compilePlanSql(
                         "insert into MySink select\n"
                                 + "  name,\n"
                                 + "  COUNT(*)\n"
                                 + "FROM MyTable\n"
                                 + "GROUP BY name, HOP(rowtime, INTERVAL '5' SECOND, INTERVAL '10' SECOND)");
-        tableEnv.executeJsonPlan(jsonPlan).await();
+        tableEnv.executePlan(compiledPlan).await();
 
         List<String> result = TestValuesTableFactory.getResults("MySink");
         assertResult(
@@ -125,14 +126,14 @@ public class GroupWindowAggregateJsonITCase extends JsonPlanTestBase {
     @Test
     public void testEventTimeSessionWindow() throws Exception {
         createTestValuesSinkTable("MySink", "name STRING", "cnt BIGINT");
-        String jsonPlan =
-                tableEnv.getJsonPlan(
+        CompiledPlan compiledPlan =
+                tableEnv.compilePlanSql(
                         "insert into MySink select\n"
                                 + "  name,\n"
                                 + "  COUNT(*)\n"
                                 + "FROM MyTable\n"
                                 + "GROUP BY name, Session(rowtime, INTERVAL '3' SECOND)");
-        tableEnv.executeJsonPlan(jsonPlan).await();
+        tableEnv.executePlan(compiledPlan).await();
 
         List<String> result = TestValuesTableFactory.getResults("MySink");
         assertResult(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/IncrementalAggregateJsonPlanITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/IncrementalAggregateJsonPlanITCase.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.planner.runtime.stream.jsonplan;
 
+import org.apache.flink.table.api.CompiledPlan;
 import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.flink.table.api.config.OptimizerConfigOptions;
 import org.apache.flink.table.planner.factories.TestValuesTableFactory;
@@ -77,13 +78,13 @@ public class IncrementalAggregateJsonPlanITCase extends JsonPlanTestBase {
                 "c varchar");
         createTestNonInsertOnlyValuesSinkTable(
                 "MySink", "b bigint", "a bigint", "primary key (b) not enforced");
-        String jsonPlan =
-                tableEnv.getJsonPlan(
+        CompiledPlan compiledPlan =
+                tableEnv.compilePlanSql(
                         "insert into MySink select b, "
                                 + "count(distinct a) as a "
                                 + "from MyTable group by b");
 
-        tableEnv.executeJsonPlan(jsonPlan).await();
+        tableEnv.executePlan(compiledPlan).await();
 
         List<String> result = TestValuesTableFactory.getResults("MySink");
         assertResult(Arrays.asList("+I[1, 1]", "+I[2, 2]"), result);

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/IntervalJoinJsonPlanITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/IntervalJoinJsonPlanITCase.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.planner.runtime.stream.jsonplan;
 
+import org.apache.flink.table.api.CompiledPlan;
 import org.apache.flink.table.planner.factories.TestValuesTableFactory;
 import org.apache.flink.table.planner.utils.JsonPlanTestBase;
 import org.apache.flink.types.Row;
@@ -49,15 +50,15 @@ public class IntervalJoinJsonPlanITCase extends JsonPlanTestBase {
                 "T2", rowT2, "a int", "b bigint", "c varchar", "proctime as PROCTIME()");
         createTestValuesSinkTable("MySink", "a int", "c1 varchar", "c2 varchar");
 
-        String jsonPlan =
-                tableEnv.getJsonPlan(
+        CompiledPlan compiledPlan =
+                tableEnv.compilePlanSql(
                         "insert into MySink "
                                 + "SELECT t2.a, t2.c, t1.c\n"
                                 + "FROM T1 as t1 join T2 as t2 ON\n"
                                 + "  t1.a = t2.a AND\n"
                                 + "  t1.proctime BETWEEN t2.proctime - INTERVAL '5' SECOND AND\n"
                                 + "    t2.proctime + INTERVAL '5' SECOND");
-        tableEnv.executeJsonPlan(jsonPlan).await();
+        tableEnv.executePlan(compiledPlan).await();
         List<String> expected =
                 Arrays.asList(
                         "+I[1, HiHi, Hi1]",
@@ -99,15 +100,15 @@ public class IntervalJoinJsonPlanITCase extends JsonPlanTestBase {
                 "watermark for rowtime as rowtime - INTERVAL '5' second");
         createTestValuesSinkTable("MySink", "a int", "c1 varchar", "c2 varchar");
 
-        String jsonPlan =
-                tableEnv.getJsonPlan(
+        CompiledPlan compiledPlan =
+                tableEnv.compilePlanSql(
                         "insert into MySink \n"
                                 + "SELECT t2.a, t2.c, t1.c\n"
                                 + "FROM T1 as t1 join T2 as t2 ON\n"
                                 + "  t1.a = t2.a AND\n"
                                 + "  t1.rowtime BETWEEN t2.rowtime - INTERVAL '5' SECOND AND\n"
                                 + "    t2.rowtime + INTERVAL '6' SECOND");
-        tableEnv.executeJsonPlan(jsonPlan).await();
+        tableEnv.executePlan(compiledPlan).await();
         List<String> expected =
                 Arrays.asList(
                         "+I[1, HiHi, Hi1]",

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/JoinJsonPlanITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/JoinJsonPlanITCase.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.planner.runtime.stream.jsonplan;
 
+import org.apache.flink.table.api.CompiledPlan;
 import org.apache.flink.table.planner.factories.TestValuesTableFactory;
 import org.apache.flink.table.planner.runtime.utils.TestData;
 import org.apache.flink.table.planner.utils.JavaScalaConversionUtil;
@@ -65,8 +66,8 @@ public class JoinJsonPlanITCase extends JsonPlanTestBase {
         createTestCsvSourceTable("T2", dataT2, "a int", "b bigint", "c varchar");
         File sinkPath = createTestCsvSinkTable("MySink", "a int", "c1 varchar", "c2 varchar");
 
-        String jsonPlan =
-                tableEnv.getJsonPlan(
+        CompiledPlan compiledPlan =
+                tableEnv.compilePlanSql(
                         "insert into MySink "
                                 + "SELECT t2.a, t2.c, t1.c\n"
                                 + "FROM (\n"
@@ -76,7 +77,7 @@ public class JoinJsonPlanITCase extends JsonPlanTestBase {
                                 + " SELECT if(a = 3, cast(null as int), a) as a, b, c FROM T2\n"
                                 + ") as t2\n"
                                 + "ON t1.a = t2.a AND t1.b > t2.b");
-        tableEnv.executeJsonPlan(jsonPlan).await();
+        tableEnv.executePlan(compiledPlan).await();
         List<String> expected =
                 Arrays.asList(
                         "1,HiHi,Hi2",
@@ -99,8 +100,8 @@ public class JoinJsonPlanITCase extends JsonPlanTestBase {
         createTestCsvSourceTable("T2", dataT2, "a int", "b bigint", "c varchar");
         createTestValuesSinkTable("MySink", "a int", "c1 varchar", "c2 varchar");
 
-        String jsonPlan =
-                tableEnv.getJsonPlan(
+        CompiledPlan compiledPlan =
+                tableEnv.compilePlanSql(
                         "insert into MySink "
                                 + "SELECT t2.a, t2.c, t1.c\n"
                                 + "FROM (\n"
@@ -113,7 +114,7 @@ public class JoinJsonPlanITCase extends JsonPlanTestBase {
                                 + "  ((t1.a is null AND t2.a is null) OR\n"
                                 + "  (t1.a = t2.a))\n"
                                 + "  AND t1.b > t2.b");
-        tableEnv.executeJsonPlan(jsonPlan).await();
+        tableEnv.executePlan(compiledPlan).await();
         List<String> expected =
                 Arrays.asList(
                         "+I[1, HiHi, Hi2]",
@@ -129,10 +130,10 @@ public class JoinJsonPlanITCase extends JsonPlanTestBase {
     @Test
     public void testJoin() throws Exception {
         createTestValuesSinkTable("MySink", "a3 varchar", "b4 varchar");
-        String jsonPlan =
-                tableEnv.getJsonPlan(
+        CompiledPlan compiledPlan =
+                tableEnv.compilePlanSql(
                         "insert into MySink \n" + "SELECT a3, b4 FROM A, B WHERE a2 = b2");
-        tableEnv.executeJsonPlan(jsonPlan).await();
+        tableEnv.executePlan(compiledPlan).await();
         List<String> expected =
                 Arrays.asList(
                         "+I[Hello world, Hallo Welt]", "+I[Hello, Hallo Welt]", "+I[Hi, Hallo]");
@@ -142,10 +143,10 @@ public class JoinJsonPlanITCase extends JsonPlanTestBase {
     @Test
     public void testInnerJoin() throws Exception {
         createTestValuesSinkTable("MySink", "a1 int", "b1 int");
-        String jsonPlan =
-                tableEnv.getJsonPlan(
+        CompiledPlan compiledPlan =
+                tableEnv.compilePlanSql(
                         "insert into MySink \n" + "SELECT a1, b1 FROM A JOIN B ON a1 = b1");
-        tableEnv.executeJsonPlan(jsonPlan).await();
+        tableEnv.executePlan(compiledPlan).await();
         List<String> expected = Arrays.asList("+I[1, 1]", "+I[2, 2]", "+I[2, 2]");
         assertResult(expected, TestValuesTableFactory.getResults("MySink"));
     }
@@ -153,11 +154,11 @@ public class JoinJsonPlanITCase extends JsonPlanTestBase {
     @Test
     public void testJoinWithFilter() throws Exception {
         createTestValuesSinkTable("MySink", "a3 varchar", "b4 varchar");
-        String jsonPlan =
-                tableEnv.getJsonPlan(
+        CompiledPlan compiledPlan =
+                tableEnv.compilePlanSql(
                         "insert into MySink \n"
                                 + "SELECT a3, b4 FROM A, B where a2 = b2 and a2 < 2");
-        tableEnv.executeJsonPlan(jsonPlan).await();
+        tableEnv.executePlan(compiledPlan).await();
         List<String> expected = Arrays.asList("+I[Hi, Hallo]");
         assertResult(expected, TestValuesTableFactory.getResults("MySink"));
     }
@@ -165,11 +166,11 @@ public class JoinJsonPlanITCase extends JsonPlanTestBase {
     @Test
     public void testInnerJoinWithDuplicateKey() throws Exception {
         createTestValuesSinkTable("MySink", "a1 int", "b1 int", "b3 int");
-        String jsonPlan =
-                tableEnv.getJsonPlan(
+        CompiledPlan compiledPlan =
+                tableEnv.compilePlanSql(
                         "insert into MySink \n"
                                 + "SELECT a1, b1, b3 FROM A JOIN B ON a1 = b1 AND a1 = b3");
-        tableEnv.executeJsonPlan(jsonPlan).await();
+        tableEnv.executePlan(compiledPlan).await();
         List<String> expected = Arrays.asList("+I[2, 2, 2]");
         assertResult(expected, TestValuesTableFactory.getResults("MySink"));
     }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/LimitJsonPlanITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/LimitJsonPlanITCase.java
@@ -42,7 +42,7 @@ public class LimitJsonPlanITCase extends JsonPlanTestBase {
                 "c int");
         createTestNonInsertOnlyValuesSinkTable("`result`", "a int", "b varchar", "c bigint");
         String sql = "insert into `result` select * from MyTable limit 3";
-        executeSqlWithJsonPlanVerified(sql).await();
+        compileSqlAndExecutePlan(sql).await();
 
         List<String> expected = Arrays.asList("+I[2, a, 6]", "+I[4, b, 8]", "+I[6, c, 10]");
         assertResult(expected, TestValuesTableFactory.getResults("result"));

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/LookupJoinJsonPlanITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/LookupJoinJsonPlanITCase.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.planner.runtime.stream.jsonplan;
 
+import org.apache.flink.table.api.CompiledPlan;
 import org.apache.flink.table.planner.factories.TestValuesTableFactory;
 import org.apache.flink.table.planner.utils.JsonPlanTestBase;
 import org.apache.flink.types.Row;
@@ -67,12 +68,12 @@ public class LookupJoinJsonPlanITCase extends JsonPlanTestBase {
     /** test join temporal table. * */
     @Test
     public void testJoinLookupTable() throws Exception {
-        String jsonPlan =
-                tableEnv.getJsonPlan(
+        CompiledPlan compiledPlan =
+                tableEnv.compilePlanSql(
                         "insert into MySink "
                                 + "SELECT T.id, T.len, T.content, D.name FROM src AS T JOIN user_table \n"
                                 + "for system_time as of T.proctime AS D ON T.id = D.id \n");
-        tableEnv.executeJsonPlan(jsonPlan).await();
+        tableEnv.executePlan(compiledPlan).await();
         List<String> expected =
                 Arrays.asList(
                         "+I[1, 12, Julian, Julian]",
@@ -83,12 +84,12 @@ public class LookupJoinJsonPlanITCase extends JsonPlanTestBase {
 
     @Test
     public void testJoinLookupTableWithPushDown() throws Exception {
-        String jsonPlan =
-                tableEnv.getJsonPlan(
+        CompiledPlan compiledPlan =
+                tableEnv.compilePlanSql(
                         "insert into MySink \n"
                                 + "SELECT T.id, T.len, T.content, D.name FROM src AS T JOIN user_table \n "
                                 + "for system_time as of T.proctime AS D ON T.id = D.id AND D.age > 20");
-        tableEnv.executeJsonPlan(jsonPlan).await();
+        tableEnv.executePlan(compiledPlan).await();
         List<String> expected =
                 Arrays.asList("+I[2, 15, Hello, Jark]", "+I[3, 15, Fabian, Fabian]");
         assertResult(expected, TestValuesTableFactory.getResults("MySink"));

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/MatchRecognizeJsonPlanITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/MatchRecognizeJsonPlanITCase.java
@@ -63,7 +63,7 @@ public class MatchRecognizeJsonPlanITCase extends JsonPlanTestBase {
                         + "                 \u006C AS name = 'b',\n"
                         + "                 C AS name = 'c'\n"
                         + "     ) AS T";
-        executeSqlWithJsonPlanVerified(sql).await();
+        compileSqlAndExecutePlan(sql).await();
 
         List<String> expected = Collections.singletonList("+I[6, 7, 8]");
         assertResult(expected, TestValuesTableFactory.getResults("MySink"));
@@ -101,7 +101,7 @@ public class MatchRecognizeJsonPlanITCase extends JsonPlanTestBase {
                         + "    DOWN AS price < LAST(DOWN.price, 1) OR LAST(DOWN.price, 1) IS NULL,\n"
                         + "    UP AS price > LAST(DOWN.price)\n"
                         + ") AS T";
-        executeSqlWithJsonPlanVerified(sql).await();
+        compileSqlAndExecutePlan(sql).await();
 
         List<String> expected = Collections.singletonList("+I[19, 13, null]");
         assertResult(expected, TestValuesTableFactory.getResults("MySink"));

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/OverAggregateJsonPlanITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/OverAggregateJsonPlanITCase.java
@@ -56,7 +56,7 @@ public class OverAggregateJsonPlanITCase extends JsonPlanTestBase {
                         + "  MIN(c) OVER ("
                         + "    PARTITION BY a ORDER BY proctime ROWS BETWEEN 4 PRECEDING AND CURRENT ROW) "
                         + "FROM MyTable";
-        executeSqlWithJsonPlanVerified(sql).await();
+        compileSqlAndExecutePlan(sql).await();
 
         List<String> expected =
                 Arrays.asList(
@@ -108,7 +108,7 @@ public class OverAggregateJsonPlanITCase extends JsonPlanTestBase {
                         + "   as sum1\n"
                         + " FROM MyTable\n"
                         + ")";
-        executeSqlWithJsonPlanVerified(sql).await();
+        compileSqlAndExecutePlan(sql).await();
         List<String> expected =
                 Arrays.asList(
                         "+I[Hello World, 1, null]",
@@ -174,7 +174,7 @@ public class OverAggregateJsonPlanITCase extends JsonPlanTestBase {
         createTestNonInsertOnlyValuesSinkTable(
                 "MySink", "a string", "b int", "c bigint", "d bigint", "e bigint");
 
-        executeSqlWithJsonPlanVerified(sql).await();
+        compileSqlAndExecutePlan(sql).await();
         List<String> expected =
                 Arrays.asList(
                         "+I[Hello, 1, 0, 1, 1]",

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/RankJsonPlanITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/RankJsonPlanITCase.java
@@ -45,7 +45,7 @@ public class RankJsonPlanITCase extends JsonPlanTestBase {
                 "insert into `result` select * from "
                         + "(select a, b, row_number() over(partition by b order by c) as c from MyTable)"
                         + " where c = 1";
-        executeSqlWithJsonPlanVerified(sql).await();
+        compileSqlAndExecutePlan(sql).await();
 
         List<String> expected = Arrays.asList("+I[1, a, 1]", "+I[3, b, 1]", "+I[5, c, 1]");
         assertResult(expected, TestValuesTableFactory.getResults("result"));
@@ -65,7 +65,7 @@ public class RankJsonPlanITCase extends JsonPlanTestBase {
                 "insert into `result1` select * from "
                         + "(select a, b, row_number() over(partition by a order by t asc) as c from MyTable1)"
                         + " where c <= 2";
-        executeSqlWithJsonPlanVerified(sql).await();
+        compileSqlAndExecutePlan(sql).await();
 
         List<String> expected =
                 Arrays.asList(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/SortLimitJsonPlanITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/SortLimitJsonPlanITCase.java
@@ -42,7 +42,7 @@ public class SortLimitJsonPlanITCase extends JsonPlanTestBase {
                 "c int");
         createTestNonInsertOnlyValuesSinkTable("`result`", "a int", "b varchar", "c bigint");
         String sql = "insert into `result` select * from MyTable order by a limit 3";
-        executeSqlWithJsonPlanVerified(sql).await();
+        compileSqlAndExecutePlan(sql).await();
 
         List<String> expected = Arrays.asList("+I[1, a, 5]", "+I[2, a, 6]", "+I[3, b, 7]");
         assertResult(expected, TestValuesTableFactory.getResults("result"));

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/TableSinkJsonPlanITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/TableSinkJsonPlanITCase.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.planner.runtime.stream.jsonplan;
 
+import org.apache.flink.table.api.CompiledPlan;
 import org.apache.flink.table.planner.factories.TestValuesTableFactory;
 import org.apache.flink.table.planner.utils.JsonPlanTestBase;
 
@@ -48,9 +49,9 @@ public class TableSinkJsonPlanITCase extends JsonPlanTestBase {
                         new String[] {"a bigint", "p int not null", "b int", "c varchar"},
                         "b");
 
-        String jsonPlan =
-                tableEnv.getJsonPlan("insert into MySink partition (b=3) select * from MyTable");
-        tableEnv.executeJsonPlan(jsonPlan).await();
+        CompiledPlan compiledPlan =
+                tableEnv.compilePlanSql("insert into MySink partition (b=3) select * from MyTable");
+        tableEnv.executePlan(compiledPlan).await();
 
         assertResult(data, sinkPath);
     }
@@ -66,8 +67,9 @@ public class TableSinkJsonPlanITCase extends JsonPlanTestBase {
                     }
                 });
 
-        String jsonPlan = tableEnv.getJsonPlan("insert into MySink select * from MyTable");
-        tableEnv.executeJsonPlan(jsonPlan).await();
+        CompiledPlan compiledPlan =
+                tableEnv.compilePlanSql("insert into MySink select * from MyTable");
+        tableEnv.executePlan(compiledPlan).await();
 
         List<String> result = TestValuesTableFactory.getResults("MySink");
         assertResult(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/TableSourceJsonPlanITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/TableSourceJsonPlanITCase.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.planner.runtime.stream.jsonplan;
 
+import org.apache.flink.table.api.CompiledPlan;
 import org.apache.flink.table.planner.runtime.utils.TestData;
 import org.apache.flink.table.planner.utils.JavaScalaConversionUtil;
 import org.apache.flink.table.planner.utils.JsonPlanTestBase;
@@ -40,8 +41,9 @@ public class TableSourceJsonPlanITCase extends JsonPlanTestBase {
         createTestCsvSourceTable("MyTable", data, "a bigint", "b int not null", "c varchar");
         File sinkPath = createTestCsvSinkTable("MySink", "a bigint", "b int");
 
-        String jsonPlan = tableEnv.getJsonPlan("insert into MySink select a, b from MyTable");
-        tableEnv.executeJsonPlan(jsonPlan).await();
+        CompiledPlan compiledPlan =
+                tableEnv.compilePlanSql("insert into MySink select a, b from MyTable");
+        tableEnv.executePlan(compiledPlan).await();
 
         assertResult(Arrays.asList("1,1", "2,1", "3,2"), sinkPath);
     }
@@ -60,8 +62,9 @@ public class TableSourceJsonPlanITCase extends JsonPlanTestBase {
 
         File sinkPath = createTestCsvSinkTable("MySink", "a bigint", "m varchar");
 
-        String jsonPlan = tableEnv.getJsonPlan("insert into MySink select a, m from MyTable");
-        tableEnv.executeJsonPlan(jsonPlan).await();
+        CompiledPlan compiledPlan =
+                tableEnv.compilePlanSql("insert into MySink select a, m from MyTable");
+        tableEnv.executePlan(compiledPlan).await();
 
         assertResult(Arrays.asList("1,Hi", "2,Hello", "3,Hello world"), sinkPath);
     }
@@ -72,9 +75,9 @@ public class TableSourceJsonPlanITCase extends JsonPlanTestBase {
         createTestCsvSourceTable("MyTable", data, "a bigint", "b int not null", "c varchar");
         File sinkPath = createTestCsvSinkTable("MySink", "a bigint", "b int", "c varchar");
 
-        String jsonPlan =
-                tableEnv.getJsonPlan("insert into MySink select * from MyTable where a > 1");
-        tableEnv.executeJsonPlan(jsonPlan).await();
+        CompiledPlan compiledPlan =
+                tableEnv.compilePlanSql("insert into MySink select * from MyTable where a > 1");
+        tableEnv.executePlan(compiledPlan).await();
 
         assertResult(Arrays.asList("2,1,hello", "3,2,hello world"), sinkPath);
     }
@@ -93,9 +96,9 @@ public class TableSourceJsonPlanITCase extends JsonPlanTestBase {
                 });
         File sinkPath = createTestCsvSinkTable("MySink", "a int", "p bigint", "c varchar");
 
-        String jsonPlan =
-                tableEnv.getJsonPlan("insert into MySink select * from MyTable where p = 2");
-        tableEnv.executeJsonPlan(jsonPlan).await();
+        CompiledPlan compiledPlan =
+                tableEnv.compilePlanSql("insert into MySink select * from MyTable where p = 2");
+        tableEnv.executePlan(compiledPlan).await();
 
         assertResult(Arrays.asList("2,2,Hello", "3,2,Hello world"), sinkPath);
     }
@@ -120,9 +123,10 @@ public class TableSourceJsonPlanITCase extends JsonPlanTestBase {
 
         File sinkPath = createTestCsvSinkTable("MySink", "a int", "b bigint", "ts timestamp(3)");
 
-        String jsonPlan =
-                tableEnv.getJsonPlan("insert into MySink select a, b, ts from MyTable where b = 3");
-        tableEnv.executeJsonPlan(jsonPlan).await();
+        CompiledPlan compiledPlan =
+                tableEnv.compilePlanSql(
+                        "insert into MySink select a, b, ts from MyTable where b = 3");
+        tableEnv.executePlan(compiledPlan).await();
 
         assertResult(
                 Arrays.asList(
@@ -156,10 +160,10 @@ public class TableSourceJsonPlanITCase extends JsonPlanTestBase {
 
         File sinkPath = createTestCsvSinkTable("MySink", "a int", "ts timestamp(3)");
 
-        String jsonPlan =
-                tableEnv.getJsonPlan(
+        CompiledPlan compiledPlan =
+                tableEnv.compilePlanSql(
                         "insert into MySink select a, ts from MyTable where b = 3 and a > 4");
-        tableEnv.executeJsonPlan(jsonPlan).await();
+        tableEnv.executePlan(compiledPlan).await();
 
         assertResult(
                 Arrays.asList("5," + toLocalDateTime(5000L), "6," + toLocalDateTime(6000L)),

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/TemporalJoinJsonPlanITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/TemporalJoinJsonPlanITCase.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.planner.runtime.stream.jsonplan;
 
+import org.apache.flink.table.api.CompiledPlan;
 import org.apache.flink.table.functions.TemporalTableFunction;
 import org.apache.flink.table.planner.factories.TestValuesTableFactory;
 import org.apache.flink.table.planner.utils.JsonPlanTestBase;
@@ -76,30 +77,28 @@ public class TemporalJoinJsonPlanITCase extends JsonPlanTestBase {
     /** test process time inner join. * */
     @Test
     public void testJoinTemporalFunction() throws Exception {
-
-        String jsonPlan =
-                tableEnv.getJsonPlan(
+        CompiledPlan compiledPlan =
+                tableEnv.compilePlanSql(
                         "INSERT INTO MySink "
                                 + "SELECT amount * r.rate "
                                 + "FROM Orders AS o,  "
                                 + "LATERAL TABLE (Rates(o.rowtime)) AS r "
                                 + "WHERE o.currency = r.currency ");
-        tableEnv.executeJsonPlan(jsonPlan).await();
+        tableEnv.executePlan(compiledPlan).await();
         List<String> expected = Arrays.asList("+I[102]", "+I[228]", "+I[348]", "+I[50]");
         assertResult(expected, TestValuesTableFactory.getResults("MySink"));
     }
 
     @Test
     public void testTemporalTableJoin() throws Exception {
-
-        String jsonPlan =
-                tableEnv.getJsonPlan(
+        CompiledPlan compiledPlan =
+                tableEnv.compilePlanSql(
                         "INSERT INTO MySink "
                                 + "SELECT amount * r.rate "
                                 + "FROM Orders AS o  "
                                 + "JOIN RatesHistory  FOR SYSTEM_TIME AS OF o.rowtime AS r "
                                 + "ON o.currency = r.currency ");
-        tableEnv.executeJsonPlan(jsonPlan).await();
+        tableEnv.executePlan(compiledPlan).await();
         List<String> expected = Arrays.asList("+I[102]", "+I[228]", "+I[348]", "+I[50]");
         assertResult(expected, TestValuesTableFactory.getResults("MySink"));
     }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/TemporalSortJsonITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/TemporalSortJsonITCase.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.planner.runtime.stream.jsonplan;
 
+import org.apache.flink.table.api.CompiledPlan;
 import org.apache.flink.table.planner.factories.TestValuesTableFactory;
 import org.apache.flink.table.planner.runtime.utils.TestData;
 import org.apache.flink.table.planner.utils.JavaScalaConversionUtil;
@@ -43,9 +44,10 @@ public class TemporalSortJsonITCase extends JsonPlanTestBase {
                 "c STRING",
                 "proctime as PROCTIME()");
         createTestValuesSinkTable("MySink", "a INT");
-        String jsonPlan =
-                tableEnv.getJsonPlan("insert into MySink SELECT a FROM MyTable order by proctime");
-        tableEnv.executeJsonPlan(jsonPlan).await();
+        CompiledPlan compiledPlan =
+                tableEnv.compilePlanSql(
+                        "insert into MySink SELECT a FROM MyTable order by proctime");
+        tableEnv.executePlan(compiledPlan).await();
 
         assertResult(
                 Arrays.asList("+I[1]", "+I[2]", "+I[3]"),
@@ -75,10 +77,10 @@ public class TemporalSortJsonITCase extends JsonPlanTestBase {
                     }
                 });
         createTestValuesSinkTable("MySink", "`int` INT");
-        String jsonPlan =
-                tableEnv.getJsonPlan(
+        CompiledPlan compiledPlan =
+                tableEnv.compilePlanSql(
                         "insert into MySink SELECT `int` FROM MyTable order by rowtime, `double`");
-        tableEnv.executeJsonPlan(jsonPlan).await();
+        tableEnv.executePlan(compiledPlan).await();
 
         assertEquals(
                 Arrays.asList(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/UnionJsonPlanITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/UnionJsonPlanITCase.java
@@ -50,7 +50,7 @@ public class UnionJsonPlanITCase extends JsonPlanTestBase {
                 "INSERT INTO MySink "
                         + "(SELECT * FROM MyTable where a >=3)"
                         + "     union all (select * from MyTable2 where a <= 3)";
-        executeSqlWithJsonPlanVerified(dml).await();
+        compileSqlAndExecutePlan(dml).await();
         List<String> expected =
                 Arrays.asList(
                         "+I[2, a, 6]",

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/ValuesJsonPlanITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/ValuesJsonPlanITCase.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.planner.runtime.stream.jsonplan;
 
+import org.apache.flink.table.api.CompiledPlan;
 import org.apache.flink.table.planner.factories.TestValuesTableFactory;
 import org.apache.flink.table.planner.utils.JsonPlanTestBase;
 
@@ -32,10 +33,10 @@ public class ValuesJsonPlanITCase extends JsonPlanTestBase {
     @Test
     public void testValues() throws Exception {
         createTestValuesSinkTable("MySink", "b INT", "a INT", "c VARCHAR");
-        String jsonPlan =
-                tableEnv.getJsonPlan(
+        CompiledPlan compiledPlan =
+                tableEnv.compilePlanSql(
                         "INSERT INTO MySink SELECT * from (VALUES (1, 2, 'Hi'), (3, 4, 'Hello'))");
-        tableEnv.executeJsonPlan(jsonPlan).await();
+        tableEnv.executePlan(compiledPlan).await();
 
         List<String> result = TestValuesTableFactory.getResults("MySink");
         assertResult(Arrays.asList("+I[1, 2, Hi]", "+I[3, 4, Hello]"), result);

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/WatermarkAssignerJsonPlanITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/WatermarkAssignerJsonPlanITCase.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.planner.runtime.stream.jsonplan;
 
+import org.apache.flink.table.api.CompiledPlan;
 import org.apache.flink.table.planner.runtime.utils.TestData;
 import org.apache.flink.table.planner.utils.JavaScalaConversionUtil;
 import org.apache.flink.table.planner.utils.JsonPlanTestBase;
@@ -53,9 +54,10 @@ public class WatermarkAssignerJsonPlanITCase extends JsonPlanTestBase {
 
         File sinkPath = createTestCsvSinkTable("MySink", "a int", "b bigint", "ts timestamp(3)");
 
-        String jsonPlan =
-                tableEnv.getJsonPlan("insert into MySink select a, b, ts from MyTable where b = 3");
-        tableEnv.executeJsonPlan(jsonPlan).await();
+        CompiledPlan compiledPlan =
+                tableEnv.compilePlanSql(
+                        "insert into MySink select a, b, ts from MyTable where b = 3");
+        tableEnv.executePlan(compiledPlan).await();
 
         assertResult(
                 Arrays.asList(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/WindowAggregateJsonITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/WindowAggregateJsonITCase.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.planner.runtime.stream.jsonplan;
 
+import org.apache.flink.table.api.CompiledPlan;
 import org.apache.flink.table.api.config.OptimizerConfigOptions;
 import org.apache.flink.table.planner.factories.TestValuesTableFactory;
 import org.apache.flink.table.planner.runtime.utils.TestData;
@@ -88,8 +89,8 @@ public class WindowAggregateJsonITCase extends JsonPlanTestBase {
                 "cnt BIGINT",
                 "sum_int INT",
                 "distinct_cnt BIGINT");
-        String jsonPlan =
-                tableEnv.getJsonPlan(
+        CompiledPlan compiledPlan =
+                tableEnv.compilePlanSql(
                         "insert into MySink select\n"
                                 + "  name,\n"
                                 + "  window_start,\n"
@@ -100,7 +101,7 @@ public class WindowAggregateJsonITCase extends JsonPlanTestBase {
                                 + "FROM TABLE(\n"
                                 + "   TUMBLE(TABLE MyTable, DESCRIPTOR(rowtime), INTERVAL '5' SECOND))\n"
                                 + "GROUP BY name, window_start, window_end");
-        tableEnv.executeJsonPlan(jsonPlan).await();
+        tableEnv.executePlan(compiledPlan).await();
 
         List<String> result = TestValuesTableFactory.getResults("MySink");
         assertResult(
@@ -117,15 +118,15 @@ public class WindowAggregateJsonITCase extends JsonPlanTestBase {
     @Test
     public void testEventTimeHopWindow() throws Exception {
         createTestValuesSinkTable("MySink", "name STRING", "cnt BIGINT");
-        String jsonPlan =
-                tableEnv.getJsonPlan(
+        CompiledPlan compiledPlan =
+                tableEnv.compilePlanSql(
                         "insert into MySink select\n"
                                 + "  name,\n"
                                 + "  COUNT(*)\n"
                                 + "FROM TABLE(\n"
                                 + "   HOP(TABLE MyTable, DESCRIPTOR(rowtime), INTERVAL '5' SECOND, INTERVAL '10' SECOND))\n"
                                 + "GROUP BY name, window_start, window_end");
-        tableEnv.executeJsonPlan(jsonPlan).await();
+        tableEnv.executePlan(compiledPlan).await();
 
         List<String> result = TestValuesTableFactory.getResults("MySink");
         assertResult(
@@ -147,8 +148,8 @@ public class WindowAggregateJsonITCase extends JsonPlanTestBase {
     @Test
     public void testEventTimeCumulateWindow() throws Exception {
         createTestValuesSinkTable("MySink", "name STRING", "cnt BIGINT");
-        String jsonPlan =
-                tableEnv.getJsonPlan(
+        CompiledPlan compiledPlan =
+                tableEnv.compilePlanSql(
                         "insert into MySink select\n"
                                 + "  name,\n"
                                 + "  COUNT(*)\n"
@@ -159,7 +160,7 @@ public class WindowAggregateJsonITCase extends JsonPlanTestBase {
                                 + "     INTERVAL '5' SECOND,\n"
                                 + "     INTERVAL '15' SECOND))"
                                 + "GROUP BY name, window_start, window_end");
-        tableEnv.executeJsonPlan(jsonPlan).await();
+        tableEnv.executePlan(compiledPlan).await();
 
         List<String> result = TestValuesTableFactory.getResults("MySink");
         assertResult(
@@ -190,8 +191,8 @@ public class WindowAggregateJsonITCase extends JsonPlanTestBase {
         createTestValuesSinkTable(
                 "MySink", "name STRING", "max_double DOUBLE", "cnt_distinct_int BIGINT");
 
-        String jsonPlan =
-                tableEnv.getJsonPlan(
+        CompiledPlan compiledPlan =
+                tableEnv.compilePlanSql(
                         "insert into MySink select name, "
                                 + "   max(`double`),\n"
                                 + "   count(distinct `int`) "
@@ -202,7 +203,7 @@ public class WindowAggregateJsonITCase extends JsonPlanTestBase {
                                 + "     INTERVAL '5' SECOND,\n"
                                 + "     INTERVAL '15' SECOND))"
                                 + "GROUP BY name, window_start, window_end");
-        tableEnv.executeJsonPlan(jsonPlan).await();
+        tableEnv.executePlan(compiledPlan).await();
 
         List<String> result = TestValuesTableFactory.getResults("MySink");
         assertResult(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/WindowDeduplicateJsonITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/WindowDeduplicateJsonITCase.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.planner.runtime.stream.jsonplan;
 
+import org.apache.flink.table.api.CompiledPlan;
 import org.apache.flink.table.planner.factories.TestValuesTableFactory;
 import org.apache.flink.table.planner.runtime.utils.TestData;
 import org.apache.flink.table.planner.utils.JavaScalaConversionUtil;
@@ -73,8 +74,8 @@ public class WindowDeduplicateJsonITCase extends JsonPlanTestBase {
                 "window_start TIMESTAMP(3)",
                 "window_end TIMESTAMP(3)",
                 "window_time TIMESTAMP(3)");
-        String jsonPlan =
-                tableEnv.getJsonPlan(
+        CompiledPlan compiledPlan =
+                tableEnv.compilePlanSql(
                         "insert into MySink select\n"
                                 + "  `ts`,\n"
                                 + "  `int`,\n"
@@ -94,7 +95,7 @@ public class WindowDeduplicateJsonITCase extends JsonPlanTestBase {
                                 + "      FROM TABLE( \n"
                                 + "              TUMBLE(TABLE MyTable, DESCRIPTOR(rowtime), INTERVAL '5' SECOND))) \n"
                                 + "WHERE rownum <= 1");
-        tableEnv.executeJsonPlan(jsonPlan).await();
+        tableEnv.executePlan(compiledPlan).await();
 
         List<String> result = TestValuesTableFactory.getResults("MySink");
         assertResult(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/WindowJoinJsonITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/WindowJoinJsonITCase.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.planner.runtime.stream.jsonplan;
 
+import org.apache.flink.table.api.CompiledPlan;
 import org.apache.flink.table.planner.factories.TestValuesTableFactory;
 import org.apache.flink.table.planner.runtime.utils.TestData;
 import org.apache.flink.table.planner.utils.JavaScalaConversionUtil;
@@ -88,8 +89,8 @@ public class WindowJoinJsonITCase extends JsonPlanTestBase {
                 "window_end TIMESTAMP(3)",
                 "uv1 BIGINT",
                 "uv2 BIGINT");
-        String jsonPlan =
-                tableEnv.getJsonPlan(
+        CompiledPlan compiledPlan =
+                tableEnv.compilePlanSql(
                         "insert into MySink select\n"
                                 + "  L.name,\n"
                                 + "  L.window_start,\n"
@@ -117,7 +118,7 @@ public class WindowJoinJsonITCase extends JsonPlanTestBase {
                                 + "  GROUP BY name, window_start, window_end\n"
                                 + "  ) R\n"
                                 + "ON L.window_start = R.window_start AND L.window_end = R.window_end AND L.name = R.name");
-        tableEnv.executeJsonPlan(jsonPlan).await();
+        tableEnv.executePlan(compiledPlan).await();
 
         List<String> result = TestValuesTableFactory.getResults("MySink");
         assertResult(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/WindowTableFunctionJsonITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/WindowTableFunctionJsonITCase.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.planner.runtime.stream.jsonplan;
 
+import org.apache.flink.table.api.CompiledPlan;
 import org.apache.flink.table.planner.factories.TestValuesTableFactory;
 import org.apache.flink.table.planner.runtime.utils.TestData;
 import org.apache.flink.table.planner.utils.JavaScalaConversionUtil;
@@ -73,8 +74,8 @@ public class WindowTableFunctionJsonITCase extends JsonPlanTestBase {
                 "window_start TIMESTAMP(3)",
                 "window_end TIMESTAMP(3)",
                 "window_time TIMESTAMP(3)");
-        String jsonPlan =
-                tableEnv.getJsonPlan(
+        CompiledPlan compiledPlan =
+                tableEnv.compilePlanSql(
                         "insert into MySink select\n"
                                 + "  `ts`,\n"
                                 + "  `int`,\n"
@@ -88,7 +89,7 @@ public class WindowTableFunctionJsonITCase extends JsonPlanTestBase {
                                 + "  window_end, \n"
                                 + "  window_time \n"
                                 + "FROM TABLE(TUMBLE(TABLE MyTable, DESCRIPTOR(rowtime), INTERVAL '5' SECOND))");
-        tableEnv.executeJsonPlan(jsonPlan).await();
+        tableEnv.executePlan(compiledPlan).await();
 
         List<String> result = TestValuesTableFactory.getResults("MySink");
         assertResult(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/utils/JsonPlanTestBase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/utils/JsonPlanTestBase.java
@@ -71,8 +71,8 @@ public abstract class JsonPlanTestBase extends AbstractTestBase {
         TestValuesTableFactory.clearAllData();
     }
 
-    protected TableResult executeSqlWithJsonPlanVerified(String sql) {
-        return tableEnv.executeJsonPlan(tableEnv.getJsonPlan(sql));
+    protected TableResult compileSqlAndExecutePlan(String sql) {
+        return tableEnv.executePlan(tableEnv.compilePlanSql(sql));
     }
 
     protected void createTestValuesSourceTable(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/utils/JsonPlanTestBase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/utils/JsonPlanTestBase.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.planner.utils;
 
 import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.PlanReference;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.api.internal.TableEnvironmentInternal;
@@ -36,6 +37,7 @@ import javax.annotation.Nullable;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -48,6 +50,7 @@ import java.util.stream.Collectors;
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /** The base class for json plan testing. */
 public abstract class JsonPlanTestBase extends AbstractTestBase {
@@ -257,5 +260,15 @@ public abstract class JsonPlanTestBase extends AbstractTestBase {
             }
         }
         return result;
+    }
+
+    public static PlanReference planReferenceFromClasspath(String classpathFilePath) {
+        try {
+            return PlanReference.fromFile(
+                    new File(JsonPlanTestBase.class.getResource(classpathFilePath).toURI()));
+        } catch (URISyntaxException | NullPointerException e) {
+            fail("Cannot load the plan reference", e);
+            return null;
+        }
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/utils/JsonPlanTestBase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/utils/JsonPlanTestBase.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.planner.utils;
 
 import org.apache.flink.table.api.EnvironmentSettings;
-import org.apache.flink.table.api.PlanReference;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.api.internal.TableEnvironmentInternal;
@@ -37,7 +36,6 @@ import javax.annotation.Nullable;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -50,7 +48,6 @@ import java.util.stream.Collectors;
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.junit.Assert.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
 
 /** The base class for json plan testing. */
 public abstract class JsonPlanTestBase extends AbstractTestBase {
@@ -260,15 +257,5 @@ public abstract class JsonPlanTestBase extends AbstractTestBase {
             }
         }
         return result;
-    }
-
-    public static PlanReference planReferenceFromClasspath(String classpathFilePath) {
-        try {
-            return PlanReference.fromFile(
-                    new File(JsonPlanTestBase.class.getResource(classpathFilePath).toURI()));
-        } catch (URISyntaxException | NullPointerException e) {
-            fail("Cannot load the plan reference", e);
-            return null;
-        }
     }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
@@ -782,8 +782,8 @@ abstract class TableTestUtilBase(test: TableTestBase, isStreamingMode: Boolean) 
    */
   def verifyJsonPlan(insert: String): Unit = {
     ExecNodeContext.resetIdCounter()
-    val jsonPlan = getTableEnv.asInstanceOf[TableEnvironmentInternal].getJsonPlan(insert)
-    val jsonPlanWithoutFlinkVersion = TableTestUtil.replaceFlinkVersion(jsonPlan)
+    val jsonPlan = getTableEnv.asInstanceOf[TableEnvironmentInternal].compilePlanSql(insert)
+    val jsonPlanWithoutFlinkVersion = TableTestUtil.replaceFlinkVersion(jsonPlan.asJsonString())
     // add the postfix to the path to avoid conflicts
     // between the test class name and the result file name
     val clazz = test.getClass


### PR DESCRIPTION
## What is the purpose of the change

This PR is the first step towards exposing the persisted plan feature to the users. It features 5 new APIs in `TableEnvironment` plus 2 new types:

* `CompiledPlan` to hold a compiled, immutable and ready to execute plan
* `PlanReference` to hold either a file reference, or a json string of a plan
* `CompiledPlan loadPlan(PlanReference planReference)` to load a plan from file/string
* `CompiledPlan compilePlanSql(String stmt)` to compile a plan from a DML statement
* `TableResult executePlan(CompiledPlan plan)` to execute a plan
* `TableResult executePlan(PlanReference planReference)` shorthand of the above method
* `explainPlan(CompiledPlan compiledPlan, ExplainDetail... extraDetails)` to explain a plan

## Brief change log

* Add the new APIs and implement them
* Replace all the usages of the previous internal "json plan" APIs, and remove them

## Verifying this change

All the tests which were using the previous "json plan" APIs are now using the new APIs, so all the new APIs should be effectively covered by previous existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
