### PR TITLE
[FLINK-25846][connector/kinesis] Async Sink does not gracefully shutdown on Cancel, KDS Sink does not fast fail when invalid configuration supplied 

### DIFF
--- a/flink-connectors/flink-connector-aws-kinesis-data-streams/src/main/java/org/apache/flink/connector/kinesis/sink/KinesisDataStreamsException.java
+++ b/flink-connectors/flink-connector-aws-kinesis-data-streams/src/main/java/org/apache/flink/connector/kinesis/sink/KinesisDataStreamsException.java
@@ -37,15 +37,15 @@ class KinesisDataStreamsException extends RuntimeException {
      */
     static class KinesisDataStreamsFailFastException extends KinesisDataStreamsException {
 
+        private static final String ERROR_MESSAGE =
+                "Encountered an exception while persisting records, not retrying due to {failOnError} being set.";
+
         public KinesisDataStreamsFailFastException() {
-            super(
-                    "Encountered an exception while persisting records, not retrying due to either: {failOnError} being set or the exception should not be retried.");
+            super(ERROR_MESSAGE);
         }
 
         public KinesisDataStreamsFailFastException(final Throwable cause) {
-            super(
-                    "Encountered an exception while persisting records, not retrying due to either: {failOnError} being set or the exception should not be retried.",
-                    cause);
+            super(ERROR_MESSAGE, cause);
         }
     }
 }

--- a/flink-connectors/flink-connector-aws-kinesis-data-streams/src/main/java/org/apache/flink/connector/kinesis/sink/KinesisDataStreamsException.java
+++ b/flink-connectors/flink-connector-aws-kinesis-data-streams/src/main/java/org/apache/flink/connector/kinesis/sink/KinesisDataStreamsException.java
@@ -39,12 +39,12 @@ class KinesisDataStreamsException extends RuntimeException {
 
         public KinesisDataStreamsFailFastException() {
             super(
-                    "Encountered an exception while persisting records, not retrying due to {failOnError} being set.");
+                    "Encountered an exception while persisting records, not retrying due to either: {failOnError} being set or the exception should not be retried.");
         }
 
         public KinesisDataStreamsFailFastException(final Throwable cause) {
             super(
-                    "Encountered an exception while persisting records, not retrying due to {failOnError} being set.",
+                    "Encountered an exception while persisting records, not retrying due to either: {failOnError} being set or the exception should not be retried.",
                     cause);
         }
     }

--- a/flink-connectors/flink-connector-aws-kinesis-data-streams/src/main/java/org/apache/flink/connector/kinesis/sink/KinesisDataStreamsSinkWriter.java
+++ b/flink-connectors/flink-connector-aws-kinesis-data-streams/src/main/java/org/apache/flink/connector/kinesis/sink/KinesisDataStreamsSinkWriter.java
@@ -24,6 +24,8 @@ import org.apache.flink.connector.base.sink.writer.ElementConverter;
 import org.apache.flink.connector.kinesis.util.AWSKinesisDataStreamsUtil;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.FlinkException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -176,11 +178,34 @@ class KinesisDataStreamsSinkWriter<InputT> extends AsyncSinkWriter<InputT, PutRe
 
     private boolean isRetryable(Throwable err) {
         if (err instanceof CompletionException
-                && err.getCause() instanceof ResourceNotFoundException) {
+                && isInterruptingSignalException(ExceptionUtils.stripCompletionException(err))) {
+            getFatalExceptionCons().accept(new FlinkException("Running job was cancelled"));
+            return false;
+        }
+        if (err instanceof CompletionException
+                && ExceptionUtils.stripCompletionException(err)
+                        instanceof ResourceNotFoundException) {
             getFatalExceptionCons()
                     .accept(
                             new KinesisDataStreamsException(
-                                    "Encountered non-recoverable exception", err));
+                                    "Encountered non-recoverable exception relating to not being able to find the specified resources",
+                                    err));
+            return false;
+        }
+        if (err instanceof CompletionException
+                && ExceptionUtils.stripCompletionException(err) instanceof StsException) {
+            getFatalExceptionCons()
+                    .accept(
+                            new KinesisDataStreamsException(
+                                    "Encountered non-recoverable exception relating to the provided credentials.",
+                                    err));
+            return false;
+        }
+        if (err instanceof Error) {
+            getFatalExceptionCons()
+                    .accept(
+                            new KinesisDataStreamsException(
+                                    "Encountered non-recoverable exception.", err));
             return false;
         }
         if (failOnError) {
@@ -192,5 +217,12 @@ class KinesisDataStreamsSinkWriter<InputT> extends AsyncSinkWriter<InputT, PutRe
         }
 
         return true;
+    }
+
+    private boolean isInterruptingSignalException(Throwable err) {
+        return err != null
+                && (err instanceof InterruptedException
+                        || (err instanceof IllegalStateException
+                                && err.getCause() instanceof InterruptedException));
     }
 }

--- a/flink-connectors/flink-connector-aws-kinesis-data-streams/src/main/java/org/apache/flink/connector/kinesis/sink/KinesisDataStreamsSinkWriter.java
+++ b/flink-connectors/flink-connector-aws-kinesis-data-streams/src/main/java/org/apache/flink/connector/kinesis/sink/KinesisDataStreamsSinkWriter.java
@@ -36,6 +36,7 @@ import software.amazon.awssdk.services.kinesis.model.PutRecordsRequestEntry;
 import software.amazon.awssdk.services.kinesis.model.PutRecordsResponse;
 import software.amazon.awssdk.services.kinesis.model.PutRecordsResultEntry;
 import software.amazon.awssdk.services.kinesis.model.ResourceNotFoundException;
+import software.amazon.awssdk.services.sts.model.StsException;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -205,7 +206,8 @@ class KinesisDataStreamsSinkWriter<InputT> extends AsyncSinkWriter<InputT, PutRe
             getFatalExceptionCons()
                     .accept(
                             new KinesisDataStreamsException(
-                                    "Encountered non-recoverable exception.", err));
+                                    "Encountered non-recoverable exception relating to not being able to find the specified resources",
+                                    err));
             return false;
         }
         if (failOnError) {

--- a/flink-connectors/flink-connector-aws-kinesis-data-streams/src/test/java/org/apache/flink/connector/kinesis/sink/KinesisDataStreamsSinkITCase.java
+++ b/flink-connectors/flink-connector-aws-kinesis-data-streams/src/test/java/org/apache/flink/connector/kinesis/sink/KinesisDataStreamsSinkITCase.java
@@ -188,7 +188,7 @@ public class KinesisDataStreamsSinkITCase extends TestLogger {
                 .havingCause()
                 .havingCause()
                 .withMessageContaining(
-                        "Encountered an exception while persisting records, not retrying due to either: {failOnError} being set or the exception should not be retried.");
+                        "Encountered an exception while persisting records, not retrying due to {failOnError} being set.");
     }
 
     @Test
@@ -269,28 +269,7 @@ public class KinesisDataStreamsSinkITCase extends TestLogger {
                 streamName,
                 failOnError,
                 properties,
-                "Encountered an exception while persisting records, not retrying due to either: {failOnError} being set or the exception should not be retried.");
-    }
-
-    @Test
-    public void missingEndpointShouldResultInFailureWhenInFailOnErrorIsOn() {
-        missingEndpointShouldResultInFailureWhenInFailOnErrorIs(true);
-    }
-
-    @Test
-    public void missingEndpointShouldResultInFailureWhenInFailOnErrorIsOff() {
-        missingEndpointShouldResultInFailureWhenInFailOnErrorIs(false);
-    }
-
-    private void missingEndpointShouldResultInFailureWhenInFailOnErrorIs(boolean failOnError) {
-        Properties properties = getDefaultProperties();
-        properties.remove(AWS_ENDPOINT);
-        String streamName = "do-not-create-new-stream";
-        assertRunWithPropertiesAndStreamShouldFailWithExceptionOfType(
-                streamName,
-                failOnError,
-                properties,
-                "Encountered an exception while persisting records, not retrying due to either: {failOnError} being set or the exception should not be retried.");
+                "Encountered non-recoverable exception relating to mis-configured client");
     }
 
     @Test
@@ -320,7 +299,7 @@ public class KinesisDataStreamsSinkITCase extends TestLogger {
         noCredentialsAndSpecifiedCredentialsProviderShouldResultInFailureWhenInFailOnErrorIs(
                 true,
                 AWSConfigConstants.CredentialProvider.ENV_VAR.toString(),
-                "Encountered an exception while persisting records, not retrying due to either: {failOnError} being set or the exception should not be retried.");
+                "Encountered non-recoverable exception relating to mis-configured client");
     }
 
     @Test
@@ -328,7 +307,7 @@ public class KinesisDataStreamsSinkITCase extends TestLogger {
         noCredentialsAndSpecifiedCredentialsProviderShouldResultInFailureWhenInFailOnErrorIs(
                 false,
                 AWSConfigConstants.CredentialProvider.ENV_VAR.toString(),
-                "Encountered an exception while persisting records, not retrying due to either: {failOnError} being set or the exception should not be retried.");
+                "Encountered non-recoverable exception relating to mis-configured client");
     }
 
     @Test
@@ -336,7 +315,7 @@ public class KinesisDataStreamsSinkITCase extends TestLogger {
         noCredentialsAndSpecifiedCredentialsProviderShouldResultInFailureWhenInFailOnErrorIs(
                 true,
                 AWSConfigConstants.CredentialProvider.SYS_PROP.toString(),
-                "Encountered an exception while persisting records, not retrying due to either: {failOnError} being set or the exception should not be retried.");
+                "Encountered non-recoverable exception relating to mis-configured client");
     }
 
     @Test
@@ -344,7 +323,7 @@ public class KinesisDataStreamsSinkITCase extends TestLogger {
         noCredentialsAndSpecifiedCredentialsProviderShouldResultInFailureWhenInFailOnErrorIs(
                 false,
                 AWSConfigConstants.CredentialProvider.SYS_PROP.toString(),
-                "Encountered an exception while persisting records, not retrying due to either: {failOnError} being set or the exception should not be retried.");
+                "Encountered non-recoverable exception relating to mis-configured client");
     }
 
     @Test
@@ -368,7 +347,7 @@ public class KinesisDataStreamsSinkITCase extends TestLogger {
         noCredentialsAndSpecifiedCredentialsProviderShouldResultInFailureWhenInFailOnErrorIs(
                 true,
                 AWSConfigConstants.CredentialProvider.BASIC.toString(),
-                "Encountered an exception while persisting records, not retrying due to either: {failOnError} being set or the exception should not be retried.");
+                "Encountered non-recoverable exception relating to missing credentials");
     }
 
     @Test
@@ -376,7 +355,7 @@ public class KinesisDataStreamsSinkITCase extends TestLogger {
         noCredentialsAndSpecifiedCredentialsProviderShouldResultInFailureWhenInFailOnErrorIs(
                 false,
                 AWSConfigConstants.CredentialProvider.BASIC.toString(),
-                "Encountered an exception while persisting records, not retrying due to either: {failOnError} being set or the exception should not be retried.");
+                "Encountered non-recoverable exception relating to missing credentials");
     }
 
     @Test
@@ -400,7 +379,7 @@ public class KinesisDataStreamsSinkITCase extends TestLogger {
         noCredentialsAndSpecifiedCredentialsProviderShouldResultInFailureWhenInFailOnErrorIs(
                 true,
                 AWSConfigConstants.CredentialProvider.WEB_IDENTITY_TOKEN.toString(),
-                "Encountered an exception while persisting records, not retrying due to either: {failOnError} being set or the exception should not be retried.");
+                "Encountered non-recoverable exception relating to missing credentials");
     }
 
     @Test
@@ -408,7 +387,7 @@ public class KinesisDataStreamsSinkITCase extends TestLogger {
         noCredentialsAndSpecifiedCredentialsProviderShouldResultInFailureWhenInFailOnErrorIs(
                 false,
                 AWSConfigConstants.CredentialProvider.WEB_IDENTITY_TOKEN.toString(),
-                "Encountered an exception while persisting records, not retrying due to either: {failOnError} being set or the exception should not be retried.");
+                "Encountered non-recoverable exception relating to missing credentials");
     }
 
     @Test

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/sink/writer/AsyncSinkRetryValidationStrategies.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/sink/writer/AsyncSinkRetryValidationStrategies.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.base.sink.writer;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.FlinkException;
+
+/** Common retry strategies needed to fail fast on common errors. */
+@Internal
+public class AsyncSinkRetryValidationStrategies {
+    public static final RetryValidationStrategy INTERRUPTED_STRATEGY =
+            new RetryValidationStrategy(
+                    err ->
+                            ExceptionUtils.findThrowable(err, InterruptedException.class)
+                                    .isPresent(),
+                    err -> new FlinkException("Running job was cancelled"));
+
+    public static final RetryValidationStrategy GENERAL_ERROR_STRATEGY =
+            new RetryValidationStrategy(
+                    err -> err instanceof Error,
+                    err -> new RuntimeException("Encountered non-recoverable exception", err));
+}

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/sink/writer/RetryValidationStrategy.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/sink/writer/RetryValidationStrategy.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.base.sink.writer;
+
+import org.apache.flink.annotation.Internal;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+/** Class acting as a classifier for exception by failed requests to be retried by sink. */
+@Internal
+public class RetryValidationStrategy {
+    private final Function<Throwable, Exception> throwableMapper;
+    private final Predicate<Throwable> validator;
+    private RetryValidationStrategy chainedStrategy;
+
+    public RetryValidationStrategy(
+            Predicate<Throwable> validator, Function<Throwable, Exception> throwableMapper) {
+        this.throwableMapper = throwableMapper;
+        this.validator = validator;
+        this.chainedStrategy = null;
+    }
+
+    public boolean shouldRetry(Throwable err, Consumer<Exception> throwableConsumer) {
+        if (validator.test(err)) {
+            throwableConsumer.accept(throwableMapper.apply(err));
+            return false;
+        }
+
+        if (chainedStrategy != null) {
+            return chainedStrategy.shouldRetry(err, throwableConsumer);
+        } else {
+            return true;
+        }
+    }
+
+    public static RetryValidationStrategy build(RetryValidationStrategy... strategies) {
+        for (int i = 1; i < strategies.length; ++i) {
+            strategies[i - 1].chainedStrategy = strategies[i];
+        }
+        return strategies[0];
+    }
+}

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/sink/writer/RetryValidationStrategyTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/sink/writer/RetryValidationStrategyTest.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.base.sink.writer;
+
+import org.apache.flink.util.ExceptionUtils;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+/** Tests the RetryValidationStrategy of the Async Sink Writer. */
+public class RetryValidationStrategyTest {
+
+    private static Integer nullReference;
+
+    private static final RetryValidationStrategy ARITHMETIC_EXCEPTION_STRATEGY =
+            new RetryValidationStrategy(
+                    err -> ExceptionUtils.findThrowable(err, ArithmeticException.class).isPresent(),
+                    err ->
+                            new RuntimeException(
+                                    "Buffer manipulation calculations resulted in a calculation exception",
+                                    err));
+
+    private static final RetryValidationStrategy NULL_POINTER_EXCEPTION_STRATEGY =
+            new RetryValidationStrategy(
+                    err ->
+                            ExceptionUtils.findThrowable(err, NullPointerException.class)
+                                    .isPresent(),
+                    err ->
+                            new RuntimeException(
+                                    "Buffer manipulation calculations resulted in a reference exception",
+                                    err));
+
+    @Test
+    public void exceptionsAreWrappedInTheContainingExceptionWhenAMatchIsFound() {
+        AtomicReference<Exception> caughtExceptionReference = new AtomicReference<>();
+        try {
+            int failedCalculation = 100 / 0;
+        } catch (Exception e) {
+            ARITHMETIC_EXCEPTION_STRATEGY.shouldRetry(e, caughtExceptionReference::set);
+        }
+        assertThatCaughtExceptionIsWrappedArithmeticDivByZeroException(
+                caughtExceptionReference.get());
+    }
+
+    @Test
+    public void noExceptionIsThrownIfTheExceptionDoesNotMatchTheOneExpected() {
+        AtomicReference<Exception> caughtException = new AtomicReference<>();
+        try {
+            System.out.print(nullReference.toString());
+        } catch (Exception e) {
+            ARITHMETIC_EXCEPTION_STRATEGY.shouldRetry(e, caughtException::set);
+        }
+        assertThat(caughtException.get()).isNull();
+    }
+
+    @Test
+    public void chainedRetryStrategiesAcceptExceptionsOnTheFirstItemOfChain() {
+        RetryValidationStrategy retryValidationStrategy =
+                RetryValidationStrategy.build(
+                        ARITHMETIC_EXCEPTION_STRATEGY, NULL_POINTER_EXCEPTION_STRATEGY);
+        AtomicReference<Exception> caughtExceptionReference = new AtomicReference<>();
+        try {
+            int failedCalculation = 100 / 0;
+        } catch (Exception e) {
+            retryValidationStrategy.shouldRetry(e, caughtExceptionReference::set);
+        }
+        assertThatCaughtExceptionIsWrappedArithmeticDivByZeroException(
+                caughtExceptionReference.get());
+    }
+
+    @Test
+    public void chainedRetryStrategiesAcceptExceptionsOnTheLastItemOfChain() {
+        RetryValidationStrategy retryValidationStrategy =
+                RetryValidationStrategy.build(
+                        ARITHMETIC_EXCEPTION_STRATEGY, NULL_POINTER_EXCEPTION_STRATEGY);
+        AtomicReference<Exception> caughtException = new AtomicReference<>();
+
+        try {
+            System.out.print(nullReference.toString());
+        } catch (Exception e) {
+            retryValidationStrategy.shouldRetry(e, caughtException::set);
+        }
+
+        assertThat(caughtException.get())
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("Buffer manipulation calculations resulted in a reference exception")
+                .getCause()
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    private void assertThatCaughtExceptionIsWrappedArithmeticDivByZeroException(
+            Exception caughtException) {
+        assertThat(caughtException)
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("Buffer manipulation calculations resulted in a calculation exception")
+                .getCause()
+                .isInstanceOf(ArithmeticException.class)
+                .hasMessage("/ by zero");
+    }
+}


### PR DESCRIPTION
> ## What is the purpose of the change
> Bugfixes: Async Sink does not gracefully shutdown on Cancel KDS Sink does not fast fail when invalid configuration supplied
> 
> ## Brief change log
> * Added more cases to the `isRetryable` method in the KDSSinkWriter to handle permanently failing cases.
> 
> ## Verifying this change
> * Added unit test cases
> 
> ## Does this pull request potentially affect one of the following parts:
> * Dependencies (does it add or upgrade a dependency): (yes / no)n
> * The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)y
> * The serializers: (yes / no / don't know)n
> * The runtime per-record code paths (performance sensitive): (yes / no / don't know)n
> * Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)n
> * The S3 file system connector: (yes / no / don't know)n
> 
> ## Documentation
> * Does this pull request introduce a new feature? (yes / no)n
> * If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) docs/javadocs

