### PR TITLE
[FLINK-25491][table-planner] Fix bug: generated code for a large IN filter can't be compiled

### DIFF
--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CodeSplitITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CodeSplitITCase.scala
@@ -117,6 +117,24 @@ class CodeSplitITCase extends BatchTestBase {
     Assert.assertEquals(expected, TestValuesTableFactory.getResults("test_many_values"))
   }
 
+  @Test
+  def testManyIns(): Unit = {
+    val sql = new StringBuilder("SELECT a FROM SmallTable3 WHERE a IN (")
+    for (i <- 1 to 10000) {
+      sql.append(i)
+      if (i != 10000) {
+        sql.append(", ")
+      }
+    }
+    sql.append(")")
+
+    val result = Seq(
+      Row.of(java.lang.Integer.valueOf(1)),
+      Row.of(java.lang.Integer.valueOf(2)),
+      Row.of(java.lang.Integer.valueOf(3)))
+    runTest(sql.mkString, result)
+  }
+
   private[flink] def runTest(sql: String, results: Seq[Row]): Unit = {
     tEnv.getConfig.getConfiguration.setInteger(
       TableConfigOptions.MAX_LENGTH_GENERATED_CODE, 4000)


### PR DESCRIPTION
## What is the purpose of the change

Although we've introduced a dedicated code splitter module in FLINK-23007 there are still some corner cases. For example, current code splitter cannot handle long constructor code.

`IN` filters with a constant set will generate an operator which constructs the set in the class constructor, so for a large IN filter its generator code may become too long to be compiled. This PR fixes this issue by moving the code for set constructing to a dedicated method.

I'm not going to handle long constructor code for the code splitter because it is sort of hard to pick out which part of the constructor code can be split out. For example, `final` class members must be assigned in the constructor, not in other methods, so we just can't move all constructor code into another method.

## Brief change log

 - Fix bug: generated code for a large IN filter can't be compiled

## Verifying this change

This change added tests and can be verified by running `CodeSplitITCase#testManyIns`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
