### PR TITLE
[FLINK-24880][python] Fix PeriodicThread to handle properly for negative wait timeout value

### DIFF
--- a/flink-python/pyflink/fn_execution/utils/operation_utils.py
+++ b/flink-python/pyflink/fn_execution/utils/operation_utils.py
@@ -338,7 +338,7 @@ class PeriodicThread(threading.Thread):
         now = time.time()
         next_call = now + self._interval
         while (next_call <= now and not self._finished.is_set()) or \
-                (not self._finished.wait(next_call - now)):
+                (next_call > now and not self._finished.wait(next_call - now)):
             if next_call <= now:
                 next_call = now + self._interval
             else:


### PR DESCRIPTION

## What is the purpose of the change

*This pull request fixes PeriodicThread to handle properly for negative wait timeout value*


## Verifying this change


This change is a trivial rework without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable )
