### PR TITLE
[FLINK-26046][rest][docs] Fix link to OpenAPI spec

### DIFF
--- a/docs/content.zh/docs/ops/rest_api.md
+++ b/docs/content.zh/docs/ops/rest_api.md
@@ -67,7 +67,7 @@ Flink 具有监控 API ，可用于查询正在运行的作业以及最近完成
 
 ### JobManager
 
-[OpenAPI specification](/generated/rest_v1_dispatcher.yml)
+[OpenAPI specification]({{< ref_static "generated/rest_v1_dispatcher.yml" >}})
 
 {{< hint warning >}}
 The OpenAPI specification is still experimental.

--- a/docs/content/docs/ops/rest_api.md
+++ b/docs/content/docs/ops/rest_api.md
@@ -74,7 +74,7 @@ The retry is only safe until the [async operation store duration]({{< ref "docs/
 
 ### JobManager
 
-[OpenAPI specification](/generated/rest_v1_dispatcher.yml)
+[OpenAPI specification]({{< ref_static "generated/rest_v1_dispatcher.yml" >}})
 
 {{< hint warning >}}
 The OpenAPI specification is still experimental.

--- a/docs/layouts/shortcodes/ref_static.html
+++ b/docs/layouts/shortcodes/ref_static.html
@@ -1,0 +1,21 @@
+{{/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/}}{{/*
+  Shortcode for embedding a link to a static resource.
+*/}}
+{{ .Site.BaseURL }}{{ .Get 0 }}


### PR DESCRIPTION
Adds a new short code for referring to static resources (because `ref` always points into content/).