### PR TITLE
[FLINK-25697][Runtime / Metrics] introduce port url config for prometheus push gateway a…

### DIFF
--- a/docs/content.zh/docs/deployment/metric_reporters.md
+++ b/docs/content.zh/docs/deployment/metric_reporters.md
@@ -192,8 +192,7 @@ Example configuration:
 
 ```yaml
 metrics.reporter.promgateway.class: org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporter
-metrics.reporter.promgateway.host: localhost
-metrics.reporter.promgateway.port: 9091
+metrics.reporter.promgateway.hostUrl: http://localhost:9091
 metrics.reporter.promgateway.jobName: myJob
 metrics.reporter.promgateway.randomJobNameSuffix: true
 metrics.reporter.promgateway.deleteOnShutdown: false

--- a/docs/content/docs/deployment/metric_reporters.md
+++ b/docs/content/docs/deployment/metric_reporters.md
@@ -192,8 +192,7 @@ Example configuration:
 
 ```yaml
 metrics.reporter.promgateway.class: org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporter
-metrics.reporter.promgateway.host: localhost
-metrics.reporter.promgateway.port: 9091
+metrics.reporter.promgateway.hostUrl: http://localhost:9091
 metrics.reporter.promgateway.jobName: myJob
 metrics.reporter.promgateway.randomJobNameSuffix: true
 metrics.reporter.promgateway.deleteOnShutdown: false

--- a/docs/layouts/shortcodes/generated/prometheus_push_gateway_reporter_configuration.html
+++ b/docs/layouts/shortcodes/generated/prometheus_push_gateway_reporter_configuration.html
@@ -27,22 +27,16 @@
             <td>Specifies the grouping key which is the group and global labels of all metrics. The label name and value are separated by '=', and labels are separated by ';', e.g., <code class="highlighter-rouge">k1=v1;k2=v2</code>. Please ensure that your grouping key meets the <a href="https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels">Prometheus requirements</a>.</td>
         </tr>
         <tr>
-            <td><h5>host</h5></td>
+            <td><h5>hostUrl</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
-            <td>The PushGateway server host.</td>
+            <td>The PushGateway server host URL including scheme, host name, and port.</td>
         </tr>
         <tr>
             <td><h5>jobName</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
             <td>The job name under which metrics will be pushed</td>
-        </tr>
-        <tr>
-            <td><h5>port</h5></td>
-            <td style="word-wrap: break-word;">-1</td>
-            <td>Integer</td>
-            <td>The PushGateway server port.</td>
         </tr>
         <tr>
             <td><h5>randomJobNameSuffix</h5></td>

--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporter.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporter.java
@@ -30,7 +30,6 @@ import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.exporter.PushGateway;
 
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Map;
 
@@ -47,25 +46,15 @@ public class PrometheusPushGatewayReporter extends AbstractPrometheusReporter im
     private final String jobName;
     private final Map<String, String> groupingKey;
     private final boolean deleteOnShutdown;
+    @VisibleForTesting final URL hostUrl;
 
     PrometheusPushGatewayReporter(
-            String host,
-            int port,
+            URL hostUrl,
             String jobName,
             Map<String, String> groupingKey,
             final boolean deleteOnShutdown) {
-        this.pushGateway = new PushGateway(host + ':' + port);
-        this.jobName = Preconditions.checkNotNull(jobName);
-        this.groupingKey = Preconditions.checkNotNull(groupingKey);
-        this.deleteOnShutdown = deleteOnShutdown;
-    }
-
-    PrometheusPushGatewayReporter(
-            String hostUrl,
-            String jobName,
-            Map<String, String> groupingKey,
-            final boolean deleteOnShutdown) {
-        this.pushGateway = new PushGateway(tryCreateUrl(hostUrl));
+        this.hostUrl = hostUrl;
+        this.pushGateway = new PushGateway(hostUrl);
         this.jobName = Preconditions.checkNotNull(jobName);
         this.groupingKey = Preconditions.checkNotNull(groupingKey);
         this.deleteOnShutdown = deleteOnShutdown;
@@ -98,18 +87,5 @@ public class PrometheusPushGatewayReporter extends AbstractPrometheusReporter im
             }
         }
         super.close();
-    }
-
-    private static URL tryCreateUrl(String hostUrl) {
-        try {
-            return new URL(hostUrl);
-        } catch (MalformedURLException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    @VisibleForTesting
-    PushGateway getPushGateway() {
-        return pushGateway;
     }
 }

--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterFactory.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterFactory.java
@@ -35,6 +35,7 @@ import java.util.Properties;
 import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterOptions.DELETE_ON_SHUTDOWN;
 import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterOptions.GROUPING_KEY;
 import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterOptions.HOST;
+import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterOptions.HOST_URL;
 import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterOptions.JOB_NAME;
 import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterOptions.PORT;
 import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterOptions.RANDOM_JOB_NAME_SUFFIX;
@@ -63,9 +64,18 @@ public class PrometheusPushGatewayReporterFactory implements MetricReporterFacto
                 parseGroupingKey(
                         metricConfig.getString(GROUPING_KEY.key(), GROUPING_KEY.defaultValue()));
 
-        if (host == null || host.isEmpty() || port < 1) {
-            throw new IllegalArgumentException(
-                    "Invalid host/port configuration. Host: " + host + " Port: " + port);
+        String hostUrlConfig = metricConfig.getString(HOST_URL.key(), HOST_URL.defaultValue());
+
+        final String hostUrl;
+        if (hostUrlConfig != null && !hostUrlConfig.isEmpty()) {
+            hostUrl = hostUrlConfig;
+        } else {
+            if (host == null || host.isEmpty() || port < 1) {
+                throw new IllegalArgumentException(
+                        "Invalid host/port configuration. Host: " + host + " Port: " + port);
+            } else {
+                hostUrl = "http://" + host + ":" + port;
+            }
         }
 
         String jobName = configuredJobName;
@@ -74,16 +84,14 @@ public class PrometheusPushGatewayReporterFactory implements MetricReporterFacto
         }
 
         LOG.info(
-                "Configured PrometheusPushGatewayReporter with {host:{}, port:{}, jobName:{}, randomJobNameSuffix:{}, deleteOnShutdown:{}, groupingKey:{}}",
-                host,
-                port,
+                "Configured PrometheusPushGatewayReporter with {hostUrl:{}, jobName:{}, randomJobNameSuffix:{}, deleteOnShutdown:{}, groupingKey:{}}",
+                hostUrl,
                 jobName,
                 randomSuffix,
                 deleteOnShutdown,
                 groupingKey);
 
-        return new PrometheusPushGatewayReporter(
-                host, port, jobName, groupingKey, deleteOnShutdown);
+        return new PrometheusPushGatewayReporter(hostUrl, jobName, groupingKey, deleteOnShutdown);
     }
 
     @VisibleForTesting

--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterOptions.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterOptions.java
@@ -29,17 +29,26 @@ import org.apache.flink.configuration.description.TextElement;
 @Documentation.SuffixOption
 public class PrometheusPushGatewayReporterOptions {
 
+    @Deprecated
     public static final ConfigOption<String> HOST =
             ConfigOptions.key("host")
                     .stringType()
                     .noDefaultValue()
-                    .withDescription("The PushGateway server host.");
+                    .withDescription("(deprecated) The PushGateway server host.");
 
+    @Deprecated
     public static final ConfigOption<Integer> PORT =
             ConfigOptions.key("port")
                     .intType()
                     .defaultValue(-1)
-                    .withDescription("The PushGateway server port.");
+                    .withDescription("(deprecated) The PushGateway server port.");
+
+    public static final ConfigOption<String> HOST_URL =
+            ConfigOptions.key("hostUrl")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "The PushGateway server host URL including scheme, host name, and port.");
 
     public static final ConfigOption<String> JOB_NAME =
             ConfigOptions.key("jobName")

--- a/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterTest.java
+++ b/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterTest.java
@@ -18,12 +18,18 @@
 
 package org.apache.flink.metrics.prometheus;
 
+import org.apache.flink.metrics.MetricConfig;
+import org.apache.flink.mock.Whitebox;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Map;
+
+import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterOptions.HOST;
+import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterOptions.HOST_URL;
+import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterOptions.PORT;
 
 /** Test for {@link PrometheusPushGatewayReporter}. */
 public class PrometheusPushGatewayReporterTest extends TestLogger {
@@ -48,5 +54,53 @@ public class PrometheusPushGatewayReporterTest extends TestLogger {
 
         groupingKey = PrometheusPushGatewayReporterFactory.parseGroupingKey("k1");
         Assert.assertTrue(groupingKey.isEmpty());
+    }
+
+    @Test
+    public void testConnectToPushGatewayUsingHostAndPort() {
+        PrometheusPushGatewayReporterFactory factory = new PrometheusPushGatewayReporterFactory();
+        MetricConfig metricConfig = new MetricConfig();
+        metricConfig.setProperty(HOST.key(), "localhost");
+        metricConfig.setProperty(PORT.key(), "18080");
+        PrometheusPushGatewayReporter reporter = factory.createMetricReporter(metricConfig);
+        String gatewayBaseURL =
+                (String) Whitebox.getInternalState(reporter.getPushGateway(), "gatewayBaseURL");
+        Assert.assertEquals(gatewayBaseURL, "http://localhost:18080/metrics/");
+    }
+
+    @Test
+    public void testConnectToPushGatewayUsingHostUrl() {
+        PrometheusPushGatewayReporterFactory factory = new PrometheusPushGatewayReporterFactory();
+        MetricConfig metricConfig = new MetricConfig();
+        metricConfig.setProperty(HOST_URL.key(), "https://localhost:18080");
+        PrometheusPushGatewayReporter reporter = factory.createMetricReporter(metricConfig);
+        String gatewayBaseURL =
+                (String) Whitebox.getInternalState(reporter.getPushGateway(), "gatewayBaseURL");
+        Assert.assertEquals(gatewayBaseURL, "https://localhost:18080/metrics/");
+    }
+
+    @Test
+    public void testConnectToPushGatewayPreferHostUrl() {
+        PrometheusPushGatewayReporterFactory factory = new PrometheusPushGatewayReporterFactory();
+        MetricConfig metricConfig = new MetricConfig();
+        metricConfig.setProperty(HOST_URL.key(), "https://localhost:18080");
+        metricConfig.setProperty(HOST.key(), "localhost1");
+        metricConfig.setProperty(PORT.key(), "18081");
+        PrometheusPushGatewayReporter reporter = factory.createMetricReporter(metricConfig);
+        String gatewayBaseURL =
+                (String) Whitebox.getInternalState(reporter.getPushGateway(), "gatewayBaseURL");
+        Assert.assertEquals(gatewayBaseURL, "https://localhost:18080/metrics/");
+    }
+
+    @Test
+    public void testConnectToPushGatewayThrowsExceptionWithoutHostInformation() {
+        PrometheusPushGatewayReporterFactory factory = new PrometheusPushGatewayReporterFactory();
+        MetricConfig metricConfig = new MetricConfig();
+        Assert.assertThrows(
+                IllegalArgumentException.class, () -> factory.createMetricReporter(metricConfig));
+
+        metricConfig.setProperty(HOST.key(), "localhost");
+        Assert.assertThrows(
+                IllegalArgumentException.class, () -> factory.createMetricReporter(metricConfig));
     }
 }

--- a/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterTest.java
+++ b/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterTest.java
@@ -19,7 +19,6 @@
 package org.apache.flink.metrics.prometheus;
 
 import org.apache.flink.metrics.MetricConfig;
-import org.apache.flink.mock.Whitebox;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Assert;
@@ -63,9 +62,8 @@ public class PrometheusPushGatewayReporterTest extends TestLogger {
         metricConfig.setProperty(HOST.key(), "localhost");
         metricConfig.setProperty(PORT.key(), "18080");
         PrometheusPushGatewayReporter reporter = factory.createMetricReporter(metricConfig);
-        String gatewayBaseURL =
-                (String) Whitebox.getInternalState(reporter.getPushGateway(), "gatewayBaseURL");
-        Assert.assertEquals(gatewayBaseURL, "http://localhost:18080/metrics/");
+        String gatewayBaseURL = factory.createMetricReporter(metricConfig).hostUrl.toString();
+        Assert.assertEquals(gatewayBaseURL, "http://localhost:18080");
     }
 
     @Test
@@ -74,9 +72,8 @@ public class PrometheusPushGatewayReporterTest extends TestLogger {
         MetricConfig metricConfig = new MetricConfig();
         metricConfig.setProperty(HOST_URL.key(), "https://localhost:18080");
         PrometheusPushGatewayReporter reporter = factory.createMetricReporter(metricConfig);
-        String gatewayBaseURL =
-                (String) Whitebox.getInternalState(reporter.getPushGateway(), "gatewayBaseURL");
-        Assert.assertEquals(gatewayBaseURL, "https://localhost:18080/metrics/");
+        String gatewayBaseURL = factory.createMetricReporter(metricConfig).hostUrl.toString();
+        Assert.assertEquals(gatewayBaseURL, "https://localhost:18080");
     }
 
     @Test
@@ -86,10 +83,8 @@ public class PrometheusPushGatewayReporterTest extends TestLogger {
         metricConfig.setProperty(HOST_URL.key(), "https://localhost:18080");
         metricConfig.setProperty(HOST.key(), "localhost1");
         metricConfig.setProperty(PORT.key(), "18081");
-        PrometheusPushGatewayReporter reporter = factory.createMetricReporter(metricConfig);
-        String gatewayBaseURL =
-                (String) Whitebox.getInternalState(reporter.getPushGateway(), "gatewayBaseURL");
-        Assert.assertEquals(gatewayBaseURL, "https://localhost:18080/metrics/");
+        String gatewayBaseURL = factory.createMetricReporter(metricConfig).hostUrl.toString();
+        Assert.assertEquals(gatewayBaseURL, "https://localhost:18080");
     }
 
     @Test
@@ -100,6 +95,11 @@ public class PrometheusPushGatewayReporterTest extends TestLogger {
                 IllegalArgumentException.class, () -> factory.createMetricReporter(metricConfig));
 
         metricConfig.setProperty(HOST.key(), "localhost");
+        Assert.assertThrows(
+                IllegalArgumentException.class, () -> factory.createMetricReporter(metricConfig));
+
+        metricConfig.clear();
+        metricConfig.setProperty(PORT.key(), "18080");
         Assert.assertThrows(
                 IllegalArgumentException.class, () -> factory.createMetricReporter(metricConfig));
     }


### PR DESCRIPTION
…nd deprecate host/port configs

## What is the purpose of the change

Support scheme specification in Prometheus Push Gateway Reporter


## Brief change log

- Introduce new host url config that unifies scheme, host, and port specification
- Deprecate host and port configs

## Verifying this change

This change added tests and can be verified as follows:

- Added unit tests to verify the final Prometheus Push Gateway URL

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector:  no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? docs
