### PR TITLE
[FLINK-25792][connectors] Only flushing the async sink base if it is …

### DIFF
--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/sink/writer/AsyncSinkWriterTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/sink/writer/AsyncSinkWriterTest.java
@@ -54,11 +54,13 @@ public class AsyncSinkWriterTest {
 
     private final List<Integer> res = new ArrayList<>();
     private TestSinkInitContext sinkInitContext;
+    private TestSinkInitContextAnyThreadMailbox sinkInitContextAnyThreadMailbox;
 
     @Before
     public void before() {
         res.clear();
         sinkInitContext = new TestSinkInitContext();
+        sinkInitContextAnyThreadMailbox = new TestSinkInitContextAnyThreadMailbox();
     }
 
     private void performNormalWriteOfEightyRecordsToMock()
@@ -241,10 +243,10 @@ public class AsyncSinkWriterTest {
                 sink, "965", Arrays.asList(25, 55), Arrays.asList());
 
         writeXToSinkAssertDestinationIsInStateYAndBufferHasZ(
-                sink, "75", Arrays.asList(25, 55), Arrays.asList(75));
+                sink, "75", Arrays.asList(25, 55, 965, 75), Arrays.asList());
 
         writeXToSinkAssertDestinationIsInStateYAndBufferHasZ(
-                sink, "95", Arrays.asList(25, 55), Arrays.asList(75, 95));
+                sink, "95", Arrays.asList(25, 55, 965, 75), Arrays.asList(95));
 
         /*
          * Writing 955 to the sink increases the buffer to size 3 containing [75, 95, 955]. This
@@ -257,16 +259,16 @@ public class AsyncSinkWriterTest {
          * 955 is in flight after failure.
          */
         writeXToSinkAssertDestinationIsInStateYAndBufferHasZ(
-                sink, "955", Arrays.asList(25, 55, 965, 75, 95), Arrays.asList());
+                sink, "955", Arrays.asList(25, 55, 965, 75), Arrays.asList(95, 955));
 
         writeXToSinkAssertDestinationIsInStateYAndBufferHasZ(
-                sink, "550", Arrays.asList(25, 55, 965, 75, 95), Arrays.asList(550));
+                sink, "550", Arrays.asList(25, 55, 965, 75, 95), Arrays.asList());
 
         /*
          * [550, 45] are attempted to be persisted
          */
         writeXToSinkAssertDestinationIsInStateYAndBufferHasZ(
-                sink, "45", Arrays.asList(25, 55, 965, 75, 95), Arrays.asList(550, 45));
+                sink, "45", Arrays.asList(25, 55, 965, 75, 95, 955, 550), Arrays.asList(45));
 
         /*
          * [550,45,35] triggers inflight request to be added, buffer should be [955,550,45,35]
@@ -276,17 +278,14 @@ public class AsyncSinkWriterTest {
          * All are persisted and batch size is 3.
          */
         writeXToSinkAssertDestinationIsInStateYAndBufferHasZ(
-                sink, "35", Arrays.asList(25, 55, 965, 75, 95, 955, 550, 45, 35), Arrays.asList());
+                sink, "35", Arrays.asList(25, 55, 965, 75, 95, 955, 550), Arrays.asList(45, 35));
 
         /* ] should be in the bufferedRequestEntries
          * [ 550] should be in the inFlightRequest, ready to be added
          * [25, 55, 965, 75, 95, 995, 45, 35] should be downstream already
          */
         writeXToSinkAssertDestinationIsInStateYAndBufferHasZ(
-                sink,
-                "535",
-                Arrays.asList(25, 55, 965, 75, 95, 955, 550, 45, 35),
-                Arrays.asList(535));
+                sink, "535", Arrays.asList(25, 55, 965, 75, 95, 955, 550, 45, 35), Arrays.asList());
 
         // Checkpoint occurs
         sink.flush(true);
@@ -297,35 +296,52 @@ public class AsyncSinkWriterTest {
     }
 
     @Test
-    public void testFailedEntriesAreRetriedInTheNextPossiblePersistRequestAndNoLater()
-            throws IOException, InterruptedException {
+    public void
+            testFailedEntriesAreRetriedInTheNextPossiblePersistRequestIfPrepareCommitIsTriggered()
+                    throws IOException, InterruptedException {
         AsyncSinkWriterImpl sink =
                 new AsyncSinkWriterImplBuilder()
                         .context(sinkInitContext)
                         .maxBatchSize(3)
                         .simulateFailures(true)
                         .build();
+        testFailedEntriesAreRetriedInTheNextPossiblePersistRequestAndNoLater(sink);
+    }
 
+    @Test
+    public void testFailedEntriesAreRetriedInTheNextPossiblePersistRequestIfBufferFillsToFull()
+            throws IOException, InterruptedException {
+        AsyncSinkWriterImpl sink =
+                new AsyncSinkWriterImplBuilder()
+                        .context(sinkInitContext)
+                        .maxBatchSize(3)
+                        .maxInFlightRequests(1)
+                        .maxBufferedRequests(8)
+                        .simulateFailures(true)
+                        .build();
+        testFailedEntriesAreRetriedInTheNextPossiblePersistRequestAndNoLater(sink);
+    }
+
+    private void testFailedEntriesAreRetriedInTheNextPossiblePersistRequestAndNoLater(
+            AsyncSinkWriterImpl sink) throws IOException, InterruptedException {
         sink.write("25");
         sink.write("55");
-        sink.write("965");
+        sink.write("965"); // Flush, 25, 55 succeeds, 965 fails and is moved in flight
         sink.write("75");
         sink.write("95");
         sink.write("955");
-        assertTrue(res.contains(965));
+        // Buffer has filled up to size 3, does not flush since there is an in flight request and
+        // the buffer still has space - in terms of both number of records and bytes
         sink.write("550");
         sink.write("645");
         sink.write("545");
         sink.write("535");
         sink.write("515");
-        assertTrue(res.contains(955));
         sink.write("505");
-        assertTrue(res.contains(550));
-        assertTrue(res.contains(645));
+        // Buffer continues to fill up without blocking on write, until eventually yield is called
+        // on the mailbox thread during the prepare commit
         sink.flush(true);
-        assertTrue(res.contains(545));
-        assertTrue(res.contains(535));
-        assertTrue(res.contains(515));
+        assertEquals(Arrays.asList(25, 55, 965, 75, 95, 955, 550, 645, 545, 535, 515, 505), res);
     }
 
     @Test
@@ -399,13 +415,10 @@ public class AsyncSinkWriterTest {
          * should occur once 7 elements have been written - an 8th element cannot be added since
          * that would make the buffer 32 bytes, which is over the threshold.
          */
-        for (int i = 0; i < 13; i++) {
+        for (int i = 0; i < 100; i++) {
             sink.write(String.valueOf(i));
+            assertEquals((i / 7) * 7, res.size());
         }
-        assertEquals(7, res.size());
-        sink.write(String.valueOf(13));
-        sink.write(String.valueOf(14));
-        assertEquals(14, res.size());
     }
 
     @Test
@@ -547,20 +560,22 @@ public class AsyncSinkWriterTest {
         AsyncSinkWriterImpl sink =
                 new AsyncSinkWriterImplBuilder()
                         .context(sinkInitContext)
-                        .maxBatchSize(3)
+                        .maxBatchSize(4)
                         .maxBufferedRequests(10)
                         .simulateFailures(true)
                         .build();
-        sink.write(String.valueOf(225)); // buffer :[225]
-        sink.write(String.valueOf(0)); // buffer [225,0]
-        sink.write(String.valueOf(1)); // buffer [225,0,1] -- flushing
-        sink.write(String.valueOf(2)); // flushing -- request should have [225,0,1], [225] fails,
-        // buffer has [2]
-        assertEquals(2, res.size());
+        sink.write(String.valueOf(225)); // buffer: [225]
+        sink.write(String.valueOf(0)); // buffer: [225, 0]
+        sink.write(String.valueOf(1)); // buffer: [225, 0, 1]
+        sink.write(String.valueOf(2)); // buffer: [225, 0, 1, 2] // flushing next round
+        sink.write(String.valueOf(3)); // flushing, request is [225, 0, 1, 2], [225] fails
+        sink.write(String.valueOf(4)); // buffer: [225, 3, 4]
+
+        assertEquals(4, res.size());
         sink.flush(false); // inflight should be added to  buffer still [225, 2]
-        assertEquals(2, res.size());
+        assertEquals(4, res.size());
         sink.flush(true); // buffer now flushed []
-        assertEquals(Arrays.asList(0, 1, 225, 2), res);
+        assertEquals(Arrays.asList(0, 1, 225, 2, 3, 4), res);
     }
 
     @Test
@@ -780,13 +795,8 @@ public class AsyncSinkWriterTest {
         CountDownLatch delayedStartLatch = new CountDownLatch(1);
         AsyncSinkWriterImpl sink =
                 new AsyncSinkReleaseAndBlockWriterImpl(
-                        sinkInitContext,
-                        3,
+                        sinkInitContextAnyThreadMailbox,
                         1,
-                        20,
-                        100,
-                        100,
-                        100,
                         blockedWriteLatch,
                         delayedStartLatch,
                         true);
@@ -816,19 +826,14 @@ public class AsyncSinkWriterTest {
         CountDownLatch delayedStartLatch = new CountDownLatch(1);
         AsyncSinkWriterImpl sink =
                 new AsyncSinkReleaseAndBlockWriterImpl(
-                        sinkInitContext,
-                        3,
+                        sinkInitContextAnyThreadMailbox,
                         2,
-                        20,
-                        100,
-                        100,
-                        100,
                         blockedWriteLatch,
                         delayedStartLatch,
                         false);
 
         writeTwoElementsAndInterleaveTheNextTwoElements(sink, blockedWriteLatch, delayedStartLatch);
-        assertEquals(new ArrayList<>(Arrays.asList(4, 1, 2, 3)), res);
+        assertEquals(Arrays.asList(4, 1, 2, 3), res);
     }
 
     private void writeTwoElementsAndInterleaveTheNextTwoElements(
@@ -860,6 +865,40 @@ public class AsyncSinkWriterTest {
         assertTrue(
                 es.awaitTermination(500, TimeUnit.MILLISECONDS),
                 "Executor Service stuck at termination, not terminated after 500ms!");
+    }
+
+    @Test
+    public void ifTheNumberOfUncompletedInFlightRequestsIsTooManyThenBlockInFlushMethod()
+            throws Exception {
+        CountDownLatch blockedWriteLatch = new CountDownLatch(1);
+        CountDownLatch delayedStartLatch = new CountDownLatch(1);
+        AsyncSinkWriterImpl sink =
+                new AsyncSinkReleaseAndBlockWriterImpl(
+                        sinkInitContextAnyThreadMailbox,
+                        1,
+                        blockedWriteLatch,
+                        delayedStartLatch,
+                        false);
+
+        Thread t =
+                new Thread(
+                        () -> {
+                            try {
+                                sink.write("1");
+                                sink.write("2");
+                                sink.write("3");
+                            } catch (IOException | InterruptedException e) {
+                                e.printStackTrace();
+                            }
+                        });
+        t.start();
+
+        delayedStartLatch.await();
+        blockedWriteLatch.countDown();
+
+        t.join();
+
+        assertEquals(Arrays.asList(1, 2, 3), res);
     }
 
     private BufferedRequestState<Integer> getWriterState(
@@ -1104,25 +1143,11 @@ public class AsyncSinkWriterTest {
 
         public AsyncSinkReleaseAndBlockWriterImpl(
                 Sink.InitContext context,
-                int maxBatchSize,
                 int maxInFlightRequests,
-                int maxBufferedRequests,
-                long maxBatchSizeInBytes,
-                long maxTimeInBufferMS,
-                long maxRecordSizeInBytes,
                 CountDownLatch blockedThreadLatch,
                 CountDownLatch delayedStartLatch,
                 boolean blockForLimitedTime) {
-            super(
-                    context,
-                    maxBatchSize,
-                    maxInFlightRequests,
-                    maxBufferedRequests,
-                    maxBatchSizeInBytes,
-                    maxTimeInBufferMS,
-                    maxRecordSizeInBytes,
-                    false,
-                    0);
+            super(context, 3, maxInFlightRequests, 20, 100, 100, 100, false, 0);
             this.blockedThreadLatch = blockedThreadLatch;
             this.delayedStartLatch = delayedStartLatch;
             this.blockForLimitedTime = blockForLimitedTime;

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/sink/writer/TestSinkInitContext.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/sink/writer/TestSinkInitContext.java
@@ -51,6 +51,24 @@ public class TestSinkInitContext implements Sink.InitContext {
     private final SinkWriterMetricGroup metricGroup =
             InternalSinkWriterMetricGroup.mock(
                     metricListener.getMetricGroup(), operatorIOMetricGroup);
+    StreamTaskActionExecutor streamTaskActionExecutor =
+            new StreamTaskActionExecutor() {
+                @Override
+                public void run(RunnableWithException e) throws Exception {
+                    e.run();
+                }
+
+                @Override
+                public <E extends Throwable> void runThrowing(ThrowingRunnable<E> throwingRunnable)
+                        throws E {
+                    throwingRunnable.run();
+                }
+
+                @Override
+                public <R> R call(Callable<R> callable) throws Exception {
+                    return callable.call();
+                }
+            };
 
     static {
         processingTimeService = new TestProcessingTimeService();
@@ -63,24 +81,6 @@ public class TestSinkInitContext implements Sink.InitContext {
 
     @Override
     public MailboxExecutor getMailboxExecutor() {
-        StreamTaskActionExecutor streamTaskActionExecutor =
-                new StreamTaskActionExecutor() {
-                    @Override
-                    public void run(RunnableWithException e) throws Exception {
-                        e.run();
-                    }
-
-                    @Override
-                    public <E extends Throwable> void runThrowing(
-                            ThrowingRunnable<E> throwingRunnable) throws E {
-                        throwingRunnable.run();
-                    }
-
-                    @Override
-                    public <R> R call(Callable<R> callable) throws Exception {
-                        return callable.call();
-                    }
-                };
         return new MailboxExecutorImpl(
                 new TaskMailboxImpl(Thread.currentThread()),
                 Integer.MAX_VALUE,

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/sink/writer/TestSinkInitContext.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/sink/writer/TestSinkInitContext.java
@@ -51,6 +51,8 @@ public class TestSinkInitContext implements Sink.InitContext {
     private final SinkWriterMetricGroup metricGroup =
             InternalSinkWriterMetricGroup.mock(
                     metricListener.getMetricGroup(), operatorIOMetricGroup);
+    private final MailboxExecutor mailboxExecutor;
+
     StreamTaskActionExecutor streamTaskActionExecutor =
             new StreamTaskActionExecutor() {
                 @Override
@@ -70,6 +72,14 @@ public class TestSinkInitContext implements Sink.InitContext {
                 }
             };
 
+    public TestSinkInitContext() {
+        mailboxExecutor =
+                new MailboxExecutorImpl(
+                        new TaskMailboxImpl(Thread.currentThread()),
+                        Integer.MAX_VALUE,
+                        streamTaskActionExecutor);
+    }
+
     static {
         processingTimeService = new TestProcessingTimeService();
     }
@@ -81,10 +91,7 @@ public class TestSinkInitContext implements Sink.InitContext {
 
     @Override
     public MailboxExecutor getMailboxExecutor() {
-        return new MailboxExecutorImpl(
-                new TaskMailboxImpl(Thread.currentThread()),
-                Integer.MAX_VALUE,
-                streamTaskActionExecutor);
+        return mailboxExecutor;
     }
 
     @Override

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/sink/writer/TestSinkInitContextAnyThreadMailbox.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/sink/writer/TestSinkInitContextAnyThreadMailbox.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.base.sink.writer;
+
+import org.apache.flink.api.common.operators.MailboxExecutor;
+import org.apache.flink.streaming.runtime.tasks.mailbox.MailboxExecutorImpl;
+import org.apache.flink.streaming.runtime.tasks.mailbox.TaskMailboxImpl;
+
+/**
+ * A mock implementation of a {@code Sink.InitContext} to be used in sink unit tests.
+ *
+ * <p>The only difference between this and {@link TestSinkInitContext} is that the mailbox thread
+ * methods of this context may be accessed from any thread. This is useful for testing fine-grained
+ * interleaving of threads that may be in the asynchronous part of {@code submitRequestEntries()} in
+ * the concrete sink against new mailbox threads entering {@code write()} in the base sink.
+ *
+ * <p>However, care must be taken to ensure deadlocks do not form in the test code, since we are
+ * artificially allowing multiple mailbox threads, when only one is supposed to exist.
+ */
+public class TestSinkInitContextAnyThreadMailbox extends TestSinkInitContext {
+    @Override
+    public MailboxExecutor getMailboxExecutor() {
+        return new MailboxExecutorImpl(
+                new AnyThreadTaskMailboxImpl(Thread.currentThread()),
+                Integer.MAX_VALUE,
+                streamTaskActionExecutor);
+    }
+
+    private static class AnyThreadTaskMailboxImpl extends TaskMailboxImpl {
+        public AnyThreadTaskMailboxImpl(Thread currentThread) {
+            super(currentThread);
+        }
+
+        @Override
+        public boolean isMailboxThread() {
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
…possible to do it in a non blocking fashion or if the buffer is full

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Only flushing the async sink base if it is possible to do it in a non blocking fashion or if the buffer is full

## Brief change log

Added conditions to flushing logic in AsyncSinkBase

## Verifying this change

Unit tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)n
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)n
  - The serializers: (yes / no / don't know)n
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)y
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)n
  - The S3 file system connector: (yes / no / don't know)n

## Documentation

  - Does this pull request introduce a new feature? (yes / no)n
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)n
