### PR TITLE
[FLINK-25974] Makes job cancellation rely on JobResultStore entry

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/JobCancellationFailedException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/JobCancellationFailedException.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher;
+
+import org.apache.flink.util.FlinkException;
+
+/** {@code JobCancellationFailedException} is thrown if the cancellation of a job failed. */
+public class JobCancellationFailedException extends FlinkException {
+
+    private static final long serialVersionUID = -5351974867056033752L;
+
+    public JobCancellationFailedException(String message) {
+        super(message);
+    }
+
+    public JobCancellationFailedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/CheckpointResourcesCleanupRunnerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/CheckpointResourcesCleanupRunnerFactory.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.dispatcher.cleanup;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
-import org.apache.flink.runtime.checkpoint.CheckpointsCleaner;
 import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.runtime.state.SharedStateRegistry;
 
@@ -42,7 +41,6 @@ public enum CheckpointResourcesCleanupRunnerFactory implements CleanupRunnerFact
         return new CheckpointResourcesCleanupRunner(
                 jobResult,
                 checkpointRecoveryFactory,
-                new CheckpointsCleaner(),
                 SharedStateRegistry.DEFAULT_FACTORY,
                 configuration,
                 cleanupExecutor,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterServiceLeadershipRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterServiceLeadershipRunner.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.jobmaster;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.dispatcher.JobCancellationFailedException;
 import org.apache.flink.runtime.execution.librarycache.LibraryCacheManager;
 import org.apache.flink.runtime.highavailability.JobResultStore;
 import org.apache.flink.runtime.jobmaster.factories.JobMasterServiceProcessFactory;
@@ -192,7 +193,7 @@ public class JobMasterServiceLeadershipRunner implements JobManagerRunner, Leade
                     .exceptionally(
                             e -> {
                                 throw new CompletionException(
-                                        new FlinkException(
+                                        new JobCancellationFailedException(
                                                 "Cancellation failed.",
                                                 ExceptionUtils.stripCompletionException(e)));
                             });

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -218,7 +218,7 @@ public class DispatcherTest extends AbstractDispatcherTest {
     public void testDuplicateJobSubmissionWithGloballyTerminatedJobId() throws Exception {
         final JobResult jobResult =
                 TestingJobResultStore.createJobResult(
-                        jobGraph.getJobID(), ApplicationStatus.UNKNOWN);
+                        jobGraph.getJobID(), ApplicationStatus.SUCCEEDED);
         haServices.getJobResultStore().createDirtyResult(new JobResultEntry(jobResult));
         dispatcher =
                 createAndStartDispatcher(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/TestingDispatcher.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/TestingDispatcher.java
@@ -180,7 +180,7 @@ class TestingDispatcher extends Dispatcher {
         private RpcService rpcService = new TestingRpcService();
         private DispatcherId fencingToken = DispatcherId.generate();
         private Collection<JobGraph> recoveredJobs = Collections.emptyList();
-        private Collection<JobResult> recoveredDirtyJobs = Collections.emptyList();
+        @Nullable private Collection<JobResult> recoveredDirtyJobs = null;
         private HighAvailabilityServices highAvailabilityServices =
                 new TestingHighAvailabilityServices();
 
@@ -232,7 +232,7 @@ class TestingDispatcher extends Dispatcher {
             return this;
         }
 
-        public Builder setRecoveredDirtyJobs(Collection<JobResult> recoveredDirtyJobs) {
+        public Builder setRecoveredDirtyJobs(@Nullable Collection<JobResult> recoveredDirtyJobs) {
             this.recoveredDirtyJobs = recoveredDirtyJobs;
             return this;
         }
@@ -359,7 +359,9 @@ class TestingDispatcher extends Dispatcher {
                     rpcService,
                     fencingToken,
                     recoveredJobs,
-                    recoveredDirtyJobs,
+                    recoveredDirtyJobs == null
+                            ? jobResultStore.getDirtyResults()
+                            : recoveredDirtyJobs,
                     configuration,
                     highAvailabilityServices,
                     resourceManagerGatewayRetriever,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/cleanup/CheckpointResourcesCleanupRunnerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/cleanup/CheckpointResourcesCleanupRunnerTest.java
@@ -25,7 +25,6 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.checkpoint.CheckpointIDCounter;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
-import org.apache.flink.runtime.checkpoint.CheckpointsCleaner;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpointStore;
 import org.apache.flink.runtime.checkpoint.TestingCheckpointIDCounter;
 import org.apache.flink.runtime.checkpoint.TestingCheckpointRecoveryFactory;
@@ -481,7 +480,6 @@ public class CheckpointResourcesCleanupRunnerTest {
         private JobResult jobResult = createDummySuccessJobResult();
         private CheckpointRecoveryFactory checkpointRecoveryFactory =
                 createCheckpointRecoveryFactory();
-        private CheckpointsCleaner checkpointsCleaner = new CheckpointsCleaner();
         private SharedStateRegistryFactory sharedStateRegistryFactory =
                 SharedStateRegistry.DEFAULT_FACTORY;
         private Executor executor = Executors.directExecutor();
@@ -496,11 +494,6 @@ public class CheckpointResourcesCleanupRunnerTest {
         public TestInstanceBuilder withCheckpointRecoveryFactory(
                 CheckpointRecoveryFactory checkpointRecoveryFactory) {
             this.checkpointRecoveryFactory = checkpointRecoveryFactory;
-            return this;
-        }
-
-        public TestInstanceBuilder withCheckpointsCleaner(CheckpointsCleaner checkpointsCleaner) {
-            this.checkpointsCleaner = checkpointsCleaner;
             return this;
         }
 
@@ -529,7 +522,6 @@ public class CheckpointResourcesCleanupRunnerTest {
             return new CheckpointResourcesCleanupRunner(
                     jobResult,
                     checkpointRecoveryFactory,
-                    checkpointsCleaner,
                     sharedStateRegistryFactory,
                     configuration,
                     executor,


### PR DESCRIPTION
## What is the purpose of the change

The introduction of the JobResultStore changes the dependencies
during cleanup a bit. The job's result is written to the JobResultStore
after it reaches a globally terminated state. The job cleanup
for the different components (including the JobManagerRunnerRegistry)
happens independently from each other.

With this commit we switch to relying on the entry in the JobResultStore
for cancellation. This is the ground-truth for globally-terminated jobs
now.


## Brief change log

* Extends `Dispatcher.cancelJob` to check the `JobResultStore` for entries

## Verifying this change

* A unit test was added to cover this code branch

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
