### PR TITLE
[FLINK-26039][table-runtime] Fix the incorrect value getter in map unnest table function

### DIFF
--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/UnnestTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/UnnestTest.xml
@@ -101,6 +101,29 @@ Calc(select=[a, b, f1 AS v])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testUnnestMapWithDifferentKeyValueType">
+    <Resource name="sql">
+      <![CDATA[SELECT a, k, v FROM MyTable, UNNEST(b) as A(k, v)]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], k=[$2], v=[$3])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
+   :- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b)]]])
+   +- LogicalProject(k=[$0], v=[$1])
+      +- Uncollect
+         +- LogicalProject(b=[$cor0.b])
+            +- LogicalValues(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, f0 AS k, f1 AS v])
++- Correlate(invocation=[UNNEST($cor0.b)], correlate=[table(UNNEST($cor0.b))], select=[a,b,f0,f1], rowType=[RecordType(INTEGER a, (VARCHAR(2147483647), INTEGER) MAP b, VARCHAR(2147483647) f0, INTEGER f1)], joinType=[INNER])
+   +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b)]]], fields=[a, b])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testJoinWithUnnestOfTuple">
     <Resource name="sql">
       <![CDATA[

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/LogicalUnnestRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/LogicalUnnestRuleTest.xml
@@ -105,6 +105,31 @@ LogicalProject(a=[$0], b=[$1], v=[$4])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testUnnestMapWithDifferentKeyValueType">
+    <Resource name="sql">
+      <![CDATA[SELECT a, k, v FROM MyTable, UNNEST(b) as A(k, v)]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], k=[$2], v=[$3])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
+   :- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b)]]])
+   +- LogicalProject(k=[$0], v=[$1])
+      +- Uncollect
+         +- LogicalProject(b=[$cor0.b])
+            +- LogicalValues(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+LogicalProject(a=[$0], k=[$2], v=[$3])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
+   :- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b)]]])
+   +- LogicalProject(k=[$0], v=[$1])
+      +- LogicalTableFunctionScan(invocation=[UNNEST($cor0.b)], rowType=[RecordType:peek_no_expand(VARCHAR(2147483647) f0, INTEGER f1)])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testJoinWithUnnestOfTuple">
     <Resource name="sql">
       <![CDATA[

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/UnnestTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/UnnestTest.xml
@@ -98,6 +98,29 @@ Calc(select=[a, b, f1 AS v])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testUnnestMapWithDifferentKeyValueType">
+    <Resource name="sql">
+      <![CDATA[SELECT a, k, v FROM MyTable, UNNEST(b) as A(k, v)]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], k=[$2], v=[$3])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
+   :- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b)]]])
+   +- LogicalProject(k=[$0], v=[$1])
+      +- Uncollect
+         +- LogicalProject(b=[$cor0.b])
+            +- LogicalValues(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, f0 AS k, f1 AS v])
++- Correlate(invocation=[UNNEST($cor0.b)], correlate=[table(UNNEST($cor0.b))], select=[a,b,f0,f1], rowType=[RecordType(INTEGER a, (VARCHAR(2147483647), INTEGER) MAP b, VARCHAR(2147483647) f0, INTEGER f1)], joinType=[INNER])
+   +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b)]]], fields=[a, b])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testJoinWithUnnestOfTuple">
     <Resource name="sql">
       <![CDATA[

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/common/UnnestTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/common/UnnestTestBase.scala
@@ -125,6 +125,15 @@ abstract class UnnestTestBase(withExecPlan: Boolean) extends TableTestBase {
     verifyPlan("SELECT a, b, A._1, A._2 FROM MyTable, UNNEST(MyTable.b) AS A where A._1 > 1")
   }
 
+  @Test
+  def testUnnestMapWithDifferentKeyValueType(): Unit = {
+    util.addTableSource("MyTable",
+      Array[TypeInformation[_]](Types.INT,
+        Types.MAP(Types.STRING, Types.INT)),
+      Array("a", "b"))
+    verifyPlan("SELECT a, k, v FROM MyTable, UNNEST(b) as A(k, v)")
+  }
+
   private def verifyPlan(sql: String): Unit = {
     if (withExecPlan) {
       util.verifyExecPlan(sql)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/UnnestITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/UnnestITCase.scala
@@ -251,4 +251,22 @@ class UnnestITCase extends BatchTestBase {
     )
   }
 
+  @Test
+  def testUnnestMapWithDifferentKeyValueType(): Unit = {
+    val data = List(
+      row(1, Map("a" -> 10, "b" -> 11).asJava),
+      row(2, Map("c" -> 20, "d" -> 21).asJava)
+    )
+
+    registerCollection("T", data,
+      new RowTypeInfo(Types.INT, Types.MAP(Types.STRING, Types.INT)),
+      "a, b")
+
+    checkResult(
+      "SELECT a, k, v FROM T, UNNEST(T.b) as A(k, v)",
+      Seq(row(1, "a", 10), row(1, "b", 11), row(2, "c", 20),
+        row(2, "d", 21))
+    )
+  }
+
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/SqlUnnestUtils.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/SqlUnnestUtils.java
@@ -61,7 +61,7 @@ public final class SqlUnnestUtils {
                         mapType,
                         RowType.of(false, mapType.getKeyType(), mapType.getValueType()),
                         ArrayData.createElementGetter(mapType.getKeyType()),
-                        ArrayData.createElementGetter(mapType.getKeyType()));
+                        ArrayData.createElementGetter(mapType.getValueType()));
             default:
                 throw new UnsupportedOperationException("Unsupported type for UNNEST: " + t);
         }


### PR DESCRIPTION
## What is the purpose of the change

Suppose we have a map field that needs to be expanded.
```sql
CREATE TABLE t (
    id INT,
    map_field MAP<STRING, INT>
) WITH (
    -- ...
)

SELECT id, k, v FROM t, unnest(map_field) as A(k, v)
```

We will get the following runtime exception:
```
Caused by: java.lang.ClassCastException: org.apache.flink.table.data.binary.BinaryStringData cannot be cast to java.lang.Integer
	at org.apache.flink.table.data.GenericRowData.getInt(GenericRowData.java:149)
	at org.apache.flink.table.data.utils.JoinedRowData.getInt(JoinedRowData.java:149)
	at org.apache.flink.table.data.RowData.lambda$createFieldGetter$245ca7d1$6(RowData.java:245)
	at org.apache.flink.table.data.RowData.lambda$createFieldGetter$25774257$1(RowData.java:296)
	at org.apache.flink.table.runtime.typeutils.RowDataSerializer.copyRowData(RowDataSerializer.java:170)
	at org.apache.flink.table.runtime.typeutils.RowDataSerializer.copy(RowDataSerializer.java:131)
	at org.apache.flink.table.runtime.typeutils.RowDataSerializer.copy(RowDataSerializer.java:48)
	at org.apache.flink.streaming.runtime.tasks.CopyingChainingOutput.pushToOperator(CopyingChainingOutput.java:80)
	at org.apache.flink.streaming.runtime.tasks.CopyingChainingOutput.collect(CopyingChainingOutput.java:57)
	at org.apache.flink.streaming.runtime.tasks.CopyingChainingOutput.collect(CopyingChainingOutput.java:29)
	at org.apache.flink.streaming.api.operators.CountingOutput.collect(CountingOutput.java:56)
	at org.apache.flink.streaming.api.operators.CountingOutput.collect(CountingOutput.java:29)
	at org.apache.flink.table.runtime.util.StreamRecordCollector.collect(StreamRecordCollector.java:44)
	at org.apache.flink.table.runtime.collector.TableFunctionCollector.outputResult(TableFunctionCollector.java:68)
	at StreamExecCorrelate$10$TableFunctionCollector$4.collect(Unknown Source)
	at org.apache.flink.table.runtime.collector.WrappingCollector.outputResult(WrappingCollector.java:39)
	at StreamExecCorrelate$10$TableFunctionResultConverterCollector$8.collect(Unknown Source)
	at org.apache.flink.table.functions.TableFunction.collect(TableFunction.java:197)
	at org.apache.flink.table.runtime.functions.SqlUnnestUtils$MapUnnestTableFunction.eval(SqlUnnestUtils.java:169)
	at StreamExecCorrelate$10.processElement(Unknown Source)
	at org.apache.flink.streaming.runtime.tasks.CopyingChainingOutput.pushToOperator(CopyingChainingOutput.java:82)
	at org.apache.flink.streaming.runtime.tasks.CopyingChainingOutput.collect(CopyingChainingOutput.java:57)
	at org.apache.flink.streaming.runtime.tasks.CopyingChainingOutput.collect(CopyingChainingOutput.java:29)
	at org.apache.flink.streaming.api.operators.CountingOutput.collect(CountingOutput.java:56)
	at org.apache.flink.streaming.api.operators.CountingOutput.collect(CountingOutput.java:29)
```

This PR is to fix it.

## Brief change log

- Fix the incorrect value getter in map unnest table function


## Verifying this change

This change added tests and can be verified as follows:
```shell
mvn test -Dtest=UnnestTest,LogicalUnnestRuleTest,UnnestITCase -DfailIfNoTests=false -pl flink-table/flink-table-runtime,flink-table/flink-table-planner
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
