### PR TITLE
[FLINK-23843][runtime] Properly fail the job when SplitEnumeratorContext.runInCoordinatorThread() throws an exception

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/MockOperatorCoordinatorContext.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/MockOperatorCoordinatorContext.java
@@ -20,6 +20,8 @@ package org.apache.flink.runtime.operators.coordination;
 
 import org.apache.flink.runtime.jobgraph.OperatorID;
 
+import java.util.concurrent.CompletableFuture;
+
 /** A simple implementation of {@link OperatorCoordinator.Context} for testing purposes. */
 public class MockOperatorCoordinatorContext implements OperatorCoordinator.Context {
 
@@ -30,6 +32,7 @@ public class MockOperatorCoordinatorContext implements OperatorCoordinator.Conte
 
     private boolean jobFailed;
     private Throwable jobFailureReason;
+    private final CompletableFuture<Void> jobFailedFuture = new CompletableFuture<>();
 
     public MockOperatorCoordinatorContext(OperatorID operatorID, int numSubtasks) {
         this(operatorID, numSubtasks, MockOperatorCoordinatorContext.class.getClassLoader());
@@ -57,6 +60,7 @@ public class MockOperatorCoordinatorContext implements OperatorCoordinator.Conte
     public void failJob(Throwable cause) {
         jobFailed = true;
         jobFailureReason = cause;
+        jobFailedFuture.complete(null);
     }
 
     @Override
@@ -82,5 +86,9 @@ public class MockOperatorCoordinatorContext implements OperatorCoordinator.Conte
 
     public Throwable getJobFailureReason() {
         return jobFailureReason;
+    }
+
+    public CompletableFuture<Void> getJobFailedFuture() {
+        return jobFailedFuture;
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorTestBase.java
@@ -78,7 +78,7 @@ public abstract class SourceCoordinatorTestBase {
         String coordinatorThreadName = TEST_OPERATOR_ID.toHexString();
         coordinatorThreadFactory =
                 new SourceCoordinatorProvider.CoordinatorExecutorThreadFactory(
-                        coordinatorThreadName, getClass().getClassLoader());
+                        coordinatorThreadName, operatorCoordinatorContext);
 
         coordinatorExecutor = Executors.newScheduledThreadPool(1, coordinatorThreadFactory);
         sourceCoordinator = getNewSourceCoordinator();


### PR DESCRIPTION
## What is the purpose of the change
Properly fail the job when `SplitEnumeratorContext.runInCoordinatorThread()` throws an exception instead of failing the whole `JobManager`.


## Brief change log

Introduce `FailJobExceptionHandler` that calls `context.failJob()`. Call it when `SplitEnumeratorContext.runInCoordinatorThread()` throws an exception by changing `CoordinatorExecutorThreadFactory` error handler.
Introduce a new `ThreadPoolExecutor` test utility to gain access to the underlying thread and use it to wait for the handler to process the exception before asserting.

## Verifying this change

This change added tests and can be verified as follows:
`SourceCoordinatorContextTest#testExceptionInRunnableFailsTheJob()`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes, fail the job instead of failing the JobManager when an exception is thrown
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no, bug fix
  - If yes, how is the feature documented? failure handling is documented in `SourceCoordinatorContext#runInCoordinatorThread`

R: @tillrohrmann 
Already squashed and split commits because some are related to `flink-test-utils` module.
