### PR TITLE
[FLINK-24446][table] Fix STRING to TIMESTAMP casting

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/DateTimeUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/DateTimeUtils.java
@@ -403,6 +403,7 @@ public class DateTimeUtils {
 
     public static TimestampData parseTimestampData(String dateStr) throws DateTimeException {
         // Precision is hardcoded to match signature of TO_TIMESTAMP
+        //  https://issues.apache.org/jira/browse/FLINK-14925
         return parseTimestampData(dateStr, 3);
     }
 
@@ -412,7 +413,7 @@ public class DateTimeUtils {
                 fromTemporalAccessor(DEFAULT_TIMESTAMP_FORMATTER.parse(dateStr), precision));
     }
 
-    public static TimestampData parseTimestampData(String dateStr, TimeZone timeZone, int precision)
+    public static TimestampData parseTimestampData(String dateStr, int precision, TimeZone timeZone)
             throws DateTimeException {
         return TimestampData.fromInstant(
                 fromTemporalAccessor(DEFAULT_TIMESTAMP_FORMATTER.parse(dateStr), precision)
@@ -426,6 +427,7 @@ public class DateTimeUtils {
         try {
             TemporalAccessor accessor = formatter.parse(dateStr);
             // Precision is hardcoded to match signature of TO_TIMESTAMP
+            //  https://issues.apache.org/jira/browse/FLINK-14925
             LocalDateTime ldt = fromTemporalAccessor(accessor, 3);
             return TimestampData.fromLocalDateTime(ldt);
         } catch (DateTimeParseException e) {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/DateTimeUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/DateTimeUtils.java
@@ -34,6 +34,7 @@ import java.math.RoundingMode;
 import java.sql.Timestamp;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.DateTimeException;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -41,6 +42,7 @@ import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.util.Collections;
@@ -131,6 +133,15 @@ public class DateTimeUtils {
     /** The valid maximum epoch seconds ('9999-12-31 23:59:59 UTC+0'). */
     private static final long MAX_EPOCH_SECONDS = 253402300799L;
 
+    private static final DateTimeFormatter DEFAULT_TIMESTAMP_FORMATTER =
+            new DateTimeFormatterBuilder()
+                    .appendPattern("yyyy-[MM][M]-dd")
+                    .optionalStart()
+                    .appendPattern(" HH:mm:ss")
+                    .appendFraction(NANO_OF_SECOND, 0, 9, true)
+                    .optionalEnd()
+                    .toFormatter();
+
     private static final String[] DEFAULT_DATETIME_FORMATS =
             new String[] {
                 "yyyy-MM-dd HH:mm:ss",
@@ -150,30 +161,15 @@ public class DateTimeUtils {
      * (string_format) => formatter
      */
     private static final ThreadLocalCache<String, SimpleDateFormat> FORMATTER_CACHE =
-            new ThreadLocalCache<String, SimpleDateFormat>() {
-                @Override
-                public SimpleDateFormat getNewInstance(String key) {
-                    return new SimpleDateFormat(key);
-                }
-            };
+            ThreadLocalCache.of(SimpleDateFormat::new);
 
     /** A ThreadLocal cache map for DateTimeFormatter. (string_format) => formatter */
     private static final ThreadLocalCache<String, DateTimeFormatter> DATETIME_FORMATTER_CACHE =
-            new ThreadLocalCache<String, DateTimeFormatter>() {
-                @Override
-                public DateTimeFormatter getNewInstance(String key) {
-                    return DateTimeFormatter.ofPattern(key);
-                }
-            };
+            ThreadLocalCache.of(DateTimeFormatter::ofPattern);
 
     /** A ThreadLocal cache map for TimeZone. (string_zone_id) => TimeZone */
     private static final ThreadLocalCache<String, TimeZone> TIMEZONE_CACHE =
-            new ThreadLocalCache<String, TimeZone>() {
-                @Override
-                public TimeZone getNewInstance(String tz) {
-                    return TimeZone.getTimeZone(tz);
-                }
-            };
+            ThreadLocalCache.of(TimeZone::getTimeZone);
 
     // --------------------------------------------------------------------------------------------
     // java.sql Date/Time/Timestamp --> internal data types
@@ -419,18 +415,17 @@ public class DateTimeUtils {
     // Parsing functions
     // --------------------------------------------------------------------------------------------
 
-    public static TimestampData parseTimestampData(String dateStr) {
-        int length = dateStr.length();
-        String format;
-        if (length == 10) {
-            format = DATE_FORMAT_STRING;
-        } else if (length >= 21 && length <= 29) {
-            format = DEFAULT_DATETIME_FORMATS[length - 20];
-        } else {
-            // otherwise fall back to second's precision
-            format = DEFAULT_DATETIME_FORMATS[0];
-        }
-        return parseTimestampData(dateStr, format);
+    public static TimestampData parseTimestampData(String dateStr, TimeZone timeZone)
+            throws DateTimeException {
+        return TimestampData.fromInstant(
+                fromTemporalAccessor(DEFAULT_TIMESTAMP_FORMATTER.parse(dateStr))
+                        .atZone(timeZone.toZoneId())
+                        .toInstant());
+    }
+
+    public static TimestampData parseTimestampData(String dateStr) throws DateTimeException {
+        return TimestampData.fromLocalDateTime(
+                fromTemporalAccessor(DEFAULT_TIMESTAMP_FORMATTER.parse(dateStr)));
     }
 
     public static TimestampData parseTimestampData(String dateStr, String format) {
@@ -438,24 +433,7 @@ public class DateTimeUtils {
 
         try {
             TemporalAccessor accessor = formatter.parse(dateStr);
-            // complement year with 1970
-            int year = accessor.isSupported(YEAR) ? accessor.get(YEAR) : 1970;
-            // complement month with 1
-            int month = accessor.isSupported(MONTH_OF_YEAR) ? accessor.get(MONTH_OF_YEAR) : 1;
-            // complement day with 1
-            int day = accessor.isSupported(DAY_OF_MONTH) ? accessor.get(DAY_OF_MONTH) : 1;
-            // complement hour with 0
-            int hour = accessor.isSupported(HOUR_OF_DAY) ? accessor.get(HOUR_OF_DAY) : 0;
-            // complement minute with 0
-            int minute = accessor.isSupported(MINUTE_OF_HOUR) ? accessor.get(MINUTE_OF_HOUR) : 0;
-            // complement second with 0
-            int second =
-                    accessor.isSupported(SECOND_OF_MINUTE) ? accessor.get(SECOND_OF_MINUTE) : 0;
-            // complement nano_of_second with 0
-            int nanoOfSecond =
-                    accessor.isSupported(NANO_OF_SECOND) ? accessor.get(NANO_OF_SECOND) : 0;
-            LocalDateTime ldt =
-                    LocalDateTime.of(year, month, day, hour, minute, second, nanoOfSecond);
+            LocalDateTime ldt = fromTemporalAccessor(accessor);
             return TimestampData.fromLocalDateTime(ldt);
         } catch (DateTimeParseException e) {
             // fall back to support cases like '1999-9-10 05:20:10' or '1999-9-10'
@@ -477,28 +455,26 @@ public class DateTimeUtils {
     }
 
     /**
-     * Parse date time string to timestamp based on the given time zone and "yyyy-MM-dd HH:mm:ss"
-     * format. Returns null if parsing failed.
-     *
-     * @param dateStr the date time string
-     * @param tz the time zone
+     * This is similar to {@link LocalDateTime#from(TemporalAccessor)}, but it's less strict and
+     * introduces default values.
      */
-    public static long parseTimestampMillis(String dateStr, TimeZone tz) throws ParseException {
-        int length = dateStr.length();
-        String format;
-        if (length == 10) {
-            format = DATE_FORMAT_STRING;
-        } else if (length == 21) {
-            format = DEFAULT_DATETIME_FORMATS[1];
-        } else if (length == 22) {
-            format = DEFAULT_DATETIME_FORMATS[2];
-        } else if (length == 23) {
-            format = DEFAULT_DATETIME_FORMATS[3];
-        } else {
-            // otherwise fall back to the default
-            format = DEFAULT_DATETIME_FORMATS[0];
-        }
-        return parseTimestampMillis(dateStr, format, tz);
+    private static LocalDateTime fromTemporalAccessor(TemporalAccessor accessor) {
+        // complement year with 1970
+        int year = accessor.isSupported(YEAR) ? accessor.get(YEAR) : 1970;
+        // complement month with 1
+        int month = accessor.isSupported(MONTH_OF_YEAR) ? accessor.get(MONTH_OF_YEAR) : 1;
+        // complement day with 1
+        int day = accessor.isSupported(DAY_OF_MONTH) ? accessor.get(DAY_OF_MONTH) : 1;
+        // complement hour with 0
+        int hour = accessor.isSupported(HOUR_OF_DAY) ? accessor.get(HOUR_OF_DAY) : 0;
+        // complement minute with 0
+        int minute = accessor.isSupported(MINUTE_OF_HOUR) ? accessor.get(MINUTE_OF_HOUR) : 0;
+        // complement second with 0
+        int second = accessor.isSupported(SECOND_OF_MINUTE) ? accessor.get(SECOND_OF_MINUTE) : 0;
+        // complement nano_of_second with 0
+        int nanoOfSecond = accessor.isSupported(NANO_OF_SECOND) ? accessor.get(NANO_OF_SECOND) : 0;
+
+        return LocalDateTime.of(year, month, day, hour, minute, second, nanoOfSecond);
     }
 
     /**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/DateTimeUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/DateTimeUtils.java
@@ -135,9 +135,9 @@ public class DateTimeUtils {
 
     private static final DateTimeFormatter DEFAULT_TIMESTAMP_FORMATTER =
             new DateTimeFormatterBuilder()
-                    .appendPattern("yyyy-[MM][M]-dd")
+                    .appendPattern("yyyy-[MM][M]-[dd][d]")
                     .optionalStart()
-                    .appendPattern(" HH:mm:ss")
+                    .appendPattern(" [HH][H]:[mm][m]:[ss][s]")
                     .appendFraction(NANO_OF_SECOND, 0, 9, true)
                     .optionalEnd()
                     .toFormatter();

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/ThreadLocalCache.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/ThreadLocalCache.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.Internal;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.function.Function;
 
 /**
  * Provides a thread local cache with a maximum cache size per thread.
@@ -74,5 +75,14 @@ public abstract class ThreadLocalCache<K, V> {
         protected boolean removeEldestEntry(Map.Entry<K, V> eldest) {
             return this.size() > maxSize;
         }
+    }
+
+    public static <K, V> ThreadLocalCache<K, V> of(Function<K, V> creator) {
+        return new ThreadLocalCache<K, V>() {
+            @Override
+            public V getNewInstance(K key) {
+                return creator.apply(key);
+            }
+        };
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/StringToTimestampCastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/StringToTimestampCastRule.java
@@ -67,8 +67,8 @@ class StringToTimestampCastRule
         return staticCall(
                 STRING_DATA_TO_TIMESTAMP_WITH_ZONE(),
                 inputTerm,
-                context.getSessionTimeZoneTerm(),
-                targetPrecision);
+                targetPrecision,
+                context.getSessionTimeZoneTerm());
     }
 
     @Override

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/StringToTimestampCastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/StringToTimestampCastRule.java
@@ -23,8 +23,6 @@ import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.LogicalTypeFamily;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
-import org.apache.flink.table.types.logical.TimestampKind;
-import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.utils.LogicalTypeChecks;
 
 import static org.apache.flink.table.planner.codegen.calls.BuiltInMethods.STRING_DATA_TO_TIMESTAMP;
@@ -52,13 +50,6 @@ class StringToTimestampCastRule
             LogicalType inputLogicalType,
             LogicalType targetLogicalType) {
         int targetPrecision = LogicalTypeChecks.getPrecision(targetLogicalType);
-        if (targetLogicalType.is(LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE)) {
-            final TimestampKind targetTimestampKind = ((TimestampType) targetLogicalType).getKind();
-            if (targetTimestampKind == TimestampKind.ROWTIME
-                    || targetTimestampKind == TimestampKind.PROCTIME) {
-                targetPrecision = 3;
-            }
-        }
 
         if (targetLogicalType.is(LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE)) {
             return staticCall(STRING_DATA_TO_TIMESTAMP(), inputTerm, targetPrecision);

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
@@ -542,10 +542,14 @@ object BuiltInMethods {
     classOf[BinaryStringDataUtil], "toTime", classOf[BinaryStringData])
 
   val STRING_DATA_TO_TIMESTAMP = Types.lookupMethod(
-    classOf[BinaryStringDataUtil], "toTimestamp", classOf[BinaryStringData])
+    classOf[BinaryStringDataUtil], "toTimestamp", classOf[BinaryStringData], classOf[Int])
 
   val STRING_DATA_TO_TIMESTAMP_WITH_ZONE = Types.lookupMethod(
-    classOf[BinaryStringDataUtil], "toTimestamp", classOf[BinaryStringData], classOf[TimeZone])
+    classOf[BinaryStringDataUtil],
+    "toTimestamp",
+    classOf[BinaryStringData],
+    classOf[TimeZone],
+    classOf[Int])
 
   val STRING_LIKE = Types.lookupMethod(
     classOf[SqlLikeUtils], "like", classOf[String], classOf[String])

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
@@ -548,8 +548,8 @@ object BuiltInMethods {
     classOf[BinaryStringDataUtil],
     "toTimestamp",
     classOf[BinaryStringData],
-    classOf[TimeZone],
-    classOf[Int])
+    classOf[Int],
+    classOf[TimeZone])
 
   val STRING_LIKE = Types.lookupMethod(
     classOf[SqlLikeUtils], "like", classOf[String], classOf[String])

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/MethodCallGen.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/MethodCallGen.scala
@@ -26,18 +26,21 @@ import org.apache.flink.table.types.logical.LogicalType
 import java.lang.reflect.Method
 import java.util.TimeZone
 
-class MethodCallGen(method: Method, argsNullable: Boolean = false) extends CallGenerator {
+class MethodCallGen(method: Method, argsNullable: Boolean = false, wrapTryCatch: Boolean = false)
+  extends CallGenerator {
 
   override def generate(
       ctx: CodeGeneratorContext,
       operands: Seq[GeneratedExpression],
       returnType: LogicalType): GeneratedExpression = {
     if (argsNullable) {
-      generateCallIfArgsNullable(ctx, returnType, operands, !method.getReturnType.isPrimitive) {
+      generateCallIfArgsNullable(
+        ctx, returnType, operands, !method.getReturnType.isPrimitive, wrapTryCatch) {
         originalTerms => convertResult(ctx, originalTerms)
       }
     } else {
-      generateCallIfArgsNotNull(ctx, returnType, operands, !method.getReturnType.isPrimitive) {
+      generateCallIfArgsNotNull(
+        ctx, returnType, operands, !method.getReturnType.isPrimitive, wrapTryCatch) {
         originalTerms => convertResult(ctx, originalTerms)
       }
     }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/StringCallGen.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/StringCallGen.scala
@@ -54,6 +54,10 @@ object StringCallGen {
       new MethodCallGen(method).generate(ctx, operands, returnType)
     }
 
+    def fallibleMethodGen(method: Method): GeneratedExpression = {
+      new MethodCallGen(method, wrapTryCatch = true).generate(ctx, operands, returnType)
+    }
+
     val generator = operator match {
 
       case LIKE =>
@@ -186,12 +190,12 @@ object StringCallGen {
         methodGen(BuiltInMethods.STRING_TO_DATE_WITH_FORMAT)
 
       case TO_TIMESTAMP if operands.size == 1 && isCharacterString(operands.head.resultType) =>
-        methodGen(BuiltInMethods.STRING_TO_TIMESTAMP)
+        fallibleMethodGen(BuiltInMethods.STRING_TO_TIMESTAMP)
 
       case TO_TIMESTAMP if operands.size == 2 &&
           isCharacterString(operands.head.resultType) &&
           isCharacterString(operands(1).resultType) =>
-        methodGen(BuiltInMethods.STRING_TO_TIMESTAMP_WITH_FORMAT)
+        fallibleMethodGen(BuiltInMethods.STRING_TO_TIMESTAMP_WITH_FORMAT)
 
       case UNIX_TIMESTAMP if operands.size == 1 && isCharacterString(operands.head.resultType) =>
         methodGen(BuiltInMethods.UNIX_TIMESTAMP_STR)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/PartitionPruner.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/PartitionPruner.scala
@@ -28,6 +28,7 @@ import org.apache.flink.table.planner.codegen.{ConstantCodeGeneratorContext, Exp
 import org.apache.flink.table.utils.DateTimeUtils
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo
 import org.apache.flink.table.types.logical.LogicalTypeRoot._
+import org.apache.flink.table.types.logical.utils.LogicalTypeChecks
 import org.apache.flink.table.types.logical.{BooleanType, DecimalType, LogicalType}
 
 import org.apache.calcite.rex.RexNode
@@ -179,9 +180,14 @@ object PartitionPruner {
         DecimalDataUtils.castFrom(v, decimalType.getPrecision, decimalType.getScale)
       case DATE => DateTimeUtils.parseDate(v)
       case TIME_WITHOUT_TIME_ZONE => DateTimeUtils.parseTime(v)
-      case TIMESTAMP_WITHOUT_TIME_ZONE => DateTimeUtils.parseTimestampData(v)
+      case TIMESTAMP_WITHOUT_TIME_ZONE =>
+        DateTimeUtils.parseTimestampData(v, LogicalTypeChecks.getPrecision(t))
       case TIMESTAMP_WITH_LOCAL_TIME_ZONE => TimestampData.fromInstant(
-        DateTimeUtils.parseTimestampData(v).toLocalDateTime.atZone(timeZone).toInstant)
+        DateTimeUtils
+          .parseTimestampData(v, LogicalTypeChecks.getPrecision(t))
+          .toLocalDateTime
+          .atZone(timeZone)
+          .toInstant)
       case _ =>
         throw new TableException(s"$t is not supported in PartitionPruner")
     }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
@@ -959,12 +959,11 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                                 "2021-09-27 12:34:56.123",
                                 fromLocalToUTC(
                                         LocalDateTime.of(2021, 9, 27, 12, 34, 56, 123000000)))
-                        // https://issues.apache.org/jira/browse/FLINK-24446 Fractional seconds are
-                        // lost
                         .fromCase(
                                 STRING(),
                                 "2021-09-27 12:34:56.123456789",
-                                fromLocalToUTC(LocalDateTime.of(2021, 9, 27, 12, 34, 56, 0)))
+                                fromLocalToUTC(
+                                        LocalDateTime.of(2021, 9, 27, 12, 34, 56, 123456789)))
 
                         // Not supported - no fix
                         .fail(BOOLEAN(), true)

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/casting/CastRulesTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/casting/CastRulesTest.java
@@ -482,6 +482,16 @@ class CastRulesTest {
                         .fail(STRING(), fromString("2021/09/27"), TableException.class)
                         .fromCase(
                                 STRING(),
+                                fromString("2021-09-27 12:34:56.123"),
+                                TimestampData.fromLocalDateTime(
+                                        LocalDateTime.of(2021, 9, 27, 12, 34, 56, 123000000)))
+                        .fromCase(
+                                STRING(),
+                                fromString("2021-09-27 12:34:56.123400000"),
+                                TimestampData.fromLocalDateTime(
+                                        LocalDateTime.of(2021, 9, 27, 12, 34, 56, 123400000)))
+                        .fromCase(
+                                STRING(),
                                 fromString("2021-09-27 12:34:56.123456789"),
                                 timestampDataFromLocalDateTime(
                                         2021, 9, 27, 12, 34, 56, 123_456_789))
@@ -524,7 +534,15 @@ class CastRulesTest {
                         .fromCase(
                                 TIMESTAMP_LTZ(7),
                                 timestampDataFromInstant(2021, 9, 27, 0, 0, 0, 123_456_700),
-                                timestampDataFromLocalDateTime(2021, 9, 26, 22, 0, 0, 123_400_000)),
+                                timestampDataFromLocalDateTime(2021, 9, 26, 22, 0, 0, 123_400_000))
+                        .fromCase(
+                                STRING(),
+                                fromString("2021-09-27 12:34:56.123"),
+                                timestampDataFromLocalDateTime(2021, 9, 27, 12, 34, 56, 123000000))
+                        .fromCase(
+                                STRING(),
+                                fromString("2021-09-27 12:34:56.12345"),
+                                timestampDataFromLocalDateTime(2021, 9, 27, 12, 34, 56, 123400000)),
                 CastTestSpecBuilder.testCastTo(TIMESTAMP_LTZ(9))
                         .fail(CHAR(3), fromString("foo"), TableException.class)
                         .fail(VARCHAR(5), fromString("Flink"), TableException.class)
@@ -537,15 +555,23 @@ class CastRulesTest {
                         .fromCase(
                                 STRING(),
                                 CET_CONTEXT,
+                                fromString("2021-09-27 12:34:56"),
+                                timestampDataFromInstant(2021, 9, 27, 12, 34, 56, 0))
+                        .fromCase(
+                                STRING(),
+                                CET_CONTEXT,
                                 fromString("2021-09-27 12:34:56.123"),
                                 timestampDataFromInstant(2021, 9, 27, 12, 34, 56, 123_000_000))
-                        // https://issues.apache.org/jira/browse/FLINK-24446 Fractional seconds are
-                        // lost
+                        .fromCase(
+                                STRING(),
+                                CET_CONTEXT,
+                                fromString("2021-09-27 12:34:56.1234"),
+                                timestampDataFromInstant(2021, 9, 27, 12, 34, 56, 123400000))
                         .fromCase(
                                 STRING(),
                                 CET_CONTEXT,
                                 fromString("2021-09-27 12:34:56.123456789"),
-                                timestampDataFromInstant(2021, 9, 27, 12, 34, 56, 0))
+                                timestampDataFromInstant(2021, 9, 27, 12, 34, 56, 123456789))
                         .fromCase(
                                 DATE(),
                                 DateTimeUtils.toInternal(LocalDate.of(2022, 1, 4)),
@@ -584,7 +610,17 @@ class CastRulesTest {
                         .fromCase(
                                 TIMESTAMP_LTZ(7),
                                 timestampDataFromInstant(2021, 9, 27, 0, 0, 0, 123_456_700),
-                                timestampDataFromInstant(2021, 9, 27, 0, 0, 0, 123_400_000)),
+                                timestampDataFromInstant(2021, 9, 27, 0, 0, 0, 123_400_000))
+                        .fromCase(
+                                STRING(),
+                                CET_CONTEXT,
+                                fromString("2021-09-27 12:34:56.123"),
+                                timestampDataFromInstant(2021, 9, 27, 12, 34, 56, 123000000))
+                        .fromCase(
+                                STRING(),
+                                CET_CONTEXT,
+                                fromString("2021-09-27 12:34:56.12345"),
+                                timestampDataFromInstant(2021, 9, 27, 12, 34, 56, 123400000)),
                 CastTestSpecBuilder.testCastTo(STRING())
                         .fromCase(STRING(), null, null)
                         .fromCase(NULL(), null, BinaryStringDataUtil.NULL_STRING)

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/casting/CastRulesTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/casting/CastRulesTest.java
@@ -487,6 +487,21 @@ class CastRulesTest {
                                         LocalDateTime.of(2021, 9, 27, 12, 34, 56, 123000000)))
                         .fromCase(
                                 STRING(),
+                                fromString("2021-9-1 1:1:1.123"),
+                                TimestampData.fromLocalDateTime(
+                                        LocalDateTime.of(2021, 9, 1, 1, 1, 1, 123000000)))
+                        .fromCase(
+                                STRING(),
+                                fromString("2021-9-01 1:01:10.123"),
+                                TimestampData.fromLocalDateTime(
+                                        LocalDateTime.of(2021, 9, 1, 1, 1, 10, 123000000)))
+                        .fromCase(
+                                STRING(),
+                                fromString("2021-09-1 01:1:01.123"),
+                                TimestampData.fromLocalDateTime(
+                                        LocalDateTime.of(2021, 9, 1, 1, 1, 1, 123000000)))
+                        .fromCase(
+                                STRING(),
                                 fromString("2021-09-27 12:34:56.123400000"),
                                 TimestampData.fromLocalDateTime(
                                         LocalDateTime.of(2021, 9, 27, 12, 34, 56, 123400000)))

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/DateTimeTestUtil.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/DateTimeTestUtil.scala
@@ -45,7 +45,7 @@ object DateTimeTestUtil {
     if (s == null) {
       null
     } else {
-      DateTimeUtils.parseTimestampData(s).toLocalDateTime
+      DateTimeUtils.parseTimestampData(s, 9).toLocalDateTime
     }
   }
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/binary/BinaryStringDataUtil.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/binary/BinaryStringDataUtil.java
@@ -611,8 +611,8 @@ public class BinaryStringDataUtil {
 
     /** Used by {@code CAST(x as TIMESTAMP_LTZ)}. */
     public static TimestampData toTimestamp(
-            BinaryStringData input, TimeZone timeZone, int precision) throws DateTimeException {
-        return DateTimeUtils.parseTimestampData(input.toString(), timeZone, precision);
+            BinaryStringData input, int precision, TimeZone timeZone) throws DateTimeException {
+        return DateTimeUtils.parseTimestampData(input.toString(), precision, timeZone);
     }
 
     /**

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/binary/BinaryStringDataUtil.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/binary/BinaryStringDataUtil.java
@@ -31,7 +31,6 @@ import org.apache.flink.table.utils.EncodingUtils;
 import java.math.BigDecimal;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.text.ParseException;
 import java.time.DateTimeException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -605,18 +604,12 @@ public class BinaryStringDataUtil {
     }
 
     public static TimestampData toTimestamp(BinaryStringData input) throws DateTimeException {
-        TimestampData timestamp = DateTimeUtils.parseTimestampData(input.toString());
-        if (timestamp == null) {
-            throw new DateTimeException("For input string: '" + input + "'.");
-        }
-
-        return timestamp;
+        return DateTimeUtils.parseTimestampData(input.toString());
     }
 
     public static TimestampData toTimestamp(BinaryStringData input, TimeZone timeZone)
-            throws ParseException {
-        long timestamp = DateTimeUtils.parseTimestampMillis(input.toString(), timeZone);
-        return TimestampData.fromEpochMillis(timestamp);
+            throws DateTimeException {
+        return DateTimeUtils.parseTimestampData(input.toString(), timeZone);
     }
 
     /**

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/binary/BinaryStringDataUtil.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/binary/BinaryStringDataUtil.java
@@ -603,13 +603,16 @@ public class BinaryStringDataUtil {
         return date;
     }
 
-    public static TimestampData toTimestamp(BinaryStringData input) throws DateTimeException {
-        return DateTimeUtils.parseTimestampData(input.toString());
+    /** Used by {@code CAST(x as TIMESTAMP)}. */
+    public static TimestampData toTimestamp(BinaryStringData input, int precision)
+            throws DateTimeException {
+        return DateTimeUtils.parseTimestampData(input.toString(), precision);
     }
 
-    public static TimestampData toTimestamp(BinaryStringData input, TimeZone timeZone)
-            throws DateTimeException {
-        return DateTimeUtils.parseTimestampData(input.toString(), timeZone);
+    /** Used by {@code CAST(x as TIMESTAMP_LTZ)}. */
+    public static TimestampData toTimestamp(
+            BinaryStringData input, TimeZone timeZone, int precision) throws DateTimeException {
+        return DateTimeUtils.parseTimestampData(input.toString(), timeZone, precision);
     }
 
     /**


### PR DESCRIPTION
This PR fixes STRING to TIMESTAMP and TIMESTAMP_LTZ which is losing the nanosecond precision.