### PR TITLE
[FLINK-25839][e2e] Print the previous logs of restarted pod for k8s e2e tests

### DIFF
--- a/flink-end-to-end-tests/test-scripts/common_kubernetes.sh
+++ b/flink-end-to-end-tests/test-scripts/common_kubernetes.sh
@@ -135,7 +135,13 @@ function debug_and_show_logs {
 
     echo "Flink logs:"
     kubectl get pods -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | while read pod;do
+        echo "Current logs for $pod: "
         kubectl logs $pod;
+        restart_count=$(kubectl get pod $pod -o jsonpath='{.status.containerStatuses[0].restartCount}')
+        if [[ ${restart_count} -gt 0 ]];then
+          echo "Previous logs for $pod: "
+          kubectl logs $pod --previous
+        fi
     done
 }
 


### PR DESCRIPTION
This PR is trying to print the previous logs of restarted pod. It is very useful to debug the failed K8s related e2e tests(e.g. FLINK-25839).