### PR TITLE
[FLINK-25953][FLINK-25954] Updates and reorganizes tests around Dispatcher cleanup

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/OnMainThreadJobManagerRunnerRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/OnMainThreadJobManagerRunnerRegistry.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.jobmaster.JobManagerRunner;
+import org.apache.flink.util.WrappingProxy;
+
+import java.util.Collection;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+/**
+ * {@code OnMainThreadJobManagerRunnerRegistry} implements {@link JobManagerRunnerRegistry} guarding
+ * the passed {@code JobManagerRunnerRegistry} instance in a way that it only allows modifying
+ * methods to be executed on the component's main thread.
+ *
+ * @see ComponentMainThreadExecutor
+ */
+public class OnMainThreadJobManagerRunnerRegistry
+        implements JobManagerRunnerRegistry, WrappingProxy<JobManagerRunnerRegistry> {
+
+    private final JobManagerRunnerRegistry delegate;
+    private final ComponentMainThreadExecutor mainThreadExecutor;
+
+    public OnMainThreadJobManagerRunnerRegistry(
+            JobManagerRunnerRegistry delegate, ComponentMainThreadExecutor mainThreadExecutor) {
+        this.delegate = delegate;
+        this.mainThreadExecutor = mainThreadExecutor;
+    }
+
+    @Override
+    public boolean isRegistered(JobID jobId) {
+        mainThreadExecutor.assertRunningInMainThread();
+        return delegate.isRegistered(jobId);
+    }
+
+    @Override
+    public void register(JobManagerRunner jobManagerRunner) {
+        mainThreadExecutor.assertRunningInMainThread();
+        delegate.register(jobManagerRunner);
+    }
+
+    @Override
+    public JobManagerRunner get(JobID jobId) {
+        mainThreadExecutor.assertRunningInMainThread();
+        return delegate.get(jobId);
+    }
+
+    @Override
+    public int size() {
+        mainThreadExecutor.assertRunningInMainThread();
+        return delegate.size();
+    }
+
+    @Override
+    public Set<JobID> getRunningJobIds() {
+        mainThreadExecutor.assertRunningInMainThread();
+        return delegate.getRunningJobIds();
+    }
+
+    @Override
+    public Collection<JobManagerRunner> getJobManagerRunners() {
+        mainThreadExecutor.assertRunningInMainThread();
+        return delegate.getJobManagerRunners();
+    }
+
+    @Override
+    public CompletableFuture<Void> globalCleanupAsync(JobID jobId, Executor executor) {
+        mainThreadExecutor.assertRunningInMainThread();
+        return delegate.globalCleanupAsync(jobId, executor);
+    }
+
+    @Override
+    public CompletableFuture<Void> localCleanupAsync(JobID jobId, Executor executor) {
+        mainThreadExecutor.assertRunningInMainThread();
+        return delegate.localCleanupAsync(jobId, executor);
+    }
+
+    @Override
+    public JobManagerRunner unregister(JobID jobId) {
+        mainThreadExecutor.assertRunningInMainThread();
+        return delegate.unregister(jobId);
+    }
+
+    /**
+     * Returns the delegated {@link JobManagerRunnerRegistry}. This method can be used to workaround
+     * the main thread safeguard.
+     */
+    @Override
+    public JobManagerRunnerRegistry getWrappedDelegate() {
+        return this.delegate;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/DispatcherResourceCleanerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/DispatcherResourceCleanerFactory.java
@@ -62,7 +62,7 @@ public class DispatcherResourceCleanerFactory implements ResourceCleanerFactory 
     }
 
     @VisibleForTesting
-    DispatcherResourceCleanerFactory(
+    public DispatcherResourceCleanerFactory(
             Executor cleanupExecutor,
             JobManagerRunnerRegistry jobManagerRunnerRegistry,
             JobGraphWriter jobGraphWriter,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/AbstractDispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/AbstractDispatcherTest.java
@@ -26,18 +26,10 @@ import org.apache.flink.runtime.blob.BlobServer;
 import org.apache.flink.runtime.blob.VoidBlobStore;
 import org.apache.flink.runtime.checkpoint.StandaloneCheckpointRecoveryFactory;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
-import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
-import org.apache.flink.runtime.highavailability.JobResultStore;
 import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
 import org.apache.flink.runtime.highavailability.nonha.embedded.EmbeddedJobResultStore;
-import org.apache.flink.runtime.jobgraph.JobGraph;
-import org.apache.flink.runtime.jobmanager.JobGraphWriter;
 import org.apache.flink.runtime.jobmanager.StandaloneJobGraphStore;
-import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.runtime.leaderretrieval.SettableLeaderRetrievalService;
-import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
-import org.apache.flink.runtime.resourcemanager.utils.TestingResourceManagerGateway;
-import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
@@ -52,11 +44,6 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
 import org.junit.rules.TestName;
-
-import java.util.Collection;
-import java.util.Collections;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ForkJoinPool;
 
 /** Abstract test for the {@link Dispatcher} component. */
 public class AbstractDispatcherTest extends TestLogger {
@@ -116,6 +103,19 @@ public class AbstractDispatcherTest extends TestLogger {
                 new BlobServer(configuration, temporaryFolder.newFolder(), new VoidBlobStore());
     }
 
+    protected TestingDispatcher.Builder createTestingDispatcherBuilder() {
+        return TestingDispatcher.builder()
+                .setRpcService(rpcService)
+                .setConfiguration(configuration)
+                .setHeartbeatServices(heartbeatServices)
+                .setHighAvailabilityServices(haServices)
+                .setJobGraphWriter(haServices.getJobGraphStore())
+                .setJobResultStore(haServices.getJobResultStore())
+                .setJobManagerRunnerFactory(JobMasterServiceLeadershipRunnerFactory.INSTANCE)
+                .setFatalErrorHandler(testingFatalErrorHandlerResource.getFatalErrorHandler())
+                .setBlobServer(blobServer);
+    }
+
     @After
     public void tearDown() throws Exception {
         if (haServices != null) {
@@ -128,116 +128,5 @@ public class AbstractDispatcherTest extends TestLogger {
 
     protected BlobServer getBlobServer() {
         return blobServer;
-    }
-
-    /** A convenient builder for the {@link TestingDispatcher}. */
-    public class TestingDispatcherBuilder {
-
-        private Collection<JobGraph> initialJobGraphs = Collections.emptyList();
-
-        private Collection<JobResult> dirtyJobResults = Collections.emptyList();
-
-        private DispatcherBootstrapFactory dispatcherBootstrapFactory =
-                (dispatcher, scheduledExecutor, errorHandler) -> new NoOpDispatcherBootstrap();
-
-        private HeartbeatServices heartbeatServices = AbstractDispatcherTest.this.heartbeatServices;
-
-        private HighAvailabilityServices haServices = AbstractDispatcherTest.this.haServices;
-
-        private JobManagerRunnerFactory jobManagerRunnerFactory =
-                JobMasterServiceLeadershipRunnerFactory.INSTANCE;
-
-        private JobGraphWriter jobGraphWriter = NoOpJobGraphWriter.INSTANCE;
-
-        private JobResultStore jobResultStore = new EmbeddedJobResultStore();
-
-        private FatalErrorHandler fatalErrorHandler =
-                testingFatalErrorHandlerResource.getFatalErrorHandler();
-
-        private HistoryServerArchivist historyServerArchivist = VoidHistoryServerArchivist.INSTANCE;
-
-        TestingDispatcherBuilder setHeartbeatServices(HeartbeatServices heartbeatServices) {
-            this.heartbeatServices = heartbeatServices;
-            return this;
-        }
-
-        TestingDispatcherBuilder setHaServices(HighAvailabilityServices haServices) {
-            this.haServices = haServices;
-            return this;
-        }
-
-        TestingDispatcherBuilder setInitialJobGraphs(Collection<JobGraph> initialJobGraphs) {
-            this.initialJobGraphs = initialJobGraphs;
-            return this;
-        }
-
-        TestingDispatcherBuilder setDirtyJobResults(Collection<JobResult> dirtyJobResults) {
-            this.dirtyJobResults = dirtyJobResults;
-            return this;
-        }
-
-        TestingDispatcherBuilder setDispatcherBootstrapFactory(
-                DispatcherBootstrapFactory dispatcherBootstrapFactory) {
-            this.dispatcherBootstrapFactory = dispatcherBootstrapFactory;
-            return this;
-        }
-
-        TestingDispatcherBuilder setJobManagerRunnerFactory(
-                JobManagerRunnerFactory jobManagerRunnerFactory) {
-            this.jobManagerRunnerFactory = jobManagerRunnerFactory;
-            return this;
-        }
-
-        TestingDispatcherBuilder setJobGraphWriter(JobGraphWriter jobGraphWriter) {
-            this.jobGraphWriter = jobGraphWriter;
-            return this;
-        }
-
-        TestingDispatcherBuilder setJobResultStore(JobResultStore jobResultStore) {
-            this.jobResultStore = jobResultStore;
-            return this;
-        }
-
-        public TestingDispatcherBuilder setFatalErrorHandler(FatalErrorHandler fatalErrorHandler) {
-            this.fatalErrorHandler = fatalErrorHandler;
-            return this;
-        }
-
-        public TestingDispatcherBuilder setHistoryServerArchivist(
-                HistoryServerArchivist historyServerArchivist) {
-            this.historyServerArchivist = historyServerArchivist;
-            return this;
-        }
-
-        TestingDispatcher build() throws Exception {
-            TestingResourceManagerGateway resourceManagerGateway =
-                    new TestingResourceManagerGateway();
-
-            final MemoryExecutionGraphInfoStore executionGraphInfoStore =
-                    new MemoryExecutionGraphInfoStore();
-
-            return new TestingDispatcher(
-                    rpcService,
-                    DispatcherId.generate(),
-                    initialJobGraphs,
-                    dirtyJobResults,
-                    dispatcherBootstrapFactory,
-                    new DispatcherServices(
-                            configuration,
-                            haServices,
-                            () -> CompletableFuture.completedFuture(resourceManagerGateway),
-                            blobServer,
-                            heartbeatServices,
-                            executionGraphInfoStore,
-                            fatalErrorHandler,
-                            historyServerArchivist,
-                            null,
-                            new DispatcherOperationCaches(),
-                            UnregisteredMetricGroups.createUnregisteredJobManagerMetricGroup(),
-                            jobGraphWriter,
-                            jobResultStore,
-                            jobManagerRunnerFactory,
-                            ForkJoinPool.commonPool()));
-        }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DefaultJobManagerRunnerRegistryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DefaultJobManagerRunnerRegistryTest.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.dispatcher;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.core.testutils.FlinkAssertions;
-import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
 import org.apache.flink.runtime.jobmaster.JobManagerRunner;
 import org.apache.flink.runtime.jobmaster.TestingJobManagerRunner;
 import org.apache.flink.util.FlinkException;
@@ -47,9 +46,7 @@ public class DefaultJobManagerRunnerRegistryTest {
 
     @BeforeEach
     public void setup() {
-        testInstance =
-                new DefaultJobManagerRunnerRegistry(
-                        4, ComponentMainThreadExecutorServiceAdapter.forMainThread());
+        testInstance = new DefaultJobManagerRunnerRegistry(4);
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherFailoverITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherFailoverITCase.java
@@ -241,13 +241,9 @@ public class DispatcherFailoverITCase extends AbstractDispatcherTest {
             }
         }
         final TestingDispatcher dispatcher =
-                new TestingDispatcherBuilder()
-                        .setJobManagerRunnerFactory(
-                                JobMasterServiceLeadershipRunnerFactory.INSTANCE)
-                        .setJobGraphWriter(haServices.getJobGraphStore())
-                        .setJobResultStore(haServices.getJobResultStore())
-                        .setInitialJobGraphs(jobGraphs)
-                        .setDirtyJobResults(haServices.getJobResultStore().getDirtyResults())
+                createTestingDispatcherBuilder()
+                        .setRecoveredJobs(jobGraphs)
+                        .setRecoveredDirtyJobs(haServices.getJobResultStore().getDirtyResults())
                         .setFatalErrorHandler(
                                 fatalErrorHandler == null
                                         ? testingFatalErrorHandlerResource.getFatalErrorHandler()

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -59,7 +59,6 @@ import org.apache.flink.runtime.jobmaster.factories.DefaultJobMasterServiceProce
 import org.apache.flink.runtime.jobmaster.factories.JobManagerJobMetricGroupFactory;
 import org.apache.flink.runtime.jobmaster.factories.JobMasterServiceProcessFactory;
 import org.apache.flink.runtime.jobmaster.factories.TestingJobMasterServiceFactory;
-import org.apache.flink.runtime.jobmaster.utils.TestingJobMasterGateway;
 import org.apache.flink.runtime.jobmaster.utils.TestingJobMasterGatewayBuilder;
 import org.apache.flink.runtime.leaderelection.LeaderElectionService;
 import org.apache.flink.runtime.leaderelection.TestingLeaderElectionService;
@@ -89,7 +88,6 @@ import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.TimeUtils;
 import org.apache.flink.util.concurrent.FutureUtils;
-import org.apache.flink.util.function.ThrowingRunnable;
 
 import org.assertj.core.api.Assertions;
 import org.hamcrest.Matchers;
@@ -110,11 +108,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.ArrayDeque;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Optional;
 import java.util.Queue;
 import java.util.UUID;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -127,12 +123,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.apache.flink.core.testutils.FlinkMatchers.containsCause;
-import static org.apache.flink.core.testutils.FlinkMatchers.containsMessage;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -178,8 +172,8 @@ public class DispatcherTest extends AbstractDispatcherTest {
             JobManagerRunnerFactory jobManagerRunnerFactory)
             throws Exception {
         final TestingDispatcher dispatcher =
-                new TestingDispatcherBuilder()
-                        .setHaServices(haServices)
+                createTestingDispatcherBuilder()
+                        .setHighAvailabilityServices(haServices)
                         .setHeartbeatServices(heartbeatServices)
                         .setJobManagerRunnerFactory(jobManagerRunnerFactory)
                         .setJobGraphWriter(haServices.getJobGraphStore())
@@ -246,11 +240,11 @@ public class DispatcherTest extends AbstractDispatcherTest {
     @Test
     public void testDuplicateJobSubmissionWithRunningJobId() throws Exception {
         dispatcher =
-                new TestingDispatcherBuilder()
+                createTestingDispatcherBuilder()
                         .setJobManagerRunnerFactory(
                                 new ExpectedJobIdJobManagerRunnerFactory(
                                         jobId, createdJobManagerRunnerLatch))
-                        .setInitialJobGraphs(Collections.singleton(jobGraph))
+                        .setRecoveredJobs(Collections.singleton(jobGraph))
                         .build();
         dispatcher.start();
         final DispatcherGateway dispatcherGateway =
@@ -474,7 +468,7 @@ public class DispatcherTest extends AbstractDispatcherTest {
         final CompletableFuture<JobManagerRunnerResult> jobTerminationFuture =
                 new CompletableFuture<>();
         dispatcher =
-                new TestingDispatcherBuilder()
+                createTestingDispatcherBuilder()
                         .setJobManagerRunnerFactory(
                                 new FinishingJobManagerRunnerFactory(
                                         jobTerminationFuture, () -> {}))
@@ -675,10 +669,9 @@ public class DispatcherTest extends AbstractDispatcherTest {
         final TestingJobManagerRunnerFactory jobManagerRunnerFactory =
                 new TestingJobManagerRunnerFactory();
         dispatcher =
-                new TestingDispatcherBuilder()
+                createTestingDispatcherBuilder()
                         .setJobManagerRunnerFactory(jobManagerRunnerFactory)
-                        .setInitialJobGraphs(
-                                Collections.singleton(JobGraphTestUtils.emptyJobGraph()))
+                        .setRecoveredJobs(Collections.singleton(JobGraphTestUtils.emptyJobGraph()))
                         .build();
 
         dispatcher.start();
@@ -721,87 +714,10 @@ public class DispatcherTest extends AbstractDispatcherTest {
         final JobResult jobResult =
                 TestingJobResultStore.createSuccessfulJobResult(jobGraph.getJobID());
         dispatcher =
-                new TestingDispatcherBuilder()
-                        .setInitialJobGraphs(Collections.singleton(jobGraph))
-                        .setDirtyJobResults(Collections.singleton(jobResult))
+                createTestingDispatcherBuilder()
+                        .setRecoveredJobs(Collections.singleton(jobGraph))
+                        .setRecoveredDirtyJobs(Collections.singleton(jobResult))
                         .build();
-    }
-
-    /** Tests that a failing {@link JobManagerRunner} will be properly cleaned up. */
-    @Test
-    public void testFailingJobManagerRunnerCleanup() throws Exception {
-        final FlinkException testException = new FlinkException("Test exception.");
-        final ArrayBlockingQueue<Optional<Exception>> queue = new ArrayBlockingQueue<>(2);
-
-        final BlockingJobManagerRunnerFactory blockingJobManagerRunnerFactory =
-                new BlockingJobManagerRunnerFactory(
-                        () -> {
-                            final Optional<Exception> maybeException = queue.take();
-                            if (maybeException.isPresent()) {
-                                throw maybeException.get();
-                            }
-                        });
-
-        final BlockingQueue<String> cleanUpEvents = new LinkedBlockingQueue<>();
-
-        // Track cleanup - ha-services
-        final CompletableFuture<JobID> cleanupJobData = new CompletableFuture<>();
-        haServices.setGlobalCleanupFuture(cleanupJobData);
-        cleanupJobData.thenAccept(jobId -> cleanUpEvents.add(CLEANUP_HA_SERVICES));
-
-        // Track cleanup - job-graph
-        final TestingJobGraphStore jobGraphStore =
-                TestingJobGraphStore.newBuilder()
-                        .setLocalCleanupFunction(
-                                (jobId, executor) -> {
-                                    cleanUpEvents.add(CLEANUP_JOB_GRAPH_RELEASE);
-                                    return FutureUtils.completedVoidFuture();
-                                })
-                        .setGlobalCleanupFunction(
-                                (jobId, executor) -> {
-                                    cleanUpEvents.add(CLEANUP_JOB_GRAPH_REMOVE);
-                                    return FutureUtils.completedVoidFuture();
-                                })
-                        .build();
-        jobGraphStore.start(null);
-        haServices.setJobGraphStore(jobGraphStore);
-
-        // Track cleanup - job result store
-        haServices.setJobResultStore(
-                TestingJobResultStore.builder()
-                        .withMarkResultAsCleanConsumer(
-                                jobID -> cleanUpEvents.add(CLEANUP_JOB_RESULT_STORE))
-                        .build());
-
-        dispatcher =
-                createAndStartDispatcher(
-                        heartbeatServices, haServices, blockingJobManagerRunnerFactory);
-
-        final DispatcherGateway dispatcherGateway =
-                dispatcher.getSelfGateway(DispatcherGateway.class);
-
-        // submit and fail during job master runner construction
-        queue.offer(Optional.of(testException));
-        try {
-            dispatcherGateway.submitJob(jobGraph, TIMEOUT).get();
-            fail("A FlinkException is expected");
-        } catch (Throwable expectedException) {
-            assertThat(expectedException, containsCause(FlinkException.class));
-            assertThat(expectedException, containsMessage(testException.getMessage()));
-            // make sure we've cleaned up in correct order (including HA)
-            assertThat(
-                    new ArrayList<>(cleanUpEvents),
-                    containsInAnyOrder(CLEANUP_JOB_GRAPH_REMOVE, CLEANUP_HA_SERVICES));
-        }
-
-        // don't fail this time
-        queue.offer(Optional.empty());
-        // submit job again
-        dispatcherGateway.submitJob(jobGraph, TIMEOUT).get();
-        blockingJobManagerRunnerFactory.setJobStatus(JobStatus.RUNNING);
-
-        // Ensure job is running
-        awaitStatus(dispatcherGateway, jobId, JobStatus.RUNNING);
     }
 
     @Test
@@ -812,7 +728,7 @@ public class DispatcherTest extends AbstractDispatcherTest {
         haServices.setJobGraphStore(submittedJobGraphStore);
 
         dispatcher =
-                new TestingDispatcherBuilder().setJobGraphWriter(submittedJobGraphStore).build();
+                createTestingDispatcherBuilder().setJobGraphWriter(submittedJobGraphStore).build();
 
         dispatcher.start();
 
@@ -930,8 +846,8 @@ public class DispatcherTest extends AbstractDispatcherTest {
         testingJobGraphStore.start(null);
 
         dispatcher =
-                new TestingDispatcherBuilder()
-                        .setInitialJobGraphs(Collections.singleton(jobGraph))
+                createTestingDispatcherBuilder()
+                        .setRecoveredJobs(Collections.singleton(jobGraph))
                         .setJobGraphWriter(testingJobGraphStore)
                         .build();
         dispatcher.start();
@@ -1110,8 +1026,8 @@ public class DispatcherTest extends AbstractDispatcherTest {
         final PermanentBlobKey blobKey2 = blobServer.putPermanent(jobId2, fileContent);
 
         dispatcher =
-                new TestingDispatcherBuilder()
-                        .setInitialJobGraphs(Collections.singleton(new JobGraph(jobId1, "foobar")))
+                createTestingDispatcherBuilder()
+                        .setRecoveredJobs(Collections.singleton(new JobGraph(jobId1, "foobar")))
                         .build();
 
         Assertions.assertThat(blobServer.getFile(jobId1, blobKey1)).hasBinaryContent(fileContent);
@@ -1362,70 +1278,6 @@ public class DispatcherTest extends AbstractDispatcherTest {
                 return future.whenComplete((r, t) -> super.closeAsync());
             }
             return super.closeAsync();
-        }
-    }
-
-    private static final class BlockingJobManagerRunnerFactory
-            extends TestingJobManagerRunnerFactory {
-
-        @Nonnull private final ThrowingRunnable<Exception> jobManagerRunnerCreationLatch;
-        private TestingJobManagerRunner testingRunner;
-
-        BlockingJobManagerRunnerFactory(
-                @Nonnull ThrowingRunnable<Exception> jobManagerRunnerCreationLatch) {
-            this.jobManagerRunnerCreationLatch = jobManagerRunnerCreationLatch;
-        }
-
-        @Override
-        public TestingJobManagerRunner createJobManagerRunner(
-                JobGraph jobGraph,
-                Configuration configuration,
-                RpcService rpcService,
-                HighAvailabilityServices highAvailabilityServices,
-                HeartbeatServices heartbeatServices,
-                JobManagerSharedServices jobManagerSharedServices,
-                JobManagerJobMetricGroupFactory jobManagerJobMetricGroupFactory,
-                FatalErrorHandler fatalErrorHandler,
-                long initializationTimestamp)
-                throws Exception {
-            jobManagerRunnerCreationLatch.run();
-
-            this.testingRunner =
-                    super.createJobManagerRunner(
-                            jobGraph,
-                            configuration,
-                            rpcService,
-                            highAvailabilityServices,
-                            heartbeatServices,
-                            jobManagerSharedServices,
-                            jobManagerJobMetricGroupFactory,
-                            fatalErrorHandler,
-                            initializationTimestamp);
-
-            TestingJobMasterGateway testingJobMasterGateway =
-                    new TestingJobMasterGatewayBuilder()
-                            .setRequestJobSupplier(
-                                    () ->
-                                            CompletableFuture.completedFuture(
-                                                    new ExecutionGraphInfo(
-                                                            ArchivedExecutionGraph
-                                                                    .createFromInitializingJob(
-                                                                            jobGraph.getJobID(),
-                                                                            jobGraph.getName(),
-                                                                            JobStatus.RUNNING,
-                                                                            null,
-                                                                            null,
-                                                                            1337))))
-                            .build();
-            testingRunner.completeJobMasterGatewayFuture(testingJobMasterGateway);
-            return testingRunner;
-        }
-
-        public void setJobStatus(JobStatus newStatus) {
-            Preconditions.checkState(
-                    testingRunner != null,
-                    "JobManagerRunner must be created before this method is available");
-            this.testingRunner.setJobStatus(newStatus);
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/TestingDispatcher.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/TestingDispatcher.java
@@ -20,16 +20,39 @@ package org.apache.flink.runtime.dispatcher;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.blob.BlobServer;
+import org.apache.flink.runtime.dispatcher.cleanup.DispatcherResourceCleanerFactory;
+import org.apache.flink.runtime.dispatcher.cleanup.ResourceCleanerFactory;
+import org.apache.flink.runtime.heartbeat.HeartbeatServices;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.highavailability.JobResultStore;
+import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
+import org.apache.flink.runtime.highavailability.nonha.embedded.EmbeddedJobResultStore;
 import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobmanager.JobGraphWriter;
 import org.apache.flink.runtime.jobmaster.JobResult;
+import org.apache.flink.runtime.metrics.groups.JobManagerMetricGroup;
+import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
+import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
+import org.apache.flink.runtime.resourcemanager.utils.TestingResourceManagerGateway;
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.scheduler.ExecutionGraphInfo;
+import org.apache.flink.runtime.util.TestingFatalErrorHandler;
+import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ForkJoinPool;
 import java.util.function.Function;
 
 /** {@link Dispatcher} implementation used for testing purposes. */
@@ -52,6 +75,58 @@ class TestingDispatcher extends Dispatcher {
                 recoveredDirtyJobResults,
                 dispatcherBootstrapFactory,
                 dispatcherServices);
+
+        this.startFuture = new CompletableFuture<>();
+    }
+
+    private TestingDispatcher(
+            RpcService rpcService,
+            DispatcherId fencingToken,
+            Collection<JobGraph> recoveredJobs,
+            Collection<JobResult> recoveredDirtyJobs,
+            Configuration configuration,
+            HighAvailabilityServices highAvailabilityServices,
+            GatewayRetriever<ResourceManagerGateway> resourceManagerGatewayRetriever,
+            HeartbeatServices heartbeatServices,
+            BlobServer blobServer,
+            FatalErrorHandler fatalErrorHandler,
+            JobGraphWriter jobGraphWriter,
+            JobResultStore jobResultStore,
+            JobManagerMetricGroup jobManagerMetricGroup,
+            @Nullable String metricServiceQueryAddress,
+            Executor ioExecutor,
+            HistoryServerArchivist historyServerArchivist,
+            ExecutionGraphInfoStore executionGraphInfoStore,
+            JobManagerRunnerFactory jobManagerRunnerFactory,
+            DispatcherBootstrapFactory dispatcherBootstrapFactory,
+            DispatcherOperationCaches dispatcherOperationCaches,
+            JobManagerRunnerRegistry jobManagerRunnerRegistry,
+            ResourceCleanerFactory resourceCleanerFactory)
+            throws Exception {
+        super(
+                rpcService,
+                fencingToken,
+                recoveredJobs,
+                recoveredDirtyJobs,
+                dispatcherBootstrapFactory,
+                new DispatcherServices(
+                        configuration,
+                        highAvailabilityServices,
+                        resourceManagerGatewayRetriever,
+                        blobServer,
+                        heartbeatServices,
+                        executionGraphInfoStore,
+                        fatalErrorHandler,
+                        historyServerArchivist,
+                        metricServiceQueryAddress,
+                        dispatcherOperationCaches,
+                        jobManagerMetricGroup,
+                        jobGraphWriter,
+                        jobResultStore,
+                        jobManagerRunnerFactory,
+                        ioExecutor),
+                jobManagerRunnerRegistry,
+                resourceCleanerFactory);
 
         this.startFuture = new CompletableFuture<>();
     }
@@ -90,5 +165,211 @@ class TestingDispatcher extends Dispatcher {
 
     void waitUntilStarted() {
         startFuture.join();
+    }
+
+    public static TestingDispatcher.Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private RpcService rpcService = new TestingRpcService();
+        private DispatcherId fencingToken = DispatcherId.generate();
+        private Collection<JobGraph> recoveredJobs = Collections.emptyList();
+        private Collection<JobResult> recoveredDirtyJobs = Collections.emptyList();
+        private HighAvailabilityServices highAvailabilityServices =
+                new TestingHighAvailabilityServices();
+
+        private TestingResourceManagerGateway resourceManagerGateway =
+                new TestingResourceManagerGateway();
+        private GatewayRetriever<ResourceManagerGateway> resourceManagerGatewayRetriever =
+                () -> CompletableFuture.completedFuture(resourceManagerGateway);
+        private HeartbeatServices heartbeatServices = new HeartbeatServices(1000L, 1000L);
+
+        private JobGraphWriter jobGraphWriter = NoOpJobGraphWriter.INSTANCE;
+        private JobResultStore jobResultStore = new EmbeddedJobResultStore();
+
+        private Configuration configuration = new Configuration();
+
+        // even-though it's labeled as @Nullable, it's a mandatory field that needs to be set before
+        // building the Dispatcher instance
+        @Nullable private BlobServer blobServer = null;
+        private FatalErrorHandler fatalErrorHandler = new TestingFatalErrorHandler();
+        private JobManagerMetricGroup jobManagerMetricGroup =
+                UnregisteredMetricGroups.createUnregisteredJobManagerMetricGroup();
+        @Nullable private String metricServiceQueryAddress = null;
+        private Executor ioExecutor = ForkJoinPool.commonPool();
+        private HistoryServerArchivist historyServerArchivist = VoidHistoryServerArchivist.INSTANCE;
+        private ExecutionGraphInfoStore executionGraphInfoStore =
+                new MemoryExecutionGraphInfoStore();
+        private JobManagerRunnerFactory jobManagerRunnerFactory =
+                new TestingJobManagerRunnerFactory(0);
+        private DispatcherBootstrapFactory dispatcherBootstrapFactory =
+                (dispatcher, scheduledExecutor, errorHandler) -> new NoOpDispatcherBootstrap();
+        private DispatcherOperationCaches dispatcherOperationCaches =
+                new DispatcherOperationCaches();
+        private JobManagerRunnerRegistry jobManagerRunnerRegistry =
+                new DefaultJobManagerRunnerRegistry(1);
+        @Nullable private ResourceCleanerFactory resourceCleanerFactory;
+
+        public Builder setRpcService(RpcService rpcService) {
+            this.rpcService = rpcService;
+            return this;
+        }
+
+        public Builder setFencingToken(DispatcherId fencingToken) {
+            this.fencingToken = fencingToken;
+            return this;
+        }
+
+        public Builder setRecoveredJobs(Collection<JobGraph> recoveredJobs) {
+            this.recoveredJobs = recoveredJobs;
+            return this;
+        }
+
+        public Builder setRecoveredDirtyJobs(Collection<JobResult> recoveredDirtyJobs) {
+            this.recoveredDirtyJobs = recoveredDirtyJobs;
+            return this;
+        }
+
+        public Builder setHighAvailabilityServices(
+                HighAvailabilityServices highAvailabilityServices) {
+            this.highAvailabilityServices = highAvailabilityServices;
+            return this;
+        }
+
+        public Builder setResourceManagerGateway(
+                TestingResourceManagerGateway resourceManagerGateway) {
+            this.resourceManagerGateway = resourceManagerGateway;
+            return this;
+        }
+
+        public Builder setResourceManagerGatewayRetriever(
+                GatewayRetriever<ResourceManagerGateway> resourceManagerGatewayRetriever) {
+            this.resourceManagerGatewayRetriever = resourceManagerGatewayRetriever;
+            return this;
+        }
+
+        public Builder setHeartbeatServices(HeartbeatServices heartbeatServices) {
+            this.heartbeatServices = heartbeatServices;
+            return this;
+        }
+
+        public Builder setJobGraphWriter(JobGraphWriter jobGraphWriter) {
+            this.jobGraphWriter = jobGraphWriter;
+            return this;
+        }
+
+        public Builder setJobResultStore(JobResultStore jobResultStore) {
+            this.jobResultStore = jobResultStore;
+            return this;
+        }
+
+        public Builder setConfiguration(Configuration configuration) {
+            this.configuration = configuration;
+            return this;
+        }
+
+        public Builder setBlobServer(BlobServer blobServer) {
+            this.blobServer = blobServer;
+            return this;
+        }
+
+        public Builder setFatalErrorHandler(FatalErrorHandler fatalErrorHandler) {
+            this.fatalErrorHandler = fatalErrorHandler;
+            return this;
+        }
+
+        public Builder setJobManagerMetricGroup(JobManagerMetricGroup jobManagerMetricGroup) {
+            this.jobManagerMetricGroup = jobManagerMetricGroup;
+            return this;
+        }
+
+        public Builder setMetricServiceQueryAddress(@Nullable String metricServiceQueryAddress) {
+            this.metricServiceQueryAddress = metricServiceQueryAddress;
+            return this;
+        }
+
+        public Builder setIoExecutor(Executor ioExecutor) {
+            this.ioExecutor = ioExecutor;
+            return this;
+        }
+
+        public Builder setHistoryServerArchivist(HistoryServerArchivist historyServerArchivist) {
+            this.historyServerArchivist = historyServerArchivist;
+            return this;
+        }
+
+        public Builder setExecutionGraphInfoStore(ExecutionGraphInfoStore executionGraphInfoStore) {
+            this.executionGraphInfoStore = executionGraphInfoStore;
+            return this;
+        }
+
+        public Builder setJobManagerRunnerFactory(JobManagerRunnerFactory jobManagerRunnerFactory) {
+            this.jobManagerRunnerFactory = jobManagerRunnerFactory;
+            return this;
+        }
+
+        public Builder setDispatcherBootstrapFactory(
+                DispatcherBootstrapFactory dispatcherBootstrapFactory) {
+            this.dispatcherBootstrapFactory = dispatcherBootstrapFactory;
+            return this;
+        }
+
+        public Builder setDispatcherOperationCaches(
+                DispatcherOperationCaches dispatcherOperationCaches) {
+            this.dispatcherOperationCaches = dispatcherOperationCaches;
+            return this;
+        }
+
+        public Builder setJobManagerRunnerRegistry(
+                JobManagerRunnerRegistry jobManagerRunnerRegistry) {
+            this.jobManagerRunnerRegistry = jobManagerRunnerRegistry;
+            return this;
+        }
+
+        public Builder setResourceCleanerFactory(ResourceCleanerFactory resourceCleanerFactory) {
+            this.resourceCleanerFactory = resourceCleanerFactory;
+            return this;
+        }
+
+        private ResourceCleanerFactory createDefaultResourceCleanerFactory() {
+            return new DispatcherResourceCleanerFactory(
+                    ioExecutor,
+                    jobManagerRunnerRegistry,
+                    jobGraphWriter,
+                    blobServer,
+                    highAvailabilityServices,
+                    jobManagerMetricGroup);
+        }
+
+        public TestingDispatcher build() throws Exception {
+            return new TestingDispatcher(
+                    rpcService,
+                    fencingToken,
+                    recoveredJobs,
+                    recoveredDirtyJobs,
+                    configuration,
+                    highAvailabilityServices,
+                    resourceManagerGatewayRetriever,
+                    heartbeatServices,
+                    Preconditions.checkNotNull(
+                            blobServer,
+                            "No BlobServer is specified for building the TestingDispatcher"),
+                    fatalErrorHandler,
+                    jobGraphWriter,
+                    jobResultStore,
+                    jobManagerMetricGroup,
+                    metricServiceQueryAddress,
+                    ioExecutor,
+                    historyServerArchivist,
+                    executionGraphInfoStore,
+                    jobManagerRunnerFactory,
+                    dispatcherBootstrapFactory,
+                    dispatcherOperationCaches,
+                    jobManagerRunnerRegistry,
+                    resourceCleanerFactory != null
+                            ? resourceCleanerFactory
+                            : createDefaultResourceCleanerFactory());
+        }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/cleanup/TestingResourceCleanerFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/cleanup/TestingResourceCleanerFactory.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher.cleanup;
+
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.concurrent.Executors;
+import org.apache.flink.util.concurrent.FutureUtils;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.concurrent.Executor;
+
+/** {@code TestingResourceCleanerFactory} for adding custom {@link ResourceCleaner} creation. */
+public class TestingResourceCleanerFactory implements ResourceCleanerFactory {
+
+    private final Collection<LocallyCleanableResource> locallyCleanableResources;
+    private final Collection<GloballyCleanableResource> globallyCleanableResources;
+
+    private final Executor cleanupExecutor;
+
+    private TestingResourceCleanerFactory(
+            Collection<LocallyCleanableResource> locallyCleanableResources,
+            Collection<GloballyCleanableResource> globallyCleanableResources,
+            Executor cleanupExecutor) {
+        this.locallyCleanableResources = locallyCleanableResources;
+        this.globallyCleanableResources = globallyCleanableResources;
+        this.cleanupExecutor = cleanupExecutor;
+    }
+
+    @Override
+    public ResourceCleaner createLocalResourceCleaner(
+            ComponentMainThreadExecutor mainThreadExecutor) {
+        return createResourceCleaner(
+                mainThreadExecutor,
+                locallyCleanableResources,
+                LocallyCleanableResource::localCleanupAsync);
+    }
+
+    @Override
+    public ResourceCleaner createGlobalResourceCleaner(
+            ComponentMainThreadExecutor mainThreadExecutor) {
+        return createResourceCleaner(
+                mainThreadExecutor,
+                globallyCleanableResources,
+                GloballyCleanableResource::globalCleanupAsync);
+    }
+
+    private <T> ResourceCleaner createResourceCleaner(
+            ComponentMainThreadExecutor mainThreadExecutor,
+            Collection<T> resources,
+            DefaultResourceCleaner.CleanupFn<T> cleanupFn) {
+        return jobId -> {
+            mainThreadExecutor.assertRunningInMainThread();
+            Throwable t = null;
+            for (T resource : resources) {
+                try {
+                    cleanupFn.cleanupAsync(resource, jobId, cleanupExecutor).get();
+                } catch (Throwable throwable) {
+                    t = ExceptionUtils.firstOrSuppressed(throwable, t);
+                }
+            }
+            return t != null
+                    ? FutureUtils.completedExceptionally(t)
+                    : FutureUtils.completedVoidFuture();
+        };
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /** {@code Builder} for creating {@code TestingResourceCleanerFactory} instances. */
+    public static class Builder {
+
+        private Collection<LocallyCleanableResource> locallyCleanableResources = new ArrayList<>();
+        private Collection<GloballyCleanableResource> globallyCleanableResources =
+                new ArrayList<>();
+
+        private Executor cleanupExecutor = Executors.directExecutor();
+
+        public Builder setLocallyCleanableResources(
+                Collection<LocallyCleanableResource> locallyCleanableResources) {
+            this.locallyCleanableResources = locallyCleanableResources;
+            return this;
+        }
+
+        public Builder withLocallyCleanableResource(
+                LocallyCleanableResource locallyCleanableResource) {
+            this.locallyCleanableResources.add(locallyCleanableResource);
+            return this;
+        }
+
+        public Builder setGloballyCleanableResources(
+                Collection<GloballyCleanableResource> globallyCleanableResources) {
+            this.globallyCleanableResources = globallyCleanableResources;
+            return this;
+        }
+
+        public Builder withGloballyCleanableResource(
+                GloballyCleanableResource globallyCleanableResource) {
+            this.globallyCleanableResources.add(globallyCleanableResource);
+            return this;
+        }
+
+        public Builder setCleanupExecutor(Executor cleanupExecutor) {
+            this.cleanupExecutor = cleanupExecutor;
+            return this;
+        }
+
+        public TestingResourceCleanerFactory build() {
+            return new TestingResourceCleanerFactory(
+                    locallyCleanableResources, globallyCleanableResources, cleanupExecutor);
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Refactored the tests around cleanup collecting cleanup-relevant tests in `DispatcherResourceCleanupTest`

## Brief change log

* Makes `BlobServerClenupTest` based on JUnit5 and AssertJ and adds cleanup-related tests
* `DispatcherResourceCleanupTest` is refactored to only rely on the cleanup without testing the downstream CleanableResources. Testing that the right components are cleaned is tested in `DispatcherResourceCleanerFactoryTest`.  The actual cleanup for each component is then tested in the corresponding component tests.
* Additionally, I added test cases in `DispatcherResourceCleanerFactoryTest` for verifying that the `JobResult` is marked as dirty before the cleanup and clean after the cleanup

## Verifying this change

The PR itself is just tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
