### PR TITLE
[FLINK-25932][table-planner] Add deterministic uid to every Transformation created by StreamExecNode

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/ExecNodeBase.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/ExecNodeBase.java
@@ -158,16 +158,16 @@ public abstract class ExecNodeBase<T> implements ExecNode<T> {
                                                 == InputProperty.DistributionType.SINGLETON);
     }
 
-    public String getOperatorUid(String operatorName) {
+    public String getTransformationUid(String operatorName) {
         return context.generateUid(operatorName);
     }
 
-    public String getOperatorName(TableConfig config) {
-        return getOperatorName(config.getConfiguration());
+    public String getTransformationName(TableConfig config) {
+        return getTransformationName(config.getConfiguration());
     }
 
-    public String getOperatorName(Configuration config) {
-        return getFormattedOperatorName(getDescription(), getSimplifiedName(), config);
+    public String getTransformationName(Configuration config) {
+        return getFormattedTransformationName(getDescription(), getSimplifiedName(), config);
     }
 
     @JsonIgnore
@@ -175,26 +175,27 @@ public abstract class ExecNodeBase<T> implements ExecNode<T> {
         return getClass().getSimpleName().replace("StreamExec", "").replace("BatchExec", "");
     }
 
-    protected String getOperatorDescription(TableConfig config) {
-        return getOperatorDescription(config.getConfiguration());
+    protected String getTransformationDescription(TableConfig config) {
+        return getTransformationDescription(config.getConfiguration());
     }
 
-    protected String getOperatorDescription(Configuration config) {
-        return getFormattedOperatorDescription(getDescription(), config);
+    protected String getTransformationDescription(Configuration config) {
+        return getFormattedTransformationDescription(getDescription(), config);
     }
 
-    public TransformationMetadata getOperatorMeta(String operatorName, TableConfig config) {
-        return getOperatorMeta(operatorName, config.getConfiguration());
+    public TransformationMetadata getTransformationMeta(String operatorName, TableConfig config) {
+        return getTransformationMeta(operatorName, config.getConfiguration());
     }
 
-    public TransformationMetadata getOperatorMeta(String operatorName, Configuration config) {
+    public TransformationMetadata getTransformationMeta(String operatorName, Configuration config) {
         return new TransformationMetadata(
-                getOperatorUid(operatorName),
-                getOperatorName(config),
-                getOperatorDescription(config));
+                getTransformationUid(operatorName),
+                getTransformationName(config),
+                getTransformationDescription(config));
     }
 
-    protected String getFormattedOperatorDescription(String description, Configuration config) {
+    protected String getFormattedTransformationDescription(
+            String description, Configuration config) {
         if (config.getBoolean(
                 OptimizerConfigOptions.TABLE_OPTIMIZER_SIMPLIFY_OPERATOR_NAME_ENABLED)) {
             return String.format("[%d]:%s", getId(), description);
@@ -202,7 +203,7 @@ public abstract class ExecNodeBase<T> implements ExecNode<T> {
         return description;
     }
 
-    protected String getFormattedOperatorName(
+    protected String getFormattedTransformationName(
             String detailName, String simplifiedName, Configuration config) {
         if (config.getBoolean(
                 OptimizerConfigOptions.TABLE_OPTIMIZER_SIMPLIFY_OPERATOR_NAME_ENABLED)) {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/ExecNodeBase.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/ExecNodeBase.java
@@ -25,6 +25,7 @@ import org.apache.flink.table.api.config.OptimizerConfigOptions;
 import org.apache.flink.table.delegation.Planner;
 import org.apache.flink.table.planner.delegation.PlannerBase;
 import org.apache.flink.table.planner.plan.nodes.exec.common.CommonExecExchange;
+import org.apache.flink.table.planner.plan.nodes.exec.utils.TransformationMetadata;
 import org.apache.flink.table.planner.plan.nodes.exec.visitor.ExecNodeVisitor;
 import org.apache.flink.table.types.logical.LogicalType;
 
@@ -157,6 +158,10 @@ public abstract class ExecNodeBase<T> implements ExecNode<T> {
                                                 == InputProperty.DistributionType.SINGLETON);
     }
 
+    public String getOperatorUid(String operatorName) {
+        return context.generateUid(operatorName);
+    }
+
     public String getOperatorName(TableConfig config) {
         return getOperatorName(config.getConfiguration());
     }
@@ -176,6 +181,17 @@ public abstract class ExecNodeBase<T> implements ExecNode<T> {
 
     protected String getOperatorDescription(Configuration config) {
         return getFormattedOperatorDescription(getDescription(), config);
+    }
+
+    public TransformationMetadata getOperatorMeta(String operatorName, TableConfig config) {
+        return getOperatorMeta(operatorName, config.getConfiguration());
+    }
+
+    public TransformationMetadata getOperatorMeta(String operatorName, Configuration config) {
+        return new TransformationMetadata(
+                getOperatorUid(operatorName),
+                getOperatorName(config),
+                getOperatorDescription(config));
     }
 
     protected String getFormattedOperatorDescription(String description, Configuration config) {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/ExecNodeBase.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/ExecNodeBase.java
@@ -158,43 +158,45 @@ public abstract class ExecNodeBase<T> implements ExecNode<T> {
                                                 == InputProperty.DistributionType.SINGLETON);
     }
 
-    public String getTransformationUid(String operatorName) {
-        return context.generateUid(operatorName);
-    }
-
-    public String getTransformationName(TableConfig config) {
-        return getTransformationName(config.getConfiguration());
-    }
-
-    public String getTransformationName(Configuration config) {
-        return getFormattedTransformationName(getDescription(), getSimplifiedName(), config);
-    }
-
     @JsonIgnore
     protected String getSimplifiedName() {
         return getClass().getSimpleName().replace("StreamExec", "").replace("BatchExec", "");
     }
 
-    protected String getTransformationDescription(TableConfig config) {
-        return getTransformationDescription(config.getConfiguration());
+    public String createTransformationUid(String operatorName) {
+        return context.generateUid(operatorName);
     }
 
-    protected String getTransformationDescription(Configuration config) {
-        return getFormattedTransformationDescription(getDescription(), config);
+    public String createTransformationName(TableConfig config) {
+        return createTransformationName(config.getConfiguration());
     }
 
-    public TransformationMetadata getTransformationMeta(String operatorName, TableConfig config) {
-        return getTransformationMeta(operatorName, config.getConfiguration());
+    public String createTransformationName(Configuration config) {
+        return createFormattedTransformationName(getDescription(), getSimplifiedName(), config);
     }
 
-    public TransformationMetadata getTransformationMeta(String operatorName, Configuration config) {
+    protected String createTransformationDescription(TableConfig config) {
+        return createTransformationDescription(config.getConfiguration());
+    }
+
+    protected String createTransformationDescription(Configuration config) {
+        return createFormattedTransformationDescription(getDescription(), config);
+    }
+
+    public TransformationMetadata createTransformationMeta(
+            String operatorName, TableConfig config) {
+        return createTransformationMeta(operatorName, config.getConfiguration());
+    }
+
+    public TransformationMetadata createTransformationMeta(
+            String operatorName, Configuration config) {
         return new TransformationMetadata(
-                getTransformationUid(operatorName),
-                getTransformationName(config),
-                getTransformationDescription(config));
+                createTransformationUid(operatorName),
+                createTransformationName(config),
+                createTransformationDescription(config));
     }
 
-    protected String getFormattedTransformationDescription(
+    protected String createFormattedTransformationDescription(
             String description, Configuration config) {
         if (config.getBoolean(
                 OptimizerConfigOptions.TABLE_OPTIMIZER_SIMPLIFY_OPERATOR_NAME_ENABLED)) {
@@ -203,7 +205,7 @@ public abstract class ExecNodeBase<T> implements ExecNode<T> {
         return description;
     }
 
-    protected String getFormattedTransformationName(
+    protected String createFormattedTransformationName(
             String detailName, String simplifiedName, Configuration config) {
         if (config.getBoolean(
                 OptimizerConfigOptions.TABLE_OPTIMIZER_SIMPLIFY_OPERATOR_NAME_ENABLED)) {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/ExecNodeContext.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/ExecNodeContext.java
@@ -115,7 +115,7 @@ public final class ExecNodeContext {
 
     /** Returns a new {@code uid} for transformations. */
     public String generateUid(String operatorName) {
-        return toString() + "_" + operatorName;
+        return String.format("%s-%s-%s", getId(), getTypeAsString(), operatorName);
     }
 
     /**

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/ExecNodeContext.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/ExecNodeContext.java
@@ -113,6 +113,11 @@ public final class ExecNodeContext {
         return version;
     }
 
+    /** Returns a new {@code uid} for transformations. */
+    public String generateUid(String operatorName) {
+        return toString() + "_" + operatorName;
+    }
+
     /**
      * Set the unique ID of the node, so that the {@link ExecNodeContext}, together with the type
      * related {@link #name} and {@link #version}, stores all the necessary info to uniquely

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/ExecNodeContext.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/ExecNodeContext.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.planner.plan.nodes.exec;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.planner.plan.utils.ExecNodeMetadataUtil;
 import org.apache.flink.table.types.logical.LogicalType;
 
@@ -31,6 +32,7 @@ import javax.annotation.Nullable;
 
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Pattern;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -46,6 +48,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  */
 @Internal
 public final class ExecNodeContext {
+
+    private static final Pattern transformationNamePattern = Pattern.compile("[a-z\\-]+");
 
     /** This is used to assign a unique ID to every ExecNode. */
     private static final AtomicInteger idCounter = new AtomicInteger(0);
@@ -114,8 +118,15 @@ public final class ExecNodeContext {
     }
 
     /** Returns a new {@code uid} for transformations. */
-    public String generateUid(String operatorName) {
-        return String.format("%s-%s-%s", getId(), getTypeAsString(), operatorName);
+    public String generateUid(String transformationName) {
+        if (!transformationNamePattern.matcher(transformationName).matches()) {
+            throw new TableException(
+                    "Invalid transformation name '"
+                            + transformationName
+                            + "'. "
+                            + "This is a bug, please file an issue.");
+        }
+        return String.format("%s_%s_%s", getId(), getTypeAsString(), transformationName);
     }
 
     /**

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/ExecNodeMetadata.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/ExecNodeMetadata.java
@@ -84,7 +84,7 @@ public @interface ExecNodeMetadata {
     String[] consumedOptions() default {};
 
     /**
-     * Set of operator names that can be part of the resulting {@link Transformation}s.
+     * Set of transformation names that can be part of the resulting {@link Transformation}s.
      *
      * <p>Restore and completeness tests can verify there exists at least one test that adds each
      * operator and that the created {@link Transformation}s contain only operators with {@link
@@ -94,7 +94,7 @@ public @interface ExecNodeMetadata {
      * various parameters (both configuration and ExecNode-specific arguments such as interval size
      * etc.).
      */
-    String[] producedOperators() default {};
+    String[] producedTransformations() default {};
 
     /**
      * Used for plan validation and potentially plan migration.

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecBoundedStreamScan.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecBoundedStreamScan.java
@@ -80,8 +80,8 @@ public class BatchExecBoundedStreamScan extends ExecNodeBase<RowData>
                     (RowType) getOutputType(),
                     qualifiedName,
                     (detailName, simplifyName) ->
-                            getFormattedOperatorName(detailName, simplifyName, config),
-                    (description) -> getFormattedOperatorDescription(description, config),
+                            getFormattedTransformationName(detailName, simplifyName, config),
+                    (description) -> getFormattedTransformationDescription(description, config),
                     JavaScalaConversionUtil.toScala(Optional.empty()),
                     "",
                     "");

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecBoundedStreamScan.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecBoundedStreamScan.java
@@ -80,8 +80,8 @@ public class BatchExecBoundedStreamScan extends ExecNodeBase<RowData>
                     (RowType) getOutputType(),
                     qualifiedName,
                     (detailName, simplifyName) ->
-                            getFormattedTransformationName(detailName, simplifyName, config),
-                    (description) -> getFormattedTransformationDescription(description, config),
+                            createFormattedTransformationName(detailName, simplifyName, config),
+                    (description) -> createFormattedTransformationDescription(description, config),
                     JavaScalaConversionUtil.toScala(Optional.empty()),
                     "",
                     "");

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecHashAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecHashAggregate.java
@@ -137,8 +137,8 @@ public class BatchExecHashAggregate extends ExecNodeBase<RowData>
 
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getOperatorName(planner.getTableConfig()),
-                getOperatorDescription(planner.getTableConfig()),
+                getTransformationName(planner.getTableConfig()),
+                getTransformationDescription(planner.getTableConfig()),
                 new CodeGenOperatorFactory<>(generatedOperator),
                 InternalTypeInfo.of(outputRowType),
                 inputTransform.getParallelism(),

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecHashAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecHashAggregate.java
@@ -137,8 +137,8 @@ public class BatchExecHashAggregate extends ExecNodeBase<RowData>
 
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getTransformationName(planner.getTableConfig()),
-                getTransformationDescription(planner.getTableConfig()),
+                createTransformationName(planner.getTableConfig()),
+                createTransformationDescription(planner.getTableConfig()),
                 new CodeGenOperatorFactory<>(generatedOperator),
                 InternalTypeInfo.of(outputRowType),
                 inputTransform.getParallelism(),

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecHashJoin.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecHashJoin.java
@@ -219,8 +219,8 @@ public class BatchExecHashJoin extends ExecNodeBase<RowData>
         return ExecNodeUtil.createTwoInputTransformation(
                 buildTransform,
                 probeTransform,
-                getTransformationName(config),
-                getTransformationDescription(config),
+                createTransformationName(config),
+                createTransformationDescription(config),
                 operator,
                 InternalTypeInfo.of(getOutputType()),
                 probeTransform.getParallelism(),

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecHashJoin.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecHashJoin.java
@@ -219,8 +219,8 @@ public class BatchExecHashJoin extends ExecNodeBase<RowData>
         return ExecNodeUtil.createTwoInputTransformation(
                 buildTransform,
                 probeTransform,
-                getOperatorName(config),
-                getOperatorDescription(config),
+                getTransformationName(config),
+                getTransformationDescription(config),
                 operator,
                 InternalTypeInfo.of(getOutputType()),
                 probeTransform.getParallelism(),

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecHashWindowAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecHashWindowAggregate.java
@@ -151,8 +151,8 @@ public class BatchExecHashWindowAggregate extends ExecNodeBase<RowData>
                         .getBytes();
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getTransformationName(tableConfig),
-                getTransformationDescription(tableConfig),
+                createTransformationName(tableConfig),
+                createTransformationDescription(tableConfig),
                 new CodeGenOperatorFactory<>(generatedOperator),
                 InternalTypeInfo.of(getOutputType()),
                 inputTransform.getParallelism(),

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecHashWindowAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecHashWindowAggregate.java
@@ -151,8 +151,8 @@ public class BatchExecHashWindowAggregate extends ExecNodeBase<RowData>
                         .getBytes();
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getOperatorName(tableConfig),
-                getOperatorDescription(tableConfig),
+                getTransformationName(tableConfig),
+                getTransformationDescription(tableConfig),
                 new CodeGenOperatorFactory<>(generatedOperator),
                 InternalTypeInfo.of(getOutputType()),
                 inputTransform.getParallelism(),

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecLegacyTableSourceScan.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecLegacyTableSourceScan.java
@@ -100,8 +100,8 @@ public class BatchExecLegacyTableSourceScan extends CommonExecLegacyTableSourceS
                     (RowType) getOutputType(),
                     qualifiedName,
                     (detailName, simplifyName) ->
-                            getFormattedTransformationName(detailName, simplifyName, config),
-                    (description) -> getFormattedTransformationDescription(description, config),
+                            createFormattedTransformationName(detailName, simplifyName, config),
+                    (description) -> createFormattedTransformationDescription(description, config),
                     JavaScalaConversionUtil.toScala(Optional.ofNullable(rowtimeExpression)),
                     "",
                     "");

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecLegacyTableSourceScan.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecLegacyTableSourceScan.java
@@ -100,8 +100,8 @@ public class BatchExecLegacyTableSourceScan extends CommonExecLegacyTableSourceS
                     (RowType) getOutputType(),
                     qualifiedName,
                     (detailName, simplifyName) ->
-                            getFormattedOperatorName(detailName, simplifyName, config),
-                    (description) -> getFormattedOperatorDescription(description, config),
+                            getFormattedTransformationName(detailName, simplifyName, config),
+                    (description) -> getFormattedTransformationDescription(description, config),
                     JavaScalaConversionUtil.toScala(Optional.ofNullable(rowtimeExpression)),
                     "",
                     "");

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecLimit.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecLimit.java
@@ -65,8 +65,8 @@ public class BatchExecLimit extends ExecNodeBase<RowData> implements BatchExecNo
         LimitOperator operator = new LimitOperator(isGlobal, limitStart, limitEnd);
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getOperatorName(planner.getTableConfig()),
-                getOperatorDescription(planner.getTableConfig()),
+                getTransformationName(planner.getTableConfig()),
+                getTransformationDescription(planner.getTableConfig()),
                 SimpleOperatorFactory.of(operator),
                 inputTransform.getOutputType(),
                 inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecLimit.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecLimit.java
@@ -65,8 +65,8 @@ public class BatchExecLimit extends ExecNodeBase<RowData> implements BatchExecNo
         LimitOperator operator = new LimitOperator(isGlobal, limitStart, limitEnd);
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getTransformationName(planner.getTableConfig()),
-                getTransformationDescription(planner.getTableConfig()),
+                createTransformationName(planner.getTableConfig()),
+                createTransformationDescription(planner.getTableConfig()),
                 SimpleOperatorFactory.of(operator),
                 inputTransform.getOutputType(),
                 inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecMultipleInput.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecMultipleInput.java
@@ -106,7 +106,7 @@ public class BatchExecMultipleInput extends ExecNodeBase<RowData>
 
         final MultipleInputTransformation<RowData> multipleInputTransform =
                 new MultipleInputTransformation<>(
-                        getTransformationName(planner.getTableConfig()),
+                        createTransformationName(planner.getTableConfig()),
                         new BatchMultipleInputStreamOperatorFactory(
                                 inputTransformAndInputSpecPairs.stream()
                                         .map(Pair::getValue)
@@ -116,7 +116,7 @@ public class BatchExecMultipleInput extends ExecNodeBase<RowData>
                         InternalTypeInfo.of(getOutputType()),
                         generator.getParallelism());
         multipleInputTransform.setDescription(
-                getTransformationDescription(planner.getTableConfig()));
+                createTransformationDescription(planner.getTableConfig()));
         inputTransformAndInputSpecPairs.forEach(
                 input -> multipleInputTransform.addInput(input.getKey()));
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecMultipleInput.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecMultipleInput.java
@@ -106,7 +106,7 @@ public class BatchExecMultipleInput extends ExecNodeBase<RowData>
 
         final MultipleInputTransformation<RowData> multipleInputTransform =
                 new MultipleInputTransformation<>(
-                        getOperatorName(planner.getTableConfig()),
+                        getTransformationName(planner.getTableConfig()),
                         new BatchMultipleInputStreamOperatorFactory(
                                 inputTransformAndInputSpecPairs.stream()
                                         .map(Pair::getValue)
@@ -115,7 +115,8 @@ public class BatchExecMultipleInput extends ExecNodeBase<RowData>
                                 generator.getTailWrapper()),
                         InternalTypeInfo.of(getOutputType()),
                         generator.getParallelism());
-        multipleInputTransform.setDescription(getOperatorDescription(planner.getTableConfig()));
+        multipleInputTransform.setDescription(
+                getTransformationDescription(planner.getTableConfig()));
         inputTransformAndInputSpecPairs.forEach(
                 input -> multipleInputTransform.addInput(input.getKey()));
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecNestedLoopJoin.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecNestedLoopJoin.java
@@ -114,8 +114,8 @@ public class BatchExecNestedLoopJoin extends ExecNodeBase<RowData>
         return ExecNodeUtil.createTwoInputTransformation(
                 leftInputTransform,
                 rightInputTransform,
-                getTransformationName(config),
-                getTransformationDescription(config),
+                createTransformationName(config),
+                createTransformationDescription(config),
                 operator,
                 InternalTypeInfo.of(getOutputType()),
                 parallelism,

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecNestedLoopJoin.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecNestedLoopJoin.java
@@ -114,8 +114,8 @@ public class BatchExecNestedLoopJoin extends ExecNodeBase<RowData>
         return ExecNodeUtil.createTwoInputTransformation(
                 leftInputTransform,
                 rightInputTransform,
-                getOperatorName(config),
-                getOperatorDescription(config),
+                getTransformationName(config),
+                getTransformationDescription(config),
                 operator,
                 InternalTypeInfo.of(getOutputType()),
                 parallelism,

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecOverAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecOverAggregate.java
@@ -172,8 +172,8 @@ public class BatchExecOverAggregate extends BatchExecOverAggregateBase {
         }
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getTransformationName(planner.getTableConfig()),
-                getTransformationDescription(planner.getTableConfig()),
+                createTransformationName(planner.getTableConfig()),
+                createTransformationDescription(planner.getTableConfig()),
                 SimpleOperatorFactory.of(operator),
                 InternalTypeInfo.of(getOutputType()),
                 inputTransform.getParallelism(),

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecOverAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecOverAggregate.java
@@ -172,8 +172,8 @@ public class BatchExecOverAggregate extends BatchExecOverAggregateBase {
         }
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getOperatorName(planner.getTableConfig()),
-                getOperatorDescription(planner.getTableConfig()),
+                getTransformationName(planner.getTableConfig()),
+                getTransformationDescription(planner.getTableConfig()),
                 SimpleOperatorFactory.of(operator),
                 InternalTypeInfo.of(getOutputType()),
                 inputTransform.getParallelism(),

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecPythonGroupAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecPythonGroupAggregate.java
@@ -124,8 +124,8 @@ public class BatchExecPythonGroupAggregate extends ExecNodeBase<RowData>
                         pythonFunctionInfos);
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getOperatorName(mergedConfig),
-                getOperatorDescription(mergedConfig),
+                getTransformationName(mergedConfig),
+                getTransformationDescription(mergedConfig),
                 pythonOperator,
                 InternalTypeInfo.of(outputRowType),
                 inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecPythonGroupAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecPythonGroupAggregate.java
@@ -124,8 +124,8 @@ public class BatchExecPythonGroupAggregate extends ExecNodeBase<RowData>
                         pythonFunctionInfos);
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getTransformationName(mergedConfig),
-                getTransformationDescription(mergedConfig),
+                createTransformationName(mergedConfig),
+                createTransformationDescription(mergedConfig),
                 pythonOperator,
                 InternalTypeInfo.of(outputRowType),
                 inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecPythonGroupWindowAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecPythonGroupWindowAggregate.java
@@ -175,8 +175,8 @@ public class BatchExecPythonGroupWindowAggregate extends ExecNodeBase<RowData>
                         pythonFunctionInfos);
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getOperatorName(mergedConfig),
-                getOperatorDescription(mergedConfig),
+                getTransformationName(mergedConfig),
+                getTransformationDescription(mergedConfig),
                 pythonOperator,
                 InternalTypeInfo.of(outputRowType),
                 inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecPythonGroupWindowAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecPythonGroupWindowAggregate.java
@@ -175,8 +175,8 @@ public class BatchExecPythonGroupWindowAggregate extends ExecNodeBase<RowData>
                         pythonFunctionInfos);
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getTransformationName(mergedConfig),
-                getTransformationDescription(mergedConfig),
+                createTransformationName(mergedConfig),
+                createTransformationDescription(mergedConfig),
                 pythonOperator,
                 InternalTypeInfo.of(outputRowType),
                 inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecPythonOverAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecPythonOverAggregate.java
@@ -187,8 +187,8 @@ public class BatchExecPythonOverAggregate extends BatchExecOverAggregateBase {
                         pythonFunctionInfos);
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getTransformationName(mergedConfig),
-                getTransformationDescription(mergedConfig),
+                createTransformationName(mergedConfig),
+                createTransformationDescription(mergedConfig),
                 pythonOperator,
                 InternalTypeInfo.of(outputRowType),
                 inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecPythonOverAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecPythonOverAggregate.java
@@ -187,8 +187,8 @@ public class BatchExecPythonOverAggregate extends BatchExecOverAggregateBase {
                         pythonFunctionInfos);
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getOperatorName(mergedConfig),
-                getOperatorDescription(mergedConfig),
+                getTransformationName(mergedConfig),
+                getTransformationDescription(mergedConfig),
                 pythonOperator,
                 InternalTypeInfo.of(outputRowType),
                 inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecRank.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecRank.java
@@ -101,8 +101,8 @@ public class BatchExecRank extends ExecNodeBase<RowData> implements BatchExecNod
 
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getTransformationName(planner.getTableConfig()),
-                getTransformationDescription(planner.getTableConfig()),
+                createTransformationName(planner.getTableConfig()),
+                createTransformationDescription(planner.getTableConfig()),
                 SimpleOperatorFactory.of(operator),
                 InternalTypeInfo.of((RowType) getOutputType()),
                 inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecRank.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecRank.java
@@ -101,8 +101,8 @@ public class BatchExecRank extends ExecNodeBase<RowData> implements BatchExecNod
 
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getOperatorName(planner.getTableConfig()),
-                getOperatorDescription(planner.getTableConfig()),
+                getTransformationName(planner.getTableConfig()),
+                getTransformationDescription(planner.getTableConfig()),
                 SimpleOperatorFactory.of(operator),
                 InternalTypeInfo.of((RowType) getOutputType()),
                 inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSort.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSort.java
@@ -81,8 +81,8 @@ public class BatchExecSort extends ExecNodeBase<RowData> implements BatchExecNod
                         .getBytes();
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getTransformationName(config),
-                getTransformationDescription(config),
+                createTransformationName(config),
+                createTransformationDescription(config),
                 SimpleOperatorFactory.of(operator),
                 InternalTypeInfo.of((RowType) getOutputType()),
                 inputTransform.getParallelism(),

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSort.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSort.java
@@ -81,8 +81,8 @@ public class BatchExecSort extends ExecNodeBase<RowData> implements BatchExecNod
                         .getBytes();
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getOperatorName(config),
-                getOperatorDescription(config),
+                getTransformationName(config),
+                getTransformationDescription(config),
                 SimpleOperatorFactory.of(operator),
                 InternalTypeInfo.of((RowType) getOutputType()),
                 inputTransform.getParallelism(),

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSortAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSortAggregate.java
@@ -126,8 +126,8 @@ public class BatchExecSortAggregate extends ExecNodeBase<RowData>
 
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getTransformationName(planner.getTableConfig()),
-                getTransformationDescription(planner.getTableConfig()),
+                createTransformationName(planner.getTableConfig()),
+                createTransformationDescription(planner.getTableConfig()),
                 new CodeGenOperatorFactory<>(generatedOperator),
                 InternalTypeInfo.of(outputRowType),
                 inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSortAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSortAggregate.java
@@ -126,8 +126,8 @@ public class BatchExecSortAggregate extends ExecNodeBase<RowData>
 
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getOperatorName(planner.getTableConfig()),
-                getOperatorDescription(planner.getTableConfig()),
+                getTransformationName(planner.getTableConfig()),
+                getTransformationDescription(planner.getTableConfig()),
                 new CodeGenOperatorFactory<>(generatedOperator),
                 InternalTypeInfo.of(outputRowType),
                 inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSortLimit.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSortLimit.java
@@ -94,8 +94,8 @@ public class BatchExecSortLimit extends ExecNodeBase<RowData>
 
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getTransformationName(planner.getTableConfig()),
-                getTransformationDescription(planner.getTableConfig()),
+                createTransformationName(planner.getTableConfig()),
+                createTransformationDescription(planner.getTableConfig()),
                 SimpleOperatorFactory.of(operator),
                 InternalTypeInfo.of(inputType),
                 inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSortLimit.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSortLimit.java
@@ -94,8 +94,8 @@ public class BatchExecSortLimit extends ExecNodeBase<RowData>
 
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getOperatorName(planner.getTableConfig()),
-                getOperatorDescription(planner.getTableConfig()),
+                getTransformationName(planner.getTableConfig()),
+                getTransformationDescription(planner.getTableConfig()),
                 SimpleOperatorFactory.of(operator),
                 InternalTypeInfo.of(inputType),
                 inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSortMergeJoin.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSortMergeJoin.java
@@ -162,8 +162,8 @@ public class BatchExecSortMergeJoin extends ExecNodeBase<RowData>
         return ExecNodeUtil.createTwoInputTransformation(
                 leftInputTransform,
                 rightInputTransform,
-                getTransformationName(planner.getTableConfig()),
-                getTransformationDescription(planner.getTableConfig()),
+                createTransformationName(planner.getTableConfig()),
+                createTransformationDescription(planner.getTableConfig()),
                 SimpleOperatorFactory.of(operator),
                 InternalTypeInfo.of(getOutputType()),
                 rightInputTransform.getParallelism(),

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSortMergeJoin.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSortMergeJoin.java
@@ -162,8 +162,8 @@ public class BatchExecSortMergeJoin extends ExecNodeBase<RowData>
         return ExecNodeUtil.createTwoInputTransformation(
                 leftInputTransform,
                 rightInputTransform,
-                getOperatorName(planner.getTableConfig()),
-                getOperatorDescription(planner.getTableConfig()),
+                getTransformationName(planner.getTableConfig()),
+                getTransformationDescription(planner.getTableConfig()),
                 SimpleOperatorFactory.of(operator),
                 InternalTypeInfo.of(getOutputType()),
                 rightInputTransform.getParallelism(),

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSortWindowAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSortWindowAggregate.java
@@ -151,8 +151,8 @@ public class BatchExecSortWindowAggregate extends ExecNodeBase<RowData>
 
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getOperatorName(tableConfig),
-                getOperatorDescription(tableConfig),
+                getTransformationName(tableConfig),
+                getTransformationDescription(tableConfig),
                 new CodeGenOperatorFactory<>(generatedOperator),
                 InternalTypeInfo.of(getOutputType()),
                 inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSortWindowAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSortWindowAggregate.java
@@ -151,8 +151,8 @@ public class BatchExecSortWindowAggregate extends ExecNodeBase<RowData>
 
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getTransformationName(tableConfig),
-                getTransformationDescription(tableConfig),
+                createTransformationName(tableConfig),
+                createTransformationDescription(tableConfig),
                 new CodeGenOperatorFactory<>(generatedOperator),
                 InternalTypeInfo.of(getOutputType()),
                 inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecCalc.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecCalc.java
@@ -50,7 +50,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public abstract class CommonExecCalc extends ExecNodeBase<RowData>
         implements SingleTransformationTranslator<RowData> {
 
-    public static final String SUBSTITUTE_STREAM_OPERATOR = "substitute-stream";
+    public static final String SUBSTITUTE_STREAM_TRANSFORMATION = "substitute-stream";
 
     public static final String FIELD_NAME_PROJECTION = "projection";
     public static final String FIELD_NAME_CONDITION = "condition";
@@ -103,7 +103,7 @@ public abstract class CommonExecCalc extends ExecNodeBase<RowData>
                         getClass().getSimpleName());
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getOperatorMeta(SUBSTITUTE_STREAM_OPERATOR, planner.getTableConfig()),
+                getTransformationMeta(SUBSTITUTE_STREAM_TRANSFORMATION, planner.getTableConfig()),
                 substituteStreamOperator,
                 InternalTypeInfo.of(getOutputType()),
                 inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecCalc.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecCalc.java
@@ -103,7 +103,8 @@ public abstract class CommonExecCalc extends ExecNodeBase<RowData>
                         getClass().getSimpleName());
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getTransformationMeta(SUBSTITUTE_STREAM_TRANSFORMATION, planner.getTableConfig()),
+                createTransformationMeta(
+                        SUBSTITUTE_STREAM_TRANSFORMATION, planner.getTableConfig()),
                 substituteStreamOperator,
                 InternalTypeInfo.of(getOutputType()),
                 inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecCalc.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecCalc.java
@@ -49,6 +49,9 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 /** Base class for exec Calc. */
 public abstract class CommonExecCalc extends ExecNodeBase<RowData>
         implements SingleTransformationTranslator<RowData> {
+
+    private static final String SUBSTITUTE_STREAM_OPERATOR = "substitute-stream";
+
     public static final String FIELD_NAME_PROJECTION = "projection";
     public static final String FIELD_NAME_CONDITION = "condition";
 
@@ -100,8 +103,7 @@ public abstract class CommonExecCalc extends ExecNodeBase<RowData>
                         getClass().getSimpleName());
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getOperatorName(planner.getTableConfig()),
-                getOperatorDescription(planner.getTableConfig()),
+                getOperatorMeta(SUBSTITUTE_STREAM_OPERATOR, planner.getTableConfig()),
                 substituteStreamOperator,
                 InternalTypeInfo.of(getOutputType()),
                 inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecCalc.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecCalc.java
@@ -50,7 +50,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public abstract class CommonExecCalc extends ExecNodeBase<RowData>
         implements SingleTransformationTranslator<RowData> {
 
-    private static final String SUBSTITUTE_STREAM_OPERATOR = "substitute-stream";
+    public static final String SUBSTITUTE_STREAM_OPERATOR = "substitute-stream";
 
     public static final String FIELD_NAME_PROJECTION = "projection";
     public static final String FIELD_NAME_CONDITION = "condition";

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecCalc.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecCalc.java
@@ -50,7 +50,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public abstract class CommonExecCalc extends ExecNodeBase<RowData>
         implements SingleTransformationTranslator<RowData> {
 
-    public static final String SUBSTITUTE_STREAM_TRANSFORMATION = "substitute-stream";
+    public static final String SUBSTITUTE_TRANSFORMATION = "substitute";
 
     public static final String FIELD_NAME_PROJECTION = "projection";
     public static final String FIELD_NAME_CONDITION = "condition";
@@ -103,8 +103,7 @@ public abstract class CommonExecCalc extends ExecNodeBase<RowData>
                         getClass().getSimpleName());
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                createTransformationMeta(
-                        SUBSTITUTE_STREAM_TRANSFORMATION, planner.getTableConfig()),
+                createTransformationMeta(SUBSTITUTE_TRANSFORMATION, planner.getTableConfig()),
                 substituteStreamOperator,
                 InternalTypeInfo.of(getOutputType()),
                 inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecCalc.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecCalc.java
@@ -50,7 +50,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public abstract class CommonExecCalc extends ExecNodeBase<RowData>
         implements SingleTransformationTranslator<RowData> {
 
-    public static final String SUBSTITUTE_TRANSFORMATION = "substitute";
+    public static final String CALC_TRANSFORMATION = "calc";
 
     public static final String FIELD_NAME_PROJECTION = "projection";
     public static final String FIELD_NAME_CONDITION = "condition";
@@ -103,7 +103,7 @@ public abstract class CommonExecCalc extends ExecNodeBase<RowData>
                         getClass().getSimpleName());
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                createTransformationMeta(SUBSTITUTE_TRANSFORMATION, planner.getTableConfig()),
+                createTransformationMeta(CALC_TRANSFORMATION, planner.getTableConfig()),
                 substituteStreamOperator,
                 InternalTypeInfo.of(getOutputType()),
                 inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecCorrelate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecCorrelate.java
@@ -50,7 +50,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public abstract class CommonExecCorrelate extends ExecNodeBase<RowData>
         implements SingleTransformationTranslator<RowData> {
 
-    public static final String CORRELATE_OPERATOR = "correlate";
+    public static final String CORRELATE_TRANSFORMATION = "correlate";
 
     public static final String FIELD_NAME_JOIN_TYPE = "joinType";
     public static final String FIELD_NAME_FUNCTION_CALL = "functionCall";
@@ -109,6 +109,6 @@ public abstract class CommonExecCorrelate extends ExecNodeBase<RowData>
                 inputTransform.getParallelism(),
                 retainHeader,
                 getClass().getSimpleName(),
-                getOperatorMeta(CORRELATE_OPERATOR, planner.getTableConfig()));
+                getTransformationMeta(CORRELATE_TRANSFORMATION, planner.getTableConfig()));
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecCorrelate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecCorrelate.java
@@ -50,6 +50,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public abstract class CommonExecCorrelate extends ExecNodeBase<RowData>
         implements SingleTransformationTranslator<RowData> {
 
+    private static final String CORRELATE_OPERATOR = "correlate";
+
     public static final String FIELD_NAME_JOIN_TYPE = "joinType";
     public static final String FIELD_NAME_FUNCTION_CALL = "functionCall";
     public static final String FIELD_NAME_CONDITION = "condition";
@@ -107,7 +109,6 @@ public abstract class CommonExecCorrelate extends ExecNodeBase<RowData>
                 inputTransform.getParallelism(),
                 retainHeader,
                 getClass().getSimpleName(),
-                getOperatorName(planner.getTableConfig()),
-                getOperatorDescription(planner.getTableConfig()));
+                getOperatorMeta(CORRELATE_OPERATOR, planner.getTableConfig()));
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecCorrelate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecCorrelate.java
@@ -109,6 +109,6 @@ public abstract class CommonExecCorrelate extends ExecNodeBase<RowData>
                 inputTransform.getParallelism(),
                 retainHeader,
                 getClass().getSimpleName(),
-                getTransformationMeta(CORRELATE_TRANSFORMATION, planner.getTableConfig()));
+                createTransformationMeta(CORRELATE_TRANSFORMATION, planner.getTableConfig()));
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecCorrelate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecCorrelate.java
@@ -50,7 +50,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public abstract class CommonExecCorrelate extends ExecNodeBase<RowData>
         implements SingleTransformationTranslator<RowData> {
 
-    private static final String CORRELATE_OPERATOR = "correlate";
+    public static final String CORRELATE_OPERATOR = "correlate";
 
     public static final String FIELD_NAME_JOIN_TYPE = "joinType";
     public static final String FIELD_NAME_FUNCTION_CALL = "functionCall";

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecExpand.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecExpand.java
@@ -47,6 +47,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public abstract class CommonExecExpand extends ExecNodeBase<RowData>
         implements SingleTransformationTranslator<RowData> {
 
+    private static final String EXPAND_OPERATOR = "expand";
+
     public static final String FIELD_NAME_PROJECTS = "projects";
 
     @JsonProperty(FIELD_NAME_PROJECTS)
@@ -90,8 +92,7 @@ public abstract class CommonExecExpand extends ExecNodeBase<RowData>
 
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getOperatorName(planner.getTableConfig()),
-                getOperatorDescription(planner.getTableConfig()),
+                getOperatorMeta(EXPAND_OPERATOR, planner.getTableConfig()),
                 operatorFactory,
                 InternalTypeInfo.of(getOutputType()),
                 inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecExpand.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecExpand.java
@@ -47,7 +47,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public abstract class CommonExecExpand extends ExecNodeBase<RowData>
         implements SingleTransformationTranslator<RowData> {
 
-    private static final String EXPAND_OPERATOR = "expand";
+    public static final String EXPAND_OPERATOR = "expand";
 
     public static final String FIELD_NAME_PROJECTS = "projects";
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecExpand.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecExpand.java
@@ -47,7 +47,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public abstract class CommonExecExpand extends ExecNodeBase<RowData>
         implements SingleTransformationTranslator<RowData> {
 
-    public static final String EXPAND_OPERATOR = "expand";
+    public static final String EXPAND_TRANSFORMATION = "expand";
 
     public static final String FIELD_NAME_PROJECTS = "projects";
 
@@ -92,7 +92,7 @@ public abstract class CommonExecExpand extends ExecNodeBase<RowData>
 
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getOperatorMeta(EXPAND_OPERATOR, planner.getTableConfig()),
+                getTransformationMeta(EXPAND_TRANSFORMATION, planner.getTableConfig()),
                 operatorFactory,
                 InternalTypeInfo.of(getOutputType()),
                 inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecExpand.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecExpand.java
@@ -92,7 +92,7 @@ public abstract class CommonExecExpand extends ExecNodeBase<RowData>
 
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getTransformationMeta(EXPAND_TRANSFORMATION, planner.getTableConfig()),
+                createTransformationMeta(EXPAND_TRANSFORMATION, planner.getTableConfig()),
                 operatorFactory,
                 InternalTypeInfo.of(getOutputType()),
                 inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecLegacySink.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecLegacySink.java
@@ -204,8 +204,8 @@ public abstract class CommonExecLegacySink<T> extends ExecNodeBase<T>
                     "SinkConversion To " + resultDataType.getConversionClass().getSimpleName();
             return ExecNodeUtil.createOneInputTransformation(
                     inputTransform,
-                    getFormattedOperatorName(description, "SinkConversion", config),
-                    getFormattedOperatorDescription(description, config),
+                    getFormattedTransformationName(description, "SinkConversion", config),
+                    getFormattedTransformationDescription(description, config),
                     converterOperator,
                     outputTypeInfo,
                     inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecLegacySink.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecLegacySink.java
@@ -204,8 +204,8 @@ public abstract class CommonExecLegacySink<T> extends ExecNodeBase<T>
                     "SinkConversion To " + resultDataType.getConversionClass().getSimpleName();
             return ExecNodeUtil.createOneInputTransformation(
                     inputTransform,
-                    getFormattedTransformationName(description, "SinkConversion", config),
-                    getFormattedTransformationDescription(description, config),
+                    createFormattedTransformationName(description, "SinkConversion", config),
+                    createFormattedTransformationDescription(description, config),
                     converterOperator,
                     outputTypeInfo,
                     inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecLookupJoin.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecLookupJoin.java
@@ -136,7 +136,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public abstract class CommonExecLookupJoin extends ExecNodeBase<RowData>
         implements SingleTransformationTranslator<RowData> {
 
-    public static final String LOOKUP_JOIN_OPERATOR = "lookup-join";
+    public static final String LOOKUP_JOIN_TRANSFORMATION = "lookup-join";
 
     public static final String FIELD_NAME_JOIN_TYPE = "joinType";
     public static final String FIELD_NAME_JOIN_CONDITION = "joinCondition";
@@ -265,7 +265,7 @@ public abstract class CommonExecLookupJoin extends ExecNodeBase<RowData>
                 (Transformation<RowData>) inputEdge.translateToPlan(planner);
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransformation,
-                getOperatorMeta(LOOKUP_JOIN_OPERATOR, planner.getTableConfig()),
+                getTransformationMeta(LOOKUP_JOIN_TRANSFORMATION, planner.getTableConfig()),
                 operatorFactory,
                 InternalTypeInfo.of(resultRowType),
                 inputTransformation.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecLookupJoin.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecLookupJoin.java
@@ -136,6 +136,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public abstract class CommonExecLookupJoin extends ExecNodeBase<RowData>
         implements SingleTransformationTranslator<RowData> {
 
+    private static final String LOOKUP_JOIN_OPERATOR = "lookup-join";
+
     public static final String FIELD_NAME_JOIN_TYPE = "joinType";
     public static final String FIELD_NAME_JOIN_CONDITION = "joinCondition";
     public static final String FIELD_NAME_TEMPORAL_TABLE = "temporalTable";
@@ -263,8 +265,7 @@ public abstract class CommonExecLookupJoin extends ExecNodeBase<RowData>
                 (Transformation<RowData>) inputEdge.translateToPlan(planner);
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransformation,
-                getOperatorName(planner.getTableConfig()),
-                getOperatorDescription(planner.getTableConfig()),
+                getOperatorMeta(LOOKUP_JOIN_OPERATOR, planner.getTableConfig()),
                 operatorFactory,
                 InternalTypeInfo.of(resultRowType),
                 inputTransformation.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecLookupJoin.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecLookupJoin.java
@@ -136,7 +136,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public abstract class CommonExecLookupJoin extends ExecNodeBase<RowData>
         implements SingleTransformationTranslator<RowData> {
 
-    private static final String LOOKUP_JOIN_OPERATOR = "lookup-join";
+    public static final String LOOKUP_JOIN_OPERATOR = "lookup-join";
 
     public static final String FIELD_NAME_JOIN_TYPE = "joinType";
     public static final String FIELD_NAME_JOIN_CONDITION = "joinCondition";

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecLookupJoin.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecLookupJoin.java
@@ -265,7 +265,7 @@ public abstract class CommonExecLookupJoin extends ExecNodeBase<RowData>
                 (Transformation<RowData>) inputEdge.translateToPlan(planner);
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransformation,
-                getTransformationMeta(LOOKUP_JOIN_TRANSFORMATION, planner.getTableConfig()),
+                createTransformationMeta(LOOKUP_JOIN_TRANSFORMATION, planner.getTableConfig()),
                 operatorFactory,
                 InternalTypeInfo.of(resultRowType),
                 inputTransformation.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecPythonCalc.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecPythonCalc.java
@@ -67,7 +67,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public abstract class CommonExecPythonCalc extends ExecNodeBase<RowData>
         implements SingleTransformationTranslator<RowData> {
 
-    private static final String PYTHON_CALC_OPERATOR = "python-calc";
+    public static final String PYTHON_CALC_OPERATOR = "python-calc";
 
     public static final String FIELD_NAME_PROJECTION = "projection";
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecPythonCalc.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecPythonCalc.java
@@ -170,7 +170,7 @@ public abstract class CommonExecPythonCalc extends ExecNodeBase<RowData>
 
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getTransformationMeta(PYTHON_CALC_TRANSFORMATION, mergedConfig),
+                createTransformationMeta(PYTHON_CALC_TRANSFORMATION, mergedConfig),
                 pythonOperator,
                 pythonOperatorResultTyeInfo,
                 inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecPythonCalc.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecPythonCalc.java
@@ -67,7 +67,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public abstract class CommonExecPythonCalc extends ExecNodeBase<RowData>
         implements SingleTransformationTranslator<RowData> {
 
-    public static final String PYTHON_CALC_OPERATOR = "python-calc";
+    public static final String PYTHON_CALC_TRANSFORMATION = "python-calc";
 
     public static final String FIELD_NAME_PROJECTION = "projection";
 
@@ -170,7 +170,7 @@ public abstract class CommonExecPythonCalc extends ExecNodeBase<RowData>
 
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getOperatorMeta(PYTHON_CALC_OPERATOR, mergedConfig),
+                getTransformationMeta(PYTHON_CALC_TRANSFORMATION, mergedConfig),
                 pythonOperator,
                 pythonOperatorResultTyeInfo,
                 inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecPythonCalc.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecPythonCalc.java
@@ -67,6 +67,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public abstract class CommonExecPythonCalc extends ExecNodeBase<RowData>
         implements SingleTransformationTranslator<RowData> {
 
+    private static final String PYTHON_CALC_OPERATOR = "python-calc";
+
     public static final String FIELD_NAME_PROJECTION = "projection";
 
     private static final String PYTHON_SCALAR_FUNCTION_OPERATOR_NAME =
@@ -168,8 +170,7 @@ public abstract class CommonExecPythonCalc extends ExecNodeBase<RowData>
 
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getOperatorName(mergedConfig),
-                getOperatorDescription(mergedConfig),
+                getOperatorMeta(PYTHON_CALC_OPERATOR, mergedConfig),
                 pythonOperator,
                 pythonOperatorResultTyeInfo,
                 inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecPythonCorrelate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecPythonCorrelate.java
@@ -61,7 +61,7 @@ import static org.apache.flink.util.Preconditions.checkArgument;
 public abstract class CommonExecPythonCorrelate extends ExecNodeBase<RowData>
         implements SingleTransformationTranslator<RowData> {
 
-    public static final String PYTHON_CORRELATE_OPERATOR = "python-correlate";
+    public static final String PYTHON_CORRELATE_TRANSFORMATION = "python-correlate";
 
     public static final String FIELD_NAME_JOIN_TYPE = "joinType";
     public static final String FIELD_NAME_FUNCTION_CALL = "functionCall";
@@ -127,7 +127,7 @@ public abstract class CommonExecPythonCorrelate extends ExecNodeBase<RowData>
                         pythonUdtfInputOffsets);
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getOperatorMeta(PYTHON_CORRELATE_OPERATOR, mergedConfig),
+                getTransformationMeta(PYTHON_CORRELATE_TRANSFORMATION, mergedConfig),
                 pythonOperator,
                 pythonOperatorOutputRowType,
                 inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecPythonCorrelate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecPythonCorrelate.java
@@ -127,7 +127,7 @@ public abstract class CommonExecPythonCorrelate extends ExecNodeBase<RowData>
                         pythonUdtfInputOffsets);
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getTransformationMeta(PYTHON_CORRELATE_TRANSFORMATION, mergedConfig),
+                createTransformationMeta(PYTHON_CORRELATE_TRANSFORMATION, mergedConfig),
                 pythonOperator,
                 pythonOperatorOutputRowType,
                 inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecPythonCorrelate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecPythonCorrelate.java
@@ -61,7 +61,7 @@ import static org.apache.flink.util.Preconditions.checkArgument;
 public abstract class CommonExecPythonCorrelate extends ExecNodeBase<RowData>
         implements SingleTransformationTranslator<RowData> {
 
-    private static final String PYTHON_CORRELATE_OPERATOR = "python-correlate";
+    public static final String PYTHON_CORRELATE_OPERATOR = "python-correlate";
 
     public static final String FIELD_NAME_JOIN_TYPE = "joinType";
     public static final String FIELD_NAME_FUNCTION_CALL = "functionCall";

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecPythonCorrelate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecPythonCorrelate.java
@@ -61,6 +61,8 @@ import static org.apache.flink.util.Preconditions.checkArgument;
 public abstract class CommonExecPythonCorrelate extends ExecNodeBase<RowData>
         implements SingleTransformationTranslator<RowData> {
 
+    private static final String PYTHON_CORRELATE_OPERATOR = "python-correlate";
+
     public static final String FIELD_NAME_JOIN_TYPE = "joinType";
     public static final String FIELD_NAME_FUNCTION_CALL = "functionCall";
 
@@ -125,8 +127,7 @@ public abstract class CommonExecPythonCorrelate extends ExecNodeBase<RowData>
                         pythonUdtfInputOffsets);
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getOperatorName(mergedConfig),
-                getOperatorDescription(mergedConfig),
+                getOperatorMeta(PYTHON_CORRELATE_OPERATOR, mergedConfig),
                 pythonOperator,
                 pythonOperatorOutputRowType,
                 inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecSink.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecSink.java
@@ -256,17 +256,17 @@ public abstract class CommonExecSink extends ExecNodeBase<Object>
         ConstraintEnforcer constraintEnforcer = validatorBuilder.build();
         if (constraintEnforcer != null) {
             final String operatorDesc =
-                    getFormattedTransformationDescription(
+                    createFormattedTransformationDescription(
                             constraintEnforcer.getOperatorName(), config.getConfiguration());
             final String operatorName =
-                    getFormattedTransformationName(
+                    createFormattedTransformationName(
                             constraintEnforcer.getOperatorName(),
                             "ConstraintEnforcer",
                             config.getConfiguration());
             return ExecNodeUtil.createOneInputTransformation(
                     inputTransform,
                     new TransformationMetadata(
-                            getTransformationUid(CONSTRAINT_VALIDATOR_TRANSFORMATION),
+                            createTransformationUid(CONSTRAINT_VALIDATOR_TRANSFORMATION),
                             operatorName,
                             operatorDesc),
                     constraintEnforcer,
@@ -389,7 +389,7 @@ public abstract class CommonExecSink extends ExecNodeBase<Object>
                         selector, KeyGroupRangeAssignment.DEFAULT_LOWER_BOUND_MAX_PARALLELISM);
         Transformation<RowData> partitionedTransform =
                 new PartitionTransformation<>(inputTransform, partitioner);
-        partitionedTransform.setUid(getTransformationUid(PARTITIONER_TRANSFORMATION));
+        partitionedTransform.setUid(createTransformationUid(PARTITIONER_TRANSFORMATION));
         partitionedTransform.setParallelism(sinkParallelism);
         return partitionedTransform;
     }
@@ -415,17 +415,17 @@ public abstract class CommonExecSink extends ExecNodeBase<Object>
                         .mapToObj(idx -> fieldNames[idx])
                         .collect(Collectors.toList());
         final String operatorDesc =
-                getFormattedTransformationDescription(
+                createFormattedTransformationDescription(
                         String.format("SinkMaterializer(pk=[%s])", String.join(", ", pkFieldNames)),
                         tableConfig.getConfiguration());
         final String operatorName =
-                getFormattedTransformationName(
+                createFormattedTransformationName(
                         operatorDesc, "SinkMaterializer", tableConfig.getConfiguration());
         OneInputTransformation<RowData, RowData> materializeTransform =
                 ExecNodeUtil.createOneInputTransformation(
                         inputTransform,
                         new TransformationMetadata(
-                                getTransformationUid(UPSERT_MATERIALIZE_TRANSFORMATION),
+                                createTransformationUid(UPSERT_MATERIALIZE_TRANSFORMATION),
                                 operatorName,
                                 operatorDesc),
                         operator,
@@ -446,8 +446,8 @@ public abstract class CommonExecSink extends ExecNodeBase<Object>
             int rowtimeFieldIndex,
             int sinkParallelism,
             Configuration config) {
-        TransformationMetadata sinkMeta = getTransformationMeta(SINK_TRANSFORMATION, config);
-        String sinkDescription = getTransformationDescription(config);
+        TransformationMetadata sinkMeta = createTransformationMeta(SINK_TRANSFORMATION, config);
+        String sinkDescription = createTransformationDescription(config);
         if (runtimeProvider instanceof DataStreamSinkProvider) {
             Transformation<RowData> sinkTransformation =
                     applyRowtimeTransformation(
@@ -551,7 +551,7 @@ public abstract class CommonExecSink extends ExecNodeBase<Object>
             return inputTransform;
         }
         final String description =
-                getFormattedTransformationDescription(
+                createFormattedTransformationDescription(
                         String.format(
                                 "StreamRecordTimestampInserter(rowtime field: %s)",
                                 rowtimeFieldIndex),
@@ -559,8 +559,8 @@ public abstract class CommonExecSink extends ExecNodeBase<Object>
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
                 new TransformationMetadata(
-                        getTransformationUid(TIMESTAMP_INSERTER_TRANSFORMATION),
-                        getFormattedTransformationName(
+                        createTransformationUid(TIMESTAMP_INSERTER_TRANSFORMATION),
+                        createFormattedTransformationName(
                                 description, "StreamRecordTimestampInserter", config),
                         description),
                 new StreamRecordTimestampInserter(rowtimeFieldIndex),

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecSink.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecSink.java
@@ -91,11 +91,11 @@ import java.util.stream.IntStream;
 public abstract class CommonExecSink extends ExecNodeBase<Object>
         implements MultipleTransformationTranslator<Object> {
 
-    private static final String CONSTRAINT_VALIDATOR_OPERATOR = "constraint-validator";
-    private static final String PARTITIONER_OPERATOR = "partitioner";
-    private static final String UPSERT_MATERIALIZE_OPERATOR = "upsert-materialize";
-    private static final String TIMESTAMP_INSERTER_OPERATOR = "timestamp-inserter";
-    private static final String SINK_OPERATOR = "sink";
+    public static final String CONSTRAINT_VALIDATOR_OPERATOR = "constraint-validator";
+    public static final String PARTITIONER_OPERATOR = "partitioner";
+    public static final String UPSERT_MATERIALIZE_OPERATOR = "upsert-materialize";
+    public static final String TIMESTAMP_INSERTER_OPERATOR = "timestamp-inserter";
+    public static final String SINK_OPERATOR = "sink";
 
     public static final String FIELD_NAME_DYNAMIC_TABLE_SINK = "dynamicTableSink";
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecSink.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecSink.java
@@ -447,16 +447,13 @@ public abstract class CommonExecSink extends ExecNodeBase<Object>
             int sinkParallelism,
             Configuration config) {
         TransformationMetadata sinkMeta = createTransformationMeta(SINK_TRANSFORMATION, config);
-        String sinkDescription = createTransformationDescription(config);
         if (runtimeProvider instanceof DataStreamSinkProvider) {
             Transformation<RowData> sinkTransformation =
                     applyRowtimeTransformation(
                             inputTransform, rowtimeFieldIndex, sinkParallelism, config);
             final DataStream<RowData> dataStream = new DataStream<>(env, sinkTransformation);
             final DataStreamSinkProvider provider = (DataStreamSinkProvider) runtimeProvider;
-            return provider.consumeDataStream(dataStream)
-                    .uid(sinkMeta.getUid())
-                    .getTransformation();
+            return provider.consumeDataStream(dataStream).getTransformation();
         } else if (runtimeProvider instanceof TransformationSinkProvider) {
             final TransformationSinkProvider provider =
                     (TransformationSinkProvider) runtimeProvider;
@@ -464,7 +461,6 @@ public abstract class CommonExecSink extends ExecNodeBase<Object>
                     provider.createTransformation(
                             TransformationSinkProvider.Context.of(
                                     inputTransform, rowtimeFieldIndex));
-            transformation.setUid(sinkMeta.getUid());
             return transformation;
         } else if (runtimeProvider instanceof SinkFunctionProvider) {
             final SinkFunction<RowData> sinkFunction =

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecSink.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecSink.java
@@ -91,11 +91,11 @@ import java.util.stream.IntStream;
 public abstract class CommonExecSink extends ExecNodeBase<Object>
         implements MultipleTransformationTranslator<Object> {
 
-    public static final String CONSTRAINT_VALIDATOR_OPERATOR = "constraint-validator";
-    public static final String PARTITIONER_OPERATOR = "partitioner";
-    public static final String UPSERT_MATERIALIZE_OPERATOR = "upsert-materialize";
-    public static final String TIMESTAMP_INSERTER_OPERATOR = "timestamp-inserter";
-    public static final String SINK_OPERATOR = "sink";
+    public static final String CONSTRAINT_VALIDATOR_TRANSFORMATION = "constraint-validator";
+    public static final String PARTITIONER_TRANSFORMATION = "partitioner";
+    public static final String UPSERT_MATERIALIZE_TRANSFORMATION = "upsert-materialize";
+    public static final String TIMESTAMP_INSERTER_TRANSFORMATION = "timestamp-inserter";
+    public static final String SINK_TRANSFORMATION = "sink";
 
     public static final String FIELD_NAME_DYNAMIC_TABLE_SINK = "dynamicTableSink";
 
@@ -256,17 +256,17 @@ public abstract class CommonExecSink extends ExecNodeBase<Object>
         ConstraintEnforcer constraintEnforcer = validatorBuilder.build();
         if (constraintEnforcer != null) {
             final String operatorDesc =
-                    getFormattedOperatorDescription(
+                    getFormattedTransformationDescription(
                             constraintEnforcer.getOperatorName(), config.getConfiguration());
             final String operatorName =
-                    getFormattedOperatorName(
+                    getFormattedTransformationName(
                             constraintEnforcer.getOperatorName(),
                             "ConstraintEnforcer",
                             config.getConfiguration());
             return ExecNodeUtil.createOneInputTransformation(
                     inputTransform,
                     new TransformationMetadata(
-                            getOperatorUid(CONSTRAINT_VALIDATOR_OPERATOR),
+                            getTransformationUid(CONSTRAINT_VALIDATOR_TRANSFORMATION),
                             operatorName,
                             operatorDesc),
                     constraintEnforcer,
@@ -389,7 +389,7 @@ public abstract class CommonExecSink extends ExecNodeBase<Object>
                         selector, KeyGroupRangeAssignment.DEFAULT_LOWER_BOUND_MAX_PARALLELISM);
         Transformation<RowData> partitionedTransform =
                 new PartitionTransformation<>(inputTransform, partitioner);
-        partitionedTransform.setUid(getOperatorUid(PARTITIONER_OPERATOR));
+        partitionedTransform.setUid(getTransformationUid(PARTITIONER_TRANSFORMATION));
         partitionedTransform.setParallelism(sinkParallelism);
         return partitionedTransform;
     }
@@ -415,17 +415,17 @@ public abstract class CommonExecSink extends ExecNodeBase<Object>
                         .mapToObj(idx -> fieldNames[idx])
                         .collect(Collectors.toList());
         final String operatorDesc =
-                getFormattedOperatorDescription(
+                getFormattedTransformationDescription(
                         String.format("SinkMaterializer(pk=[%s])", String.join(", ", pkFieldNames)),
                         tableConfig.getConfiguration());
         final String operatorName =
-                getFormattedOperatorName(
+                getFormattedTransformationName(
                         operatorDesc, "SinkMaterializer", tableConfig.getConfiguration());
         OneInputTransformation<RowData, RowData> materializeTransform =
                 ExecNodeUtil.createOneInputTransformation(
                         inputTransform,
                         new TransformationMetadata(
-                                getOperatorUid(UPSERT_MATERIALIZE_OPERATOR),
+                                getTransformationUid(UPSERT_MATERIALIZE_TRANSFORMATION),
                                 operatorName,
                                 operatorDesc),
                         operator,
@@ -446,8 +446,8 @@ public abstract class CommonExecSink extends ExecNodeBase<Object>
             int rowtimeFieldIndex,
             int sinkParallelism,
             Configuration config) {
-        TransformationMetadata sinkMeta = getOperatorMeta(SINK_OPERATOR, config);
-        String sinkDescription = getOperatorDescription(config);
+        TransformationMetadata sinkMeta = getTransformationMeta(SINK_TRANSFORMATION, config);
+        String sinkDescription = getTransformationDescription(config);
         if (runtimeProvider instanceof DataStreamSinkProvider) {
             Transformation<RowData> sinkTransformation =
                     applyRowtimeTransformation(
@@ -551,7 +551,7 @@ public abstract class CommonExecSink extends ExecNodeBase<Object>
             return inputTransform;
         }
         final String description =
-                getFormattedOperatorDescription(
+                getFormattedTransformationDescription(
                         String.format(
                                 "StreamRecordTimestampInserter(rowtime field: %s)",
                                 rowtimeFieldIndex),
@@ -559,8 +559,8 @@ public abstract class CommonExecSink extends ExecNodeBase<Object>
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
                 new TransformationMetadata(
-                        getOperatorUid(TIMESTAMP_INSERTER_OPERATOR),
-                        getFormattedOperatorName(
+                        getTransformationUid(TIMESTAMP_INSERTER_TRANSFORMATION),
+                        getFormattedTransformationName(
                                 description, "StreamRecordTimestampInserter", config),
                         description),
                 new StreamRecordTimestampInserter(rowtimeFieldIndex),

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecSink.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecSink.java
@@ -514,8 +514,7 @@ public abstract class CommonExecSink extends ExecNodeBase<Object>
                                     dataStream, ((SinkV2Provider) runtimeProvider).createSink())
                             .getTransformation();
             transformation.setParallelism(sinkParallelism);
-            transformation.setName(sinkName);
-            transformation.setDescription(sinkDescription);
+            sinkMeta.fill(transformation);
             return transformation;
         } else {
             throw new TableException("Unsupported sink runtime provider.");

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecTableSourceScan.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecTableSourceScan.java
@@ -58,7 +58,7 @@ import java.util.Collections;
 public abstract class CommonExecTableSourceScan extends ExecNodeBase<RowData>
         implements MultipleTransformationTranslator<RowData> {
 
-    public static final String SOURCE_OPERATOR = "source";
+    public static final String SOURCE_TRANSFORMATION = "source";
 
     public static final String FIELD_NAME_SCAN_TABLE_SOURCE = "scanTableSource";
 
@@ -88,7 +88,7 @@ public abstract class CommonExecTableSourceScan extends ExecNodeBase<RowData>
     protected Transformation<RowData> translateToPlanInternal(PlannerBase planner) {
         final StreamExecutionEnvironment env = planner.getExecEnv();
         final TransformationMetadata meta =
-                getOperatorMeta(SOURCE_OPERATOR, planner.getTableConfig());
+                getTransformationMeta(SOURCE_TRANSFORMATION, planner.getTableConfig());
         final InternalTypeInfo<RowData> outputTypeInfo =
                 InternalTypeInfo.of((RowType) getOutputType());
         final ScanTableSource tableSource =

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecTableSourceScan.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecTableSourceScan.java
@@ -42,6 +42,7 @@ import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeContext;
 import org.apache.flink.table.planner.plan.nodes.exec.MultipleTransformationTranslator;
 import org.apache.flink.table.planner.plan.nodes.exec.spec.DynamicTableSourceSpec;
+import org.apache.flink.table.planner.plan.nodes.exec.utils.TransformationMetadata;
 import org.apache.flink.table.runtime.connector.source.ScanRuntimeProviderContext;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.types.logical.LogicalType;
@@ -56,6 +57,8 @@ import java.util.Collections;
  */
 public abstract class CommonExecTableSourceScan extends ExecNodeBase<RowData>
         implements MultipleTransformationTranslator<RowData> {
+    private static final String SOURCE_OPERATOR = "source";
+
     public static final String FIELD_NAME_SCAN_TABLE_SOURCE = "scanTableSource";
 
     @JsonProperty(FIELD_NAME_SCAN_TABLE_SOURCE)
@@ -83,7 +86,8 @@ public abstract class CommonExecTableSourceScan extends ExecNodeBase<RowData>
     @Override
     protected Transformation<RowData> translateToPlanInternal(PlannerBase planner) {
         final StreamExecutionEnvironment env = planner.getExecEnv();
-        final String operatorName = getOperatorName(planner.getTableConfig());
+        final TransformationMetadata meta =
+                getOperatorMeta(SOURCE_OPERATOR, planner.getTableConfig());
         final InternalTypeInfo<RowData> outputTypeInfo =
                 InternalTypeInfo.of((RowType) getOutputType());
         final ScanTableSource tableSource =
@@ -98,17 +102,16 @@ public abstract class CommonExecTableSourceScan extends ExecNodeBase<RowData>
                             env,
                             function,
                             sourceFunctionProvider.isBounded(),
-                            operatorName,
+                            meta.getName(),
                             outputTypeInfo);
-            transformation.setDescription(getOperatorDescription(planner.getTableConfig()));
-            return transformation;
+            return meta.fill(transformation);
         } else if (provider instanceof InputFormatProvider) {
             final InputFormat<RowData, ?> inputFormat =
                     ((InputFormatProvider) provider).createInputFormat();
             final Transformation<RowData> transformation =
-                    createInputFormatTransformation(env, inputFormat, outputTypeInfo, operatorName);
-            transformation.setDescription(getOperatorDescription(planner.getTableConfig()));
-            return transformation;
+                    createInputFormatTransformation(
+                            env, inputFormat, outputTypeInfo, meta.getName());
+            return meta.fill(transformation);
         } else if (provider instanceof SourceProvider) {
             final Source<RowData, ?, ?> source = ((SourceProvider) provider).createSource();
             // TODO: Push down watermark strategy to source scan
@@ -116,19 +119,20 @@ public abstract class CommonExecTableSourceScan extends ExecNodeBase<RowData>
                     env.fromSource(
                                     source,
                                     WatermarkStrategy.noWatermarks(),
-                                    operatorName,
+                                    meta.getName(),
                                     outputTypeInfo)
                             .getTransformation();
-            transformation.setDescription(getOperatorDescription(planner.getTableConfig()));
-            return transformation;
+            return meta.fill(transformation);
         } else if (provider instanceof DataStreamScanProvider) {
             Transformation<RowData> transformation =
                     ((DataStreamScanProvider) provider).produceDataStream(env).getTransformation();
+            meta.fill(transformation);
             transformation.setOutputType(outputTypeInfo);
             return transformation;
         } else if (provider instanceof TransformationScanProvider) {
             final Transformation<RowData> transformation =
                     ((TransformationScanProvider) provider).createTransformation();
+            meta.fill(transformation);
             transformation.setOutputType(outputTypeInfo);
             return transformation;
         } else {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecTableSourceScan.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecTableSourceScan.java
@@ -57,7 +57,8 @@ import java.util.Collections;
  */
 public abstract class CommonExecTableSourceScan extends ExecNodeBase<RowData>
         implements MultipleTransformationTranslator<RowData> {
-    private static final String SOURCE_OPERATOR = "source";
+
+    public static final String SOURCE_OPERATOR = "source";
 
     public static final String FIELD_NAME_SCAN_TABLE_SOURCE = "scanTableSource";
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecTableSourceScan.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecTableSourceScan.java
@@ -88,7 +88,7 @@ public abstract class CommonExecTableSourceScan extends ExecNodeBase<RowData>
     protected Transformation<RowData> translateToPlanInternal(PlannerBase planner) {
         final StreamExecutionEnvironment env = planner.getExecEnv();
         final TransformationMetadata meta =
-                getTransformationMeta(SOURCE_TRANSFORMATION, planner.getTableConfig());
+                createTransformationMeta(SOURCE_TRANSFORMATION, planner.getTableConfig());
         final InternalTypeInfo<RowData> outputTypeInfo =
                 InternalTypeInfo.of((RowType) getOutputType());
         final ScanTableSource tableSource =

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecUnion.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecUnion.java
@@ -58,7 +58,7 @@ public abstract class CommonExecUnion extends ExecNodeBase<RowData>
         for (ExecEdge inputEdge : getInputEdges()) {
             inputTransforms.add((Transformation<RowData>) inputEdge.translateToPlan(planner));
         }
-        return getTransformationMeta(UNION_TRANSFORMATION, planner.getTableConfig())
+        return createTransformationMeta(UNION_TRANSFORMATION, planner.getTableConfig())
                 .fill(new UnionTransformation(inputTransforms));
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecUnion.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecUnion.java
@@ -40,7 +40,7 @@ import java.util.List;
 public abstract class CommonExecUnion extends ExecNodeBase<RowData>
         implements SingleTransformationTranslator<RowData> {
 
-    private static final String UNION_OPERATOR = "union";
+    public static final String UNION_OPERATOR = "union";
 
     public CommonExecUnion(
             int id,

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecUnion.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecUnion.java
@@ -40,8 +40,6 @@ import java.util.List;
 public abstract class CommonExecUnion extends ExecNodeBase<RowData>
         implements SingleTransformationTranslator<RowData> {
 
-    public static final String UNION_TRANSFORMATION = "union";
-
     public CommonExecUnion(
             int id,
             ExecNodeContext context,
@@ -58,7 +56,6 @@ public abstract class CommonExecUnion extends ExecNodeBase<RowData>
         for (ExecEdge inputEdge : getInputEdges()) {
             inputTransforms.add((Transformation<RowData>) inputEdge.translateToPlan(planner));
         }
-        return createTransformationMeta(UNION_TRANSFORMATION, planner.getTableConfig())
-                .fill(new UnionTransformation(inputTransforms));
+        return new UnionTransformation(inputTransforms);
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecUnion.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecUnion.java
@@ -40,7 +40,7 @@ import java.util.List;
 public abstract class CommonExecUnion extends ExecNodeBase<RowData>
         implements SingleTransformationTranslator<RowData> {
 
-    public static final String UNION_OPERATOR = "union";
+    public static final String UNION_TRANSFORMATION = "union";
 
     public CommonExecUnion(
             int id,
@@ -58,7 +58,7 @@ public abstract class CommonExecUnion extends ExecNodeBase<RowData>
         for (ExecEdge inputEdge : getInputEdges()) {
             inputTransforms.add((Transformation<RowData>) inputEdge.translateToPlan(planner));
         }
-        return getOperatorMeta(UNION_OPERATOR, planner.getTableConfig())
+        return getTransformationMeta(UNION_TRANSFORMATION, planner.getTableConfig())
                 .fill(new UnionTransformation(inputTransforms));
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecUnion.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecUnion.java
@@ -40,6 +40,8 @@ import java.util.List;
 public abstract class CommonExecUnion extends ExecNodeBase<RowData>
         implements SingleTransformationTranslator<RowData> {
 
+    private static final String UNION_OPERATOR = "union";
+
     public CommonExecUnion(
             int id,
             ExecNodeContext context,
@@ -56,6 +58,7 @@ public abstract class CommonExecUnion extends ExecNodeBase<RowData>
         for (ExecEdge inputEdge : getInputEdges()) {
             inputTransforms.add((Transformation<RowData>) inputEdge.translateToPlan(planner));
         }
-        return new UnionTransformation(inputTransforms);
+        return getOperatorMeta(UNION_OPERATOR, planner.getTableConfig())
+                .fill(new UnionTransformation(inputTransforms));
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecValues.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecValues.java
@@ -42,6 +42,8 @@ import java.util.List;
 public abstract class CommonExecValues extends ExecNodeBase<RowData>
         implements SingleTransformationTranslator<RowData> {
 
+    private static final String VALUES_OPERATOR = "values";
+
     public static final String FIELD_NAME_TUPLES = "tuples";
 
     private final List<List<RexLiteral>> tuples;
@@ -68,8 +70,7 @@ public abstract class CommonExecValues extends ExecNodeBase<RowData>
                 planner.getExecEnv()
                         .createInput(inputFormat, inputFormat.getProducedType())
                         .getTransformation();
-        transformation.setName(getOperatorName(planner.getTableConfig()));
-        transformation.setDescription(getOperatorDescription(planner.getTableConfig()));
+        getOperatorMeta(VALUES_OPERATOR, planner.getTableConfig()).fill(transformation);
         transformation.setParallelism(1);
         transformation.setMaxParallelism(1);
         return transformation;

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecValues.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecValues.java
@@ -42,7 +42,7 @@ import java.util.List;
 public abstract class CommonExecValues extends ExecNodeBase<RowData>
         implements SingleTransformationTranslator<RowData> {
 
-    public static final String VALUES_OPERATOR = "values";
+    public static final String VALUES_TRANSFORMATION = "values";
 
     public static final String FIELD_NAME_TUPLES = "tuples";
 
@@ -70,7 +70,7 @@ public abstract class CommonExecValues extends ExecNodeBase<RowData>
                 planner.getExecEnv()
                         .createInput(inputFormat, inputFormat.getProducedType())
                         .getTransformation();
-        getOperatorMeta(VALUES_OPERATOR, planner.getTableConfig()).fill(transformation);
+        getTransformationMeta(VALUES_TRANSFORMATION, planner.getTableConfig()).fill(transformation);
         transformation.setParallelism(1);
         transformation.setMaxParallelism(1);
         return transformation;

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecValues.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecValues.java
@@ -70,7 +70,8 @@ public abstract class CommonExecValues extends ExecNodeBase<RowData>
                 planner.getExecEnv()
                         .createInput(inputFormat, inputFormat.getProducedType())
                         .getTransformation();
-        getTransformationMeta(VALUES_TRANSFORMATION, planner.getTableConfig()).fill(transformation);
+        createTransformationMeta(VALUES_TRANSFORMATION, planner.getTableConfig())
+                .fill(transformation);
         transformation.setParallelism(1);
         transformation.setMaxParallelism(1);
         return transformation;

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecValues.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecValues.java
@@ -42,7 +42,7 @@ import java.util.List;
 public abstract class CommonExecValues extends ExecNodeBase<RowData>
         implements SingleTransformationTranslator<RowData> {
 
-    private static final String VALUES_OPERATOR = "values";
+    public static final String VALUES_OPERATOR = "values";
 
     public static final String FIELD_NAME_TUPLES = "tuples";
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecWindowTableFunction.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecWindowTableFunction.java
@@ -50,6 +50,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public abstract class CommonExecWindowTableFunction extends ExecNodeBase<RowData>
         implements BatchExecNode<RowData>, SingleTransformationTranslator<RowData> {
 
+    private static final String WINDOW_TVF_OPERATOR = "window-tvf";
+
     public static final String FIELD_NAME_WINDOWING = "windowing";
 
     @JsonProperty(FIELD_NAME_WINDOWING)
@@ -82,8 +84,7 @@ public abstract class CommonExecWindowTableFunction extends ExecNodeBase<RowData
                         windowAssigner, windowingStrategy.getTimeAttributeIndex(), shiftTimeZone);
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getOperatorName(planner.getTableConfig()),
-                getOperatorDescription(planner.getTableConfig()),
+                getOperatorMeta(WINDOW_TVF_OPERATOR, planner.getTableConfig()),
                 windowTableFunctionOperator,
                 InternalTypeInfo.of(getOutputType()),
                 inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecWindowTableFunction.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecWindowTableFunction.java
@@ -50,7 +50,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public abstract class CommonExecWindowTableFunction extends ExecNodeBase<RowData>
         implements BatchExecNode<RowData>, SingleTransformationTranslator<RowData> {
 
-    public static final String WINDOW_TVF_OPERATOR = "window-tvf";
+    public static final String WINDOW_TVF_TRANSFORMATION = "window-tvf";
 
     public static final String FIELD_NAME_WINDOWING = "windowing";
 
@@ -84,7 +84,7 @@ public abstract class CommonExecWindowTableFunction extends ExecNodeBase<RowData
                         windowAssigner, windowingStrategy.getTimeAttributeIndex(), shiftTimeZone);
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getOperatorMeta(WINDOW_TVF_OPERATOR, planner.getTableConfig()),
+                getTransformationMeta(WINDOW_TVF_TRANSFORMATION, planner.getTableConfig()),
                 windowTableFunctionOperator,
                 InternalTypeInfo.of(getOutputType()),
                 inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecWindowTableFunction.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecWindowTableFunction.java
@@ -50,7 +50,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public abstract class CommonExecWindowTableFunction extends ExecNodeBase<RowData>
         implements BatchExecNode<RowData>, SingleTransformationTranslator<RowData> {
 
-    private static final String WINDOW_TVF_OPERATOR = "window-tvf";
+    public static final String WINDOW_TVF_OPERATOR = "window-tvf";
 
     public static final String FIELD_NAME_WINDOWING = "windowing";
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecWindowTableFunction.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecWindowTableFunction.java
@@ -50,7 +50,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public abstract class CommonExecWindowTableFunction extends ExecNodeBase<RowData>
         implements BatchExecNode<RowData>, SingleTransformationTranslator<RowData> {
 
-    public static final String WINDOW_TVF_TRANSFORMATION = "window-tvf";
+    public static final String WINDOW_TRANSFORMATION = "window";
 
     public static final String FIELD_NAME_WINDOWING = "windowing";
 
@@ -84,7 +84,7 @@ public abstract class CommonExecWindowTableFunction extends ExecNodeBase<RowData
                         windowAssigner, windowingStrategy.getTimeAttributeIndex(), shiftTimeZone);
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                createTransformationMeta(WINDOW_TVF_TRANSFORMATION, planner.getTableConfig()),
+                createTransformationMeta(WINDOW_TRANSFORMATION, planner.getTableConfig()),
                 windowTableFunctionOperator,
                 InternalTypeInfo.of(getOutputType()),
                 inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecWindowTableFunction.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecWindowTableFunction.java
@@ -84,7 +84,7 @@ public abstract class CommonExecWindowTableFunction extends ExecNodeBase<RowData
                         windowAssigner, windowingStrategy.getTimeAttributeIndex(), shiftTimeZone);
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getTransformationMeta(WINDOW_TVF_TRANSFORMATION, planner.getTableConfig()),
+                createTransformationMeta(WINDOW_TVF_TRANSFORMATION, planner.getTableConfig()),
                 windowTableFunctionOperator,
                 InternalTypeInfo.of(getOutputType()),
                 inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecCalc.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecCalc.java
@@ -42,7 +42,7 @@ import java.util.List;
 @ExecNodeMetadata(
         name = "stream-exec-calc",
         version = 1,
-        producedTransformations = CommonExecCalc.SUBSTITUTE_STREAM_TRANSFORMATION,
+        producedTransformations = CommonExecCalc.SUBSTITUTE_TRANSFORMATION,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecCalc extends CommonExecCalc implements StreamExecNode<RowData> {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecCalc.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecCalc.java
@@ -42,7 +42,7 @@ import java.util.List;
 @ExecNodeMetadata(
         name = "stream-exec-calc",
         version = 1,
-        producedTransformations = CommonExecCalc.SUBSTITUTE_TRANSFORMATION,
+        producedTransformations = CommonExecCalc.CALC_TRANSFORMATION,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecCalc extends CommonExecCalc implements StreamExecNode<RowData> {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecCalc.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecCalc.java
@@ -42,7 +42,7 @@ import java.util.List;
 @ExecNodeMetadata(
         name = "stream-exec-calc",
         version = 1,
-        producedOperators = CommonExecCalc.SUBSTITUTE_STREAM_OPERATOR,
+        producedTransformations = CommonExecCalc.SUBSTITUTE_STREAM_TRANSFORMATION,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecCalc extends CommonExecCalc implements StreamExecNode<RowData> {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecCalc.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecCalc.java
@@ -42,6 +42,7 @@ import java.util.List;
 @ExecNodeMetadata(
         name = "stream-exec-calc",
         version = 1,
+        producedOperators = CommonExecCalc.SUBSTITUTE_STREAM_OPERATOR,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecCalc extends CommonExecCalc implements StreamExecNode<RowData> {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecChangelogNormalize.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecChangelogNormalize.java
@@ -68,6 +68,8 @@ import java.util.List;
 public class StreamExecChangelogNormalize extends ExecNodeBase<RowData>
         implements StreamExecNode<RowData>, SingleTransformationTranslator<RowData> {
 
+    private static final String CHANGELOG_NORMALIZE_OPERATOR = "changelog-normalize";
+
     public static final String FIELD_NAME_UNIQUE_KEYS = "uniqueKeys";
     public static final String FIELD_NAME_GENERATE_UPDATE_BEFORE = "generateUpdateBefore";
 
@@ -157,8 +159,7 @@ public class StreamExecChangelogNormalize extends ExecNodeBase<RowData>
         final OneInputTransformation<RowData, RowData> transform =
                 ExecNodeUtil.createOneInputTransformation(
                         inputTransform,
-                        getOperatorName(tableConfig),
-                        getOperatorDescription(tableConfig),
+                        getOperatorMeta(CHANGELOG_NORMALIZE_OPERATOR, tableConfig),
                         operator,
                         rowTypeInfo,
                         inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecChangelogNormalize.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecChangelogNormalize.java
@@ -160,7 +160,7 @@ public class StreamExecChangelogNormalize extends ExecNodeBase<RowData>
         final OneInputTransformation<RowData, RowData> transform =
                 ExecNodeUtil.createOneInputTransformation(
                         inputTransform,
-                        getTransformationMeta(CHANGELOG_NORMALIZE_TRANSFORMATION, tableConfig),
+                        createTransformationMeta(CHANGELOG_NORMALIZE_TRANSFORMATION, tableConfig),
                         operator,
                         rowTypeInfo,
                         inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecChangelogNormalize.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecChangelogNormalize.java
@@ -63,12 +63,13 @@ import java.util.List;
 @ExecNodeMetadata(
         name = "stream-exec-changelog-normalize",
         version = 1,
+        producedOperators = StreamExecChangelogNormalize.CHANGELOG_NORMALIZE_OPERATOR,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecChangelogNormalize extends ExecNodeBase<RowData>
         implements StreamExecNode<RowData>, SingleTransformationTranslator<RowData> {
 
-    private static final String CHANGELOG_NORMALIZE_OPERATOR = "changelog-normalize";
+    public static final String CHANGELOG_NORMALIZE_OPERATOR = "changelog-normalize";
 
     public static final String FIELD_NAME_UNIQUE_KEYS = "uniqueKeys";
     public static final String FIELD_NAME_GENERATE_UPDATE_BEFORE = "generateUpdateBefore";

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecChangelogNormalize.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecChangelogNormalize.java
@@ -63,13 +63,13 @@ import java.util.List;
 @ExecNodeMetadata(
         name = "stream-exec-changelog-normalize",
         version = 1,
-        producedOperators = StreamExecChangelogNormalize.CHANGELOG_NORMALIZE_OPERATOR,
+        producedTransformations = StreamExecChangelogNormalize.CHANGELOG_NORMALIZE_TRANSFORMATION,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecChangelogNormalize extends ExecNodeBase<RowData>
         implements StreamExecNode<RowData>, SingleTransformationTranslator<RowData> {
 
-    public static final String CHANGELOG_NORMALIZE_OPERATOR = "changelog-normalize";
+    public static final String CHANGELOG_NORMALIZE_TRANSFORMATION = "changelog-normalize";
 
     public static final String FIELD_NAME_UNIQUE_KEYS = "uniqueKeys";
     public static final String FIELD_NAME_GENERATE_UPDATE_BEFORE = "generateUpdateBefore";
@@ -160,7 +160,7 @@ public class StreamExecChangelogNormalize extends ExecNodeBase<RowData>
         final OneInputTransformation<RowData, RowData> transform =
                 ExecNodeUtil.createOneInputTransformation(
                         inputTransform,
-                        getOperatorMeta(CHANGELOG_NORMALIZE_OPERATOR, tableConfig),
+                        getTransformationMeta(CHANGELOG_NORMALIZE_TRANSFORMATION, tableConfig),
                         operator,
                         rowTypeInfo,
                         inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecCorrelate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecCorrelate.java
@@ -46,6 +46,7 @@ import java.util.List;
 @ExecNodeMetadata(
         name = "stream-exec-correlate",
         version = 1,
+        producedOperators = CommonExecCorrelate.CORRELATE_OPERATOR,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecCorrelate extends CommonExecCorrelate implements StreamExecNode<RowData> {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecCorrelate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecCorrelate.java
@@ -46,7 +46,7 @@ import java.util.List;
 @ExecNodeMetadata(
         name = "stream-exec-correlate",
         version = 1,
-        producedOperators = CommonExecCorrelate.CORRELATE_OPERATOR,
+        producedTransformations = CommonExecCorrelate.CORRELATE_TRANSFORMATION,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecCorrelate extends CommonExecCorrelate implements StreamExecNode<RowData> {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecDataStreamScan.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecDataStreamScan.java
@@ -56,8 +56,6 @@ import static org.apache.flink.table.typeutils.TimeIndicatorTypeInfo.ROWTIME_STR
 public class StreamExecDataStreamScan extends ExecNodeBase<RowData>
         implements StreamExecNode<RowData>, MultipleTransformationTranslator<RowData> {
 
-    private static final String DATA_STREAM_SOURCE_TRANSFORMATION = "data-stream-source";
-
     private final DataStream<?> dataStream;
     private final DataType sourceType;
     private final int[] fieldIndexes;
@@ -128,7 +126,6 @@ public class StreamExecDataStreamScan extends ExecNodeBase<RowData>
         } else {
             transformation = (Transformation<RowData>) sourceTransform;
         }
-        transformation.setUid(createTransformationUid(DATA_STREAM_SOURCE_TRANSFORMATION));
         return transformation;
     }
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecDataStreamScan.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecDataStreamScan.java
@@ -55,6 +55,9 @@ import static org.apache.flink.table.typeutils.TimeIndicatorTypeInfo.ROWTIME_STR
 /** Stream {@link ExecNode} to connect a given {@link DataStream} and consume data from it. */
 public class StreamExecDataStreamScan extends ExecNodeBase<RowData>
         implements StreamExecNode<RowData>, MultipleTransformationTranslator<RowData> {
+
+    private static final String DATA_STREAM_SOURCE_OPERATOR = "data-stream-source";
+
     private final DataStream<?> dataStream;
     private final DataType sourceType;
     private final int[] fieldIndexes;
@@ -123,6 +126,7 @@ public class StreamExecDataStreamScan extends ExecNodeBase<RowData>
         } else {
             transformation = (Transformation<RowData>) sourceTransform;
         }
+        transformation.setUid(getOperatorUid(DATA_STREAM_SOURCE_OPERATOR));
         return transformation;
     }
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecDataStreamScan.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecDataStreamScan.java
@@ -56,7 +56,7 @@ import static org.apache.flink.table.typeutils.TimeIndicatorTypeInfo.ROWTIME_STR
 public class StreamExecDataStreamScan extends ExecNodeBase<RowData>
         implements StreamExecNode<RowData>, MultipleTransformationTranslator<RowData> {
 
-    private static final String DATA_STREAM_SOURCE_OPERATOR = "data-stream-source";
+    private static final String DATA_STREAM_SOURCE_TRANSFORMATION = "data-stream-source";
 
     private final DataStream<?> dataStream;
     private final DataType sourceType;
@@ -118,15 +118,17 @@ public class StreamExecDataStreamScan extends ExecNodeBase<RowData>
                             (RowType) getOutputType(),
                             qualifiedName,
                             (detailName, simplifyName) ->
-                                    getFormattedOperatorName(detailName, simplifyName, config),
-                            (description) -> getFormattedOperatorDescription(description, config),
+                                    getFormattedTransformationName(
+                                            detailName, simplifyName, config),
+                            (description) ->
+                                    getFormattedTransformationDescription(description, config),
                             JavaScalaConversionUtil.toScala(rowtimeExpr),
                             extractElement,
                             resetElement);
         } else {
             transformation = (Transformation<RowData>) sourceTransform;
         }
-        transformation.setUid(getOperatorUid(DATA_STREAM_SOURCE_OPERATOR));
+        transformation.setUid(getTransformationUid(DATA_STREAM_SOURCE_TRANSFORMATION));
         return transformation;
     }
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecDataStreamScan.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecDataStreamScan.java
@@ -118,17 +118,17 @@ public class StreamExecDataStreamScan extends ExecNodeBase<RowData>
                             (RowType) getOutputType(),
                             qualifiedName,
                             (detailName, simplifyName) ->
-                                    getFormattedTransformationName(
+                                    createFormattedTransformationName(
                                             detailName, simplifyName, config),
                             (description) ->
-                                    getFormattedTransformationDescription(description, config),
+                                    createFormattedTransformationDescription(description, config),
                             JavaScalaConversionUtil.toScala(rowtimeExpr),
                             extractElement,
                             resetElement);
         } else {
             transformation = (Transformation<RowData>) sourceTransform;
         }
-        transformation.setUid(getTransformationUid(DATA_STREAM_SOURCE_TRANSFORMATION));
+        transformation.setUid(createTransformationUid(DATA_STREAM_SOURCE_TRANSFORMATION));
         return transformation;
     }
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecDeduplicate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecDeduplicate.java
@@ -79,6 +79,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public class StreamExecDeduplicate extends ExecNodeBase<RowData>
         implements StreamExecNode<RowData>, SingleTransformationTranslator<RowData> {
 
+    private static final String DEDUPLICATE_OPERATOR = "deduplicate";
+
     public static final String FIELD_NAME_UNIQUE_KEYS = "uniqueKeys";
     public static final String FIELD_NAME_IS_ROWTIME = "isRowtime";
     public static final String FIELD_NAME_KEEP_LAST_ROW = "keepLastRow";
@@ -199,8 +201,7 @@ public class StreamExecDeduplicate extends ExecNodeBase<RowData>
         final OneInputTransformation<RowData, RowData> transform =
                 ExecNodeUtil.createOneInputTransformation(
                         inputTransform,
-                        getOperatorName(planner.getTableConfig()),
-                        getOperatorDescription(planner.getTableConfig()),
+                        getOperatorMeta(DEDUPLICATE_OPERATOR, planner.getTableConfig()),
                         operator,
                         rowTypeInfo,
                         inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecDeduplicate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecDeduplicate.java
@@ -74,13 +74,13 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @ExecNodeMetadata(
         name = "stream-exec-deduplicate",
         version = 1,
-        producedOperators = StreamExecDeduplicate.DEDUPLICATE_OPERATOR,
+        producedTransformations = StreamExecDeduplicate.DEDUPLICATE_TRANSFORMATION,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecDeduplicate extends ExecNodeBase<RowData>
         implements StreamExecNode<RowData>, SingleTransformationTranslator<RowData> {
 
-    public static final String DEDUPLICATE_OPERATOR = "deduplicate";
+    public static final String DEDUPLICATE_TRANSFORMATION = "deduplicate";
 
     public static final String FIELD_NAME_UNIQUE_KEYS = "uniqueKeys";
     public static final String FIELD_NAME_IS_ROWTIME = "isRowtime";
@@ -202,7 +202,7 @@ public class StreamExecDeduplicate extends ExecNodeBase<RowData>
         final OneInputTransformation<RowData, RowData> transform =
                 ExecNodeUtil.createOneInputTransformation(
                         inputTransform,
-                        getOperatorMeta(DEDUPLICATE_OPERATOR, planner.getTableConfig()),
+                        getTransformationMeta(DEDUPLICATE_TRANSFORMATION, planner.getTableConfig()),
                         operator,
                         rowTypeInfo,
                         inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecDeduplicate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecDeduplicate.java
@@ -202,7 +202,8 @@ public class StreamExecDeduplicate extends ExecNodeBase<RowData>
         final OneInputTransformation<RowData, RowData> transform =
                 ExecNodeUtil.createOneInputTransformation(
                         inputTransform,
-                        getTransformationMeta(DEDUPLICATE_TRANSFORMATION, planner.getTableConfig()),
+                        createTransformationMeta(
+                                DEDUPLICATE_TRANSFORMATION, planner.getTableConfig()),
                         operator,
                         rowTypeInfo,
                         inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecDeduplicate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecDeduplicate.java
@@ -74,12 +74,13 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @ExecNodeMetadata(
         name = "stream-exec-deduplicate",
         version = 1,
+        producedOperators = StreamExecDeduplicate.DEDUPLICATE_OPERATOR,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecDeduplicate extends ExecNodeBase<RowData>
         implements StreamExecNode<RowData>, SingleTransformationTranslator<RowData> {
 
-    private static final String DEDUPLICATE_OPERATOR = "deduplicate";
+    public static final String DEDUPLICATE_OPERATOR = "deduplicate";
 
     public static final String FIELD_NAME_UNIQUE_KEYS = "uniqueKeys";
     public static final String FIELD_NAME_IS_ROWTIME = "isRowtime";

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecDropUpdateBefore.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecDropUpdateBefore.java
@@ -47,12 +47,13 @@ import java.util.List;
 @ExecNodeMetadata(
         name = "stream-exec-drop-update-before",
         version = 1,
+        producedOperators = StreamExecDropUpdateBefore.DROP_UPDATE_BEFORE_OPERATOR,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecDropUpdateBefore extends ExecNodeBase<RowData>
         implements StreamExecNode<RowData>, SingleTransformationTranslator<RowData> {
 
-    private static final String DROP_UPDATE_BEFORE_OPERATOR = "drop-update-before";
+    public static final String DROP_UPDATE_BEFORE_OPERATOR = "drop-update-before";
 
     public StreamExecDropUpdateBefore(
             InputProperty inputProperty, RowType outputType, String description) {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecDropUpdateBefore.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecDropUpdateBefore.java
@@ -84,7 +84,8 @@ public class StreamExecDropUpdateBefore extends ExecNodeBase<RowData>
 
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getTransformationMeta(DROP_UPDATE_BEFORE_TRANSFORMATION, planner.getTableConfig()),
+                createTransformationMeta(
+                        DROP_UPDATE_BEFORE_TRANSFORMATION, planner.getTableConfig()),
                 operator,
                 inputTransform.getOutputType(),
                 inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecDropUpdateBefore.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecDropUpdateBefore.java
@@ -52,6 +52,8 @@ import java.util.List;
 public class StreamExecDropUpdateBefore extends ExecNodeBase<RowData>
         implements StreamExecNode<RowData>, SingleTransformationTranslator<RowData> {
 
+    private static final String DROP_UPDATE_BEFORE_OPERATOR = "drop-update-before";
+
     public StreamExecDropUpdateBefore(
             InputProperty inputProperty, RowType outputType, String description) {
         this(
@@ -81,8 +83,7 @@ public class StreamExecDropUpdateBefore extends ExecNodeBase<RowData>
 
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getOperatorName(planner.getTableConfig()),
-                getOperatorDescription(planner.getTableConfig()),
+                getOperatorMeta(DROP_UPDATE_BEFORE_OPERATOR, planner.getTableConfig()),
                 operator,
                 inputTransform.getOutputType(),
                 inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecDropUpdateBefore.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecDropUpdateBefore.java
@@ -47,13 +47,13 @@ import java.util.List;
 @ExecNodeMetadata(
         name = "stream-exec-drop-update-before",
         version = 1,
-        producedOperators = StreamExecDropUpdateBefore.DROP_UPDATE_BEFORE_OPERATOR,
+        producedTransformations = StreamExecDropUpdateBefore.DROP_UPDATE_BEFORE_TRANSFORMATION,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecDropUpdateBefore extends ExecNodeBase<RowData>
         implements StreamExecNode<RowData>, SingleTransformationTranslator<RowData> {
 
-    public static final String DROP_UPDATE_BEFORE_OPERATOR = "drop-update-before";
+    public static final String DROP_UPDATE_BEFORE_TRANSFORMATION = "drop-update-before";
 
     public StreamExecDropUpdateBefore(
             InputProperty inputProperty, RowType outputType, String description) {
@@ -84,7 +84,7 @@ public class StreamExecDropUpdateBefore extends ExecNodeBase<RowData>
 
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getOperatorMeta(DROP_UPDATE_BEFORE_OPERATOR, planner.getTableConfig()),
+                getTransformationMeta(DROP_UPDATE_BEFORE_TRANSFORMATION, planner.getTableConfig()),
                 operator,
                 inputTransform.getOutputType(),
                 inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecExchange.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecExchange.java
@@ -56,12 +56,12 @@ import static org.apache.flink.util.Preconditions.checkArgument;
 @ExecNodeMetadata(
         name = "stream-exec-exchange",
         version = 1,
-        producedOperators = StreamExecExchange.EXCHANGE_OPERATOR,
+        producedTransformations = StreamExecExchange.EXCHANGE_TRANSFORMATION,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecExchange extends CommonExecExchange implements StreamExecNode<RowData> {
 
-    public static final String EXCHANGE_OPERATOR = "exchange";
+    public static final String EXCHANGE_TRANSFORMATION = "exchange";
 
     public StreamExecExchange(InputProperty inputProperty, RowType outputType, String description) {
         this(
@@ -118,7 +118,8 @@ public class StreamExecExchange extends CommonExecExchange implements StreamExec
 
         final Transformation<RowData> transformation =
                 new PartitionTransformation<>(inputTransform, partitioner);
-        getOperatorMeta(EXCHANGE_OPERATOR, planner.getTableConfig()).fill(transformation);
+        getTransformationMeta(EXCHANGE_TRANSFORMATION, planner.getTableConfig())
+                .fill(transformation);
         transformation.setParallelism(parallelism);
         transformation.setOutputType(InternalTypeInfo.of(getOutputType()));
         return transformation;

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecExchange.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecExchange.java
@@ -118,7 +118,7 @@ public class StreamExecExchange extends CommonExecExchange implements StreamExec
 
         final Transformation<RowData> transformation =
                 new PartitionTransformation<>(inputTransform, partitioner);
-        getTransformationMeta(EXCHANGE_TRANSFORMATION, planner.getTableConfig())
+        createTransformationMeta(EXCHANGE_TRANSFORMATION, planner.getTableConfig())
                 .fill(transformation);
         transformation.setParallelism(parallelism);
         transformation.setOutputType(InternalTypeInfo.of(getOutputType()));

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecExchange.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecExchange.java
@@ -60,6 +60,8 @@ import static org.apache.flink.util.Preconditions.checkArgument;
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecExchange extends CommonExecExchange implements StreamExecNode<RowData> {
 
+    private static final String EXCHANGE_OPERATOR = "exchange";
+
     public StreamExecExchange(InputProperty inputProperty, RowType outputType, String description) {
         this(
                 ExecNodeContext.newNodeId(),
@@ -115,6 +117,7 @@ public class StreamExecExchange extends CommonExecExchange implements StreamExec
 
         final Transformation<RowData> transformation =
                 new PartitionTransformation<>(inputTransform, partitioner);
+        getOperatorMeta(EXCHANGE_OPERATOR, planner.getTableConfig()).fill(transformation);
         transformation.setParallelism(parallelism);
         transformation.setOutputType(InternalTypeInfo.of(getOutputType()));
         return transformation;

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecExchange.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecExchange.java
@@ -56,11 +56,12 @@ import static org.apache.flink.util.Preconditions.checkArgument;
 @ExecNodeMetadata(
         name = "stream-exec-exchange",
         version = 1,
+        producedOperators = StreamExecExchange.EXCHANGE_OPERATOR,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecExchange extends CommonExecExchange implements StreamExecNode<RowData> {
 
-    private static final String EXCHANGE_OPERATOR = "exchange";
+    public static final String EXCHANGE_OPERATOR = "exchange";
 
     public StreamExecExchange(InputProperty inputProperty, RowType outputType, String description) {
         this(

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecExpand.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecExpand.java
@@ -39,6 +39,7 @@ import java.util.List;
 @ExecNodeMetadata(
         name = "stream-exec-expand",
         version = 1,
+        producedOperators = CommonExecExpand.EXPAND_OPERATOR,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecExpand extends CommonExecExpand implements StreamExecNode<RowData> {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecExpand.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecExpand.java
@@ -39,7 +39,7 @@ import java.util.List;
 @ExecNodeMetadata(
         name = "stream-exec-expand",
         version = 1,
-        producedOperators = CommonExecExpand.EXPAND_OPERATOR,
+        producedTransformations = CommonExecExpand.EXPAND_TRANSFORMATION,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecExpand extends CommonExecExpand implements StreamExecNode<RowData> {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGlobalGroupAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGlobalGroupAggregate.java
@@ -78,13 +78,14 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @ExecNodeMetadata(
         name = "stream-exec-global-group-aggregate",
         version = 1,
+        producedOperators = StreamExecGlobalGroupAggregate.GLOBAL_GROUP_AGGREGATE_OPERATOR,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecGlobalGroupAggregate extends StreamExecAggregateBase {
 
     private static final Logger LOG = LoggerFactory.getLogger(StreamExecGlobalGroupAggregate.class);
 
-    private static final String GLOBAL_GROUP_AGGREGATE_OPERATOR = "global-group-aggregate";
+    public static final String GLOBAL_GROUP_AGGREGATE_OPERATOR = "global-group-aggregate";
 
     public static final String FIELD_NAME_LOCAL_AGG_INPUT_ROW_TYPE = "localAggInputRowType";
     public static final String FIELD_NAME_INDEX_OF_COUNT_STAR = "indexOfCountStar";

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGlobalGroupAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGlobalGroupAggregate.java
@@ -81,7 +81,10 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecGlobalGroupAggregate extends StreamExecAggregateBase {
+
     private static final Logger LOG = LoggerFactory.getLogger(StreamExecGlobalGroupAggregate.class);
+
+    private static final String GLOBAL_GROUP_AGGREGATE_OPERATOR = "global-group-aggregate";
 
     public static final String FIELD_NAME_LOCAL_AGG_INPUT_ROW_TYPE = "localAggInputRowType";
     public static final String FIELD_NAME_INDEX_OF_COUNT_STAR = "indexOfCountStar";
@@ -261,8 +264,7 @@ public class StreamExecGlobalGroupAggregate extends StreamExecAggregateBase {
         final OneInputTransformation<RowData, RowData> transform =
                 ExecNodeUtil.createOneInputTransformation(
                         inputTransform,
-                        getOperatorName(tableConfig),
-                        getOperatorDescription(tableConfig),
+                        getOperatorMeta(GLOBAL_GROUP_AGGREGATE_OPERATOR, tableConfig),
                         operator,
                         InternalTypeInfo.of(getOutputType()),
                         inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGlobalGroupAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGlobalGroupAggregate.java
@@ -78,14 +78,15 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @ExecNodeMetadata(
         name = "stream-exec-global-group-aggregate",
         version = 1,
-        producedOperators = StreamExecGlobalGroupAggregate.GLOBAL_GROUP_AGGREGATE_OPERATOR,
+        producedTransformations =
+                StreamExecGlobalGroupAggregate.GLOBAL_GROUP_AGGREGATE_TRANSFORMATION,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecGlobalGroupAggregate extends StreamExecAggregateBase {
 
     private static final Logger LOG = LoggerFactory.getLogger(StreamExecGlobalGroupAggregate.class);
 
-    public static final String GLOBAL_GROUP_AGGREGATE_OPERATOR = "global-group-aggregate";
+    public static final String GLOBAL_GROUP_AGGREGATE_TRANSFORMATION = "global-group-aggregate";
 
     public static final String FIELD_NAME_LOCAL_AGG_INPUT_ROW_TYPE = "localAggInputRowType";
     public static final String FIELD_NAME_INDEX_OF_COUNT_STAR = "indexOfCountStar";
@@ -265,7 +266,7 @@ public class StreamExecGlobalGroupAggregate extends StreamExecAggregateBase {
         final OneInputTransformation<RowData, RowData> transform =
                 ExecNodeUtil.createOneInputTransformation(
                         inputTransform,
-                        getOperatorMeta(GLOBAL_GROUP_AGGREGATE_OPERATOR, tableConfig),
+                        getTransformationMeta(GLOBAL_GROUP_AGGREGATE_TRANSFORMATION, tableConfig),
                         operator,
                         InternalTypeInfo.of(getOutputType()),
                         inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGlobalGroupAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGlobalGroupAggregate.java
@@ -266,7 +266,8 @@ public class StreamExecGlobalGroupAggregate extends StreamExecAggregateBase {
         final OneInputTransformation<RowData, RowData> transform =
                 ExecNodeUtil.createOneInputTransformation(
                         inputTransform,
-                        getTransformationMeta(GLOBAL_GROUP_AGGREGATE_TRANSFORMATION, tableConfig),
+                        createTransformationMeta(
+                                GLOBAL_GROUP_AGGREGATE_TRANSFORMATION, tableConfig),
                         operator,
                         InternalTypeInfo.of(getOutputType()),
                         inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGlobalWindowAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGlobalWindowAggregate.java
@@ -236,7 +236,7 @@ public class StreamExecGlobalWindowAggregate extends StreamExecWindowAggregateBa
         final OneInputTransformation<RowData, RowData> transform =
                 ExecNodeUtil.createOneInputTransformation(
                         inputTransform,
-                        getTransformationMeta(
+                        createTransformationMeta(
                                 GLOBAL_WINDOW_AGGREGATE_TRANSFORMATION, planner.getTableConfig()),
                         SimpleOperatorFactory.of(windowOperator),
                         InternalTypeInfo.of(getOutputType()),

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGlobalWindowAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGlobalWindowAggregate.java
@@ -74,14 +74,15 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @ExecNodeMetadata(
         name = "stream-exec-global-window-aggregate",
         version = 1,
-        producedOperators = StreamExecGlobalWindowAggregate.GLOBAL_WINDOW_AGGREGATE_OPERATOR,
+        producedTransformations =
+                StreamExecGlobalWindowAggregate.GLOBAL_WINDOW_AGGREGATE_TRANSFORMATION,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecGlobalWindowAggregate extends StreamExecWindowAggregateBase {
 
     public static final String FIELD_NAME_LOCAL_AGG_INPUT_ROW_TYPE = "localAggInputRowType";
 
-    public static final String GLOBAL_WINDOW_AGGREGATE_OPERATOR = "global-window-aggregate";
+    public static final String GLOBAL_WINDOW_AGGREGATE_TRANSFORMATION = "global-window-aggregate";
 
     @JsonProperty(FIELD_NAME_GROUPING)
     private final int[] grouping;
@@ -235,7 +236,8 @@ public class StreamExecGlobalWindowAggregate extends StreamExecWindowAggregateBa
         final OneInputTransformation<RowData, RowData> transform =
                 ExecNodeUtil.createOneInputTransformation(
                         inputTransform,
-                        getOperatorMeta(GLOBAL_WINDOW_AGGREGATE_OPERATOR, planner.getTableConfig()),
+                        getTransformationMeta(
+                                GLOBAL_WINDOW_AGGREGATE_TRANSFORMATION, planner.getTableConfig()),
                         SimpleOperatorFactory.of(windowOperator),
                         InternalTypeInfo.of(getOutputType()),
                         inputTransform.getParallelism(),

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGlobalWindowAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGlobalWindowAggregate.java
@@ -80,9 +80,9 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecGlobalWindowAggregate extends StreamExecWindowAggregateBase {
 
-    public static final String FIELD_NAME_LOCAL_AGG_INPUT_ROW_TYPE = "localAggInputRowType";
-
     public static final String GLOBAL_WINDOW_AGGREGATE_TRANSFORMATION = "global-window-aggregate";
+
+    public static final String FIELD_NAME_LOCAL_AGG_INPUT_ROW_TYPE = "localAggInputRowType";
 
     @JsonProperty(FIELD_NAME_GROUPING)
     private final int[] grouping;

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGlobalWindowAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGlobalWindowAggregate.java
@@ -74,13 +74,14 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @ExecNodeMetadata(
         name = "stream-exec-global-window-aggregate",
         version = 1,
+        producedOperators = StreamExecGlobalWindowAggregate.GLOBAL_WINDOW_AGGREGATE_OPERATOR,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecGlobalWindowAggregate extends StreamExecWindowAggregateBase {
 
     public static final String FIELD_NAME_LOCAL_AGG_INPUT_ROW_TYPE = "localAggInputRowType";
 
-    private static final String GLOBAL_WINDOW_AGGREGATE_OPERATOR = "global-window-aggregate";
+    public static final String GLOBAL_WINDOW_AGGREGATE_OPERATOR = "global-window-aggregate";
 
     @JsonProperty(FIELD_NAME_GROUPING)
     private final int[] grouping;

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGlobalWindowAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGlobalWindowAggregate.java
@@ -80,6 +80,8 @@ public class StreamExecGlobalWindowAggregate extends StreamExecWindowAggregateBa
 
     public static final String FIELD_NAME_LOCAL_AGG_INPUT_ROW_TYPE = "localAggInputRowType";
 
+    private static final String GLOBAL_WINDOW_AGGREGATE_OPERATOR = "global-window-aggregate";
+
     @JsonProperty(FIELD_NAME_GROUPING)
     private final int[] grouping;
 
@@ -232,8 +234,7 @@ public class StreamExecGlobalWindowAggregate extends StreamExecWindowAggregateBa
         final OneInputTransformation<RowData, RowData> transform =
                 ExecNodeUtil.createOneInputTransformation(
                         inputTransform,
-                        getOperatorName(planner.getTableConfig()),
-                        getOperatorDescription(planner.getTableConfig()),
+                        getOperatorMeta(GLOBAL_WINDOW_AGGREGATE_OPERATOR, planner.getTableConfig()),
                         SimpleOperatorFactory.of(windowOperator),
                         InternalTypeInfo.of(getOutputType()),
                         inputTransform.getParallelism(),

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGroupAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGroupAggregate.java
@@ -76,7 +76,10 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecGroupAggregate extends StreamExecAggregateBase {
+
     private static final Logger LOG = LoggerFactory.getLogger(StreamExecGroupAggregate.class);
+
+    private static final String GROUP_AGGREGATE_OPERATOR = "group-aggregate";
 
     @JsonProperty(FIELD_NAME_GROUPING)
     private final int[] grouping;
@@ -230,8 +233,7 @@ public class StreamExecGroupAggregate extends StreamExecAggregateBase {
         final OneInputTransformation<RowData, RowData> transform =
                 ExecNodeUtil.createOneInputTransformation(
                         inputTransform,
-                        getOperatorName(tableConfig),
-                        getOperatorDescription(tableConfig),
+                        getOperatorMeta(GROUP_AGGREGATE_OPERATOR, tableConfig),
                         operator,
                         InternalTypeInfo.of(getOutputType()),
                         inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGroupAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGroupAggregate.java
@@ -73,14 +73,14 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @ExecNodeMetadata(
         name = "stream-exec-group-aggregate",
         version = 1,
-        producedOperators = StreamExecGroupAggregate.GROUP_AGGREGATE_OPERATOR,
+        producedTransformations = StreamExecGroupAggregate.GROUP_AGGREGATE_TRANSFORMATION,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecGroupAggregate extends StreamExecAggregateBase {
 
     private static final Logger LOG = LoggerFactory.getLogger(StreamExecGroupAggregate.class);
 
-    public static final String GROUP_AGGREGATE_OPERATOR = "group-aggregate";
+    public static final String GROUP_AGGREGATE_TRANSFORMATION = "group-aggregate";
 
     @JsonProperty(FIELD_NAME_GROUPING)
     private final int[] grouping;
@@ -234,7 +234,7 @@ public class StreamExecGroupAggregate extends StreamExecAggregateBase {
         final OneInputTransformation<RowData, RowData> transform =
                 ExecNodeUtil.createOneInputTransformation(
                         inputTransform,
-                        getOperatorMeta(GROUP_AGGREGATE_OPERATOR, tableConfig),
+                        getTransformationMeta(GROUP_AGGREGATE_TRANSFORMATION, tableConfig),
                         operator,
                         InternalTypeInfo.of(getOutputType()),
                         inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGroupAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGroupAggregate.java
@@ -73,13 +73,14 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @ExecNodeMetadata(
         name = "stream-exec-group-aggregate",
         version = 1,
+        producedOperators = StreamExecGroupAggregate.GROUP_AGGREGATE_OPERATOR,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecGroupAggregate extends StreamExecAggregateBase {
 
     private static final Logger LOG = LoggerFactory.getLogger(StreamExecGroupAggregate.class);
 
-    private static final String GROUP_AGGREGATE_OPERATOR = "group-aggregate";
+    public static final String GROUP_AGGREGATE_OPERATOR = "group-aggregate";
 
     @JsonProperty(FIELD_NAME_GROUPING)
     private final int[] grouping;

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGroupAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGroupAggregate.java
@@ -234,7 +234,7 @@ public class StreamExecGroupAggregate extends StreamExecAggregateBase {
         final OneInputTransformation<RowData, RowData> transform =
                 ExecNodeUtil.createOneInputTransformation(
                         inputTransform,
-                        getTransformationMeta(GROUP_AGGREGATE_TRANSFORMATION, tableConfig),
+                        createTransformationMeta(GROUP_AGGREGATE_TRANSFORMATION, tableConfig),
                         operator,
                         InternalTypeInfo.of(getOutputType()),
                         inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGroupTableAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGroupTableAggregate.java
@@ -57,7 +57,10 @@ import java.util.Collections;
 /** Stream {@link ExecNode} for unbounded java/scala group table aggregate. */
 public class StreamExecGroupTableAggregate extends ExecNodeBase<RowData>
         implements StreamExecNode<RowData>, SingleTransformationTranslator<RowData> {
+
     private static final Logger LOG = LoggerFactory.getLogger(StreamExecGroupTableAggregate.class);
+
+    private static final String GROUP_TABLE_AGGREGATE_OPERATOR = "group-table-aggregate";
 
     private final int[] grouping;
     private final AggregateCall[] aggCalls;
@@ -155,8 +158,7 @@ public class StreamExecGroupTableAggregate extends ExecNodeBase<RowData>
         final OneInputTransformation<RowData, RowData> transform =
                 ExecNodeUtil.createOneInputTransformation(
                         inputTransform,
-                        getOperatorName(planner.getTableConfig()),
-                        getOperatorDescription(planner.getTableConfig()),
+                        getOperatorMeta(GROUP_TABLE_AGGREGATE_OPERATOR, planner.getTableConfig()),
                         operator,
                         InternalTypeInfo.of(getOutputType()),
                         inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGroupTableAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGroupTableAggregate.java
@@ -60,7 +60,7 @@ public class StreamExecGroupTableAggregate extends ExecNodeBase<RowData>
 
     private static final Logger LOG = LoggerFactory.getLogger(StreamExecGroupTableAggregate.class);
 
-    private static final String GROUP_TABLE_AGGREGATE_OPERATOR = "group-table-aggregate";
+    private static final String GROUP_TABLE_AGGREGATE_TRANSFORMATION = "group-table-aggregate";
 
     private final int[] grouping;
     private final AggregateCall[] aggCalls;
@@ -158,7 +158,8 @@ public class StreamExecGroupTableAggregate extends ExecNodeBase<RowData>
         final OneInputTransformation<RowData, RowData> transform =
                 ExecNodeUtil.createOneInputTransformation(
                         inputTransform,
-                        getOperatorMeta(GROUP_TABLE_AGGREGATE_OPERATOR, planner.getTableConfig()),
+                        getTransformationMeta(
+                                GROUP_TABLE_AGGREGATE_TRANSFORMATION, planner.getTableConfig()),
                         operator,
                         InternalTypeInfo.of(getOutputType()),
                         inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGroupTableAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGroupTableAggregate.java
@@ -158,7 +158,7 @@ public class StreamExecGroupTableAggregate extends ExecNodeBase<RowData>
         final OneInputTransformation<RowData, RowData> transform =
                 ExecNodeUtil.createOneInputTransformation(
                         inputTransform,
-                        getTransformationMeta(
+                        createTransformationMeta(
                                 GROUP_TABLE_AGGREGATE_TRANSFORMATION, planner.getTableConfig()),
                         operator,
                         InternalTypeInfo.of(getOutputType()),

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGroupWindowAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGroupWindowAggregate.java
@@ -275,7 +275,7 @@ public class StreamExecGroupWindowAggregate extends StreamExecAggregateBase {
         final OneInputTransformation<RowData, RowData> transform =
                 ExecNodeUtil.createOneInputTransformation(
                         inputTransform,
-                        getTransformationMeta(
+                        createTransformationMeta(
                                 GROUP_WINDOW_TRANSFORMATION, planner.getTableConfig()),
                         operator,
                         InternalTypeInfo.of(getOutputType()),

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGroupWindowAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGroupWindowAggregate.java
@@ -105,6 +105,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @ExecNodeMetadata(
         name = "stream-exec-group-window-aggregate",
         version = 1,
+        producedOperators = StreamExecGroupWindowAggregate.GROUP_WINDOW_OPERATOR,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecGroupWindowAggregate extends StreamExecAggregateBase {
@@ -112,7 +113,7 @@ public class StreamExecGroupWindowAggregate extends StreamExecAggregateBase {
     private static final Logger LOGGER =
             LoggerFactory.getLogger(StreamExecGroupWindowAggregate.class);
 
-    private static final String GROUP_WINDOW_OPERATOR = "group-window-aggregate";
+    public static final String GROUP_WINDOW_OPERATOR = "group-window-aggregate";
 
     public static final String FIELD_NAME_WINDOW = "window";
     public static final String FIELD_NAME_NAMED_WINDOW_PROPERTIES = "namedWindowProperties";

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGroupWindowAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGroupWindowAggregate.java
@@ -105,7 +105,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @ExecNodeMetadata(
         name = "stream-exec-group-window-aggregate",
         version = 1,
-        producedOperators = StreamExecGroupWindowAggregate.GROUP_WINDOW_OPERATOR,
+        producedTransformations = StreamExecGroupWindowAggregate.GROUP_WINDOW_TRANSFORMATION,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecGroupWindowAggregate extends StreamExecAggregateBase {
@@ -113,7 +113,7 @@ public class StreamExecGroupWindowAggregate extends StreamExecAggregateBase {
     private static final Logger LOGGER =
             LoggerFactory.getLogger(StreamExecGroupWindowAggregate.class);
 
-    public static final String GROUP_WINDOW_OPERATOR = "group-window-aggregate";
+    public static final String GROUP_WINDOW_TRANSFORMATION = "group-window-aggregate";
 
     public static final String FIELD_NAME_WINDOW = "window";
     public static final String FIELD_NAME_NAMED_WINDOW_PROPERTIES = "namedWindowProperties";
@@ -275,7 +275,8 @@ public class StreamExecGroupWindowAggregate extends StreamExecAggregateBase {
         final OneInputTransformation<RowData, RowData> transform =
                 ExecNodeUtil.createOneInputTransformation(
                         inputTransform,
-                        getOperatorMeta(GROUP_WINDOW_OPERATOR, planner.getTableConfig()),
+                        getTransformationMeta(
+                                GROUP_WINDOW_TRANSFORMATION, planner.getTableConfig()),
                         operator,
                         InternalTypeInfo.of(getOutputType()),
                         inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGroupWindowAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGroupWindowAggregate.java
@@ -109,11 +109,13 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecGroupWindowAggregate extends StreamExecAggregateBase {
 
-    public static final String FIELD_NAME_WINDOW = "window";
-    public static final String FIELD_NAME_NAMED_WINDOW_PROPERTIES = "namedWindowProperties";
-
     private static final Logger LOGGER =
             LoggerFactory.getLogger(StreamExecGroupWindowAggregate.class);
+
+    private static final String GROUP_WINDOW_OPERATOR = "group-window-aggregate";
+
+    public static final String FIELD_NAME_WINDOW = "window";
+    public static final String FIELD_NAME_NAMED_WINDOW_PROPERTIES = "namedWindowProperties";
 
     @JsonProperty(FIELD_NAME_GROUPING)
     private final int[] grouping;
@@ -272,8 +274,7 @@ public class StreamExecGroupWindowAggregate extends StreamExecAggregateBase {
         final OneInputTransformation<RowData, RowData> transform =
                 ExecNodeUtil.createOneInputTransformation(
                         inputTransform,
-                        getOperatorName(planner.getTableConfig()),
-                        getOperatorDescription(planner.getTableConfig()),
+                        getOperatorMeta(GROUP_WINDOW_OPERATOR, planner.getTableConfig()),
                         operator,
                         InternalTypeInfo.of(getOutputType()),
                         inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecIncrementalGroupAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecIncrementalGroupAggregate.java
@@ -66,12 +66,13 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @ExecNodeMetadata(
         name = "stream-exec-incremental-group-aggregate",
         version = 1,
+        producedOperators =
+                StreamExecIncrementalGroupAggregate.INCREMENTAL_GROUP_AGGREGATE_OPERATOR,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecIncrementalGroupAggregate extends StreamExecAggregateBase {
 
-    private static final String INCREMENTAL_GROUP_AGGREGATE_OPERATOR =
-            "incremental-group-aggregate";
+    public static final String INCREMENTAL_GROUP_AGGREGATE_OPERATOR = "incremental-group-aggregate";
 
     public static final String FIELD_NAME_PARTIAL_AGG_GROUPING = "partialAggGrouping";
     public static final String FIELD_NAME_FINAL_AGG_GROUPING = "finalAggGrouping";

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecIncrementalGroupAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecIncrementalGroupAggregate.java
@@ -66,13 +66,14 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @ExecNodeMetadata(
         name = "stream-exec-incremental-group-aggregate",
         version = 1,
-        producedOperators =
-                StreamExecIncrementalGroupAggregate.INCREMENTAL_GROUP_AGGREGATE_OPERATOR,
+        producedTransformations =
+                StreamExecIncrementalGroupAggregate.INCREMENTAL_GROUP_AGGREGATE_TRANSFORMATION,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecIncrementalGroupAggregate extends StreamExecAggregateBase {
 
-    public static final String INCREMENTAL_GROUP_AGGREGATE_OPERATOR = "incremental-group-aggregate";
+    public static final String INCREMENTAL_GROUP_AGGREGATE_TRANSFORMATION =
+            "incremental-group-aggregate";
 
     public static final String FIELD_NAME_PARTIAL_AGG_GROUPING = "partialAggGrouping";
     public static final String FIELD_NAME_FINAL_AGG_GROUPING = "finalAggGrouping";
@@ -225,8 +226,9 @@ public class StreamExecIncrementalGroupAggregate extends StreamExecAggregateBase
         final OneInputTransformation<RowData, RowData> transform =
                 ExecNodeUtil.createOneInputTransformation(
                         inputTransform,
-                        getOperatorMeta(
-                                INCREMENTAL_GROUP_AGGREGATE_OPERATOR, planner.getTableConfig()),
+                        getTransformationMeta(
+                                INCREMENTAL_GROUP_AGGREGATE_TRANSFORMATION,
+                                planner.getTableConfig()),
                         operator,
                         InternalTypeInfo.of(getOutputType()),
                         inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecIncrementalGroupAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecIncrementalGroupAggregate.java
@@ -70,6 +70,9 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecIncrementalGroupAggregate extends StreamExecAggregateBase {
 
+    private static final String INCREMENTAL_GROUP_AGGREGATE_OPERATOR =
+            "incremental-group-aggregate";
+
     public static final String FIELD_NAME_PARTIAL_AGG_GROUPING = "partialAggGrouping";
     public static final String FIELD_NAME_FINAL_AGG_GROUPING = "finalAggGrouping";
     public static final String FIELD_NAME_PARTIAL_ORIGINAL_AGG_CALLS = "partialOriginalAggCalls";
@@ -221,8 +224,8 @@ public class StreamExecIncrementalGroupAggregate extends StreamExecAggregateBase
         final OneInputTransformation<RowData, RowData> transform =
                 ExecNodeUtil.createOneInputTransformation(
                         inputTransform,
-                        getOperatorName(planner.getTableConfig()),
-                        getOperatorDescription(planner.getTableConfig()),
+                        getOperatorMeta(
+                                INCREMENTAL_GROUP_AGGREGATE_OPERATOR, planner.getTableConfig()),
                         operator,
                         InternalTypeInfo.of(getOutputType()),
                         inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecIncrementalGroupAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecIncrementalGroupAggregate.java
@@ -226,7 +226,7 @@ public class StreamExecIncrementalGroupAggregate extends StreamExecAggregateBase
         final OneInputTransformation<RowData, RowData> transform =
                 ExecNodeUtil.createOneInputTransformation(
                         inputTransform,
-                        getTransformationMeta(
+                        createTransformationMeta(
                                 INCREMENTAL_GROUP_AGGREGATE_TRANSFORMATION,
                                 planner.getTableConfig()),
                         operator,

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecIntervalJoin.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecIntervalJoin.java
@@ -294,33 +294,21 @@ public class StreamExecIntervalJoin extends ExecNodeBase<RowData>
                 createFormattedTransformationName(
                         padRightStream.getDescription(), "PadRight", config));
 
-        Transformation<RowData> transformation;
         switch (joinSpec.getJoinType()) {
             case INNER:
-                transformation =
-                        new UnionTransformation<>(
-                                Lists.newArrayList(filterAllLeftStream, filterAllRightStream));
-                break;
+                return new UnionTransformation<>(
+                        Lists.newArrayList(filterAllLeftStream, filterAllRightStream));
             case LEFT:
-                transformation =
-                        new UnionTransformation<>(
-                                Lists.newArrayList(padLeftStream, filterAllRightStream));
-                break;
+                return new UnionTransformation<>(
+                        Lists.newArrayList(padLeftStream, filterAllRightStream));
             case RIGHT:
-                transformation =
-                        new UnionTransformation<>(
-                                Lists.newArrayList(filterAllLeftStream, padRightStream));
-                break;
+                return new UnionTransformation<>(
+                        Lists.newArrayList(filterAllLeftStream, padRightStream));
             case FULL:
-                transformation =
-                        new UnionTransformation<>(
-                                Lists.newArrayList(padLeftStream, padRightStream));
-                break;
+                return new UnionTransformation<>(Lists.newArrayList(padLeftStream, padRightStream));
             default:
                 throw new TableException("should no reach here");
         }
-        transformation.setUid(createTransformationUid(INTERVAL_JOIN_TRANSFORMATION));
-        return transformation;
     }
 
     private TwoInputTransformation<RowData, RowData, RowData> createProcTimeJoin(

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecIntervalJoin.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecIntervalJoin.java
@@ -69,12 +69,12 @@ import java.util.List;
 @ExecNodeMetadata(
         name = "stream-exec-interval-join",
         version = 1,
-        producedOperators = {
-            StreamExecIntervalJoin.FILTER_LEFT_OPERATOR,
-            StreamExecIntervalJoin.FILTER_RIGHT_OPERATOR,
-            StreamExecIntervalJoin.PAD_LEFT_OPERATOR,
-            StreamExecIntervalJoin.PAD_RIGHT_OPERATOR,
-            StreamExecIntervalJoin.INTERVAL_JOIN_OPERATOR
+        producedTransformations = {
+            StreamExecIntervalJoin.FILTER_LEFT_TRANSFORMATION,
+            StreamExecIntervalJoin.FILTER_RIGHT_TRANSFORMATION,
+            StreamExecIntervalJoin.PAD_LEFT_TRANSFORMATION,
+            StreamExecIntervalJoin.PAD_RIGHT_TRANSFORMATION,
+            StreamExecIntervalJoin.INTERVAL_JOIN_TRANSFORMATION
         },
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
@@ -83,11 +83,11 @@ public class StreamExecIntervalJoin extends ExecNodeBase<RowData>
 
     private static final Logger LOGGER = LoggerFactory.getLogger(StreamExecIntervalJoin.class);
 
-    public static final String FILTER_LEFT_OPERATOR = "filter-left";
-    public static final String FILTER_RIGHT_OPERATOR = "filter-right";
-    public static final String PAD_LEFT_OPERATOR = "pad-left";
-    public static final String PAD_RIGHT_OPERATOR = "pad-right";
-    public static final String INTERVAL_JOIN_OPERATOR = "interval-join";
+    public static final String FILTER_LEFT_TRANSFORMATION = "filter-left";
+    public static final String FILTER_RIGHT_TRANSFORMATION = "filter-right";
+    public static final String PAD_LEFT_TRANSFORMATION = "pad-left";
+    public static final String PAD_RIGHT_TRANSFORMATION = "pad-right";
+    public static final String INTERVAL_JOIN_TRANSFORMATION = "interval-join";
 
     public static final String FIELD_NAME_INTERVAL_JOIN_SPEC = "intervalJoinSpec";
 
@@ -243,11 +243,12 @@ public class StreamExecIntervalJoin extends ExecNodeBase<RowData>
                         new StreamFlatMap<>(allFilter),
                         returnTypeInfo,
                         leftParallelism);
-        filterAllLeftStream.setUid(getOperatorUid(FILTER_LEFT_OPERATOR));
+        filterAllLeftStream.setUid(getTransformationUid(FILTER_LEFT_TRANSFORMATION));
         filterAllLeftStream.setDescription(
-                getFormattedOperatorDescription("filter all left input transformation", config));
+                getFormattedTransformationDescription(
+                        "filter all left input transformation", config));
         filterAllLeftStream.setName(
-                getFormattedOperatorName(
+                getFormattedTransformationName(
                         filterAllLeftStream.getDescription(), "FilterLeft", config));
 
         OneInputTransformation<RowData, RowData> filterAllRightStream =
@@ -257,11 +258,12 @@ public class StreamExecIntervalJoin extends ExecNodeBase<RowData>
                         new StreamFlatMap<>(allFilter),
                         returnTypeInfo,
                         rightParallelism);
-        filterAllRightStream.setUid(getOperatorUid(FILTER_RIGHT_OPERATOR));
+        filterAllRightStream.setUid(getTransformationUid(FILTER_RIGHT_TRANSFORMATION));
         filterAllRightStream.setDescription(
-                getFormattedOperatorDescription("filter all right input transformation", config));
+                getFormattedTransformationDescription(
+                        "filter all right input transformation", config));
         filterAllRightStream.setName(
-                getFormattedOperatorName(
+                getFormattedTransformationName(
                         filterAllRightStream.getDescription(), "FilterRight", config));
 
         OneInputTransformation<RowData, RowData> padLeftStream =
@@ -271,11 +273,11 @@ public class StreamExecIntervalJoin extends ExecNodeBase<RowData>
                         new StreamMap<>(leftPadder),
                         returnTypeInfo,
                         leftParallelism);
-        padLeftStream.setUid(getOperatorUid(PAD_LEFT_OPERATOR));
+        padLeftStream.setUid(getTransformationUid(PAD_LEFT_TRANSFORMATION));
         padLeftStream.setDescription(
-                getFormattedOperatorDescription("pad left input transformation", config));
+                getFormattedTransformationDescription("pad left input transformation", config));
         padLeftStream.setName(
-                getFormattedOperatorName(padLeftStream.getDescription(), "PadLeft", config));
+                getFormattedTransformationName(padLeftStream.getDescription(), "PadLeft", config));
 
         OneInputTransformation<RowData, RowData> padRightStream =
                 new OneInputTransformation<>(
@@ -284,11 +286,12 @@ public class StreamExecIntervalJoin extends ExecNodeBase<RowData>
                         new StreamMap<>(rightPadder),
                         returnTypeInfo,
                         rightParallelism);
-        padRightStream.setUid(getOperatorUid(PAD_RIGHT_OPERATOR));
+        padRightStream.setUid(getTransformationUid(PAD_RIGHT_TRANSFORMATION));
         padRightStream.setDescription(
-                getFormattedOperatorDescription("pad right input transformation", config));
+                getFormattedTransformationDescription("pad right input transformation", config));
         padRightStream.setName(
-                getFormattedOperatorName(padRightStream.getDescription(), "PadRight", config));
+                getFormattedTransformationName(
+                        padRightStream.getDescription(), "PadRight", config));
 
         Transformation<RowData> transformation;
         switch (joinSpec.getJoinType()) {
@@ -315,7 +318,7 @@ public class StreamExecIntervalJoin extends ExecNodeBase<RowData>
             default:
                 throw new TableException("should no reach here");
         }
-        transformation.setUid(getOperatorUid(INTERVAL_JOIN_OPERATOR));
+        transformation.setUid(getTransformationUid(INTERVAL_JOIN_TRANSFORMATION));
         return transformation;
     }
 
@@ -343,7 +346,7 @@ public class StreamExecIntervalJoin extends ExecNodeBase<RowData>
         return ExecNodeUtil.createTwoInputTransformation(
                 leftInputTransform,
                 rightInputTransform,
-                getOperatorMeta(INTERVAL_JOIN_OPERATOR, config),
+                getTransformationMeta(INTERVAL_JOIN_TRANSFORMATION, config),
                 new KeyedCoProcessOperator<>(procJoinFunc),
                 returnTypeInfo,
                 leftInputTransform.getParallelism());
@@ -377,7 +380,7 @@ public class StreamExecIntervalJoin extends ExecNodeBase<RowData>
         return ExecNodeUtil.createTwoInputTransformation(
                 leftInputTransform,
                 rightInputTransform,
-                getOperatorMeta(INTERVAL_JOIN_OPERATOR, config),
+                getTransformationMeta(INTERVAL_JOIN_TRANSFORMATION, config),
                 new KeyedCoProcessOperatorWithWatermarkDelay<>(
                         rowJoinFunc, rowJoinFunc.getMaxOutputDelay()),
                 returnTypeInfo,

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecIntervalJoin.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecIntervalJoin.java
@@ -243,12 +243,12 @@ public class StreamExecIntervalJoin extends ExecNodeBase<RowData>
                         new StreamFlatMap<>(allFilter),
                         returnTypeInfo,
                         leftParallelism);
-        filterAllLeftStream.setUid(getTransformationUid(FILTER_LEFT_TRANSFORMATION));
+        filterAllLeftStream.setUid(createTransformationUid(FILTER_LEFT_TRANSFORMATION));
         filterAllLeftStream.setDescription(
-                getFormattedTransformationDescription(
+                createFormattedTransformationDescription(
                         "filter all left input transformation", config));
         filterAllLeftStream.setName(
-                getFormattedTransformationName(
+                createFormattedTransformationName(
                         filterAllLeftStream.getDescription(), "FilterLeft", config));
 
         OneInputTransformation<RowData, RowData> filterAllRightStream =
@@ -258,12 +258,12 @@ public class StreamExecIntervalJoin extends ExecNodeBase<RowData>
                         new StreamFlatMap<>(allFilter),
                         returnTypeInfo,
                         rightParallelism);
-        filterAllRightStream.setUid(getTransformationUid(FILTER_RIGHT_TRANSFORMATION));
+        filterAllRightStream.setUid(createTransformationUid(FILTER_RIGHT_TRANSFORMATION));
         filterAllRightStream.setDescription(
-                getFormattedTransformationDescription(
+                createFormattedTransformationDescription(
                         "filter all right input transformation", config));
         filterAllRightStream.setName(
-                getFormattedTransformationName(
+                createFormattedTransformationName(
                         filterAllRightStream.getDescription(), "FilterRight", config));
 
         OneInputTransformation<RowData, RowData> padLeftStream =
@@ -273,11 +273,12 @@ public class StreamExecIntervalJoin extends ExecNodeBase<RowData>
                         new StreamMap<>(leftPadder),
                         returnTypeInfo,
                         leftParallelism);
-        padLeftStream.setUid(getTransformationUid(PAD_LEFT_TRANSFORMATION));
+        padLeftStream.setUid(createTransformationUid(PAD_LEFT_TRANSFORMATION));
         padLeftStream.setDescription(
-                getFormattedTransformationDescription("pad left input transformation", config));
+                createFormattedTransformationDescription("pad left input transformation", config));
         padLeftStream.setName(
-                getFormattedTransformationName(padLeftStream.getDescription(), "PadLeft", config));
+                createFormattedTransformationName(
+                        padLeftStream.getDescription(), "PadLeft", config));
 
         OneInputTransformation<RowData, RowData> padRightStream =
                 new OneInputTransformation<>(
@@ -286,11 +287,11 @@ public class StreamExecIntervalJoin extends ExecNodeBase<RowData>
                         new StreamMap<>(rightPadder),
                         returnTypeInfo,
                         rightParallelism);
-        padRightStream.setUid(getTransformationUid(PAD_RIGHT_TRANSFORMATION));
+        padRightStream.setUid(createTransformationUid(PAD_RIGHT_TRANSFORMATION));
         padRightStream.setDescription(
-                getFormattedTransformationDescription("pad right input transformation", config));
+                createFormattedTransformationDescription("pad right input transformation", config));
         padRightStream.setName(
-                getFormattedTransformationName(
+                createFormattedTransformationName(
                         padRightStream.getDescription(), "PadRight", config));
 
         Transformation<RowData> transformation;
@@ -318,7 +319,7 @@ public class StreamExecIntervalJoin extends ExecNodeBase<RowData>
             default:
                 throw new TableException("should no reach here");
         }
-        transformation.setUid(getTransformationUid(INTERVAL_JOIN_TRANSFORMATION));
+        transformation.setUid(createTransformationUid(INTERVAL_JOIN_TRANSFORMATION));
         return transformation;
     }
 
@@ -346,7 +347,7 @@ public class StreamExecIntervalJoin extends ExecNodeBase<RowData>
         return ExecNodeUtil.createTwoInputTransformation(
                 leftInputTransform,
                 rightInputTransform,
-                getTransformationMeta(INTERVAL_JOIN_TRANSFORMATION, config),
+                createTransformationMeta(INTERVAL_JOIN_TRANSFORMATION, config),
                 new KeyedCoProcessOperator<>(procJoinFunc),
                 returnTypeInfo,
                 leftInputTransform.getParallelism());
@@ -380,7 +381,7 @@ public class StreamExecIntervalJoin extends ExecNodeBase<RowData>
         return ExecNodeUtil.createTwoInputTransformation(
                 leftInputTransform,
                 rightInputTransform,
-                getTransformationMeta(INTERVAL_JOIN_TRANSFORMATION, config),
+                createTransformationMeta(INTERVAL_JOIN_TRANSFORMATION, config),
                 new KeyedCoProcessOperatorWithWatermarkDelay<>(
                         rowJoinFunc, rowJoinFunc.getMaxOutputDelay()),
                 returnTypeInfo,

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecIntervalJoin.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecIntervalJoin.java
@@ -69,6 +69,13 @@ import java.util.List;
 @ExecNodeMetadata(
         name = "stream-exec-interval-join",
         version = 1,
+        producedOperators = {
+            StreamExecIntervalJoin.FILTER_LEFT_OPERATOR,
+            StreamExecIntervalJoin.FILTER_RIGHT_OPERATOR,
+            StreamExecIntervalJoin.PAD_LEFT_OPERATOR,
+            StreamExecIntervalJoin.PAD_RIGHT_OPERATOR,
+            StreamExecIntervalJoin.INTERVAL_JOIN_OPERATOR
+        },
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecIntervalJoin extends ExecNodeBase<RowData>
@@ -76,11 +83,11 @@ public class StreamExecIntervalJoin extends ExecNodeBase<RowData>
 
     private static final Logger LOGGER = LoggerFactory.getLogger(StreamExecIntervalJoin.class);
 
-    private static final String FILTER_LEFT_OPERATOR = "filter-left";
-    private static final String FILTER_RIGHT_OPERATOR = "filter-right";
-    private static final String PAD_LEFT_OPERATOR = "pad-left";
-    private static final String PAD_RIGHT_OPERATOR = "pad-right";
-    private static final String INTERVAL_JOIN_OPERATOR = "interval-join";
+    public static final String FILTER_LEFT_OPERATOR = "filter-left";
+    public static final String FILTER_RIGHT_OPERATOR = "filter-right";
+    public static final String PAD_LEFT_OPERATOR = "pad-left";
+    public static final String PAD_RIGHT_OPERATOR = "pad-right";
+    public static final String INTERVAL_JOIN_OPERATOR = "interval-join";
 
     public static final String FIELD_NAME_INTERVAL_JOIN_SPEC = "intervalJoinSpec";
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecJoin.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecJoin.java
@@ -67,6 +67,9 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecJoin extends ExecNodeBase<RowData>
         implements StreamExecNode<RowData>, SingleTransformationTranslator<RowData> {
+
+    private static final String JOIN_OPERATOR = "join";
+
     public static final String FIELD_NAME_JOIN_SPEC = "joinSpec";
     public static final String FIELD_NAME_LEFT_UNIQUE_KEYS = "leftUniqueKeys";
     public static final String FIELD_NAME_RIGHT_UNIQUE_KEYS = "rightUniqueKeys";
@@ -183,8 +186,7 @@ public class StreamExecJoin extends ExecNodeBase<RowData>
                 ExecNodeUtil.createTwoInputTransformation(
                         leftTransform,
                         rightTransform,
-                        getOperatorName(tableConfig),
-                        getOperatorDescription(tableConfig),
+                        getOperatorMeta(JOIN_OPERATOR, tableConfig),
                         operator,
                         InternalTypeInfo.of(returnType),
                         leftTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecJoin.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecJoin.java
@@ -63,12 +63,13 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @ExecNodeMetadata(
         name = "stream-exec-join",
         version = 1,
+        producedOperators = StreamExecJoin.JOIN_OPERATOR,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecJoin extends ExecNodeBase<RowData>
         implements StreamExecNode<RowData>, SingleTransformationTranslator<RowData> {
 
-    private static final String JOIN_OPERATOR = "join";
+    public static final String JOIN_OPERATOR = "join";
 
     public static final String FIELD_NAME_JOIN_SPEC = "joinSpec";
     public static final String FIELD_NAME_LEFT_UNIQUE_KEYS = "leftUniqueKeys";

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecJoin.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecJoin.java
@@ -63,13 +63,13 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @ExecNodeMetadata(
         name = "stream-exec-join",
         version = 1,
-        producedOperators = StreamExecJoin.JOIN_OPERATOR,
+        producedTransformations = StreamExecJoin.JOIN_TRANSFORMATION,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecJoin extends ExecNodeBase<RowData>
         implements StreamExecNode<RowData>, SingleTransformationTranslator<RowData> {
 
-    public static final String JOIN_OPERATOR = "join";
+    public static final String JOIN_TRANSFORMATION = "join";
 
     public static final String FIELD_NAME_JOIN_SPEC = "joinSpec";
     public static final String FIELD_NAME_LEFT_UNIQUE_KEYS = "leftUniqueKeys";
@@ -187,7 +187,7 @@ public class StreamExecJoin extends ExecNodeBase<RowData>
                 ExecNodeUtil.createTwoInputTransformation(
                         leftTransform,
                         rightTransform,
-                        getOperatorMeta(JOIN_OPERATOR, tableConfig),
+                        getTransformationMeta(JOIN_TRANSFORMATION, tableConfig),
                         operator,
                         InternalTypeInfo.of(returnType),
                         leftTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecJoin.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecJoin.java
@@ -187,7 +187,7 @@ public class StreamExecJoin extends ExecNodeBase<RowData>
                 ExecNodeUtil.createTwoInputTransformation(
                         leftTransform,
                         rightTransform,
-                        getTransformationMeta(JOIN_TRANSFORMATION, tableConfig),
+                        createTransformationMeta(JOIN_TRANSFORMATION, tableConfig),
                         operator,
                         InternalTypeInfo.of(returnType),
                         leftTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecLegacyTableSourceScan.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecLegacyTableSourceScan.java
@@ -116,10 +116,10 @@ public class StreamExecLegacyTableSourceScan extends CommonExecLegacyTableSource
                             outputType,
                             qualifiedName,
                             (detailName, simplifyName) ->
-                                    getFormattedTransformationName(
+                                    createFormattedTransformationName(
                                             detailName, simplifyName, config),
                             (description) ->
-                                    getFormattedTransformationDescription(description, config),
+                                    createFormattedTransformationDescription(description, config),
                             JavaScalaConversionUtil.toScala(Optional.ofNullable(rowtimeExpression)),
                             extractElement,
                             resetElement);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecLegacyTableSourceScan.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecLegacyTableSourceScan.java
@@ -116,8 +116,10 @@ public class StreamExecLegacyTableSourceScan extends CommonExecLegacyTableSource
                             outputType,
                             qualifiedName,
                             (detailName, simplifyName) ->
-                                    getFormattedOperatorName(detailName, simplifyName, config),
-                            (description) -> getFormattedOperatorDescription(description, config),
+                                    getFormattedTransformationName(
+                                            detailName, simplifyName, config),
+                            (description) ->
+                                    getFormattedTransformationDescription(description, config),
                             JavaScalaConversionUtil.toScala(Optional.ofNullable(rowtimeExpression)),
                             extractElement,
                             resetElement);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecLimit.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecLimit.java
@@ -44,7 +44,7 @@ import java.util.List;
 @ExecNodeMetadata(
         name = "stream-exec-limit",
         version = 1,
-        producedOperators = StreamExecRank.RANK_OPERATOR,
+        producedTransformations = StreamExecRank.RANK_TRANSFORMATION,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecLimit extends StreamExecRank {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecLimit.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecLimit.java
@@ -44,6 +44,7 @@ import java.util.List;
 @ExecNodeMetadata(
         name = "stream-exec-limit",
         version = 1,
+        producedOperators = StreamExecRank.RANK_OPERATOR,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecLimit extends StreamExecRank {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecLocalGroupAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecLocalGroupAggregate.java
@@ -61,6 +61,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecLocalGroupAggregate extends StreamExecAggregateBase {
 
+    private static final String LOCAL_GROUP_AGGREGATE_OPERATOR = "local-group-aggregate";
+
     @JsonProperty(FIELD_NAME_GROUPING)
     private final int[] grouping;
 
@@ -159,8 +161,7 @@ public class StreamExecLocalGroupAggregate extends StreamExecAggregateBase {
 
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getOperatorName(planner.getTableConfig()),
-                getOperatorDescription(planner.getTableConfig()),
+                getOperatorMeta(LOCAL_GROUP_AGGREGATE_OPERATOR, planner.getTableConfig()),
                 operator,
                 InternalTypeInfo.of(getOutputType()),
                 inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecLocalGroupAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecLocalGroupAggregate.java
@@ -57,12 +57,13 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @ExecNodeMetadata(
         name = "stream-exec-local-group-aggregate",
         version = 1,
-        producedOperators = StreamExecLocalGroupAggregate.LOCAL_GROUP_AGGREGATE_OPERATOR,
+        producedTransformations =
+                StreamExecLocalGroupAggregate.LOCAL_GROUP_AGGREGATE_TRANSFORMATION,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecLocalGroupAggregate extends StreamExecAggregateBase {
 
-    public static final String LOCAL_GROUP_AGGREGATE_OPERATOR = "local-group-aggregate";
+    public static final String LOCAL_GROUP_AGGREGATE_TRANSFORMATION = "local-group-aggregate";
 
     @JsonProperty(FIELD_NAME_GROUPING)
     private final int[] grouping;
@@ -162,7 +163,8 @@ public class StreamExecLocalGroupAggregate extends StreamExecAggregateBase {
 
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getOperatorMeta(LOCAL_GROUP_AGGREGATE_OPERATOR, planner.getTableConfig()),
+                getTransformationMeta(
+                        LOCAL_GROUP_AGGREGATE_TRANSFORMATION, planner.getTableConfig()),
                 operator,
                 InternalTypeInfo.of(getOutputType()),
                 inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecLocalGroupAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecLocalGroupAggregate.java
@@ -163,7 +163,7 @@ public class StreamExecLocalGroupAggregate extends StreamExecAggregateBase {
 
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getTransformationMeta(
+                createTransformationMeta(
                         LOCAL_GROUP_AGGREGATE_TRANSFORMATION, planner.getTableConfig()),
                 operator,
                 InternalTypeInfo.of(getOutputType()),

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecLocalGroupAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecLocalGroupAggregate.java
@@ -57,11 +57,12 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @ExecNodeMetadata(
         name = "stream-exec-local-group-aggregate",
         version = 1,
+        producedOperators = StreamExecLocalGroupAggregate.LOCAL_GROUP_AGGREGATE_OPERATOR,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecLocalGroupAggregate extends StreamExecAggregateBase {
 
-    private static final String LOCAL_GROUP_AGGREGATE_OPERATOR = "local-group-aggregate";
+    public static final String LOCAL_GROUP_AGGREGATE_OPERATOR = "local-group-aggregate";
 
     @JsonProperty(FIELD_NAME_GROUPING)
     private final int[] grouping;

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecLocalWindowAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecLocalWindowAggregate.java
@@ -170,7 +170,7 @@ public class StreamExecLocalWindowAggregate extends StreamExecWindowAggregateBas
 
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getTransformationMeta(
+                createTransformationMeta(
                         LOCAL_WINDOW_AGGREGATE_TRANSFORMATION, planner.getTableConfig()),
                 SimpleOperatorFactory.of(localAggOperator),
                 InternalTypeInfo.of(getOutputType()),

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecLocalWindowAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecLocalWindowAggregate.java
@@ -70,12 +70,13 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @ExecNodeMetadata(
         name = "stream-exec-local-window-aggregate",
         version = 1,
-        producedOperators = StreamExecLocalWindowAggregate.LOCAL_WINDOW_AGGREGATE_OPERATOR,
+        producedTransformations =
+                StreamExecLocalWindowAggregate.LOCAL_WINDOW_AGGREGATE_TRANSFORMATION,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecLocalWindowAggregate extends StreamExecWindowAggregateBase {
 
-    public static final String LOCAL_WINDOW_AGGREGATE_OPERATOR = "local-window-aggregate";
+    public static final String LOCAL_WINDOW_AGGREGATE_TRANSFORMATION = "local-window-aggregate";
 
     private static final long WINDOW_AGG_MEMORY_RATIO = 100;
 
@@ -169,7 +170,8 @@ public class StreamExecLocalWindowAggregate extends StreamExecWindowAggregateBas
 
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getOperatorMeta(LOCAL_WINDOW_AGGREGATE_OPERATOR, planner.getTableConfig()),
+                getTransformationMeta(
+                        LOCAL_WINDOW_AGGREGATE_TRANSFORMATION, planner.getTableConfig()),
                 SimpleOperatorFactory.of(localAggOperator),
                 InternalTypeInfo.of(getOutputType()),
                 inputTransform.getParallelism(),

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecLocalWindowAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecLocalWindowAggregate.java
@@ -70,11 +70,12 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @ExecNodeMetadata(
         name = "stream-exec-local-window-aggregate",
         version = 1,
+        producedOperators = StreamExecLocalWindowAggregate.LOCAL_WINDOW_AGGREGATE_OPERATOR,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecLocalWindowAggregate extends StreamExecWindowAggregateBase {
 
-    private static final String LOCAL_WINDOW_AGGREGATE_OPERATOR = "local-window-aggregate";
+    public static final String LOCAL_WINDOW_AGGREGATE_OPERATOR = "local-window-aggregate";
 
     private static final long WINDOW_AGG_MEMORY_RATIO = 100;
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecLocalWindowAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecLocalWindowAggregate.java
@@ -74,6 +74,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecLocalWindowAggregate extends StreamExecWindowAggregateBase {
 
+    private static final String LOCAL_WINDOW_AGGREGATE_OPERATOR = "local-window-aggregate";
+
     private static final long WINDOW_AGG_MEMORY_RATIO = 100;
 
     public static final String FIELD_NAME_WINDOWING = "windowing";
@@ -166,8 +168,7 @@ public class StreamExecLocalWindowAggregate extends StreamExecWindowAggregateBas
 
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getOperatorName(planner.getTableConfig()),
-                getOperatorDescription(planner.getTableConfig()),
+                getOperatorMeta(LOCAL_WINDOW_AGGREGATE_OPERATOR, planner.getTableConfig()),
                 SimpleOperatorFactory.of(localAggOperator),
                 InternalTypeInfo.of(getOutputType()),
                 inputTransform.getParallelism(),

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecLookupJoin.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecLookupJoin.java
@@ -44,7 +44,7 @@ import java.util.Map;
 @ExecNodeMetadata(
         name = "stream-exec-lookup-join",
         version = 1,
-        producedOperators = CommonExecLookupJoin.LOOKUP_JOIN_OPERATOR,
+        producedTransformations = CommonExecLookupJoin.LOOKUP_JOIN_TRANSFORMATION,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecLookupJoin extends CommonExecLookupJoin implements StreamExecNode<RowData> {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecLookupJoin.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecLookupJoin.java
@@ -44,6 +44,7 @@ import java.util.Map;
 @ExecNodeMetadata(
         name = "stream-exec-lookup-join",
         version = 1,
+        producedOperators = CommonExecLookupJoin.LOOKUP_JOIN_OPERATOR,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecLookupJoin extends CommonExecLookupJoin implements StreamExecNode<RowData> {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecMatch.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecMatch.java
@@ -92,17 +92,17 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @ExecNodeMetadata(
         name = "stream-exec-match",
         version = 1,
-        producedOperators = {
-            StreamExecMatch.TIMESTAMP_INSERTER_OPERATOR,
-            StreamExecMatch.MATCH_OPERATOR
+        producedTransformations = {
+            StreamExecMatch.TIMESTAMP_INSERTER_TRANSFORMATION,
+            StreamExecMatch.MATCH_TRANSFORMATION
         },
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecMatch extends ExecNodeBase<RowData>
         implements StreamExecNode<RowData>, MultipleTransformationTranslator<RowData> {
 
-    public static final String TIMESTAMP_INSERTER_OPERATOR = "timestamp-inserter";
-    public static final String MATCH_OPERATOR = "match";
+    public static final String TIMESTAMP_INSERTER_TRANSFORMATION = "timestamp-inserter";
+    public static final String MATCH_TRANSFORMATION = "match";
 
     public static final String FIELD_NAME_MATCH_SPEC = "matchSpec";
 
@@ -211,7 +211,7 @@ public class StreamExecMatch extends ExecNodeBase<RowData>
         final OneInputTransformation<RowData, RowData> transform =
                 ExecNodeUtil.createOneInputTransformation(
                         timestampedInputTransform,
-                        getOperatorMeta(MATCH_OPERATOR, config),
+                        createTransformationMeta(MATCH_TRANSFORMATION, config),
                         operator,
                         InternalTypeInfo.of(getOutputType()),
                         timestampedInputTransform.getParallelism());
@@ -276,7 +276,7 @@ public class StreamExecMatch extends ExecNodeBase<RowData>
                     ExecNodeUtil.createOneInputTransformation(
                             inputTransform,
                             new TransformationMetadata(
-                                    getOperatorUid(TIMESTAMP_INSERTER_OPERATOR),
+                                    createTransformationUid(TIMESTAMP_INSERTER_TRANSFORMATION),
                                     "StreamRecordTimestampInserter",
                                     String.format(
                                             "StreamRecordTimestampInserter(rowtime field: %s)",

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecMatch.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecMatch.java
@@ -92,13 +92,17 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @ExecNodeMetadata(
         name = "stream-exec-match",
         version = 1,
+        producedOperators = {
+            StreamExecMatch.TIMESTAMP_INSERTER_OPERATOR,
+            StreamExecMatch.MATCH_OPERATOR
+        },
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecMatch extends ExecNodeBase<RowData>
         implements StreamExecNode<RowData>, MultipleTransformationTranslator<RowData> {
 
-    private static final String TIMESTAMP_INSERTER_OPERATOR = "timestamp-inserter";
-    private static final String MATCH_OPERATOR = "match";
+    public static final String TIMESTAMP_INSERTER_OPERATOR = "timestamp-inserter";
+    public static final String MATCH_OPERATOR = "match";
 
     public static final String FIELD_NAME_MATCH_SPEC = "matchSpec";
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecMiniBatchAssigner.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecMiniBatchAssigner.java
@@ -58,12 +58,13 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @ExecNodeMetadata(
         name = "stream-exec-mini-batch-assigner",
         version = 1,
+        producedOperators = StreamExecMiniBatchAssigner.MINI_BATCH_ASSIGNER_OPERATOR,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecMiniBatchAssigner extends ExecNodeBase<RowData>
         implements StreamExecNode<RowData>, SingleTransformationTranslator<RowData> {
 
-    private static final String MINI_BATCH_ASSIGNER_OPERATOR = "mini-batch-assigner";
+    public static final String MINI_BATCH_ASSIGNER_OPERATOR = "mini-batch-assigner";
 
     public static final String FIELD_NAME_MINI_BATCH_INTERVAL = "miniBatchInterval";
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecMiniBatchAssigner.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecMiniBatchAssigner.java
@@ -117,7 +117,8 @@ public class StreamExecMiniBatchAssigner extends ExecNodeBase<RowData>
 
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getTransformationMeta(MINI_BATCH_ASSIGNER_TRANSFORMATION, planner.getTableConfig()),
+                createTransformationMeta(
+                        MINI_BATCH_ASSIGNER_TRANSFORMATION, planner.getTableConfig()),
                 operator,
                 InternalTypeInfo.of(getOutputType()),
                 inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecMiniBatchAssigner.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecMiniBatchAssigner.java
@@ -58,13 +58,13 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @ExecNodeMetadata(
         name = "stream-exec-mini-batch-assigner",
         version = 1,
-        producedOperators = StreamExecMiniBatchAssigner.MINI_BATCH_ASSIGNER_OPERATOR,
+        producedTransformations = StreamExecMiniBatchAssigner.MINI_BATCH_ASSIGNER_TRANSFORMATION,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecMiniBatchAssigner extends ExecNodeBase<RowData>
         implements StreamExecNode<RowData>, SingleTransformationTranslator<RowData> {
 
-    public static final String MINI_BATCH_ASSIGNER_OPERATOR = "mini-batch-assigner";
+    public static final String MINI_BATCH_ASSIGNER_TRANSFORMATION = "mini-batch-assigner";
 
     public static final String FIELD_NAME_MINI_BATCH_INTERVAL = "miniBatchInterval";
 
@@ -117,7 +117,7 @@ public class StreamExecMiniBatchAssigner extends ExecNodeBase<RowData>
 
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getOperatorMeta(MINI_BATCH_ASSIGNER_OPERATOR, planner.getTableConfig()),
+                getTransformationMeta(MINI_BATCH_ASSIGNER_TRANSFORMATION, planner.getTableConfig()),
                 operator,
                 InternalTypeInfo.of(getOutputType()),
                 inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecMiniBatchAssigner.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecMiniBatchAssigner.java
@@ -63,6 +63,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public class StreamExecMiniBatchAssigner extends ExecNodeBase<RowData>
         implements StreamExecNode<RowData>, SingleTransformationTranslator<RowData> {
 
+    private static final String MINI_BATCH_ASSIGNER_OPERATOR = "mini-batch-assigner";
+
     public static final String FIELD_NAME_MINI_BATCH_INTERVAL = "miniBatchInterval";
 
     @JsonProperty(FIELD_NAME_MINI_BATCH_INTERVAL)
@@ -114,8 +116,7 @@ public class StreamExecMiniBatchAssigner extends ExecNodeBase<RowData>
 
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getOperatorName(planner.getTableConfig()),
-                getOperatorDescription(planner.getTableConfig()),
+                getOperatorMeta(MINI_BATCH_ASSIGNER_OPERATOR, planner.getTableConfig()),
                 operator,
                 InternalTypeInfo.of(getOutputType()),
                 inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecOverAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecOverAggregate.java
@@ -87,7 +87,10 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecOverAggregate extends ExecNodeBase<RowData>
         implements StreamExecNode<RowData>, SingleTransformationTranslator<RowData> {
+
     private static final Logger LOG = LoggerFactory.getLogger(StreamExecOverAggregate.class);
+
+    private static final String OVER_AGGREGATE_OPERATOR = "over-aggregate";
 
     public static final String FIELD_NAME_OVER_SPEC = "overSpec";
 
@@ -230,8 +233,7 @@ public class StreamExecOverAggregate extends ExecNodeBase<RowData>
         OneInputTransformation<RowData, RowData> transform =
                 ExecNodeUtil.createOneInputTransformation(
                         inputTransform,
-                        getOperatorName(tableConfig),
-                        getOperatorDescription(tableConfig),
+                        getOperatorMeta(OVER_AGGREGATE_OPERATOR, tableConfig),
                         operator,
                         InternalTypeInfo.of(getOutputType()),
                         inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecOverAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecOverAggregate.java
@@ -234,7 +234,7 @@ public class StreamExecOverAggregate extends ExecNodeBase<RowData>
         OneInputTransformation<RowData, RowData> transform =
                 ExecNodeUtil.createOneInputTransformation(
                         inputTransform,
-                        getTransformationMeta(OVER_AGGREGATE_TRANSFORMATION, tableConfig),
+                        createTransformationMeta(OVER_AGGREGATE_TRANSFORMATION, tableConfig),
                         operator,
                         InternalTypeInfo.of(getOutputType()),
                         inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecOverAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecOverAggregate.java
@@ -83,6 +83,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @ExecNodeMetadata(
         name = "stream-exec-over-aggregate",
         version = 1,
+        producedOperators = StreamExecOverAggregate.OVER_AGGREGATE_OPERATOR,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecOverAggregate extends ExecNodeBase<RowData>
@@ -90,7 +91,7 @@ public class StreamExecOverAggregate extends ExecNodeBase<RowData>
 
     private static final Logger LOG = LoggerFactory.getLogger(StreamExecOverAggregate.class);
 
-    private static final String OVER_AGGREGATE_OPERATOR = "over-aggregate";
+    public static final String OVER_AGGREGATE_OPERATOR = "over-aggregate";
 
     public static final String FIELD_NAME_OVER_SPEC = "overSpec";
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecOverAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecOverAggregate.java
@@ -83,7 +83,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @ExecNodeMetadata(
         name = "stream-exec-over-aggregate",
         version = 1,
-        producedOperators = StreamExecOverAggregate.OVER_AGGREGATE_OPERATOR,
+        producedTransformations = StreamExecOverAggregate.OVER_AGGREGATE_TRANSFORMATION,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecOverAggregate extends ExecNodeBase<RowData>
@@ -91,7 +91,7 @@ public class StreamExecOverAggregate extends ExecNodeBase<RowData>
 
     private static final Logger LOG = LoggerFactory.getLogger(StreamExecOverAggregate.class);
 
-    public static final String OVER_AGGREGATE_OPERATOR = "over-aggregate";
+    public static final String OVER_AGGREGATE_TRANSFORMATION = "over-aggregate";
 
     public static final String FIELD_NAME_OVER_SPEC = "overSpec";
 
@@ -234,7 +234,7 @@ public class StreamExecOverAggregate extends ExecNodeBase<RowData>
         OneInputTransformation<RowData, RowData> transform =
                 ExecNodeUtil.createOneInputTransformation(
                         inputTransform,
-                        getOperatorMeta(OVER_AGGREGATE_OPERATOR, tableConfig),
+                        getTransformationMeta(OVER_AGGREGATE_TRANSFORMATION, tableConfig),
                         operator,
                         InternalTypeInfo.of(getOutputType()),
                         inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonCalc.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonCalc.java
@@ -39,6 +39,7 @@ import java.util.List;
 @ExecNodeMetadata(
         name = "stream-exec-python-calc",
         version = 1,
+        producedOperators = CommonExecPythonCalc.PYTHON_CALC_OPERATOR,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecPythonCalc extends CommonExecPythonCalc implements StreamExecNode<RowData> {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonCalc.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonCalc.java
@@ -39,7 +39,7 @@ import java.util.List;
 @ExecNodeMetadata(
         name = "stream-exec-python-calc",
         version = 1,
-        producedOperators = CommonExecPythonCalc.PYTHON_CALC_OPERATOR,
+        producedTransformations = CommonExecPythonCalc.PYTHON_CALC_TRANSFORMATION,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecPythonCalc extends CommonExecPythonCalc implements StreamExecNode<RowData> {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonCorrelate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonCorrelate.java
@@ -40,7 +40,7 @@ import java.util.List;
 @ExecNodeMetadata(
         name = "stream-exec-python-correlate",
         version = 1,
-        producedOperators = CommonExecPythonCorrelate.PYTHON_CORRELATE_OPERATOR,
+        producedTransformations = CommonExecPythonCorrelate.PYTHON_CORRELATE_TRANSFORMATION,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecPythonCorrelate extends CommonExecPythonCorrelate

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonCorrelate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonCorrelate.java
@@ -40,6 +40,7 @@ import java.util.List;
 @ExecNodeMetadata(
         name = "stream-exec-python-correlate",
         version = 1,
+        producedOperators = CommonExecPythonCorrelate.PYTHON_CORRELATE_OPERATOR,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecPythonCorrelate extends CommonExecPythonCorrelate

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonGroupAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonGroupAggregate.java
@@ -65,14 +65,14 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @ExecNodeMetadata(
         name = "stream-exec-python-group-aggregate",
         version = 1,
-        producedOperators = StreamExecPythonGroupAggregate.GROUP_AGGREGATE_OPERATOR,
+        producedTransformations = StreamExecPythonGroupAggregate.GROUP_AGGREGATE_TRANSFORMATION,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecPythonGroupAggregate extends StreamExecAggregateBase {
 
     private static final Logger LOG = LoggerFactory.getLogger(StreamExecPythonGroupAggregate.class);
 
-    public static final String GROUP_AGGREGATE_OPERATOR = "group-aggregate";
+    public static final String GROUP_AGGREGATE_TRANSFORMATION = "group-aggregate";
 
     private static final String PYTHON_STREAM_AGGREAGTE_OPERATOR_NAME =
             "org.apache.flink.table.runtime.operators.python.aggregate.PythonStreamGroupAggregateOperator";
@@ -182,7 +182,7 @@ public class StreamExecPythonGroupAggregate extends StreamExecAggregateBase {
         OneInputTransformation<RowData, RowData> transform =
                 ExecNodeUtil.createOneInputTransformation(
                         inputTransform,
-                        getOperatorMeta(GROUP_AGGREGATE_OPERATOR, config),
+                        getTransformationMeta(GROUP_AGGREGATE_TRANSFORMATION, config),
                         operator,
                         InternalTypeInfo.of(getOutputType()),
                         inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonGroupAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonGroupAggregate.java
@@ -65,13 +65,14 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @ExecNodeMetadata(
         name = "stream-exec-python-group-aggregate",
         version = 1,
+        producedOperators = StreamExecPythonGroupAggregate.GROUP_AGGREGATE_OPERATOR,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecPythonGroupAggregate extends StreamExecAggregateBase {
 
     private static final Logger LOG = LoggerFactory.getLogger(StreamExecPythonGroupAggregate.class);
 
-    private static final String GROUP_AGGREGATE_OPERATOR = "group-aggregate";
+    public static final String GROUP_AGGREGATE_OPERATOR = "group-aggregate";
 
     private static final String PYTHON_STREAM_AGGREAGTE_OPERATOR_NAME =
             "org.apache.flink.table.runtime.operators.python.aggregate.PythonStreamGroupAggregateOperator";

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonGroupAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonGroupAggregate.java
@@ -182,7 +182,7 @@ public class StreamExecPythonGroupAggregate extends StreamExecAggregateBase {
         OneInputTransformation<RowData, RowData> transform =
                 ExecNodeUtil.createOneInputTransformation(
                         inputTransform,
-                        getTransformationMeta(GROUP_AGGREGATE_TRANSFORMATION, config),
+                        createTransformationMeta(GROUP_AGGREGATE_TRANSFORMATION, config),
                         operator,
                         InternalTypeInfo.of(getOutputType()),
                         inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonGroupAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonGroupAggregate.java
@@ -70,6 +70,9 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public class StreamExecPythonGroupAggregate extends StreamExecAggregateBase {
 
     private static final Logger LOG = LoggerFactory.getLogger(StreamExecPythonGroupAggregate.class);
+
+    private static final String GROUP_AGGREGATE_OPERATOR = "group-aggregate";
+
     private static final String PYTHON_STREAM_AGGREAGTE_OPERATOR_NAME =
             "org.apache.flink.table.runtime.operators.python.aggregate.PythonStreamGroupAggregateOperator";
 
@@ -178,8 +181,7 @@ public class StreamExecPythonGroupAggregate extends StreamExecAggregateBase {
         OneInputTransformation<RowData, RowData> transform =
                 ExecNodeUtil.createOneInputTransformation(
                         inputTransform,
-                        getOperatorName(config),
-                        getOperatorDescription(config),
+                        getOperatorMeta(GROUP_AGGREGATE_OPERATOR, config),
                         operator,
                         InternalTypeInfo.of(getOutputType()),
                         inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonGroupTableAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonGroupTableAggregate.java
@@ -142,7 +142,7 @@ public class StreamExecPythonGroupTableAggregate extends ExecNodeBase<RowData>
         OneInputTransformation<RowData, RowData> transform =
                 ExecNodeUtil.createOneInputTransformation(
                         inputTransform,
-                        getTransformationMeta(GROUP_TABLE_AGGREGATE_TRANSFORMATION, config),
+                        createTransformationMeta(GROUP_TABLE_AGGREGATE_TRANSFORMATION, config),
                         pythonOperator,
                         InternalTypeInfo.of(getOutputType()),
                         inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonGroupTableAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonGroupTableAggregate.java
@@ -58,12 +58,16 @@ import java.util.Collections;
 /** Stream {@link ExecNode} for unbounded python group table aggregate. */
 public class StreamExecPythonGroupTableAggregate extends ExecNodeBase<RowData>
         implements StreamExecNode<RowData>, SingleTransformationTranslator<RowData> {
+
     private static final Logger LOG =
             LoggerFactory.getLogger(StreamExecPythonGroupTableAggregate.class);
+
+    private static final String GROUP_TABLE_AGGREGATE_OPERATOR = "group-table-aggregate";
 
     private static final String PYTHON_STREAM_TABLE_AGGREGATE_OPERATOR_NAME =
             "org.apache.flink.table.runtime.operators.python.aggregate."
                     + "PythonStreamGroupTableAggregateOperator";
+
     private final int[] grouping;
     private final AggregateCall[] aggCalls;
     private final boolean[] aggCallNeedRetractions;
@@ -138,8 +142,7 @@ public class StreamExecPythonGroupTableAggregate extends ExecNodeBase<RowData>
         OneInputTransformation<RowData, RowData> transform =
                 ExecNodeUtil.createOneInputTransformation(
                         inputTransform,
-                        getOperatorName(config),
-                        getOperatorDescription(config),
+                        getOperatorMeta(GROUP_TABLE_AGGREGATE_OPERATOR, config),
                         pythonOperator,
                         InternalTypeInfo.of(getOutputType()),
                         inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonGroupTableAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonGroupTableAggregate.java
@@ -62,8 +62,6 @@ public class StreamExecPythonGroupTableAggregate extends ExecNodeBase<RowData>
     private static final Logger LOG =
             LoggerFactory.getLogger(StreamExecPythonGroupTableAggregate.class);
 
-    private static final String GROUP_TABLE_AGGREGATE_TRANSFORMATION = "group-table-aggregate";
-
     private static final String PYTHON_STREAM_TABLE_AGGREGATE_OPERATOR_NAME =
             "org.apache.flink.table.runtime.operators.python.aggregate."
                     + "PythonStreamGroupTableAggregateOperator";
@@ -142,7 +140,8 @@ public class StreamExecPythonGroupTableAggregate extends ExecNodeBase<RowData>
         OneInputTransformation<RowData, RowData> transform =
                 ExecNodeUtil.createOneInputTransformation(
                         inputTransform,
-                        createTransformationMeta(GROUP_TABLE_AGGREGATE_TRANSFORMATION, config),
+                        createTransformationName(config),
+                        createTransformationDescription(config),
                         pythonOperator,
                         InternalTypeInfo.of(getOutputType()),
                         inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonGroupTableAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonGroupTableAggregate.java
@@ -62,7 +62,7 @@ public class StreamExecPythonGroupTableAggregate extends ExecNodeBase<RowData>
     private static final Logger LOG =
             LoggerFactory.getLogger(StreamExecPythonGroupTableAggregate.class);
 
-    private static final String GROUP_TABLE_AGGREGATE_OPERATOR = "group-table-aggregate";
+    private static final String GROUP_TABLE_AGGREGATE_TRANSFORMATION = "group-table-aggregate";
 
     private static final String PYTHON_STREAM_TABLE_AGGREGATE_OPERATOR_NAME =
             "org.apache.flink.table.runtime.operators.python.aggregate."
@@ -142,7 +142,7 @@ public class StreamExecPythonGroupTableAggregate extends ExecNodeBase<RowData>
         OneInputTransformation<RowData, RowData> transform =
                 ExecNodeUtil.createOneInputTransformation(
                         inputTransform,
-                        getOperatorMeta(GROUP_TABLE_AGGREGATE_OPERATOR, config),
+                        getTransformationMeta(GROUP_TABLE_AGGREGATE_TRANSFORMATION, config),
                         pythonOperator,
                         InternalTypeInfo.of(getOutputType()),
                         inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonGroupWindowAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonGroupWindowAggregate.java
@@ -110,8 +110,11 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecPythonGroupWindowAggregate extends StreamExecAggregateBase {
+
     private static final Logger LOGGER =
             LoggerFactory.getLogger(StreamExecPythonGroupWindowAggregate.class);
+
+    private static final String GROUP_WINDOW_AGGREGATE_OPERATOR = "group-window-aggregate";
 
     private static final String ARROW_STREAM_PYTHON_GROUP_WINDOW_AGGREGATE_FUNCTION_OPERATOR_NAME =
             "org.apache.flink.table.runtime.operators.python.aggregate.arrow.stream."
@@ -405,8 +408,7 @@ public class StreamExecPythonGroupWindowAggregate extends StreamExecAggregateBas
                         shiftTimeZone);
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getOperatorName(mergedConfig),
-                getOperatorDescription(mergedConfig),
+                getOperatorMeta(GROUP_WINDOW_AGGREGATE_OPERATOR, tableConfig),
                 pythonOperator,
                 InternalTypeInfo.of(outputRowType),
                 inputTransform.getParallelism());
@@ -446,8 +448,7 @@ public class StreamExecPythonGroupWindowAggregate extends StreamExecAggregateBas
 
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getOperatorName(config),
-                getOperatorDescription(config),
+                getOperatorMeta(GROUP_WINDOW_AGGREGATE_OPERATOR, config),
                 pythonOperator,
                 InternalTypeInfo.of(outputRowType),
                 inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonGroupWindowAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonGroupWindowAggregate.java
@@ -408,7 +408,7 @@ public class StreamExecPythonGroupWindowAggregate extends StreamExecAggregateBas
                         shiftTimeZone);
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getTransformationMeta(GROUP_WINDOW_AGGREGATE_TRANSFORMATION, tableConfig),
+                createTransformationMeta(GROUP_WINDOW_AGGREGATE_TRANSFORMATION, tableConfig),
                 pythonOperator,
                 InternalTypeInfo.of(outputRowType),
                 inputTransform.getParallelism());
@@ -448,7 +448,7 @@ public class StreamExecPythonGroupWindowAggregate extends StreamExecAggregateBas
 
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getTransformationMeta(GROUP_WINDOW_AGGREGATE_TRANSFORMATION, config),
+                createTransformationMeta(GROUP_WINDOW_AGGREGATE_TRANSFORMATION, config),
                 pythonOperator,
                 InternalTypeInfo.of(outputRowType),
                 inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonGroupWindowAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonGroupWindowAggregate.java
@@ -114,7 +114,7 @@ public class StreamExecPythonGroupWindowAggregate extends StreamExecAggregateBas
     private static final Logger LOGGER =
             LoggerFactory.getLogger(StreamExecPythonGroupWindowAggregate.class);
 
-    private static final String GROUP_WINDOW_AGGREGATE_OPERATOR = "group-window-aggregate";
+    private static final String GROUP_WINDOW_AGGREGATE_TRANSFORMATION = "group-window-aggregate";
 
     private static final String ARROW_STREAM_PYTHON_GROUP_WINDOW_AGGREGATE_FUNCTION_OPERATOR_NAME =
             "org.apache.flink.table.runtime.operators.python.aggregate.arrow.stream."
@@ -408,7 +408,7 @@ public class StreamExecPythonGroupWindowAggregate extends StreamExecAggregateBas
                         shiftTimeZone);
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getOperatorMeta(GROUP_WINDOW_AGGREGATE_OPERATOR, tableConfig),
+                getTransformationMeta(GROUP_WINDOW_AGGREGATE_TRANSFORMATION, tableConfig),
                 pythonOperator,
                 InternalTypeInfo.of(outputRowType),
                 inputTransform.getParallelism());
@@ -448,7 +448,7 @@ public class StreamExecPythonGroupWindowAggregate extends StreamExecAggregateBas
 
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getOperatorMeta(GROUP_WINDOW_AGGREGATE_OPERATOR, config),
+                getTransformationMeta(GROUP_WINDOW_AGGREGATE_TRANSFORMATION, config),
                 pythonOperator,
                 InternalTypeInfo.of(outputRowType),
                 inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonOverAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonOverAggregate.java
@@ -73,6 +73,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @ExecNodeMetadata(
         name = "stream-exec-python-over-aggregate",
         version = 1,
+        producedOperators = StreamExecPythonOverAggregate.OVER_AGGREGATE_OPERATOR,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecPythonOverAggregate extends ExecNodeBase<RowData>
@@ -80,7 +81,7 @@ public class StreamExecPythonOverAggregate extends ExecNodeBase<RowData>
 
     private static final Logger LOG = LoggerFactory.getLogger(StreamExecPythonOverAggregate.class);
 
-    private static final String OVER_AGGREGATE_OPERATOR = "over-aggregate";
+    public static final String OVER_AGGREGATE_OPERATOR = "over-aggregate";
 
     private static final String
             ARROW_PYTHON_OVER_WINDOW_RANGE_ROW_TIME_AGGREGATE_FUNCTION_OPERATOR_NAME =

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonOverAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonOverAggregate.java
@@ -73,7 +73,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @ExecNodeMetadata(
         name = "stream-exec-python-over-aggregate",
         version = 1,
-        producedOperators = StreamExecPythonOverAggregate.OVER_AGGREGATE_OPERATOR,
+        producedTransformations = StreamExecPythonOverAggregate.OVER_AGGREGATE_TRANSFORMATION,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecPythonOverAggregate extends ExecNodeBase<RowData>
@@ -81,7 +81,7 @@ public class StreamExecPythonOverAggregate extends ExecNodeBase<RowData>
 
     private static final Logger LOG = LoggerFactory.getLogger(StreamExecPythonOverAggregate.class);
 
-    public static final String OVER_AGGREGATE_OPERATOR = "over-aggregate";
+    public static final String OVER_AGGREGATE_TRANSFORMATION = "over-aggregate";
 
     private static final String
             ARROW_PYTHON_OVER_WINDOW_RANGE_ROW_TIME_AGGREGATE_FUNCTION_OPERATOR_NAME =
@@ -253,7 +253,7 @@ public class StreamExecPythonOverAggregate extends ExecNodeBase<RowData>
 
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getOperatorMeta(OVER_AGGREGATE_OPERATOR, mergedConfig),
+                getTransformationMeta(OVER_AGGREGATE_TRANSFORMATION, mergedConfig),
                 pythonOperator,
                 InternalTypeInfo.of(outputRowType),
                 inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonOverAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonOverAggregate.java
@@ -253,7 +253,7 @@ public class StreamExecPythonOverAggregate extends ExecNodeBase<RowData>
 
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getTransformationMeta(OVER_AGGREGATE_TRANSFORMATION, mergedConfig),
+                createTransformationMeta(OVER_AGGREGATE_TRANSFORMATION, mergedConfig),
                 pythonOperator,
                 InternalTypeInfo.of(outputRowType),
                 inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonOverAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonOverAggregate.java
@@ -77,7 +77,10 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecPythonOverAggregate extends ExecNodeBase<RowData>
         implements StreamExecNode<RowData>, SingleTransformationTranslator<RowData> {
+
     private static final Logger LOG = LoggerFactory.getLogger(StreamExecPythonOverAggregate.class);
+
+    private static final String OVER_AGGREGATE_OPERATOR = "over-aggregate";
 
     private static final String
             ARROW_PYTHON_OVER_WINDOW_RANGE_ROW_TIME_AGGREGATE_FUNCTION_OPERATOR_NAME =
@@ -249,8 +252,7 @@ public class StreamExecPythonOverAggregate extends ExecNodeBase<RowData>
 
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getOperatorName(mergedConfig),
-                getOperatorDescription(mergedConfig),
+                getOperatorMeta(OVER_AGGREGATE_OPERATOR, mergedConfig),
                 pythonOperator,
                 InternalTypeInfo.of(outputRowType),
                 inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecRank.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecRank.java
@@ -322,7 +322,7 @@ public class StreamExecRank extends ExecNodeBase<RowData>
         OneInputTransformation<RowData, RowData> transform =
                 ExecNodeUtil.createOneInputTransformation(
                         inputTransform,
-                        getTransformationMeta(RANK_TRANSFORMATION, tableConfig),
+                        createTransformationMeta(RANK_TRANSFORMATION, tableConfig),
                         operator,
                         InternalTypeInfo.of((RowType) getOutputType()),
                         inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecRank.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecRank.java
@@ -75,12 +75,13 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @ExecNodeMetadata(
         name = "stream-exec-rank",
         version = 1,
+        producedOperators = StreamExecRank.RANK_OPERATOR,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecRank extends ExecNodeBase<RowData>
         implements StreamExecNode<RowData>, SingleTransformationTranslator<RowData> {
 
-    private static final String RANK_OPERATOR = "rank";
+    public static final String RANK_OPERATOR = "rank";
 
     public static final String FIELD_NAME_RANK_TYPE = "rankType";
     public static final String FIELD_NAME_PARTITION_SPEC = "partition";

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecRank.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecRank.java
@@ -80,6 +80,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public class StreamExecRank extends ExecNodeBase<RowData>
         implements StreamExecNode<RowData>, SingleTransformationTranslator<RowData> {
 
+    private static final String RANK_OPERATOR = "rank";
+
     public static final String FIELD_NAME_RANK_TYPE = "rankType";
     public static final String FIELD_NAME_PARTITION_SPEC = "partition";
     public static final String FIELD_NAME_SORT_SPEC = "orderBy";
@@ -319,8 +321,7 @@ public class StreamExecRank extends ExecNodeBase<RowData>
         OneInputTransformation<RowData, RowData> transform =
                 ExecNodeUtil.createOneInputTransformation(
                         inputTransform,
-                        getOperatorName(tableConfig),
-                        getOperatorDescription(tableConfig),
+                        getOperatorMeta(RANK_OPERATOR, tableConfig),
                         operator,
                         InternalTypeInfo.of((RowType) getOutputType()),
                         inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecRank.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecRank.java
@@ -75,13 +75,13 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @ExecNodeMetadata(
         name = "stream-exec-rank",
         version = 1,
-        producedOperators = StreamExecRank.RANK_OPERATOR,
+        producedTransformations = StreamExecRank.RANK_TRANSFORMATION,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecRank extends ExecNodeBase<RowData>
         implements StreamExecNode<RowData>, SingleTransformationTranslator<RowData> {
 
-    public static final String RANK_OPERATOR = "rank";
+    public static final String RANK_TRANSFORMATION = "rank";
 
     public static final String FIELD_NAME_RANK_TYPE = "rankType";
     public static final String FIELD_NAME_PARTITION_SPEC = "partition";
@@ -322,7 +322,7 @@ public class StreamExecRank extends ExecNodeBase<RowData>
         OneInputTransformation<RowData, RowData> transform =
                 ExecNodeUtil.createOneInputTransformation(
                         inputTransform,
-                        getOperatorMeta(RANK_OPERATOR, tableConfig),
+                        getTransformationMeta(RANK_TRANSFORMATION, tableConfig),
                         operator,
                         InternalTypeInfo.of((RowType) getOutputType()),
                         inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecSink.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecSink.java
@@ -57,12 +57,12 @@ import java.util.stream.Collectors;
 @ExecNodeMetadata(
         name = "stream-exec-sink",
         version = 1,
-        producedOperators = {
-            CommonExecSink.CONSTRAINT_VALIDATOR_OPERATOR,
-            CommonExecSink.PARTITIONER_OPERATOR,
-            CommonExecSink.UPSERT_MATERIALIZE_OPERATOR,
-            CommonExecSink.TIMESTAMP_INSERTER_OPERATOR,
-            CommonExecSink.SINK_OPERATOR
+        producedTransformations = {
+            CommonExecSink.CONSTRAINT_VALIDATOR_TRANSFORMATION,
+            CommonExecSink.PARTITIONER_TRANSFORMATION,
+            CommonExecSink.UPSERT_MATERIALIZE_TRANSFORMATION,
+            CommonExecSink.TIMESTAMP_INSERTER_TRANSFORMATION,
+            CommonExecSink.SINK_TRANSFORMATION
         },
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecSink.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecSink.java
@@ -57,6 +57,13 @@ import java.util.stream.Collectors;
 @ExecNodeMetadata(
         name = "stream-exec-sink",
         version = 1,
+        producedOperators = {
+            CommonExecSink.CONSTRAINT_VALIDATOR_OPERATOR,
+            CommonExecSink.PARTITIONER_OPERATOR,
+            CommonExecSink.UPSERT_MATERIALIZE_OPERATOR,
+            CommonExecSink.TIMESTAMP_INSERTER_OPERATOR,
+            CommonExecSink.SINK_OPERATOR
+        },
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecSink extends CommonExecSink implements StreamExecNode<Object> {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecSort.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecSort.java
@@ -48,7 +48,7 @@ import java.util.Collections;
  */
 public class StreamExecSort extends ExecNodeBase<RowData> implements StreamExecNode<RowData> {
 
-    private static final String SORT_OPERATOR = "sort";
+    private static final String SORT_TRANSFORMATION = "sort";
 
     @Experimental
     public static final ConfigOption<Boolean> TABLE_EXEC_NON_TEMPORAL_SORT_ENABLED =
@@ -96,7 +96,7 @@ public class StreamExecSort extends ExecNodeBase<RowData> implements StreamExecN
 
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getOperatorMeta(SORT_OPERATOR, config),
+                createTransformationMeta(SORT_TRANSFORMATION, config),
                 sortOperator,
                 InternalTypeInfo.of(inputType),
                 inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecSort.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecSort.java
@@ -48,6 +48,8 @@ import java.util.Collections;
  */
 public class StreamExecSort extends ExecNodeBase<RowData> implements StreamExecNode<RowData> {
 
+    private static final String SORT_OPERATOR = "sort";
+
     @Experimental
     public static final ConfigOption<Boolean> TABLE_EXEC_NON_TEMPORAL_SORT_ENABLED =
             ConfigOptions.key("table.exec.non-temporal-sort.enabled")
@@ -94,8 +96,7 @@ public class StreamExecSort extends ExecNodeBase<RowData> implements StreamExecN
 
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getOperatorName(config),
-                getOperatorDescription(config),
+                getOperatorMeta(SORT_OPERATOR, config),
                 sortOperator,
                 InternalTypeInfo.of(inputType),
                 inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecSortLimit.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecSortLimit.java
@@ -43,6 +43,7 @@ import java.util.List;
 @ExecNodeMetadata(
         name = "stream-exec-sort-limit",
         version = 1,
+        producedOperators = StreamExecRank.RANK_OPERATOR,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecSortLimit extends StreamExecRank {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecSortLimit.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecSortLimit.java
@@ -43,7 +43,7 @@ import java.util.List;
 @ExecNodeMetadata(
         name = "stream-exec-sort-limit",
         version = 1,
-        producedOperators = StreamExecRank.RANK_OPERATOR,
+        producedTransformations = StreamExecRank.RANK_TRANSFORMATION,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecSortLimit extends StreamExecRank {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecTableSourceScan.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecTableSourceScan.java
@@ -42,6 +42,7 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonPro
 @ExecNodeMetadata(
         name = "stream-exec-table-source-scan",
         version = 1,
+        producedOperators = CommonExecTableSourceScan.SOURCE_OPERATOR,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecTableSourceScan extends CommonExecTableSourceScan

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecTableSourceScan.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecTableSourceScan.java
@@ -42,7 +42,7 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonPro
 @ExecNodeMetadata(
         name = "stream-exec-table-source-scan",
         version = 1,
-        producedOperators = CommonExecTableSourceScan.SOURCE_OPERATOR,
+        producedTransformations = CommonExecTableSourceScan.SOURCE_TRANSFORMATION,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecTableSourceScan extends CommonExecTableSourceScan

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecTemporalJoin.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecTemporalJoin.java
@@ -180,7 +180,7 @@ public class StreamExecTemporalJoin extends ExecNodeBase<RowData>
                 ExecNodeUtil.createTwoInputTransformation(
                         leftTransform,
                         rightTransform,
-                        getTransformationMeta(
+                        createTransformationMeta(
                                 TEMPORAL_JOIN_TRANSFORMATION, planner.getTableConfig()),
                         joinOperator,
                         InternalTypeInfo.of(returnType),

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecTemporalJoin.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecTemporalJoin.java
@@ -74,6 +74,8 @@ import java.util.Optional;
 public class StreamExecTemporalJoin extends ExecNodeBase<RowData>
         implements StreamExecNode<RowData>, SingleTransformationTranslator<RowData> {
 
+    private static final String TEMPORAL_JOIN_OPERATOR = "temporal-join";
+
     public static final String FIELD_NAME_JOIN_SPEC = "joinSpec";
     public static final String FIELD_NAME_IS_TEMPORAL_FUNCTION_JOIN = "isTemporalFunctionJoin";
     public static final String FIELD_NAME_LEFT_TIME_ATTRIBUTE_INDEX = "leftTimeAttributeIndex";
@@ -177,8 +179,7 @@ public class StreamExecTemporalJoin extends ExecNodeBase<RowData>
                 ExecNodeUtil.createTwoInputTransformation(
                         leftTransform,
                         rightTransform,
-                        getOperatorName(planner.getTableConfig()),
-                        getOperatorDescription(planner.getTableConfig()),
+                        getOperatorMeta(TEMPORAL_JOIN_OPERATOR, planner.getTableConfig()),
                         joinOperator,
                         InternalTypeInfo.of(returnType),
                         leftTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecTemporalJoin.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecTemporalJoin.java
@@ -69,12 +69,13 @@ import java.util.Optional;
 @ExecNodeMetadata(
         name = "stream-exec-temporal-join",
         version = 1,
+        producedOperators = StreamExecTemporalJoin.TEMPORAL_JOIN_OPERATOR,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecTemporalJoin extends ExecNodeBase<RowData>
         implements StreamExecNode<RowData>, SingleTransformationTranslator<RowData> {
 
-    private static final String TEMPORAL_JOIN_OPERATOR = "temporal-join";
+    public static final String TEMPORAL_JOIN_OPERATOR = "temporal-join";
 
     public static final String FIELD_NAME_JOIN_SPEC = "joinSpec";
     public static final String FIELD_NAME_IS_TEMPORAL_FUNCTION_JOIN = "isTemporalFunctionJoin";

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecTemporalJoin.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecTemporalJoin.java
@@ -69,13 +69,13 @@ import java.util.Optional;
 @ExecNodeMetadata(
         name = "stream-exec-temporal-join",
         version = 1,
-        producedOperators = StreamExecTemporalJoin.TEMPORAL_JOIN_OPERATOR,
+        producedTransformations = StreamExecTemporalJoin.TEMPORAL_JOIN_TRANSFORMATION,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecTemporalJoin extends ExecNodeBase<RowData>
         implements StreamExecNode<RowData>, SingleTransformationTranslator<RowData> {
 
-    public static final String TEMPORAL_JOIN_OPERATOR = "temporal-join";
+    public static final String TEMPORAL_JOIN_TRANSFORMATION = "temporal-join";
 
     public static final String FIELD_NAME_JOIN_SPEC = "joinSpec";
     public static final String FIELD_NAME_IS_TEMPORAL_FUNCTION_JOIN = "isTemporalFunctionJoin";
@@ -180,7 +180,8 @@ public class StreamExecTemporalJoin extends ExecNodeBase<RowData>
                 ExecNodeUtil.createTwoInputTransformation(
                         leftTransform,
                         rightTransform,
-                        getOperatorMeta(TEMPORAL_JOIN_OPERATOR, planner.getTableConfig()),
+                        getTransformationMeta(
+                                TEMPORAL_JOIN_TRANSFORMATION, planner.getTableConfig()),
                         joinOperator,
                         InternalTypeInfo.of(returnType),
                         leftTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecTemporalSort.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecTemporalSort.java
@@ -144,7 +144,7 @@ public class StreamExecTemporalSort extends ExecNodeBase<RowData>
             OneInputTransformation<RowData, RowData> transform =
                     ExecNodeUtil.createOneInputTransformation(
                             inputTransform,
-                            getTransformationMeta(TEMPORAL_SORT_TRANSFORMATION, tableConfig),
+                            createTransformationMeta(TEMPORAL_SORT_TRANSFORMATION, tableConfig),
                             sortOperator,
                             InternalTypeInfo.of(inputType),
                             inputTransform.getParallelism());
@@ -185,7 +185,7 @@ public class StreamExecTemporalSort extends ExecNodeBase<RowData>
         OneInputTransformation<RowData, RowData> transform =
                 ExecNodeUtil.createOneInputTransformation(
                         inputTransform,
-                        getTransformationMeta(TEMPORAL_SORT_TRANSFORMATION, tableConfig),
+                        createTransformationMeta(TEMPORAL_SORT_TRANSFORMATION, tableConfig),
                         sortOperator,
                         InternalTypeInfo.of(inputType),
                         inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecTemporalSort.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecTemporalSort.java
@@ -57,13 +57,13 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @ExecNodeMetadata(
         name = "stream-exec-temporal-sort",
         version = 1,
-        producedOperators = StreamExecTemporalSort.TEMPORAL_SORT_OPERATOR,
+        producedTransformations = StreamExecTemporalSort.TEMPORAL_SORT_TRANSFORMATION,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecTemporalSort extends ExecNodeBase<RowData>
         implements StreamExecNode<RowData>, MultipleTransformationTranslator<RowData> {
 
-    public static final String TEMPORAL_SORT_OPERATOR = "temporal-sort";
+    public static final String TEMPORAL_SORT_TRANSFORMATION = "temporal-sort";
 
     public static final String FIELD_NAME_SORT_SPEC = "orderBy";
 
@@ -144,7 +144,7 @@ public class StreamExecTemporalSort extends ExecNodeBase<RowData>
             OneInputTransformation<RowData, RowData> transform =
                     ExecNodeUtil.createOneInputTransformation(
                             inputTransform,
-                            getOperatorMeta(TEMPORAL_SORT_OPERATOR, tableConfig),
+                            getTransformationMeta(TEMPORAL_SORT_TRANSFORMATION, tableConfig),
                             sortOperator,
                             InternalTypeInfo.of(inputType),
                             inputTransform.getParallelism());
@@ -185,7 +185,7 @@ public class StreamExecTemporalSort extends ExecNodeBase<RowData>
         OneInputTransformation<RowData, RowData> transform =
                 ExecNodeUtil.createOneInputTransformation(
                         inputTransform,
-                        getOperatorMeta(TEMPORAL_SORT_OPERATOR, tableConfig),
+                        getTransformationMeta(TEMPORAL_SORT_TRANSFORMATION, tableConfig),
                         sortOperator,
                         InternalTypeInfo.of(inputType),
                         inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecTemporalSort.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecTemporalSort.java
@@ -57,12 +57,13 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @ExecNodeMetadata(
         name = "stream-exec-temporal-sort",
         version = 1,
+        producedOperators = StreamExecTemporalSort.TEMPORAL_SORT_OPERATOR,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecTemporalSort extends ExecNodeBase<RowData>
         implements StreamExecNode<RowData>, MultipleTransformationTranslator<RowData> {
 
-    private static final String TEMPORAL_SORT_OPERATOR = "temporal-sort";
+    public static final String TEMPORAL_SORT_OPERATOR = "temporal-sort";
 
     public static final String FIELD_NAME_SORT_SPEC = "orderBy";
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecTemporalSort.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecTemporalSort.java
@@ -62,6 +62,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public class StreamExecTemporalSort extends ExecNodeBase<RowData>
         implements StreamExecNode<RowData>, MultipleTransformationTranslator<RowData> {
 
+    private static final String TEMPORAL_SORT_OPERATOR = "temporal-sort";
+
     public static final String FIELD_NAME_SORT_SPEC = "orderBy";
 
     @JsonProperty(FIELD_NAME_SORT_SPEC)
@@ -141,8 +143,7 @@ public class StreamExecTemporalSort extends ExecNodeBase<RowData>
             OneInputTransformation<RowData, RowData> transform =
                     ExecNodeUtil.createOneInputTransformation(
                             inputTransform,
-                            getOperatorName(tableConfig),
-                            getOperatorDescription(tableConfig),
+                            getOperatorMeta(TEMPORAL_SORT_OPERATOR, tableConfig),
                             sortOperator,
                             InternalTypeInfo.of(inputType),
                             inputTransform.getParallelism());
@@ -183,8 +184,7 @@ public class StreamExecTemporalSort extends ExecNodeBase<RowData>
         OneInputTransformation<RowData, RowData> transform =
                 ExecNodeUtil.createOneInputTransformation(
                         inputTransform,
-                        getOperatorName(tableConfig),
-                        getOperatorDescription(tableConfig),
+                        getOperatorMeta(TEMPORAL_SORT_OPERATOR, tableConfig),
                         sortOperator,
                         InternalTypeInfo.of(inputType),
                         inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecUnion.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecUnion.java
@@ -39,7 +39,7 @@ import java.util.List;
 @ExecNodeMetadata(
         name = "stream-exec-union",
         version = 1,
-        producedOperators = CommonExecUnion.UNION_OPERATOR,
+        producedTransformations = CommonExecUnion.UNION_TRANSFORMATION,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecUnion extends CommonExecUnion implements StreamExecNode<RowData> {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecUnion.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecUnion.java
@@ -39,6 +39,7 @@ import java.util.List;
 @ExecNodeMetadata(
         name = "stream-exec-union",
         version = 1,
+        producedOperators = CommonExecUnion.UNION_OPERATOR,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecUnion extends CommonExecUnion implements StreamExecNode<RowData> {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecUnion.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecUnion.java
@@ -39,7 +39,6 @@ import java.util.List;
 @ExecNodeMetadata(
         name = "stream-exec-union",
         version = 1,
-        producedTransformations = CommonExecUnion.UNION_TRANSFORMATION,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecUnion extends CommonExecUnion implements StreamExecNode<RowData> {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecValues.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecValues.java
@@ -37,6 +37,7 @@ import java.util.List;
 @ExecNodeMetadata(
         name = "stream-exec-values",
         version = 1,
+        producedOperators = CommonExecValues.VALUES_OPERATOR,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecValues extends CommonExecValues implements StreamExecNode<RowData> {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecValues.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecValues.java
@@ -37,7 +37,7 @@ import java.util.List;
 @ExecNodeMetadata(
         name = "stream-exec-values",
         version = 1,
-        producedOperators = CommonExecValues.VALUES_OPERATOR,
+        producedTransformations = CommonExecValues.VALUES_TRANSFORMATION,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecValues extends CommonExecValues implements StreamExecNode<RowData> {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWatermarkAssigner.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWatermarkAssigner.java
@@ -55,13 +55,13 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @ExecNodeMetadata(
         name = "stream-exec-watermark-assigner",
         version = 1,
-        producedOperators = StreamExecWatermarkAssigner.WATERMARK_ASSIGNER_OPERATOR,
+        producedTransformations = StreamExecWatermarkAssigner.WATERMARK_ASSIGNER_TRANSFORMATION,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecWatermarkAssigner extends ExecNodeBase<RowData>
         implements StreamExecNode<RowData>, SingleTransformationTranslator<RowData> {
 
-    public static final String WATERMARK_ASSIGNER_OPERATOR = "watermark-assigner";
+    public static final String WATERMARK_ASSIGNER_TRANSFORMATION = "watermark-assigner";
 
     public static final String FIELD_NAME_WATERMARK_EXPR = "watermarkExpr";
     public static final String FIELD_NAME_ROWTIME_FIELD_INDEX = "rowtimeFieldIndex";
@@ -130,7 +130,7 @@ public class StreamExecWatermarkAssigner extends ExecNodeBase<RowData>
 
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getOperatorMeta(WATERMARK_ASSIGNER_OPERATOR, planner.getTableConfig()),
+                getTransformationMeta(WATERMARK_ASSIGNER_TRANSFORMATION, planner.getTableConfig()),
                 operatorFactory,
                 InternalTypeInfo.of(getOutputType()),
                 inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWatermarkAssigner.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWatermarkAssigner.java
@@ -59,6 +59,9 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecWatermarkAssigner extends ExecNodeBase<RowData>
         implements StreamExecNode<RowData>, SingleTransformationTranslator<RowData> {
+
+    private static final String WATERMARK_ASSIGNER_OPERATOR = "watermark-assigner";
+
     public static final String FIELD_NAME_WATERMARK_EXPR = "watermarkExpr";
     public static final String FIELD_NAME_ROWTIME_FIELD_INDEX = "rowtimeFieldIndex";
 
@@ -126,8 +129,7 @@ public class StreamExecWatermarkAssigner extends ExecNodeBase<RowData>
 
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getOperatorName(planner.getTableConfig()),
-                getOperatorDescription(planner.getTableConfig()),
+                getOperatorMeta(WATERMARK_ASSIGNER_OPERATOR, planner.getTableConfig()),
                 operatorFactory,
                 InternalTypeInfo.of(getOutputType()),
                 inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWatermarkAssigner.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWatermarkAssigner.java
@@ -130,7 +130,8 @@ public class StreamExecWatermarkAssigner extends ExecNodeBase<RowData>
 
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,
-                getTransformationMeta(WATERMARK_ASSIGNER_TRANSFORMATION, planner.getTableConfig()),
+                createTransformationMeta(
+                        WATERMARK_ASSIGNER_TRANSFORMATION, planner.getTableConfig()),
                 operatorFactory,
                 InternalTypeInfo.of(getOutputType()),
                 inputTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWatermarkAssigner.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWatermarkAssigner.java
@@ -55,12 +55,13 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @ExecNodeMetadata(
         name = "stream-exec-watermark-assigner",
         version = 1,
+        producedOperators = StreamExecWatermarkAssigner.WATERMARK_ASSIGNER_OPERATOR,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecWatermarkAssigner extends ExecNodeBase<RowData>
         implements StreamExecNode<RowData>, SingleTransformationTranslator<RowData> {
 
-    private static final String WATERMARK_ASSIGNER_OPERATOR = "watermark-assigner";
+    public static final String WATERMARK_ASSIGNER_OPERATOR = "watermark-assigner";
 
     public static final String FIELD_NAME_WATERMARK_EXPR = "watermarkExpr";
     public static final String FIELD_NAME_ROWTIME_FIELD_INDEX = "rowtimeFieldIndex";

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowAggregate.java
@@ -81,6 +81,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecWindowAggregate extends StreamExecWindowAggregateBase {
 
+    private static final String WINDOW_AGGREGATE_OPERATOR = "window-aggregate";
+
     private static final long WINDOW_AGG_MEMORY_RATIO = 100;
 
     public static final String FIELD_NAME_WINDOWING = "windowing";
@@ -187,8 +189,7 @@ public class StreamExecWindowAggregate extends StreamExecWindowAggregateBase {
         final OneInputTransformation<RowData, RowData> transform =
                 ExecNodeUtil.createOneInputTransformation(
                         inputTransform,
-                        getOperatorName(planner.getTableConfig()),
-                        getOperatorDescription(planner.getTableConfig()),
+                        getOperatorMeta(WINDOW_AGGREGATE_OPERATOR, planner.getTableConfig()),
                         SimpleOperatorFactory.of(windowOperator),
                         InternalTypeInfo.of(getOutputType()),
                         inputTransform.getParallelism(),

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowAggregate.java
@@ -77,11 +77,12 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @ExecNodeMetadata(
         name = "stream-exec-window-aggregate",
         version = 1,
+        producedOperators = StreamExecWindowAggregate.WINDOW_AGGREGATE_OPERATOR,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecWindowAggregate extends StreamExecWindowAggregateBase {
 
-    private static final String WINDOW_AGGREGATE_OPERATOR = "window-aggregate";
+    public static final String WINDOW_AGGREGATE_OPERATOR = "window-aggregate";
 
     private static final long WINDOW_AGG_MEMORY_RATIO = 100;
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowAggregate.java
@@ -190,7 +190,7 @@ public class StreamExecWindowAggregate extends StreamExecWindowAggregateBase {
         final OneInputTransformation<RowData, RowData> transform =
                 ExecNodeUtil.createOneInputTransformation(
                         inputTransform,
-                        getTransformationMeta(
+                        createTransformationMeta(
                                 WINDOW_AGGREGATE_TRANSFORMATION, planner.getTableConfig()),
                         SimpleOperatorFactory.of(windowOperator),
                         InternalTypeInfo.of(getOutputType()),

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowAggregate.java
@@ -77,12 +77,12 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @ExecNodeMetadata(
         name = "stream-exec-window-aggregate",
         version = 1,
-        producedOperators = StreamExecWindowAggregate.WINDOW_AGGREGATE_OPERATOR,
+        producedTransformations = StreamExecWindowAggregate.WINDOW_AGGREGATE_TRANSFORMATION,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecWindowAggregate extends StreamExecWindowAggregateBase {
 
-    public static final String WINDOW_AGGREGATE_OPERATOR = "window-aggregate";
+    public static final String WINDOW_AGGREGATE_TRANSFORMATION = "window-aggregate";
 
     private static final long WINDOW_AGG_MEMORY_RATIO = 100;
 
@@ -190,7 +190,8 @@ public class StreamExecWindowAggregate extends StreamExecWindowAggregateBase {
         final OneInputTransformation<RowData, RowData> transform =
                 ExecNodeUtil.createOneInputTransformation(
                         inputTransform,
-                        getOperatorMeta(WINDOW_AGGREGATE_OPERATOR, planner.getTableConfig()),
+                        getTransformationMeta(
+                                WINDOW_AGGREGATE_TRANSFORMATION, planner.getTableConfig()),
                         SimpleOperatorFactory.of(windowOperator),
                         InternalTypeInfo.of(getOutputType()),
                         inputTransform.getParallelism(),

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowDeduplicate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowDeduplicate.java
@@ -168,7 +168,7 @@ public class StreamExecWindowDeduplicate extends ExecNodeBase<RowData>
         OneInputTransformation<RowData, RowData> transform =
                 ExecNodeUtil.createOneInputTransformation(
                         inputTransform,
-                        getTransformationMeta(WINDOW_DEDUPLICATE_TRANSFORMATION, tableConfig),
+                        createTransformationMeta(WINDOW_DEDUPLICATE_TRANSFORMATION, tableConfig),
                         SimpleOperatorFactory.of(operator),
                         InternalTypeInfo.of(getOutputType()),
                         inputTransform.getParallelism(),

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowDeduplicate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowDeduplicate.java
@@ -60,12 +60,13 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @ExecNodeMetadata(
         name = "stream-exec-window-deduplicate",
         version = 1,
+        producedOperators = StreamExecWindowDeduplicate.WINDOW_DEDUPLICATE_OPERATOR,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecWindowDeduplicate extends ExecNodeBase<RowData>
         implements StreamExecNode<RowData>, SingleTransformationTranslator<RowData> {
 
-    private static final String WINDOW_DEDUPLICATE_OPERATOR = "window-deduplicate";
+    public static final String WINDOW_DEDUPLICATE_OPERATOR = "window-deduplicate";
 
     private static final long WINDOW_RANK_MEMORY_RATIO = 100;
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowDeduplicate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowDeduplicate.java
@@ -60,13 +60,13 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @ExecNodeMetadata(
         name = "stream-exec-window-deduplicate",
         version = 1,
-        producedOperators = StreamExecWindowDeduplicate.WINDOW_DEDUPLICATE_OPERATOR,
+        producedTransformations = StreamExecWindowDeduplicate.WINDOW_DEDUPLICATE_TRANSFORMATION,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecWindowDeduplicate extends ExecNodeBase<RowData>
         implements StreamExecNode<RowData>, SingleTransformationTranslator<RowData> {
 
-    public static final String WINDOW_DEDUPLICATE_OPERATOR = "window-deduplicate";
+    public static final String WINDOW_DEDUPLICATE_TRANSFORMATION = "window-deduplicate";
 
     private static final long WINDOW_RANK_MEMORY_RATIO = 100;
 
@@ -168,7 +168,7 @@ public class StreamExecWindowDeduplicate extends ExecNodeBase<RowData>
         OneInputTransformation<RowData, RowData> transform =
                 ExecNodeUtil.createOneInputTransformation(
                         inputTransform,
-                        getOperatorMeta(WINDOW_DEDUPLICATE_OPERATOR, tableConfig),
+                        getTransformationMeta(WINDOW_DEDUPLICATE_TRANSFORMATION, tableConfig),
                         SimpleOperatorFactory.of(operator),
                         InternalTypeInfo.of(getOutputType()),
                         inputTransform.getParallelism(),

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowDeduplicate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowDeduplicate.java
@@ -65,6 +65,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public class StreamExecWindowDeduplicate extends ExecNodeBase<RowData>
         implements StreamExecNode<RowData>, SingleTransformationTranslator<RowData> {
 
+    private static final String WINDOW_DEDUPLICATE_OPERATOR = "window-deduplicate";
+
     private static final long WINDOW_RANK_MEMORY_RATIO = 100;
 
     public static final String FIELD_NAME_PARTITION_KEYS = "partitionKeys";
@@ -165,8 +167,7 @@ public class StreamExecWindowDeduplicate extends ExecNodeBase<RowData>
         OneInputTransformation<RowData, RowData> transform =
                 ExecNodeUtil.createOneInputTransformation(
                         inputTransform,
-                        getOperatorName(tableConfig),
-                        getOperatorDescription(tableConfig),
+                        getOperatorMeta(WINDOW_DEDUPLICATE_OPERATOR, tableConfig),
                         SimpleOperatorFactory.of(operator),
                         InternalTypeInfo.of(getOutputType()),
                         inputTransform.getParallelism(),

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowJoin.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowJoin.java
@@ -60,13 +60,13 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @ExecNodeMetadata(
         name = "stream-exec-window-join",
         version = 1,
-        producedOperators = StreamExecWindowJoin.WINDOW_JOIN_OPERATOR,
+        producedTransformations = StreamExecWindowJoin.WINDOW_JOIN_TRANSFORMATION,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecWindowJoin extends ExecNodeBase<RowData>
         implements StreamExecNode<RowData>, SingleTransformationTranslator<RowData> {
 
-    public static final String WINDOW_JOIN_OPERATOR = "window-join";
+    public static final String WINDOW_JOIN_TRANSFORMATION = "window-join";
 
     public static final String FIELD_NAME_JOIN_SPEC = "joinSpec";
     public static final String FIELD_NAME_LEFT_WINDOWING = "leftWindowing";
@@ -176,7 +176,7 @@ public class StreamExecWindowJoin extends ExecNodeBase<RowData>
                 ExecNodeUtil.createTwoInputTransformation(
                         leftTransform,
                         rightTransform,
-                        getOperatorMeta(WINDOW_JOIN_OPERATOR, planner.getTableConfig()),
+                        getTransformationMeta(WINDOW_JOIN_TRANSFORMATION, planner.getTableConfig()),
                         operator,
                         InternalTypeInfo.of(returnType),
                         leftTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowJoin.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowJoin.java
@@ -176,7 +176,8 @@ public class StreamExecWindowJoin extends ExecNodeBase<RowData>
                 ExecNodeUtil.createTwoInputTransformation(
                         leftTransform,
                         rightTransform,
-                        getTransformationMeta(WINDOW_JOIN_TRANSFORMATION, planner.getTableConfig()),
+                        createTransformationMeta(
+                                WINDOW_JOIN_TRANSFORMATION, planner.getTableConfig()),
                         operator,
                         InternalTypeInfo.of(returnType),
                         leftTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowJoin.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowJoin.java
@@ -64,6 +64,9 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecWindowJoin extends ExecNodeBase<RowData>
         implements StreamExecNode<RowData>, SingleTransformationTranslator<RowData> {
+
+    private static final String WINDOW_JOIN_OPERATOR = "window-join";
+
     public static final String FIELD_NAME_JOIN_SPEC = "joinSpec";
     public static final String FIELD_NAME_LEFT_WINDOWING = "leftWindowing";
     public static final String FIELD_NAME_RIGHT_WINDOWING = "rightWindowing";
@@ -172,8 +175,7 @@ public class StreamExecWindowJoin extends ExecNodeBase<RowData>
                 ExecNodeUtil.createTwoInputTransformation(
                         leftTransform,
                         rightTransform,
-                        getOperatorName(planner.getTableConfig()),
-                        getOperatorDescription(planner.getTableConfig()),
+                        getOperatorMeta(WINDOW_JOIN_OPERATOR, planner.getTableConfig()),
                         operator,
                         InternalTypeInfo.of(returnType),
                         leftTransform.getParallelism());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowJoin.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowJoin.java
@@ -60,12 +60,13 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @ExecNodeMetadata(
         name = "stream-exec-window-join",
         version = 1,
+        producedOperators = StreamExecWindowJoin.WINDOW_JOIN_OPERATOR,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecWindowJoin extends ExecNodeBase<RowData>
         implements StreamExecNode<RowData>, SingleTransformationTranslator<RowData> {
 
-    private static final String WINDOW_JOIN_OPERATOR = "window-join";
+    public static final String WINDOW_JOIN_OPERATOR = "window-join";
 
     public static final String FIELD_NAME_JOIN_SPEC = "joinSpec";
     public static final String FIELD_NAME_LEFT_WINDOWING = "leftWindowing";

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowRank.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowRank.java
@@ -68,13 +68,13 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @ExecNodeMetadata(
         name = "stream-exec-window-rank",
         version = 1,
-        producedOperators = StreamExecWindowRank.WINDOW_RANK_OPERATOR,
+        producedTransformations = StreamExecWindowRank.WINDOW_RANK_TRANSFORMATION,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecWindowRank extends ExecNodeBase<RowData>
         implements StreamExecNode<RowData>, SingleTransformationTranslator<RowData> {
 
-    public static final String WINDOW_RANK_OPERATOR = "window-rank";
+    public static final String WINDOW_RANK_TRANSFORMATION = "window-rank";
 
     private static final long WINDOW_RANK_MEMORY_RATIO = 100;
 
@@ -245,7 +245,7 @@ public class StreamExecWindowRank extends ExecNodeBase<RowData>
         OneInputTransformation<RowData, RowData> transform =
                 ExecNodeUtil.createOneInputTransformation(
                         inputTransform,
-                        getOperatorMeta(WINDOW_RANK_OPERATOR, planner.getTableConfig()),
+                        getTransformationMeta(WINDOW_RANK_TRANSFORMATION, planner.getTableConfig()),
                         SimpleOperatorFactory.of(operator),
                         InternalTypeInfo.of(getOutputType()),
                         inputTransform.getParallelism(),

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowRank.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowRank.java
@@ -245,7 +245,8 @@ public class StreamExecWindowRank extends ExecNodeBase<RowData>
         OneInputTransformation<RowData, RowData> transform =
                 ExecNodeUtil.createOneInputTransformation(
                         inputTransform,
-                        getTransformationMeta(WINDOW_RANK_TRANSFORMATION, planner.getTableConfig()),
+                        createTransformationMeta(
+                                WINDOW_RANK_TRANSFORMATION, planner.getTableConfig()),
                         SimpleOperatorFactory.of(operator),
                         InternalTypeInfo.of(getOutputType()),
                         inputTransform.getParallelism(),

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowRank.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowRank.java
@@ -73,6 +73,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public class StreamExecWindowRank extends ExecNodeBase<RowData>
         implements StreamExecNode<RowData>, SingleTransformationTranslator<RowData> {
 
+    private static final String WINDOW_RANK_OPERATOR = "window-rank";
+
     private static final long WINDOW_RANK_MEMORY_RATIO = 100;
 
     public static final String FIELD_NAME_RANK_TYPE = "rankType";
@@ -242,8 +244,7 @@ public class StreamExecWindowRank extends ExecNodeBase<RowData>
         OneInputTransformation<RowData, RowData> transform =
                 ExecNodeUtil.createOneInputTransformation(
                         inputTransform,
-                        getOperatorName(planner.getTableConfig()),
-                        getOperatorDescription(planner.getTableConfig()),
+                        getOperatorMeta(WINDOW_RANK_OPERATOR, planner.getTableConfig()),
                         SimpleOperatorFactory.of(operator),
                         InternalTypeInfo.of(getOutputType()),
                         inputTransform.getParallelism(),

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowRank.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowRank.java
@@ -68,12 +68,13 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @ExecNodeMetadata(
         name = "stream-exec-window-rank",
         version = 1,
+        producedOperators = StreamExecWindowRank.WINDOW_RANK_OPERATOR,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecWindowRank extends ExecNodeBase<RowData>
         implements StreamExecNode<RowData>, SingleTransformationTranslator<RowData> {
 
-    private static final String WINDOW_RANK_OPERATOR = "window-rank";
+    public static final String WINDOW_RANK_OPERATOR = "window-rank";
 
     private static final long WINDOW_RANK_MEMORY_RATIO = 100;
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowTableFunction.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowTableFunction.java
@@ -43,7 +43,7 @@ import java.util.List;
 @ExecNodeMetadata(
         name = "stream-exec-window-table-function",
         version = 1,
-        producedOperators = CommonExecWindowTableFunction.WINDOW_TVF_OPERATOR,
+        producedTransformations = CommonExecWindowTableFunction.WINDOW_TVF_TRANSFORMATION,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecWindowTableFunction extends CommonExecWindowTableFunction

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowTableFunction.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowTableFunction.java
@@ -43,6 +43,7 @@ import java.util.List;
 @ExecNodeMetadata(
         name = "stream-exec-window-table-function",
         version = 1,
+        producedOperators = CommonExecWindowTableFunction.WINDOW_TVF_OPERATOR,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecWindowTableFunction extends CommonExecWindowTableFunction

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowTableFunction.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowTableFunction.java
@@ -43,7 +43,7 @@ import java.util.List;
 @ExecNodeMetadata(
         name = "stream-exec-window-table-function",
         version = 1,
-        producedTransformations = CommonExecWindowTableFunction.WINDOW_TVF_TRANSFORMATION,
+        producedTransformations = CommonExecWindowTableFunction.WINDOW_TRANSFORMATION,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecWindowTableFunction extends CommonExecWindowTableFunction

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/utils/ExecNodeUtil.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/utils/ExecNodeUtil.java
@@ -60,32 +60,57 @@ public class ExecNodeUtil {
     /** Create a {@link OneInputTransformation}. */
     public static <I, O> OneInputTransformation<I, O> createOneInputTransformation(
             Transformation<I> input,
-            String name,
-            String desc,
+            TransformationMetadata transformationMeta,
             StreamOperator<O> operator,
             TypeInformation<O> outputType,
             int parallelism) {
         return createOneInputTransformation(
-                input, name, desc, operator, outputType, parallelism, 0);
+                input, transformationMeta, operator, outputType, parallelism, 0);
     }
 
-    /** Create a {@link OneInputTransformation} with memoryBytes. */
+    /** Create a {@link OneInputTransformation}. */
     public static <I, O> OneInputTransformation<I, O> createOneInputTransformation(
             Transformation<I> input,
             String name,
             String desc,
             StreamOperator<O> operator,
             TypeInformation<O> outputType,
+            int parallelism) {
+        return createOneInputTransformation(
+                input,
+                new TransformationMetadata(null, name, desc),
+                operator,
+                outputType,
+                parallelism,
+                0);
+    }
+
+    /** Create a {@link OneInputTransformation} with memoryBytes. */
+    public static <I, O> OneInputTransformation<I, O> createOneInputTransformation(
+            Transformation<I> input,
+            TransformationMetadata transformationMeta,
+            StreamOperator<O> operator,
+            TypeInformation<O> outputType,
             int parallelism,
             long memoryBytes) {
         return createOneInputTransformation(
                 input,
-                name,
-                desc,
+                transformationMeta,
                 SimpleOperatorFactory.of(operator),
                 outputType,
                 parallelism,
                 memoryBytes);
+    }
+
+    /** Create a {@link OneInputTransformation}. */
+    public static <I, O> OneInputTransformation<I, O> createOneInputTransformation(
+            Transformation<I> input,
+            TransformationMetadata transformationMeta,
+            StreamOperatorFactory<O> operatorFactory,
+            TypeInformation<O> outputType,
+            int parallelism) {
+        return createOneInputTransformation(
+                input, transformationMeta, operatorFactory, outputType, parallelism, 0);
     }
 
     /** Create a {@link OneInputTransformation}. */
@@ -97,7 +122,12 @@ public class ExecNodeUtil {
             TypeInformation<O> outputType,
             int parallelism) {
         return createOneInputTransformation(
-                input, name, desc, operatorFactory, outputType, parallelism, 0);
+                input,
+                new TransformationMetadata(null, name, desc),
+                operatorFactory,
+                outputType,
+                parallelism,
+                0);
     }
 
     /** Create a {@link OneInputTransformation} with memoryBytes. */
@@ -109,11 +139,45 @@ public class ExecNodeUtil {
             TypeInformation<O> outputType,
             int parallelism,
             long memoryBytes) {
+        return createOneInputTransformation(
+                input,
+                new TransformationMetadata(null, name, desc),
+                operatorFactory,
+                outputType,
+                parallelism,
+                memoryBytes);
+    }
+
+    /** Create a {@link OneInputTransformation} with memoryBytes. */
+    public static <I, O> OneInputTransformation<I, O> createOneInputTransformation(
+            Transformation<I> input,
+            TransformationMetadata transformationMeta,
+            StreamOperatorFactory<O> operatorFactory,
+            TypeInformation<O> outputType,
+            int parallelism,
+            long memoryBytes) {
         OneInputTransformation<I, O> transformation =
-                new OneInputTransformation<>(input, name, operatorFactory, outputType, parallelism);
+                new OneInputTransformation<>(
+                        input,
+                        transformationMeta.getName(),
+                        operatorFactory,
+                        outputType,
+                        parallelism);
         setManagedMemoryWeight(transformation, memoryBytes);
-        transformation.setDescription(desc);
+        transformationMeta.fill(transformation);
         return transformation;
+    }
+
+    /** Create a {@link TwoInputTransformation} with memoryBytes. */
+    public static <IN1, IN2, O> TwoInputTransformation<IN1, IN2, O> createTwoInputTransformation(
+            Transformation<IN1> input1,
+            Transformation<IN2> input2,
+            TransformationMetadata transformationMeta,
+            TwoInputStreamOperator<IN1, IN2, O> operator,
+            TypeInformation<O> outputType,
+            int parallelism) {
+        return createTwoInputTransformation(
+                input1, input2, transformationMeta, operator, outputType, parallelism, 0);
     }
 
     /** Create a {@link TwoInputTransformation} with memoryBytes. */
@@ -126,7 +190,32 @@ public class ExecNodeUtil {
             TypeInformation<O> outputType,
             int parallelism) {
         return createTwoInputTransformation(
-                input1, input2, name, desc, operator, outputType, parallelism, 0);
+                input1,
+                input2,
+                new TransformationMetadata(null, name, desc),
+                operator,
+                outputType,
+                parallelism,
+                0);
+    }
+
+    /** Create a {@link TwoInputTransformation} with memoryBytes. */
+    public static <IN1, IN2, O> TwoInputTransformation<IN1, IN2, O> createTwoInputTransformation(
+            Transformation<IN1> input1,
+            Transformation<IN2> input2,
+            TransformationMetadata transformationMeta,
+            TwoInputStreamOperator<IN1, IN2, O> operator,
+            TypeInformation<O> outputType,
+            int parallelism,
+            long memoryBytes) {
+        return createTwoInputTransformation(
+                input1,
+                input2,
+                transformationMeta,
+                SimpleOperatorFactory.of(operator),
+                outputType,
+                parallelism,
+                memoryBytes);
     }
 
     /** Create a {@link TwoInputTransformation} with memoryBytes. */
@@ -142,12 +231,33 @@ public class ExecNodeUtil {
         return createTwoInputTransformation(
                 input1,
                 input2,
-                name,
-                desc,
+                new TransformationMetadata(null, name, desc),
                 SimpleOperatorFactory.of(operator),
                 outputType,
                 parallelism,
                 memoryBytes);
+    }
+
+    /** Create a {@link TwoInputTransformation} with memoryBytes. */
+    public static <I1, I2, O> TwoInputTransformation<I1, I2, O> createTwoInputTransformation(
+            Transformation<I1> input1,
+            Transformation<I2> input2,
+            TransformationMetadata transformationMeta,
+            StreamOperatorFactory<O> operatorFactory,
+            TypeInformation<O> outputType,
+            int parallelism,
+            long memoryBytes) {
+        TwoInputTransformation<I1, I2, O> transformation =
+                new TwoInputTransformation<>(
+                        input1,
+                        input2,
+                        transformationMeta.getName(),
+                        operatorFactory,
+                        outputType,
+                        parallelism);
+        setManagedMemoryWeight(transformation, memoryBytes);
+        transformationMeta.fill(transformation);
+        return transformation;
     }
 
     /** Create a {@link TwoInputTransformation} with memoryBytes. */
@@ -160,12 +270,14 @@ public class ExecNodeUtil {
             TypeInformation<O> outputType,
             int parallelism,
             long memoryBytes) {
-        TwoInputTransformation<I1, I2, O> transformation =
-                new TwoInputTransformation<>(
-                        input1, input2, name, operatorFactory, outputType, parallelism);
-        setManagedMemoryWeight(transformation, memoryBytes);
-        transformation.setDescription(desc);
-        return transformation;
+        return createTwoInputTransformation(
+                input1,
+                input2,
+                new TransformationMetadata(null, name, desc),
+                operatorFactory,
+                outputType,
+                parallelism,
+                memoryBytes);
     }
 
     /** Return description for multiple input node. */

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/utils/ExecNodeUtil.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/utils/ExecNodeUtil.java
@@ -78,7 +78,7 @@ public class ExecNodeUtil {
             int parallelism) {
         return createOneInputTransformation(
                 input,
-                new TransformationMetadata(null, name, desc),
+                new TransformationMetadata(name, desc),
                 operator,
                 outputType,
                 parallelism,
@@ -123,7 +123,7 @@ public class ExecNodeUtil {
             int parallelism) {
         return createOneInputTransformation(
                 input,
-                new TransformationMetadata(null, name, desc),
+                new TransformationMetadata(name, desc),
                 operatorFactory,
                 outputType,
                 parallelism,
@@ -141,7 +141,7 @@ public class ExecNodeUtil {
             long memoryBytes) {
         return createOneInputTransformation(
                 input,
-                new TransformationMetadata(null, name, desc),
+                new TransformationMetadata(name, desc),
                 operatorFactory,
                 outputType,
                 parallelism,
@@ -192,7 +192,7 @@ public class ExecNodeUtil {
         return createTwoInputTransformation(
                 input1,
                 input2,
-                new TransformationMetadata(null, name, desc),
+                new TransformationMetadata(name, desc),
                 operator,
                 outputType,
                 parallelism,
@@ -231,7 +231,7 @@ public class ExecNodeUtil {
         return createTwoInputTransformation(
                 input1,
                 input2,
-                new TransformationMetadata(null, name, desc),
+                new TransformationMetadata(name, desc),
                 SimpleOperatorFactory.of(operator),
                 outputType,
                 parallelism,
@@ -273,7 +273,7 @@ public class ExecNodeUtil {
         return createTwoInputTransformation(
                 input1,
                 input2,
-                new TransformationMetadata(null, name, desc),
+                new TransformationMetadata(name, desc),
                 operatorFactory,
                 outputType,
                 parallelism,

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/utils/TransformationMetadata.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/utils/TransformationMetadata.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.exec.utils;
+
+import org.apache.flink.api.dag.Transformation;
+
+import javax.annotation.Nullable;
+
+/**
+ * This POJO is meant to hold some metadata information about operators, which usually needs to be
+ * passed to "factory" methods for {@link Transformation}.
+ */
+public class TransformationMetadata {
+    private final @Nullable String uid;
+    private final String name;
+    private final String desc;
+
+    public TransformationMetadata(@Nullable String uid, String name, String desc) {
+        this.uid = uid;
+        this.name = name;
+        this.desc = desc;
+    }
+
+    public @Nullable String getUid() {
+        return uid;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDescription() {
+        return desc;
+    }
+
+    /** Fill a transformation with this meta. */
+    public <T extends Transformation<?>> T fill(T transformation) {
+        transformation.setName(getName());
+        transformation.setDescription(getDescription());
+        if (getUid() != null) {
+            transformation.setUid(getUid());
+        }
+        return transformation;
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/utils/TransformationMetadata.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/utils/TransformationMetadata.java
@@ -19,6 +19,8 @@
 package org.apache.flink.table.planner.plan.nodes.exec.utils;
 
 import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.table.planner.plan.nodes.exec.batch.BatchExecNode;
+import org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecNode;
 
 import javax.annotation.Nullable;
 
@@ -31,10 +33,12 @@ public class TransformationMetadata {
     private final String name;
     private final String desc;
 
-    TransformationMetadata(String name, String desc) {
+    /** Used by {@link BatchExecNode}, as they don't require the uid. */
+    public TransformationMetadata(String name, String desc) {
         this(null, name, desc);
     }
 
+    /** Used by {@link StreamExecNode}, as they require the uid. */
     public TransformationMetadata(String uid, String name, String desc) {
         this.uid = uid;
         this.name = name;

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/utils/TransformationMetadata.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/utils/TransformationMetadata.java
@@ -31,7 +31,11 @@ public class TransformationMetadata {
     private final String name;
     private final String desc;
 
-    public TransformationMetadata(@Nullable String uid, String name, String desc) {
+    TransformationMetadata(String name, String desc) {
+        this(null, name, desc);
+    }
+
+    public TransformationMetadata(String uid, String name, String desc) {
         this.uid = uid;
         this.name = name;
         this.desc = desc;

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CorrelateCodeGenerator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CorrelateCodeGenerator.scala
@@ -28,7 +28,7 @@ import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.codegen.CodeGenUtils._
 import org.apache.flink.table.planner.functions.bridging.BridgingSqlFunction
 import org.apache.flink.table.planner.functions.utils.TableSqlFunction
-import org.apache.flink.table.planner.plan.nodes.exec.utils.ExecNodeUtil
+import org.apache.flink.table.planner.plan.nodes.exec.utils.{ExecNodeUtil, TransformationMetadata}
 import org.apache.flink.table.runtime.operators.CodeGenOperatorFactory
 import org.apache.flink.table.runtime.operators.join.FlinkJoinType
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo
@@ -51,8 +51,7 @@ object CorrelateCodeGenerator {
       parallelism: Int,
       retainHeader: Boolean,
       opName: String,
-      transformationName: String,
-      transformationDescription: String)
+      transformationMeta: TransformationMetadata)
   : Transformation[RowData] = {
 
     // according to the SQL standard, every scalar function should also be a table function
@@ -86,8 +85,7 @@ object CorrelateCodeGenerator {
 
     ExecNodeUtil.createOneInputTransformation(
       inputTransformation,
-      transformationName,
-      transformationDescription,
+      transformationMeta,
       substituteStreamOperator,
       InternalTypeInfo.of(outputType),
       parallelism,


### PR DESCRIPTION
## What is the purpose of the change

This PR makes sure every transformation has a deterministic uid, required to restore previous savepoints.

## Brief change log

* Add `TransformationMetadata` to hold transformation uid, name and description
* Make sure every StreamExecNode, not part of `ExecNodeMetadataUtil#UNSUPPORTED_JSON_SERDE_CLASSES`, is creating `Transformation`s with deterministic uids.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
