### PR TITLE
[FLINK-25955][runtime] Introduces `JobManagerRunner` implementation for cleanup

### DIFF
--- a/flink-clients/src/test/java/org/apache/flink/client/deployment/application/ApplicationDispatcherBootstrapITCase.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/deployment/application/ApplicationDispatcherBootstrapITCase.java
@@ -214,11 +214,11 @@ public class ApplicationDispatcherBootstrapITCase {
         assertThat(
                         jobResultStore.hasDirtyJobResultEntry(
                                 ApplicationDispatcherBootstrap.ZERO_JOB_ID))
-                .isTrue();
+                .isFalse();
         assertThat(
                         jobResultStore.hasCleanJobResultEntry(
                                 ApplicationDispatcherBootstrap.ZERO_JOB_ID))
-                .isFalse();
+                .isTrue();
     }
 
     @Test

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/ApplicationStatus.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/ApplicationStatus.java
@@ -20,24 +20,37 @@ package org.apache.flink.runtime.clusterframework;
 
 import org.apache.flink.api.common.JobStatus;
 
+import org.apache.flink.shaded.guava30.com.google.common.collect.BiMap;
+import org.apache.flink.shaded.guava30.com.google.common.collect.EnumBiMap;
+
 /** The status of an application. */
 public enum ApplicationStatus {
 
-    /** Application finished successfully */
+    /** Application finished successfully. */
     SUCCEEDED(0),
 
-    /** Application encountered an unrecoverable failure or error */
+    /** Application encountered an unrecoverable failure or error. */
     FAILED(1443),
 
-    /** Application was canceled or killed on request */
+    /** Application was canceled or killed on request. */
     CANCELED(0),
 
-    /** Application status is not known */
+    /** Application status is not known. */
     UNKNOWN(1445);
 
     // ------------------------------------------------------------------------
 
-    /** The associated process exit code */
+    private static final BiMap<JobStatus, ApplicationStatus> JOB_STATUS_APPLICATION_STATUS_BI_MAP =
+            EnumBiMap.create(JobStatus.class, ApplicationStatus.class);
+
+    static {
+        // only globally-terminated JobStatus have a corresponding ApplicationStatus
+        JOB_STATUS_APPLICATION_STATUS_BI_MAP.put(JobStatus.FAILED, ApplicationStatus.FAILED);
+        JOB_STATUS_APPLICATION_STATUS_BI_MAP.put(JobStatus.CANCELED, ApplicationStatus.CANCELED);
+        JOB_STATUS_APPLICATION_STATUS_BI_MAP.put(JobStatus.FINISHED, ApplicationStatus.SUCCEEDED);
+    }
+
+    /** The associated process exit code. */
     private final int processExitCode;
 
     ApplicationStatus(int exitCode) {
@@ -45,7 +58,7 @@ public enum ApplicationStatus {
     }
 
     /**
-     * Gets the process exit code associated with this status
+     * Gets the process exit code associated with this status.
      *
      * @return The associated process exit code.
      */
@@ -59,20 +72,21 @@ public enum ApplicationStatus {
      * #UNKNOWN}.
      */
     public static ApplicationStatus fromJobStatus(JobStatus jobStatus) {
-        if (jobStatus == null) {
-            return UNKNOWN;
-        } else {
-            switch (jobStatus) {
-                case FAILED:
-                    return FAILED;
-                case CANCELED:
-                    return CANCELED;
-                case FINISHED:
-                    return SUCCEEDED;
+        return JOB_STATUS_APPLICATION_STATUS_BI_MAP.getOrDefault(jobStatus, UNKNOWN);
+    }
 
-                default:
-                    return UNKNOWN;
-            }
+    /**
+     * Derives the {@link JobStatus} from the {@code ApplicationStatus}.
+     *
+     * @return The corresponding {@code JobStatus}.
+     * @throws UnsupportedOperationException for {@link #UNKNOWN}.
+     */
+    public JobStatus deriveJobStatus() {
+        if (!JOB_STATUS_APPLICATION_STATUS_BI_MAP.inverse().containsKey(this)) {
+            throw new UnsupportedOperationException(
+                    this.name() + " cannot be mapped to a JobStatus.");
         }
+
+        return JOB_STATUS_APPLICATION_STATUS_BI_MAP.inverse().get(this);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherServices.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.dispatcher;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobServer;
+import org.apache.flink.runtime.dispatcher.cleanup.CleanupRunnerFactory;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.highavailability.JobResultStore;
@@ -65,6 +66,8 @@ public class DispatcherServices {
 
     private final JobManagerRunnerFactory jobManagerRunnerFactory;
 
+    private final CleanupRunnerFactory cleanupRunnerFactory;
+
     private final Executor ioExecutor;
 
     DispatcherServices(
@@ -82,6 +85,7 @@ public class DispatcherServices {
             JobGraphWriter jobGraphWriter,
             JobResultStore jobResultStore,
             JobManagerRunnerFactory jobManagerRunnerFactory,
+            CleanupRunnerFactory cleanupRunnerFactory,
             Executor ioExecutor) {
         this.configuration = Preconditions.checkNotNull(configuration, "Configuration");
         this.highAvailabilityServices =
@@ -104,6 +108,8 @@ public class DispatcherServices {
         this.jobResultStore = Preconditions.checkNotNull(jobResultStore, "JobResultStore");
         this.jobManagerRunnerFactory =
                 Preconditions.checkNotNull(jobManagerRunnerFactory, "JobManagerRunnerFactory");
+        this.cleanupRunnerFactory =
+                Preconditions.checkNotNull(cleanupRunnerFactory, "CleanupRunnerFactory");
         this.ioExecutor = Preconditions.checkNotNull(ioExecutor, "IOExecutor");
     }
 
@@ -164,6 +170,10 @@ public class DispatcherServices {
         return jobManagerRunnerFactory;
     }
 
+    CleanupRunnerFactory getCleanupRunnerFactory() {
+        return cleanupRunnerFactory;
+    }
+
     public Executor getIoExecutor() {
         return ioExecutor;
     }
@@ -171,7 +181,8 @@ public class DispatcherServices {
     public static DispatcherServices from(
             PartialDispatcherServicesWithJobPersistenceComponents
                     partialDispatcherServicesWithJobPersistenceComponents,
-            JobManagerRunnerFactory jobManagerRunnerFactory) {
+            JobManagerRunnerFactory jobManagerRunnerFactory,
+            CleanupRunnerFactory cleanupRunnerFactory) {
         return new DispatcherServices(
                 partialDispatcherServicesWithJobPersistenceComponents.getConfiguration(),
                 partialDispatcherServicesWithJobPersistenceComponents.getHighAvailabilityServices(),
@@ -192,6 +203,7 @@ public class DispatcherServices {
                 partialDispatcherServicesWithJobPersistenceComponents.getJobGraphWriter(),
                 partialDispatcherServicesWithJobPersistenceComponents.getJobResultStore(),
                 jobManagerRunnerFactory,
+                cleanupRunnerFactory,
                 partialDispatcherServicesWithJobPersistenceComponents.getIoExecutor());
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/JobDispatcherFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/JobDispatcherFactory.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.dispatcher;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.dispatcher.cleanup.CheckpointResourcesCleanupRunnerFactory;
 import org.apache.flink.runtime.entrypoint.ClusterEntrypoint;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmaster.JobResult;
@@ -64,7 +65,8 @@ public enum JobDispatcherFactory implements DispatcherFactory {
                 fencingToken,
                 DispatcherServices.from(
                         partialDispatcherServicesWithJobPersistenceComponents,
-                        JobMasterServiceLeadershipRunnerFactory.INSTANCE),
+                        JobMasterServiceLeadershipRunnerFactory.INSTANCE,
+                        CheckpointResourcesCleanupRunnerFactory.INSTANCE),
                 recoveredJobGraph,
                 recoveredDirtyJob,
                 dispatcherBootstrapFactory,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/SessionDispatcherFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/SessionDispatcherFactory.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.dispatcher;
 
+import org.apache.flink.runtime.dispatcher.cleanup.CheckpointResourcesCleanupRunnerFactory;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.runtime.rpc.RpcService;
@@ -47,6 +48,7 @@ public enum SessionDispatcherFactory implements DispatcherFactory {
                 dispatcherBootstrapFactory,
                 DispatcherServices.from(
                         partialDispatcherServicesWithJobPersistenceComponents,
-                        JobMasterServiceLeadershipRunnerFactory.INSTANCE));
+                        JobMasterServiceLeadershipRunnerFactory.INSTANCE,
+                        CheckpointResourcesCleanupRunnerFactory.INSTANCE));
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/CheckpointResourcesCleanupRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/CheckpointResourcesCleanupRunner.java
@@ -1,0 +1,230 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher.cleanup;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.checkpoint.CheckpointIDCounter;
+import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
+import org.apache.flink.runtime.checkpoint.CheckpointsCleaner;
+import org.apache.flink.runtime.checkpoint.CompletedCheckpointStore;
+import org.apache.flink.runtime.checkpoint.DefaultCompletedCheckpointStoreUtils;
+import org.apache.flink.runtime.dispatcher.UnavailableDispatcherOperationException;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
+import org.apache.flink.runtime.jobmaster.JobManagerRunner;
+import org.apache.flink.runtime.jobmaster.JobManagerRunnerResult;
+import org.apache.flink.runtime.jobmaster.JobMaster;
+import org.apache.flink.runtime.jobmaster.JobMasterGateway;
+import org.apache.flink.runtime.jobmaster.JobResult;
+import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.messages.webmonitor.JobDetails;
+import org.apache.flink.runtime.scheduler.ExecutionGraphInfo;
+import org.apache.flink.runtime.state.SharedStateRegistryFactory;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.concurrent.FutureUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executor;
+
+/**
+ * {@code CheckpointResourcesCleanupRunner} implements {@link JobManagerRunner} in a way, that only
+ * the checkpoint-related resources are instantiated. It triggers any job-specific cleanup that's
+ * usually performed by the {@link JobMaster} without rebuilding the corresponding {@link
+ * org.apache.flink.runtime.executiongraph.ExecutionGraph}.
+ */
+public class CheckpointResourcesCleanupRunner implements JobManagerRunner {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(CheckpointResourcesCleanupRunner.class);
+
+    private final JobResult jobResult;
+    private final CheckpointRecoveryFactory checkpointRecoveryFactory;
+    private final CheckpointsCleaner checkpointsCleaner;
+    private final SharedStateRegistryFactory sharedStateRegistryFactory;
+    private final Configuration jobManagerConfiguration;
+    private final Executor cleanupExecutor;
+
+    private final long initializationTimestamp;
+
+    // we have to have two separate futures because closeAsync relies on the completion of
+    // getResultFuture which is always already completed but the cleanupFuture is only
+    // instantiated when calling start
+    private CompletableFuture<Void> cleanupFuture;
+    private final CompletableFuture<Void> closeFuture = new CompletableFuture<>();
+
+    public CheckpointResourcesCleanupRunner(
+            JobResult jobResult,
+            CheckpointRecoveryFactory checkpointRecoveryFactory,
+            CheckpointsCleaner checkpointsCleaner,
+            SharedStateRegistryFactory sharedStateRegistryFactory,
+            Configuration jobManagerConfiguration,
+            Executor cleanupExecutor,
+            long initializationTimestamp) {
+        this.jobResult = Preconditions.checkNotNull(jobResult);
+        this.checkpointRecoveryFactory = Preconditions.checkNotNull(checkpointRecoveryFactory);
+        this.checkpointsCleaner = Preconditions.checkNotNull(checkpointsCleaner);
+        this.sharedStateRegistryFactory = Preconditions.checkNotNull(sharedStateRegistryFactory);
+        this.jobManagerConfiguration = Preconditions.checkNotNull(jobManagerConfiguration);
+        this.cleanupExecutor = Preconditions.checkNotNull(cleanupExecutor);
+        this.initializationTimestamp = initializationTimestamp;
+    }
+
+    @Override
+    public CompletableFuture<Void> closeAsync() {
+        return closeFuture;
+    }
+
+    @Override
+    public void start() throws Exception {
+        cleanupFuture =
+                CompletableFuture.runAsync(
+                        () -> {
+                            try {
+                                cleanupCheckpoints();
+                            } catch (Exception e) {
+                                throw new CompletionException(e);
+                            }
+                        },
+                        cleanupExecutor);
+
+        FutureUtils.forward(cleanupFuture, closeFuture);
+    }
+
+    private void cleanupCheckpoints() throws Exception {
+        final CompletedCheckpointStore completedCheckpointStore = createCompletedCheckpointStore();
+        final CheckpointIDCounter checkpointIDCounter = createCheckpointIDCounter();
+
+        Exception exception = null;
+        try {
+            completedCheckpointStore.shutdown(getJobStatus(), checkpointsCleaner);
+        } catch (Exception e) {
+            exception = e;
+        }
+
+        try {
+            checkpointIDCounter.shutdown(getJobStatus());
+        } catch (Exception e) {
+            exception = ExceptionUtils.firstOrSuppressed(e, exception);
+        }
+
+        if (exception != null) {
+            throw exception;
+        }
+    }
+
+    private CompletedCheckpointStore createCompletedCheckpointStore() throws Exception {
+        return checkpointRecoveryFactory.createRecoveredCompletedCheckpointStore(
+                getJobID(),
+                DefaultCompletedCheckpointStoreUtils.getMaximumNumberOfRetainedCheckpoints(
+                        jobManagerConfiguration, LOG),
+                sharedStateRegistryFactory,
+                cleanupExecutor);
+    }
+
+    private CheckpointIDCounter createCheckpointIDCounter() throws Exception {
+        return checkpointRecoveryFactory.createCheckpointIDCounter(getJobID());
+    }
+
+    @Override
+    public CompletableFuture<JobMasterGateway> getJobMasterGateway() {
+        return FutureUtils.completedExceptionally(
+                new UnavailableDispatcherOperationException(
+                        "Unable to get JobMasterGateway for job in cleanup phase. The requested operation is not available in that stage."));
+    }
+
+    @Override
+    public CompletableFuture<JobManagerRunnerResult> getResultFuture() {
+        return CompletableFuture.completedFuture(
+                JobManagerRunnerResult.forSuccess(createExecutionGraphInfoFromJobResult()));
+    }
+
+    @Override
+    public JobID getJobID() {
+        return jobResult.getJobId();
+    }
+
+    @Override
+    public CompletableFuture<Acknowledge> cancel(Time timeout) {
+        Preconditions.checkState(
+                cleanupFuture != null,
+                "The CheckpointResourcesCleanupRunner was not started, yet.");
+        if (cleanupFuture.cancel(true)) {
+            return CompletableFuture.completedFuture(Acknowledge.get());
+        }
+
+        return FutureUtils.completedExceptionally(
+                new FlinkException("Cleanup task couldn't be cancelled."));
+    }
+
+    @Override
+    public CompletableFuture<JobStatus> requestJobStatus(Time timeout) {
+        return CompletableFuture.completedFuture(getJobStatus());
+    }
+
+    @Override
+    public CompletableFuture<JobDetails> requestJobDetails(Time timeout) {
+        return requestJob(timeout)
+                .thenApply(
+                        executionGraphInfo ->
+                                JobDetails.createDetailsForJob(
+                                        executionGraphInfo.getArchivedExecutionGraph()));
+    }
+
+    @Override
+    public CompletableFuture<ExecutionGraphInfo> requestJob(Time timeout) {
+        return CompletableFuture.completedFuture(createExecutionGraphInfoFromJobResult());
+    }
+
+    @Override
+    public boolean isInitialized() {
+        return true;
+    }
+
+    private ExecutionGraphInfo createExecutionGraphInfoFromJobResult() {
+        return generateExecutionGraphInfo(jobResult, initializationTimestamp);
+    }
+
+    private JobStatus getJobStatus() {
+        return getJobStatus(jobResult);
+    }
+
+    private static JobStatus getJobStatus(JobResult jobResult) {
+        return jobResult.getApplicationStatus().deriveJobStatus();
+    }
+
+    private static ExecutionGraphInfo generateExecutionGraphInfo(
+            JobResult jobResult, long initializationTimestamp) {
+        return new ExecutionGraphInfo(
+                ArchivedExecutionGraph.createFromInitializingJob(
+                        jobResult.getJobId(),
+                        "unknown",
+                        getJobStatus(jobResult),
+                        jobResult.getSerializedThrowable().orElse(null),
+                        null,
+                        initializationTimestamp));
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/CheckpointResourcesCleanupRunnerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/CheckpointResourcesCleanupRunnerFactory.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher.cleanup;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
+import org.apache.flink.runtime.checkpoint.CheckpointsCleaner;
+import org.apache.flink.runtime.jobmaster.JobResult;
+import org.apache.flink.runtime.state.SharedStateRegistry;
+
+import java.util.concurrent.Executor;
+
+/**
+ * {@code CheckpointResourcesCleanupRunnerFactory} implements {@link CleanupRunnerFactory} providing
+ * a factory method for creating {@link CheckpointResourcesCleanupRunner} instances.
+ */
+public enum CheckpointResourcesCleanupRunnerFactory implements CleanupRunnerFactory {
+    INSTANCE;
+
+    @Override
+    public CheckpointResourcesCleanupRunner create(
+            JobResult jobResult,
+            CheckpointRecoveryFactory checkpointRecoveryFactory,
+            Configuration configuration,
+            Executor cleanupExecutor) {
+        return new CheckpointResourcesCleanupRunner(
+                jobResult,
+                checkpointRecoveryFactory,
+                new CheckpointsCleaner(),
+                SharedStateRegistry.DEFAULT_FACTORY,
+                configuration,
+                cleanupExecutor,
+                System.currentTimeMillis());
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/CleanupRunnerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/CleanupRunnerFactory.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher.cleanup;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
+import org.apache.flink.runtime.jobmaster.JobManagerRunner;
+import org.apache.flink.runtime.jobmaster.JobResult;
+
+import java.util.concurrent.Executor;
+
+/**
+ * {@code CleanupRunnerFactory} provides a factory method for creating {@link
+ * CheckpointResourcesCleanupRunner} instances.
+ */
+@FunctionalInterface
+public interface CleanupRunnerFactory {
+    JobManagerRunner create(
+            JobResult jobResult,
+            CheckpointRecoveryFactory checkpointRecoveryFactory,
+            Configuration configuration,
+            Executor cleanupExecutor);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerUtils.java
@@ -20,13 +20,13 @@ package org.apache.flink.runtime.scheduler;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.checkpoint.CheckpointIDCounter;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpointStore;
 import org.apache.flink.runtime.checkpoint.DeactivatedCheckpointCompletedCheckpointStore;
 import org.apache.flink.runtime.checkpoint.DeactivatedCheckpointIDCounter;
+import org.apache.flink.runtime.checkpoint.DefaultCompletedCheckpointStoreUtils;
 import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.executiongraph.DefaultExecutionGraphBuilder;
 import org.apache.flink.runtime.jobgraph.JobGraph;
@@ -75,25 +75,10 @@ public final class SchedulerUtils {
             Logger log,
             JobID jobId)
             throws Exception {
-        int maxNumberOfCheckpointsToRetain =
-                jobManagerConfig.getInteger(CheckpointingOptions.MAX_RETAINED_CHECKPOINTS);
-
-        if (maxNumberOfCheckpointsToRetain <= 0) {
-            // warning and use 1 as the default value if the setting in
-            // state.checkpoints.max-retained-checkpoints is not greater than 0.
-            log.warn(
-                    "The setting for '{} : {}' is invalid. Using default value of {}",
-                    CheckpointingOptions.MAX_RETAINED_CHECKPOINTS.key(),
-                    maxNumberOfCheckpointsToRetain,
-                    CheckpointingOptions.MAX_RETAINED_CHECKPOINTS.defaultValue());
-
-            maxNumberOfCheckpointsToRetain =
-                    CheckpointingOptions.MAX_RETAINED_CHECKPOINTS.defaultValue();
-        }
-
         return recoveryFactory.createRecoveredCompletedCheckpointStore(
                 jobId,
-                maxNumberOfCheckpointsToRetain,
+                DefaultCompletedCheckpointStoreUtils.getMaximumNumberOfRetainedCheckpoints(
+                        jobManagerConfig, log),
                 SharedStateRegistry.DEFAULT_FACTORY,
                 ioExecutor);
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/DefaultCompletedCheckpointStoreUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/DefaultCompletedCheckpointStoreUtilsTest.java
@@ -20,6 +20,8 @@ package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.CheckpointingOptions;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.persistence.TestingStateHandleStore;
 import org.apache.flink.runtime.state.RetrievableStateHandle;
 import org.apache.flink.runtime.state.testutils.TestCompletedCheckpointStorageLocation;
@@ -27,6 +29,8 @@ import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -38,6 +42,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
@@ -134,5 +139,17 @@ public class DefaultCompletedCheckpointStoreUtilsTest extends TestLogger {
                 () ->
                         DefaultCompletedCheckpointStoreUtils.retrieveCompletedCheckpoints(
                                 stateHandleStore, new SimpleCheckpointStoreUtil()));
+    }
+
+    @ParameterizedTest(name = "actual: {0}; expected: {1}")
+    @CsvSource({"10,10", "0,1", "-1,1"})
+    public void testGetMaximumNumberOfRetainedCheckpoints(int actualValue, int expectedValue) {
+        final Configuration jobManagerConfig = new Configuration();
+        jobManagerConfig.setInteger(CheckpointingOptions.MAX_RETAINED_CHECKPOINTS, actualValue);
+
+        assertThat(
+                        DefaultCompletedCheckpointStoreUtils.getMaximumNumberOfRetainedCheckpoints(
+                                jobManagerConfig, log))
+                .isEqualTo(expectedValue);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/DefaultSchedulerCheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/DefaultSchedulerCheckpointCoordinatorTest.java
@@ -56,10 +56,14 @@ public class DefaultSchedulerCheckpointCoordinatorTest extends TestLogger {
     public void testClosingSchedulerShutsDownCheckpointCoordinatorOnFailedExecutionGraph()
             throws Exception {
         final CompletableFuture<JobStatus> counterShutdownFuture = new CompletableFuture<>();
-        CheckpointIDCounter counter = new TestingCheckpointIDCounter(counterShutdownFuture);
+        CheckpointIDCounter counter =
+                TestingCheckpointIDCounter.createStoreWithShutdownCheckAndNoStartAction(
+                        counterShutdownFuture);
 
         final CompletableFuture<JobStatus> storeShutdownFuture = new CompletableFuture<>();
-        CompletedCheckpointStore store = new TestingCompletedCheckpointStore(storeShutdownFuture);
+        CompletedCheckpointStore store =
+                TestingCompletedCheckpointStore
+                        .createStoreWithShutdownCheckAndNoCompletedCheckpoints(storeShutdownFuture);
 
         final SchedulerBase scheduler = createSchedulerAndEnableCheckpointing(counter, store);
         final ExecutionGraph graph = scheduler.getExecutionGraph();
@@ -82,10 +86,14 @@ public class DefaultSchedulerCheckpointCoordinatorTest extends TestLogger {
     public void testClosingSchedulerShutsDownCheckpointCoordinatorOnSuspendedExecutionGraph()
             throws Exception {
         final CompletableFuture<JobStatus> counterShutdownFuture = new CompletableFuture<>();
-        CheckpointIDCounter counter = new TestingCheckpointIDCounter(counterShutdownFuture);
+        CheckpointIDCounter counter =
+                TestingCheckpointIDCounter.createStoreWithShutdownCheckAndNoStartAction(
+                        counterShutdownFuture);
 
         final CompletableFuture<JobStatus> storeShutdownFuture = new CompletableFuture<>();
-        CompletedCheckpointStore store = new TestingCompletedCheckpointStore(storeShutdownFuture);
+        CompletedCheckpointStore store =
+                TestingCompletedCheckpointStore
+                        .createStoreWithShutdownCheckAndNoCompletedCheckpoints(storeShutdownFuture);
 
         final SchedulerBase scheduler = createSchedulerAndEnableCheckpointing(counter, store);
         final ExecutionGraph graph = scheduler.getExecutionGraph();
@@ -108,10 +116,14 @@ public class DefaultSchedulerCheckpointCoordinatorTest extends TestLogger {
     public void testClosingSchedulerShutsDownCheckpointCoordinatorOnFinishedExecutionGraph()
             throws Exception {
         final CompletableFuture<JobStatus> counterShutdownFuture = new CompletableFuture<>();
-        CheckpointIDCounter counter = new TestingCheckpointIDCounter(counterShutdownFuture);
+        CheckpointIDCounter counter =
+                TestingCheckpointIDCounter.createStoreWithShutdownCheckAndNoStartAction(
+                        counterShutdownFuture);
 
         final CompletableFuture<JobStatus> storeShutdownFuture = new CompletableFuture<>();
-        CompletedCheckpointStore store = new TestingCompletedCheckpointStore(storeShutdownFuture);
+        CompletedCheckpointStore store =
+                TestingCompletedCheckpointStore
+                        .createStoreWithShutdownCheckAndNoCompletedCheckpoints(storeShutdownFuture);
 
         final SchedulerBase scheduler = createSchedulerAndEnableCheckpointing(counter, store);
         final ExecutionGraph graph = scheduler.getExecutionGraph();
@@ -143,10 +155,14 @@ public class DefaultSchedulerCheckpointCoordinatorTest extends TestLogger {
     public void testClosingSchedulerSuspendsExecutionGraphAndShutsDownCheckpointCoordinator()
             throws Exception {
         final CompletableFuture<JobStatus> counterShutdownFuture = new CompletableFuture<>();
-        CheckpointIDCounter counter = new TestingCheckpointIDCounter(counterShutdownFuture);
+        CheckpointIDCounter counter =
+                TestingCheckpointIDCounter.createStoreWithShutdownCheckAndNoStartAction(
+                        counterShutdownFuture);
 
         final CompletableFuture<JobStatus> storeShutdownFuture = new CompletableFuture<>();
-        CompletedCheckpointStore store = new TestingCompletedCheckpointStore(storeShutdownFuture);
+        CompletedCheckpointStore store =
+                TestingCompletedCheckpointStore
+                        .createStoreWithShutdownCheckAndNoCompletedCheckpoints(storeShutdownFuture);
 
         final SchedulerBase scheduler = createSchedulerAndEnableCheckpointing(counter, store);
         final ExecutionGraph graph = scheduler.getExecutionGraph();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PerJobCheckpointRecoveryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PerJobCheckpointRecoveryTest.java
@@ -36,7 +36,9 @@ public class PerJobCheckpointRecoveryTest extends TestLogger {
     @Test
     public void testFactoryWithoutCheckpointStoreRecovery() throws Exception {
         final TestingCompletedCheckpointStore store =
-                new TestingCompletedCheckpointStore(new CompletableFuture<>());
+                TestingCompletedCheckpointStore
+                        .createStoreWithShutdownCheckAndNoCompletedCheckpoints(
+                                new CompletableFuture<>());
         final CheckpointRecoveryFactory factory =
                 PerJobCheckpointRecoveryFactory.withoutCheckpointStoreRecovery(
                         maxCheckpoints -> store);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/TestingCheckpointIDCounter.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/TestingCheckpointIDCounter.java
@@ -20,36 +20,109 @@ package org.apache.flink.runtime.checkpoint;
 import org.apache.flink.api.common.JobStatus;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 /** Test {@link CheckpointIDCounter} implementation for testing the shutdown behavior. */
 public final class TestingCheckpointIDCounter implements CheckpointIDCounter {
 
-    private final CompletableFuture<JobStatus> shutdownStatus;
+    private final Runnable startRunnable;
+    private final Consumer<JobStatus> shutdownConsumer;
+    private final Supplier<Integer> getAndIncrementSupplier;
+    private final Supplier<Integer> getSupplier;
+    private final Consumer<Long> setCountConsumer;
 
-    public TestingCheckpointIDCounter(CompletableFuture<JobStatus> shutdownStatus) {
-        this.shutdownStatus = shutdownStatus;
+    public static TestingCheckpointIDCounter createStoreWithShutdownCheckAndNoStartAction(
+            CompletableFuture<JobStatus> shutdownFuture) {
+        return TestingCheckpointIDCounter.builder()
+                .withStartRunnable(() -> {})
+                .withShutdownConsumer(shutdownFuture::complete)
+                .build();
+    }
+
+    private TestingCheckpointIDCounter(
+            Runnable startRunnable,
+            Consumer<JobStatus> shutdownConsumer,
+            Supplier<Integer> getAndIncrementSupplier,
+            Supplier<Integer> getSupplier,
+            Consumer<Long> setCountConsumer) {
+        this.startRunnable = startRunnable;
+        this.shutdownConsumer = shutdownConsumer;
+        this.getAndIncrementSupplier = getAndIncrementSupplier;
+        this.getSupplier = getSupplier;
+        this.setCountConsumer = setCountConsumer;
     }
 
     @Override
-    public void start() {}
+    public void start() {
+        startRunnable.run();
+    }
 
     @Override
     public void shutdown(JobStatus jobStatus) {
-        shutdownStatus.complete(jobStatus);
+        shutdownConsumer.accept(jobStatus);
     }
 
     @Override
     public long getAndIncrement() {
-        throw new UnsupportedOperationException("Not implemented.");
+        return getAndIncrementSupplier.get();
     }
 
     @Override
     public long get() {
-        throw new UnsupportedOperationException("Not implemented.");
+        return getSupplier.get();
     }
 
     @Override
     public void setCount(long newId) {
-        throw new UnsupportedOperationException("Not implemented.");
+        setCountConsumer.accept(newId);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /** {@code Builder} for creating {@code TestingCheckpointIDCounter} instances. */
+    public static class Builder {
+
+        private Runnable startRunnable;
+        private Consumer<JobStatus> shutdownConsumer;
+        private Supplier<Integer> getAndIncrementSupplier;
+        private Supplier<Integer> getSupplier;
+        private Consumer<Long> setCountConsumer;
+
+        public Builder withStartRunnable(Runnable startRunnable) {
+            this.startRunnable = startRunnable;
+            return this;
+        }
+
+        public Builder withShutdownConsumer(Consumer<JobStatus> shutdownConsumer) {
+            this.shutdownConsumer = shutdownConsumer;
+            return this;
+        }
+
+        public Builder withGetAndIncrementSupplier(Supplier<Integer> getAndIncrementSupplier) {
+            this.getAndIncrementSupplier = getAndIncrementSupplier;
+            return this;
+        }
+
+        public Builder withGetSupplier(Supplier<Integer> getSupplier) {
+            this.getSupplier = getSupplier;
+            return this;
+        }
+
+        public Builder withSetCountConsumer(Consumer<Long> setCountConsumer) {
+            this.setCountConsumer = setCountConsumer;
+            return this;
+        }
+
+        public TestingCheckpointIDCounter build() {
+            return new TestingCheckpointIDCounter(
+                    startRunnable,
+                    shutdownConsumer,
+                    getAndIncrementSupplier,
+                    getSupplier,
+                    setCountConsumer);
+        }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/TestingCompletedCheckpointStore.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/TestingCompletedCheckpointStore.java
@@ -19,18 +19,54 @@ package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.runtime.state.SharedStateRegistry;
+import org.apache.flink.util.function.TriFunction;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.BiConsumer;
+import java.util.function.Supplier;
 
 /** Test {@link CompletedCheckpointStore} implementation for testing the shutdown behavior. */
 public final class TestingCompletedCheckpointStore implements CompletedCheckpointStore {
 
-    private final CompletableFuture<JobStatus> shutdownStatus;
+    private final TriFunction<
+                    CompletedCheckpoint, CheckpointsCleaner, Runnable, CompletedCheckpoint>
+            addCheckpointAndSubsumeOldestOneFunction;
+    private final BiConsumer<JobStatus, CheckpointsCleaner> shutdownConsumer;
+    private final Supplier<List<CompletedCheckpoint>> getAllCheckpointsSupplier;
+    private final Supplier<Integer> getNumberOfRetainedCheckpointsSuppler;
+    private final Supplier<Integer> getMaxNumberOfRetainedCheckpointsSupplier;
+    private final Supplier<Boolean> requiresExternalizedCheckpointsSupplier;
+    private final Supplier<SharedStateRegistry> getSharedStateRegistrySupplier;
 
-    public TestingCompletedCheckpointStore(CompletableFuture<JobStatus> shutdownStatus) {
-        this.shutdownStatus = shutdownStatus;
+    public static TestingCompletedCheckpointStore
+            createStoreWithShutdownCheckAndNoCompletedCheckpoints(
+                    CompletableFuture<JobStatus> shutdownFuture) {
+        return TestingCompletedCheckpointStore.builder()
+                .withShutdownConsumer(
+                        ((jobStatus, ignoredCheckpointsCleaner) ->
+                                shutdownFuture.complete(jobStatus)))
+                .withGetAllCheckpointsSupplier(Collections::emptyList)
+                .build();
+    }
+
+    private TestingCompletedCheckpointStore(
+            TriFunction<CompletedCheckpoint, CheckpointsCleaner, Runnable, CompletedCheckpoint>
+                    addCheckpointAndSubsumeOldestOneFunction,
+            BiConsumer<JobStatus, CheckpointsCleaner> shutdownConsumer,
+            Supplier<List<CompletedCheckpoint>> getAllCheckpointsSupplier,
+            Supplier<Integer> getNumberOfRetainedCheckpointsSuppler,
+            Supplier<Integer> getMaxNumberOfRetainedCheckpointsSupplier,
+            Supplier<Boolean> requiresExternalizedCheckpointsSupplier,
+            Supplier<SharedStateRegistry> getSharedStateRegistrySupplier) {
+        this.addCheckpointAndSubsumeOldestOneFunction = addCheckpointAndSubsumeOldestOneFunction;
+        this.shutdownConsumer = shutdownConsumer;
+        this.getAllCheckpointsSupplier = getAllCheckpointsSupplier;
+        this.getNumberOfRetainedCheckpointsSuppler = getNumberOfRetainedCheckpointsSuppler;
+        this.getMaxNumberOfRetainedCheckpointsSupplier = getMaxNumberOfRetainedCheckpointsSupplier;
+        this.requiresExternalizedCheckpointsSupplier = requiresExternalizedCheckpointsSupplier;
+        this.getSharedStateRegistrySupplier = getSharedStateRegistrySupplier;
     }
 
     @Override
@@ -38,41 +74,138 @@ public final class TestingCompletedCheckpointStore implements CompletedCheckpoin
             CompletedCheckpoint checkpoint,
             CheckpointsCleaner checkpointsCleaner,
             Runnable postCleanup) {
-        throw new UnsupportedOperationException("Not implemented.");
-    }
-
-    @Override
-    public CompletedCheckpoint getLatestCheckpoint() {
-        return null;
+        return addCheckpointAndSubsumeOldestOneFunction.apply(
+                checkpoint, checkpointsCleaner, postCleanup);
     }
 
     @Override
     public void shutdown(JobStatus jobStatus, CheckpointsCleaner checkpointsCleaner) {
-        shutdownStatus.complete(jobStatus);
+        shutdownConsumer.accept(jobStatus, checkpointsCleaner);
     }
 
     @Override
     public List<CompletedCheckpoint> getAllCheckpoints() {
-        return Collections.emptyList();
+        return getAllCheckpointsSupplier.get();
     }
 
     @Override
     public int getNumberOfRetainedCheckpoints() {
-        throw new UnsupportedOperationException("Not implemented.");
+        return getNumberOfRetainedCheckpointsSuppler.get();
     }
 
     @Override
     public int getMaxNumberOfRetainedCheckpoints() {
-        throw new UnsupportedOperationException("Not implemented.");
+        return getMaxNumberOfRetainedCheckpointsSupplier.get();
     }
 
     @Override
     public boolean requiresExternalizedCheckpoints() {
-        throw new UnsupportedOperationException("Not implemented.");
+        return requiresExternalizedCheckpointsSupplier.get();
     }
 
     @Override
     public SharedStateRegistry getSharedStateRegistry() {
-        throw new UnsupportedOperationException("Not implemented.");
+        return getSharedStateRegistrySupplier.get();
+    }
+
+    public static Builder builder() {
+        return new TestingCompletedCheckpointStore.Builder();
+    }
+
+    /** {@code Builder} for creating {@code TestingCompletedCheckpointStore} instances. */
+    public static class Builder {
+
+        private TriFunction<CompletedCheckpoint, CheckpointsCleaner, Runnable, CompletedCheckpoint>
+                addCheckpointAndSubsumeOldestOneFunction =
+                        (ignoredCompletedCheckpoint,
+                                ignoredCheckpointsCleaner,
+                                ignoredPostCleanup) -> {
+                            throw new UnsupportedOperationException(
+                                    "addCheckpointAndSubsumeOldestOne is not implemented.");
+                        };
+        private BiConsumer<JobStatus, CheckpointsCleaner> shutdownConsumer =
+                (ignoredJobStatus, ignoredCheckpointsCleaner) -> {
+                    throw new UnsupportedOperationException("shutdown is not implemented.");
+                };
+        private Supplier<List<CompletedCheckpoint>> getAllCheckpointsSupplier =
+                () -> {
+                    throw new UnsupportedOperationException(
+                            "getAllCheckpoints is not implemented.");
+                };
+        private Supplier<Integer> getNumberOfRetainedCheckpointsSuppler =
+                () -> {
+                    throw new UnsupportedOperationException(
+                            "getNumberOfRetainedCheckpointsis not implemented.");
+                };
+        private Supplier<Integer> getMaxNumberOfRetainedCheckpointsSupplier =
+                () -> {
+                    throw new UnsupportedOperationException(
+                            "getMaxNumberOfRetainedCheckpoints is not implemented.");
+                };
+        private Supplier<Boolean> requiresExternalizedCheckpointsSupplier =
+                () -> {
+                    throw new UnsupportedOperationException(
+                            "requiresExternalizedCheckpoints is not implemented.");
+                };
+        private Supplier<SharedStateRegistry> getSharedStateRegistrySupplier =
+                () -> {
+                    throw new UnsupportedOperationException(
+                            "getSharedStateRegistry is not implemented.");
+                };
+
+        public Builder withAddCheckpointAndSubsumeOldestOneFunction(
+                TriFunction<CompletedCheckpoint, CheckpointsCleaner, Runnable, CompletedCheckpoint>
+                        addCheckpointAndSubsumeOldestOneFunction) {
+            this.addCheckpointAndSubsumeOldestOneFunction =
+                    addCheckpointAndSubsumeOldestOneFunction;
+            return this;
+        }
+
+        public Builder withShutdownConsumer(
+                BiConsumer<JobStatus, CheckpointsCleaner> shutdownConsumer) {
+            this.shutdownConsumer = shutdownConsumer;
+            return this;
+        }
+
+        public Builder withGetAllCheckpointsSupplier(
+                Supplier<List<CompletedCheckpoint>> getAllCheckpointsSupplier) {
+            this.getAllCheckpointsSupplier = getAllCheckpointsSupplier;
+            return this;
+        }
+
+        public Builder withGetNumberOfRetainedCheckpointsSupplier(
+                Supplier<Integer> getNumberOfRetainedCheckpointsSuppler) {
+            this.getNumberOfRetainedCheckpointsSuppler = getNumberOfRetainedCheckpointsSuppler;
+            return this;
+        }
+
+        public Builder withGetMaxNumberOfRetainedCheckpointsSupplier(
+                Supplier<Integer> getMaxNumberOfRetainedCheckpoints) {
+            this.getMaxNumberOfRetainedCheckpointsSupplier = getMaxNumberOfRetainedCheckpoints;
+            return this;
+        }
+
+        public Builder withRequiresExternalizedCheckpointsSupplier(
+                Supplier<Boolean> requiresExternalizedCheckpointsSupplier) {
+            this.requiresExternalizedCheckpointsSupplier = requiresExternalizedCheckpointsSupplier;
+            return this;
+        }
+
+        public Builder withGetSharedStateRegistrySupplier(
+                Supplier<SharedStateRegistry> getSharedStateRegistrySupplier) {
+            this.getSharedStateRegistrySupplier = getSharedStateRegistrySupplier;
+            return this;
+        }
+
+        public TestingCompletedCheckpointStore build() {
+            return new TestingCompletedCheckpointStore(
+                    addCheckpointAndSubsumeOldestOneFunction,
+                    shutdownConsumer,
+                    getAllCheckpointsSupplier,
+                    getNumberOfRetainedCheckpointsSuppler,
+                    getMaxNumberOfRetainedCheckpointsSupplier,
+                    requiresExternalizedCheckpointsSupplier,
+                    getSharedStateRegistrySupplier);
+        }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/AbstractDispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/AbstractDispatcherTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobServer;
 import org.apache.flink.runtime.blob.VoidBlobStore;
 import org.apache.flink.runtime.checkpoint.StandaloneCheckpointRecoveryFactory;
+import org.apache.flink.runtime.dispatcher.cleanup.CheckpointResourcesCleanupRunnerFactory;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
 import org.apache.flink.runtime.highavailability.nonha.embedded.EmbeddedJobResultStore;
@@ -112,6 +113,7 @@ public class AbstractDispatcherTest extends TestLogger {
                 .setJobGraphWriter(haServices.getJobGraphStore())
                 .setJobResultStore(haServices.getJobResultStore())
                 .setJobManagerRunnerFactory(JobMasterServiceLeadershipRunnerFactory.INSTANCE)
+                .setCleanupRunnerFactory(CheckpointResourcesCleanupRunnerFactory.INSTANCE)
                 .setFatalErrorHandler(testingFatalErrorHandlerResource.getFatalErrorHandler())
                 .setBlobServer(blobServer);
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherResourceCleanupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherResourceCleanupTest.java
@@ -149,8 +149,8 @@ public class DispatcherResourceCleanupTest extends TestLogger {
     private TestingJobManagerRunnerFactory startDispatcherAndSubmitJob(
             TestingDispatcher.Builder dispatcherBuilder, int numBlockingJobManagerRunners)
             throws Exception {
-        final TestingJobManagerRunnerFactory testingJobManagerRunnerFactoryNG =
-                new TestingJobManagerRunnerFactory(numBlockingJobManagerRunners);
+        final TestingJobMasterServiceLeadershipRunnerFactory testingJobManagerRunnerFactoryNG =
+                new TestingJobMasterServiceLeadershipRunnerFactory(numBlockingJobManagerRunners);
         startDispatcher(dispatcherBuilder, testingJobManagerRunnerFactoryNG);
         submitJobAndWait();
 
@@ -652,7 +652,7 @@ public class DispatcherResourceCleanupTest extends TestLogger {
     }
 
     private static final class BlockingJobManagerRunnerFactory
-            extends TestingJobManagerRunnerFactory {
+            extends TestingJobMasterServiceLeadershipRunnerFactory {
 
         private final ThrowingRunnable<Exception> jobManagerRunnerCreationLatch;
         private TestingJobManagerRunner testingRunner;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/MiniDispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/MiniDispatcherTest.java
@@ -22,10 +22,10 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.blob.BlobServer;
 import org.apache.flink.runtime.blob.VoidBlobStore;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
+import org.apache.flink.runtime.dispatcher.cleanup.TestingCleanupRunnerFactory;
 import org.apache.flink.runtime.entrypoint.ClusterEntrypoint;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
@@ -96,7 +96,8 @@ public class MiniDispatcherTest extends TestLogger {
 
     private TestingHighAvailabilityServices highAvailabilityServices;
 
-    private TestingJobManagerRunnerFactory testingJobManagerRunnerFactory;
+    private TestingJobMasterServiceLeadershipRunnerFactory testingJobManagerRunnerFactory;
+    private TestingCleanupRunnerFactory testingCleanupRunnerFactory;
 
     @BeforeClass
     public static void setupClass() throws IOException {
@@ -120,7 +121,8 @@ public class MiniDispatcherTest extends TestLogger {
     public void setup() throws Exception {
         highAvailabilityServices = new TestingHighAvailabilityServicesBuilder().build();
 
-        testingJobManagerRunnerFactory = new TestingJobManagerRunnerFactory();
+        testingJobManagerRunnerFactory = new TestingJobMasterServiceLeadershipRunnerFactory();
+        testingCleanupRunnerFactory = new TestingCleanupRunnerFactory();
     }
 
     @AfterClass
@@ -156,22 +158,19 @@ public class MiniDispatcherTest extends TestLogger {
     /** Tests that the {@link MiniDispatcher} recovers the single job with which it was started. */
     @Test
     public void testDirtyJobResultCleanup() throws Exception {
-        final OneShotLatch dispatcherBootstrapLatch = new OneShotLatch();
+        final JobID jobId = new JobID();
         final MiniDispatcher miniDispatcher =
                 createMiniDispatcher(
                         ClusterEntrypoint.ExecutionMode.DETACHED,
                         null,
-                        TestingJobResultStore.createSuccessfulJobResult(new JobID()),
-                        (dispatcher, scheduledExecutor, errorHandler) -> {
-                            dispatcherBootstrapLatch.trigger();
-                            return new NoOpDispatcherBootstrap();
-                        });
+                        TestingJobResultStore.createSuccessfulJobResult(jobId));
 
         miniDispatcher.start();
 
         try {
-            dispatcherBootstrapLatch.await();
-            assertThat(testingJobManagerRunnerFactory.getQueueSize(), is(0));
+            final TestingJobManagerRunner testingCleanupRunner =
+                    testingCleanupRunnerFactory.takeCreatedJobManagerRunner();
+            assertThat(testingCleanupRunner.getJobID(), is(jobId));
         } finally {
             RpcUtils.terminateRpcEndpoint(miniDispatcher, timeout);
         }
@@ -303,18 +302,13 @@ public class MiniDispatcherTest extends TestLogger {
 
     private MiniDispatcher createMiniDispatcher(ClusterEntrypoint.ExecutionMode executionMode)
             throws Exception {
-        return createMiniDispatcher(
-                executionMode,
-                jobGraph,
-                null,
-                (dispatcher, scheduledExecutor, errorHandler) -> new NoOpDispatcherBootstrap());
+        return createMiniDispatcher(executionMode, jobGraph, null);
     }
 
     private MiniDispatcher createMiniDispatcher(
             ClusterEntrypoint.ExecutionMode executionMode,
             @Nullable JobGraph recoveredJobGraph,
-            @Nullable JobResult recoveredDirtyJob,
-            DispatcherBootstrapFactory dispatcherBootstrapFactory)
+            @Nullable JobResult recoveredDirtyJob)
             throws Exception {
         return new MiniDispatcher(
                 rpcService,
@@ -334,10 +328,11 @@ public class MiniDispatcherTest extends TestLogger {
                         highAvailabilityServices.getJobGraphStore(),
                         highAvailabilityServices.getJobResultStore(),
                         testingJobManagerRunnerFactory,
+                        testingCleanupRunnerFactory,
                         ForkJoinPool.commonPool()),
                 recoveredJobGraph,
                 recoveredDirtyJob,
-                dispatcherBootstrapFactory,
+                (dispatcher, scheduledExecutor, errorHandler) -> new NoOpDispatcherBootstrap(),
                 executionMode);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/TestingDispatcher.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/TestingDispatcher.java
@@ -22,8 +22,10 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobServer;
+import org.apache.flink.runtime.dispatcher.cleanup.CleanupRunnerFactory;
 import org.apache.flink.runtime.dispatcher.cleanup.DispatcherResourceCleanerFactory;
 import org.apache.flink.runtime.dispatcher.cleanup.ResourceCleanerFactory;
+import org.apache.flink.runtime.dispatcher.cleanup.TestingCleanupRunnerFactory;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.highavailability.JobResultStore;
@@ -98,6 +100,7 @@ class TestingDispatcher extends Dispatcher {
             HistoryServerArchivist historyServerArchivist,
             ExecutionGraphInfoStore executionGraphInfoStore,
             JobManagerRunnerFactory jobManagerRunnerFactory,
+            CleanupRunnerFactory cleanupRunnerFactory,
             DispatcherBootstrapFactory dispatcherBootstrapFactory,
             DispatcherOperationCaches dispatcherOperationCaches,
             JobManagerRunnerRegistry jobManagerRunnerRegistry,
@@ -124,6 +127,7 @@ class TestingDispatcher extends Dispatcher {
                         jobGraphWriter,
                         jobResultStore,
                         jobManagerRunnerFactory,
+                        cleanupRunnerFactory,
                         ioExecutor),
                 jobManagerRunnerRegistry,
                 resourceCleanerFactory);
@@ -202,7 +206,8 @@ class TestingDispatcher extends Dispatcher {
         private ExecutionGraphInfoStore executionGraphInfoStore =
                 new MemoryExecutionGraphInfoStore();
         private JobManagerRunnerFactory jobManagerRunnerFactory =
-                new TestingJobManagerRunnerFactory(0);
+                new TestingJobMasterServiceLeadershipRunnerFactory();
+        private CleanupRunnerFactory cleanupRunnerFactory = new TestingCleanupRunnerFactory();
         private DispatcherBootstrapFactory dispatcherBootstrapFactory =
                 (dispatcher, scheduledExecutor, errorHandler) -> new NoOpDispatcherBootstrap();
         private DispatcherOperationCaches dispatcherOperationCaches =
@@ -309,6 +314,11 @@ class TestingDispatcher extends Dispatcher {
             return this;
         }
 
+        public Builder setCleanupRunnerFactory(CleanupRunnerFactory cleanupRunnerFactory) {
+            this.cleanupRunnerFactory = cleanupRunnerFactory;
+            return this;
+        }
+
         public Builder setDispatcherBootstrapFactory(
                 DispatcherBootstrapFactory dispatcherBootstrapFactory) {
             this.dispatcherBootstrapFactory = dispatcherBootstrapFactory;
@@ -364,6 +374,7 @@ class TestingDispatcher extends Dispatcher {
                     historyServerArchivist,
                     executionGraphInfoStore,
                     jobManagerRunnerFactory,
+                    cleanupRunnerFactory,
                     dispatcherBootstrapFactory,
                     dispatcherOperationCaches,
                     jobManagerRunnerRegistry,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/TestingJobManagerRunnerFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/TestingJobManagerRunnerFactory.java
@@ -18,18 +18,9 @@
 
 package org.apache.flink.runtime.dispatcher;
 
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.runtime.heartbeat.HeartbeatServices;
-import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
-import org.apache.flink.runtime.jobgraph.JobGraph;
-import org.apache.flink.runtime.jobmaster.JobManagerSharedServices;
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.jobmaster.TestingJobManagerRunner;
-import org.apache.flink.runtime.jobmaster.factories.JobManagerJobMetricGroupFactory;
-import org.apache.flink.runtime.rpc.FatalErrorHandler;
-import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.util.Preconditions;
-
-import javax.annotation.Nonnull;
 
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
@@ -39,46 +30,30 @@ import java.util.concurrent.atomic.AtomicInteger;
  * Testing implementation of {@link JobManagerRunnerFactory} which returns a {@link
  * TestingJobManagerRunner}.
  */
-public class TestingJobManagerRunnerFactory implements JobManagerRunnerFactory {
+public class TestingJobManagerRunnerFactory {
 
     private final BlockingQueue<TestingJobManagerRunner> createdJobManagerRunner =
             new ArrayBlockingQueue<>(16);
 
     private final AtomicInteger numBlockingJobManagerRunners;
 
-    public TestingJobManagerRunnerFactory() {
-        this(0);
-    }
-
-    public TestingJobManagerRunnerFactory(int numBlockingJobManagerRunners) {
+    protected TestingJobManagerRunnerFactory(int numBlockingJobManagerRunners) {
         this.numBlockingJobManagerRunners = new AtomicInteger(numBlockingJobManagerRunners);
     }
 
-    @Override
-    public TestingJobManagerRunner createJobManagerRunner(
-            JobGraph jobGraph,
-            Configuration configuration,
-            RpcService rpcService,
-            HighAvailabilityServices highAvailabilityServices,
-            HeartbeatServices heartbeatServices,
-            JobManagerSharedServices jobManagerServices,
-            JobManagerJobMetricGroupFactory jobManagerJobMetricGroupFactory,
-            FatalErrorHandler fatalErrorHandler,
-            long initializationTimestamp)
-            throws Exception {
+    protected TestingJobManagerRunner offerTestingJobManagerRunner(JobID jobId) {
         final TestingJobManagerRunner testingJobManagerRunner =
-                createTestingJobManagerRunner(jobGraph);
+                createTestingJobManagerRunner(jobId);
         Preconditions.checkState(
                 createdJobManagerRunner.offer(testingJobManagerRunner),
                 "Unable to persist created the new runner.");
         return testingJobManagerRunner;
     }
 
-    @Nonnull
-    private TestingJobManagerRunner createTestingJobManagerRunner(JobGraph jobGraph) {
+    private TestingJobManagerRunner createTestingJobManagerRunner(JobID jobId) {
         final boolean blockingTermination = numBlockingJobManagerRunners.getAndDecrement() > 0;
         return TestingJobManagerRunner.newBuilder()
-                .setJobId(jobGraph.getJobID())
+                .setJobId(jobId)
                 .setBlockingTermination(blockingTermination)
                 .build();
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/TestingJobMasterServiceLeadershipRunnerFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/TestingJobMasterServiceLeadershipRunnerFactory.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.heartbeat.HeartbeatServices;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobmaster.JobManagerSharedServices;
+import org.apache.flink.runtime.jobmaster.TestingJobManagerRunner;
+import org.apache.flink.runtime.jobmaster.factories.JobManagerJobMetricGroupFactory;
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.runtime.rpc.RpcService;
+
+/**
+ * {@code TestingJobMasterServiceLeadershipRunnerFactory} implements {@code JobManagerRunnerFactory}
+ * providing a factory method usually used for {@link
+ * org.apache.flink.runtime.jobmaster.JobMasterServiceLeadershipRunner} creations.
+ */
+public class TestingJobMasterServiceLeadershipRunnerFactory extends TestingJobManagerRunnerFactory
+        implements JobManagerRunnerFactory {
+
+    public TestingJobMasterServiceLeadershipRunnerFactory() {
+        this(0);
+    }
+
+    public TestingJobMasterServiceLeadershipRunnerFactory(int numBlockingJobManagerRunners) {
+        super(numBlockingJobManagerRunners);
+    }
+
+    @Override
+    public TestingJobManagerRunner createJobManagerRunner(
+            JobGraph jobGraph,
+            Configuration configuration,
+            RpcService rpcService,
+            HighAvailabilityServices highAvailabilityServices,
+            HeartbeatServices heartbeatServices,
+            JobManagerSharedServices jobManagerServices,
+            JobManagerJobMetricGroupFactory jobManagerJobMetricGroupFactory,
+            FatalErrorHandler fatalErrorHandler,
+            long initializationTimestamp)
+            throws Exception {
+        return offerTestingJobManagerRunner(jobGraph.getJobID());
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/cleanup/CheckpointResourcesCleanupRunnerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/cleanup/CheckpointResourcesCleanupRunnerTest.java
@@ -1,0 +1,589 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher.cleanup;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.testutils.OneShotLatch;
+import org.apache.flink.runtime.checkpoint.CheckpointIDCounter;
+import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
+import org.apache.flink.runtime.checkpoint.CheckpointsCleaner;
+import org.apache.flink.runtime.checkpoint.CompletedCheckpointStore;
+import org.apache.flink.runtime.checkpoint.TestingCheckpointIDCounter;
+import org.apache.flink.runtime.checkpoint.TestingCheckpointRecoveryFactory;
+import org.apache.flink.runtime.checkpoint.TestingCompletedCheckpointStore;
+import org.apache.flink.runtime.clusterframework.ApplicationStatus;
+import org.apache.flink.runtime.dispatcher.UnavailableDispatcherOperationException;
+import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ErrorInfo;
+import org.apache.flink.runtime.jobmaster.JobManagerRunnerResult;
+import org.apache.flink.runtime.jobmaster.JobResult;
+import org.apache.flink.runtime.scheduler.ExecutionGraphInfo;
+import org.apache.flink.runtime.state.SharedStateRegistry;
+import org.apache.flink.runtime.state.SharedStateRegistryFactory;
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.SerializedThrowable;
+import org.apache.flink.util.concurrent.Executors;
+import org.apache.flink.util.function.ThrowingConsumer;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ForkJoinPool;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * {@code CheckpointResourcesCleanupRunnerTest} tests the {@link CheckpointResourcesCleanupRunner}
+ * implementation.
+ */
+public class CheckpointResourcesCleanupRunnerTest {
+
+    private static final ThrowingConsumer<CheckpointResourcesCleanupRunner, ? extends Exception>
+            BEFORE_START = ignored -> {};
+    private static final ThrowingConsumer<CheckpointResourcesCleanupRunner, ? extends Exception>
+            AFTER_START = CheckpointResourcesCleanupRunner::start;
+    private static final ThrowingConsumer<CheckpointResourcesCleanupRunner, ? extends Exception>
+            AFTER_CLOSE =
+                    runner -> {
+                        runner.start();
+                        runner.close();
+                    };
+
+    @Test
+    public void testIsInitializedBeforeStart() throws Exception {
+        testIsInitialized(BEFORE_START);
+    }
+
+    @Test
+    public void testIsInitializedAfterStart() throws Exception {
+        testIsInitialized(AFTER_START);
+    }
+
+    @Test
+    public void testIsInitializedAfterClose() throws Exception {
+        testIsInitialized(AFTER_CLOSE);
+    }
+
+    private static void testIsInitialized(
+            ThrowingConsumer<CheckpointResourcesCleanupRunner, ? extends Exception>
+                    preCheckLifecycleHandling)
+            throws Exception {
+        final CheckpointResourcesCleanupRunner testInstance = new TestInstanceBuilder().build();
+        preCheckLifecycleHandling.accept(testInstance);
+
+        assertThat(testInstance.isInitialized()).isTrue();
+    }
+
+    @Test
+    public void testCloseAsyncBeforeStart() {
+        final CheckpointResourcesCleanupRunner testInstance = new TestInstanceBuilder().build();
+        assertThat(testInstance.closeAsync()).isNotCompleted();
+    }
+
+    @Test
+    public void testSuccessfulCloseAsyncAfterStart() throws Exception {
+        final CompletableFuture<JobStatus> completedCheckpointStoreShutdownFuture =
+                new CompletableFuture<>();
+        final CompletableFuture<JobStatus> checkpointIdCounterShutdownFuture =
+                new CompletableFuture<>();
+
+        final HaltingCheckpointRecoveryFactory checkpointRecoveryFactory =
+                new HaltingCheckpointRecoveryFactory(
+                        completedCheckpointStoreShutdownFuture, checkpointIdCounterShutdownFuture);
+        final CheckpointResourcesCleanupRunner testInstance =
+                new TestInstanceBuilder()
+                        .withCheckpointRecoveryFactory(checkpointRecoveryFactory)
+                        .withExecutor(ForkJoinPool.commonPool())
+                        .build();
+        testInstance.start();
+
+        assertThat(completedCheckpointStoreShutdownFuture)
+                .as("The CompletedCheckpointStore shouldn't have been shut down, yet.")
+                .isNotCompleted();
+        assertThat(checkpointIdCounterShutdownFuture)
+                .as("The CheckpointIDCounter shouldn't have been shut down, yet.")
+                .isNotCompleted();
+
+        assertThat(testInstance.closeAsync())
+                .as(
+                        "closeAsync shouldn't have been completed, yet, since the shutdown of the components is not completed.")
+                .isNotCompleted();
+
+        checkpointRecoveryFactory.triggerCreation();
+
+        assertThat(completedCheckpointStoreShutdownFuture)
+                .as("The CompletedCheckpointStore should have been shut down properly.")
+                .succeedsWithin(Duration.ofMillis(100))
+                .isEqualTo(JobStatus.FINISHED);
+        assertThat(checkpointIdCounterShutdownFuture)
+                .as("The CheckpointIDCounter should have been shut down properly.")
+                .succeedsWithin(Duration.ofMillis(100))
+                .isEqualTo(JobStatus.FINISHED);
+
+        assertThat(testInstance.closeAsync()).succeedsWithin(Duration.ofMillis(100));
+    }
+
+    @Test
+    public void testCloseAsyncAfterStartAndErrorInCompletedCheckpointStoreShutdown()
+            throws Exception {
+        final CompletableFuture<JobStatus> checkpointIdCounterShutdownFuture =
+                new CompletableFuture<>();
+
+        final HaltingCheckpointRecoveryFactory checkpointRecoveryFactory =
+                new HaltingCheckpointRecoveryFactory(
+                        TestingCompletedCheckpointStore.builder()
+                                .withShutdownConsumer(
+                                        (ignoredJobStatus, ignoredCheckpointsCleaner) -> {
+                                            throw new RuntimeException(
+                                                    "Expected RuntimeException simulating an error during shutdown.");
+                                        })
+                                .build(),
+                        TestingCheckpointIDCounter.createStoreWithShutdownCheckAndNoStartAction(
+                                checkpointIdCounterShutdownFuture));
+        final CheckpointResourcesCleanupRunner testInstance =
+                new TestInstanceBuilder()
+                        .withCheckpointRecoveryFactory(checkpointRecoveryFactory)
+                        .withExecutor(ForkJoinPool.commonPool())
+                        .build();
+        testInstance.start();
+
+        assertThat(checkpointIdCounterShutdownFuture)
+                .as("The CheckpointIDCounter shouldn't have been shut down, yet.")
+                .isNotCompleted();
+
+        assertThat(testInstance.closeAsync())
+                .as(
+                        "closeAsync shouldn't have been completed, yet, since the shutdown of the components is not completed.")
+                .isNotCompleted();
+
+        checkpointRecoveryFactory.triggerCreation();
+
+        assertThat(checkpointIdCounterShutdownFuture)
+                .as("The CheckpointIDCounter should have been shut down properly.")
+                .succeedsWithin(Duration.ofMillis(100))
+                .isEqualTo(JobStatus.FINISHED);
+
+        assertThat(testInstance.closeAsync())
+                .failsWithin(Duration.ofMillis(100))
+                .withThrowableOfType(ExecutionException.class)
+                .withCauseInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    public void testCloseAsyncAfterStartAndErrorInCheckpointIDCounterShutdown() throws Exception {
+        final CompletableFuture<JobStatus> completedCheckpointStoreShutdownFuture =
+                new CompletableFuture<>();
+
+        final HaltingCheckpointRecoveryFactory checkpointRecoveryFactory =
+                new HaltingCheckpointRecoveryFactory(
+                        TestingCompletedCheckpointStore
+                                .createStoreWithShutdownCheckAndNoCompletedCheckpoints(
+                                        completedCheckpointStoreShutdownFuture),
+                        TestingCheckpointIDCounter.builder()
+                                .withShutdownConsumer(
+                                        ignoredJobStatus -> {
+                                            throw new RuntimeException(
+                                                    "Expected RuntimeException simulating an error during shutdown.");
+                                        })
+                                .build());
+        final CheckpointResourcesCleanupRunner testInstance =
+                new TestInstanceBuilder()
+                        .withCheckpointRecoveryFactory(checkpointRecoveryFactory)
+                        .withExecutor(ForkJoinPool.commonPool())
+                        .build();
+        testInstance.start();
+
+        assertThat(completedCheckpointStoreShutdownFuture)
+                .as("The CompletedCheckpointStore shouldn't have been shut down, yet.")
+                .isNotCompleted();
+
+        assertThat(testInstance.closeAsync())
+                .as(
+                        "closeAsync shouldn't have been completed, yet, since the shutdown of the components is not completed.")
+                .isNotCompleted();
+
+        checkpointRecoveryFactory.triggerCreation();
+
+        assertThat(completedCheckpointStoreShutdownFuture)
+                .as("The CompletedCheckpointStore should have been shut down properly.")
+                .succeedsWithin(Duration.ofMillis(100))
+                .isEqualTo(JobStatus.FINISHED);
+
+        assertThat(testInstance.closeAsync())
+                .failsWithin(Duration.ofMillis(100))
+                .withThrowableOfType(ExecutionException.class)
+                .withCauseInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    public void testResultFutureWithSuccessBeforeStart() throws Exception {
+        testResultFutureWithSuccess(BEFORE_START);
+    }
+
+    @Test
+    public void testResultFutureWithSuccessAfterStart() throws Exception {
+        testResultFutureWithSuccess(AFTER_START);
+    }
+
+    @Test
+    public void testResultFutureWithSuccessAfterClose() throws Exception {
+        testResultFutureWithSuccess(AFTER_CLOSE);
+    }
+
+    private static void testResultFutureWithSuccess(
+            ThrowingConsumer<CheckpointResourcesCleanupRunner, ? extends Exception>
+                    preCheckLifecycleHandling)
+            throws Exception {
+        testResultFuture(createDummySuccessJobResult(), preCheckLifecycleHandling);
+    }
+
+    @Test
+    public void testResultFutureWithErrorBeforeStart() throws Exception {
+        testResultFutureWithError(BEFORE_START);
+    }
+
+    @Test
+    public void testResultFutureWithErrorAfterStart() throws Exception {
+        testResultFutureWithError(AFTER_START);
+    }
+
+    @Test
+    public void testResultFutureWithErrorAfterClose() throws Exception {
+        testResultFutureWithError(AFTER_CLOSE);
+    }
+
+    private static void testResultFutureWithError(
+            ThrowingConsumer<CheckpointResourcesCleanupRunner, ? extends Exception>
+                    preCheckLifecycleHandling)
+            throws Exception {
+        final SerializedThrowable expectedError =
+                new SerializedThrowable(new Exception("Expected exception"));
+        final CompletableFuture<JobManagerRunnerResult> actualResult =
+                testResultFuture(
+                        createJobResultWithFailure(expectedError), preCheckLifecycleHandling);
+
+        assertThat(actualResult)
+                .succeedsWithin(Duration.ZERO)
+                .extracting(JobManagerRunnerResult::getExecutionGraphInfo)
+                .extracting(ExecutionGraphInfo::getArchivedExecutionGraph)
+                .extracting(AccessExecutionGraph::getFailureInfo)
+                .extracting(ErrorInfo::getException)
+                .isEqualTo(expectedError);
+    }
+
+    private static CompletableFuture<JobManagerRunnerResult> testResultFuture(
+            JobResult jobResult,
+            ThrowingConsumer<CheckpointResourcesCleanupRunner, ? extends Exception>
+                    preCheckLifecycleHandling)
+            throws Exception {
+        final CheckpointResourcesCleanupRunner testInstance =
+                new TestInstanceBuilder().withJobResult(jobResult).build();
+        preCheckLifecycleHandling.accept(testInstance);
+
+        assertThat(testInstance.getResultFuture())
+                .succeedsWithin(Duration.ZERO)
+                .extracting(JobManagerRunnerResult::isSuccess)
+                .isEqualTo(true);
+
+        return testInstance.getResultFuture();
+    }
+
+    @Test
+    public void testGetJobID() {
+        final JobID jobId = new JobID();
+        final CheckpointResourcesCleanupRunner testInstance =
+                new TestInstanceBuilder()
+                        .withJobResult(createJobResult(jobId, ApplicationStatus.CANCELED))
+                        .build();
+        assertThat(testInstance.getJobID()).isEqualTo(jobId);
+    }
+
+    @Test
+    public void testGetJobMasterGatewayBeforeStart() throws Exception {
+        testGetJobMasterGateway(BEFORE_START);
+    }
+
+    @Test
+    public void testGetJobMasterGatewayAfterStart() throws Exception {
+        testGetJobMasterGateway(AFTER_START);
+    }
+
+    @Test
+    public void testGetJobMasterGatewayAfterClose() throws Exception {
+        testGetJobMasterGateway(AFTER_CLOSE);
+    }
+
+    private static void testGetJobMasterGateway(
+            ThrowingConsumer<CheckpointResourcesCleanupRunner, ? extends Exception>
+                    preCheckLifecycleHandling)
+            throws Exception {
+        final CheckpointResourcesCleanupRunner testInstance = new TestInstanceBuilder().build();
+        preCheckLifecycleHandling.accept(testInstance);
+
+        assertThat(testInstance.getJobMasterGateway())
+                .failsWithin(Duration.ZERO)
+                .withThrowableOfType(ExecutionException.class)
+                .withCauseInstanceOf(UnavailableDispatcherOperationException.class);
+    }
+
+    @Test
+    public void testRequestJob_ExceptionHistory() {
+        testRequestJob(
+                createDummySuccessJobResult(),
+                System.currentTimeMillis(),
+                actualExecutionGraphInfo ->
+                        assertThat(actualExecutionGraphInfo)
+                                .extracting(ExecutionGraphInfo::getExceptionHistory)
+                                .asList()
+                                .isEmpty());
+    }
+
+    @Test
+    public void testRequestJob_JobName() {
+        testRequestJobExecutionGraph(
+                createDummySuccessJobResult(),
+                System.currentTimeMillis(),
+                actualExecutionGraph ->
+                        assertThat(actualExecutionGraph)
+                                .extracting(AccessExecutionGraph::getJobName)
+                                .isEqualTo("unknown"));
+    }
+
+    @Test
+    public void testRequestJob_JobId() {
+        final JobResult jobResult = createDummySuccessJobResult();
+        testRequestJobExecutionGraph(
+                jobResult,
+                System.currentTimeMillis(),
+                actualExecutionGraph ->
+                        assertThat(actualExecutionGraph)
+                                .extracting(AccessExecutionGraph::getJobID)
+                                .isEqualTo(jobResult.getJobId()));
+    }
+
+    @Test
+    public void testRequestJob_JobState() {
+        final JobResult jobResult = createDummySuccessJobResult();
+        testRequestJobExecutionGraph(
+                jobResult,
+                System.currentTimeMillis(),
+                actualExecutionGraph ->
+                        assertThat(actualExecutionGraph)
+                                .extracting(AccessExecutionGraph::getState)
+                                .isEqualTo(jobResult.getApplicationStatus().deriveJobStatus()));
+    }
+
+    @Test
+    public void testRequestJob_InitiatizationTimestamp() {
+        final long initializationTimestamp = System.currentTimeMillis();
+        testRequestJobExecutionGraph(
+                createDummySuccessJobResult(),
+                initializationTimestamp,
+                actualExecutionGraph ->
+                        assertThat(actualExecutionGraph.getStatusTimestamp(JobStatus.INITIALIZING))
+                                .isEqualTo(initializationTimestamp));
+    }
+
+    @Test
+    public void testRequestJobWithFailure() {
+        final SerializedThrowable expectedError =
+                new SerializedThrowable(new Exception("Expected exception"));
+        final JobResult jobResult = createJobResultWithFailure(expectedError);
+        testRequestJobExecutionGraph(
+                jobResult,
+                System.currentTimeMillis(),
+                actualExecutionGraph ->
+                        assertThat(actualExecutionGraph)
+                                .extracting(AccessExecutionGraph::getFailureInfo)
+                                .extracting(ErrorInfo::getException)
+                                .isEqualTo(expectedError));
+    }
+
+    private static void testRequestJobExecutionGraph(
+            JobResult jobResult,
+            long initializationTimestamp,
+            ThrowingConsumer<AccessExecutionGraph, ? extends Exception> assertion) {
+        testRequestJob(
+                jobResult,
+                initializationTimestamp,
+                actualExecutionGraphInfo ->
+                        assertThat(actualExecutionGraphInfo)
+                                .extracting(ExecutionGraphInfo::getArchivedExecutionGraph)
+                                .satisfies(assertion::accept));
+    }
+
+    private static void testRequestJob(
+            JobResult jobResult,
+            long initializationTimestamp,
+            ThrowingConsumer<ExecutionGraphInfo, ? extends Exception> assertion) {
+        final CheckpointResourcesCleanupRunner testInstance =
+                new TestInstanceBuilder()
+                        .withJobResult(jobResult)
+                        .withInitializationTimestamp(initializationTimestamp)
+                        .build();
+
+        final CompletableFuture<ExecutionGraphInfo> response =
+                testInstance.requestJob(Time.milliseconds(0));
+        assertThat(response).succeedsWithin(Duration.ZERO).satisfies(assertion::accept);
+    }
+
+    private static JobResult createDummySuccessJobResult() {
+        return createJobResult(new JobID(), ApplicationStatus.SUCCEEDED);
+    }
+
+    private static JobResult createJobResultWithFailure(SerializedThrowable throwable) {
+        return new JobResult.Builder()
+                .jobId(new JobID())
+                .applicationStatus(ApplicationStatus.FAILED)
+                .serializedThrowable(throwable)
+                .netRuntime(1)
+                .build();
+    }
+
+    private static JobResult createJobResult(JobID jobId, ApplicationStatus applicationStatus) {
+        return new JobResult.Builder()
+                .jobId(jobId)
+                .applicationStatus(applicationStatus)
+                .netRuntime(1)
+                .build();
+    }
+
+    private static CheckpointRecoveryFactory createCheckpointRecoveryFactory() {
+        return new TestingCheckpointRecoveryFactory(
+                TestingCompletedCheckpointStore
+                        .createStoreWithShutdownCheckAndNoCompletedCheckpoints(
+                                new CompletableFuture<>()),
+                TestingCheckpointIDCounter.createStoreWithShutdownCheckAndNoStartAction(
+                        new CompletableFuture<>()));
+    }
+
+    private static class TestInstanceBuilder {
+
+        private JobResult jobResult = createDummySuccessJobResult();
+        private CheckpointRecoveryFactory checkpointRecoveryFactory =
+                createCheckpointRecoveryFactory();
+        private CheckpointsCleaner checkpointsCleaner = new CheckpointsCleaner();
+        private SharedStateRegistryFactory sharedStateRegistryFactory =
+                SharedStateRegistry.DEFAULT_FACTORY;
+        private Executor executor = Executors.directExecutor();
+        private Configuration configuration = new Configuration();
+        private long initializationTimestamp = System.currentTimeMillis();
+
+        public TestInstanceBuilder withJobResult(JobResult jobResult) {
+            this.jobResult = jobResult;
+            return this;
+        }
+
+        public TestInstanceBuilder withCheckpointRecoveryFactory(
+                CheckpointRecoveryFactory checkpointRecoveryFactory) {
+            this.checkpointRecoveryFactory = checkpointRecoveryFactory;
+            return this;
+        }
+
+        public TestInstanceBuilder withCheckpointsCleaner(CheckpointsCleaner checkpointsCleaner) {
+            this.checkpointsCleaner = checkpointsCleaner;
+            return this;
+        }
+
+        public TestInstanceBuilder withSharedStateRegistryFactory(
+                SharedStateRegistryFactory sharedStateRegistryFactory) {
+            this.sharedStateRegistryFactory = sharedStateRegistryFactory;
+            return this;
+        }
+
+        public TestInstanceBuilder withExecutor(Executor executor) {
+            this.executor = executor;
+            return this;
+        }
+
+        public TestInstanceBuilder withConfiguration(Configuration configuration) {
+            this.configuration = configuration;
+            return this;
+        }
+
+        public TestInstanceBuilder withInitializationTimestamp(long initializationTimestamp) {
+            this.initializationTimestamp = initializationTimestamp;
+            return this;
+        }
+
+        public CheckpointResourcesCleanupRunner build() {
+            return new CheckpointResourcesCleanupRunner(
+                    jobResult,
+                    checkpointRecoveryFactory,
+                    checkpointsCleaner,
+                    sharedStateRegistryFactory,
+                    configuration,
+                    executor,
+                    initializationTimestamp);
+        }
+    }
+
+    private static class HaltingCheckpointRecoveryFactory implements CheckpointRecoveryFactory {
+
+        private final CompletedCheckpointStore completedCheckpointStore;
+        private final CheckpointIDCounter checkpointIDCounter;
+
+        private final OneShotLatch creationLatch = new OneShotLatch();
+
+        public HaltingCheckpointRecoveryFactory(
+                CompletableFuture<JobStatus> completableCheckpointStoreShutDownFuture,
+                CompletableFuture<JobStatus> checkpointIDCounterShutDownFuture) {
+            this(
+                    TestingCompletedCheckpointStore
+                            .createStoreWithShutdownCheckAndNoCompletedCheckpoints(
+                                    completableCheckpointStoreShutDownFuture),
+                    TestingCheckpointIDCounter.createStoreWithShutdownCheckAndNoStartAction(
+                            checkpointIDCounterShutDownFuture));
+        }
+
+        public HaltingCheckpointRecoveryFactory(
+                CompletedCheckpointStore completedCheckpointStore,
+                CheckpointIDCounter checkpointIDCounter) {
+            this.completedCheckpointStore = Preconditions.checkNotNull(completedCheckpointStore);
+            this.checkpointIDCounter = Preconditions.checkNotNull(checkpointIDCounter);
+        }
+
+        @Override
+        public CompletedCheckpointStore createRecoveredCompletedCheckpointStore(
+                JobID jobId,
+                int maxNumberOfCheckpointsToRetain,
+                SharedStateRegistryFactory sharedStateRegistryFactory,
+                Executor ioExecutor)
+                throws Exception {
+            creationLatch.await();
+            return completedCheckpointStore;
+        }
+
+        @Override
+        public CheckpointIDCounter createCheckpointIDCounter(JobID jobId) throws Exception {
+            creationLatch.await();
+            return checkpointIDCounter;
+        }
+
+        public void triggerCreation() {
+            creationLatch.trigger();
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/cleanup/TestingCleanupRunnerFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/cleanup/TestingCleanupRunnerFactory.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher.cleanup;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
+import org.apache.flink.runtime.dispatcher.TestingJobManagerRunnerFactory;
+import org.apache.flink.runtime.jobmaster.JobResult;
+import org.apache.flink.runtime.jobmaster.TestingJobManagerRunner;
+
+import java.util.concurrent.Executor;
+
+/**
+ * {@code TestingCleanupRunnerFactory} implements {@link CleanupRunnerFactory} providing a factory
+ * method usually used for {@link CheckpointResourcesCleanupRunner} creations.
+ */
+public class TestingCleanupRunnerFactory extends TestingJobManagerRunnerFactory
+        implements CleanupRunnerFactory {
+
+    public TestingCleanupRunnerFactory() {
+        super(0);
+    }
+
+    @Override
+    public TestingJobManagerRunner create(
+            JobResult jobResult,
+            CheckpointRecoveryFactory checkpointRecoveryFactory,
+            Configuration configuration,
+            Executor cleanupExecutor) {
+        try {
+            return offerTestingJobManagerRunner(jobResult.getJobId());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerTest.java
@@ -807,12 +807,15 @@ public class AdaptiveSchedulerTest extends TestLogger {
         final CompletableFuture<JobStatus> completedCheckpointStoreShutdownFuture =
                 new CompletableFuture<>();
         final CompletedCheckpointStore completedCheckpointStore =
-                new TestingCompletedCheckpointStore(completedCheckpointStoreShutdownFuture);
+                TestingCompletedCheckpointStore
+                        .createStoreWithShutdownCheckAndNoCompletedCheckpoints(
+                                completedCheckpointStoreShutdownFuture);
 
         final CompletableFuture<JobStatus> checkpointIdCounterShutdownFuture =
                 new CompletableFuture<>();
         final CheckpointIDCounter checkpointIdCounter =
-                new TestingCheckpointIDCounter(checkpointIdCounterShutdownFuture);
+                TestingCheckpointIDCounter.createStoreWithShutdownCheckAndNoStartAction(
+                        checkpointIdCounterShutdownFuture);
 
         final JobGraph jobGraph = createJobGraph();
         // checkpointing components are only created if checkpointing is enabled


### PR DESCRIPTION
This PR is related to [FLIP-194](https://cwiki.apache.org/confluence/display/FLINK/FLIP-194%3A+Introduce+the+JobResultStore) and based on PR #18626 . It's labeled as a draft as long as PR #18626 isn't merged into `master` because the diff contains the PR #18626 changes as well.

## What is the purpose of the change

This change introduces a `JobManagerRunner` implementation taking care of the cleanup of a otherwise finished job.

## Brief change log

* makes certain `Testing*` implementations more general to make testing of the new functionality easier
* Moves extraction of `state.checkpoints.num-retained` from `SchedulerUtils` into `DefaultCompletedCheckpointStoreUtils` (which is renamed into `CompletedCheckpointStoreUtils`) to align with the new use case for this functionality
* Makes `ApplicationStatus` <-> `JobStatus` mapping (partially) symmetric
* Introduces `CheckpointResourcesCleanupRunner` as a new `JobManagerRunner` implementation (+ correspondng factory class to support testing) and integrates it into the `Dispatcher`
* Reorganizes Dispatcher tests moving certain tests out of `DispatcherTest` into `DispatcherResourceCleanupTest`

## Verifying this change

This change added tests and can be verified as follows:

* ApplicationMode is tests in `ApplicationDispatcheerBootstrapITCase`
* General Dispatcher is tested in `DispatcherFailoverITCase`
* `DispatcherTest.testJobCleanupWithoutRecoveredJobGraph` testing that the job is cleaned up through a `CheckpointResourcesCleanupRunner` rather than initializing a new `JobMaster`
* `CheckpointResourcesCleanupRunnerTest` was added to cover new class `CheckpointResourcesCleanupRunner`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs / JavaDocs
    * JavaDoc is provided
    * A `JobResultStore` section is added under `Deployment / High Availability`
    * `JobResultStore` is added to the glossary