### PR TITLE
[FLINK-25745] Document incremental savepoints in CLAIM mode limitation

### DIFF
--- a/docs/content/docs/ops/state/savepoints.md
+++ b/docs/content/docs/ops/state/savepoints.md
@@ -269,10 +269,18 @@ the snapshot, while others still depend on it.
   {{< img src="/fig/restore-mode-claim.svg" alt="CLAIM restore mode" width="70%" >}}
 </div>
 
-{{< hint info >}}
-Retained checkpoints are stored in a path like `<checkpoint_dir>/<job_id>/chk_<x>`. Flink does not
+{{< hint warning >}}
+**Attention:**
+1. Retained checkpoints are stored in a path like `<checkpoint_dir>/<job_id>/chk_<x>`. Flink does not
 take ownership of the `<checkpoint_dir>/<job_id>` directory, but only the `chk_<x>`. The directory
 of the old job will not be deleted by Flink
+
+2. [Native](#savepoint-format) format supports incremental RocksDB savepoints. For those savepoints we put all
+SST files inside the savepoints directory. This means such savepoints are self-contained and relocatable.
+However, when restored in CLAIM mode, subsequent checkpoints might reuse some SST files, which
+in turn might block deleting the savepoints directory at the time the savepoint is subsumed. Later
+on we will delete the reused shared SST files, but we won't retry deleting the savepoints directory.
+Therefore, it is possible Flink leaves an empty savepoints directory if it was restored in CLAIM mode.    
 {{< /hint >}}
 
 **LEGACY**


### PR DESCRIPTION
## What is the purpose of the change
Document the limitation of CLAIM restore mode in combination with incremental savepoints.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
