### PR TITLE
[FLINK-25956][kryo] Remove noisy warnings

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializer.java
@@ -496,9 +496,11 @@ public class KryoSerializer<T> extends TypeSerializer<T> {
                 | IllegalAccessException
                 | InvocationTargetException e) {
 
-            LOG.warn(
-                    "Falling back to default Kryo serializer because Chill serializer couldn't be found.",
-                    e);
+            if (LOG.isDebugEnabled()) {
+                LOG.info("Kryo serializer scala extensions are not available.", e);
+            } else {
+                LOG.info("Kryo serializer scala extensions are not available.");
+            }
 
             Kryo.DefaultInstantiatorStrategy initStrategy = new Kryo.DefaultInstantiatorStrategy();
             initStrategy.setFallbackInstantiatorStrategy(new StdInstantiatorStrategy());


### PR DESCRIPTION
When scala is not on the classpath and Kryo is used the KryoSerializer logs a full ClassNotFoundException as a warning.

Since this is now an expected situation it should logged on info. The exception should only be logged if debug logging is enabled.
