### PR TITLE
[FLINK-26036] Only respond to TaskExecutor.freeSlot when running

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -2697,7 +2697,7 @@ public class TaskExecutorTest extends TestLogger {
                     jobMasterGateway.getAddress(),
                     resourceManagerGateway.getFencingToken());
 
-            taskExecutor.freeInactiveSlots(jobId, timeout);
+            taskExecutorGateway.freeInactiveSlots(jobId, timeout);
 
             // the slot should be freed
             assertThat(availableSlotFuture.get().f1, is(slotId));


### PR DESCRIPTION
This commit changes the TaskExecutor to only respond to freeSlot when running.
This avoids that during the shut down of a TaskExecutor a JobMaster free slot
call will delete the slot allocation snapshot. The JobMaster will send these
rpcs because the TaskExecutor disconnects from it. It is important to keep the
slot allocation snapshot in order to be able to recover this information when
restarting the process.