### PR TITLE
[FLINK-25943][connector/common] Add buffered requests to snapshot state in AsyncSyncWriter.

### DIFF
--- a/flink-connectors/flink-connector-aws-kinesis-data-streams/pom.xml
+++ b/flink-connectors/flink-connector-aws-kinesis-data-streams/pom.xml
@@ -87,6 +87,14 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-base</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-connector-aws-base</artifactId>
 			<version>${project.version}</version>
 			<type>test-jar</type>

--- a/flink-connectors/flink-connector-aws-kinesis-data-streams/src/main/java/org/apache/flink/connector/kinesis/sink/KinesisDataStreamsSink.java
+++ b/flink-connectors/flink-connector-aws-kinesis-data-streams/src/main/java/org/apache/flink/connector/kinesis/sink/KinesisDataStreamsSink.java
@@ -21,13 +21,13 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.connector.sink.SinkWriter;
 import org.apache.flink.connector.base.sink.AsyncSinkBase;
+import org.apache.flink.connector.base.sink.writer.BufferedRequestState;
 import org.apache.flink.connector.base.sink.writer.ElementConverter;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.util.Preconditions;
 
 import software.amazon.awssdk.services.kinesis.model.PutRecordsRequestEntry;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
@@ -113,8 +113,8 @@ public class KinesisDataStreamsSink<InputT> extends AsyncSinkBase<InputT, PutRec
 
     @Internal
     @Override
-    public SinkWriter<InputT, Void, Collection<PutRecordsRequestEntry>> createWriter(
-            InitContext context, List<Collection<PutRecordsRequestEntry>> states) {
+    public SinkWriter<InputT, Void, BufferedRequestState<PutRecordsRequestEntry>> createWriter(
+            InitContext context, List<BufferedRequestState<PutRecordsRequestEntry>> states) {
         return new KinesisDataStreamsSinkWriter<>(
                 getElementConverter(),
                 context,
@@ -126,13 +126,14 @@ public class KinesisDataStreamsSink<InputT> extends AsyncSinkBase<InputT, PutRec
                 getMaxRecordSizeInBytes(),
                 failOnError,
                 streamName,
-                kinesisClientProperties);
+                kinesisClientProperties,
+                states);
     }
 
     @Internal
     @Override
-    public Optional<SimpleVersionedSerializer<Collection<PutRecordsRequestEntry>>>
+    public Optional<SimpleVersionedSerializer<BufferedRequestState<PutRecordsRequestEntry>>>
             getWriterStateSerializer() {
-        return Optional.empty();
+        return Optional.of(new KinesisDataStreamsStateSerializer());
     }
 }

--- a/flink-connectors/flink-connector-aws-kinesis-data-streams/src/main/java/org/apache/flink/connector/kinesis/sink/KinesisDataStreamsSinkWriter.java
+++ b/flink-connectors/flink-connector-aws-kinesis-data-streams/src/main/java/org/apache/flink/connector/kinesis/sink/KinesisDataStreamsSinkWriter.java
@@ -21,6 +21,7 @@ import org.apache.flink.api.connector.sink.Sink;
 import org.apache.flink.connector.aws.util.AWSAsyncSinkUtil;
 import org.apache.flink.connector.aws.util.AWSGeneralUtil;
 import org.apache.flink.connector.base.sink.writer.AsyncSinkWriter;
+import org.apache.flink.connector.base.sink.writer.BufferedRequestState;
 import org.apache.flink.connector.base.sink.writer.ElementConverter;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
@@ -83,6 +84,34 @@ class KinesisDataStreamsSinkWriter<InputT> extends AsyncSinkWriter<InputT, PutRe
             boolean failOnError,
             String streamName,
             Properties kinesisClientProperties) {
+        this(
+                elementConverter,
+                context,
+                maxBatchSize,
+                maxInFlightRequests,
+                maxBufferedRequests,
+                maxBatchSizeInBytes,
+                maxTimeInBufferMS,
+                maxRecordSizeInBytes,
+                failOnError,
+                streamName,
+                kinesisClientProperties,
+                Collections.emptyList());
+    }
+
+    KinesisDataStreamsSinkWriter(
+            ElementConverter<InputT, PutRecordsRequestEntry> elementConverter,
+            Sink.InitContext context,
+            int maxBatchSize,
+            int maxInFlightRequests,
+            int maxBufferedRequests,
+            long maxBatchSizeInBytes,
+            long maxTimeInBufferMS,
+            long maxRecordSizeInBytes,
+            boolean failOnError,
+            String streamName,
+            Properties kinesisClientProperties,
+            List<BufferedRequestState<PutRecordsRequestEntry>> states) {
         super(
                 elementConverter,
                 context,
@@ -91,7 +120,8 @@ class KinesisDataStreamsSinkWriter<InputT> extends AsyncSinkWriter<InputT, PutRe
                 maxBufferedRequests,
                 maxBatchSizeInBytes,
                 maxTimeInBufferMS,
-                maxRecordSizeInBytes);
+                maxRecordSizeInBytes,
+                states);
         this.failOnError = failOnError;
         this.streamName = streamName;
         this.metrics = context.metricGroup();

--- a/flink-connectors/flink-connector-aws-kinesis-data-streams/src/main/java/org/apache/flink/connector/kinesis/sink/KinesisDataStreamsStateSerializer.java
+++ b/flink-connectors/flink-connector-aws-kinesis-data-streams/src/main/java/org/apache/flink/connector/kinesis/sink/KinesisDataStreamsStateSerializer.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.sink;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.connector.base.sink.writer.AsyncSinkWriterStateSerializer;
+
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.kinesis.model.PutRecordsRequestEntry;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+/** Kinesis Streams implementation {@link AsyncSinkWriterStateSerializer}. */
+@Internal
+public class KinesisDataStreamsStateSerializer
+        extends AsyncSinkWriterStateSerializer<PutRecordsRequestEntry> {
+    @Override
+    protected void serializeRequestToStream(PutRecordsRequestEntry request, DataOutputStream out)
+            throws IOException {
+        out.write(request.data().asByteArrayUnsafe());
+        serializePartitionKeyToStream(request.partitionKey(), out);
+        validateExplicitHashKey(request);
+    }
+
+    protected void serializePartitionKeyToStream(String partitionKey, DataOutputStream out)
+            throws IOException {
+        out.writeInt(partitionKey.length());
+        out.write(partitionKey.getBytes(StandardCharsets.UTF_8));
+    }
+
+    protected void validateExplicitHashKey(PutRecordsRequestEntry request) {
+        if (request.explicitHashKey() != null) {
+            throw new IllegalStateException(
+                    String.format(
+                            "KinesisDataStreamsStateSerializer is incompatible with ElementConverter."
+                                    + "Serializer version %d  does not support explicit hash key.",
+                            getVersion()));
+        }
+    }
+
+    @Override
+    protected PutRecordsRequestEntry deserializeRequestFromStream(
+            long requestSize, DataInputStream in) throws IOException {
+        byte[] requestData = new byte[(int) requestSize];
+        in.read(requestData);
+
+        return PutRecordsRequestEntry.builder()
+                .data(SdkBytes.fromByteArray(requestData))
+                .partitionKey(deserializePartitionKeyFromStream(in))
+                .build();
+    }
+
+    protected String deserializePartitionKeyFromStream(DataInputStream in) throws IOException {
+        int partitionKeyLength = in.readInt();
+        byte[] requestPartitionKeyData = new byte[(int) partitionKeyLength];
+        in.read(requestPartitionKeyData);
+        return new String(requestPartitionKeyData, StandardCharsets.UTF_8);
+    }
+
+    @Override
+    public int getVersion() {
+        return 1;
+    }
+}

--- a/flink-connectors/flink-connector-aws-kinesis-data-streams/src/test/java/org/apache/flink/connector/kinesis/sink/KinesisDataStreamsStateSerializerTest.java
+++ b/flink-connectors/flink-connector-aws-kinesis-data-streams/src/test/java/org/apache/flink/connector/kinesis/sink/KinesisDataStreamsStateSerializerTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kinesis.sink;
+
+import org.apache.flink.api.common.serialization.SimpleStringSchema;
+import org.apache.flink.connector.base.sink.writer.BufferedRequestState;
+import org.apache.flink.connector.base.sink.writer.ElementConverter;
+
+import org.junit.Test;
+import software.amazon.awssdk.services.kinesis.model.PutRecordsRequestEntry;
+
+import java.io.IOException;
+
+import static org.apache.flink.connector.base.sink.writer.AsyncSinkWriterTestUtils.assertThatBufferStatesAreEqual;
+import static org.apache.flink.connector.base.sink.writer.AsyncSinkWriterTestUtils.getTestState;
+
+/** Test class for {@link KinesisDataStreamsStateSerializer}. */
+public class KinesisDataStreamsStateSerializerTest {
+
+    private static final ElementConverter<String, PutRecordsRequestEntry> ELEMENT_CONVERTER =
+            KinesisDataStreamsSinkElementConverter.<String>builder()
+                    .setSerializationSchema(new SimpleStringSchema())
+                    .setPartitionKeyGenerator(element -> String.valueOf(element.hashCode()))
+                    .build();
+
+    @Test
+    public void testSerializeAndDeserialize() throws IOException {
+        BufferedRequestState<PutRecordsRequestEntry> expectedState =
+                getTestState(ELEMENT_CONVERTER, this::getRequestSize);
+
+        KinesisDataStreamsStateSerializer serializer = new KinesisDataStreamsStateSerializer();
+        BufferedRequestState<PutRecordsRequestEntry> actualState =
+                serializer.deserialize(1, serializer.serialize(expectedState));
+        assertThatBufferStatesAreEqual(actualState, expectedState);
+    }
+
+    private int getRequestSize(PutRecordsRequestEntry requestEntry) {
+        return requestEntry.data().asByteArrayUnsafe().length;
+    }
+}

--- a/flink-connectors/flink-connector-aws-kinesis-firehose/src/main/java/org/apache/flink/connector/firehose/sink/KinesisFirehoseSink.java
+++ b/flink-connectors/flink-connector-aws-kinesis-firehose/src/main/java/org/apache/flink/connector/firehose/sink/KinesisFirehoseSink.java
@@ -20,13 +20,13 @@ package org.apache.flink.connector.firehose.sink;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.connector.sink.SinkWriter;
 import org.apache.flink.connector.base.sink.AsyncSinkBase;
+import org.apache.flink.connector.base.sink.writer.BufferedRequestState;
 import org.apache.flink.connector.base.sink.writer.ElementConverter;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.util.Preconditions;
 
 import software.amazon.awssdk.services.firehose.model.Record;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
@@ -92,8 +92,8 @@ public class KinesisFirehoseSink<InputT> extends AsyncSinkBase<InputT, Record> {
     }
 
     @Override
-    public SinkWriter<InputT, Void, Collection<Record>> createWriter(
-            InitContext context, List<Collection<Record>> states) {
+    public SinkWriter<InputT, Void, BufferedRequestState<Record>> createWriter(
+            InitContext context, List<BufferedRequestState<Record>> states) {
         return new KinesisFirehoseSinkWriter<>(
                 getElementConverter(),
                 context,
@@ -105,11 +105,13 @@ public class KinesisFirehoseSink<InputT> extends AsyncSinkBase<InputT, Record> {
                 getMaxRecordSizeInBytes(),
                 failOnError,
                 deliveryStreamName,
-                firehoseClientProperties);
+                firehoseClientProperties,
+                states);
     }
 
     @Override
-    public Optional<SimpleVersionedSerializer<Collection<Record>>> getWriterStateSerializer() {
-        return Optional.empty();
+    public Optional<SimpleVersionedSerializer<BufferedRequestState<Record>>>
+            getWriterStateSerializer() {
+        return Optional.of(new KinesisFirehoseStateSerializer());
     }
 }

--- a/flink-connectors/flink-connector-aws-kinesis-firehose/src/main/java/org/apache/flink/connector/firehose/sink/KinesisFirehoseSinkWriter.java
+++ b/flink-connectors/flink-connector-aws-kinesis-firehose/src/main/java/org/apache/flink/connector/firehose/sink/KinesisFirehoseSinkWriter.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.connector.sink.Sink;
 import org.apache.flink.connector.aws.util.AWSAsyncSinkUtil;
 import org.apache.flink.connector.aws.util.AWSGeneralUtil;
 import org.apache.flink.connector.base.sink.writer.AsyncSinkWriter;
+import org.apache.flink.connector.base.sink.writer.BufferedRequestState;
 import org.apache.flink.connector.base.sink.writer.ElementConverter;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
@@ -103,6 +104,34 @@ class KinesisFirehoseSinkWriter<InputT> extends AsyncSinkWriter<InputT, Record> 
             boolean failOnError,
             String deliveryStreamName,
             Properties firehoseClientProperties) {
+        this(
+                elementConverter,
+                context,
+                maxBatchSize,
+                maxInFlightRequests,
+                maxBufferedRequests,
+                maxBatchSizeInBytes,
+                maxTimeInBufferMS,
+                maxRecordSizeInBytes,
+                failOnError,
+                deliveryStreamName,
+                firehoseClientProperties,
+                Collections.emptyList());
+    }
+
+    KinesisFirehoseSinkWriter(
+            ElementConverter<InputT, Record> elementConverter,
+            Sink.InitContext context,
+            int maxBatchSize,
+            int maxInFlightRequests,
+            int maxBufferedRequests,
+            long maxBatchSizeInBytes,
+            long maxTimeInBufferMS,
+            long maxRecordSizeInBytes,
+            boolean failOnError,
+            String deliveryStreamName,
+            Properties firehoseClientProperties,
+            List<BufferedRequestState<Record>> initialStates) {
         super(
                 elementConverter,
                 context,
@@ -111,7 +140,8 @@ class KinesisFirehoseSinkWriter<InputT> extends AsyncSinkWriter<InputT, Record> 
                 maxBufferedRequests,
                 maxBatchSizeInBytes,
                 maxTimeInBufferMS,
-                maxRecordSizeInBytes);
+                maxRecordSizeInBytes,
+                initialStates);
         this.failOnError = failOnError;
         this.deliveryStreamName = deliveryStreamName;
         this.metrics = context.metricGroup();

--- a/flink-connectors/flink-connector-aws-kinesis-firehose/src/main/java/org/apache/flink/connector/firehose/sink/KinesisFirehoseStateSerializer.java
+++ b/flink-connectors/flink-connector-aws-kinesis-firehose/src/main/java/org/apache/flink/connector/firehose/sink/KinesisFirehoseStateSerializer.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.firehose.sink;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.connector.base.sink.writer.AsyncSinkWriterStateSerializer;
+
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.firehose.model.Record;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+/** Kinesis Firehose implementation {@link AsyncSinkWriterStateSerializer}. */
+@Internal
+public class KinesisFirehoseStateSerializer extends AsyncSinkWriterStateSerializer<Record> {
+    @Override
+    protected void serializeRequestToStream(Record request, DataOutputStream out)
+            throws IOException {
+        out.write(request.data().asByteArrayUnsafe());
+    }
+
+    @Override
+    protected Record deserializeRequestFromStream(long requestSize, DataInputStream in)
+            throws IOException {
+        byte[] requestData = new byte[(int) requestSize];
+        in.read(requestData);
+        return Record.builder().data(SdkBytes.fromByteArray(requestData)).build();
+    }
+
+    @Override
+    public int getVersion() {
+        return 1;
+    }
+}

--- a/flink-connectors/flink-connector-aws-kinesis-firehose/src/test/java/org/apache/flink/connector/firehose/sink/KinesisFirehoseSinkWriterTest.java
+++ b/flink-connectors/flink-connector-aws-kinesis-firehose/src/test/java/org/apache/flink/connector/firehose/sink/KinesisFirehoseSinkWriterTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.connector.firehose.sink;
 import org.apache.flink.api.common.serialization.SimpleStringSchema;
 import org.apache.flink.api.connector.sink.SinkWriter;
 import org.apache.flink.connector.aws.config.AWSConfigConstants;
+import org.apache.flink.connector.base.sink.writer.BufferedRequestState;
 import org.apache.flink.connector.base.sink.writer.ElementConverter;
 import org.apache.flink.connector.base.sink.writer.TestSinkInitContext;
 
@@ -32,7 +33,6 @@ import software.amazon.awssdk.services.firehose.model.Record;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Properties;
 
 import static org.apache.flink.connector.aws.config.AWSConfigConstants.AWS_ENDPOINT;
@@ -95,7 +95,7 @@ public class KinesisFirehoseSinkWriterTest {
                         true,
                         "test-stream",
                         prop);
-        SinkWriter<String, Void, Collection<Record>> writer =
+        SinkWriter<String, Void, BufferedRequestState<Record>> writer =
                 kinesisFirehoseSink.createWriter(ctx, new ArrayList<>());
 
         for (int i = 0; i < 12; i++) {

--- a/flink-connectors/flink-connector-aws-kinesis-firehose/src/test/java/org/apache/flink/connector/firehose/sink/KinesisFirehoseStateSerializerTest.java
+++ b/flink-connectors/flink-connector-aws-kinesis-firehose/src/test/java/org/apache/flink/connector/firehose/sink/KinesisFirehoseStateSerializerTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.firehose.sink;
+
+import org.apache.flink.api.common.serialization.SimpleStringSchema;
+import org.apache.flink.connector.base.sink.writer.BufferedRequestState;
+import org.apache.flink.connector.base.sink.writer.ElementConverter;
+
+import org.junit.Test;
+import software.amazon.awssdk.services.firehose.model.Record;
+
+import java.io.IOException;
+
+import static org.apache.flink.connector.base.sink.writer.AsyncSinkWriterTestUtils.assertThatBufferStatesAreEqual;
+import static org.apache.flink.connector.base.sink.writer.AsyncSinkWriterTestUtils.getTestState;
+
+/** Test class for {@link KinesisFirehoseStateSerializer}. */
+public class KinesisFirehoseStateSerializerTest {
+
+    private static final ElementConverter<String, Record> ELEMENT_CONVERTER =
+            KinesisFirehoseSinkElementConverter.<String>builder()
+                    .setSerializationSchema(new SimpleStringSchema())
+                    .build();
+
+    @Test
+    public void testSerializeAndDeserialize() throws IOException {
+        BufferedRequestState<Record> expectedState =
+                getTestState(ELEMENT_CONVERTER, this::getRequestSize);
+
+        KinesisFirehoseStateSerializer serializer = new KinesisFirehoseStateSerializer();
+        BufferedRequestState<Record> actualState =
+                serializer.deserialize(1, serializer.serialize(expectedState));
+
+        assertThatBufferStatesAreEqual(actualState, expectedState);
+    }
+
+    private int getRequestSize(Record requestEntry) {
+        return requestEntry.data().asByteArrayUnsafe().length;
+    }
+}

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/sink/AsyncSinkBase.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/sink/AsyncSinkBase.java
@@ -21,12 +21,12 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.connector.sink.Committer;
 import org.apache.flink.api.connector.sink.GlobalCommitter;
 import org.apache.flink.api.connector.sink.Sink;
+import org.apache.flink.connector.base.sink.writer.BufferedRequestState;
 import org.apache.flink.connector.base.sink.writer.ElementConverter;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.util.Preconditions;
 
 import java.io.Serializable;
-import java.util.Collection;
 import java.util.Optional;
 
 /**
@@ -49,7 +49,7 @@ import java.util.Optional;
  */
 @PublicEvolving
 public abstract class AsyncSinkBase<InputT, RequestEntryT extends Serializable>
-        implements Sink<InputT, Void, Collection<RequestEntryT>, Void> {
+        implements Sink<InputT, Void, BufferedRequestState<RequestEntryT>, Void> {
 
     private final ElementConverter<InputT, RequestEntryT> elementConverter;
     private final int maxBatchSize;

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/sink/writer/AsyncSinkWriterStateSerializer.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/sink/writer/AsyncSinkWriterStateSerializer.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.base.sink.writer;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Serializer class for {@link AsyncSinkWriter} state.
+ *
+ * @param <RequestEntryT> Writer Request Entry type
+ */
+@Internal
+public abstract class AsyncSinkWriterStateSerializer<RequestEntryT extends Serializable>
+        implements SimpleVersionedSerializer<BufferedRequestState<RequestEntryT>> {
+    private static final long DATA_IDENTIFIER = -1;
+
+    /**
+     * Serializes state in form of
+     * [DATA_IDENTIFIER,NUM_OF_ELEMENTS,SIZE1,REQUEST1,SIZE2,REQUEST2....].
+     */
+    @Override
+    public byte[] serialize(BufferedRequestState<RequestEntryT> obj) throws IOException {
+        Collection<RequestEntryWrapper<RequestEntryT>> bufferState =
+                obj.getBufferedRequestEntries();
+
+        try (final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                final DataOutputStream out = new DataOutputStream(baos)) {
+
+            out.writeLong(DATA_IDENTIFIER);
+            out.writeInt(bufferState.size());
+
+            for (RequestEntryWrapper<RequestEntryT> wrapper : bufferState) {
+                out.writeLong(wrapper.getSize());
+                serializeRequestToStream(wrapper.getRequestEntry(), out);
+            }
+
+            return baos.toByteArray();
+        }
+    }
+
+    @Override
+    public BufferedRequestState<RequestEntryT> deserialize(int version, byte[] serialized)
+            throws IOException {
+        try (final ByteArrayInputStream bais = new ByteArrayInputStream(serialized);
+                final DataInputStream in = new DataInputStream(bais)) {
+
+            validateIdentifier(in);
+
+            int size = in.readInt();
+            List<RequestEntryWrapper<RequestEntryT>> serializedState = new ArrayList<>();
+
+            for (int i = 0; i < size; i++) {
+                long requestSize = in.readLong();
+                RequestEntryT request = deserializeRequestFromStream(requestSize, in);
+                serializedState.add(new RequestEntryWrapper<>(request, requestSize));
+            }
+
+            return new BufferedRequestState<>(serializedState);
+        }
+    }
+
+    protected abstract void serializeRequestToStream(RequestEntryT request, DataOutputStream out)
+            throws IOException;
+
+    protected abstract RequestEntryT deserializeRequestFromStream(
+            long requestSize, DataInputStream in) throws IOException;
+
+    private void validateIdentifier(DataInputStream in) throws IOException {
+        if (in.readLong() != DATA_IDENTIFIER) {
+            throw new IllegalStateException("Corrupted data to deserialize");
+        }
+    }
+}

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/sink/writer/BufferedRequestState.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/sink/writer/BufferedRequestState.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.base.sink.writer;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.List;
+
+/**
+ * Class holding state of {@link AsyncSinkWriter} needed at taking a snapshot. The state captures
+ * the {@code bufferedRequestEntries} buffer for the writer at snapshot to resume the requests. This
+ * guarantees at least once semantic in sending requests where restoring from a snapshot where
+ * buffered requests were flushed to the sink will cause duplicate requests.
+ *
+ * @param <RequestEntryT> request type.
+ */
+@PublicEvolving
+public class BufferedRequestState<RequestEntryT extends Serializable> implements Serializable {
+    private final List<RequestEntryWrapper<RequestEntryT>> bufferedRequestEntries;
+    private final long stateSize;
+
+    public BufferedRequestState(Deque<RequestEntryWrapper<RequestEntryT>> bufferedRequestEntries) {
+        this.bufferedRequestEntries = new ArrayList<>(bufferedRequestEntries);
+        this.stateSize = calculateStateSize();
+    }
+
+    public BufferedRequestState(List<RequestEntryWrapper<RequestEntryT>> bufferedRequestEntries) {
+        this.bufferedRequestEntries = new ArrayList<>(bufferedRequestEntries);
+        this.stateSize = calculateStateSize();
+    }
+
+    public List<RequestEntryWrapper<RequestEntryT>> getBufferedRequestEntries() {
+        return bufferedRequestEntries;
+    }
+
+    public long getStateSize() {
+        return stateSize;
+    }
+
+    private long calculateStateSize() {
+        long stateSize = 0;
+        for (RequestEntryWrapper<RequestEntryT> requestEntryWrapper : bufferedRequestEntries) {
+            stateSize += requestEntryWrapper.getSize();
+        }
+
+        return stateSize;
+    }
+
+    public static <T extends Serializable> BufferedRequestState<T> emptyState() {
+        return new BufferedRequestState<>(Collections.emptyList());
+    }
+}

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/sink/ArrayListAsyncSink.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/sink/ArrayListAsyncSink.java
@@ -19,10 +19,10 @@ package org.apache.flink.connector.base.sink;
 
 import org.apache.flink.api.connector.sink.SinkWriter;
 import org.apache.flink.connector.base.sink.writer.AsyncSinkWriter;
+import org.apache.flink.connector.base.sink.writer.BufferedRequestState;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -52,8 +52,8 @@ public class ArrayListAsyncSink extends AsyncSinkBase<String, Integer> {
     }
 
     @Override
-    public SinkWriter<String, Void, Collection<Integer>> createWriter(
-            InitContext context, List<Collection<Integer>> states) {
+    public SinkWriter<String, Void, BufferedRequestState<Integer>> createWriter(
+            InitContext context, List<BufferedRequestState<Integer>> states) {
         /* SinkWriter implementing {@code submitRequestEntries} that is used to define the persistence
          * logic into {@code ArrayListDestination}.
          */
@@ -86,7 +86,8 @@ public class ArrayListAsyncSink extends AsyncSinkBase<String, Integer> {
     }
 
     @Override
-    public Optional<SimpleVersionedSerializer<Collection<Integer>>> getWriterStateSerializer() {
+    public Optional<SimpleVersionedSerializer<BufferedRequestState<Integer>>>
+            getWriterStateSerializer() {
         return Optional.empty();
     }
 }

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/sink/writer/AsyncSinkWriterStateSerializerTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/sink/writer/AsyncSinkWriterStateSerializerTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.base.sink.writer;
+
+import org.junit.Test;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.apache.flink.connector.base.sink.writer.AsyncSinkWriterTestUtils.assertThatBufferStatesAreEqual;
+import static org.apache.flink.connector.base.sink.writer.AsyncSinkWriterTestUtils.getTestState;
+
+/** Test class for {@link AsyncSinkWriterStateSerializer}. */
+public class AsyncSinkWriterStateSerializerTest {
+
+    @Test
+    public void testSerializeAndDeSerialize() throws IOException {
+        AsyncSinkWriterStateSerializerImpl stateSerializer =
+                new AsyncSinkWriterStateSerializerImpl();
+        BufferedRequestState<String> state =
+                getTestState((element, context) -> element, String::length);
+        BufferedRequestState<String> deserializedState =
+                stateSerializer.deserialize(0, stateSerializer.serialize(state));
+
+        assertThatBufferStatesAreEqual(state, deserializedState);
+    }
+
+    private static class AsyncSinkWriterStateSerializerImpl
+            extends AsyncSinkWriterStateSerializer<String> {
+
+        @Override
+        protected void serializeRequestToStream(String request, DataOutputStream out)
+                throws IOException {
+            out.write(request.getBytes(StandardCharsets.UTF_8));
+        }
+
+        @Override
+        protected String deserializeRequestFromStream(long requestSize, DataInputStream in)
+                throws IOException {
+            byte[] requestData = new byte[(int) requestSize];
+            in.read(requestData);
+            return new String(requestData, StandardCharsets.UTF_8);
+        }
+
+        @Override
+        public int getVersion() {
+            return 1;
+        }
+    }
+}

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/sink/writer/AsyncSinkWriterTestUtils.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/sink/writer/AsyncSinkWriterTestUtils.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.base.sink.writer;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** Utils class for {@link AsyncSinkWriter} related test. */
+public class AsyncSinkWriterTestUtils {
+
+    public static <T extends Serializable> BufferedRequestState<T> getTestState(
+            ElementConverter<String, T> elementConverter,
+            Function<T, Integer> requestSizeExtractor) {
+        return new BufferedRequestState<>(
+                IntStream.range(0, 100)
+                        .mapToObj(i -> String.format("value:%d", i))
+                        .map(element -> elementConverter.apply(element, null))
+                        .map(
+                                request ->
+                                        new RequestEntryWrapper<>(
+                                                request, requestSizeExtractor.apply(request)))
+                        .collect(Collectors.toList()));
+    }
+
+    public static <T extends Serializable> void assertThatBufferStatesAreEqual(
+            BufferedRequestState<T> actual, BufferedRequestState<T> expected) {
+        // Equal states must have equal sizes
+        assertEquals(actual.getStateSize(), expected.getStateSize());
+
+        // Equal states must have the same number of requests.
+        int actualLength = actual.getBufferedRequestEntries().size();
+        assertEquals(actualLength, expected.getBufferedRequestEntries().size());
+
+        List<RequestEntryWrapper<T>> actualRequests = actual.getBufferedRequestEntries();
+        List<RequestEntryWrapper<T>> expectedRequests = expected.getBufferedRequestEntries();
+
+        // Equal states must have same requests in the same order.
+        for (int i = 0; i < actualLength; i++) {
+            assertEquals(
+                    actualRequests.get(i).getRequestEntry(),
+                    expectedRequests.get(i).getRequestEntry());
+            assertEquals(actualRequests.get(i).getSize(), expectedRequests.get(i).getSize());
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change
- Adding buffered requests in snapshot state of `AsyncSinkWriter` and its implementation so that the writers can resume the buffered requests when restoring from a checkpoint/savepoint.


## Brief change log


  - Added `BufferedRequestsState` in `flink-connector-base`.
  - Added `AsyncSinkWriterStateSerializer` in `flink-connector-base`.
  - implemented `AsyncSinkWriterStateSerializer` in both `flink-connector-aws-kinesis-data-streams` and `flink-connector-aws-kinesis-firehose`.
  
## Verifying this change

- Added unit tests for new serializer class.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: yes
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no


## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
