### PR TITLE
[FLINK-25880][Docs] Implement Matomo in Flink documentation

### DIFF
--- a/docs/layouts/_default/baseof.html
+++ b/docs/layouts/_default/baseof.html
@@ -65,17 +65,6 @@ under the License.
   </main>
 
   {{ partial "docs/inject/body" . }}
-
-  <!-- Google Analytics -->
-  <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-    ga('create', 'UA-52545728-1', 'auto');
-    ga('send', 'pageview');
-  </script>
 </body>
 
 </html>

--- a/docs/layouts/_default/baseof.html
+++ b/docs/layouts/_default/baseof.html
@@ -23,6 +23,25 @@ under the License.
   {{ hugo.Generator }}
   {{ partial "docs/html-head" . }}
   {{ partial "docs/inject/head" . }}
+    <!-- Matomo -->
+    <script>
+      var _paq = window._paq = window._paq || [];
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      /* We explicitly disable cookie tracking to avoid privacy issues */
+      _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
+      _paq.push(['trackPageView']);
+      _paq.push(['enableLinkTracking']);
+      (function() {
+        var u="//matomo.privacy.apache.org/";
+        _paq.push(['setTrackerUrl', u+'matomo.php']);
+        _paq.push(['setSiteId', '1']);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+      })();
+    </script>
+    <!-- End Matomo Code -->
 </head>
 
 <body dir={{ .Site.Language.LanguageDirection }}>


### PR DESCRIPTION
## What is the purpose of the change

* This PR removes the current Google Analytics web analytics tracking from the Flink documentation and replaces it with the ASF hosted Matomo installation, as discussed on the Dev mailing list https://lists.apache.org/thread/kv0mf1y9cq4cdsf4jkq3gb6jo7b81cq3

## Brief change log

* ef12918d1aa00b4c529f34a5a7ed6a1edd79c920 Removes Google Analytics implementation
* 0b1ad7917d4839b0226cb874702ed4089a91e706 Adds Matomo setup. This was previously done for flink-web via https://github.com/apache/flink-web/pull/502 and https://github.com/apache/flink-web/pull/503

## Verifying this change

* You can inspect the network traffic in your browser using the Developer Tools. Right now, you'll see calls being made to the google-analytics.com domain. When checking ef12918d1aa00b4c529f34a5a7ed6a1edd79c920 you'll see that these calls are no longer made.

*  0b1ad7917d4839b0226cb874702ed4089a91e706 introduces calls being made to https://matomo.privacy.apache.org/ - This is where the self-hosted Matomo instance is hosted (on a VM provided by ASF Infra)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable / the goal and what data is stored in Matomo is explained in the Privacy Policy on the Flink project website. 
