### PR TITLE
[FLINK-25952] Savepoints on S3 are not relocatable even if entropy injection is not enabled

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/fs/EntropyInjectingFileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/EntropyInjectingFileSystem.java
@@ -20,6 +20,8 @@ package org.apache.flink.core.fs;
 
 import org.apache.flink.annotation.PublicEvolving;
 
+import javax.annotation.Nullable;
+
 /**
  * An interface to be implemented by a {@link FileSystem} that is aware of entropy injection.
  *
@@ -39,7 +41,10 @@ public interface EntropyInjectingFileSystem {
     /**
      * Gets the marker string that represents the substring of a path to be replaced by the entropy
      * characters.
+     *
+     * <p>You can disable entropy injection if you return null here.
      */
+    @Nullable
     String getEntropyInjectionKey();
 
     /** Creates a string with random entropy to be injected into a path. */

--- a/flink-core/src/main/java/org/apache/flink/core/fs/EntropyInjector.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/EntropyInjector.java
@@ -104,7 +104,8 @@ public class EntropyInjector {
     // ------------------------------------------------------------------------
 
     public static boolean isEntropyInjecting(FileSystem fs) {
-        return getEntropyFs(fs) != null;
+        final EntropyInjectingFileSystem entropyFs = getEntropyFs(fs);
+        return entropyFs != null && entropyFs.getEntropyInjectionKey() != null;
     }
 
     @Nullable

--- a/flink-core/src/test/java/org/apache/flink/core/fs/EntropyInjectorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/fs/EntropyInjectorTest.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.net.URI;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -219,6 +220,13 @@ public class EntropyInjectorTest {
         final FileSystem efs = new TestEntropyInjectingFs("test", "ignored");
 
         assertTrue(EntropyInjector.isEntropyInjecting(efs));
+    }
+
+    @Test
+    public void testIsEntropyFsWithNullEntropyKey() {
+        final FileSystem efs = new TestEntropyInjectingFs(null, "ignored");
+
+        assertFalse(EntropyInjector.isEntropyInjecting(efs));
     }
 
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStreamFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStreamFactoryTest.java
@@ -19,36 +19,26 @@
 package org.apache.flink.runtime.state.filesystem;
 
 import org.apache.flink.core.fs.FileSystem;
-import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.state.CheckpointedStateScope;
 import org.apache.flink.runtime.state.StreamStateHandle;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /** Unit tests for the {@link FsCheckpointStreamFactory}. */
 public class FsCheckpointStreamFactoryTest {
 
-    @Rule public final TemporaryFolder TMP = new TemporaryFolder();
-
-    private Path exclusiveStateDir;
-    private Path sharedStateDir;
-
-    @Before
-    public void createStateDirectories() throws IOException {
-        exclusiveStateDir = Path.fromLocalFile(TMP.newFolder("exclusive"));
-        sharedStateDir = Path.fromLocalFile(TMP.newFolder("shared"));
-    }
+    @TempDir private Path exclusiveStateDir;
+    @TempDir private Path sharedStateDir;
 
     // ------------------------------------------------------------------------
     //  tests
@@ -141,10 +131,11 @@ public class FsCheckpointStreamFactoryTest {
     //  test utils
     // ------------------------------------------------------------------------
 
-    private static void assertPathsEqual(Path expected, Path actual) {
-        final Path reNormalizedExpected = new Path(expected.toString());
-        final Path reNormalizedActual = new Path(actual.toString());
-        assertEquals(reNormalizedExpected, reNormalizedActual);
+    private static void assertPathsEqual(Path expected, org.apache.flink.core.fs.Path actual) {
+        final org.apache.flink.core.fs.Path reNormalizedExpected =
+                new org.apache.flink.core.fs.Path(
+                        new org.apache.flink.core.fs.Path(expected.toUri()).toString());
+        assertEquals(reNormalizedExpected, actual);
     }
 
     private FsCheckpointStreamFactory createFactory(FileSystem fs, int fileSizeThreshold) {
@@ -154,6 +145,10 @@ public class FsCheckpointStreamFactoryTest {
     private FsCheckpointStreamFactory createFactory(
             FileSystem fs, int fileSizeThreshold, int bufferSize) {
         return new FsCheckpointStreamFactory(
-                fs, exclusiveStateDir, sharedStateDir, fileSizeThreshold, bufferSize);
+                fs,
+                new org.apache.flink.core.fs.Path(exclusiveStateDir.toUri()),
+                new org.apache.flink.core.fs.Path(sharedStateDir.toUri()),
+                fileSizeThreshold,
+                bufferSize);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStreamFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStreamFactoryTest.java
@@ -18,7 +18,9 @@
 
 package org.apache.flink.runtime.state.filesystem;
 
+import org.apache.flink.core.fs.EntropyInjectingFileSystem;
 import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.local.LocalFileSystem;
 import org.apache.flink.runtime.state.CheckpointedStateScope;
 import org.apache.flink.runtime.state.StreamStateHandle;
 
@@ -107,6 +109,20 @@ public class FsCheckpointStreamFactoryTest {
     }
 
     @Test
+    public void testFSWithDisabledEntropyHasRelativePaths() throws IOException {
+        final FsCheckpointStreamFactory factory = createFactory(new DisabledEntropyFS(), 0);
+
+        final FsCheckpointStreamFactory.FsCheckpointStateOutputStream stream =
+                factory.createCheckpointStateOutputStream(CheckpointedStateScope.EXCLUSIVE);
+        stream.write(0);
+        final StreamStateHandle handle = stream.closeAndGetHandle();
+
+        assertThat(handle, instanceOf(RelativeFileStateHandle.class));
+        assertPathsEqual(
+                exclusiveStateDir, ((RelativeFileStateHandle) handle).getFilePath().getParent());
+    }
+
+    @Test
     public void testFlushUnderThreshold() throws IOException {
         flushAndVerify(10, 10, true);
     }
@@ -150,5 +166,18 @@ public class FsCheckpointStreamFactoryTest {
                 new org.apache.flink.core.fs.Path(sharedStateDir.toUri()),
                 fileSizeThreshold,
                 bufferSize);
+    }
+
+    private static final class DisabledEntropyFS extends LocalFileSystem
+            implements EntropyInjectingFileSystem {
+        @Override
+        public String getEntropyInjectionKey() {
+            return null;
+        }
+
+        @Override
+        public String generateEntropy() {
+            return null;
+        }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

We treat all filesystems that extend from EntropyInjectingFileSystem as
if they always inject entropy. However, we support returning null from
EntropyInjectingFileSystem#getEntropyInjectionKey which translates to
disabled entropy injections. In such cases we should support savepoints
relocation by creating relative paths for exclusive files.

## Verifying this change

Added tests in:
* `FsCheckpointStreamFactoryTest`
* `EntropyInjectorTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (**yes** / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
