### PR TITLE
[FLINK-25827][task] Fix potential memory leak in SourceOperator when using CompletableFuture.anyOf

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/MultipleFuturesAvailabilityHelper.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/MultipleFuturesAvailabilityHelper.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.io;
+
+import org.apache.flink.annotation.Internal;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.apache.flink.util.concurrent.FutureUtils.assertNoException;
+
+/**
+ * This class is semi-thread safe. Only method {@link #notifyCompletion()} is allowed to be executed
+ * from an outside of the task thread.
+ *
+ * <p>It solves a problem of a potential memory leak as described in FLINK-25728. In short we have
+ * to ensure, that if there is one input (future) that rarely (or never) completes, that such future
+ * would not prevent previously returned combined futures (like {@link
+ * CompletableFuture#anyOf(CompletableFuture[])} from being garbage collected. Additionally, we
+ * don't want to accumulate more and more completion stages on such rarely completed future, so we
+ * are registering {@link CompletableFuture#thenRun(Runnable)} only if it has not already been done.
+ *
+ * <p>Note {@link #resetToUnAvailable()} doesn't de register previously registered futures. If
+ * future was registered in the past, but for whatever reason now it is not, such future can still
+ * complete the newly created future.
+ *
+ * <p>It might be no longer needed after upgrading to JDK9
+ * (https://bugs.openjdk.java.net/browse/JDK-8160402).
+ */
+@Internal
+public class MultipleFuturesAvailabilityHelper {
+    private final CompletableFuture<?>[] futuresToCombine;
+
+    private volatile CompletableFuture<?> availableFuture = new CompletableFuture<>();
+
+    public MultipleFuturesAvailabilityHelper(int size) {
+        futuresToCombine = new CompletableFuture[size];
+    }
+
+    /** @return combined future using anyOf logic */
+    public CompletableFuture<?> getAvailableFuture() {
+        return availableFuture;
+    }
+
+    public void resetToUnAvailable() {
+        if (availableFuture.isDone()) {
+            availableFuture = new CompletableFuture<>();
+        }
+    }
+
+    private void notifyCompletion() {
+        availableFuture.complete(null);
+    }
+
+    /**
+     * Combine {@code availabilityFuture} using anyOf logic with other previously registered
+     * futures.
+     */
+    public void anyOf(final int idx, CompletableFuture<?> availabilityFuture) {
+        if (futuresToCombine[idx] == null || futuresToCombine[idx].isDone()) {
+            futuresToCombine[idx] = availabilityFuture;
+            assertNoException(availabilityFuture.thenRun(this::notifyCompletion));
+        }
+    }
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorIdleTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorIdleTest.java
@@ -1,0 +1,69 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package org.apache.flink.streaming.api.operators;
+
+import org.apache.flink.api.connector.source.mocks.MockSourceSplit;
+import org.apache.flink.runtime.io.AvailabilityProvider;
+import org.apache.flink.streaming.api.operators.source.CollectingDataOutput;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.annotation.Nullable;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertFalse;
+
+/** Unit test for idle {@link SourceOperator}. */
+@SuppressWarnings("serial")
+public class SourceOperatorIdleTest {
+
+    @Nullable private SourceOperatorTestContext context;
+    @Nullable private SourceOperator<Integer, MockSourceSplit> operator;
+
+    @Before
+    public void setup() throws Exception {
+        context = new SourceOperatorTestContext();
+        operator = context.getOperator();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        context.close();
+        context = null;
+        operator = null;
+    }
+
+    @Test
+    public void testSameAvailabilityFuture() throws Exception {
+        operator.initializeState(context.createStateContext());
+        operator.open();
+        operator.emitNext(new CollectingDataOutput<>());
+        final CompletableFuture<?> initialFuture = operator.getAvailableFuture();
+        assertFalse(initialFuture.isDone());
+        final CompletableFuture<?> secondFuture = operator.getAvailableFuture();
+        assertThat(initialFuture, not(sameInstance(AvailabilityProvider.AVAILABLE)));
+        assertThat(secondFuture, sameInstance(initialFuture));
+    }
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorTest.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.connector.source.SourceEvent;
 import org.apache.flink.api.connector.source.mocks.MockSourceReader;
 import org.apache.flink.api.connector.source.mocks.MockSourceSplit;
 import org.apache.flink.api.connector.source.mocks.MockSourceSplitSerializer;
-import org.apache.flink.runtime.io.AvailabilityProvider;
 import org.apache.flink.runtime.io.network.api.StopMode;
 import org.apache.flink.runtime.operators.coordination.MockOperatorEventGateway;
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
@@ -46,9 +45,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.sameInstance;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -195,13 +191,5 @@ public class SourceOperatorTest {
         operator.snapshotState(new StateSnapshotContextSynchronousImpl(100L, 100L));
         operator.notifyCheckpointAborted(100L);
         assertEquals(100L, (long) mockSourceReader.getAbortedCheckpoints().get(0));
-    }
-
-    @Test
-    public void testSameAvailabilityFuture() {
-        final CompletableFuture<?> initialFuture = operator.getAvailableFuture();
-        final CompletableFuture<?> secondFuture = operator.getAvailableFuture();
-        assertThat(initialFuture, not(sameInstance(AvailabilityProvider.AVAILABLE)));
-        assertThat(secondFuture, sameInstance(initialFuture));
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorTest.java
@@ -18,46 +18,29 @@ limitations under the License.
 
 package org.apache.flink.streaming.api.operators;
 
-import org.apache.flink.api.common.ExecutionConfig;
-import org.apache.flink.api.common.state.OperatorStateStore;
 import org.apache.flink.api.connector.source.SourceEvent;
 import org.apache.flink.api.connector.source.mocks.MockSourceReader;
 import org.apache.flink.api.connector.source.mocks.MockSourceSplit;
 import org.apache.flink.api.connector.source.mocks.MockSourceSplitSerializer;
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.core.fs.CloseableRegistry;
-import org.apache.flink.core.io.SimpleVersionedSerialization;
-import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.io.AvailabilityProvider;
 import org.apache.flink.runtime.io.network.api.StopMode;
 import org.apache.flink.runtime.operators.coordination.MockOperatorEventGateway;
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
-import org.apache.flink.runtime.operators.testutils.MockEnvironment;
-import org.apache.flink.runtime.operators.testutils.MockEnvironmentBuilder;
-import org.apache.flink.runtime.operators.testutils.MockInputSplitProvider;
 import org.apache.flink.runtime.source.event.AddSplitEvent;
 import org.apache.flink.runtime.source.event.ReaderRegistrationEvent;
 import org.apache.flink.runtime.source.event.SourceEventWrapper;
-import org.apache.flink.runtime.state.AbstractStateBackend;
 import org.apache.flink.runtime.state.StateInitializationContext;
-import org.apache.flink.runtime.state.StateInitializationContextImpl;
 import org.apache.flink.runtime.state.StateSnapshotContextSynchronousImpl;
-import org.apache.flink.runtime.state.TestTaskStateManager;
-import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.streaming.api.operators.source.CollectingDataOutput;
-import org.apache.flink.streaming.api.operators.source.TestingSourceOperator;
 import org.apache.flink.streaming.runtime.io.DataInputStatus;
-import org.apache.flink.streaming.runtime.tasks.SourceOperatorStreamTask;
-import org.apache.flink.streaming.runtime.tasks.StreamMockEnvironment;
-import org.apache.flink.streaming.util.MockOutput;
-import org.apache.flink.streaming.util.MockStreamConfig;
 import org.apache.flink.util.CollectionUtil;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.ArrayList;
+import javax.annotation.Nullable;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -75,41 +58,31 @@ import static org.junit.Assert.assertTrue;
 @SuppressWarnings("serial")
 public class SourceOperatorTest {
 
-    private static final int SUBTASK_INDEX = 1;
-    private static final MockSourceSplit MOCK_SPLIT = new MockSourceSplit(1234, 10);
-
-    private MockSourceReader mockSourceReader;
-    private MockOperatorEventGateway mockGateway;
-    private SourceOperator<Integer, MockSourceSplit> operator;
+    @Nullable private SourceOperatorTestContext context;
+    @Nullable private SourceOperator<Integer, MockSourceSplit> operator;
+    @Nullable private MockSourceReader mockSourceReader;
+    @Nullable private MockOperatorEventGateway mockGateway;
 
     @Before
     public void setup() throws Exception {
-        this.mockSourceReader = new MockSourceReader();
-        this.mockGateway = new MockOperatorEventGateway();
-        this.operator =
-                new TestingSourceOperator<>(
-                        mockSourceReader,
-                        mockGateway,
-                        SUBTASK_INDEX,
-                        true /* emit progressive watermarks */);
-        Environment env = getTestingEnvironment();
-        this.operator.setup(
-                new SourceOperatorStreamTask<Integer>(env),
-                new MockStreamConfig(new Configuration(), 1),
-                new MockOutput<>(new ArrayList<>()));
-        this.operator.initializeState(
-                new StreamTaskStateInitializerImpl(env, new MemoryStateBackend()));
+        context = new SourceOperatorTestContext();
+        operator = context.getOperator();
+        mockSourceReader = context.getSourceReader();
+        mockGateway = context.getGateway();
     }
 
     @After
-    public void cleanUp() throws Exception {
-        operator.close();
-        assertTrue(mockSourceReader.isClosed());
+    public void tearDown() throws Exception {
+        context.close();
+        context = null;
+        operator = null;
+        mockSourceReader = null;
+        mockGateway = null;
     }
 
     @Test
     public void testInitializeState() throws Exception {
-        StateInitializationContext stateContext = getStateContext();
+        StateInitializationContext stateContext = context.createStateContext();
         operator.initializeState(stateContext);
 
         assertNotNull(
@@ -121,11 +94,13 @@ public class SourceOperatorTest {
     @Test
     public void testOpen() throws Exception {
         // Initialize the operator.
-        operator.initializeState(getStateContext());
+        operator.initializeState(context.createStateContext());
         // Open the operator.
         operator.open();
         // The source reader should have been assigned a split.
-        assertEquals(Collections.singletonList(MOCK_SPLIT), mockSourceReader.getAssignedSplits());
+        assertEquals(
+                Collections.singletonList(SourceOperatorTestContext.MOCK_SPLIT),
+                mockSourceReader.getAssignedSplits());
         // The source reader should have started.
         assertTrue(mockSourceReader.isStarted());
 
@@ -133,17 +108,21 @@ public class SourceOperatorTest {
         assertEquals(1, mockGateway.getEventsSent().size());
         OperatorEvent operatorEvent = mockGateway.getEventsSent().get(0);
         assertTrue(operatorEvent instanceof ReaderRegistrationEvent);
-        assertEquals(SUBTASK_INDEX, ((ReaderRegistrationEvent) operatorEvent).subtaskId());
+        assertEquals(
+                SourceOperatorTestContext.SUBTASK_INDEX,
+                ((ReaderRegistrationEvent) operatorEvent).subtaskId());
     }
 
     @Test
     public void testStop() throws Exception {
         // Initialize the operator.
-        operator.initializeState(getStateContext());
+        operator.initializeState(context.createStateContext());
         // Open the operator.
         operator.open();
         // The source reader should have been assigned a split.
-        assertEquals(Collections.singletonList(MOCK_SPLIT), mockSourceReader.getAssignedSplits());
+        assertEquals(
+                Collections.singletonList(SourceOperatorTestContext.MOCK_SPLIT),
+                mockSourceReader.getAssignedSplits());
 
         CollectingDataOutput<Integer> dataOutput = new CollectingDataOutput<>();
         assertEquals(DataInputStatus.NOTHING_AVAILABLE, operator.emitNext(dataOutput));
@@ -159,19 +138,21 @@ public class SourceOperatorTest {
 
     @Test
     public void testHandleAddSplitsEvent() throws Exception {
-        operator.initializeState(getStateContext());
+        operator.initializeState(context.createStateContext());
         operator.open();
         MockSourceSplit newSplit = new MockSourceSplit((2));
         operator.handleOperatorEvent(
                 new AddSplitEvent<>(
                         Collections.singletonList(newSplit), new MockSourceSplitSerializer()));
         // The source reader should have been assigned two splits.
-        assertEquals(Arrays.asList(MOCK_SPLIT, newSplit), mockSourceReader.getAssignedSplits());
+        assertEquals(
+                Arrays.asList(SourceOperatorTestContext.MOCK_SPLIT, newSplit),
+                mockSourceReader.getAssignedSplits());
     }
 
     @Test
     public void testHandleAddSourceEvent() throws Exception {
-        operator.initializeState(getStateContext());
+        operator.initializeState(context.createStateContext());
         operator.open();
         SourceEvent event = new SourceEvent() {};
         operator.handleOperatorEvent(new SourceEventWrapper(event));
@@ -181,7 +162,7 @@ public class SourceOperatorTest {
 
     @Test
     public void testSnapshotState() throws Exception {
-        StateInitializationContext stateContext = getStateContext();
+        StateInitializationContext stateContext = context.createStateContext();
         operator.initializeState(stateContext);
         operator.open();
         MockSourceSplit newSplit = new MockSourceSplit((2));
@@ -193,12 +174,12 @@ public class SourceOperatorTest {
         // Verify the splits in state.
         List<MockSourceSplit> splitsInState =
                 CollectionUtil.iterableToList(operator.getReaderState().get());
-        assertEquals(Arrays.asList(MOCK_SPLIT, newSplit), splitsInState);
+        assertEquals(Arrays.asList(SourceOperatorTestContext.MOCK_SPLIT, newSplit), splitsInState);
     }
 
     @Test
     public void testNotifyCheckpointComplete() throws Exception {
-        StateInitializationContext stateContext = getStateContext();
+        StateInitializationContext stateContext = context.createStateContext();
         operator.initializeState(stateContext);
         operator.open();
         operator.snapshotState(new StateSnapshotContextSynchronousImpl(100L, 100L));
@@ -208,7 +189,7 @@ public class SourceOperatorTest {
 
     @Test
     public void testNotifyCheckpointAborted() throws Exception {
-        StateInitializationContext stateContext = getStateContext();
+        StateInitializationContext stateContext = context.createStateContext();
         operator.initializeState(stateContext);
         operator.open();
         operator.snapshotState(new StateSnapshotContextSynchronousImpl(100L, 100L));
@@ -222,46 +203,5 @@ public class SourceOperatorTest {
         final CompletableFuture<?> secondFuture = operator.getAvailableFuture();
         assertThat(initialFuture, not(sameInstance(AvailabilityProvider.AVAILABLE)));
         assertThat(secondFuture, sameInstance(initialFuture));
-    }
-
-    // ---------------- helper methods -------------------------
-
-    private StateInitializationContext getStateContext() throws Exception {
-        // Create a mock split.
-        byte[] serializedSplitWithVersion =
-                SimpleVersionedSerialization.writeVersionAndSerialize(
-                        new MockSourceSplitSerializer(), MOCK_SPLIT);
-
-        // Crate the state context.
-        OperatorStateStore operatorStateStore = createOperatorStateStore();
-        StateInitializationContext stateContext =
-                new StateInitializationContextImpl(null, operatorStateStore, null, null, null);
-
-        // Update the context.
-        stateContext
-                .getOperatorStateStore()
-                .getListState(SourceOperator.SPLITS_STATE_DESC)
-                .update(Collections.singletonList(serializedSplitWithVersion));
-
-        return stateContext;
-    }
-
-    private OperatorStateStore createOperatorStateStore() throws Exception {
-        MockEnvironment env = new MockEnvironmentBuilder().build();
-        final AbstractStateBackend abstractStateBackend = new MemoryStateBackend();
-        CloseableRegistry cancelStreamRegistry = new CloseableRegistry();
-        return abstractStateBackend.createOperatorStateBackend(
-                env, "test-operator", Collections.emptyList(), cancelStreamRegistry);
-    }
-
-    private Environment getTestingEnvironment() {
-        return new StreamMockEnvironment(
-                new Configuration(),
-                new Configuration(),
-                new ExecutionConfig(),
-                1L,
-                new MockInputSplitProvider(),
-                1,
-                new TestTaskStateManager());
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorTestContext.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorTestContext.java
@@ -47,7 +47,7 @@ import java.util.Collections;
 
 import static org.apache.flink.util.Preconditions.checkState;
 
-/** Base class for testing {@link SourceOperator}. */
+/** Helper class for testing {@link SourceOperator}. */
 @SuppressWarnings("serial")
 public class SourceOperatorTestContext implements AutoCloseable {
 
@@ -59,7 +59,11 @@ public class SourceOperatorTestContext implements AutoCloseable {
     private SourceOperator<Integer, MockSourceSplit> operator;
 
     public SourceOperatorTestContext() throws Exception {
-        mockSourceReader = new MockSourceReader();
+        this(false);
+    }
+
+    public SourceOperatorTestContext(boolean idle) throws Exception {
+        mockSourceReader = new MockSourceReader(idle, idle);
         mockGateway = new MockOperatorEventGateway();
         operator =
                 new TestingSourceOperator<>(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorTestContext.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorTestContext.java
@@ -1,0 +1,134 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package org.apache.flink.streaming.api.operators;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.state.OperatorStateStore;
+import org.apache.flink.api.connector.source.mocks.MockSourceReader;
+import org.apache.flink.api.connector.source.mocks.MockSourceSplit;
+import org.apache.flink.api.connector.source.mocks.MockSourceSplitSerializer;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.CloseableRegistry;
+import org.apache.flink.core.io.SimpleVersionedSerialization;
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.operators.coordination.MockOperatorEventGateway;
+import org.apache.flink.runtime.operators.testutils.MockEnvironment;
+import org.apache.flink.runtime.operators.testutils.MockEnvironmentBuilder;
+import org.apache.flink.runtime.operators.testutils.MockInputSplitProvider;
+import org.apache.flink.runtime.state.AbstractStateBackend;
+import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.runtime.state.StateInitializationContextImpl;
+import org.apache.flink.runtime.state.TestTaskStateManager;
+import org.apache.flink.runtime.state.memory.MemoryStateBackend;
+import org.apache.flink.streaming.api.operators.source.TestingSourceOperator;
+import org.apache.flink.streaming.runtime.tasks.SourceOperatorStreamTask;
+import org.apache.flink.streaming.runtime.tasks.StreamMockEnvironment;
+import org.apache.flink.streaming.util.MockOutput;
+import org.apache.flink.streaming.util.MockStreamConfig;
+
+import java.util.ArrayList;
+import java.util.Collections;
+
+import static org.apache.flink.util.Preconditions.checkState;
+
+/** Base class for testing {@link SourceOperator}. */
+@SuppressWarnings("serial")
+public class SourceOperatorTestContext implements AutoCloseable {
+
+    public static final int SUBTASK_INDEX = 1;
+    public static final MockSourceSplit MOCK_SPLIT = new MockSourceSplit(1234, 10);
+
+    private MockSourceReader mockSourceReader;
+    private MockOperatorEventGateway mockGateway;
+    private SourceOperator<Integer, MockSourceSplit> operator;
+
+    public SourceOperatorTestContext() throws Exception {
+        mockSourceReader = new MockSourceReader();
+        mockGateway = new MockOperatorEventGateway();
+        operator =
+                new TestingSourceOperator<>(
+                        mockSourceReader,
+                        mockGateway,
+                        SUBTASK_INDEX,
+                        true /* emit progressive watermarks */);
+        Environment env = getTestingEnvironment();
+        operator.setup(
+                new SourceOperatorStreamTask<Integer>(env),
+                new MockStreamConfig(new Configuration(), 1),
+                new MockOutput<>(new ArrayList<>()));
+        operator.initializeState(new StreamTaskStateInitializerImpl(env, new MemoryStateBackend()));
+    }
+
+    @Override
+    public void close() throws Exception {
+        operator.close();
+        checkState(mockSourceReader.isClosed());
+    }
+
+    public SourceOperator<Integer, MockSourceSplit> getOperator() {
+        return operator;
+    }
+
+    public MockOperatorEventGateway getGateway() {
+        return mockGateway;
+    }
+
+    public MockSourceReader getSourceReader() {
+        return mockSourceReader;
+    }
+
+    public StateInitializationContext createStateContext() throws Exception {
+        // Create a mock split.
+        byte[] serializedSplitWithVersion =
+                SimpleVersionedSerialization.writeVersionAndSerialize(
+                        new MockSourceSplitSerializer(), MOCK_SPLIT);
+
+        // Crate the state context.
+        OperatorStateStore operatorStateStore = createOperatorStateStore();
+        StateInitializationContext stateContext =
+                new StateInitializationContextImpl(null, operatorStateStore, null, null, null);
+
+        // Update the context.
+        stateContext
+                .getOperatorStateStore()
+                .getListState(SourceOperator.SPLITS_STATE_DESC)
+                .update(Collections.singletonList(serializedSplitWithVersion));
+
+        return stateContext;
+    }
+
+    private OperatorStateStore createOperatorStateStore() throws Exception {
+        MockEnvironment env = new MockEnvironmentBuilder().build();
+        final AbstractStateBackend abstractStateBackend = new MemoryStateBackend();
+        CloseableRegistry cancelStreamRegistry = new CloseableRegistry();
+        return abstractStateBackend.createOperatorStateBackend(
+                env, "test-operator", Collections.emptyList(), cancelStreamRegistry);
+    }
+
+    private Environment getTestingEnvironment() {
+        return new StreamMockEnvironment(
+                new Configuration(),
+                new Configuration(),
+                new ExecutionConfig(),
+                1L,
+                new MockInputSplitProvider(),
+                1,
+                new TestTaskStateManager());
+    }
+}


### PR DESCRIPTION
SourceOperator.SourceOperatorAvailabilityHelper is prone to the same type of memory leak as FLINK-25728. Every time new CompletableFuture.any is created:
```
                currentCombinedFuture =
                        CompletableFuture.anyOf(forcedStopFuture, sourceReaderFuture);
                return currentCombinedFuture;
```
Such future is never garbage collected, because forcedStopFuture will keep a reference to it. This will eventually lead to a memory leak, or force stopping might take very long time to complete.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
