### PR TITLE
[hotfix][table-planner] Fix Jackson annotations

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/sink/OverwriteSpec.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/sink/OverwriteSpec.java
@@ -23,6 +23,7 @@ import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.sink.abilities.SupportsOverwrite;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonTypeName;
 
@@ -32,6 +33,7 @@ import java.util.Objects;
  * A sub-class of {@link SinkAbilitySpec} that can not only serialize/deserialize the overwrite flag
  * to/from JSON, but also can overwrite existing data for {@link SupportsOverwrite}.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonTypeName("Overwrite")
 public final class OverwriteSpec implements SinkAbilitySpec {
     public static final String FIELD_NAME_OVERWRITE = "overwrite";

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/sink/PartitioningSpec.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/sink/PartitioningSpec.java
@@ -23,6 +23,7 @@ import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.sink.abilities.SupportsPartitioning;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonTypeName;
 
@@ -35,6 +36,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * A sub-class of {@link SinkAbilitySpec} that can not only serialize/deserialize the partition
  * to/from JSON, but also can write partitioned data for {@link SupportsPartitioning}.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonTypeName("Partitioning")
 public final class PartitioningSpec implements SinkAbilitySpec {
     public static final String FIELD_NAME_PARTITION = "partition";

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/sink/SinkAbilitySpec.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/sink/SinkAbilitySpec.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.planner.plan.abilities.sink;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonSubTypes;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonTypeInfo;
 
@@ -28,6 +29,7 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonTyp
  * An interface that can not only serialize/deserialize the sink abilities to/from JSON, but also
  * can apply the abilities to a {@link DynamicTableSink}.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 @JsonSubTypes({
     @JsonSubTypes.Type(value = OverwriteSpec.class),

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/sink/WritingMetadataSpec.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/sink/WritingMetadataSpec.java
@@ -28,6 +28,7 @@ import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.utils.TypeConversions;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonTypeName;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -41,6 +42,7 @@ import java.util.Objects;
  * columns to/from JSON, but also can write the metadata columns for {@link
  * SupportsWritingMetadata}.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonTypeName("WritingMetadata")
 public final class WritingMetadataSpec implements SinkAbilitySpec {
     public static final String FIELD_NAME_METADATA_KEYS = "metadataKeys";

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/spec/DynamicTableSinkSpec.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/spec/DynamicTableSinkSpec.java
@@ -28,7 +28,6 @@ import org.apache.flink.table.planner.plan.abilities.sink.SinkAbilitySpec;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonGetter;
-import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInclude;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
@@ -43,7 +42,6 @@ import java.util.Objects;
  * and create {@link DynamicTableSink} from the deserialization result.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class DynamicTableSinkSpec extends DynamicTableSpecBase {
 
     public static final String FIELD_NAME_CATALOG_TABLE = "table";
@@ -52,7 +50,7 @@ public class DynamicTableSinkSpec extends DynamicTableSpecBase {
     private final ContextResolvedTable contextResolvedTable;
     private final @Nullable List<SinkAbilitySpec> sinkAbilities;
 
-    @JsonIgnore private DynamicTableSink tableSink;
+    private DynamicTableSink tableSink;
 
     @JsonCreator
     public DynamicTableSinkSpec(
@@ -69,6 +67,7 @@ public class DynamicTableSinkSpec extends DynamicTableSpecBase {
     }
 
     @JsonGetter(FIELD_NAME_SINK_ABILITIES)
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @Nullable
     public List<SinkAbilitySpec> getSinkAbilities() {
         return sinkAbilities;

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/spec/DynamicTableSourceSpec.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/spec/DynamicTableSourceSpec.java
@@ -33,7 +33,6 @@ import org.apache.flink.table.types.logical.RowType;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonGetter;
-import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInclude;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
@@ -48,7 +47,6 @@ import java.util.Objects;
  * and create {@link DynamicTableSource} from the deserialization result.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class DynamicTableSourceSpec extends DynamicTableSpecBase {
 
     public static final String FIELD_NAME_CATALOG_TABLE = "table";
@@ -57,7 +55,7 @@ public class DynamicTableSourceSpec extends DynamicTableSpecBase {
     private final ContextResolvedTable contextResolvedTable;
     private final @Nullable List<SourceAbilitySpec> sourceAbilities;
 
-    @JsonIgnore private DynamicTableSource tableSource;
+    private DynamicTableSource tableSource;
 
     @JsonCreator
     public DynamicTableSourceSpec(
@@ -136,6 +134,7 @@ public class DynamicTableSourceSpec extends DynamicTableSpecBase {
     }
 
     @JsonGetter(FIELD_NAME_SOURCE_ABILITIES)
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @Nullable
     public List<SourceAbilitySpec> getSourceAbilities() {
         return sourceAbilities;

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/spec/PartitionSpec.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/spec/PartitionSpec.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.planner.plan.nodes.exec.spec;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnore;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Arrays;
@@ -27,6 +28,7 @@ import java.util.Arrays;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** {@link PartitionSpec} describes how data is partitioned in Rank. */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class PartitionSpec {
 
     public static final String FIELD_NAME_FIELDS = "fields";

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/spec/SortSpec.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/spec/SortSpec.java
@@ -24,6 +24,7 @@ import org.apache.flink.util.Preconditions;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnore;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Arrays;
@@ -36,6 +37,7 @@ import java.util.stream.Stream;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** {@link SortSpec} describes how the data will be sorted. */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class SortSpec {
 
     public static final String FIELD_NAME_FIELDS = "fields";
@@ -128,6 +130,7 @@ public class SortSpec {
     }
 
     /** Sort info for a Field. */
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class SortFieldSpec {
         public static final String FIELD_NAME_INDEX = "index";
         public static final String FIELD_NAME_IS_ASCENDING = "isAscending";


### PR DESCRIPTION
Following: #18574

Make use of `JsonIgnoreProperties` where ever possible and protect
from future fields to be added by mistake to the json plans.
Move the `JsonInclude` next to the corresponding fields, so that
is 100% visible what fields are affected.
