### PR TITLE
[FLINK-25433][runtime] Adds retry mechanism to DefaultResourceCleaner

### DIFF
--- a/docs/layouts/shortcodes/generated/all_jobmanager_section.html
+++ b/docs/layouts/shortcodes/generated/all_jobmanager_section.html
@@ -33,6 +33,18 @@
             <td>Dictionary for JobManager to store the archives of completed jobs.</td>
         </tr>
         <tr>
+            <td><h5>jobmanager.cleanup.max-delay</h5></td>
+            <td style="word-wrap: break-word;">1 h</td>
+            <td>Duration</td>
+            <td>The cleanup of each job is retried up to the point where it succeeds. The maximum delay marks the maximum amount of time used for a retry interval up to which the retry interval increases exponentially.</td>
+        </tr>
+        <tr>
+            <td><h5>jobmanager.cleanup.min-delay</h5></td>
+            <td style="word-wrap: break-word;">1 s</td>
+            <td>Duration</td>
+            <td>The cleanup of each job is retried up to the point where it succeeds. The minimum delay is used for the first retry of a cleanup task. The delay will increase exponentially.</td>
+        </tr>
+        <tr>
             <td><h5>jobmanager.execution.attempts-history-size</h5></td>
             <td style="word-wrap: break-word;">16</td>
             <td>Integer</td>

--- a/docs/layouts/shortcodes/generated/job_manager_configuration.html
+++ b/docs/layouts/shortcodes/generated/job_manager_configuration.html
@@ -39,6 +39,18 @@
             <td>The local address of the network interface that the job manager binds to. If not configured, '0.0.0.0' will be used.</td>
         </tr>
         <tr>
+            <td><h5>jobmanager.cleanup.max-delay</h5></td>
+            <td style="word-wrap: break-word;">1 h</td>
+            <td>Duration</td>
+            <td>The cleanup of each job is retried up to the point where it succeeds. The maximum delay marks the maximum amount of time used for a retry interval up to which the retry interval increases exponentially.</td>
+        </tr>
+        <tr>
+            <td><h5>jobmanager.cleanup.min-delay</h5></td>
+            <td style="word-wrap: break-word;">1 s</td>
+            <td>Duration</td>
+            <td>The cleanup of each job is retried up to the point where it succeeds. The minimum delay is used for the first retry of a cleanup task. The delay will increase exponentially.</td>
+        </tr>
+        <tr>
             <td><h5>jobmanager.execution.attempts-history-size</h5></td>
             <td style="word-wrap: break-word;">16</td>
             <td>Integer</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
@@ -287,6 +287,22 @@ public class JobManagerOptions {
                                                             "here")))
                                     .build());
 
+    /** The minimum delay for the exponentially-increasing job cleanup retry interval. */
+    @Documentation.Section(Documentation.Sections.ALL_JOB_MANAGER)
+    public static final ConfigOption<Duration> JOB_CLEANUP_MINIMUM_DELAY =
+            key("jobmanager.cleanup.min-delay")
+                    .defaultValue(Duration.ofSeconds(1))
+                    .withDescription(
+                            "The cleanup of each job is retried up to the point where it succeeds. The minimum delay is used for the first retry of a cleanup task. The delay will increase exponentially.");
+
+    /** The minimum delay for the exponentially-increasing job cleanup retry interval. */
+    @Documentation.Section(Documentation.Sections.ALL_JOB_MANAGER)
+    public static final ConfigOption<Duration> JOB_CLEANUP_MAXIMUM_DELAY =
+            key("jobmanager.cleanup.max-delay")
+                    .defaultValue(Duration.ofHours(1))
+                    .withDescription(
+                            "The cleanup of each job is retried up to the point where it succeeds. The maximum delay marks the maximum amount of time used for a retry interval up to which the retry interval increases exponentially.");
+
     /** The location where the JobManager stores the archives of completed jobs. */
     @Documentation.Section(Documentation.Sections.ALL_JOB_MANAGER)
     public static final ConfigOption<String> ARCHIVE_DIR =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/DefaultResourceCleaner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/DefaultResourceCleaner.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.util.concurrent.FutureUtils;
+import org.apache.flink.util.concurrent.RetryStrategy;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -29,7 +30,11 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
 
-/** {@code DefaultResourceCleaner} is the default implementation of {@link ResourceCleaner}. */
+/**
+ * {@code DefaultResourceCleaner} is the default implementation of {@link ResourceCleaner}. It will
+ * try to clean up any resource that was added. Failure will result in an individual retry of the
+ * cleanup. The overall cleanup result succeeds after all subtasks succeeded.
+ */
 public class DefaultResourceCleaner<T> implements ResourceCleaner {
 
     private final ComponentMainThreadExecutor mainThreadExecutor;
@@ -39,24 +44,37 @@ public class DefaultResourceCleaner<T> implements ResourceCleaner {
     private final Collection<T> prioritizedCleanup;
     private final Collection<T> regularCleanup;
 
+    private final RetryStrategy retryStrategy;
+
     public static Builder<LocallyCleanableResource> forLocallyCleanableResources(
-            ComponentMainThreadExecutor mainThreadExecutor, Executor cleanupExecutor) {
+            ComponentMainThreadExecutor mainThreadExecutor,
+            Executor cleanupExecutor,
+            RetryStrategy retryStrategy) {
         return forCleanableResources(
-                mainThreadExecutor, cleanupExecutor, LocallyCleanableResource::localCleanupAsync);
+                mainThreadExecutor,
+                cleanupExecutor,
+                LocallyCleanableResource::localCleanupAsync,
+                retryStrategy);
     }
 
     public static Builder<GloballyCleanableResource> forGloballyCleanableResources(
-            ComponentMainThreadExecutor mainThreadExecutor, Executor cleanupExecutor) {
+            ComponentMainThreadExecutor mainThreadExecutor,
+            Executor cleanupExecutor,
+            RetryStrategy retryStrategy) {
         return forCleanableResources(
-                mainThreadExecutor, cleanupExecutor, GloballyCleanableResource::globalCleanupAsync);
+                mainThreadExecutor,
+                cleanupExecutor,
+                GloballyCleanableResource::globalCleanupAsync,
+                retryStrategy);
     }
 
     @VisibleForTesting
     static <T> Builder<T> forCleanableResources(
             ComponentMainThreadExecutor mainThreadExecutor,
             Executor cleanupExecutor,
-            CleanupFn<T> cleanupFunction) {
-        return new Builder<>(mainThreadExecutor, cleanupExecutor, cleanupFunction);
+            CleanupFn<T> cleanupFunction,
+            RetryStrategy retryStrategy) {
+        return new Builder<>(mainThreadExecutor, cleanupExecutor, cleanupFunction, retryStrategy);
     }
 
     @VisibleForTesting
@@ -77,16 +95,20 @@ public class DefaultResourceCleaner<T> implements ResourceCleaner {
         private final Executor cleanupExecutor;
         private final CleanupFn<T> cleanupFn;
 
+        private final RetryStrategy retryStrategy;
+
         private final Collection<T> prioritizedCleanup = new ArrayList<>();
         private final Collection<T> regularCleanup = new ArrayList<>();
 
         private Builder(
                 ComponentMainThreadExecutor mainThreadExecutor,
                 Executor cleanupExecutor,
-                CleanupFn<T> cleanupFn) {
+                CleanupFn<T> cleanupFn,
+                RetryStrategy retryStrategy) {
             this.mainThreadExecutor = mainThreadExecutor;
             this.cleanupExecutor = cleanupExecutor;
             this.cleanupFn = cleanupFn;
+            this.retryStrategy = retryStrategy;
         }
 
         public Builder<T> withPrioritizedCleanup(T prioritizedCleanup) {
@@ -105,7 +127,8 @@ public class DefaultResourceCleaner<T> implements ResourceCleaner {
                     cleanupExecutor,
                     cleanupFn,
                     prioritizedCleanup,
-                    regularCleanup);
+                    regularCleanup,
+                    retryStrategy);
         }
     }
 
@@ -114,32 +137,37 @@ public class DefaultResourceCleaner<T> implements ResourceCleaner {
             Executor cleanupExecutor,
             CleanupFn<T> cleanupFn,
             Collection<T> prioritizedCleanup,
-            Collection<T> regularCleanup) {
+            Collection<T> regularCleanup,
+            RetryStrategy retryStrategy) {
         this.mainThreadExecutor = mainThreadExecutor;
         this.cleanupExecutor = cleanupExecutor;
         this.cleanupFn = cleanupFn;
         this.prioritizedCleanup = prioritizedCleanup;
         this.regularCleanup = regularCleanup;
+        this.retryStrategy = retryStrategy;
     }
 
     @Override
     public CompletableFuture<Void> cleanupAsync(JobID jobId) {
         mainThreadExecutor.assertRunningInMainThread();
+
         CompletableFuture<Void> cleanupFuture = FutureUtils.completedVoidFuture();
         for (T cleanup : prioritizedCleanup) {
-            cleanupFuture =
-                    cleanupFuture.thenCompose(
-                            ignoredValue ->
-                                    cleanupFn.cleanupAsync(cleanup, jobId, cleanupExecutor));
+            cleanupFuture = cleanupFuture.thenCompose(ignoredValue -> withRetry(jobId, cleanup));
         }
+
         return cleanupFuture.thenCompose(
                 ignoredValue ->
                         FutureUtils.completeAll(
                                 regularCleanup.stream()
-                                        .map(
-                                                cleanup ->
-                                                        cleanupFn.cleanupAsync(
-                                                                cleanup, jobId, cleanupExecutor))
+                                        .map(cleanup -> withRetry(jobId, cleanup))
                                         .collect(Collectors.toList())));
+    }
+
+    private CompletableFuture<Void> withRetry(JobID jobId, T cleanup) {
+        return FutureUtils.retryWithDelay(
+                () -> cleanupFn.cleanupAsync(cleanup, jobId, cleanupExecutor),
+                retryStrategy,
+                mainThreadExecutor);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherCleanupITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherCleanupITCase.java
@@ -20,20 +20,24 @@ package org.apache.flink.runtime.dispatcher;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.common.time.Deadline;
+import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.checkpoint.EmbeddedCompletedCheckpointStore;
 import org.apache.flink.runtime.checkpoint.PerJobCheckpointRecoveryFactory;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
+import org.apache.flink.runtime.dispatcher.cleanup.DispatcherResourceCleanerFactory;
+import org.apache.flink.runtime.dispatcher.cleanup.TestingRetryStrategies;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobGraphBuilder;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
 import org.apache.flink.runtime.jobgraph.tasks.JobCheckpointingSettings;
+import org.apache.flink.runtime.jobmanager.JobGraphStore;
 import org.apache.flink.runtime.jobmaster.JobMasterGateway;
 import org.apache.flink.runtime.jobmaster.JobMasterId;
 import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.runtime.leaderelection.TestingLeaderElectionService;
-import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.rpc.RpcEndpoint;
 import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
@@ -49,9 +53,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import javax.annotation.Nullable;
-
-import java.util.ArrayList;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -59,15 +61,17 @@ import java.util.UUID;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertTrue;
 
 /** An integration test for various fail-over scenarios of the {@link Dispatcher} component. */
-public class DispatcherFailoverITCase extends AbstractDispatcherTest {
+public class DispatcherCleanupITCase extends AbstractDispatcherTest {
 
     private final BlockingQueue<RpcEndpoint> toTerminate = new LinkedBlockingQueue<>();
 
@@ -110,28 +114,22 @@ public class DispatcherFailoverITCase extends AbstractDispatcherTest {
     }
 
     @Test
-    public void testRecoverFromCheckpointAfterJobGraphRemovalOfTerminatedJobFailed()
-            throws Exception {
+    public void testCleanupThroughRetries() throws Exception {
         final JobGraph jobGraph = createJobGraph();
         final JobID jobId = jobGraph.getJobID();
 
-        // Construct job graph store.
-        final Error temporaryError = new Error("Unable to remove job graph.");
-        final AtomicReference<? extends Error> temporaryErrorRef =
-                new AtomicReference<>(temporaryError);
-        final TestingJobGraphStore jobGraphStore =
-                TestingJobGraphStore.newBuilder()
-                        .setGlobalCleanupFunction(
-                                (ignoredJobId, ignoredExecutor) -> {
-                                    final Error error = temporaryErrorRef.getAndSet(null);
-                                    if (error != null) {
-                                        throw error;
-                                    }
-
-                                    return FutureUtils.completedVoidFuture();
-                                })
-                        .build();
-        jobGraphStore.start(null);
+        // JobGraphStore
+        final AtomicInteger actualGlobalCleanupCallCount = new AtomicInteger();
+        final OneShotLatch successfulCleanupLatch = new OneShotLatch();
+        final int numberOfErrors = 5;
+        final RuntimeException temporaryError =
+                new RuntimeException("Expected RuntimeException: Unable to remove job graph.");
+        final JobGraphStore jobGraphStore =
+                createAndStartJobGraphStoreWithCleanupFailures(
+                        numberOfErrors,
+                        temporaryError,
+                        actualGlobalCleanupCallCount,
+                        successfulCleanupLatch);
         haServices.setJobGraphStore(jobGraphStore);
 
         // Construct leader election service.
@@ -139,41 +137,94 @@ public class DispatcherFailoverITCase extends AbstractDispatcherTest {
                 new TestingLeaderElectionService();
         haServices.setJobMasterLeaderElectionService(jobId, leaderElectionService);
 
-        // Start the first dispatcher and submit the job.
-        final CountDownLatch jobGraphRemovalErrorReceived = new CountDownLatch(1);
+        // start the dispatcher with enough retries on cleanup
+        final JobManagerRunnerRegistry jobManagerRunnerRegistry =
+                new DefaultJobManagerRunnerRegistry(2);
         final Dispatcher dispatcher =
-                createRecoveredDispatcher(
-                        throwable -> {
-                            final Optional<Error> maybeError =
-                                    ExceptionUtils.findThrowable(throwable, Error.class);
-                            if (maybeError.isPresent() && temporaryError.equals(maybeError.get())) {
-                                jobGraphRemovalErrorReceived.countDown();
-                            } else {
-                                testingFatalErrorHandlerResource
-                                        .getFatalErrorHandler()
-                                        .onFatalError(throwable);
-                            }
-                        });
+                createTestingDispatcherBuilder()
+                        .setResourceCleanerFactory(
+                                new DispatcherResourceCleanerFactory(
+                                        ForkJoinPool.commonPool(),
+                                        TestingRetryStrategies.createWithNumberOfRetries(
+                                                numberOfErrors),
+                                        jobManagerRunnerRegistry,
+                                        haServices.getJobGraphStore(),
+                                        blobServer,
+                                        haServices,
+                                        UnregisteredMetricGroups
+                                                .createUnregisteredJobManagerMetricGroup()))
+                        .build();
+        dispatcher.start();
+
         toTerminate.add(dispatcher);
         leaderElectionService.isLeader(UUID.randomUUID());
         final DispatcherGateway dispatcherGateway =
                 dispatcher.getSelfGateway(DispatcherGateway.class);
         dispatcherGateway.submitJob(jobGraph, TIMEOUT).get();
 
-        // Run vertices, checkpoint and finish.
-        final JobMasterGateway jobMasterGateway =
-                connectToLeadingJobMaster(leaderElectionService).get();
-        try (final JobMasterTester tester =
-                new JobMasterTester(rpcService, jobId, jobMasterGateway)) {
-            final CompletableFuture<List<TaskDeploymentDescriptor>> descriptorsFuture =
-                    tester.deployVertices(2);
-            awaitStatus(dispatcherGateway, jobId, JobStatus.RUNNING);
-            tester.transitionTo(descriptorsFuture.get(), ExecutionState.INITIALIZING).get();
-            tester.transitionTo(descriptorsFuture.get(), ExecutionState.RUNNING).get();
-            tester.getCheckpointFuture(1L).get();
-            tester.transitionTo(descriptorsFuture.get(), ExecutionState.FINISHED).get();
-        }
-        awaitStatus(dispatcherGateway, jobId, JobStatus.FINISHED);
+        waitForJobToFinish(leaderElectionService, dispatcherGateway, jobId);
+
+        successfulCleanupLatch.await();
+
+        assertThat(actualGlobalCleanupCallCount.get(), equalTo(numberOfErrors + 1));
+
+        assertThat(
+                "The JobGraph should be removed from JobGraphStore.",
+                haServices.getJobGraphStore().getJobIds(),
+                IsEmptyCollection.empty());
+
+        CommonTestUtils.waitUntilCondition(
+                () -> haServices.getJobResultStore().hasJobResultEntry(jobId),
+                Deadline.fromNow(Duration.ofMinutes(5)),
+                "The JobResultStore should have this job marked as clean.");
+    }
+
+    @Test
+    public void testCleanupAfterLeadershipChange() throws Exception {
+        final JobGraph jobGraph = createJobGraph();
+        final JobID jobId = jobGraph.getJobID();
+
+        // Construct job graph store.
+        final AtomicInteger actualGlobalCleanupCallCount = new AtomicInteger();
+        final OneShotLatch successfulCleanupLatch = new OneShotLatch();
+        final RuntimeException temporaryError = new RuntimeException("Unable to remove job graph.");
+        final JobGraphStore jobGraphStore =
+                createAndStartJobGraphStoreWithCleanupFailures(
+                        1, temporaryError, actualGlobalCleanupCallCount, successfulCleanupLatch);
+        haServices.setJobGraphStore(jobGraphStore);
+
+        // Construct leader election service.
+        final TestingLeaderElectionService leaderElectionService =
+                new TestingLeaderElectionService();
+        haServices.setJobMasterLeaderElectionService(jobId, leaderElectionService);
+
+        // start the dispatcher with no retries on cleanup
+        final CountDownLatch jobGraphRemovalErrorReceived = new CountDownLatch(1);
+        final Dispatcher dispatcher =
+                createTestingDispatcherBuilder()
+                        .setFatalErrorHandler(
+                                throwable -> {
+                                    final Optional<Throwable> maybeError =
+                                            ExceptionUtils.findThrowable(
+                                                    throwable, temporaryError::equals);
+                                    if (maybeError.isPresent()) {
+                                        jobGraphRemovalErrorReceived.countDown();
+                                    } else {
+                                        testingFatalErrorHandlerResource
+                                                .getFatalErrorHandler()
+                                                .onFatalError(throwable);
+                                    }
+                                })
+                        .build();
+        dispatcher.start();
+
+        toTerminate.add(dispatcher);
+        leaderElectionService.isLeader(UUID.randomUUID());
+        final DispatcherGateway dispatcherGateway =
+                dispatcher.getSelfGateway(DispatcherGateway.class);
+        dispatcherGateway.submitJob(jobGraph, TIMEOUT).get();
+
+        waitForJobToFinish(leaderElectionService, dispatcherGateway, jobId);
         jobGraphRemovalErrorReceived.await();
 
         // Remove job master leadership.
@@ -181,6 +232,8 @@ public class DispatcherFailoverITCase extends AbstractDispatcherTest {
 
         // This will clear internal state of election service, so a new contender can register.
         leaderElectionService.stop();
+
+        assertThat(successfulCleanupLatch.isTriggered(), CoreMatchers.is(false));
 
         assertThat(
                 "The JobGraph is still stored in the JobGraphStore.",
@@ -194,7 +247,12 @@ public class DispatcherFailoverITCase extends AbstractDispatcherTest {
                 CoreMatchers.is(Collections.singleton(jobId)));
 
         // Run a second dispatcher, that restores our finished job.
-        final Dispatcher secondDispatcher = createRecoveredDispatcher(null);
+        final Dispatcher secondDispatcher =
+                createTestingDispatcherBuilder()
+                        .setRecoveredDirtyJobs(haServices.getJobResultStore().getDirtyResults())
+                        .build();
+        secondDispatcher.start();
+
         toTerminate.add(secondDispatcher);
         leaderElectionService.isLeader(UUID.randomUUID());
 
@@ -209,6 +267,57 @@ public class DispatcherFailoverITCase extends AbstractDispatcherTest {
         assertTrue(
                 "The JobResultStore has the job listed as clean.",
                 haServices.getJobResultStore().hasJobResultEntry(jobId));
+
+        // wait for the successful cleanup to be triggered
+        successfulCleanupLatch.await();
+
+        assertThat(actualGlobalCleanupCallCount.get(), equalTo(2));
+    }
+
+    private JobGraphStore createAndStartJobGraphStoreWithCleanupFailures(
+            int numberOfCleanupFailures,
+            Throwable throwable,
+            AtomicInteger actualCleanupCallCount,
+            OneShotLatch successfulCleanupLatch)
+            throws Exception {
+        final AtomicInteger failureCount = new AtomicInteger(numberOfCleanupFailures);
+        final JobGraphStore jobGraphStore =
+                TestingJobGraphStore.newBuilder()
+                        .setGlobalCleanupFunction(
+                                (ignoredJobId, ignoredExecutor) -> {
+                                    actualCleanupCallCount.incrementAndGet();
+
+                                    if (failureCount.getAndDecrement() > 0) {
+                                        return FutureUtils.completedExceptionally(throwable);
+                                    }
+
+                                    successfulCleanupLatch.trigger();
+                                    return FutureUtils.completedVoidFuture();
+                                })
+                        .build();
+
+        jobGraphStore.start(null);
+        return jobGraphStore;
+    }
+
+    private void waitForJobToFinish(
+            TestingLeaderElectionService leaderElectionService,
+            DispatcherGateway dispatcherGateway,
+            JobID jobId)
+            throws Exception {
+        final JobMasterGateway jobMasterGateway =
+                connectToLeadingJobMaster(leaderElectionService).get();
+        try (final JobMasterTester tester =
+                new JobMasterTester(rpcService, jobId, jobMasterGateway)) {
+            final CompletableFuture<List<TaskDeploymentDescriptor>> descriptorsFuture =
+                    tester.deployVertices(2);
+            awaitStatus(dispatcherGateway, jobId, JobStatus.RUNNING);
+            tester.transitionTo(descriptorsFuture.get(), ExecutionState.INITIALIZING).get();
+            tester.transitionTo(descriptorsFuture.get(), ExecutionState.RUNNING).get();
+            tester.getCheckpointFuture(1L).get();
+            tester.transitionTo(descriptorsFuture.get(), ExecutionState.FINISHED).get();
+        }
+        awaitStatus(dispatcherGateway, jobId, JobStatus.FINISHED);
     }
 
     private JobGraph createJobGraph() {
@@ -233,28 +342,6 @@ public class DispatcherFailoverITCase extends AbstractDispatcherTest {
                 .addJobVertex(secondVertex)
                 .setJobCheckpointingSettings(checkpointingSettings)
                 .build();
-    }
-
-    private TestingDispatcher createRecoveredDispatcher(
-            @Nullable FatalErrorHandler fatalErrorHandler) throws Exception {
-        final List<JobGraph> jobGraphs = new ArrayList<>();
-        for (JobID jobId : haServices.getJobGraphStore().getJobIds()) {
-            // there shouldn't be an overlap between dirty JobResults and recovered JobGraphs
-            if (!haServices.getJobResultStore().hasJobResultEntry(jobId)) {
-                jobGraphs.add(haServices.getJobGraphStore().recoverJobGraph(jobId));
-            }
-        }
-        final TestingDispatcher dispatcher =
-                createTestingDispatcherBuilder()
-                        .setRecoveredJobs(jobGraphs)
-                        .setRecoveredDirtyJobs(haServices.getJobResultStore().getDirtyResults())
-                        .setFatalErrorHandler(
-                                fatalErrorHandler == null
-                                        ? testingFatalErrorHandlerResource.getFatalErrorHandler()
-                                        : fatalErrorHandler)
-                        .build();
-        dispatcher.start();
-        return dispatcher;
     }
 
     private static CompletableFuture<JobMasterGateway> connectToLeadingJobMaster(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/TestingDispatcher.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/TestingDispatcher.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.dispatcher.cleanup.CleanupRunnerFactory;
 import org.apache.flink.runtime.dispatcher.cleanup.DispatcherResourceCleanerFactory;
 import org.apache.flink.runtime.dispatcher.cleanup.ResourceCleanerFactory;
 import org.apache.flink.runtime.dispatcher.cleanup.TestingCleanupRunnerFactory;
+import org.apache.flink.runtime.dispatcher.cleanup.TestingRetryStrategies;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.highavailability.JobResultStore;
@@ -345,6 +346,7 @@ class TestingDispatcher extends Dispatcher {
         private ResourceCleanerFactory createDefaultResourceCleanerFactory() {
             return new DispatcherResourceCleanerFactory(
                     ioExecutor,
+                    TestingRetryStrategies.NO_RETRY_STRATEGY,
                     jobManagerRunnerRegistry,
                     jobGraphWriter,
                     blobServer,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/cleanup/DispatcherResourceCleanerFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/cleanup/DispatcherResourceCleanerFactoryTest.java
@@ -84,6 +84,7 @@ public class DispatcherResourceCleanerFactoryTest {
         testInstance =
                 new DispatcherResourceCleanerFactory(
                         Executors.directExecutor(),
+                        TestingRetryStrategies.NO_RETRY_STRATEGY,
                         createJobManagerRunnerRegistry(),
                         createJobGraphWriter(),
                         blobServer,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/cleanup/TestingRetryStrategies.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/cleanup/TestingRetryStrategies.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher.cleanup;
+
+import org.apache.flink.util.concurrent.FixedRetryStrategy;
+import org.apache.flink.util.concurrent.RetryStrategy;
+
+import java.time.Duration;
+
+/** {@code TestingRetryStrategies} collects common {@link RetryStrategy} variants. */
+public class TestingRetryStrategies {
+
+    private TestingRetryStrategies() {
+        // utility class shouldn't be instantiated
+    }
+
+    private static final Duration TESTING_DEFAULT_RETRY_DELAY = Duration.ofMillis(10);
+
+    public static final RetryStrategy NO_RETRY_STRATEGY = new FixedRetryStrategy(0, Duration.ZERO);
+
+    public static RetryStrategy createWithNumberOfRetries(int retryCount) {
+        return new FixedRetryStrategy(retryCount, TESTING_DEFAULT_RETRY_DELAY);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/retriever/impl/RpcGatewayRetrieverTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/retriever/impl/RpcGatewayRetrieverTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.webmonitor.retriever.impl;
 
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.dispatcher.cleanup.TestingRetryStrategies;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.leaderretrieval.SettableLeaderRetrievalService;
 import org.apache.flink.runtime.rpc.FencedRpcGateway;
@@ -28,13 +29,11 @@ import org.apache.flink.runtime.rpc.RpcTimeout;
 import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.util.TestLogger;
-import org.apache.flink.util.concurrent.FixedRetryStrategy;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.time.Duration;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -80,7 +79,7 @@ public class RpcGatewayRetrieverTest extends TestLogger {
                         rpcService,
                         DummyGateway.class,
                         Function.identity(),
-                        new FixedRetryStrategy(0, Duration.ZERO));
+                        TestingRetryStrategies.NO_RETRY_STRATEGY);
         SettableLeaderRetrievalService settableLeaderRetrievalService =
                 new SettableLeaderRetrievalService();
         DummyRpcEndpoint dummyRpcEndpoint =


### PR DESCRIPTION
## What is the purpose of the change

We want to make the cleanup try to run infinitely until the cleanup is resolved.

## Brief change log

* Adds `FutureUtils.retryWithDelay` in `DefaultResourceCleaner`

## Verifying this change

* `DefaultResourceCleanerTest` was extended to cover the retry mechanism

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
