### PR TITLE
[FLINK-25984] Replace deprecated, untyped `defaultValue` & `noDefaultValue`

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveOptions.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveOptions.java
@@ -33,6 +33,7 @@ public class HiveOptions {
 
     public static final ConfigOption<Boolean> TABLE_EXEC_HIVE_FALLBACK_MAPRED_READER =
             key("table.exec.hive.fallback-mapred-reader")
+                    .booleanType()
                     .defaultValue(false)
                     .withDescription(
                             "If it is false, using flink native vectorized reader to read orc files; "
@@ -40,6 +41,7 @@ public class HiveOptions {
 
     public static final ConfigOption<Boolean> TABLE_EXEC_HIVE_INFER_SOURCE_PARALLELISM =
             key("table.exec.hive.infer-source-parallelism")
+                    .booleanType()
                     .defaultValue(true)
                     .withDescription(
                             "If is false, parallelism of source are set by config.\n"
@@ -47,6 +49,7 @@ public class HiveOptions {
 
     public static final ConfigOption<Integer> TABLE_EXEC_HIVE_INFER_SOURCE_PARALLELISM_MAX =
             key("table.exec.hive.infer-source-parallelism.max")
+                    .intType()
                     .defaultValue(1000)
                     .withDescription("Sets max infer parallelism for source operator.");
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/AkkaOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/AkkaOptions.java
@@ -278,6 +278,7 @@ public class AkkaOptions {
     @Deprecated
     public static final ConfigOption<String> WATCH_HEARTBEAT_INTERVAL =
             ConfigOptions.key("akka.watch.heartbeat.interval")
+                    .stringType()
                     .defaultValue(ASK_TIMEOUT.defaultValue())
                     .withDescription(
                             Description.builder()
@@ -299,6 +300,7 @@ public class AkkaOptions {
     @Deprecated
     public static final ConfigOption<String> WATCH_HEARTBEAT_PAUSE =
             ConfigOptions.key("akka.watch.heartbeat.pause")
+                    .stringType()
                     .defaultValue("60 s")
                     .withDescription(
                             Description.builder()
@@ -321,6 +323,7 @@ public class AkkaOptions {
     @Deprecated
     public static final ConfigOption<Integer> WATCH_THRESHOLD =
             ConfigOptions.key("akka.watch.threshold")
+                    .intType()
                     .defaultValue(12)
                     .withDescription(
                             Description.builder()

--- a/flink-core/src/main/java/org/apache/flink/configuration/AlgorithmOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/AlgorithmOptions.java
@@ -25,6 +25,7 @@ public class AlgorithmOptions {
 
     public static final ConfigOption<Boolean> HASH_JOIN_BLOOM_FILTERS =
             key("taskmanager.runtime.hashjoin-bloom-filters")
+                    .booleanType()
                     .defaultValue(false)
                     .withDescription(
                             "Flag to activate/deactivate bloom filters in the hybrid hash join implementation."
@@ -34,6 +35,7 @@ public class AlgorithmOptions {
 
     public static final ConfigOption<Integer> SPILLING_MAX_FAN =
             key("taskmanager.runtime.max-fan")
+                    .intType()
                     .defaultValue(128)
                     .withDescription(
                             "The maximal fan-in for external merge joins and fan-out for spilling hash tables. Limits"
@@ -42,12 +44,14 @@ public class AlgorithmOptions {
 
     public static final ConfigOption<Float> SORT_SPILLING_THRESHOLD =
             key("taskmanager.runtime.sort-spilling-threshold")
+                    .floatType()
                     .defaultValue(0.8f)
                     .withDescription(
                             "A sort operation starts spilling when this fraction of its memory budget is full.");
 
     public static final ConfigOption<Boolean> USE_LARGE_RECORDS_HANDLER =
             key("taskmanager.runtime.large-record-handler")
+                    .booleanType()
                     .defaultValue(false)
                     .withDescription(
                             "Whether to use the LargeRecordHandler when spilling. If a record will not fit into the sorting"

--- a/flink-core/src/main/java/org/apache/flink/configuration/BlobServerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/BlobServerOptions.java
@@ -31,6 +31,7 @@ public class BlobServerOptions {
     /** The config parameter defining the storage directory to be used by the blob server. */
     public static final ConfigOption<String> STORAGE_DIRECTORY =
             key("blob.storage.directory")
+                    .stringType()
                     .noDefaultValue()
                     .withDescription(
                             "The config parameter defining the local storage directory to be used by the blob server. "
@@ -39,6 +40,7 @@ public class BlobServerOptions {
     /** The config parameter defining number of retires for failed BLOB fetches. */
     public static final ConfigOption<Integer> FETCH_RETRIES =
             key("blob.fetch.retries")
+                    .intType()
                     .defaultValue(5)
                     .withDescription(
                             "The config parameter defining number of retires for failed BLOB fetches.");
@@ -49,6 +51,7 @@ public class BlobServerOptions {
      */
     public static final ConfigOption<Integer> FETCH_CONCURRENT =
             key("blob.fetch.num-concurrent")
+                    .intType()
                     .defaultValue(50)
                     .withDescription(
                             "The config parameter defining the maximum number of concurrent BLOB fetches that the JobManager serves.");
@@ -56,6 +59,7 @@ public class BlobServerOptions {
     /** The config parameter defining the backlog of BLOB fetches on the JobManager. */
     public static final ConfigOption<Integer> FETCH_BACKLOG =
             key("blob.fetch.backlog")
+                    .intType()
                     .defaultValue(1000)
                     .withDescription(
                             Description.builder()
@@ -74,6 +78,7 @@ public class BlobServerOptions {
      */
     public static final ConfigOption<String> PORT =
             key("blob.server.port")
+                    .stringType()
                     .defaultValue("0")
                     .withDescription(
                             "The config parameter defining the server port of the blob service.");
@@ -81,6 +86,7 @@ public class BlobServerOptions {
     /** Flag to override ssl support for the blob service transport. */
     public static final ConfigOption<Boolean> SSL_ENABLED =
             key("blob.service.ssl.enabled")
+                    .booleanType()
                     .defaultValue(true)
                     .withDescription(
                             "Flag to override ssl support for the blob service transport.");
@@ -96,6 +102,7 @@ public class BlobServerOptions {
      */
     public static final ConfigOption<Long> CLEANUP_INTERVAL =
             key("blob.service.cleanup.interval")
+                    .longType()
                     .defaultValue(3_600L) // once per hour
                     .withDeprecatedKeys("library-cache-manager.cleanup.interval")
                     .withDescription(
@@ -104,6 +111,7 @@ public class BlobServerOptions {
     /** The minimum size for messages to be offloaded to the BlobServer. */
     public static final ConfigOption<Integer> OFFLOAD_MINSIZE =
             key("blob.offload.minsize")
+                    .intType()
                     .defaultValue(1_024 * 1_024) // 1MiB by default
                     .withDescription(
                             "The minimum size for messages to be offloaded to the BlobServer.");
@@ -111,12 +119,14 @@ public class BlobServerOptions {
     /** The socket timeout in milliseconds for the blob client. */
     public static final ConfigOption<Integer> SO_TIMEOUT =
             key("blob.client.socket.timeout")
+                    .intType()
                     .defaultValue(300_000)
                     .withDescription("The socket timeout in milliseconds for the blob client.");
 
     /** The connection timeout in milliseconds for the blob client. */
     public static final ConfigOption<Integer> CONNECT_TIMEOUT =
             key("blob.client.connect.timeout")
+                    .intType()
                     .defaultValue(0)
                     .withDescription("The connection timeout in milliseconds for the blob client.");
 }

--- a/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
@@ -104,6 +104,7 @@ public class CheckpointingOptions {
     @Documentation.Section(Documentation.Sections.COMMON_STATE_BACKENDS)
     public static final ConfigOption<Integer> MAX_RETAINED_CHECKPOINTS =
             ConfigOptions.key("state.checkpoints.num-retained")
+                    .intType()
                     .defaultValue(1)
                     .withDescription("The maximum number of completed checkpoints to retain.");
 
@@ -128,6 +129,7 @@ public class CheckpointingOptions {
     @Documentation.Section(Documentation.Sections.COMMON_STATE_BACKENDS)
     public static final ConfigOption<Boolean> INCREMENTAL_CHECKPOINTS =
             ConfigOptions.key("state.backend.incremental")
+                    .booleanType()
                     .defaultValue(false)
                     .withDescription(
                             "Option whether the state backend should create incremental checkpoints, if possible. For"
@@ -146,6 +148,7 @@ public class CheckpointingOptions {
     @Documentation.Section(Documentation.Sections.COMMON_STATE_BACKENDS)
     public static final ConfigOption<Boolean> LOCAL_RECOVERY =
             ConfigOptions.key("state.backend.local-recovery")
+                    .booleanType()
                     .defaultValue(false)
                     .withDescription(
                             "This option configures local recovery for this state backend. By default, local recovery is "
@@ -162,6 +165,7 @@ public class CheckpointingOptions {
     @Documentation.Section(Documentation.Sections.COMMON_STATE_BACKENDS)
     public static final ConfigOption<String> LOCAL_RECOVERY_TASK_MANAGER_STATE_ROOT_DIRS =
             ConfigOptions.key("taskmanager.state.local.root-dirs")
+                    .stringType()
                     .noDefaultValue()
                     .withDescription(
                             Description.builder()
@@ -188,6 +192,7 @@ public class CheckpointingOptions {
     @Documentation.Section(value = Documentation.Sections.COMMON_STATE_BACKENDS, position = 3)
     public static final ConfigOption<String> SAVEPOINT_DIRECTORY =
             ConfigOptions.key("state.savepoints.dir")
+                    .stringType()
                     .noDefaultValue()
                     .withDeprecatedKeys("savepoints.state.backend.fs.dir")
                     .withDescription(

--- a/flink-core/src/main/java/org/apache/flink/configuration/ClusterOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ClusterOptions.java
@@ -37,6 +37,7 @@ public class ClusterOptions {
     @Documentation.Section(Documentation.Sections.EXPERT_FAULT_TOLERANCE)
     public static final ConfigOption<Long> INITIAL_REGISTRATION_TIMEOUT =
             ConfigOptions.key("cluster.registration.initial-timeout")
+                    .longType()
                     .defaultValue(100L)
                     .withDescription(
                             "Initial registration timeout between cluster components in milliseconds.");
@@ -44,6 +45,7 @@ public class ClusterOptions {
     @Documentation.Section(Documentation.Sections.EXPERT_FAULT_TOLERANCE)
     public static final ConfigOption<Long> MAX_REGISTRATION_TIMEOUT =
             ConfigOptions.key("cluster.registration.max-timeout")
+                    .longType()
                     .defaultValue(30000L)
                     .withDescription(
                             "Maximum registration timeout between cluster components in milliseconds.");
@@ -51,6 +53,7 @@ public class ClusterOptions {
     @Documentation.Section(Documentation.Sections.EXPERT_FAULT_TOLERANCE)
     public static final ConfigOption<Long> ERROR_REGISTRATION_DELAY =
             ConfigOptions.key("cluster.registration.error-delay")
+                    .longType()
                     .defaultValue(10000L)
                     .withDescription(
                             "The pause made after an registration attempt caused an exception (other than timeout) in milliseconds.");
@@ -58,6 +61,7 @@ public class ClusterOptions {
     @Documentation.Section(Documentation.Sections.EXPERT_FAULT_TOLERANCE)
     public static final ConfigOption<Long> REFUSED_REGISTRATION_DELAY =
             ConfigOptions.key("cluster.registration.refused-registration-delay")
+                    .longType()
                     .defaultValue(30000L)
                     .withDescription(
                             "The pause made after the registration attempt was refused in milliseconds.");
@@ -65,6 +69,7 @@ public class ClusterOptions {
     @Documentation.Section(Documentation.Sections.EXPERT_FAULT_TOLERANCE)
     public static final ConfigOption<Long> CLUSTER_SERVICES_SHUTDOWN_TIMEOUT =
             ConfigOptions.key("cluster.services.shutdown-timeout")
+                    .longType()
                     .defaultValue(30000L)
                     .withDescription(
                             "The shutdown timeout for cluster services like executors in milliseconds.");
@@ -82,6 +87,7 @@ public class ClusterOptions {
     @Documentation.Section(Documentation.Sections.EXPERT_SCHEDULING)
     public static final ConfigOption<Boolean> EVENLY_SPREAD_OUT_SLOTS_STRATEGY =
             ConfigOptions.key("cluster.evenly-spread-out-slots")
+                    .booleanType()
                     .defaultValue(false)
                     .withDescription(
                             Description.builder()

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -75,7 +75,7 @@ public final class ConfigConstants {
      */
     @Deprecated @PublicEvolving
     public static final ConfigOption<String> RESTART_STRATEGY_FIXED_DELAY_DELAY =
-            key("restart-strategy.fixed-delay.delay").defaultValue("0 s");
+            key("restart-strategy.fixed-delay.delay").stringType().defaultValue("0 s");
 
     /**
      * Maximum number of restarts in given time interval {@link
@@ -1460,7 +1460,7 @@ public final class ConfigConstants {
      */
     @Deprecated
     public static final ConfigOption<String> DEFAULT_JOB_MANAGER_WEB_FRONTEND_ADDRESS =
-            key("jobmanager.web.address").noDefaultValue();
+            key("jobmanager.web.address").stringType().noDefaultValue();
 
     /**
      * The config key for the port of the JobManager web frontend. Setting this value to {@code -1}

--- a/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
@@ -65,6 +65,7 @@ public class CoreOptions {
     @Documentation.Section(Documentation.Sections.EXPERT_CLASS_LOADING)
     public static final ConfigOption<String> CLASSLOADER_RESOLVE_ORDER =
             ConfigOptions.key("classloader.resolve-order")
+                    .stringType()
                     .defaultValue("child-first")
                     .withDescription(
                             "Defines the class resolution strategy when loading classes from user code, meaning whether to"
@@ -277,6 +278,7 @@ public class CoreOptions {
     @SuppressWarnings("unused")
     public static final ConfigOption<String> FLINK_LOG_DIR =
             ConfigOptions.key("env.log.dir")
+                    .stringType()
                     .noDefaultValue()
                     .withDescription(
                             "Defines the directory where the Flink logs are saved. It has to be an absolute path."
@@ -288,6 +290,7 @@ public class CoreOptions {
      */
     public static final ConfigOption<String> FLINK_PID_DIR =
             ConfigOptions.key("env.pid.dir")
+                    .stringType()
                     .defaultValue("/tmp")
                     .withDescription(
                             "Defines the directory where the flink-<host>-<process>.pid files are saved.");
@@ -299,6 +302,7 @@ public class CoreOptions {
     @SuppressWarnings("unused")
     public static final ConfigOption<Integer> FLINK_LOG_MAX =
             ConfigOptions.key("env.log.max")
+                    .intType()
                     .defaultValue(5)
                     .withDescription("The maximum number of old log files to keep.");
 
@@ -309,6 +313,7 @@ public class CoreOptions {
     @SuppressWarnings("unused")
     public static final ConfigOption<String> FLINK_SSH_OPTIONS =
             ConfigOptions.key("env.ssh.opts")
+                    .stringType()
                     .noDefaultValue()
                     .withDescription(
                             "Additional command line options passed to SSH clients when starting or stopping JobManager,"
@@ -322,6 +327,7 @@ public class CoreOptions {
     @SuppressWarnings("unused")
     public static final ConfigOption<String> FLINK_HADOOP_CONF_DIR =
             ConfigOptions.key("env.hadoop.conf.dir")
+                    .stringType()
                     .noDefaultValue()
                     .withDescription(
                             "Path to hadoop configuration directory. It is required to read HDFS and/or YARN"
@@ -334,6 +340,7 @@ public class CoreOptions {
     @SuppressWarnings("unused")
     public static final ConfigOption<String> FLINK_YARN_CONF_DIR =
             ConfigOptions.key("env.yarn.conf.dir")
+                    .stringType()
                     .noDefaultValue()
                     .withDescription(
                             "Path to yarn configuration directory. It is required to run flink on YARN. You can also"
@@ -346,6 +353,7 @@ public class CoreOptions {
     @SuppressWarnings("unused")
     public static final ConfigOption<String> FLINK_HBASE_CONF_DIR =
             ConfigOptions.key("env.hbase.conf.dir")
+                    .stringType()
                     .noDefaultValue()
                     .withDescription(
                             "Path to hbase configuration directory. It is required to read HBASE configuration."
@@ -364,6 +372,7 @@ public class CoreOptions {
     @Documentation.Section(Documentation.Sections.COMMON_MISCELLANEOUS)
     public static final ConfigOption<String> TMP_DIRS =
             key("io.tmp.dirs")
+                    .stringType()
                     .defaultValue(System.getProperty("java.io.tmpdir"))
                     .withDeprecatedKeys("taskmanager.tmp.dirs")
                     .withDescription(
@@ -375,6 +384,7 @@ public class CoreOptions {
 
     public static final ConfigOption<Integer> DEFAULT_PARALLELISM =
             ConfigOptions.key("parallelism.default")
+                    .intType()
                     .defaultValue(1)
                     .withDescription("Default parallelism for jobs.");
 
@@ -386,6 +396,7 @@ public class CoreOptions {
     @Documentation.Section(Documentation.Sections.COMMON_MISCELLANEOUS)
     public static final ConfigOption<String> DEFAULT_FILESYSTEM_SCHEME =
             ConfigOptions.key("fs.default-scheme")
+                    .stringType()
                     .noDefaultValue()
                     .withDescription(
                             "The default filesystem scheme, used for paths that do not declare a scheme explicitly."
@@ -404,6 +415,7 @@ public class CoreOptions {
     @Documentation.Section(Documentation.Sections.DEPRECATED_FILE_SINKS)
     public static final ConfigOption<Boolean> FILESYTEM_DEFAULT_OVERRIDE =
             key("fs.overwrite-files")
+                    .booleanType()
                     .defaultValue(false)
                     .withDescription(
                             "Specifies whether file output writers should overwrite existing files by default. Set to"
@@ -416,6 +428,7 @@ public class CoreOptions {
     @Documentation.Section(Documentation.Sections.DEPRECATED_FILE_SINKS)
     public static final ConfigOption<Boolean> FILESYSTEM_OUTPUT_ALWAYS_CREATE_DIRECTORY =
             key("fs.output.always-create-directory")
+                    .booleanType()
                     .defaultValue(false)
                     .withDescription(
                             "File writers running with a parallelism larger than one create a directory for the output"
@@ -430,7 +443,7 @@ public class CoreOptions {
      * open. Unlimited be default.
      */
     public static ConfigOption<Integer> fileSystemConnectionLimit(String scheme) {
-        return ConfigOptions.key("fs." + scheme + ".limit.total").defaultValue(-1);
+        return ConfigOptions.key("fs." + scheme + ".limit.total").intType().defaultValue(-1);
     }
 
     /**
@@ -438,7 +451,7 @@ public class CoreOptions {
      * Unlimited be default.
      */
     public static ConfigOption<Integer> fileSystemConnectionLimitIn(String scheme) {
-        return ConfigOptions.key("fs." + scheme + ".limit.input").defaultValue(-1);
+        return ConfigOptions.key("fs." + scheme + ".limit.input").intType().defaultValue(-1);
     }
 
     /**
@@ -446,7 +459,7 @@ public class CoreOptions {
      * Unlimited be default.
      */
     public static ConfigOption<Integer> fileSystemConnectionLimitOut(String scheme) {
-        return ConfigOptions.key("fs." + scheme + ".limit.output").defaultValue(-1);
+        return ConfigOptions.key("fs." + scheme + ".limit.output").intType().defaultValue(-1);
     }
 
     /**
@@ -455,7 +468,7 @@ public class CoreOptions {
      * connection becomes available. Unlimited timeout be default.
      */
     public static ConfigOption<Long> fileSystemConnectionLimitTimeout(String scheme) {
-        return ConfigOptions.key("fs." + scheme + ".limit.timeout").defaultValue(0L);
+        return ConfigOptions.key("fs." + scheme + ".limit.timeout").longType().defaultValue(0L);
     }
 
     /**
@@ -466,6 +479,8 @@ public class CoreOptions {
      */
     public static ConfigOption<Long> fileSystemConnectionLimitStreamInactivityTimeout(
             String scheme) {
-        return ConfigOptions.key("fs." + scheme + ".limit.stream-timeout").defaultValue(0L);
+        return ConfigOptions.key("fs." + scheme + ".limit.stream-timeout")
+                .longType()
+                .defaultValue(0L);
     }
 }

--- a/flink-core/src/main/java/org/apache/flink/configuration/HeartbeatManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/HeartbeatManagerOptions.java
@@ -33,6 +33,7 @@ public class HeartbeatManagerOptions {
     @Documentation.Section(Documentation.Sections.EXPERT_FAULT_TOLERANCE)
     public static final ConfigOption<Long> HEARTBEAT_INTERVAL =
             key("heartbeat.interval")
+                    .longType()
                     .defaultValue(10000L)
                     .withDescription(
                             "Time interval between heartbeat RPC requests from the sender to the receiver side.");
@@ -41,6 +42,7 @@ public class HeartbeatManagerOptions {
     @Documentation.Section(Documentation.Sections.EXPERT_FAULT_TOLERANCE)
     public static final ConfigOption<Long> HEARTBEAT_TIMEOUT =
             key("heartbeat.timeout")
+                    .longType()
                     .defaultValue(50000L)
                     .withDescription(
                             "Timeout for requesting and receiving heartbeats for both sender and receiver sides.");

--- a/flink-core/src/main/java/org/apache/flink/configuration/HighAvailabilityOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/HighAvailabilityOptions.java
@@ -39,6 +39,7 @@ public class HighAvailabilityOptions {
     @Documentation.Section(Documentation.Sections.COMMON_HIGH_AVAILABILITY)
     public static final ConfigOption<String> HA_MODE =
             key("high-availability")
+                    .stringType()
                     .defaultValue("NONE")
                     .withDeprecatedKeys("recovery.mode")
                     .withDescription(
@@ -52,6 +53,7 @@ public class HighAvailabilityOptions {
     @Documentation.Section(Documentation.Sections.COMMON_HIGH_AVAILABILITY)
     public static final ConfigOption<String> HA_CLUSTER_ID =
             key("high-availability.cluster-id")
+                    .stringType()
                     .defaultValue("/default")
                     .withDeprecatedKeys(
                             "high-availability.zookeeper.path.namespace",
@@ -64,6 +66,7 @@ public class HighAvailabilityOptions {
     @Documentation.Section(Documentation.Sections.COMMON_HIGH_AVAILABILITY)
     public static final ConfigOption<String> HA_STORAGE_PATH =
             key("high-availability.storageDir")
+                    .stringType()
                     .noDefaultValue()
                     .withDeprecatedKeys(
                             "high-availability.zookeeper.storageDir",
@@ -101,6 +104,7 @@ public class HighAvailabilityOptions {
     @Documentation.Section(Documentation.Sections.COMMON_HIGH_AVAILABILITY_ZOOKEEPER)
     public static final ConfigOption<String> HA_ZOOKEEPER_QUORUM =
             key("high-availability.zookeeper.quorum")
+                    .stringType()
                     .noDefaultValue()
                     .withDeprecatedKeys("recovery.zookeeper.quorum")
                     .withDescription(
@@ -110,6 +114,7 @@ public class HighAvailabilityOptions {
     @Documentation.Section(Documentation.Sections.COMMON_HIGH_AVAILABILITY_ZOOKEEPER)
     public static final ConfigOption<String> HA_ZOOKEEPER_ROOT =
             key("high-availability.zookeeper.path.root")
+                    .stringType()
                     .defaultValue("/flink")
                     .withDeprecatedKeys("recovery.zookeeper.path.root")
                     .withDescription(
@@ -119,6 +124,7 @@ public class HighAvailabilityOptions {
     @Documentation.Section(Documentation.Sections.EXPERT_ZOOKEEPER_HIGH_AVAILABILITY)
     public static final ConfigOption<String> HA_ZOOKEEPER_JOBGRAPHS_PATH =
             key("high-availability.zookeeper.path.jobgraphs")
+                    .stringType()
                     .defaultValue("/jobgraphs")
                     .withDeprecatedKeys("recovery.zookeeper.path.jobgraphs")
                     .withDescription("ZooKeeper root path (ZNode) for job graphs");
@@ -130,6 +136,7 @@ public class HighAvailabilityOptions {
     @Documentation.Section(Documentation.Sections.EXPERT_ZOOKEEPER_HIGH_AVAILABILITY)
     public static final ConfigOption<Integer> ZOOKEEPER_SESSION_TIMEOUT =
             key("high-availability.zookeeper.client.session-timeout")
+                    .intType()
                     .defaultValue(60000)
                     .withDeprecatedKeys("recovery.zookeeper.client.session-timeout")
                     .withDescription(
@@ -138,6 +145,7 @@ public class HighAvailabilityOptions {
     @Documentation.Section(Documentation.Sections.EXPERT_ZOOKEEPER_HIGH_AVAILABILITY)
     public static final ConfigOption<Integer> ZOOKEEPER_CONNECTION_TIMEOUT =
             key("high-availability.zookeeper.client.connection-timeout")
+                    .intType()
                     .defaultValue(15000)
                     .withDeprecatedKeys("recovery.zookeeper.client.connection-timeout")
                     .withDescription("Defines the connection timeout for ZooKeeper in ms.");
@@ -145,6 +153,7 @@ public class HighAvailabilityOptions {
     @Documentation.Section(Documentation.Sections.EXPERT_ZOOKEEPER_HIGH_AVAILABILITY)
     public static final ConfigOption<Integer> ZOOKEEPER_RETRY_WAIT =
             key("high-availability.zookeeper.client.retry-wait")
+                    .intType()
                     .defaultValue(5000)
                     .withDeprecatedKeys("recovery.zookeeper.client.retry-wait")
                     .withDescription("Defines the pause between consecutive retries in ms.");
@@ -152,6 +161,7 @@ public class HighAvailabilityOptions {
     @Documentation.Section(Documentation.Sections.EXPERT_ZOOKEEPER_HIGH_AVAILABILITY)
     public static final ConfigOption<Integer> ZOOKEEPER_MAX_RETRY_ATTEMPTS =
             key("high-availability.zookeeper.client.max-retry-attempts")
+                    .intType()
                     .defaultValue(3)
                     .withDeprecatedKeys("recovery.zookeeper.client.max-retry-attempts")
                     .withDescription(
@@ -160,11 +170,13 @@ public class HighAvailabilityOptions {
     @Documentation.Section(Documentation.Sections.EXPERT_ZOOKEEPER_HIGH_AVAILABILITY)
     public static final ConfigOption<String> ZOOKEEPER_RUNNING_JOB_REGISTRY_PATH =
             key("high-availability.zookeeper.path.running-registry")
+                    .stringType()
                     .defaultValue("/running_job_registry/");
 
     @Documentation.Section(Documentation.Sections.EXPERT_ZOOKEEPER_HIGH_AVAILABILITY)
     public static final ConfigOption<String> ZOOKEEPER_CLIENT_ACL =
             key("high-availability.zookeeper.client.acl")
+                    .stringType()
                     .defaultValue("open")
                     .withDescription(
                             "Defines the ACL (open|creator) to be configured on ZK node. The configuration value can be"
@@ -199,6 +211,7 @@ public class HighAvailabilityOptions {
     @Deprecated
     public static final ConfigOption<String> HA_JOB_DELAY =
             key("high-availability.job.delay")
+                    .stringType()
                     .noDefaultValue()
                     .withDeprecatedKeys("recovery.job.delay")
                     .withDescription(

--- a/flink-core/src/main/java/org/apache/flink/configuration/HistoryServerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/HistoryServerOptions.java
@@ -34,6 +34,7 @@ public class HistoryServerOptions {
      */
     public static final ConfigOption<Long> HISTORY_SERVER_ARCHIVE_REFRESH_INTERVAL =
             key("historyserver.archive.fs.refresh-interval")
+                    .longType()
                     .defaultValue(10000L)
                     .withDescription(
                             "Interval in milliseconds for refreshing the archived job directories.");
@@ -41,6 +42,7 @@ public class HistoryServerOptions {
     /** Comma-separated list of directories which the HistoryServer polls for new archives. */
     public static final ConfigOption<String> HISTORY_SERVER_ARCHIVE_DIRS =
             key("historyserver.archive.fs.dir")
+                    .stringType()
                     .noDefaultValue()
                     .withDescription(
                             "Comma separated list of directories to fetch archived jobs from. The history server will"
@@ -50,6 +52,7 @@ public class HistoryServerOptions {
     /** If this option is enabled then deleted job archives are also deleted from HistoryServer. */
     public static final ConfigOption<Boolean> HISTORY_SERVER_CLEANUP_EXPIRED_JOBS =
             key("historyserver.archive.clean-expired-jobs")
+                    .booleanType()
                     .defaultValue(false)
                     .withDescription(
                             String.format(
@@ -60,6 +63,7 @@ public class HistoryServerOptions {
     /** The local directory used by the HistoryServer web-frontend. */
     public static final ConfigOption<String> HISTORY_SERVER_WEB_DIR =
             key("historyserver.web.tmpdir")
+                    .stringType()
                     .noDefaultValue()
                     .withDescription(
                             "Local directory that is used by the history server REST API for temporary files.");
@@ -67,18 +71,21 @@ public class HistoryServerOptions {
     /** The address under which the HistoryServer web-frontend is accessible. */
     public static final ConfigOption<String> HISTORY_SERVER_WEB_ADDRESS =
             key("historyserver.web.address")
+                    .stringType()
                     .noDefaultValue()
                     .withDescription("Address of the HistoryServer's web interface.");
 
     /** The port under which the HistoryServer web-frontend is accessible. */
     public static final ConfigOption<Integer> HISTORY_SERVER_WEB_PORT =
             key("historyserver.web.port")
+                    .intType()
                     .defaultValue(8082)
                     .withDescription("Port of the HistoryServers's web interface.");
 
     /** The refresh interval for the HistoryServer web-frontend in milliseconds. */
     public static final ConfigOption<Long> HISTORY_SERVER_WEB_REFRESH_INTERVAL =
             key("historyserver.web.refresh-interval")
+                    .longType()
                     .defaultValue(10000L)
                     .withDescription(
                             "The refresh interval for the HistoryServer web-frontend in milliseconds.");
@@ -89,6 +96,7 @@ public class HistoryServerOptions {
      */
     public static final ConfigOption<Boolean> HISTORY_SERVER_WEB_SSL_ENABLED =
             key("historyserver.web.ssl.enabled")
+                    .booleanType()
                     .defaultValue(false)
                     .withDescription(
                             "Enable HTTPs access to the HistoryServer web frontend. This is applicable only when the"

--- a/flink-core/src/main/java/org/apache/flink/configuration/JMXServerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/JMXServerOptions.java
@@ -32,6 +32,7 @@ public class JMXServerOptions {
     @Documentation.Section(Documentation.Sections.EXPERT_DEBUGGING_AND_TUNING)
     public static final ConfigOption<String> JMX_SERVER_PORT =
             key("jmx.server.port")
+                    .stringType()
                     .noDefaultValue()
                     .withDescription(
                             new Description.DescriptionBuilder()

--- a/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
@@ -51,6 +51,7 @@ public class JobManagerOptions {
     })
     public static final ConfigOption<String> ADDRESS =
             key("jobmanager.rpc.address")
+                    .stringType()
                     .noDefaultValue()
                     .withDescription(
                             "The config parameter defining the network address to connect to"
@@ -86,6 +87,7 @@ public class JobManagerOptions {
     })
     public static final ConfigOption<Integer> PORT =
             key("jobmanager.rpc.port")
+                    .intType()
                     .defaultValue(6123)
                     .withDescription(
                             "The config parameter defining the network port to connect to"
@@ -252,6 +254,7 @@ public class JobManagerOptions {
     @Documentation.Section(Documentation.Sections.ALL_JOB_MANAGER)
     public static final ConfigOption<Integer> MAX_ATTEMPTS_HISTORY_SIZE =
             key("jobmanager.execution.attempts-history-size")
+                    .intType()
                     .defaultValue(16)
                     .withDeprecatedKeys("job-manager.max-attempts-history-size")
                     .withDescription(
@@ -288,6 +291,7 @@ public class JobManagerOptions {
     @Documentation.Section(Documentation.Sections.ALL_JOB_MANAGER)
     public static final ConfigOption<String> ARCHIVE_DIR =
             key("jobmanager.archive.fs.dir")
+                    .stringType()
                     .noDefaultValue()
                     .withDescription(
                             "Dictionary for JobManager to store the archives of completed jobs.");
@@ -296,6 +300,7 @@ public class JobManagerOptions {
     @Documentation.Section(Documentation.Sections.ALL_JOB_MANAGER)
     public static final ConfigOption<Long> JOB_STORE_CACHE_SIZE =
             key("jobstore.cache-size")
+                    .longType()
                     .defaultValue(50L * 1024L * 1024L)
                     .withDescription(
                             "The job store cache size in bytes which is used to keep completed jobs in memory.");
@@ -304,6 +309,7 @@ public class JobManagerOptions {
     @Documentation.Section(Documentation.Sections.ALL_JOB_MANAGER)
     public static final ConfigOption<Long> JOB_STORE_EXPIRATION_TIME =
             key("jobstore.expiration-time")
+                    .longType()
                     .defaultValue(60L * 60L)
                     .withDescription(
                             "The time in seconds after which a completed job expires and is purged from the job store.");
@@ -312,6 +318,7 @@ public class JobManagerOptions {
     @Documentation.Section(Documentation.Sections.ALL_JOB_MANAGER)
     public static final ConfigOption<Integer> JOB_STORE_MAX_CAPACITY =
             key("jobstore.max-capacity")
+                    .intType()
                     .defaultValue(Integer.MAX_VALUE)
                     .withDescription(
                             "The max number of completed jobs that can be kept in the job store.");
@@ -323,6 +330,7 @@ public class JobManagerOptions {
     @Documentation.Section(Documentation.Sections.ALL_JOB_MANAGER)
     public static final ConfigOption<Boolean> RETRIEVE_TASK_MANAGER_HOSTNAME =
             key("jobmanager.retrieve-taskmanager-hostname")
+                    .booleanType()
                     .defaultValue(true)
                     .withDescription(
                             "Flag indicating whether JobManager would retrieve canonical "
@@ -361,6 +369,7 @@ public class JobManagerOptions {
     @Documentation.Section(Documentation.Sections.EXPERT_SCHEDULING)
     public static final ConfigOption<Long> SLOT_REQUEST_TIMEOUT =
             key("slot.request.timeout")
+                    .longType()
                     .defaultValue(5L * 60L * 1000L)
                     .withDescription(
                             "The timeout in milliseconds for requesting a slot from Slot Pool.");
@@ -369,6 +378,7 @@ public class JobManagerOptions {
     @Documentation.Section(Documentation.Sections.EXPERT_SCHEDULING)
     public static final ConfigOption<Long> SLOT_IDLE_TIMEOUT =
             key("slot.idle.timeout")
+                    .longType()
                     // default matches heartbeat.timeout so that sticky allocation is not lost on
                     // timeouts for local recovery
                     .defaultValue(HeartbeatManagerOptions.HEARTBEAT_TIMEOUT.defaultValue())
@@ -479,6 +489,7 @@ public class JobManagerOptions {
                     + "We aim at removing this flag eventually.")
     public static final ConfigOption<Boolean> PARTITION_RELEASE_DURING_JOB_EXECUTION =
             key("jobmanager.partition.release-during-job-execution")
+                    .booleanType()
                     .defaultValue(true)
                     .withDescription(
                             "Controls whether partitions should already be released during the job execution.");

--- a/flink-core/src/main/java/org/apache/flink/configuration/MetricOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/MetricOptions.java
@@ -53,6 +53,7 @@ public class MetricOptions {
      */
     public static final ConfigOption<String> REPORTERS_LIST =
             key("metrics.reporters")
+                    .stringType()
                     .noDefaultValue()
                     .withDescription(
                             "An optional list of reporter names. If configured, only reporters whose name matches"
@@ -61,6 +62,7 @@ public class MetricOptions {
 
     public static final ConfigOption<String> REPORTER_CLASS =
             key("metrics.reporter.<name>.class")
+                    .stringType()
                     .noDefaultValue()
                     .withDescription("The reporter class to use for the reporter named <name>.");
 
@@ -72,6 +74,7 @@ public class MetricOptions {
 
     public static final ConfigOption<String> REPORTER_CONFIG_PARAMETER =
             key("metrics.reporter.<name>.<parameter>")
+                    .stringType()
                     .noDefaultValue()
                     .withDescription(
                             "Configures the parameter <parameter> for the reporter named <name>.");
@@ -79,12 +82,14 @@ public class MetricOptions {
     /** The delimiter used to assemble the metric identifier. */
     public static final ConfigOption<String> SCOPE_DELIMITER =
             key("metrics.scope.delimiter")
+                    .stringType()
                     .defaultValue(".")
                     .withDescription("Delimiter used to assemble the metric identifier.");
 
     /** The scope format string that is applied to all metrics scoped to a JobManager. */
     public static final ConfigOption<String> SCOPE_NAMING_JM =
             key("metrics.scope.jm")
+                    .stringType()
                     .defaultValue("<host>.jobmanager")
                     .withDescription(
                             "Defines the scope format string that is applied to all metrics scoped to a JobManager.");
@@ -92,6 +97,7 @@ public class MetricOptions {
     /** The scope format string that is applied to all metrics scoped to a TaskManager. */
     public static final ConfigOption<String> SCOPE_NAMING_TM =
             key("metrics.scope.tm")
+                    .stringType()
                     .defaultValue("<host>.taskmanager.<tm_id>")
                     .withDescription(
                             "Defines the scope format string that is applied to all metrics scoped to a TaskManager.");
@@ -99,6 +105,7 @@ public class MetricOptions {
     /** The scope format string that is applied to all metrics scoped to a job on a JobManager. */
     public static final ConfigOption<String> SCOPE_NAMING_JM_JOB =
             key("metrics.scope.jm.job")
+                    .stringType()
                     .defaultValue("<host>.jobmanager.<job_name>")
                     .withDescription(
                             "Defines the scope format string that is applied to all metrics scoped to a job on a JobManager.");
@@ -106,6 +113,7 @@ public class MetricOptions {
     /** The scope format string that is applied to all metrics scoped to a job on a TaskManager. */
     public static final ConfigOption<String> SCOPE_NAMING_TM_JOB =
             key("metrics.scope.tm.job")
+                    .stringType()
                     .defaultValue("<host>.taskmanager.<tm_id>.<job_name>")
                     .withDescription(
                             "Defines the scope format string that is applied to all metrics scoped to a job on a TaskManager.");
@@ -113,6 +121,7 @@ public class MetricOptions {
     /** The scope format string that is applied to all metrics scoped to a task. */
     public static final ConfigOption<String> SCOPE_NAMING_TASK =
             key("metrics.scope.task")
+                    .stringType()
                     .defaultValue(
                             "<host>.taskmanager.<tm_id>.<job_name>.<task_name>.<subtask_index>")
                     .withDescription(
@@ -121,6 +130,7 @@ public class MetricOptions {
     /** The scope format string that is applied to all metrics scoped to an operator. */
     public static final ConfigOption<String> SCOPE_NAMING_OPERATOR =
             key("metrics.scope.operator")
+                    .stringType()
                     .defaultValue(
                             "<host>.taskmanager.<tm_id>.<job_name>.<operator_name>.<subtask_index>")
                     .withDescription(
@@ -128,6 +138,7 @@ public class MetricOptions {
 
     public static final ConfigOption<Long> LATENCY_INTERVAL =
             key("metrics.latency.interval")
+                    .longType()
                     .defaultValue(0L)
                     .withDescription(
                             "Defines the interval at which latency tracking marks are emitted from the sources."
@@ -136,6 +147,7 @@ public class MetricOptions {
 
     public static final ConfigOption<String> LATENCY_SOURCE_GRANULARITY =
             key("metrics.latency.granularity")
+                    .stringType()
                     .defaultValue("operator")
                     .withDescription(
                             Description.builder()
@@ -153,6 +165,7 @@ public class MetricOptions {
     /** The number of measured latencies to maintain at each operator. */
     public static final ConfigOption<Integer> LATENCY_HISTORY_SIZE =
             key("metrics.latency.history-size")
+                    .intType()
                     .defaultValue(128)
                     .withDescription(
                             "Defines the number of measured latencies to maintain at each operator.");
@@ -163,6 +176,7 @@ public class MetricOptions {
      */
     public static final ConfigOption<Boolean> SYSTEM_RESOURCE_METRICS =
             key("metrics.system-resource")
+                    .booleanType()
                     .defaultValue(false)
                     .withDescription(
                             "Flag indicating whether Flink should report system resource metrics such as machine's CPU,"
@@ -173,6 +187,7 @@ public class MetricOptions {
      */
     public static final ConfigOption<Long> SYSTEM_RESOURCE_METRICS_PROBING_INTERVAL =
             key("metrics.system-resource-probing-interval")
+                    .longType()
                     .defaultValue(5000L)
                     .withDescription(
                             "Interval between probing of system resource metrics specified in milliseconds. Has an effect"
@@ -187,6 +202,7 @@ public class MetricOptions {
     @Documentation.Section(Documentation.Sections.COMMON_HOST_PORT)
     public static final ConfigOption<String> QUERY_SERVICE_PORT =
             key("metrics.internal.query-service.port")
+                    .stringType()
                     .defaultValue("0")
                     .withDescription(
                             "The port range used for Flink's internal metric query service. Accepts a list of ports "
@@ -200,6 +216,7 @@ public class MetricOptions {
      */
     public static final ConfigOption<Integer> QUERY_SERVICE_THREAD_PRIORITY =
             key("metrics.internal.query-service.thread-priority")
+                    .intType()
                     .defaultValue(1)
                     .withDescription(
                             "The thread priority used for Flink's internal metric query service. The thread is created"
@@ -212,6 +229,7 @@ public class MetricOptions {
      */
     public static final ConfigOption<Long> METRIC_FETCHER_UPDATE_INTERVAL =
             key("metrics.fetcher.update-interval")
+                    .longType()
                     .defaultValue(10000L)
                     .withDescription(
                             "Update interval for the metric fetcher used by the web UI in milliseconds. Decrease this value for "

--- a/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
@@ -41,6 +41,7 @@ public class NettyShuffleEnvironmentOptions {
     })
     public static final ConfigOption<Integer> DATA_PORT =
             key("taskmanager.data.port")
+                    .intType()
                     .defaultValue(0)
                     .withDescription(
                             "The task manager’s external port used for data exchange operations.");
@@ -59,6 +60,7 @@ public class NettyShuffleEnvironmentOptions {
     @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER)
     public static final ConfigOption<Boolean> DATA_SSL_ENABLED =
             key("taskmanager.data.ssl.enabled")
+                    .booleanType()
                     .defaultValue(true)
                     .withDescription(
                             "Enable SSL support for the taskmanager data transport. This is applicable only when the"
@@ -89,6 +91,7 @@ public class NettyShuffleEnvironmentOptions {
     @Documentation.ExcludeFromDocumentation("Currently, LZ4 is the only legal option.")
     public static final ConfigOption<String> SHUFFLE_COMPRESSION_CODEC =
             key("taskmanager.network.compression.codec")
+                    .stringType()
                     .defaultValue("LZ4")
                     .withDescription("The codec to be used when compressing shuffle data.");
 
@@ -99,6 +102,7 @@ public class NettyShuffleEnvironmentOptions {
     @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER_NETWORK)
     public static final ConfigOption<Boolean> NETWORK_DETAILED_METRICS =
             key("taskmanager.network.detailed-metrics")
+                    .booleanType()
                     .defaultValue(false)
                     .withDescription(
                             "Boolean flag to enable/disable more detailed metrics about inbound/outbound network queue lengths.");
@@ -113,7 +117,7 @@ public class NettyShuffleEnvironmentOptions {
      */
     @Deprecated
     public static final ConfigOption<Integer> NETWORK_NUM_BUFFERS =
-            key("taskmanager.network.numberOfBuffers").defaultValue(2048);
+            key("taskmanager.network.numberOfBuffers").intType().defaultValue(2048);
 
     /**
      * Fraction of JVM memory to use for network buffers.
@@ -123,6 +127,7 @@ public class NettyShuffleEnvironmentOptions {
     @Deprecated
     public static final ConfigOption<Float> NETWORK_BUFFERS_MEMORY_FRACTION =
             key("taskmanager.network.memory.fraction")
+                    .floatType()
                     .defaultValue(0.1f)
                     .withDescription(
                             "Fraction of JVM memory to use for network buffers. This determines how many streaming"
@@ -139,6 +144,7 @@ public class NettyShuffleEnvironmentOptions {
     @Deprecated
     public static final ConfigOption<String> NETWORK_BUFFERS_MEMORY_MIN =
             key("taskmanager.network.memory.min")
+                    .stringType()
                     .defaultValue("64mb")
                     .withDescription("Minimum memory size for network buffers.");
 
@@ -150,6 +156,7 @@ public class NettyShuffleEnvironmentOptions {
     @Deprecated
     public static final ConfigOption<String> NETWORK_BUFFERS_MEMORY_MAX =
             key("taskmanager.network.memory.max")
+                    .stringType()
                     .defaultValue("1gb")
                     .withDescription("Maximum memory size for network buffers.");
 
@@ -176,6 +183,7 @@ public class NettyShuffleEnvironmentOptions {
     @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER_NETWORK)
     public static final ConfigOption<Integer> NETWORK_BUFFERS_PER_CHANNEL =
             key("taskmanager.network.memory.buffers-per-channel")
+                    .intType()
                     .defaultValue(2)
                     .withDescription(
                             "Number of exclusive network buffers to use for each outgoing/incoming "
@@ -198,6 +206,7 @@ public class NettyShuffleEnvironmentOptions {
     @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER_NETWORK)
     public static final ConfigOption<Integer> NETWORK_EXTRA_BUFFERS_PER_GATE =
             key("taskmanager.network.memory.floating-buffers-per-gate")
+                    .intType()
                     .defaultValue(8)
                     .withDescription(
                             "Number of extra network buffers to use for each outgoing/incoming gate (result partition/input gate)."
@@ -255,6 +264,7 @@ public class NettyShuffleEnvironmentOptions {
     @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER_NETWORK)
     public static final ConfigOption<Integer> NETWORK_MAX_BUFFERS_PER_CHANNEL =
             key("taskmanager.network.memory.max-buffers-per-channel")
+                    .intType()
                     .defaultValue(10)
                     .withDescription(
                             "Number of max buffers that can be used for each channel. If a channel exceeds the number of max"
@@ -269,6 +279,7 @@ public class NettyShuffleEnvironmentOptions {
             "This option is purely implementation related, and may be removed as the implementation changes.")
     public static final ConfigOption<Long> NETWORK_EXCLUSIVE_BUFFERS_REQUEST_TIMEOUT_MILLISECONDS =
             key("taskmanager.network.memory.exclusive-buffers-request-timeout-ms")
+                    .longType()
                     .defaultValue(30000L)
                     .withDescription(
                             "The timeout for requesting exclusive buffers for each channel. Since the number of maximum buffers and "
@@ -279,6 +290,7 @@ public class NettyShuffleEnvironmentOptions {
     @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER_NETWORK)
     public static final ConfigOption<String> NETWORK_BLOCKING_SHUFFLE_TYPE =
             key("taskmanager.network.blocking-shuffle.type")
+                    .stringType()
                     .defaultValue("file")
                     .withDescription(
                             "The blocking shuffle type, either \"mmap\" or \"file\". The \"auto\" means selecting the property type automatically"
@@ -293,6 +305,7 @@ public class NettyShuffleEnvironmentOptions {
     @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER_NETWORK)
     public static final ConfigOption<Integer> NUM_ARENAS =
             key("taskmanager.network.netty.num-arenas")
+                    .intType()
                     .defaultValue(-1)
                     .withDeprecatedKeys("taskmanager.net.num-arenas")
                     .withDescription("The number of Netty arenas.");
@@ -300,6 +313,7 @@ public class NettyShuffleEnvironmentOptions {
     @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER_NETWORK)
     public static final ConfigOption<Integer> NUM_THREADS_SERVER =
             key("taskmanager.network.netty.server.numThreads")
+                    .intType()
                     .defaultValue(-1)
                     .withDeprecatedKeys("taskmanager.net.server.numThreads")
                     .withDescription("The number of Netty server threads.");
@@ -307,6 +321,7 @@ public class NettyShuffleEnvironmentOptions {
     @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER_NETWORK)
     public static final ConfigOption<Integer> NUM_THREADS_CLIENT =
             key("taskmanager.network.netty.client.numThreads")
+                    .intType()
                     .defaultValue(-1)
                     .withDeprecatedKeys("taskmanager.net.client.numThreads")
                     .withDescription("The number of Netty client threads.");
@@ -314,6 +329,7 @@ public class NettyShuffleEnvironmentOptions {
     @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER_NETWORK)
     public static final ConfigOption<Integer> CONNECT_BACKLOG =
             key("taskmanager.network.netty.server.backlog")
+                    .intType()
                     .defaultValue(0) // default: 0 => Netty's default
                     .withDeprecatedKeys("taskmanager.net.server.backlog")
                     .withDescription("The netty server connection backlog.");
@@ -321,6 +337,7 @@ public class NettyShuffleEnvironmentOptions {
     @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER_NETWORK)
     public static final ConfigOption<Integer> CLIENT_CONNECT_TIMEOUT_SECONDS =
             key("taskmanager.network.netty.client.connectTimeoutSec")
+                    .intType()
                     .defaultValue(120) // default: 120s = 2min
                     .withDeprecatedKeys("taskmanager.net.client.connectTimeoutSec")
                     .withDescription("The Netty client connection timeout.");
@@ -328,6 +345,7 @@ public class NettyShuffleEnvironmentOptions {
     @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER_NETWORK)
     public static final ConfigOption<Integer> NETWORK_RETRIES =
             key("taskmanager.network.retries")
+                    .intType()
                     .defaultValue(0)
                     .withDeprecatedKeys("taskmanager.network.retries")
                     .withDescription(
@@ -337,6 +355,7 @@ public class NettyShuffleEnvironmentOptions {
     @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER_NETWORK)
     public static final ConfigOption<Integer> SEND_RECEIVE_BUFFER_SIZE =
             key("taskmanager.network.netty.sendReceiveBufferSize")
+                    .intType()
                     .defaultValue(0) // default: 0 => Netty's default
                     .withDeprecatedKeys("taskmanager.net.sendReceiveBufferSize")
                     .withDescription(
@@ -346,6 +365,7 @@ public class NettyShuffleEnvironmentOptions {
     @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER_NETWORK)
     public static final ConfigOption<String> TRANSPORT_TYPE =
             key("taskmanager.network.netty.transport")
+                    .stringType()
                     .defaultValue("auto")
                     .withDeprecatedKeys("taskmanager.net.transport")
                     .withDescription(
@@ -361,6 +381,7 @@ public class NettyShuffleEnvironmentOptions {
     @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER_NETWORK)
     public static final ConfigOption<Integer> NETWORK_REQUEST_BACKOFF_INITIAL =
             key("taskmanager.network.request-backoff.initial")
+                    .intType()
                     .defaultValue(100)
                     .withDeprecatedKeys("taskmanager.net.request-backoff.initial")
                     .withDescription(
@@ -370,6 +391,7 @@ public class NettyShuffleEnvironmentOptions {
     @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER_NETWORK)
     public static final ConfigOption<Integer> NETWORK_REQUEST_BACKOFF_MAX =
             key("taskmanager.network.request-backoff.max")
+                    .intType()
                     .defaultValue(10000)
                     .withDeprecatedKeys("taskmanager.net.request-backoff.max")
                     .withDescription(

--- a/flink-core/src/main/java/org/apache/flink/configuration/OptimizerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/OptimizerOptions.java
@@ -33,6 +33,7 @@ public class OptimizerOptions {
      */
     public static final ConfigOption<Integer> DELIMITED_FORMAT_MAX_LINE_SAMPLES =
             key("compiler.delimited-informat.max-line-samples")
+                    .intType()
                     .defaultValue(10)
                     .withDescription(
                             "The maximum number of line samples taken by the compiler for delimited inputs. The samples"
@@ -46,6 +47,7 @@ public class OptimizerOptions {
      */
     public static final ConfigOption<Integer> DELIMITED_FORMAT_MIN_LINE_SAMPLES =
             key("compiler.delimited-informat.min-line-samples")
+                    .intType()
                     .defaultValue(2)
                     .withDescription(
                             "The minimum number of line samples taken by the compiler for delimited inputs. The samples"
@@ -60,6 +62,7 @@ public class OptimizerOptions {
      */
     public static final ConfigOption<Integer> DELIMITED_FORMAT_MAX_SAMPLE_LEN =
             key("compiler.delimited-informat.max-sample-len")
+                    .intType()
                     .defaultValue(2097152)
                     .withDescription(
                             "The maximal length of a line sample that the compiler takes for delimited inputs. If the"

--- a/flink-core/src/main/java/org/apache/flink/configuration/QueryableStateOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/QueryableStateOptions.java
@@ -50,6 +50,7 @@ public class QueryableStateOptions {
      */
     public static final ConfigOption<String> PROXY_PORT_RANGE =
             key("queryable-state.proxy.ports")
+                    .stringType()
                     .defaultValue("9069")
                     .withDescription(
                             "The port range of the queryable state proxy. The specified range can be a single "
@@ -60,6 +61,7 @@ public class QueryableStateOptions {
     /** Number of network (event loop) threads for the client proxy (0 => #slots). */
     public static final ConfigOption<Integer> PROXY_NETWORK_THREADS =
             key("queryable-state.proxy.network-threads")
+                    .intType()
                     .defaultValue(0)
                     .withDescription(
                             "Number of network (Netty's event loop) Threads for queryable state proxy.")
@@ -68,6 +70,7 @@ public class QueryableStateOptions {
     /** Number of async query threads for the client proxy (0 => #slots). */
     public static final ConfigOption<Integer> PROXY_ASYNC_QUERY_THREADS =
             key("queryable-state.proxy.query-threads")
+                    .intType()
                     .defaultValue(0)
                     .withDescription(
                             "Number of query Threads for queryable state proxy. Uses the number of slots if set to 0.")
@@ -93,6 +96,7 @@ public class QueryableStateOptions {
      */
     public static final ConfigOption<String> SERVER_PORT_RANGE =
             key("queryable-state.server.ports")
+                    .stringType()
                     .defaultValue("9067")
                     .withDescription(
                             "The port range of the queryable state server. The specified range can be a single "
@@ -103,6 +107,7 @@ public class QueryableStateOptions {
     /** Number of network (event loop) threads for the KvState server (0 => #slots). */
     public static final ConfigOption<Integer> SERVER_NETWORK_THREADS =
             key("queryable-state.server.network-threads")
+                    .intType()
                     .defaultValue(0)
                     .withDescription(
                             "Number of network (Netty's event loop) Threads for queryable state server.")
@@ -111,6 +116,7 @@ public class QueryableStateOptions {
     /** Number of async query threads for the KvStateServerHandler (0 => #slots). */
     public static final ConfigOption<Integer> SERVER_ASYNC_QUERY_THREADS =
             key("queryable-state.server.query-threads")
+                    .intType()
                     .defaultValue(0)
                     .withDescription(
                             "Number of query Threads for queryable state server. Uses the number of slots if set to 0.")
@@ -125,6 +131,7 @@ public class QueryableStateOptions {
      */
     public static final ConfigOption<Boolean> ENABLE_QUERYABLE_STATE_PROXY_SERVER =
             key("queryable-state.enable")
+                    .booleanType()
                     .defaultValue(false)
                     .withDescription(
                             "Option whether the queryable state proxy and server should be enabled where possible"
@@ -140,6 +147,7 @@ public class QueryableStateOptions {
      */
     public static final ConfigOption<Integer> CLIENT_NETWORK_THREADS =
             key("queryable-state.client.network-threads")
+                    .intType()
                     .defaultValue(0)
                     .withDescription(
                             "Number of network (Netty's event loop) Threads for queryable state client.")

--- a/flink-core/src/main/java/org/apache/flink/configuration/ResourceManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ResourceManagerOptions.java
@@ -35,6 +35,7 @@ public class ResourceManagerOptions {
     /** Timeout for jobs which don't have a job manager as leader assigned. */
     public static final ConfigOption<String> JOB_TIMEOUT =
             ConfigOptions.key("resourcemanager.job.timeout")
+                    .stringType()
                     .defaultValue("5 minutes")
                     .withDescription(
                             "Timeout for jobs which don't have a job manager as leader assigned.");
@@ -43,6 +44,7 @@ public class ResourceManagerOptions {
     @Deprecated
     public static final ConfigOption<Integer> LOCAL_NUMBER_RESOURCE_MANAGER =
             ConfigOptions.key("local.number-resourcemanager")
+                    .intType()
                     .defaultValue(1)
                     .withDescription("The number of resource managers start.");
 
@@ -53,6 +55,7 @@ public class ResourceManagerOptions {
      */
     public static final ConfigOption<Integer> IPC_PORT =
             ConfigOptions.key("resourcemanager.rpc.port")
+                    .intType()
                     .defaultValue(0)
                     .withDescription(
                             "Defines the network port to connect to for communication with the resource manager. By"
@@ -147,6 +150,7 @@ public class ResourceManagerOptions {
     @Deprecated
     public static final ConfigOption<Long> SLOT_REQUEST_TIMEOUT =
             ConfigOptions.key("slotmanager.request-timeout")
+                    .longType()
                     .defaultValue(-1L)
                     .withDescription("The timeout for a slot request to be discarded.");
 
@@ -181,12 +185,14 @@ public class ResourceManagerOptions {
     @Deprecated
     public static final ConfigOption<Long> SLOT_MANAGER_TASK_MANAGER_TIMEOUT =
             ConfigOptions.key("slotmanager.taskmanager-timeout")
+                    .longType()
                     .defaultValue(30000L)
                     .withDescription("The timeout for an idle task manager to be released.");
 
     /** The timeout for an idle task manager to be released, in milliseconds. */
     public static final ConfigOption<Long> TASK_MANAGER_TIMEOUT =
             ConfigOptions.key("resourcemanager.taskmanager-timeout")
+                    .longType()
                     .defaultValue(30000L)
                     .withDeprecatedKeys(SLOT_MANAGER_TASK_MANAGER_TIMEOUT.key())
                     .withDescription(
@@ -206,6 +212,7 @@ public class ResourceManagerOptions {
     @Deprecated
     public static final ConfigOption<Boolean> TASK_MANAGER_RELEASE_WHEN_RESULT_CONSUMED =
             ConfigOptions.key("resourcemanager.taskmanager-release.wait.result.consumed")
+                    .booleanType()
                     .defaultValue(true)
                     .withDescription(
                             Description.builder()

--- a/flink-core/src/main/java/org/apache/flink/configuration/RestOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/RestOptions.java
@@ -37,6 +37,7 @@ public class RestOptions {
     @Documentation.Section(Documentation.Sections.COMMON_HOST_PORT)
     public static final ConfigOption<String> BIND_ADDRESS =
             key("rest.bind-address")
+                    .stringType()
                     .noDefaultValue()
                     .withFallbackKeys(WebOptions.ADDRESS.key())
                     .withDeprecatedKeys(
@@ -47,6 +48,7 @@ public class RestOptions {
     @Documentation.Section(Documentation.Sections.COMMON_HOST_PORT)
     public static final ConfigOption<String> BIND_PORT =
             key("rest.bind-port")
+                    .stringType()
                     .defaultValue("8081")
                     .withFallbackKeys(REST_PORT_KEY)
                     .withDeprecatedKeys(
@@ -60,6 +62,7 @@ public class RestOptions {
     @Documentation.Section(Documentation.Sections.COMMON_HOST_PORT)
     public static final ConfigOption<String> ADDRESS =
             key("rest.address")
+                    .stringType()
                     .noDefaultValue()
                     .withFallbackKeys(JobManagerOptions.ADDRESS.key())
                     .withDescription(
@@ -72,6 +75,7 @@ public class RestOptions {
     @Documentation.Section(Documentation.Sections.COMMON_HOST_PORT)
     public static final ConfigOption<Integer> PORT =
             key(REST_PORT_KEY)
+                    .intType()
                     .defaultValue(8081)
                     .withDeprecatedKeys(WebOptions.PORT.key())
                     .withDescription(
@@ -88,6 +92,7 @@ public class RestOptions {
     @Documentation.Section(Documentation.Sections.EXPERT_REST)
     public static final ConfigOption<Long> AWAIT_LEADER_TIMEOUT =
             key("rest.await-leader-timeout")
+                    .longType()
                     .defaultValue(30_000L)
                     .withDescription(
                             "The time in ms that the client waits for the leader address, e.g., "
@@ -101,6 +106,7 @@ public class RestOptions {
     @Documentation.Section(Documentation.Sections.EXPERT_REST)
     public static final ConfigOption<Integer> RETRY_MAX_ATTEMPTS =
             key("rest.retry.max-attempts")
+                    .intType()
                     .defaultValue(20)
                     .withDescription(
                             "The number of retries the client will attempt if a retryable "
@@ -114,6 +120,7 @@ public class RestOptions {
     @Documentation.Section(Documentation.Sections.EXPERT_REST)
     public static final ConfigOption<Long> RETRY_DELAY =
             key("rest.retry.delay")
+                    .longType()
                     .defaultValue(3_000L)
                     .withDescription(
                             String.format(
@@ -125,6 +132,7 @@ public class RestOptions {
     @Documentation.Section(Documentation.Sections.EXPERT_REST)
     public static final ConfigOption<Long> CONNECTION_TIMEOUT =
             key("rest.connection-timeout")
+                    .longType()
                     .defaultValue(15_000L)
                     .withDescription(
                             "The maximum time in ms for the client to establish a TCP connection.");
@@ -133,6 +141,7 @@ public class RestOptions {
     @Documentation.Section(Documentation.Sections.EXPERT_REST)
     public static final ConfigOption<Long> IDLENESS_TIMEOUT =
             key("rest.idleness-timeout")
+                    .longType()
                     .defaultValue(5L * 60L * 1_000L) // 5 minutes
                     .withDescription(
                             "The maximum time in ms for a connection to stay idle before failing.");
@@ -141,6 +150,7 @@ public class RestOptions {
     @Documentation.Section(Documentation.Sections.EXPERT_REST)
     public static final ConfigOption<Integer> SERVER_MAX_CONTENT_LENGTH =
             key("rest.server.max-content-length")
+                    .intType()
                     .defaultValue(104_857_600)
                     .withDescription(
                             "The maximum content length in bytes that the server will handle.");
@@ -149,6 +159,7 @@ public class RestOptions {
     @Documentation.Section(Documentation.Sections.EXPERT_REST)
     public static final ConfigOption<Integer> CLIENT_MAX_CONTENT_LENGTH =
             key("rest.client.max-content-length")
+                    .intType()
                     .defaultValue(104_857_600)
                     .withDescription(
                             "The maximum content length in bytes that the client will handle.");
@@ -156,6 +167,7 @@ public class RestOptions {
     @Documentation.Section(Documentation.Sections.EXPERT_REST)
     public static final ConfigOption<Integer> SERVER_NUM_THREADS =
             key("rest.server.numThreads")
+                    .intType()
                     .defaultValue(4)
                     .withDescription(
                             "The number of threads for the asynchronous processing of requests.");
@@ -163,6 +175,7 @@ public class RestOptions {
     @Documentation.Section(Documentation.Sections.EXPERT_REST)
     public static final ConfigOption<Integer> SERVER_THREAD_PRIORITY =
             key("rest.server.thread-priority")
+                    .intType()
                     .defaultValue(Thread.NORM_PRIORITY)
                     .withDescription(
                             "Thread priority of the REST server's executor for processing asynchronous requests. "

--- a/flink-core/src/main/java/org/apache/flink/configuration/RestartStrategyOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/RestartStrategyOptions.java
@@ -47,6 +47,7 @@ public class RestartStrategyOptions {
 
     public static final ConfigOption<String> RESTART_STRATEGY =
             ConfigOptions.key("restart-strategy")
+                    .stringType()
                     .noDefaultValue()
                     .withDescription(
                             Description.builder()
@@ -116,6 +117,7 @@ public class RestartStrategyOptions {
     public static final ConfigOption<Integer>
             RESTART_STRATEGY_FAILURE_RATE_MAX_FAILURES_PER_INTERVAL =
                     ConfigOptions.key("restart-strategy.failure-rate.max-failures-per-interval")
+                            .intType()
                             .defaultValue(1)
                             .withDescription(
                                     Description.builder()

--- a/flink-core/src/main/java/org/apache/flink/configuration/WebOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/WebOptions.java
@@ -33,6 +33,7 @@ public class WebOptions {
     @Deprecated
     public static final ConfigOption<String> ADDRESS =
             key("web.address")
+                    .stringType()
                     .noDefaultValue()
                     .withDeprecatedKeys("jobmanager.web.address")
                     .withDescription("Address for runtime monitor web-frontend server.");
@@ -44,7 +45,7 @@ public class WebOptions {
      */
     @Deprecated
     public static final ConfigOption<Integer> PORT =
-            key("web.port").defaultValue(8081).withDeprecatedKeys("jobmanager.web.port");
+            key("web.port").intType().defaultValue(8081).withDeprecatedKeys("jobmanager.web.port");
 
     /**
      * The config parameter defining the Access-Control-Allow-Origin header for all responses from
@@ -52,6 +53,7 @@ public class WebOptions {
      */
     public static final ConfigOption<String> ACCESS_CONTROL_ALLOW_ORIGIN =
             key("web.access-control-allow-origin")
+                    .stringType()
                     .defaultValue("*")
                     .withDeprecatedKeys("jobmanager.web.access-control-allow-origin")
                     .withDescription(
@@ -60,6 +62,7 @@ public class WebOptions {
     /** The config parameter defining the refresh interval for the web-frontend in milliseconds. */
     public static final ConfigOption<Long> REFRESH_INTERVAL =
             key("web.refresh-interval")
+                    .longType()
                     .defaultValue(3000L)
                     .withDeprecatedKeys("jobmanager.web.refresh-interval")
                     .withDescription("Refresh interval for the web-frontend in milliseconds.");
@@ -68,6 +71,7 @@ public class WebOptions {
     @Deprecated
     public static final ConfigOption<Boolean> SSL_ENABLED =
             key("web.ssl.enabled")
+                    .booleanType()
                     .defaultValue(true)
                     .withDeprecatedKeys("jobmanager.web.ssl.enabled")
                     .withDescription(
@@ -77,6 +81,7 @@ public class WebOptions {
     @Documentation.OverrideDefault("System.getProperty(\"java.io.tmpdir\")")
     public static final ConfigOption<String> TMP_DIR =
             key("web.tmpdir")
+                    .stringType()
                     .defaultValue(System.getProperty("java.io.tmpdir"))
                     .withDeprecatedKeys("jobmanager.web.tmpdir")
                     .withDescription(
@@ -88,6 +93,7 @@ public class WebOptions {
      */
     public static final ConfigOption<String> UPLOAD_DIR =
             key("web.upload.dir")
+                    .stringType()
                     .noDefaultValue()
                     .withDeprecatedKeys("jobmanager.web.upload.dir")
                     .withDescription(
@@ -101,6 +107,7 @@ public class WebOptions {
     /** The config parameter defining the number of archived jobs for the JobManager. */
     public static final ConfigOption<Integer> ARCHIVE_COUNT =
             key("web.history")
+                    .intType()
                     .defaultValue(5)
                     .withDeprecatedKeys("jobmanager.web.history")
                     .withDescription("Number of archived jobs for the JobManager.");
@@ -111,6 +118,7 @@ public class WebOptions {
      */
     public static final ConfigOption<String> LOG_PATH =
             key("web.log.path")
+                    .stringType()
                     .noDefaultValue()
                     .withDeprecatedKeys("jobmanager.web.log.path")
                     .withDescription(
@@ -119,6 +127,7 @@ public class WebOptions {
     /** Config parameter indicating whether jobs can be uploaded and run from the web-frontend. */
     public static final ConfigOption<Boolean> SUBMIT_ENABLE =
             key("web.submit.enable")
+                    .booleanType()
                     .defaultValue(true)
                     .withDeprecatedKeys("jobmanager.web.submit.enable")
                     .withDescription(
@@ -135,6 +144,7 @@ public class WebOptions {
     /** Config parameter defining the number of checkpoints to remember for recent history. */
     public static final ConfigOption<Integer> CHECKPOINTS_HISTORY_SIZE =
             key("web.checkpoints.history")
+                    .intType()
                     .defaultValue(10)
                     .withDeprecatedKeys("jobmanager.web.checkpoints.history")
                     .withDescription("Number of checkpoints to remember for recent history.");
@@ -153,6 +163,7 @@ public class WebOptions {
     @Deprecated
     public static final ConfigOption<Integer> BACKPRESSURE_CLEANUP_INTERVAL =
             key("web.backpressure.cleanup-interval")
+                    .intType()
                     .defaultValue(10 * 60 * 1000)
                     .withDeprecatedKeys("jobmanager.web.backpressure.cleanup-interval")
                     .withDescription("This config option is no longer used");
@@ -161,6 +172,7 @@ public class WebOptions {
     @Deprecated
     public static final ConfigOption<Integer> BACKPRESSURE_REFRESH_INTERVAL =
             key("web.backpressure.refresh-interval")
+                    .intType()
                     .defaultValue(60 * 1000)
                     .withDeprecatedKeys("jobmanager.web.backpressure.refresh-interval")
                     .withDescription("This config option is no longer used");
@@ -169,6 +181,7 @@ public class WebOptions {
     @Deprecated
     public static final ConfigOption<Integer> BACKPRESSURE_NUM_SAMPLES =
             key("web.backpressure.num-samples")
+                    .intType()
                     .defaultValue(100)
                     .withDeprecatedKeys("jobmanager.web.backpressure.num-samples")
                     .withDescription("This config option is no longer used");
@@ -177,6 +190,7 @@ public class WebOptions {
     @Deprecated
     public static final ConfigOption<Integer> BACKPRESSURE_DELAY =
             key("web.backpressure.delay-between-samples")
+                    .intType()
                     .defaultValue(50)
                     .withDeprecatedKeys("jobmanager.web.backpressure.delay-between-samples")
                     .withDescription("This config option is no longer used");
@@ -184,6 +198,7 @@ public class WebOptions {
     /** Timeout for asynchronous operations by the web monitor in milliseconds. */
     public static final ConfigOption<Long> TIMEOUT =
             key("web.timeout")
+                    .longType()
                     .defaultValue(10L * 60L * 1000L)
                     .withDescription(
                             "Timeout for asynchronous operations by the web monitor in milliseconds.");

--- a/flink-core/src/test/java/org/apache/flink/configuration/ConfigOptionTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/ConfigOptionTest.java
@@ -43,6 +43,7 @@ public class ConfigOptionTest extends TestLogger {
     public void testDeprecationFlagForDeprecatedKeys() {
         final ConfigOption<Integer> optionWithDeprecatedKeys =
                 ConfigOptions.key("key")
+                        .intType()
                         .defaultValue(0)
                         .withDeprecatedKeys("deprecated1", "deprecated2");
 
@@ -55,7 +56,10 @@ public class ConfigOptionTest extends TestLogger {
     @Test
     public void testDeprecationFlagForFallbackKeys() {
         final ConfigOption<Integer> optionWithFallbackKeys =
-                ConfigOptions.key("key").defaultValue(0).withFallbackKeys("fallback1", "fallback2");
+                ConfigOptions.key("key")
+                        .intType()
+                        .defaultValue(0)
+                        .withFallbackKeys("fallback1", "fallback2");
 
         assertTrue(optionWithFallbackKeys.hasFallbackKeys());
         for (final FallbackKey fallbackKey : optionWithFallbackKeys.fallbackKeys()) {
@@ -67,6 +71,7 @@ public class ConfigOptionTest extends TestLogger {
     public void testDeprecationFlagForMixedAlternativeKeys() {
         final ConfigOption<Integer> optionWithMixedKeys =
                 ConfigOptions.key("key")
+                        .intType()
                         .defaultValue(0)
                         .withDeprecatedKeys("deprecated1", "deprecated2")
                         .withFallbackKeys("fallback1", "fallback2");
@@ -95,6 +100,7 @@ public class ConfigOptionTest extends TestLogger {
 
         final ConfigOption<Integer> optionWithDeprecatedKeys =
                 ConfigOptions.key("key")
+                        .intType()
                         .defaultValue(0)
                         .withDeprecatedKeys(deprecatedKeys)
                         .withFallbackKeys("fallback1");
@@ -107,7 +113,7 @@ public class ConfigOptionTest extends TestLogger {
     @Test
     public void testNoDeprecationForFallbackKeysWithoutDeprecated() {
         final ConfigOption<Integer> optionWithFallbackKeys =
-                ConfigOptions.key("key").defaultValue(0).withFallbackKeys("fallback1");
+                ConfigOptions.key("key").intType().defaultValue(0).withFallbackKeys("fallback1");
 
         assertFalse(optionWithFallbackKeys.hasDeprecatedKeys());
     }

--- a/flink-core/src/test/java/org/apache/flink/configuration/ConfigurationTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/ConfigurationTest.java
@@ -46,7 +46,7 @@ import static org.junit.Assert.fail;
 public class ConfigurationTest extends TestLogger {
 
     private static final ConfigOption<String> STRING_OPTION =
-            ConfigOptions.key("test-string-key").noDefaultValue();
+            ConfigOptions.key("test-string-key").stringType().noDefaultValue();
 
     private static final ConfigOption<List<String>> LIST_STRING_OPTION =
             ConfigOptions.key("test-list-key").stringType().asList().noDefaultValue();
@@ -127,8 +127,9 @@ public class ConfigurationTest extends TestLogger {
         cfg.setString("string-key", "abc");
 
         ConfigOption<String> presentStringOption =
-                ConfigOptions.key("string-key").defaultValue("my-beautiful-default");
-        ConfigOption<Integer> presentIntOption = ConfigOptions.key("int-key").defaultValue(87);
+                ConfigOptions.key("string-key").stringType().defaultValue("my-beautiful-default");
+        ConfigOption<Integer> presentIntOption =
+                ConfigOptions.key("int-key").intType().defaultValue(87);
 
         assertEquals("abc", cfg.getString(presentStringOption));
         assertEquals("abc", cfg.getValue(presentStringOption));
@@ -139,8 +140,8 @@ public class ConfigurationTest extends TestLogger {
         // test getting default when no value is present
 
         ConfigOption<String> stringOption =
-                ConfigOptions.key("test").defaultValue("my-beautiful-default");
-        ConfigOption<Integer> intOption = ConfigOptions.key("test2").defaultValue(87);
+                ConfigOptions.key("test").stringType().defaultValue("my-beautiful-default");
+        ConfigOption<Integer> intOption = ConfigOptions.key("test2").intType().defaultValue(87);
 
         // getting strings with default value should work
         assertEquals("my-beautiful-default", cfg.getValue(stringOption));
@@ -160,14 +161,15 @@ public class ConfigurationTest extends TestLogger {
         cfg.setInteger("int-key", 11);
         cfg.setString("string-key", "abc");
 
-        ConfigOption<String> presentStringOption = ConfigOptions.key("string-key").noDefaultValue();
+        ConfigOption<String> presentStringOption =
+                ConfigOptions.key("string-key").stringType().noDefaultValue();
 
         assertEquals("abc", cfg.getString(presentStringOption));
         assertEquals("abc", cfg.getValue(presentStringOption));
 
         // test getting default when no value is present
 
-        ConfigOption<String> stringOption = ConfigOptions.key("test").noDefaultValue();
+        ConfigOption<String> stringOption = ConfigOptions.key("test").stringType().noDefaultValue();
 
         // getting strings for null should work
         assertNull(cfg.getValue(stringOption));
@@ -186,21 +188,25 @@ public class ConfigurationTest extends TestLogger {
 
         ConfigOption<Integer> matchesFirst =
                 ConfigOptions.key("the-key")
+                        .intType()
                         .defaultValue(-1)
                         .withDeprecatedKeys("old-key", "older-key");
 
         ConfigOption<Integer> matchesSecond =
                 ConfigOptions.key("does-not-exist")
+                        .intType()
                         .defaultValue(-1)
                         .withDeprecatedKeys("old-key", "older-key");
 
         ConfigOption<Integer> matchesThird =
                 ConfigOptions.key("does-not-exist")
+                        .intType()
                         .defaultValue(-1)
                         .withDeprecatedKeys("foo", "older-key");
 
         ConfigOption<Integer> notContained =
                 ConfigOptions.key("does-not-exist")
+                        .intType()
                         .defaultValue(-1)
                         .withDeprecatedKeys("not-there", "also-not-there");
 
@@ -219,21 +225,25 @@ public class ConfigurationTest extends TestLogger {
 
         ConfigOption<Integer> matchesFirst =
                 ConfigOptions.key("the-key")
+                        .intType()
                         .defaultValue(-1)
                         .withFallbackKeys("old-key", "older-key");
 
         ConfigOption<Integer> matchesSecond =
                 ConfigOptions.key("does-not-exist")
+                        .intType()
                         .defaultValue(-1)
                         .withFallbackKeys("old-key", "older-key");
 
         ConfigOption<Integer> matchesThird =
                 ConfigOptions.key("does-not-exist")
+                        .intType()
                         .defaultValue(-1)
                         .withFallbackKeys("foo", "older-key");
 
         ConfigOption<Integer> notContained =
                 ConfigOptions.key("does-not-exist")
+                        .intType()
                         .defaultValue(-1)
                         .withFallbackKeys("not-there", "also-not-there");
 
@@ -245,12 +255,15 @@ public class ConfigurationTest extends TestLogger {
 
     @Test
     public void testFallbackAndDeprecatedKeys() {
-        final ConfigOption<Integer> fallback = ConfigOptions.key("fallback").defaultValue(-1);
+        final ConfigOption<Integer> fallback =
+                ConfigOptions.key("fallback").intType().defaultValue(-1);
 
-        final ConfigOption<Integer> deprecated = ConfigOptions.key("deprecated").defaultValue(-1);
+        final ConfigOption<Integer> deprecated =
+                ConfigOptions.key("deprecated").intType().defaultValue(-1);
 
         final ConfigOption<Integer> mainOption =
                 ConfigOptions.key("main")
+                        .intType()
                         .defaultValue(-1)
                         .withFallbackKeys(fallback.key())
                         .withDeprecatedKeys(deprecated.key());
@@ -267,6 +280,7 @@ public class ConfigurationTest extends TestLogger {
         // first
         final ConfigOption<Integer> reversedMainOption =
                 ConfigOptions.key("main")
+                        .intType()
                         .defaultValue(-1)
                         .withDeprecatedKeys(deprecated.key())
                         .withFallbackKeys(fallback.key());
@@ -284,13 +298,13 @@ public class ConfigurationTest extends TestLogger {
         cfg.setInteger("a", 1);
         cfg.setInteger("b", 2);
 
-        ConfigOption<Integer> validOption = ConfigOptions.key("a").defaultValue(-1);
+        ConfigOption<Integer> validOption = ConfigOptions.key("a").intType().defaultValue(-1);
 
         ConfigOption<Integer> deprecatedOption =
-                ConfigOptions.key("c").defaultValue(-1).withDeprecatedKeys("d", "b");
+                ConfigOptions.key("c").intType().defaultValue(-1).withDeprecatedKeys("d", "b");
 
         ConfigOption<Integer> unexistedOption =
-                ConfigOptions.key("e").defaultValue(-1).withDeprecatedKeys("f", "g", "j");
+                ConfigOptions.key("e").intType().defaultValue(-1).withDeprecatedKeys("f", "g", "j");
 
         assertEquals("Wrong expectation about size", cfg.keySet().size(), 2);
         assertTrue("Expected 'validOption' is removed", cfg.removeConfig(validOption));

--- a/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/DataStreamAllroundTestJobFactory.java
+++ b/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/DataStreamAllroundTestJobFactory.java
@@ -134,18 +134,21 @@ import static org.apache.flink.streaming.tests.TestOperatorEnum.RESULT_TYPE_QUER
 public class DataStreamAllroundTestJobFactory {
     private static final ConfigOption<String> TEST_SEMANTICS =
             ConfigOptions.key("test.semantics")
+                    .stringType()
                     .defaultValue("exactly-once")
                     .withDescription(
                             "This configures the semantics to test. Can be 'exactly-once' or 'at-least-once'");
 
     private static final ConfigOption<Boolean> TEST_SIMULATE_FAILURE =
             ConfigOptions.key("test.simulate_failure")
+                    .booleanType()
                     .defaultValue(false)
                     .withDescription(
                             "This configures whether or not to simulate failures by throwing exceptions within the job.");
 
     private static final ConfigOption<Long> TEST_SIMULATE_FAILURE_NUM_RECORDS =
             ConfigOptions.key("test.simulate_failure.num_records")
+                    .longType()
                     .defaultValue(100L)
                     .withDescription(
                             "The number of records to process before throwing an exception, per job execution attempt."
@@ -153,6 +156,7 @@ public class DataStreamAllroundTestJobFactory {
 
     private static final ConfigOption<Long> TEST_SIMULATE_FAILURE_NUM_CHECKPOINTS =
             ConfigOptions.key("test.simulate_failure.num_checkpoints")
+                    .longType()
                     .defaultValue(1L)
                     .withDescription(
                             "The number of complete checkpoints before throwing an exception, per job execution attempt."
@@ -160,6 +164,7 @@ public class DataStreamAllroundTestJobFactory {
 
     private static final ConfigOption<Integer> TEST_SIMULATE_FAILURE_MAX_FAILURES =
             ConfigOptions.key("test.simulate_failure.max_failures")
+                    .intType()
                     .defaultValue(1)
                     .withDescription(
                             "The maximum number of times to fail the job. This also takes into account failures that were not triggered"
@@ -167,35 +172,47 @@ public class DataStreamAllroundTestJobFactory {
                                     + " Only relevant if configured to simulate failures.");
 
     private static final ConfigOption<Long> ENVIRONMENT_CHECKPOINT_INTERVAL =
-            ConfigOptions.key("environment.checkpoint_interval").defaultValue(1000L);
+            ConfigOptions.key("environment.checkpoint_interval").longType().defaultValue(1000L);
 
     private static final ConfigOption<Boolean> ENVIRONMENT_EXTERNALIZE_CHECKPOINT =
-            ConfigOptions.key("environment.externalize_checkpoint").defaultValue(false);
+            ConfigOptions.key("environment.externalize_checkpoint")
+                    .booleanType()
+                    .defaultValue(false);
 
     private static final ConfigOption<String> ENVIRONMENT_EXTERNALIZE_CHECKPOINT_CLEANUP =
-            ConfigOptions.key("environment.externalize_checkpoint.cleanup").defaultValue("retain");
+            ConfigOptions.key("environment.externalize_checkpoint.cleanup")
+                    .stringType()
+                    .defaultValue("retain");
 
     private static final ConfigOption<Integer> ENVIRONMENT_TOLERABLE_DECLINED_CHECKPOINT_NUMBER =
-            ConfigOptions.key("environment.tolerable_declined_checkpoint_number ").defaultValue(0);
+            ConfigOptions.key("environment.tolerable_declined_checkpoint_number ")
+                    .intType()
+                    .defaultValue(0);
 
     private static final ConfigOption<Integer> ENVIRONMENT_PARALLELISM =
-            ConfigOptions.key("environment.parallelism").defaultValue(1);
+            ConfigOptions.key("environment.parallelism").intType().defaultValue(1);
 
     private static final ConfigOption<Integer> ENVIRONMENT_MAX_PARALLELISM =
-            ConfigOptions.key("environment.max_parallelism").defaultValue(128);
+            ConfigOptions.key("environment.max_parallelism").intType().defaultValue(128);
 
     private static final ConfigOption<String> ENVIRONMENT_RESTART_STRATEGY =
-            ConfigOptions.key("environment.restart_strategy").defaultValue("fixed_delay");
+            ConfigOptions.key("environment.restart_strategy")
+                    .stringType()
+                    .defaultValue("fixed_delay");
 
     private static final ConfigOption<Integer> ENVIRONMENT_RESTART_STRATEGY_FIXED_ATTEMPTS =
             ConfigOptions.key("environment.restart_strategy.fixed_delay.attempts")
+                    .intType()
                     .defaultValue(Integer.MAX_VALUE);
 
     private static final ConfigOption<Long> ENVIRONMENT_RESTART_STRATEGY_FIXED_DELAY =
-            ConfigOptions.key("environment.restart_strategy.fixed.delay").defaultValue(0L);
+            ConfigOptions.key("environment.restart_strategy.fixed.delay")
+                    .longType()
+                    .defaultValue(0L);
 
     private static final ConfigOption<String> STATE_BACKEND =
             ConfigOptions.key("state_backend")
+                    .stringType()
                     .defaultValue("hashmap")
                     .withDescription(
                             "Supported values are 'hashmap' for HashMapStateBackend and 'rocks' "
@@ -203,43 +220,49 @@ public class DataStreamAllroundTestJobFactory {
 
     private static final ConfigOption<String> STATE_BACKEND_CHECKPOINT_DIR =
             ConfigOptions.key("state_backend.checkpoint_directory")
+                    .stringType()
                     .noDefaultValue()
                     .withDescription("The checkpoint directory.");
 
     private static final ConfigOption<Boolean> STATE_BACKEND_ROCKS_INCREMENTAL =
             ConfigOptions.key("state_backend.rocks.incremental")
+                    .booleanType()
                     .defaultValue(false)
                     .withDescription(
                             "Activate or deactivate incremental snapshots if RocksDBStateBackend is selected.");
 
     private static final ConfigOption<Integer> SEQUENCE_GENERATOR_SRC_KEYSPACE =
-            ConfigOptions.key("sequence_generator_source.keyspace").defaultValue(200);
+            ConfigOptions.key("sequence_generator_source.keyspace").intType().defaultValue(200);
 
     private static final ConfigOption<Integer> SEQUENCE_GENERATOR_SRC_PAYLOAD_SIZE =
-            ConfigOptions.key("sequence_generator_source.payload_size").defaultValue(20);
+            ConfigOptions.key("sequence_generator_source.payload_size").intType().defaultValue(20);
 
     private static final ConfigOption<Long> SEQUENCE_GENERATOR_SRC_SLEEP_TIME =
-            ConfigOptions.key("sequence_generator_source.sleep_time").defaultValue(0L);
+            ConfigOptions.key("sequence_generator_source.sleep_time").longType().defaultValue(0L);
 
     private static final ConfigOption<Long> SEQUENCE_GENERATOR_SRC_SLEEP_AFTER_ELEMENTS =
-            ConfigOptions.key("sequence_generator_source.sleep_after_elements").defaultValue(0L);
+            ConfigOptions.key("sequence_generator_source.sleep_after_elements")
+                    .longType()
+                    .defaultValue(0L);
 
     private static final ConfigOption<Long> SEQUENCE_GENERATOR_SRC_EVENT_TIME_MAX_OUT_OF_ORDERNESS =
             ConfigOptions.key("sequence_generator_source.event_time.max_out_of_order")
+                    .longType()
                     .defaultValue(0L);
 
     private static final ConfigOption<Long> SEQUENCE_GENERATOR_SRC_EVENT_TIME_CLOCK_PROGRESS =
             ConfigOptions.key("sequence_generator_source.event_time.clock_progress")
+                    .longType()
                     .defaultValue(100L);
 
     private static final ConfigOption<Long> TUMBLING_WINDOW_OPERATOR_NUM_EVENTS =
-            ConfigOptions.key("tumbling_window_operator.num_events").defaultValue(20L);
+            ConfigOptions.key("tumbling_window_operator.num_events").longType().defaultValue(20L);
 
     private static final ConfigOption<Integer> TEST_SLIDE_FACTOR =
-            ConfigOptions.key("test_slide_factor").defaultValue(3);
+            ConfigOptions.key("test_slide_factor").intType().defaultValue(3);
 
     private static final ConfigOption<Long> TEST_SLIDE_SIZE =
-            ConfigOptions.key("test_slide_size").defaultValue(250L);
+            ConfigOptions.key("test_slide_size").longType().defaultValue(250L);
 
     public static void setupEnvironment(StreamExecutionEnvironment env, ParameterTool pt)
             throws Exception {

--- a/flink-end-to-end-tests/flink-heavy-deployment-stress-test/src/main/java/org/apache/flink/deployment/HeavyDeploymentStressTestProgram.java
+++ b/flink-end-to-end-tests/flink-heavy-deployment-stress-test/src/main/java/org/apache/flink/deployment/HeavyDeploymentStressTestProgram.java
@@ -43,10 +43,13 @@ import static org.apache.flink.streaming.tests.DataStreamAllroundTestJobFactory.
 public class HeavyDeploymentStressTestProgram {
 
     private static final ConfigOption<Integer> NUM_LIST_STATES_PER_OP =
-            ConfigOptions.key("heavy_deployment_test.num_list_states_per_op").defaultValue(100);
+            ConfigOptions.key("heavy_deployment_test.num_list_states_per_op")
+                    .intType()
+                    .defaultValue(100);
 
     private static final ConfigOption<Integer> NUM_PARTITIONS_PER_LIST_STATE =
             ConfigOptions.key("heavy_deployment_test.num_partitions_per_list_state")
+                    .intType()
                     .defaultValue(100);
 
     public static void main(String[] args) throws Exception {

--- a/flink-end-to-end-tests/flink-netty-shuffle-memory-control-test/src/main/java/org/apache/flink/streaming/tests/NettyShuffleMemoryControlTestProgram.java
+++ b/flink-end-to-end-tests/flink-netty-shuffle-memory-control-test/src/main/java/org/apache/flink/streaming/tests/NettyShuffleMemoryControlTestProgram.java
@@ -47,16 +47,19 @@ public class NettyShuffleMemoryControlTestProgram {
 
     private static final ConfigOption<Integer> RUNNING_TIME_IN_SECONDS =
             ConfigOptions.key("test.running_time_in_seconds")
+                    .intType()
                     .defaultValue(120)
                     .withDescription("The time to run.");
 
     private static final ConfigOption<Integer> MAP_PARALLELISM =
             ConfigOptions.key("test.map_parallelism")
+                    .intType()
                     .defaultValue(1)
                     .withDescription("The number of map tasks.");
 
     private static final ConfigOption<Integer> REDUCE_PARALLELISM =
             ConfigOptions.key("test.reduce_parallelism")
+                    .intType()
                     .defaultValue(1)
                     .withDescription("The number of reduce tasks.");
 

--- a/flink-end-to-end-tests/flink-stream-state-ttl-test/src/main/java/org/apache/flink/streaming/tests/TtlTestConfig.java
+++ b/flink-end-to-end-tests/flink-stream-state-ttl-test/src/main/java/org/apache/flink/streaming/tests/TtlTestConfig.java
@@ -25,19 +25,21 @@ import org.apache.flink.configuration.ConfigOptions;
 
 class TtlTestConfig {
     private static final ConfigOption<Integer> UPDATE_GENERATOR_SRC_KEYSPACE =
-            ConfigOptions.key("update_generator_source.keyspace").defaultValue(100);
+            ConfigOptions.key("update_generator_source.keyspace").intType().defaultValue(100);
 
     private static final ConfigOption<Long> UPDATE_GENERATOR_SRC_SLEEP_TIME =
-            ConfigOptions.key("update_generator_source.sleep_time").defaultValue(0L);
+            ConfigOptions.key("update_generator_source.sleep_time").longType().defaultValue(0L);
 
     private static final ConfigOption<Long> UPDATE_GENERATOR_SRC_SLEEP_AFTER_ELEMENTS =
-            ConfigOptions.key("update_generator_source.sleep_after_elements").defaultValue(0L);
+            ConfigOptions.key("update_generator_source.sleep_after_elements")
+                    .longType()
+                    .defaultValue(0L);
 
     private static final ConfigOption<Long> STATE_TTL_VERIFIER_TTL_MILLI =
-            ConfigOptions.key("state_ttl_verifier.ttl_milli").defaultValue(1000L);
+            ConfigOptions.key("state_ttl_verifier.ttl_milli").longType().defaultValue(1000L);
 
     private static final ConfigOption<Long> REPORT_STAT_AFTER_UPDATES_NUM =
-            ConfigOptions.key("report_stat.after_updates_num").defaultValue(200L);
+            ConfigOptions.key("report_stat.after_updates_num").longType().defaultValue(200L);
 
     final int keySpace;
     final long sleepAfterElements;

--- a/flink-end-to-end-tests/flink-stream-stateful-job-upgrade-test/src/main/java/org/apache/flink/streaming/tests/StatefulStreamJobUpgradeTestProgram.java
+++ b/flink-end-to-end-tests/flink-stream-stateful-job-upgrade-test/src/main/java/org/apache/flink/streaming/tests/StatefulStreamJobUpgradeTestProgram.java
@@ -66,6 +66,7 @@ public class StatefulStreamJobUpgradeTestProgram {
 
     private static final ConfigOption<String> TEST_JOB_VARIANT =
             ConfigOptions.key("test.job.variant")
+                    .stringType()
                     .defaultValue(TEST_JOB_VARIANT_ORIGINAL)
                     .withDescription(
                             String.format(

--- a/flink-filesystems/flink-s3-fs-base/src/main/java/org/apache/flink/fs/s3/common/AbstractS3FileSystemFactory.java
+++ b/flink-filesystems/flink-s3-fs-base/src/main/java/org/apache/flink/fs/s3/common/AbstractS3FileSystemFactory.java
@@ -42,6 +42,7 @@ public abstract class AbstractS3FileSystemFactory implements FileSystemFactory {
 
     public static final ConfigOption<Long> PART_UPLOAD_MIN_SIZE =
             ConfigOptions.key("s3.upload.min.part.size")
+                    .longType()
                     .defaultValue(FlinkS3FileSystem.S3_MULTIPART_MIN_PART_SIZE)
                     .withDescription(
                             "This option is relevant to the Recoverable Writer and sets the min size of data that "
@@ -50,6 +51,7 @@ public abstract class AbstractS3FileSystemFactory implements FileSystemFactory {
 
     public static final ConfigOption<Integer> MAX_CONCURRENT_UPLOADS =
             ConfigOptions.key("s3.upload.max.concurrent.uploads")
+                    .intType()
                     .defaultValue(Runtime.getRuntime().availableProcessors())
                     .withDescription(
                             "This option is relevant to the Recoverable Writer and limits the number of "
@@ -60,6 +62,7 @@ public abstract class AbstractS3FileSystemFactory implements FileSystemFactory {
     /** The substring to be replaced by random entropy in checkpoint paths. */
     public static final ConfigOption<String> ENTROPY_INJECT_KEY_OPTION =
             ConfigOptions.key("s3.entropy.key")
+                    .stringType()
                     .noDefaultValue()
                     .withDescription(
                             "This option can be used to improve performance due to sharding issues on Amazon S3. "
@@ -69,6 +72,7 @@ public abstract class AbstractS3FileSystemFactory implements FileSystemFactory {
     /** The number of entropy characters, in case entropy injection is configured. */
     public static final ConfigOption<Integer> ENTROPY_INJECT_LENGTH_OPTION =
             ConfigOptions.key("s3.entropy.length")
+                    .intType()
                     .defaultValue(4)
                     .withDescription(
                             "When '"

--- a/flink-metrics/flink-metrics-influxdb/src/main/java/org/apache/flink/metrics/influxdb/InfluxdbReporterOptions.java
+++ b/flink-metrics/flink-metrics-influxdb/src/main/java/org/apache/flink/metrics/influxdb/InfluxdbReporterOptions.java
@@ -32,7 +32,10 @@ import org.influxdb.InfluxDB;
 public class InfluxdbReporterOptions {
 
     public static final ConfigOption<String> HOST =
-            ConfigOptions.key("host").noDefaultValue().withDescription("the InfluxDB server host");
+            ConfigOptions.key("host")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("the InfluxDB server host");
 
     public static final ConfigOption<Scheme> SCHEME =
             ConfigOptions.key("scheme")
@@ -42,27 +45,32 @@ public class InfluxdbReporterOptions {
 
     public static final ConfigOption<Integer> PORT =
             ConfigOptions.key("port")
+                    .intType()
                     .defaultValue(8086)
                     .withDescription("the InfluxDB server port");
 
     public static final ConfigOption<String> USERNAME =
             ConfigOptions.key("username")
+                    .stringType()
                     .noDefaultValue()
                     .withDescription("(optional) InfluxDB username used for authentication");
 
     public static final ConfigOption<String> PASSWORD =
             ConfigOptions.key("password")
+                    .stringType()
                     .noDefaultValue()
                     .withDescription(
                             "(optional) InfluxDB username's password used for authentication");
 
     public static final ConfigOption<String> DB =
             ConfigOptions.key("db")
+                    .stringType()
                     .noDefaultValue()
                     .withDescription("the InfluxDB database to store metrics");
 
     public static final ConfigOption<String> RETENTION_POLICY =
             ConfigOptions.key("retentionPolicy")
+                    .stringType()
                     .defaultValue("")
                     .withDescription("(optional) the InfluxDB retention policy for metrics");
 
@@ -74,11 +82,13 @@ public class InfluxdbReporterOptions {
 
     public static final ConfigOption<Integer> CONNECT_TIMEOUT =
             ConfigOptions.key("connectTimeout")
+                    .intType()
                     .defaultValue(10000)
                     .withDescription("(optional) the InfluxDB connect timeout for metrics");
 
     public static final ConfigOption<Integer> WRITE_TIMEOUT =
             ConfigOptions.key("writeTimeout")
+                    .intType()
                     .defaultValue(10000)
                     .withDescription("(optional) the InfluxDB write timeout for metrics");
 

--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterOptions.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterOptions.java
@@ -31,27 +31,32 @@ public class PrometheusPushGatewayReporterOptions {
 
     public static final ConfigOption<String> HOST =
             ConfigOptions.key("host")
+                    .stringType()
                     .noDefaultValue()
                     .withDescription("The PushGateway server host.");
 
     public static final ConfigOption<Integer> PORT =
             ConfigOptions.key("port")
+                    .intType()
                     .defaultValue(-1)
                     .withDescription("The PushGateway server port.");
 
     public static final ConfigOption<String> JOB_NAME =
             ConfigOptions.key("jobName")
+                    .stringType()
                     .defaultValue("")
                     .withDescription("The job name under which metrics will be pushed");
 
     public static final ConfigOption<Boolean> RANDOM_JOB_NAME_SUFFIX =
             ConfigOptions.key("randomJobNameSuffix")
+                    .booleanType()
                     .defaultValue(true)
                     .withDescription(
                             "Specifies whether a random suffix should be appended to the job name.");
 
     public static final ConfigOption<Boolean> DELETE_ON_SHUTDOWN =
             ConfigOptions.key("deleteOnShutdown")
+                    .booleanType()
                     .defaultValue(true)
                     .withDescription(
                             Description.builder()
@@ -65,6 +70,7 @@ public class PrometheusPushGatewayReporterOptions {
 
     public static final ConfigOption<Boolean> FILTER_LABEL_VALUE_CHARACTER =
             ConfigOptions.key("filterLabelValueCharacters")
+                    .booleanType()
                     .defaultValue(true)
                     .withDescription(
                             Description.builder()
@@ -81,6 +87,7 @@ public class PrometheusPushGatewayReporterOptions {
 
     public static final ConfigOption<String> GROUPING_KEY =
             ConfigOptions.key("groupingKey")
+                    .stringType()
                     .defaultValue("")
                     .withDescription(
                             Description.builder()

--- a/flink-python/src/main/java/org/apache/flink/python/PythonOptions.java
+++ b/flink-python/src/main/java/org/apache/flink/python/PythonOptions.java
@@ -32,6 +32,7 @@ public class PythonOptions {
     /** The maximum number of elements to include in a bundle. */
     public static final ConfigOption<Integer> MAX_BUNDLE_SIZE =
             ConfigOptions.key("python.fn-execution.bundle.size")
+                    .intType()
                     .defaultValue(100000)
                     .withDescription(
                             "The maximum number of elements to include in a bundle for Python "
@@ -42,6 +43,7 @@ public class PythonOptions {
     /** The maximum time to wait before finalising a bundle (in milliseconds). */
     public static final ConfigOption<Long> MAX_BUNDLE_TIME_MILLS =
             ConfigOptions.key("python.fn-execution.bundle.time")
+                    .longType()
                     .defaultValue(1000L)
                     .withDescription(
                             "Sets the waiting timeout(in milliseconds) before processing a bundle for "
@@ -51,6 +53,7 @@ public class PythonOptions {
     /** The maximum number of elements to include in an arrow batch. */
     public static final ConfigOption<Integer> MAX_ARROW_BATCH_SIZE =
             ConfigOptions.key("python.fn-execution.arrow.batch.size")
+                    .intType()
                     .defaultValue(10000)
                     .withDescription(
                             "The maximum number of elements to include in an arrow batch for Python "
@@ -60,6 +63,7 @@ public class PythonOptions {
     /** The configuration to enable or disable metric for Python execution. */
     public static final ConfigOption<Boolean> PYTHON_METRIC_ENABLED =
             ConfigOptions.key("python.metric.enabled")
+                    .booleanType()
                     .defaultValue(true)
                     .withDescription(
                             "When it is false, metric for Python will be disabled. You can "
@@ -162,6 +166,7 @@ public class PythonOptions {
     /** Whether the memory used by the Python framework is managed memory. */
     public static final ConfigOption<Boolean> USE_MANAGED_MEMORY =
             ConfigOptions.key("python.fn-execution.memory.managed")
+                    .booleanType()
                     .defaultValue(true)
                     .withDescription(
                             String.format(
@@ -175,6 +180,7 @@ public class PythonOptions {
     @Experimental
     public static final ConfigOption<Integer> STATE_CACHE_SIZE =
             ConfigOptions.key("python.state.cache-size")
+                    .intType()
                     .defaultValue(1000)
                     .withDescription(
                             "The maximum number of states cached in a Python UDF worker. Note that this "
@@ -184,6 +190,7 @@ public class PythonOptions {
     @Experimental
     public static final ConfigOption<Integer> MAP_STATE_READ_CACHE_SIZE =
             ConfigOptions.key("python.map-state.read-cache-size")
+                    .intType()
                     .defaultValue(1000)
                     .withDescription(
                             "The maximum number of cached entries for a single Python MapState. "
@@ -193,6 +200,7 @@ public class PythonOptions {
     @Experimental
     public static final ConfigOption<Integer> MAP_STATE_WRITE_CACHE_SIZE =
             ConfigOptions.key("python.map-state.write-cache-size")
+                    .intType()
                     .defaultValue(1000)
                     .withDescription(
                             "The maximum number of cached write requests for a single Python "
@@ -208,6 +216,7 @@ public class PythonOptions {
     @Experimental
     public static final ConfigOption<Integer> MAP_STATE_ITERATE_RESPONSE_BATCH_SIZE =
             ConfigOptions.key("python.map-state.iterate-response-batch-size")
+                    .intType()
                     .defaultValue(1000)
                     .withDescription(
                             "The maximum number of the MapState keys/entries sent to Python UDF worker "
@@ -219,6 +228,7 @@ public class PythonOptions {
     @Experimental
     public static final ConfigOption<String> PYTHON_EXECUTION_MODE =
             ConfigOptions.key("python.execution-mode")
+                    .stringType()
                     .defaultValue("process")
                     .withDescription(
                             "Specify the python runtime execution mode. The optional values are `process`, `multi-thread` and `sub-interpreter`. "

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/BootstrapTools.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/BootstrapTools.java
@@ -51,7 +51,7 @@ import static org.apache.flink.configuration.ConfigOptions.key;
 public class BootstrapTools {
     /** Internal option which says if default value is used for {@link CoreOptions#TMP_DIRS}. */
     private static final ConfigOption<Boolean> USE_LOCAL_DEFAULT_TMP_DIRS =
-            key("internal.io.tmpdirs.use-local-default").defaultValue(false);
+            key("internal.io.tmpdirs.use-local-default").booleanType().defaultValue(false);
 
     private static final Logger LOG = LoggerFactory.getLogger(BootstrapTools.class);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -109,6 +109,7 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
 
     public static final ConfigOption<String> INTERNAL_CLUSTER_EXECUTION_MODE =
             ConfigOptions.key("internal.cluster.execution-mode")
+                    .stringType()
                     .defaultValue(ExecutionMode.NORMAL.toString());
 
     protected static final Logger LOG = LoggerFactory.getLogger(ClusterEntrypoint.class);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/FileJobGraphRetriever.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/FileJobGraphRetriever.java
@@ -45,7 +45,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public class FileJobGraphRetriever extends AbstractUserClassPathJobGraphRetriever {
 
     public static final ConfigOption<String> JOB_GRAPH_FILE_PATH =
-            ConfigOptions.key("internal.jobgraph-path").defaultValue("job.graph");
+            ConfigOptions.key("internal.jobgraph-path").stringType().defaultValue("job.graph");
 
     @Nonnull private final String jobGraphFile;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleServiceOptions.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleServiceOptions.java
@@ -32,6 +32,7 @@ public class ShuffleServiceOptions {
      */
     public static final ConfigOption<String> SHUFFLE_SERVICE_FACTORY_CLASS =
             ConfigOptions.key("shuffle-service-factory.class")
+                    .stringType()
                     .defaultValue("org.apache.flink.runtime.io.network.NettyShuffleServiceFactory")
                     .withDescription(
                             "The full class name of the shuffle service factory implementation to be used by the cluster. "

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBNativeMetricOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBNativeMetricOptions.java
@@ -44,33 +44,39 @@ public class RocksDBNativeMetricOptions implements Serializable {
 
     public static final ConfigOption<Boolean> MONITOR_NUM_IMMUTABLE_MEM_TABLES =
             ConfigOptions.key(RocksDBProperty.NumImmutableMemTable.getConfigKey())
+                    .booleanType()
                     .defaultValue(false)
                     .withDescription("Monitor the number of immutable memtables in RocksDB.");
 
     public static final ConfigOption<Boolean> MONITOR_MEM_TABLE_FLUSH_PENDING =
             ConfigOptions.key(RocksDBProperty.MemTableFlushPending.getConfigKey())
+                    .booleanType()
                     .defaultValue(false)
                     .withDescription("Monitor the number of pending memtable flushes in RocksDB.");
 
     public static final ConfigOption<Boolean> TRACK_COMPACTION_PENDING =
             ConfigOptions.key(RocksDBProperty.CompactionPending.getConfigKey())
+                    .booleanType()
                     .defaultValue(false)
                     .withDescription(
                             "Track pending compactions in RocksDB. Returns 1 if a compaction is pending, 0 otherwise.");
 
     public static final ConfigOption<Boolean> MONITOR_BACKGROUND_ERRORS =
             ConfigOptions.key(RocksDBProperty.BackgroundErrors.getConfigKey())
+                    .booleanType()
                     .defaultValue(false)
                     .withDescription("Monitor the number of background errors in RocksDB.");
 
     public static final ConfigOption<Boolean> MONITOR_CUR_SIZE_ACTIVE_MEM_TABLE =
             ConfigOptions.key(RocksDBProperty.CurSizeActiveMemTable.getConfigKey())
+                    .booleanType()
                     .defaultValue(false)
                     .withDescription(
                             "Monitor the approximate size of the active memtable in bytes.");
 
     public static final ConfigOption<Boolean> MONITOR_CUR_SIZE_ALL_MEM_TABLE =
             ConfigOptions.key(RocksDBProperty.CurSizeAllMemTables.getConfigKey())
+                    .booleanType()
                     .defaultValue(false)
                     .withDescription(
                             "Monitor the approximate size of the active and unflushed immutable memtables"
@@ -78,6 +84,7 @@ public class RocksDBNativeMetricOptions implements Serializable {
 
     public static final ConfigOption<Boolean> MONITOR_SIZE_ALL_MEM_TABLES =
             ConfigOptions.key(RocksDBProperty.SizeAllMemTables.getConfigKey())
+                    .booleanType()
                     .defaultValue(false)
                     .withDescription(
                             "Monitor the approximate size of the active, unflushed immutable, "
@@ -85,34 +92,40 @@ public class RocksDBNativeMetricOptions implements Serializable {
 
     public static final ConfigOption<Boolean> MONITOR_NUM_ENTRIES_ACTIVE_MEM_TABLE =
             ConfigOptions.key(RocksDBProperty.NumEntriesActiveMemTable.getConfigKey())
+                    .booleanType()
                     .defaultValue(false)
                     .withDescription("Monitor the total number of entries in the active memtable.");
 
     public static final ConfigOption<Boolean> MONITOR_NUM_ENTRIES_IMM_MEM_TABLES =
             ConfigOptions.key(RocksDBProperty.NumEntriesImmMemTables.getConfigKey())
+                    .booleanType()
                     .defaultValue(false)
                     .withDescription(
                             "Monitor the total number of entries in the unflushed immutable memtables.");
 
     public static final ConfigOption<Boolean> MONITOR_NUM_DELETES_ACTIVE_MEM_TABLE =
             ConfigOptions.key(RocksDBProperty.NumDeletesActiveMemTable.getConfigKey())
+                    .booleanType()
                     .defaultValue(false)
                     .withDescription(
                             "Monitor the total number of delete entries in the active memtable.");
 
     public static final ConfigOption<Boolean> MONITOR_NUM_DELETES_IMM_MEM_TABLE =
             ConfigOptions.key(RocksDBProperty.NumDeletesImmMemTables.getConfigKey())
+                    .booleanType()
                     .defaultValue(false)
                     .withDescription(
                             "Monitor the total number of delete entries in the unflushed immutable memtables.");
 
     public static final ConfigOption<Boolean> ESTIMATE_NUM_KEYS =
             ConfigOptions.key(RocksDBProperty.EstimateNumKeys.getConfigKey())
+                    .booleanType()
                     .defaultValue(false)
                     .withDescription("Estimate the number of keys in RocksDB.");
 
     public static final ConfigOption<Boolean> ESTIMATE_TABLE_READERS_MEM =
             ConfigOptions.key(RocksDBProperty.EstimateTableReadersMem.getConfigKey())
+                    .booleanType()
                     .defaultValue(false)
                     .withDescription(
                             "Estimate the memory used for reading SST tables, excluding memory"
@@ -120,11 +133,13 @@ public class RocksDBNativeMetricOptions implements Serializable {
 
     public static final ConfigOption<Boolean> MONITOR_NUM_SNAPSHOTS =
             ConfigOptions.key(RocksDBProperty.NumSnapshots.getConfigKey())
+                    .booleanType()
                     .defaultValue(false)
                     .withDescription("Monitor the number of unreleased snapshots of the database.");
 
     public static final ConfigOption<Boolean> MONITOR_NUM_LIVE_VERSIONS =
             ConfigOptions.key(RocksDBProperty.NumLiveVersions.getConfigKey())
+                    .booleanType()
                     .defaultValue(false)
                     .withDescription(
                             "Monitor number of live versions. Version is an internal data structure. "
@@ -133,12 +148,14 @@ public class RocksDBNativeMetricOptions implements Serializable {
 
     public static final ConfigOption<Boolean> ESTIMATE_LIVE_DATA_SIZE =
             ConfigOptions.key(RocksDBProperty.EstimateLiveDataSize.getConfigKey())
+                    .booleanType()
                     .defaultValue(false)
                     .withDescription(
                             "Estimate of the amount of live data in bytes (usually smaller than sst files size due to space amplification).");
 
     public static final ConfigOption<Boolean> MONITOR_TOTAL_SST_FILES_SIZE =
             ConfigOptions.key(RocksDBProperty.TotalSstFilesSize.getConfigKey())
+                    .booleanType()
                     .defaultValue(false)
                     .withDescription(
                             "Monitor the total size (bytes) of all SST files of all versions."
@@ -154,6 +171,7 @@ public class RocksDBNativeMetricOptions implements Serializable {
 
     public static final ConfigOption<Boolean> ESTIMATE_PENDING_COMPACTION_BYTES =
             ConfigOptions.key(RocksDBProperty.EstimatePendingCompactionBytes.getConfigKey())
+                    .booleanType()
                     .defaultValue(false)
                     .withDescription(
                             "Estimated total number of bytes compaction needs to rewrite to get all levels "
@@ -161,16 +179,19 @@ public class RocksDBNativeMetricOptions implements Serializable {
 
     public static final ConfigOption<Boolean> MONITOR_NUM_RUNNING_COMPACTIONS =
             ConfigOptions.key(RocksDBProperty.NumRunningCompactions.getConfigKey())
+                    .booleanType()
                     .defaultValue(false)
                     .withDescription("Monitor the number of currently running compactions.");
 
     public static final ConfigOption<Boolean> MONITOR_NUM_RUNNING_FLUSHES =
             ConfigOptions.key(RocksDBProperty.NumRunningFlushes.getConfigKey())
+                    .booleanType()
                     .defaultValue(false)
                     .withDescription("Monitor the number of currently running flushes.");
 
     public static final ConfigOption<Boolean> MONITOR_ACTUAL_DELAYED_WRITE_RATE =
             ConfigOptions.key(RocksDBProperty.ActualDelayedWriteRate.getConfigKey())
+                    .booleanType()
                     .defaultValue(false)
                     .withDescription(
                             "Monitor the current actual delayed write rate. 0 means no delay.");
@@ -204,6 +225,7 @@ public class RocksDBNativeMetricOptions implements Serializable {
 
     public static final ConfigOption<Boolean> COLUMN_FAMILY_AS_VARIABLE =
             ConfigOptions.key(METRICS_COLUMN_FAMILY_AS_VARIABLE_KEY)
+                    .booleanType()
                     .defaultValue(false)
                     .withDescription("Whether to expose the column family as a variable.");
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
@@ -176,6 +176,7 @@ public class ExecutionConfigOptions {
     @Documentation.TableOption(execMode = Documentation.ExecMode.BATCH)
     public static final ConfigOption<Integer> TABLE_EXEC_SORT_DEFAULT_LIMIT =
             key("table.exec.sort.default-limit")
+                    .intType()
                     .defaultValue(-1)
                     .withDescription(
                             "Default limit when user don't set a limit after order by. -1 indicates that this configuration is ignored.");
@@ -183,6 +184,7 @@ public class ExecutionConfigOptions {
     @Documentation.TableOption(execMode = Documentation.ExecMode.BATCH)
     public static final ConfigOption<Integer> TABLE_EXEC_SORT_MAX_NUM_FILE_HANDLES =
             key("table.exec.sort.max-num-file-handles")
+                    .intType()
                     .defaultValue(128)
                     .withDescription(
                             "The maximal fan-in for external merge sort. It limits the number of file handles per operator. "
@@ -192,6 +194,7 @@ public class ExecutionConfigOptions {
     @Documentation.TableOption(execMode = Documentation.ExecMode.BATCH)
     public static final ConfigOption<Boolean> TABLE_EXEC_SORT_ASYNC_MERGE_ENABLED =
             key("table.exec.sort.async-merge-enabled")
+                    .booleanType()
                     .defaultValue(true)
                     .withDescription("Whether to asynchronously merge sorted spill files.");
 
@@ -201,6 +204,7 @@ public class ExecutionConfigOptions {
     @Documentation.TableOption(execMode = Documentation.ExecMode.BATCH)
     public static final ConfigOption<Boolean> TABLE_EXEC_SPILL_COMPRESSION_ENABLED =
             key("table.exec.spill-compression.enabled")
+                    .booleanType()
                     .defaultValue(true)
                     .withDescription(
                             "Whether to compress spilled data. "
@@ -222,6 +226,7 @@ public class ExecutionConfigOptions {
     @Documentation.TableOption(execMode = Documentation.ExecMode.BATCH_STREAMING)
     public static final ConfigOption<Integer> TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM =
             key("table.exec.resource.default-parallelism")
+                    .intType()
                     .defaultValue(-1)
                     .withDescription(
                             "Sets default parallelism for all operators "
@@ -294,6 +299,7 @@ public class ExecutionConfigOptions {
     @Documentation.TableOption(execMode = Documentation.ExecMode.BATCH)
     public static final ConfigOption<Integer> TABLE_EXEC_WINDOW_AGG_BUFFER_SIZE_LIMIT =
             key("table.exec.window-agg.buffer-size-limit")
+                    .intType()
                     .defaultValue(100 * 1000)
                     .withDescription(
                             "Sets the window elements buffer size limit used in group window agg operator.");
@@ -304,6 +310,7 @@ public class ExecutionConfigOptions {
     @Documentation.TableOption(execMode = Documentation.ExecMode.BATCH_STREAMING)
     public static final ConfigOption<Integer> TABLE_EXEC_ASYNC_LOOKUP_BUFFER_CAPACITY =
             key("table.exec.async-lookup.buffer-capacity")
+                    .intType()
                     .defaultValue(100)
                     .withDescription(
                             "The max number of async i/o operation that the async lookup join can trigger.");
@@ -322,6 +329,7 @@ public class ExecutionConfigOptions {
     @Documentation.TableOption(execMode = Documentation.ExecMode.STREAMING)
     public static final ConfigOption<Boolean> TABLE_EXEC_MINIBATCH_ENABLED =
             key("table.exec.mini-batch.enabled")
+                    .booleanType()
                     .defaultValue(false)
                     .withDescription(
                             "Specifies whether to enable MiniBatch optimization. "
@@ -346,6 +354,7 @@ public class ExecutionConfigOptions {
     @Documentation.TableOption(execMode = Documentation.ExecMode.STREAMING)
     public static final ConfigOption<Long> TABLE_EXEC_MINIBATCH_SIZE =
             key("table.exec.mini-batch.size")
+                    .longType()
                     .defaultValue(-1L)
                     .withDescription(
                             "The maximum number of input records can be buffered for MiniBatch. "
@@ -361,6 +370,7 @@ public class ExecutionConfigOptions {
     @Documentation.TableOption(execMode = Documentation.ExecMode.BATCH)
     public static final ConfigOption<String> TABLE_EXEC_DISABLED_OPERATORS =
             key("table.exec.disabled-operators")
+                    .stringType()
                     .noDefaultValue()
                     .withDescription(
                             "Mainly for testing. A comma-separated list of operator names, each name "

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/OptimizerConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/OptimizerConfigOptions.java
@@ -38,6 +38,7 @@ public class OptimizerConfigOptions {
     @Documentation.TableOption(execMode = Documentation.ExecMode.BATCH_STREAMING)
     public static final ConfigOption<String> TABLE_OPTIMIZER_AGG_PHASE_STRATEGY =
             key("table.optimizer.agg-phase-strategy")
+                    .stringType()
                     .defaultValue("AUTO")
                     .withDescription(
                             "Strategy for aggregate phase. Only AUTO, TWO_PHASE or ONE_PHASE can be set.\n"
@@ -50,6 +51,7 @@ public class OptimizerConfigOptions {
     @Documentation.TableOption(execMode = Documentation.ExecMode.BATCH)
     public static final ConfigOption<Long> TABLE_OPTIMIZER_BROADCAST_JOIN_THRESHOLD =
             key("table.optimizer.join.broadcast-threshold")
+                    .longType()
                     .defaultValue(1024 * 1024L)
                     .withDescription(
                             "Configures the maximum size in bytes for a table that will be broadcast to all worker "
@@ -58,6 +60,7 @@ public class OptimizerConfigOptions {
     @Documentation.TableOption(execMode = Documentation.ExecMode.STREAMING)
     public static final ConfigOption<Boolean> TABLE_OPTIMIZER_DISTINCT_AGG_SPLIT_ENABLED =
             key("table.optimizer.distinct-agg.split.enabled")
+                    .booleanType()
                     .defaultValue(false)
                     .withDescription(
                             "Tells the optimizer whether to split distinct aggregation "
@@ -70,6 +73,7 @@ public class OptimizerConfigOptions {
     @Documentation.TableOption(execMode = Documentation.ExecMode.STREAMING)
     public static final ConfigOption<Integer> TABLE_OPTIMIZER_DISTINCT_AGG_SPLIT_BUCKET_NUM =
             key("table.optimizer.distinct-agg.split.bucket-num")
+                    .intType()
                     .defaultValue(1024)
                     .withDescription(
                             "Configure the number of buckets when splitting distinct aggregation. "
@@ -79,6 +83,7 @@ public class OptimizerConfigOptions {
     @Documentation.TableOption(execMode = Documentation.ExecMode.BATCH_STREAMING)
     public static final ConfigOption<Boolean> TABLE_OPTIMIZER_REUSE_SUB_PLAN_ENABLED =
             key("table.optimizer.reuse-sub-plan-enabled")
+                    .booleanType()
                     .defaultValue(true)
                     .withDescription(
                             "When it is true, the optimizer will try to find out duplicated sub-plans and reuse them.");
@@ -86,6 +91,7 @@ public class OptimizerConfigOptions {
     @Documentation.TableOption(execMode = Documentation.ExecMode.BATCH_STREAMING)
     public static final ConfigOption<Boolean> TABLE_OPTIMIZER_REUSE_SOURCE_ENABLED =
             key("table.optimizer.reuse-source-enabled")
+                    .booleanType()
                     .defaultValue(true)
                     .withDescription(
                             "When it is true, the optimizer will try to find out duplicated table sources and "
@@ -105,6 +111,7 @@ public class OptimizerConfigOptions {
     @Documentation.TableOption(execMode = Documentation.ExecMode.BATCH_STREAMING)
     public static final ConfigOption<Boolean> TABLE_OPTIMIZER_SOURCE_PREDICATE_PUSHDOWN_ENABLED =
             key("table.optimizer.source.predicate-pushdown-enabled")
+                    .booleanType()
                     .defaultValue(true)
                     .withDescription(
                             "When it is true, the optimizer will push down predicates into the FilterableTableSource. "
@@ -113,12 +120,14 @@ public class OptimizerConfigOptions {
     @Documentation.TableOption(execMode = Documentation.ExecMode.BATCH_STREAMING)
     public static final ConfigOption<Boolean> TABLE_OPTIMIZER_JOIN_REORDER_ENABLED =
             key("table.optimizer.join-reorder-enabled")
+                    .booleanType()
                     .defaultValue(false)
                     .withDescription("Enables join reorder in optimizer. Default is disabled.");
 
     @Documentation.TableOption(execMode = Documentation.ExecMode.BATCH)
     public static final ConfigOption<Boolean> TABLE_OPTIMIZER_MULTIPLE_INPUT_ENABLED =
             key("table.optimizer.multiple-input-enabled")
+                    .booleanType()
                     .defaultValue(true)
                     .withDescription(
                             "When it is true, the optimizer will merge the operators with pipelined shuffling "
@@ -127,6 +136,7 @@ public class OptimizerConfigOptions {
     @Documentation.TableOption(execMode = Documentation.ExecMode.BATCH_STREAMING)
     public static final ConfigOption<Boolean> TABLE_OPTIMIZER_SIMPLIFY_OPERATOR_NAME_ENABLED =
             key("table.optimizer.simplify-operator-name-enabled")
+                    .booleanType()
                     .defaultValue(true)
                     .withDescription(
                             "When it is true, the optimizer will simplify the operator name with id and type of ExecNode and keep detail in description. Default value is true.");

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdRowCount.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdRowCount.scala
@@ -449,8 +449,9 @@ object FlinkRelMdRowCount {
   @Experimental
   val TABLE_OPTIMIZER_ROWS_PER_LOCALAGG: ConfigOption[JLong] =
     key("table.optimizer.rows-per-local-agg")
+        .longType()
         .defaultValue(JLong.valueOf(1000000L))
-        .withDescription("Sets estimated number of records that one local-agg processes. " +
-            "Optimizer will infer whether to use local/global aggregate according to it.")
+        .withDescription("Sets estimated number of records that one local-agg processes. "
+            + "Optimizer will infer whether to use local/global aggregate according to it.")
 
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdRowCount.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdRowCount.scala
@@ -451,7 +451,7 @@ object FlinkRelMdRowCount {
     key("table.optimizer.rows-per-local-agg")
         .longType()
         .defaultValue(JLong.valueOf(1000000L))
-        .withDescription("Sets estimated number of records that one local-agg processes. "
-            + "Optimizer will infer whether to use local/global aggregate according to it.")
+        .withDescription("Sets estimated number of records that one local-agg processes. " +
+            "Optimizer will infer whether to use local/global aggregate according to it.")
 
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/RelNodeBlock.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/RelNodeBlock.scala
@@ -389,6 +389,7 @@ object RelNodeBlockPlanBuilder {
   @Experimental
   val TABLE_OPTIMIZER_UNIONALL_AS_BREAKPOINT_ENABLED: ConfigOption[JBoolean] =
     key("table.optimizer.union-all-as-breakpoint-enabled")
+        .booleanType()
         .defaultValue(JBoolean.valueOf(true))
         .withDescription("When true, the optimizer will breakup the graph at union-all node " +
           "when it's a breakpoint. When false, the optimizer will skip the union-all node " +
@@ -398,6 +399,7 @@ object RelNodeBlockPlanBuilder {
   @Experimental
   val TABLE_OPTIMIZER_REUSE_OPTIMIZE_BLOCK_WITH_DIGEST_ENABLED: ConfigOption[JBoolean] =
     key("table.optimizer.reuse-optimize-block-with-digest-enabled")
+        .booleanType()
         .defaultValue(JBoolean.valueOf(false))
         .withDescription("When true, the optimizer will try to find out duplicated sub-plan by " +
             "digest to build optimize block(a.k.a. common sub-graph). " +

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/JoinDeriveNullFilterRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/JoinDeriveNullFilterRule.scala
@@ -100,6 +100,7 @@ object JoinDeriveNullFilterRule {
   @Experimental
   val TABLE_OPTIMIZER_JOIN_NULL_FILTER_THRESHOLD: ConfigOption[JLong] =
     key("table.optimizer.join.null-filter-threshold")
+        .longType()
         .defaultValue(JLong.valueOf(2000000L))
         .withDescription("To avoid the impact of null values on the single join node, " +
             "We will add a null filter (possibly be pushed down) before the join to filter" +

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalJoinRuleBase.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalJoinRuleBase.scala
@@ -84,6 +84,7 @@ object BatchPhysicalJoinRuleBase {
   @Experimental
   val TABLE_OPTIMIZER_SEMI_JOIN_BUILD_DISTINCT_NDV_RATIO: ConfigOption[JDouble] =
     key("table.optimizer.semi-anti-join.build-distinct.ndv-ratio")
+      .doubleType()
       .defaultValue(JDouble.valueOf(0.8))
       .withDescription("In order to reduce the amount of data on semi/anti join's" +
           " build side, we will add distinct node before semi/anti join when" +
@@ -95,6 +96,7 @@ object BatchPhysicalJoinRuleBase {
   @Experimental
   val TABLE_OPTIMIZER_SHUFFLE_BY_PARTIAL_KEY_ENABLED: ConfigOption[JBoolean] =
     key("table.optimizer.shuffle-by-partial-key-enabled")
+        .booleanType()
         .defaultValue(JBoolean.valueOf(false))
         .withDescription("Enables shuffling by partial partition keys. " +
             "For example, A join with join condition: L.c1 = R.c1 and L.c2 = R.c2. " +

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalJoinRuleBase.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalJoinRuleBase.scala
@@ -84,9 +84,9 @@ object BatchPhysicalJoinRuleBase {
   @Experimental
   val TABLE_OPTIMIZER_SEMI_JOIN_BUILD_DISTINCT_NDV_RATIO: ConfigOption[JDouble] =
     key("table.optimizer.semi-anti-join.build-distinct.ndv-ratio")
-      .doubleType()
-      .defaultValue(JDouble.valueOf(0.8))
-      .withDescription("In order to reduce the amount of data on semi/anti join's" +
+        .doubleType()
+        .defaultValue(JDouble.valueOf(0.8))
+        .withDescription("In order to reduce the amount of data on semi/anti join's" +
           " build side, we will add distinct node before semi/anti join when" +
           "  the semi-side or semi/anti join can distinct a lot of data in advance." +
           " We add this configuration to help the optimizer to decide whether to" +

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalSortMergeJoinRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalSortMergeJoinRule.scala
@@ -150,6 +150,7 @@ object BatchPhysicalSortMergeJoinRule {
   @Experimental
   val TABLE_OPTIMIZER_SMJ_REMOVE_SORT_ENABLED: ConfigOption[JBoolean] =
     key("table.optimizer.smj.remove-sort-enabled")
+         .booleanType()
         .defaultValue(JBoolean.FALSE)
         .withDescription("When true, the optimizer will try to remove redundant sort " +
             "for sort merge join. However that will increase optimization time. " +

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalSortMergeJoinRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalSortMergeJoinRule.scala
@@ -150,7 +150,7 @@ object BatchPhysicalSortMergeJoinRule {
   @Experimental
   val TABLE_OPTIMIZER_SMJ_REMOVE_SORT_ENABLED: ConfigOption[JBoolean] =
     key("table.optimizer.smj.remove-sort-enabled")
-         .booleanType()
+        .booleanType()
         .defaultValue(JBoolean.FALSE)
         .withDescription("When true, the optimizer will try to remove redundant sort " +
             "for sort merge join. However that will increase optimization time. " +

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalSortRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalSortRule.scala
@@ -83,6 +83,7 @@ object BatchPhysicalSortRule {
   @Experimental
   val TABLE_EXEC_RANGE_SORT_ENABLED: ConfigOption[JBoolean] =
   key("table.exec.range-sort.enabled")
+      .booleanType()
       .defaultValue(JBoolean.valueOf(false))
       .withDescription("Sets whether to enable range sort, use range sort to sort all data in" +
           " several partitions. When it is false, sorting in only one partition")

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/IncrementalAggregateRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/IncrementalAggregateRule.scala
@@ -152,6 +152,7 @@ object IncrementalAggregateRule {
   @Experimental
   val TABLE_OPTIMIZER_INCREMENTAL_AGG_ENABLED: ConfigOption[JBoolean] =
   key("table.optimizer.incremental-agg-enabled")
+      .booleanType()
       .defaultValue(JBoolean.valueOf(true))
       .withDescription("When both local aggregation and distinct aggregation splitting " +
           "are enabled, a distinct aggregation will be optimized into four aggregations, " +

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/FlinkRexUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/FlinkRexUtil.scala
@@ -53,7 +53,8 @@ object FlinkRexUtil {
   @Experimental
   private[flink] val TABLE_OPTIMIZER_CNF_NODES_LIMIT: ConfigOption[Integer] =
     key("table.optimizer.cnf-nodes-limit")
-      .defaultValue(Integer.valueOf(-1))
+      .intType()
+       .defaultValue(Integer.valueOf(-1))
       .withDescription("When converting to conjunctive normal form (CNF, like '(a AND b) OR" +
         " c' will be converted to '(a OR c) AND (b OR c)'), fail if the expression  exceeds " +
         "this threshold; (e.g. predicate in TPC-DS q41.sql will be converted to hundreds of " +

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/FlinkRexUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/FlinkRexUtil.scala
@@ -53,9 +53,9 @@ object FlinkRexUtil {
   @Experimental
   private[flink] val TABLE_OPTIMIZER_CNF_NODES_LIMIT: ConfigOption[Integer] =
     key("table.optimizer.cnf-nodes-limit")
-      .intType()
+       .intType()
        .defaultValue(Integer.valueOf(-1))
-      .withDescription("When converting to conjunctive normal form (CNF, like '(a AND b) OR" +
+       .withDescription("When converting to conjunctive normal form (CNF, like '(a AND b) OR" +
         " c' will be converted to '(a OR c) AND (b OR c)'), fail if the expression  exceeds " +
         "this threshold; (e.g. predicate in TPC-DS q41.sql will be converted to hundreds of " +
         "thousands of CNF nodes.) the threshold is expressed in terms of number of nodes " +

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/WindowEmitStrategy.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/WindowEmitStrategy.scala
@@ -195,6 +195,7 @@ object WindowEmitStrategy {
   @Experimental
   val TABLE_EXEC_EMIT_EARLY_FIRE_ENABLED: ConfigOption[JBoolean] =
   key("table.exec.emit.early-fire.enabled")
+      .booleanType()
       .defaultValue(Boolean.box(false))
       .withDescription("Specifies whether to enable early-fire emit." +
           "Early-fire is an emit strategy before watermark advanced to end of window.")
@@ -215,6 +216,7 @@ object WindowEmitStrategy {
   @Experimental
   val TABLE_EXEC_EMIT_LATE_FIRE_ENABLED: ConfigOption[JBoolean] =
   key("table.exec.emit.late-fire.enabled")
+      .booleanType()
       .defaultValue(Boolean.box(false))
       .withDescription("Specifies whether to enable late-fire emit. " +
           "Late-fire is an emit strategy after watermark advanced to end of window.")


### PR DESCRIPTION
## What is the purpose of the change

Add types to `ConfigOptions` and replace usages of the untyped methods
`defaultValue` and `noDefaultValue` with the corresponding typed ones.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
