### PR TITLE
[FLINK-25907][runtime][security] Add pluggable delegation token manager

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -32,6 +32,7 @@ import org.apache.flink.configuration.JMXServerOptions;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.configuration.SchedulerExecutionMode;
+import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.configuration.WebOptions;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.plugin.PluginManager;
@@ -47,6 +48,7 @@ import org.apache.flink.runtime.dispatcher.MiniDispatcher;
 import org.apache.flink.runtime.entrypoint.component.DispatcherResourceManagerComponent;
 import org.apache.flink.runtime.entrypoint.component.DispatcherResourceManagerComponentFactory;
 import org.apache.flink.runtime.entrypoint.parser.CommandLineParser;
+import org.apache.flink.runtime.hadoop.HadoopDependency;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServicesUtils;
@@ -65,6 +67,9 @@ import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.security.SecurityConfiguration;
 import org.apache.flink.runtime.security.SecurityUtils;
 import org.apache.flink.runtime.security.contexts.SecurityContext;
+import org.apache.flink.runtime.security.token.DelegationTokenManager;
+import org.apache.flink.runtime.security.token.KerberosDelegationTokenManager;
+import org.apache.flink.runtime.security.token.NoOpDelegationTokenManager;
 import org.apache.flink.runtime.util.ZooKeeperUtils;
 import org.apache.flink.runtime.webmonitor.retriever.impl.RpcMetricQueryServiceRetriever;
 import org.apache.flink.util.AutoCloseableAsync;
@@ -148,6 +153,9 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
 
     @GuardedBy("lock")
     private HeartbeatServices heartbeatServices;
+
+    @GuardedBy("lock")
+    private DelegationTokenManager delegationTokenManager;
 
     @GuardedBy("lock")
     private RpcService commonRpcService;
@@ -293,6 +301,7 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
                             haServices,
                             blobServer,
                             heartbeatServices,
+                            delegationTokenManager,
                             metricRegistry,
                             executionGraphInfoStore,
                             new RpcMetricQueryServiceRetriever(
@@ -382,6 +391,12 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
             blobServer.start();
             configuration.setString(BlobServerOptions.PORT, String.valueOf(blobServer.getPort()));
             heartbeatServices = createHeartbeatServices(configuration);
+            delegationTokenManager =
+                    configuration.getBoolean(SecurityOptions.KERBEROS_FETCH_DELEGATION_TOKEN)
+                                    && HadoopDependency.isHadoopCommonOnClasspath(
+                                            getClass().getClassLoader())
+                            ? new KerberosDelegationTokenManager(configuration)
+                            : new NoOpDelegationTokenManager();
             metricRegistry = createMetricRegistry(configuration, pluginManager, rpcSystem);
 
             final RpcService metricQueryServiceRpcService =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/DefaultDispatcherResourceManagerComponentFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/DefaultDispatcherResourceManagerComponentFactory.java
@@ -54,6 +54,7 @@ import org.apache.flink.runtime.rest.handler.legacy.metrics.VoidMetricFetcher;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.RpcUtils;
+import org.apache.flink.runtime.security.token.DelegationTokenManager;
 import org.apache.flink.runtime.webmonitor.WebMonitorEndpoint;
 import org.apache.flink.runtime.webmonitor.retriever.LeaderGatewayRetriever;
 import org.apache.flink.runtime.webmonitor.retriever.MetricQueryServiceRetriever;
@@ -108,6 +109,7 @@ public class DefaultDispatcherResourceManagerComponentFactory
             HighAvailabilityServices highAvailabilityServices,
             BlobServer blobServer,
             HeartbeatServices heartbeatServices,
+            DelegationTokenManager delegationTokenManager,
             MetricRegistry metricRegistry,
             ExecutionGraphInfoStore executionGraphInfoStore,
             MetricQueryServiceRetriever metricQueryServiceRetriever,
@@ -184,6 +186,7 @@ public class DefaultDispatcherResourceManagerComponentFactory
                             rpcService,
                             highAvailabilityServices,
                             heartbeatServices,
+                            delegationTokenManager,
                             fatalErrorHandler,
                             new ClusterInformation(hostname, blobServer.getPort()),
                             webMonitorEndpoint.getRestBaseUrl(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/DispatcherResourceManagerComponentFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/DispatcherResourceManagerComponentFactory.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.runtime.security.token.DelegationTokenManager;
 import org.apache.flink.runtime.webmonitor.retriever.MetricQueryServiceRetriever;
 
 import java.util.concurrent.Executor;
@@ -42,6 +43,7 @@ public interface DispatcherResourceManagerComponentFactory {
             HighAvailabilityServices highAvailabilityServices,
             BlobServer blobServer,
             HeartbeatServices heartbeatServices,
+            DelegationTokenManager delegationTokenManager,
             MetricRegistry metricRegistry,
             ExecutionGraphInfoStore executionGraphInfoStore,
             MetricQueryServiceRetriever metricQueryServiceRetriever,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/hadoop/HadoopDependency.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/hadoop/HadoopDependency.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.hadoop;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Responsible telling if specific Hadoop dependencies are on classpath. */
+public class HadoopDependency {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HadoopDependency.class);
+
+    public static boolean isHadoopCommonOnClasspath(ClassLoader classLoader) {
+        try {
+            LOG.debug("Checking whether hadoop common dependency in on classpath.");
+            Class.forName("org.apache.hadoop.conf.Configuration", false, classLoader);
+            Class.forName("org.apache.hadoop.security.UserGroupInformation", false, classLoader);
+            LOG.debug("Hadoop common dependency found on classpath.");
+            return true;
+        } catch (ClassNotFoundException e) {
+            LOG.debug("Hadoop common dependency cannot be found on classpath.");
+            return false;
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerFactory.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.metrics.groups.ResourceManagerMetricGroup;
 import org.apache.flink.runtime.metrics.groups.SlotManagerMetricGroup;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.runtime.security.token.DelegationTokenManager;
 import org.apache.flink.util.ConfigurationException;
 
 import org.slf4j.Logger;
@@ -54,6 +55,7 @@ public abstract class ResourceManagerFactory<T extends ResourceIDRetrievable> {
             RpcService rpcService,
             HighAvailabilityServices highAvailabilityServices,
             HeartbeatServices heartbeatServices,
+            DelegationTokenManager delegationTokenManager,
             FatalErrorHandler fatalErrorHandler,
             ClusterInformation clusterInformation,
             @Nullable String webInterfaceUrl,
@@ -83,6 +85,7 @@ public abstract class ResourceManagerFactory<T extends ResourceIDRetrievable> {
                 rpcService,
                 highAvailabilityServices,
                 heartbeatServices,
+                delegationTokenManager,
                 fatalErrorHandler,
                 clusterInformation,
                 webInterfaceUrl,
@@ -107,6 +110,7 @@ public abstract class ResourceManagerFactory<T extends ResourceIDRetrievable> {
                 context.getRpcService(),
                 leaderSessionId,
                 context.getHeartbeatServices(),
+                context.getDelegationTokenManager(),
                 context.getFatalErrorHandler(),
                 context.getClusterInformation(),
                 context.getWebInterfaceUrl(),
@@ -145,6 +149,7 @@ public abstract class ResourceManagerFactory<T extends ResourceIDRetrievable> {
             RpcService rpcService,
             UUID leaderSessionId,
             HeartbeatServices heartbeatServices,
+            DelegationTokenManager delegationTokenManager,
             FatalErrorHandler fatalErrorHandler,
             ClusterInformation clusterInformation,
             @Nullable String webInterfaceUrl,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerProcessContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerProcessContext.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.metrics.groups.ResourceManagerMetricGroup;
 import org.apache.flink.runtime.metrics.groups.SlotManagerMetricGroup;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.runtime.security.token.DelegationTokenManager;
 
 import javax.annotation.Nullable;
 
@@ -47,6 +48,7 @@ public class ResourceManagerProcessContext {
     private final RpcService rpcService;
     private final HighAvailabilityServices highAvailabilityServices;
     private final HeartbeatServices heartbeatServices;
+    private final DelegationTokenManager delegationTokenManager;
     private final FatalErrorHandler fatalErrorHandler;
     private final ClusterInformation clusterInformation;
     @Nullable private final String webInterfaceUrl;
@@ -61,6 +63,7 @@ public class ResourceManagerProcessContext {
             RpcService rpcService,
             HighAvailabilityServices highAvailabilityServices,
             HeartbeatServices heartbeatServices,
+            DelegationTokenManager delegationTokenManager,
             FatalErrorHandler fatalErrorHandler,
             ClusterInformation clusterInformation,
             @Nullable String webInterfaceUrl,
@@ -73,6 +76,7 @@ public class ResourceManagerProcessContext {
         this.rpcService = checkNotNull(rpcService);
         this.highAvailabilityServices = checkNotNull(highAvailabilityServices);
         this.heartbeatServices = checkNotNull(heartbeatServices);
+        this.delegationTokenManager = checkNotNull(delegationTokenManager);
         this.fatalErrorHandler = checkNotNull(fatalErrorHandler);
         this.clusterInformation = checkNotNull(clusterInformation);
         this.resourceManagerMetricGroup = checkNotNull(resourceManagerMetricGroup);
@@ -104,6 +108,10 @@ public class ResourceManagerProcessContext {
 
     public HeartbeatServices getHeartbeatServices() {
         return heartbeatServices;
+    }
+
+    public DelegationTokenManager getDelegationTokenManager() {
+        return delegationTokenManager;
     }
 
     public FatalErrorHandler getFatalErrorHandler() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerServiceImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerServiceImpl.java
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.leaderelection.LeaderElectionService;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.runtime.security.token.DelegationTokenManager;
 import org.apache.flink.util.ConfigurationException;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.concurrent.FutureUtils;
@@ -346,6 +347,7 @@ public class ResourceManagerServiceImpl implements ResourceManagerService, Leade
             RpcService rpcService,
             HighAvailabilityServices highAvailabilityServices,
             HeartbeatServices heartbeatServices,
+            DelegationTokenManager delegationTokenManager,
             FatalErrorHandler fatalErrorHandler,
             ClusterInformation clusterInformation,
             @Nullable String webInterfaceUrl,
@@ -362,6 +364,7 @@ public class ResourceManagerServiceImpl implements ResourceManagerService, Leade
                         rpcService,
                         highAvailabilityServices,
                         heartbeatServices,
+                        delegationTokenManager,
                         fatalErrorHandler,
                         clusterInformation,
                         webInterfaceUrl,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/StandaloneResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/StandaloneResourceManager.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.resourcemanager.exceptions.ResourceManagerExcept
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.runtime.security.token.DelegationTokenManager;
 import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nullable;
@@ -53,6 +54,7 @@ public class StandaloneResourceManager extends ResourceManager<ResourceID> {
             UUID leaderSessionId,
             ResourceID resourceId,
             HeartbeatServices heartbeatServices,
+            DelegationTokenManager delegationTokenManager,
             SlotManager slotManager,
             ResourceManagerPartitionTrackerFactory clusterPartitionTrackerFactory,
             JobLeaderIdService jobLeaderIdService,
@@ -67,6 +69,7 @@ public class StandaloneResourceManager extends ResourceManager<ResourceID> {
                 leaderSessionId,
                 resourceId,
                 heartbeatServices,
+                delegationTokenManager,
                 slotManager,
                 clusterPartitionTrackerFactory,
                 jobLeaderIdService,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/StandaloneResourceManagerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/StandaloneResourceManagerFactory.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.io.network.partition.ResourceManagerPartitionTra
 import org.apache.flink.runtime.metrics.groups.ResourceManagerMetricGroup;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.runtime.security.token.DelegationTokenManager;
 import org.apache.flink.util.ConfigurationException;
 
 import org.slf4j.Logger;
@@ -62,6 +63,7 @@ public final class StandaloneResourceManagerFactory extends ResourceManagerFacto
             RpcService rpcService,
             UUID leaderSessionId,
             HeartbeatServices heartbeatServices,
+            DelegationTokenManager delegationTokenManager,
             FatalErrorHandler fatalErrorHandler,
             ClusterInformation clusterInformation,
             @Nullable String webInterfaceUrl,
@@ -77,6 +79,7 @@ public final class StandaloneResourceManagerFactory extends ResourceManagerFacto
                 leaderSessionId,
                 resourceId,
                 heartbeatServices,
+                delegationTokenManager,
                 resourceManagerRuntimeServices.getSlotManager(),
                 ResourceManagerPartitionTrackerImpl::new,
                 resourceManagerRuntimeServices.getJobLeaderIdService(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManager.java
@@ -40,6 +40,7 @@ import org.apache.flink.runtime.resourcemanager.exceptions.ResourceManagerExcept
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.runtime.security.token.DelegationTokenManager;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.concurrent.FutureUtils;
 import org.apache.flink.util.concurrent.ScheduledExecutor;
@@ -107,6 +108,7 @@ public class ActiveResourceManager<WorkerType extends ResourceIDRetrievable>
             UUID leaderSessionId,
             ResourceID resourceId,
             HeartbeatServices heartbeatServices,
+            DelegationTokenManager delegationTokenManager,
             SlotManager slotManager,
             ResourceManagerPartitionTrackerFactory clusterPartitionTrackerFactory,
             JobLeaderIdService jobLeaderIdService,
@@ -122,6 +124,7 @@ public class ActiveResourceManager<WorkerType extends ResourceIDRetrievable>
                 leaderSessionId,
                 resourceId,
                 heartbeatServices,
+                delegationTokenManager,
                 slotManager,
                 clusterPartitionTrackerFactory,
                 jobLeaderIdService,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerFactory.java
@@ -38,6 +38,7 @@ import org.apache.flink.runtime.resourcemanager.ResourceManagerFactory;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerRuntimeServices;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.runtime.security.token.DelegationTokenManager;
 
 import javax.annotation.Nullable;
 
@@ -93,6 +94,7 @@ public abstract class ActiveResourceManagerFactory<WorkerType extends ResourceID
             RpcService rpcService,
             UUID leaderSessionId,
             HeartbeatServices heartbeatServices,
+            DelegationTokenManager delegationTokenManager,
             FatalErrorHandler fatalErrorHandler,
             ClusterInformation clusterInformation,
             @Nullable String webInterfaceUrl,
@@ -114,6 +116,7 @@ public abstract class ActiveResourceManagerFactory<WorkerType extends ResourceID
                 leaderSessionId,
                 resourceId,
                 heartbeatServices,
+                delegationTokenManager,
                 resourceManagerRuntimeServices.getSlotManager(),
                 ResourceManagerPartitionTrackerImpl::new,
                 resourceManagerRuntimeServices.getJobLeaderIdService(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/contexts/HadoopSecurityContextFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/contexts/HadoopSecurityContextFactory.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.security.contexts;
 
+import org.apache.flink.runtime.hadoop.HadoopDependency;
 import org.apache.flink.runtime.security.SecurityConfiguration;
 import org.apache.flink.runtime.security.SecurityContextInitializeException;
 import org.apache.flink.runtime.security.modules.HadoopModuleFactory;
@@ -43,17 +44,13 @@ public class HadoopSecurityContextFactory implements SecurityContextFactory {
             return false;
         }
         // not compatible if Hadoop binary not in classpath.
-        try {
-            Class.forName(
-                    "org.apache.hadoop.security.UserGroupInformation",
-                    false,
-                    HadoopSecurityContextFactory.class.getClassLoader());
-            return true;
-        } catch (ClassNotFoundException e) {
+        if (!HadoopDependency.isHadoopCommonOnClasspath(
+                HadoopSecurityContextFactory.class.getClassLoader())) {
             LOG.info(
                     "Cannot install HadoopSecurityContext because Hadoop cannot be found in the Classpath.");
             return false;
         }
+        return true;
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/modules/HadoopModuleFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/modules/HadoopModuleFactory.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.security.modules;
 
+import org.apache.flink.runtime.hadoop.HadoopDependency;
 import org.apache.flink.runtime.security.SecurityConfiguration;
 import org.apache.flink.runtime.util.HadoopUtils;
 
@@ -36,12 +37,7 @@ public class HadoopModuleFactory implements SecurityModuleFactory {
     @Override
     public SecurityModule createModule(SecurityConfiguration securityConfig) {
         // First check if we have Hadoop in the ClassPath. If not, we simply don't do anything.
-        try {
-            Class.forName(
-                    "org.apache.hadoop.conf.Configuration",
-                    false,
-                    HadoopModule.class.getClassLoader());
-        } catch (ClassNotFoundException e) {
+        if (!HadoopDependency.isHadoopCommonOnClasspath(HadoopModule.class.getClassLoader())) {
             LOG.info(
                     "Cannot create Hadoop Security Module because Hadoop cannot be found in the Classpath.");
             return null;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DelegationTokenConverter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DelegationTokenConverter.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.security.token;
+
+import org.apache.hadoop.io.DataOutputBuffer;
+import org.apache.hadoop.security.Credentials;
+
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.io.IOException;
+
+/** Delegation token serializer and deserializer functionality. */
+public class DelegationTokenConverter {
+    /** Serializes delegation tokens. */
+    public static byte[] serialize(Credentials credentials) throws IOException {
+        try (DataOutputBuffer dob = new DataOutputBuffer()) {
+            credentials.writeTokenStorageToStream(dob);
+            return dob.getData();
+        }
+    }
+
+    /** Deserializes delegation tokens. */
+    public static Credentials deserialize(byte[] credentialsBytes) throws IOException {
+        try (DataInputStream dis =
+                new DataInputStream(new ByteArrayInputStream(credentialsBytes))) {
+            Credentials credentials = new Credentials();
+            credentials.readTokenStorageStream(dis);
+            return credentials;
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DelegationTokenManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DelegationTokenManager.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.security.token;
+
+import org.apache.hadoop.security.Credentials;
+
+/**
+ * Manager for delegation tokens in a Flink cluster.
+ *
+ * <p>When delegation token renewal is enabled, this manager will make sure long-running apps can
+ * run without interruption while accessing secured services. It must contact all the configured
+ * secure services to obtain delegation tokens to be distributed to the rest of the application.
+ */
+public interface DelegationTokenManager {
+
+    /**
+     * Obtains new tokens in a one-time fashion and leaves it up to the caller to distribute them.
+     */
+    void obtainDelegationTokens(Credentials credentials);
+
+    /**
+     * Creates a re-occurring task which obtains new tokens and automatically distributes them to
+     * task managers.
+     */
+    void start();
+
+    /** Stops re-occurring token obtain task. */
+    void stop();
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DelegationTokenProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DelegationTokenProvider.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.security.token;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.configuration.Configuration;
+
+import org.apache.hadoop.security.Credentials;
+
+import java.util.Optional;
+
+/**
+ * Delegation token provider API. Instances of token providers are loaded by {@link
+ * DelegationTokenManager} through service loader.
+ */
+@Experimental
+public interface DelegationTokenProvider {
+    /** Name of the service to provide delegation tokens. This name should be unique. */
+    String serviceName();
+
+    /**
+     * Called by {@link DelegationTokenManager} to initialize provider after construction.
+     *
+     * @param configuration Configuration to initialize the provider.
+     */
+    void init(Configuration configuration);
+
+    /**
+     * Return whether delegation tokens are required for this service.
+     *
+     * @return true if delegation tokens are required.
+     */
+    boolean delegationTokensRequired();
+
+    /**
+     * Obtain delegation tokens for this service.
+     *
+     * @param credentials Credentials to add tokens and security keys to.
+     * @return If the returned tokens are renewable and can be renewed, return the time of the next
+     *     renewal, otherwise `Optional.empty()` should be returned.
+     */
+    Optional<Long> obtainDelegationTokens(Credentials credentials);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/KerberosDelegationTokenManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/KerberosDelegationTokenManager.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.security.token;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.configuration.Configuration;
+
+import org.apache.hadoop.security.Credentials;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.ServiceLoader;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Manager for delegation tokens in a Flink cluster.
+ *
+ * <p>When delegation token renewal is enabled, this manager will make sure long-running apps can
+ * run without interruption while accessing secured services. It periodically logs in to the KDC
+ * with user-provided credentials, and contacts all the configured secure services to obtain
+ * delegation tokens to be distributed to the rest of the application.
+ */
+public class KerberosDelegationTokenManager implements DelegationTokenManager {
+
+    private static final Logger LOG = LoggerFactory.getLogger(KerberosDelegationTokenManager.class);
+
+    private final Configuration configuration;
+
+    @VisibleForTesting final Map<String, DelegationTokenProvider> delegationTokenProviders;
+
+    public KerberosDelegationTokenManager(Configuration configuration) {
+        this.configuration = checkNotNull(configuration, "Flink configuration must not be null");
+        this.delegationTokenProviders = loadProviders();
+    }
+
+    private Map<String, DelegationTokenProvider> loadProviders() {
+        LOG.info("Loading delegation token providers");
+
+        ServiceLoader<DelegationTokenProvider> serviceLoader =
+                ServiceLoader.load(DelegationTokenProvider.class);
+
+        Map<String, DelegationTokenProvider> providers = new HashMap<>();
+        for (DelegationTokenProvider provider : serviceLoader) {
+            try {
+                if (isProviderEnabled(provider.serviceName())) {
+                    provider.init(configuration);
+                    LOG.info(
+                            "Delegation token provider {} loaded and initialized",
+                            provider.serviceName());
+                    providers.put(provider.serviceName(), provider);
+                } else {
+                    LOG.info(
+                            "Delegation token provider {} is disabled so not loaded",
+                            provider.serviceName());
+                }
+            } catch (Exception e) {
+                LOG.error(
+                        "Failed to initialize delegation token provider {}.",
+                        provider.serviceName(),
+                        e);
+                throw e;
+            }
+        }
+
+        LOG.info("Delegation token providers loaded successfully");
+
+        return providers;
+    }
+
+    @VisibleForTesting
+    boolean isProviderEnabled(String serviceName) {
+        return configuration.getBoolean(
+                String.format("security.kerberos.token.provider.%s.enabled", serviceName), true);
+    }
+
+    @VisibleForTesting
+    boolean isProviderLoaded(String serviceName) {
+        return delegationTokenProviders.containsKey(serviceName);
+    }
+
+    /**
+     * Obtains new tokens in a one-time fashion and leaves it up to the caller to distribute them.
+     */
+    @Override
+    public void obtainDelegationTokens(Credentials credentials) {
+        LOG.info("Obtaining delegation tokens");
+    }
+
+    /**
+     * Creates a re-occurring task which obtains new tokens and automatically distributes them to
+     * task managers.
+     */
+    @Override
+    public void start() {
+        LOG.info("Starting renewal task");
+    }
+
+    /** Stops re-occurring token obtain task. */
+    @Override
+    public void stop() {
+        LOG.info("Stopping renewal task");
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/NoOpDelegationTokenManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/NoOpDelegationTokenManager.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.security.token;
+
+import org.apache.hadoop.security.Credentials;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** {@link DelegationTokenManager} implementation which does nothing. */
+public class NoOpDelegationTokenManager implements DelegationTokenManager {
+
+    private static final Logger LOG = LoggerFactory.getLogger(NoOpDelegationTokenManager.class);
+
+    public NoOpDelegationTokenManager() {
+        LOG.debug("NoOpDelegationTokenManager");
+    }
+
+    @Override
+    public void obtainDelegationTokens(Credentials credentials) {
+        LOG.debug("obtainDelegationTokens");
+    }
+
+    @Override
+    public void start() {
+        LOG.debug("start");
+    }
+
+    @Override
+    public void stop() {
+        LOG.debug("stop");
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/ExecutionGraphInfoStoreTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/ExecutionGraphInfoStoreTestUtils.java
@@ -40,6 +40,7 @@ import org.apache.flink.runtime.resourcemanager.StandaloneResourceManagerFactory
 import org.apache.flink.runtime.rest.handler.legacy.utils.ArchivedExecutionGraphBuilder;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.scheduler.ExecutionGraphInfo;
+import org.apache.flink.runtime.security.token.DelegationTokenManager;
 import org.apache.flink.runtime.webmonitor.retriever.MetricQueryServiceRetriever;
 import org.apache.flink.testutils.TestingUtils;
 import org.apache.flink.util.Preconditions;
@@ -192,6 +193,7 @@ public class ExecutionGraphInfoStoreTestUtils {
                         RpcServiceFactory rpcServiceFactory,
                         BlobServer blobServer,
                         HeartbeatServices heartbeatServices,
+                        DelegationTokenManager delegationTokenManager,
                         MetricRegistry metricRegistry,
                         MetricQueryServiceRetriever metricQueryServiceRetriever,
                         FatalErrorHandler fatalErrorHandler)
@@ -232,6 +234,7 @@ public class ExecutionGraphInfoStoreTestUtils {
                             getHaServices(),
                             blobServer,
                             heartbeatServices,
+                            delegationTokenManager,
                             metricRegistry,
                             executionGraphInfoStore,
                             metricQueryServiceRetriever,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/minicluster/TestingMiniCluster.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/minicluster/TestingMiniCluster.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.runtime.security.token.DelegationTokenManager;
 import org.apache.flink.runtime.webmonitor.retriever.MetricQueryServiceRetriever;
 import org.apache.flink.util.concurrent.FutureUtils;
 
@@ -144,6 +145,7 @@ public class TestingMiniCluster extends MiniCluster {
                     RpcServiceFactory rpcServiceFactory,
                     BlobServer blobServer,
                     HeartbeatServices heartbeatServices,
+                    DelegationTokenManager delegationTokenManager,
                     MetricRegistry metricRegistry,
                     MetricQueryServiceRetriever metricQueryServiceRetriever,
                     FatalErrorHandler fatalErrorHandler)
@@ -170,6 +172,7 @@ public class TestingMiniCluster extends MiniCluster {
                             thisHaServices,
                             blobServer,
                             heartbeatServices,
+                            delegationTokenManager,
                             metricRegistry,
                             new MemoryExecutionGraphInfoStore(),
                             metricQueryServiceRetriever,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerServiceImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerServiceImplTest.java
@@ -31,6 +31,8 @@ import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.metrics.util.TestingMetricRegistry;
 import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.rpc.TestingRpcService;
+import org.apache.flink.runtime.security.token.DelegationTokenManager;
+import org.apache.flink.runtime.security.token.NoOpDelegationTokenManager;
 import org.apache.flink.runtime.util.TestingFatalErrorHandler;
 import org.apache.flink.util.TestLogger;
 
@@ -58,6 +60,8 @@ public class ResourceManagerServiceImplTest extends TestLogger {
     private static final Time FAST_TIMEOUT = Time.milliseconds(50L);
 
     private static final HeartbeatServices heartbeatServices = new TestingHeartbeatServices();
+    private static final DelegationTokenManager delegationTokenManager =
+            new NoOpDelegationTokenManager();
     private static final ClusterInformation clusterInformation =
             new ClusterInformation("localhost", 1234);
     private static final MetricRegistry metricRegistry = TestingMetricRegistry.builder().build();
@@ -125,6 +129,7 @@ public class ResourceManagerServiceImplTest extends TestLogger {
                         rpcService,
                         haService,
                         heartbeatServices,
+                        delegationTokenManager,
                         fatalErrorHandler,
                         clusterInformation,
                         null,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTest.java
@@ -43,6 +43,7 @@ import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerInfo;
 import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.rpc.exceptions.RecipientUnreachableException;
+import org.apache.flink.runtime.security.token.NoOpDelegationTokenManager;
 import org.apache.flink.runtime.slots.ResourceRequirement;
 import org.apache.flink.runtime.slots.ResourceRequirements;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
@@ -655,6 +656,7 @@ public class ResourceManagerTest extends TestLogger {
                             resourceManagerId.toUUID(),
                             resourceManagerResourceId,
                             heartbeatServices,
+                            new NoOpDelegationTokenManager(),
                             slotManager,
                             NoOpResourceManagerPartitionTracker::get,
                             jobLeaderIdService,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/StandaloneResourceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/StandaloneResourceManagerTest.java
@@ -32,6 +32,7 @@ import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.rpc.TestingRpcServiceResource;
+import org.apache.flink.runtime.security.token.DelegationTokenManager;
 import org.apache.flink.runtime.util.TestingFatalErrorHandler;
 import org.apache.flink.util.TestLogger;
 
@@ -108,6 +109,7 @@ public class StandaloneResourceManagerTest extends TestLogger {
                         UUID.randomUUID(),
                         ResourceID.generate(),
                         rmServices.heartbeatServices,
+                        rmServices.delegationTokenManager,
                         rmServices.slotManager,
                         rmServices.jobLeaderIdService,
                         new ClusterInformation("localhost", 1234),
@@ -128,6 +130,7 @@ public class StandaloneResourceManagerTest extends TestLogger {
                 UUID leaderSessionId,
                 ResourceID resourceId,
                 HeartbeatServices heartbeatServices,
+                DelegationTokenManager delegationTokenManager,
                 SlotManager slotManager,
                 JobLeaderIdService jobLeaderIdService,
                 ClusterInformation clusterInformation,
@@ -139,6 +142,7 @@ public class StandaloneResourceManagerTest extends TestLogger {
                     leaderSessionId,
                     resourceId,
                     heartbeatServices,
+                    delegationTokenManager,
                     slotManager,
                     NoOpResourceManagerPartitionTracker::get,
                     jobLeaderIdService,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/TestingResourceManager.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/TestingResourceManager.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.RpcUtils;
+import org.apache.flink.runtime.security.token.DelegationTokenManager;
 
 import javax.annotation.Nullable;
 
@@ -46,6 +47,7 @@ public class TestingResourceManager extends ResourceManager<ResourceID> {
             UUID leaderSessionId,
             ResourceID resourceId,
             HeartbeatServices heartbeatServices,
+            DelegationTokenManager delegationTokenManager,
             SlotManager slotManager,
             ResourceManagerPartitionTrackerFactory clusterPartitionTrackerFactory,
             JobLeaderIdService jobLeaderIdService,
@@ -57,6 +59,7 @@ public class TestingResourceManager extends ResourceManager<ResourceID> {
                 leaderSessionId,
                 resourceId,
                 heartbeatServices,
+                delegationTokenManager,
                 slotManager,
                 clusterPartitionTrackerFactory,
                 jobLeaderIdService,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/TestingResourceManagerFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/TestingResourceManagerFactory.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.metrics.groups.ResourceManagerMetricGroup;
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.runtime.security.token.DelegationTokenManager;
 import org.apache.flink.util.ConfigurationException;
 import org.apache.flink.util.function.TriConsumer;
 
@@ -74,6 +75,7 @@ public class TestingResourceManagerFactory extends ResourceManagerFactory<Resour
             RpcService rpcService,
             UUID leaderSessionId,
             HeartbeatServices heartbeatServices,
+            DelegationTokenManager delegationTokenManager,
             FatalErrorHandler fatalErrorHandler,
             ClusterInformation clusterInformation,
             @Nullable String webInterfaceUrl,
@@ -86,6 +88,7 @@ public class TestingResourceManagerFactory extends ResourceManagerFactory<Resour
                 leaderSessionId,
                 resourceId,
                 heartbeatServices,
+                delegationTokenManager,
                 resourceManagerRuntimeServices.getSlotManager(),
                 ResourceManagerPartitionTrackerImpl::new,
                 resourceManagerRuntimeServices.getJobLeaderIdService(),
@@ -167,6 +170,7 @@ public class TestingResourceManagerFactory extends ResourceManagerFactory<Resour
                 UUID leaderSessionId,
                 ResourceID resourceId,
                 HeartbeatServices heartbeatServices,
+                DelegationTokenManager delegationTokenManager,
                 SlotManager slotManager,
                 ResourceManagerPartitionTrackerFactory clusterPartitionTrackerFactory,
                 JobLeaderIdService jobLeaderIdService,
@@ -180,6 +184,7 @@ public class TestingResourceManagerFactory extends ResourceManagerFactory<Resour
                     leaderSessionId,
                     resourceId,
                     heartbeatServices,
+                    delegationTokenManager,
                     slotManager,
                     clusterPartitionTrackerFactory,
                     jobLeaderIdService,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/TestingResourceManagerService.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/TestingResourceManagerService.java
@@ -33,6 +33,7 @@ import org.apache.flink.runtime.rpc.FencedRpcEndpoint;
 import org.apache.flink.runtime.rpc.RpcEndpoint;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.TestingRpcService;
+import org.apache.flink.runtime.security.token.NoOpDelegationTokenManager;
 import org.apache.flink.runtime.util.TestingFatalErrorHandler;
 import org.apache.flink.util.concurrent.FutureUtils;
 
@@ -189,6 +190,7 @@ public class TestingResourceManagerService implements ResourceManagerService {
                             rpcService,
                             haServices,
                             new TestingHeartbeatServices(),
+                            new NoOpDelegationTokenManager(),
                             fatalErrorHandler,
                             new ClusterInformation("localhost", 1234),
                             null,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerTest.java
@@ -894,6 +894,7 @@ public class ActiveResourceManagerTest extends TestLogger {
                             UUID.randomUUID(),
                             ResourceID.generate(),
                             rmServices.heartbeatServices,
+                            rmServices.delegationTokenManager,
                             rmServices.slotManager,
                             NoOpResourceManagerPartitionTracker::get,
                             rmServices.jobLeaderIdService,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/utils/MockResourceManagerRuntimeServices.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/utils/MockResourceManagerRuntimeServices.java
@@ -28,6 +28,8 @@ import org.apache.flink.runtime.resourcemanager.JobLeaderIdService;
 import org.apache.flink.runtime.resourcemanager.slotmanager.DeclarativeSlotManagerBuilder;
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
 import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.runtime.security.token.DelegationTokenManager;
+import org.apache.flink.runtime.security.token.NoOpDelegationTokenManager;
 import org.apache.flink.runtime.testutils.DirectScheduledExecutorService;
 import org.apache.flink.util.concurrent.ScheduledExecutorServiceAdapter;
 
@@ -40,6 +42,7 @@ public class MockResourceManagerRuntimeServices {
     public final Time timeout;
     public final TestingHighAvailabilityServices highAvailabilityServices;
     public final HeartbeatServices heartbeatServices;
+    public final DelegationTokenManager delegationTokenManager;
     public final TestingLeaderElectionService rmLeaderElectionService;
     public final JobLeaderIdService jobLeaderIdService;
     public final SlotManager slotManager;
@@ -67,6 +70,7 @@ public class MockResourceManagerRuntimeServices {
         rmLeaderElectionService = new TestingLeaderElectionService();
         highAvailabilityServices.setResourceManagerLeaderElectionService(rmLeaderElectionService);
         heartbeatServices = new TestingHeartbeatServices();
+        delegationTokenManager = new NoOpDelegationTokenManager();
         jobLeaderIdService =
                 new DefaultJobLeaderIdService(
                         highAvailabilityServices,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/DelegationTokenConverterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/DelegationTokenConverterTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.security.token;
+
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.security.Credentials;
+import org.apache.hadoop.security.token.Token;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/** Test for {@link DelegationTokenConverter}. */
+public class DelegationTokenConverterTest {
+
+    @Test
+    public void testRoundTrip() throws IOException {
+        final Text tokenKind = new Text("TEST_TOKEN_KIND");
+        final Text tokenService = new Text("TEST_TOKEN_SERVICE");
+        Credentials credentials = new Credentials();
+        credentials.addToken(
+                tokenService, new Token<>(new byte[4], new byte[4], tokenKind, tokenService));
+
+        byte[] credentialsBytes = DelegationTokenConverter.serialize(credentials);
+        Credentials deserializedCredentials =
+                DelegationTokenConverter.deserialize(credentialsBytes);
+
+        assertEquals(1, credentials.getAllTokens().size());
+        assertEquals(1, deserializedCredentials.getAllTokens().size());
+        assertNotNull(credentials.getToken(tokenService));
+        assertNotNull(deserializedCredentials.getToken(tokenService));
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/ExceptionThrowingDelegationTokenProvider.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/ExceptionThrowingDelegationTokenProvider.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.security.token;
+
+import org.apache.flink.configuration.Configuration;
+
+import org.apache.hadoop.security.Credentials;
+
+import java.util.Optional;
+
+/**
+ * An example implementation of {@link DelegationTokenProvider} which throws exception when enabled.
+ */
+public class ExceptionThrowingDelegationTokenProvider implements DelegationTokenProvider {
+
+    public static volatile boolean enabled = false;
+    public static volatile boolean constructed = false;
+
+    public ExceptionThrowingDelegationTokenProvider() {
+        constructed = true;
+    }
+
+    @Override
+    public String serviceName() {
+        return "throw";
+    }
+
+    @Override
+    public void init(Configuration configuration) {
+        if (enabled) {
+            throw new IllegalArgumentException();
+        }
+    }
+
+    @Override
+    public boolean delegationTokensRequired() {
+        if (enabled) {
+            throw new IllegalArgumentException();
+        }
+        return false;
+    }
+
+    @Override
+    public Optional<Long> obtainDelegationTokens(Credentials credentials) {
+        if (enabled) {
+            throw new IllegalArgumentException();
+        }
+        return Optional.empty();
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/KerberosDelegationTokenManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/KerberosDelegationTokenManagerTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.security.token;
+
+import org.apache.flink.configuration.Configuration;
+
+import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Test for {@link DelegationTokenManager}. */
+public class KerberosDelegationTokenManagerTest {
+
+    @Test
+    public void isProviderEnabledMustGiveBackTrueByDefault() {
+        ExceptionThrowingDelegationTokenProvider.enabled = false;
+        Configuration configuration = new Configuration();
+        KerberosDelegationTokenManager delegationTokenManager =
+                new KerberosDelegationTokenManager(configuration);
+
+        assertTrue(delegationTokenManager.isProviderEnabled("test"));
+    }
+
+    @Test
+    public void isProviderEnabledMustGiveBackFalseWhenDisabled() {
+        ExceptionThrowingDelegationTokenProvider.enabled = false;
+        Configuration configuration = new Configuration();
+        configuration.setBoolean("security.kerberos.token.provider.test.enabled", false);
+        KerberosDelegationTokenManager delegationTokenManager =
+                new KerberosDelegationTokenManager(configuration);
+
+        assertFalse(delegationTokenManager.isProviderEnabled("test"));
+    }
+
+    @Test(expected = Exception.class)
+    public void configurationIsNullMustFailFast() {
+        new KerberosDelegationTokenManager(null);
+    }
+
+    @Test(expected = Exception.class)
+    public void oneProviderThrowsExceptionMustFailFast() {
+        try {
+            ExceptionThrowingDelegationTokenProvider.enabled = true;
+            new KerberosDelegationTokenManager(new Configuration());
+        } finally {
+            ExceptionThrowingDelegationTokenProvider.enabled = false;
+        }
+    }
+
+    @Test
+    public void testAllProvidersLoaded() {
+        ExceptionThrowingDelegationTokenProvider.enabled = false;
+        ExceptionThrowingDelegationTokenProvider.constructed = false;
+        Configuration configuration = new Configuration();
+        configuration.setBoolean("security.kerberos.token.provider.throw.enabled", false);
+        KerberosDelegationTokenManager delegationTokenManager =
+                new KerberosDelegationTokenManager(configuration);
+
+        assertEquals(1, delegationTokenManager.delegationTokenProviders.size());
+        assertTrue(delegationTokenManager.isProviderLoaded("test"));
+        assertTrue(ExceptionThrowingDelegationTokenProvider.constructed);
+        assertFalse(delegationTokenManager.isProviderLoaded("throw"));
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/TestDelegationTokenProvider.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/TestDelegationTokenProvider.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.security.token;
+
+import org.apache.flink.configuration.Configuration;
+
+import org.apache.hadoop.security.Credentials;
+
+import java.util.Optional;
+
+/** An example implementation of {@link DelegationTokenProvider} which does nothing. */
+public class TestDelegationTokenProvider implements DelegationTokenProvider {
+
+    @Override
+    public String serviceName() {
+        return "test";
+    }
+
+    @Override
+    public void init(Configuration configuration) {}
+
+    @Override
+    public boolean delegationTokensRequired() {
+        return false;
+    }
+
+    @Override
+    public Optional<Long> obtainDelegationTokens(Credentials credentials) {
+        return Optional.empty();
+    }
+}

--- a/flink-runtime/src/test/resources/META-INF/services/org.apache.flink.runtime.security.token.DelegationTokenProvider
+++ b/flink-runtime/src/test/resources/META-INF/services/org.apache.flink.runtime.security.token.DelegationTokenProvider
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.runtime.security.token.TestDelegationTokenProvider
+org.apache.flink.runtime.security.token.ExceptionThrowingDelegationTokenProvider

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
@@ -48,6 +48,7 @@ import org.apache.flink.runtime.rpc.AddressResolution;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.RpcSystem;
 import org.apache.flink.runtime.rpc.RpcUtils;
+import org.apache.flink.runtime.security.token.NoOpDelegationTokenManager;
 import org.apache.flink.runtime.util.BlobServerResource;
 import org.apache.flink.runtime.util.TestingFatalErrorHandler;
 import org.apache.flink.runtime.webmonitor.retriever.impl.VoidMetricQueryServiceRetriever;
@@ -147,6 +148,7 @@ public class ProcessFailureCancelingITCase extends TestLogger {
                             haServices,
                             blobServerResource.getBlobServer(),
                             new HeartbeatServices(100L, 10000L, 2),
+                            new NoOpDelegationTokenManager(),
                             NoOpMetricRegistry.INSTANCE,
                             new MemoryExecutionGraphInfoStore(),
                             VoidMetricQueryServiceRetriever.INSTANCE,

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/TaskManagerDisconnectOnShutdownITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/TaskManagerDisconnectOnShutdownITCase.java
@@ -44,6 +44,7 @@ import org.apache.flink.runtime.resourcemanager.StandaloneResourceManager;
 import org.apache.flink.runtime.resourcemanager.StandaloneResourceManagerFactory;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.runtime.security.token.DelegationTokenManager;
 import org.apache.flink.runtime.taskexecutor.SlotReport;
 import org.apache.flink.test.recovery.utils.TaskExecutorProcessEntryPoint;
 import org.apache.flink.test.util.TestProcessBuilder;
@@ -175,6 +176,7 @@ public class TaskManagerDisconnectOnShutdownITCase {
                 RpcService rpcService,
                 UUID leaderSessionId,
                 HeartbeatServices heartbeatServices,
+                DelegationTokenManager delegationTokenManager,
                 FatalErrorHandler fatalErrorHandler,
                 ClusterInformation clusterInformation,
                 @Nullable String webInterfaceUrl,
@@ -190,6 +192,7 @@ public class TaskManagerDisconnectOnShutdownITCase {
                     leaderSessionId,
                     resourceId,
                     heartbeatServices,
+                    delegationTokenManager,
                     resourceManagerRuntimeServices.getSlotManager(),
                     ResourceManagerPartitionTrackerImpl::new,
                     resourceManagerRuntimeServices.getJobLeaderIdService(),

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.ConfigUtils;
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
 import org.apache.flink.runtime.clusterframework.ContaineredTaskManagerParameters;
+import org.apache.flink.runtime.security.token.DelegationTokenConverter;
 import org.apache.flink.runtime.util.HadoopUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.StringUtils;
@@ -221,16 +222,9 @@ public final class Utils {
             LOG.info("Adding user token " + token.getService() + " with " + token);
             credentials.addToken(token.getService(), token);
         }
-        try (DataOutputBuffer dob = new DataOutputBuffer()) {
-            credentials.writeTokenStorageToStream(dob);
 
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Wrote tokens. Credentials buffer length: " + dob.getLength());
-            }
-
-            ByteBuffer securityTokens = ByteBuffer.wrap(dob.getData(), 0, dob.getLength());
-            amContainer.setTokens(securityTokens);
-        }
+        ByteBuffer tokens = ByteBuffer.wrap(DelegationTokenConverter.serialize(credentials));
+        amContainer.setTokens(tokens);
     }
 
     /** Obtain Kerberos security token for HBase. */


### PR DESCRIPTION
## What is the purpose of the change

It adds a pluggable delegation token framework to Flink. From high level perspective delegation token framework is loaded in all deployment modes when:
* `security.kerberos.fetch.delegation-token` is `true`
* `hadoop-common` dependency is on classpath

Please note that this PR is not adding the whole feature, there are several subtasks in [FLINK-21232](https://issues.apache.org/jira/browse/FLINK-21232) which needs to be solved as well.

## Brief change log

* Added generic `DelegationTokenManager` which is loaded in `ClusterEntrypoint`
* Added `DelegationTokenProvider` API
* `DelegationTokenProvider` implementations are loaded by `DelegationTokenManager` which is covered in unit tests
* Added delegation token serialization/deserialization functionality with unit tests
* Added the new framework usage to `YarnClusterDescriptor`

## Verifying this change

* Existing + new unit tests
* Manually
  * `security.kerberos.fetch.delegation-token=true` + `hadoop-common` dependency is on classpath
  * `security.kerberos.fetch.delegation-token=false` + `hadoop-common` dependency is on classpath
  * `security.kerberos.fetch.delegation-token=true` + `hadoop-common` dependency is NOT on classpath
  * `security.kerberos.fetch.delegation-token=false` + `hadoop-common` dependency is NOT on classpath

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? All documentation is intended to be added in [FLINK-25911](https://issues.apache.org/jira/browse/FLINK-25911) when everything works as a whole
