### PR TITLE
[hotfix][docs] replace deprecated class and fix typos

### DIFF
--- a/docs/content.zh/docs/connectors/datastream/filesystem.md
+++ b/docs/content.zh/docs/connectors/datastream/filesystem.md
@@ -384,7 +384,7 @@ The latter rolls on every checkpoint. A policy can roll additionally based on si
 ##### Parquet format
 
 Flink contains built in convenience methods for creating Parquet writer factories for Avro data. These methods
-and their associated documentation can be found in the ParquetAvroWriters class.
+and their associated documentation can be found in the AvroParquetWriters class.
 
 For writing to other Parquet compatible data formats, users need to create the ParquetWriterFactory with a custom implementation of the ParquetBuilder interface.
 
@@ -398,7 +398,7 @@ A `FileSink` that writes Avro data to Parquet format can be created like this:
 {{< tab "Java" >}}
 ```java
 import org.apache.flink.connector.file.sink.FileSink;
-import org.apache.flink.formats.parquet.avro.ParquetAvroWriters;
+import org.apache.flink.formats.parquet.avro.AvroParquetWriters;
 import org.apache.avro.Schema;
 
 
@@ -406,7 +406,7 @@ Schema schema = ...;
 DataStream<GenericRecord> input = ...;
 
 final FileSink<GenericRecord> sink = FileSink
-	.forBulkFormat(outputBasePath, ParquetAvroWriters.forGenericRecord(schema))
+	.forBulkFormat(outputBasePath, AvroParquetWriters.forGenericRecord(schema))
 	.build();
 
 input.sinkTo(sink);
@@ -416,14 +416,14 @@ input.sinkTo(sink);
 {{< tab "Scala" >}}
 ```scala
 import org.apache.flink.connector.file.sink.FileSink;
-import org.apache.flink.formats.parquet.avro.ParquetAvroWriters
+import org.apache.flink.formats.parquet.avro.AvroParquetWriters
 import org.apache.avro.Schema
 
 val schema: Schema = ...
 val input: DataStream[GenericRecord] = ...
 
 val sink: FileSink[GenericRecord] = FileSink
-    .forBulkFormat(outputBasePath, ParquetAvroWriters.forGenericRecord(schema))
+    .forBulkFormat(outputBasePath, AvroParquetWriters.forGenericRecord(schema))
     .build()
 
 input.sinkTo(sink)

--- a/docs/content/docs/connectors/datastream/filesystem.md
+++ b/docs/content/docs/connectors/datastream/filesystem.md
@@ -383,7 +383,7 @@ The latter rolls on every checkpoint. A policy can roll additionally based on si
 ##### Parquet format
 
 Flink contains built in convenience methods for creating Parquet writer factories for Avro data. These methods
-and their associated documentation can be found in the ParquetAvroWriters class.
+and their associated documentation can be found in the AvroParquetWriters class.
 
 For writing to other Parquet compatible data formats, users need to create the ParquetWriterFactory with a custom implementation of the ParquetBuilder interface.
 
@@ -397,7 +397,7 @@ A `FileSink` that writes Avro data to Parquet format can be created like this:
 {{< tab "Java" >}}
 ```java
 import org.apache.flink.connector.file.sink.FileSink;
-import org.apache.flink.formats.parquet.avro.ParquetAvroWriters;
+import org.apache.flink.formats.parquet.avro.AvroParquetWriters;
 import org.apache.avro.Schema;
 
 
@@ -415,14 +415,14 @@ input.sinkTo(sink);
 {{< tab "Scala" >}}
 ```scala
 import org.apache.flink.connector.file.sink.FileSink;
-import org.apache.flink.formats.parquet.avro.ParquetAvroWriters
+import org.apache.flink.formats.parquet.avro.AvroParquetWriters
 import org.apache.avro.Schema
 
 val schema: Schema = ...
 val input: DataStream[GenericRecord] = ...
 
 val sink: FileSink[GenericRecord] = FileSink
-    .forBulkFormat(outputBasePath, ParquetAvroWriters.forGenericRecord(schema))
+    .forBulkFormat(outputBasePath, AvroParquetWriters.forGenericRecord(schema))
     .build()
 
 input.sinkTo(sink)

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/avro/AvroParquetRecordFormat.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/avro/AvroParquetRecordFormat.java
@@ -42,7 +42,7 @@ import java.io.IOException;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 
-/** */
+/** A reader format that reads individual Avro records from a Parquet stream. */
 public class AvroParquetRecordFormat<E> implements StreamFormat<E> {
 
     private static final long serialVersionUID = 1L;

--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/avro/AvroParquetStreamingFileSinkITCase.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/avro/AvroParquetStreamingFileSinkITCase.java
@@ -62,7 +62,7 @@ import static org.junit.Assert.assertTrue;
  * with Parquet.
  */
 @SuppressWarnings("serial")
-public class ParquetAvroStreamingFileSinkITCase extends AbstractTestBase {
+public class AvroParquetStreamingFileSinkITCase extends AbstractTestBase {
 
     @Rule public final Timeout timeoutPerTest = Timeout.seconds(20);
 
@@ -87,7 +87,7 @@ public class ParquetAvroStreamingFileSinkITCase extends AbstractTestBase {
         stream.addSink(
                 StreamingFileSink.forBulkFormat(
                                 Path.fromLocalFile(folder),
-                                ParquetAvroWriters.forSpecificRecord(Address.class))
+                                AvroParquetWriters.forSpecificRecord(Address.class))
                         .withBucketAssigner(new UniqueBucketAssigner<>("test"))
                         .build());
 
@@ -115,7 +115,7 @@ public class ParquetAvroStreamingFileSinkITCase extends AbstractTestBase {
         stream.addSink(
                 StreamingFileSink.forBulkFormat(
                                 Path.fromLocalFile(folder),
-                                ParquetAvroWriters.forGenericRecord(schema))
+                                AvroParquetWriters.forGenericRecord(schema))
                         .withBucketAssigner(new UniqueBucketAssigner<>("test"))
                         .build());
 
@@ -147,7 +147,7 @@ public class ParquetAvroStreamingFileSinkITCase extends AbstractTestBase {
         stream.addSink(
                 StreamingFileSink.forBulkFormat(
                                 Path.fromLocalFile(folder),
-                                ParquetAvroWriters.forReflectRecord(Datum.class))
+                                AvroParquetWriters.forReflectRecord(Datum.class))
                         .withBucketAssigner(new UniqueBucketAssigner<>("test"))
                         .build());
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -264,7 +264,7 @@ public class StreamExecutionEnvironment {
                 userClassloader == null ? getClass().getClassLoader() : userClassloader;
 
         // the configuration of a job or an operator can be specified at the following places:
-        //     i) at the operator level using e.g. parallelism using the
+        //     i) at the operator level via e.g. parallelism by using the
         // SingleOutputStreamOperator.setParallelism().
         //     ii) programmatically by using e.g. the env.setRestartStrategy() method
         //     iii) in the configuration passed here
@@ -481,7 +481,7 @@ public class StreamExecutionEnvironment {
      * <p>The job draws checkpoints periodically, in the given interval. The state will be stored in
      * the configured state backend.
      *
-     * <p>NOTE: Checkpointing iterative streaming dataflows in not properly supported at the moment.
+     * <p>NOTE: Checkpointing iterative streaming dataflows is not properly supported at the moment.
      * For that reason, iterative jobs will not be started if used with enabled checkpointing. To
      * override this mechanism, use the {@link #enableCheckpointing(long, CheckpointingMode,
      * boolean)} method.
@@ -502,7 +502,7 @@ public class StreamExecutionEnvironment {
      * {@link CheckpointingMode} for the checkpointing ("exactly once" vs "at least once"). The
      * state will be stored in the configured state backend.
      *
-     * <p>NOTE: Checkpointing iterative streaming dataflows in not properly supported at the moment.
+     * <p>NOTE: Checkpointing iterative streaming dataflows is not properly supported at the moment.
      * For that reason, iterative jobs will not be started if used with enabled checkpointing. To
      * override this mechanism, use the {@link #enableCheckpointing(long, CheckpointingMode,
      * boolean)} method.
@@ -525,7 +525,7 @@ public class StreamExecutionEnvironment {
      * <p>The job draws checkpoints periodically, in the given interval. The state will be stored in
      * the configured state backend.
      *
-     * <p>NOTE: Checkpointing iterative streaming dataflows in not properly supported at the moment.
+     * <p>NOTE: Checkpointing iterative streaming dataflows is not properly supported at the moment.
      * If the "force" parameter is set to true, the system will execute the job nonetheless.
      *
      * @param interval Time interval between state checkpoints in millis.
@@ -555,7 +555,7 @@ public class StreamExecutionEnvironment {
      * <p>The job draws checkpoints periodically, in the default interval. The state will be stored
      * in the configured state backend.
      *
-     * <p>NOTE: Checkpointing iterative streaming dataflows in not properly supported at the moment.
+     * <p>NOTE: Checkpointing iterative streaming dataflows is not properly supported at the moment.
      * For that reason, iterative jobs will not be started if used with enabled checkpointing. To
      * override this mechanism, use the {@link #enableCheckpointing(long, CheckpointingMode,
      * boolean)} method.
@@ -1140,7 +1140,7 @@ public class StreamExecutionEnvironment {
     }
 
     /**
-     * Creates a new data set that contains the given elements. The framework will determine the
+     * Creates a new data stream that contains the given elements. The framework will determine the
      * type according to the based type user supplied. The elements should be the same or be the
      * subclass to the based type. The sequence of elements must not be empty. Note that this
      * operation will result in a non-parallel data stream source, i.e. a data stream source with a


### PR DESCRIPTION
## What is the purpose of the change

Replace deprecated class, update doc, and fix typos


## Brief change log

  - Refactoring - replace the deprecated `ParquetAvroWriters` with the `AvroParquetWriters`
  - Update doc to use `AvroParquetWriters`
  - typos fix in `StreamExecutionEnvironment`


## Verifying this change

This change is a code and doc cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)