### PR TITLE
[FLINK-25900][Table][Timezone][docs] Added aliases to functions calls to match the columns in docs instead of EXPR$5, EXPR$6, EXPR$7

### DIFF
--- a/docs/content.zh/docs/dev/table/timezone.md
+++ b/docs/content.zh/docs/dev/table/timezone.md
@@ -133,7 +133,7 @@ session （会话）中配置的时区会对以下函数生效。
 
 ```sql
 Flink SQL> SET 'sql-client.execution.result-mode' = 'tableau';
-Flink SQL> CREATE VIEW MyView1 AS SELECT LOCALTIME, LOCALTIMESTAMP, CURRENT_DATE, CURRENT_TIME, CURRENT_TIMESTAMP, CURRENT_ROW_TIMESTAMP(), NOW(), PROCTIME();
+Flink SQL> CREATE VIEW MyView1 AS SELECT LOCALTIME, LOCALTIMESTAMP, CURRENT_DATE, CURRENT_TIME, CURRENT_TIMESTAMP, CURRENT_ROW_TIMESTAMP() AS `CURRENT_ROW_TIMESTAMP()`, NOW() AS `NOW()`, PROCTIME() AS `PROCTIME()`;
 Flink SQL> DESC MyView1;
 ```
 
@@ -265,7 +265,7 @@ Flink SQL 使用函数 `PROCTIME()` 来定义处理时间属性， 该函数返�
 
 ```sql
 Flink SQL> SET 'table.local-time-zone' = 'UTC';
-Flink SQL> SELECT PROCTIME();
+Flink SQL> SELECT PROCTIME() AS `PROCTIME()`;
 ```
 ```
 +-------------------------+
@@ -277,7 +277,7 @@ Flink SQL> SELECT PROCTIME();
 
 ```sql
 Flink SQL> SET 'table.local-time-zone' = 'Asia/Shanghai';
-Flink SQL> SELECT PROCTIME();
+Flink SQL> SELECT PROCTIME() AS `PROCTIME()`;
 ```
 ```
 +-------------------------+

--- a/docs/content/docs/dev/table/timezone.md
+++ b/docs/content/docs/dev/table/timezone.md
@@ -133,7 +133,7 @@ The following time functions are influenced by the configured time zone:
 
 ```sql
 Flink SQL> SET 'sql-client.execution.result-mode' = 'tableau';
-Flink SQL> CREATE VIEW MyView1 AS SELECT LOCALTIME, LOCALTIMESTAMP, CURRENT_DATE, CURRENT_TIME, CURRENT_TIMESTAMP, CURRENT_ROW_TIMESTAMP(), NOW(), PROCTIME();
+Flink SQL> CREATE VIEW MyView1 AS SELECT LOCALTIME, LOCALTIMESTAMP, CURRENT_DATE, CURRENT_TIME, CURRENT_TIMESTAMP, CURRENT_ROW_TIMESTAMP() AS `CURRENT_ROW_TIMESTAMP()`, NOW() AS `NOW()`, PROCTIME() AS `PROCTIME()`;
 Flink SQL> DESC MyView1;
 ```
 
@@ -266,7 +266,7 @@ The PROCTIME() always represents your local timestamp value, using TIMESTAMP_LTZ
 
 ```sql
 Flink SQL> SET 'table.local-time-zone' = 'UTC';
-Flink SQL> SELECT PROCTIME();
+Flink SQL> SELECT PROCTIME() AS `PROCTIME()`;
 ```
 ```
 +-------------------------+
@@ -278,7 +278,7 @@ Flink SQL> SELECT PROCTIME();
 
 ```sql
 Flink SQL> SET 'table.local-time-zone' = 'Asia/Shanghai';
-Flink SQL> SELECT PROCTIME();
+Flink SQL> SELECT PROCTIME() AS `PROCTIME()`;
 ```
 ```
 +-------------------------+


### PR DESCRIPTION
## What is the purpose of the change

* Create view example does not assign alias to functions resulting in generated names like **EXPR$5**, **EXPR$6**, **EXPR$7** while the docs show aliased names (CURRENT_ROW_TIMESTAMP(), NOW(), PROCTIME()) in the result table.  On executing the create view as documented we get the following:

Flink SQL> CREATE VIEW MyView1 AS SELECT LOCALTIME, LOCALTIMESTAMP, CURRENT_DATE, CURRENT_TIME, CURRENT_TIMESTAMP, CURRENT_ROW_TIMESTAMP(), NOW(), PROCTIME();

Flink SQL> describe MyView1;
```
+-------------------+-----------------------------+-------+-----+--------+-----------+
|              name |                        type |  null | key | extras | watermark |
+-------------------+-----------------------------+-------+-----+--------+-----------+
|         LOCALTIME |                     TIME(0) | FALSE |     |        |           |
|    LOCALTIMESTAMP |                TIMESTAMP(3) | FALSE |     |        |           |
|      CURRENT_DATE |                        DATE | FALSE |     |        |           |
|      CURRENT_TIME |                     TIME(0) | FALSE |     |        |           |
| CURRENT_TIMESTAMP |            TIMESTAMP_LTZ(3) | FALSE |     |        |           |
|            EXPR$5 |            TIMESTAMP_LTZ(3) | FALSE |     |        |           |
|            EXPR$6 |            TIMESTAMP_LTZ(3) | FALSE |     |        |           |
|            EXPR$7 | TIMESTAMP_LTZ(3) *PROCTIME* | FALSE |     |        |           |
+-------------------+-----------------------------+-------+-----+--------+-----------+
8 rows in set
```
## Brief change log

* Added aliases to function calls in the docs.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
