### PR TITLE
[FLINK-25926][Connectors][JDBC] Update org.postgresql:postgresql to 42.3.3

### DIFF
--- a/flink-connectors/flink-connector-jdbc/pom.xml
+++ b/flink-connectors/flink-connector-jdbc/pom.xml
@@ -36,7 +36,7 @@ under the License.
 	<packaging>jar</packaging>
 
 	<properties>
-		<postgres.version>42.2.10</postgres.version>
+		<postgres.version>42.3.3</postgres.version>
 		<oracle.version>19.3.0.0</oracle.version>
 	</properties>
 

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/dialect/psql/PostgresTypeMapper.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/dialect/psql/PostgresTypeMapper.java
@@ -49,6 +49,7 @@ public class PostgresTypeMapper implements JdbcDialectTypeMapper {
     // float <=> float8
     // boolean <=> bool
     // decimal <=> numeric
+    private static final String PG_SMALLSERIAL = "smallserial";
     private static final String PG_SERIAL = "serial";
     private static final String PG_BIGSERIAL = "bigserial";
     private static final String PG_BYTEA = "bytea";
@@ -102,6 +103,7 @@ public class PostgresTypeMapper implements JdbcDialectTypeMapper {
             case PG_BYTEA_ARRAY:
                 return DataTypes.ARRAY(DataTypes.BYTES());
             case PG_SMALLINT:
+            case PG_SMALLSERIAL:
                 return DataTypes.SMALLINT();
             case PG_SMALLINT_ARRAY:
                 return DataTypes.ARRAY(DataTypes.SMALLINT());

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/converter/PostgresRowConverter.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/converter/PostgresRowConverter.java
@@ -22,13 +22,11 @@ import org.apache.flink.connector.jdbc.converter.AbstractJdbcRowConverter;
 import org.apache.flink.table.data.GenericArrayData;
 import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.LogicalType;
-import org.apache.flink.table.types.logical.LogicalTypeFamily;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.utils.LogicalTypeUtils;
 
 import org.postgresql.jdbc.PgArray;
-import org.postgresql.util.PGobject;
 
 import java.lang.reflect.Array;
 
@@ -78,38 +76,21 @@ public class PostgresRowConverter extends AbstractJdbcRowConverter {
     }
 
     private JdbcDeserializationConverter createPostgresArrayConverter(ArrayType arrayType) {
-        // PG's bytea[] is wrapped in PGobject, rather than primitive byte arrays
-        if (arrayType.getElementType().is(LogicalTypeFamily.BINARY_STRING)) {
-            final Class<?> elementClass =
-                    LogicalTypeUtils.toInternalConversionClass(arrayType.getElementType());
-            final JdbcDeserializationConverter elementConverter =
-                    createNullableInternalConverter(arrayType.getElementType());
-
-            return val -> {
-                PgArray pgArray = (PgArray) val;
-                Object[] in = (Object[]) pgArray.getArray();
-                final Object[] array = (Object[]) Array.newInstance(elementClass, in.length);
-                for (int i = 0; i < in.length; i++) {
-                    array[i] =
-                            elementConverter.deserialize(((PGobject) in[i]).getValue().getBytes());
-                }
-                return new GenericArrayData(array);
-            };
-        } else {
-            final Class<?> elementClass =
-                    LogicalTypeUtils.toInternalConversionClass(arrayType.getElementType());
-            final JdbcDeserializationConverter elementConverter =
-                    createNullableInternalConverter(arrayType.getElementType());
-            return val -> {
-                PgArray pgArray = (PgArray) val;
-                Object[] in = (Object[]) pgArray.getArray();
-                final Object[] array = (Object[]) Array.newInstance(elementClass, in.length);
-                for (int i = 0; i < in.length; i++) {
-                    array[i] = elementConverter.deserialize(in[i]);
-                }
-                return new GenericArrayData(array);
-            };
-        }
+        // Since PGJDBC 42.2.15 (https://github.com/pgjdbc/pgjdbc/pull/1194) bytea[] is wrapped in
+        // primitive byte arrays
+        final Class<?> elementClass =
+                LogicalTypeUtils.toInternalConversionClass(arrayType.getElementType());
+        final JdbcDeserializationConverter elementConverter =
+                createNullableInternalConverter(arrayType.getElementType());
+        return val -> {
+            PgArray pgArray = (PgArray) val;
+            Object[] in = (Object[]) pgArray.getArray();
+            final Object[] array = (Object[]) Array.newInstance(elementClass, in.length);
+            for (int i = 0; i < in.length; i++) {
+                array[i] = elementConverter.deserialize(in[i]);
+            }
+            return new GenericArrayData(array);
+        };
     }
 
     // Have its own method so that Postgres can support primitives that super class doesn't support

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/catalog/PostgresCatalogITCase.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/catalog/PostgresCatalogITCase.java
@@ -154,7 +154,7 @@ public class PostgresCatalogITCase extends PostgresCatalogTestBase {
         assertEquals(
                 "[+I["
                         + "[1, 2, 3], "
-                        + "[[92, 120, 51, 50], [92, 120, 51, 51], [92, 120, 51, 52]], "
+                        + "[[50], [51], [52]], "
                         + "[3, 4, 5], "
                         + "[4, 5, 6], "
                         + "[5.5, 6.6, 7.7], "


### PR DESCRIPTION
## What is the purpose of the change

* Update PostgreSQL to the latest available version to address CVE-2022-21724 and GHSA-673j-qm5f-xpv8

## Brief change log

* Updated POM

## Verifying this change

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
