### PR TITLE
[FLINK-26001][avro] Implement ProjectableDecodingFormat for avro BulkDecodingFormat

### DIFF
--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroFileFormatFactory.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroFileFormatFactory.java
@@ -31,7 +31,9 @@ import org.apache.flink.connector.file.table.format.BulkDecodingFormat;
 import org.apache.flink.core.fs.FSDataOutputStream;
 import org.apache.flink.formats.avro.typeutils.AvroSchemaConverter;
 import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.Projection;
 import org.apache.flink.table.connector.format.EncodingFormat;
+import org.apache.flink.table.connector.format.ProjectableDecodingFormat;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.data.GenericRowData;
@@ -65,19 +67,7 @@ public class AvroFileFormatFactory implements BulkReaderFormatFactory, BulkWrite
     @Override
     public BulkDecodingFormat<RowData> createDecodingFormat(
             DynamicTableFactory.Context context, ReadableConfig formatOptions) {
-        return new BulkDecodingFormat<RowData>() {
-            @Override
-            public BulkFormat<RowData, FileSourceSplit> createRuntimeDecoder(
-                    DynamicTableSource.Context sourceContext, DataType producedDataType) {
-                return new AvroGenericRecordBulkFormat(
-                        sourceContext, (RowType) producedDataType.getLogicalType().copy(false));
-            }
-
-            @Override
-            public ChangelogMode getChangelogMode() {
-                return ChangelogMode.insertOnly();
-            }
-        };
+        return new AvroBulkDecodingFormat();
     }
 
     @Override
@@ -120,6 +110,26 @@ public class AvroFileFormatFactory implements BulkReaderFormatFactory, BulkWrite
     @Override
     public Set<ConfigOption<?>> forwardOptions() {
         return optionalOptions();
+    }
+
+    private static class AvroBulkDecodingFormat
+            implements BulkDecodingFormat<RowData>,
+                    ProjectableDecodingFormat<BulkFormat<RowData, FileSourceSplit>> {
+
+        @Override
+        public BulkFormat<RowData, FileSourceSplit> createRuntimeDecoder(
+                DynamicTableSource.Context context,
+                DataType physicalDataType,
+                int[][] projections) {
+            DataType producedDataType = Projection.of(projections).project(physicalDataType);
+            return new AvroGenericRecordBulkFormat(
+                    context, (RowType) producedDataType.getLogicalType().copy(false));
+        }
+
+        @Override
+        public ChangelogMode getChangelogMode() {
+            return ChangelogMode.insertOnly();
+        }
     }
 
     private static class AvroGenericRecordBulkFormat


### PR DESCRIPTION
## What is the purpose of the change

Currently `BulkDecodingFormat` of avro does not also implement `ProjectableDecodingFormat` and the reader will have to read unused columns.

This PR implements `ProjectableDecodingFormat` to optimize reading from avro files.

## Brief change log

 - Implement `ProjectableDecodingFormat` for avro `BulkDecodingFormat`.

## Verifying this change

This change is already covered by existing tests, such as `AvroFilesystemITCase#testProjectPushDown`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable