### PR TITLE
[FLINK-21752] NullPointerException on restore in PojoSerializer 

### DIFF
--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/TypeSerializerUpgradeTestBase.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/TypeSerializerUpgradeTestBase.java
@@ -422,7 +422,13 @@ public abstract class TypeSerializerUpgradeTestBase<PreviousElementT, UpgradedEl
                 readAndThenWriteData(dataInput, serializer, serializer, testDataMatcher);
         TypeSerializerSnapshot<T> snapshot = writeAndThenReadSerializerSnapshot(serializer);
         TypeSerializer<T> restoreSerializer = snapshot.restoreSerializer();
-        readAndThenWriteData(serializedData, restoreSerializer, restoreSerializer, testDataMatcher);
+        serializedData =
+                readAndThenWriteData(
+                        serializedData, restoreSerializer, restoreSerializer, testDataMatcher);
+
+        TypeSerializer<T> duplicateSerializer = snapshot.restoreSerializer().duplicate();
+        readAndThenWriteData(
+                serializedData, duplicateSerializer, duplicateSerializer, testDataMatcher);
     }
 
     // ------------------------------------------------------------------------------


### PR DESCRIPTION
## What is the purpose of the change

In order to support Pojo schema migration, we added a new ctor to the
PojoSerializer, which uses data extracted from a snapshot. However the
duplicate method still used the old ctor which tries to recreate parts
of the data from the current context.

We should use the same ctor as we use for schema migration in the
duplicate methods. We must make sure though all serializers are properly
duplicated.


## Verifying this change

Tests in `PojoSerializerUpgradeTest` pass (I added a call to TypeSerializer#duplicate)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (**yes** / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
