### PR TITLE
[FLINK-26044][table] Properly declare an internal UNNEST function

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -151,6 +151,16 @@ public final class BuiltInFunctionDefinitions {
                     .internal()
                     .build();
 
+    public static final BuiltInFunctionDefinition INTERNAL_UNNEST_ROWS =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("$UNNEST_ROWS$1")
+                    .kind(TABLE)
+                    .outputTypeStrategy(TypeStrategies.MISSING)
+                    .runtimeClass(
+                            "org.apache.flink.table.runtime.functions.table.UnnestRowsFunction")
+                    .internal()
+                    .build();
+
     // --------------------------------------------------------------------------------------------
     // Logic functions
     // --------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/UnnestTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/UnnestTest.xml
@@ -34,7 +34,7 @@ LogicalProject(a=[$0], s=[$3])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, f0 AS s])
-+- Correlate(invocation=[UNNEST($cor0.c)], correlate=[table(UNNEST($cor0.c))], select=[a,b,c,f0], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) ARRAY c, VARCHAR(2147483647) f0)], joinType=[INNER])
++- Correlate(invocation=[$UNNEST_ROWS$1($cor0.c)], correlate=[table($UNNEST_ROWS$1($cor0.c))], select=[a,b,c,f0], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) ARRAY c, VARCHAR(2147483647) f0)], joinType=[INNER])
    +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
     </Resource>
@@ -67,7 +67,7 @@ LogicalProject(b=[$0], s=[$2])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[b, f0 AS s])
-+- Correlate(invocation=[UNNEST($cor0.set)], correlate=[table(UNNEST($cor0.set))], select=[b,set,f0], rowType=[RecordType(BIGINT b, BIGINT MULTISET set, BIGINT f0)], joinType=[INNER])
++- Correlate(invocation=[$UNNEST_ROWS$1($cor0.set)], correlate=[table($UNNEST_ROWS$1($cor0.set))], select=[b,set,f0], rowType=[RecordType(BIGINT b, BIGINT MULTISET set, BIGINT f0)], joinType=[INNER])
    +- SortWindowAggregate(groupBy=[b], window=[TumblingGroupWindow('w$, rowtime, 3000)], select=[b, Final_COLLECT(set) AS set])
       +- Sort(orderBy=[b ASC, assignedWindow$ ASC])
          +- Exchange(distribution=[hash[b]])
@@ -96,7 +96,7 @@ LogicalProject(a=[$0], b=[$1], v=[$4])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b, f1 AS v])
-+- Correlate(invocation=[UNNEST($cor0.c)], correlate=[table(UNNEST($cor0.c))], select=[a,b,c,f0,f1], rowType=[RecordType(INTEGER a, BIGINT b, (VARCHAR(2147483647), VARCHAR(2147483647)) MAP c, VARCHAR(2147483647) f0, VARCHAR(2147483647) f1)], joinType=[INNER])
++- Correlate(invocation=[$UNNEST_ROWS$1($cor0.c)], correlate=[table($UNNEST_ROWS$1($cor0.c))], select=[a,b,c,f0,f1], rowType=[RecordType(INTEGER a, BIGINT b, (VARCHAR(2147483647), VARCHAR(2147483647)) MAP c, VARCHAR(2147483647) f0, VARCHAR(2147483647) f1)], joinType=[INNER])
    +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
     </Resource>
@@ -127,7 +127,7 @@ LogicalProject(a=[$0], b=[$1], x=[$2], y=[$3])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b, _1, _2], where=[(_1 > a)])
-+- Correlate(invocation=[UNNEST($cor0.b)], correlate=[table(UNNEST($cor0.b))], select=[a,b,_1,_2], rowType=[RecordType(INTEGER a, RecordType:peek_no_expand(INTEGER _1, VARCHAR(2147483647) _2) ARRAY b, INTEGER _1, VARCHAR(2147483647) _2)], joinType=[INNER])
++- Correlate(invocation=[$UNNEST_ROWS$1($cor0.b)], correlate=[table($UNNEST_ROWS$1($cor0.b))], select=[a,b,_1,_2], rowType=[RecordType(INTEGER a, RecordType:peek_no_expand(INTEGER _1, VARCHAR(2147483647) _2) ARRAY b, INTEGER _1, VARCHAR(2147483647) _2)], joinType=[INNER])
    +- Calc(select=[a, b], where=[(a < 3)])
       +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b)]]], fields=[a, b])
 ]]>
@@ -157,7 +157,7 @@ LogicalProject(a=[$0], s=[$2])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, f0 AS s])
-+- Correlate(invocation=[UNNEST($cor0.set)], correlate=[table(UNNEST($cor0.set))], select=[a,set,f0], rowType=[RecordType(INTEGER a, VARCHAR(2147483647) MULTISET set, VARCHAR(2147483647) f0)], joinType=[LEFT])
++- Correlate(invocation=[$UNNEST_ROWS$1($cor0.set)], correlate=[table($UNNEST_ROWS$1($cor0.set))], select=[a,set,f0], rowType=[RecordType(INTEGER a, VARCHAR(2147483647) MULTISET set, VARCHAR(2147483647) f0)], joinType=[LEFT])
    +- SortAggregate(isMerge=[true], groupBy=[a], select=[a, Final_COLLECT(set) AS set])
       +- Sort(orderBy=[a ASC])
          +- Exchange(distribution=[hash[a]])
@@ -186,7 +186,7 @@ LogicalProject(a=[$0], s=[$3])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, f0 AS s])
-+- Correlate(invocation=[UNNEST($cor0.c)], correlate=[table(UNNEST($cor0.c))], select=[a,b,c,f0], rowType=[RecordType(INTEGER a, INTEGER ARRAY b, INTEGER ARRAY ARRAY c, INTEGER ARRAY f0)], joinType=[INNER])
++- Correlate(invocation=[$UNNEST_ROWS$1($cor0.c)], correlate=[table($UNNEST_ROWS$1($cor0.c))], select=[a,b,c,f0], rowType=[RecordType(INTEGER a, INTEGER ARRAY b, INTEGER ARRAY ARRAY c, INTEGER ARRAY f0)], joinType=[INNER])
    +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
     </Resource>
@@ -215,7 +215,7 @@ LogicalProject(b=[$0], id=[$2], point=[$3])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[b, _1 AS id, _2 AS point])
-+- Correlate(invocation=[UNNEST($cor0.set)], correlate=[table(UNNEST($cor0.set))], select=[b,set,_1,_2], rowType=[RecordType(INTEGER b, RecordType:peek_no_expand(INTEGER _1, VARCHAR(2147483647) _2) MULTISET set, INTEGER _1, VARCHAR(2147483647) _2)], joinType=[INNER])
++- Correlate(invocation=[$UNNEST_ROWS$1($cor0.set)], correlate=[table($UNNEST_ROWS$1($cor0.set))], select=[b,set,_1,_2], rowType=[RecordType(INTEGER b, RecordType:peek_no_expand(INTEGER _1, VARCHAR(2147483647) _2) MULTISET set, INTEGER _1, VARCHAR(2147483647) _2)], joinType=[INNER])
    +- SortAggregate(isMerge=[true], groupBy=[b], select=[b, Final_COLLECT(set) AS set])
       +- Sort(orderBy=[b ASC])
          +- Exchange(distribution=[hash[b]])
@@ -244,7 +244,7 @@ LogicalProject(a=[$0], b=[$1], s=[$3])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b, f0 AS s])
-+- Correlate(invocation=[UNNEST($cor0.b)], correlate=[table(UNNEST($cor0.b))], select=[a,b,c,f0], rowType=[RecordType(INTEGER a, INTEGER ARRAY b, INTEGER ARRAY ARRAY c, INTEGER f0)], joinType=[INNER])
++- Correlate(invocation=[$UNNEST_ROWS$1($cor0.b)], correlate=[table($UNNEST_ROWS$1($cor0.b))], select=[a,b,c,f0], rowType=[RecordType(INTEGER a, INTEGER ARRAY b, INTEGER ARRAY ARRAY c, INTEGER f0)], joinType=[INNER])
    +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
     </Resource>
@@ -267,7 +267,7 @@ LogicalProject(a=[$0], b=[$1], s=[$2], t=[$3])
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Correlate(invocation=[UNNEST($cor0.b)], correlate=[table(UNNEST($cor0.b))], select=[a,b,_1,_2], rowType=[RecordType(INTEGER a, RecordType:peek_no_expand(INTEGER _1, VARCHAR(2147483647) _2) ARRAY b, INTEGER _1, VARCHAR(2147483647) _2)], joinType=[INNER], condition=[>($0, 13)])
+Correlate(invocation=[$UNNEST_ROWS$1($cor0.b)], correlate=[table($UNNEST_ROWS$1($cor0.b))], select=[a,b,_1,_2], rowType=[RecordType(INTEGER a, RecordType:peek_no_expand(INTEGER _1, VARCHAR(2147483647) _2) ARRAY b, INTEGER _1, VARCHAR(2147483647) _2)], joinType=[INNER], condition=[>($0, 13)])
 +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b)]]], fields=[a, b])
 ]]>
     </Resource>
@@ -289,7 +289,7 @@ LogicalProject(a=[$0], b=[$1], _1=[$2], _2=[$3])
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Correlate(invocation=[UNNEST($cor0.b)], correlate=[table(UNNEST($cor0.b))], select=[a,b,_1,_2], rowType=[RecordType(INTEGER a, RecordType:peek_no_expand(INTEGER _1, VARCHAR(2147483647) _2) ARRAY b, INTEGER _1, VARCHAR(2147483647) _2)], joinType=[INNER], condition=[>($0, 1)])
+Correlate(invocation=[$UNNEST_ROWS$1($cor0.b)], correlate=[table($UNNEST_ROWS$1($cor0.b))], select=[a,b,_1,_2], rowType=[RecordType(INTEGER a, RecordType:peek_no_expand(INTEGER _1, VARCHAR(2147483647) _2) ARRAY b, INTEGER _1, VARCHAR(2147483647) _2)], joinType=[INNER], condition=[>($0, 1)])
 +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b)]]], fields=[a, b])
 ]]>
     </Resource>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/LogicalUnnestRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/LogicalUnnestRuleTest.xml
@@ -37,7 +37,7 @@ LogicalProject(a=[$0], s=[$3])
 +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{2}])
    :- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
    +- LogicalProject(s=[$0])
-      +- LogicalTableFunctionScan(invocation=[UNNEST($cor0.c)], rowType=[RecordType:peek_no_expand(VARCHAR(2147483647) f0)])
+      +- LogicalTableFunctionScan(invocation=[$UNNEST_ROWS$1($cor0.c)], rowType=[RecordType:peek_no_expand(VARCHAR(2147483647) f0)])
 ]]>
     </Resource>
   </TestCase>
@@ -76,7 +76,7 @@ LogicalProject(b=[$0], s=[$2])
       :     +- LogicalProject(b=[$1], $f1=[$TUMBLE($3, 3000:INTERVAL SECOND)])
       :        +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
       +- LogicalProject(s=[$0])
-         +- LogicalTableFunctionScan(invocation=[UNNEST($cor0.set)], rowType=[RecordType:peek_no_expand(BIGINT f0)])
+         +- LogicalTableFunctionScan(invocation=[$UNNEST_ROWS$1($cor0.set)], rowType=[RecordType:peek_no_expand(BIGINT f0)])
 ]]>
     </Resource>
   </TestCase>
@@ -101,7 +101,7 @@ LogicalProject(a=[$0], b=[$1], v=[$4])
 +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{2}])
    :- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
    +- LogicalProject(k=[$0], v=[$1])
-      +- LogicalTableFunctionScan(invocation=[UNNEST($cor0.c)], rowType=[RecordType:peek_no_expand(VARCHAR(2147483647) f0, VARCHAR(2147483647) f1)])
+      +- LogicalTableFunctionScan(invocation=[$UNNEST_ROWS$1($cor0.c)], rowType=[RecordType:peek_no_expand(VARCHAR(2147483647) f0, VARCHAR(2147483647) f1)])
 ]]>
     </Resource>
   </TestCase>
@@ -137,7 +137,7 @@ LogicalProject(a=[$0], b=[$1], x=[$2], y=[$3])
       :  +- LogicalFilter(condition=[<($0, 3)])
       :     +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b)]]])
       +- LogicalProject(x=[$0], y=[$1])
-         +- LogicalTableFunctionScan(invocation=[UNNEST($cor0.b)], rowType=[RecordType:peek_no_expand(INTEGER _1, VARCHAR(2147483647) _2)])
+         +- LogicalTableFunctionScan(invocation=[$UNNEST_ROWS$1($cor0.b)], rowType=[RecordType:peek_no_expand(INTEGER _1, VARCHAR(2147483647) _2)])
 ]]>
     </Resource>
   </TestCase>
@@ -171,7 +171,7 @@ LogicalProject(a=[$0], s=[$2])
       :  +- LogicalProject(a=[$0], b=[$1])
       :     +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
       +- LogicalProject(s=[$0])
-         +- LogicalTableFunctionScan(invocation=[UNNEST($cor0.set)], rowType=[RecordType:peek_no_expand(VARCHAR(2147483647) f0)])
+         +- LogicalTableFunctionScan(invocation=[$UNNEST_ROWS$1($cor0.set)], rowType=[RecordType:peek_no_expand(VARCHAR(2147483647) f0)])
 ]]>
     </Resource>
   </TestCase>
@@ -196,7 +196,7 @@ LogicalProject(a=[$0], s=[$3])
 +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{2}])
    :- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
    +- LogicalProject(s=[$0])
-      +- LogicalTableFunctionScan(invocation=[UNNEST($cor0.c)], rowType=[RecordType:peek_no_expand(INTEGER ARRAY f0)])
+      +- LogicalTableFunctionScan(invocation=[$UNNEST_ROWS$1($cor0.c)], rowType=[RecordType:peek_no_expand(INTEGER ARRAY f0)])
 ]]>
     </Resource>
   </TestCase>
@@ -230,7 +230,7 @@ LogicalProject(b=[$0], id=[$2], point=[$3])
       :  +- LogicalProject(b=[$1], c=[$2])
       :     +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
       +- LogicalProject(id=[$0], point=[$1])
-         +- LogicalTableFunctionScan(invocation=[UNNEST($cor0.set)], rowType=[RecordType:peek_no_expand(INTEGER _1, VARCHAR(2147483647) _2)])
+         +- LogicalTableFunctionScan(invocation=[$UNNEST_ROWS$1($cor0.set)], rowType=[RecordType:peek_no_expand(INTEGER _1, VARCHAR(2147483647) _2)])
 ]]>
     </Resource>
   </TestCase>
@@ -255,7 +255,7 @@ LogicalProject(a=[$0], b=[$1], s=[$3])
 +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
    :- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
    +- LogicalProject(s=[$0])
-      +- LogicalTableFunctionScan(invocation=[UNNEST($cor0.b)], rowType=[RecordType:peek_no_expand(INTEGER f0)])
+      +- LogicalTableFunctionScan(invocation=[$UNNEST_ROWS$1($cor0.b)], rowType=[RecordType:peek_no_expand(INTEGER f0)])
 ]]>
     </Resource>
   </TestCase>
@@ -282,7 +282,7 @@ LogicalProject(a=[$0], b=[$1], s=[$2], t=[$3])
    +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
       :- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b)]]])
       +- LogicalProject(s=[$0], t=[$1])
-         +- LogicalTableFunctionScan(invocation=[UNNEST($cor0.b)], rowType=[RecordType:peek_no_expand(INTEGER _1, VARCHAR(2147483647) _2)])
+         +- LogicalTableFunctionScan(invocation=[$UNNEST_ROWS$1($cor0.b)], rowType=[RecordType:peek_no_expand(INTEGER _1, VARCHAR(2147483647) _2)])
 ]]>
     </Resource>
   </TestCase>
@@ -307,7 +307,7 @@ LogicalProject(a=[$0], b=[$1], _1=[$2], _2=[$3])
 +- LogicalFilter(condition=[>($2, 1)])
    +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
       :- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b)]]])
-      +- LogicalTableFunctionScan(invocation=[UNNEST($cor0.b)], rowType=[RecordType:peek_no_expand(INTEGER _1, VARCHAR(2147483647) _2)])
+      +- LogicalTableFunctionScan(invocation=[$UNNEST_ROWS$1($cor0.b)], rowType=[RecordType:peek_no_expand(INTEGER _1, VARCHAR(2147483647) _2)])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/UnnestTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/UnnestTest.xml
@@ -34,7 +34,7 @@ LogicalProject(a=[$0], s=[$3])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, f0 AS s])
-+- Correlate(invocation=[UNNEST($cor0.c)], correlate=[table(UNNEST($cor0.c))], select=[a,b,c,f0], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) ARRAY c, VARCHAR(2147483647) f0)], joinType=[INNER])
++- Correlate(invocation=[$UNNEST_ROWS$1($cor0.c)], correlate=[table($UNNEST_ROWS$1($cor0.c))], select=[a,b,c,f0], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) ARRAY c, VARCHAR(2147483647) f0)], joinType=[INNER])
    +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
     </Resource>
@@ -67,7 +67,7 @@ LogicalProject(b=[$0], s=[$2])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[b, f0 AS s])
-+- Correlate(invocation=[UNNEST($cor0.set)], correlate=[table(UNNEST($cor0.set))], select=[b,set,f0], rowType=[RecordType(BIGINT b, BIGINT MULTISET set, BIGINT f0)], joinType=[INNER])
++- Correlate(invocation=[$UNNEST_ROWS$1($cor0.set)], correlate=[table($UNNEST_ROWS$1($cor0.set))], select=[b,set,f0], rowType=[RecordType(BIGINT b, BIGINT MULTISET set, BIGINT f0)], joinType=[INNER])
    +- GroupWindowAggregate(groupBy=[b], window=[TumblingGroupWindow('w$, rowtime, 3000)], select=[b, COLLECT(b) AS set])
       +- Exchange(distribution=[hash[b]])
          +- Calc(select=[b, rowtime], where=[(b < 3)])
@@ -93,7 +93,7 @@ LogicalProject(a=[$0], b=[$1], v=[$4])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b, f1 AS v])
-+- Correlate(invocation=[UNNEST($cor0.c)], correlate=[table(UNNEST($cor0.c))], select=[a,b,c,f0,f1], rowType=[RecordType(INTEGER a, BIGINT b, (VARCHAR(2147483647), VARCHAR(2147483647)) MAP c, VARCHAR(2147483647) f0, VARCHAR(2147483647) f1)], joinType=[INNER])
++- Correlate(invocation=[$UNNEST_ROWS$1($cor0.c)], correlate=[table($UNNEST_ROWS$1($cor0.c))], select=[a,b,c,f0,f1], rowType=[RecordType(INTEGER a, BIGINT b, (VARCHAR(2147483647), VARCHAR(2147483647)) MAP c, VARCHAR(2147483647) f0, VARCHAR(2147483647) f1)], joinType=[INNER])
    +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
     </Resource>
@@ -124,7 +124,7 @@ LogicalProject(a=[$0], b=[$1], x=[$2], y=[$3])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b, _1, _2], where=[(_1 > a)])
-+- Correlate(invocation=[UNNEST($cor0.b)], correlate=[table(UNNEST($cor0.b))], select=[a,b,_1,_2], rowType=[RecordType(INTEGER a, RecordType:peek_no_expand(INTEGER _1, VARCHAR(2147483647) _2) ARRAY b, INTEGER _1, VARCHAR(2147483647) _2)], joinType=[INNER])
++- Correlate(invocation=[$UNNEST_ROWS$1($cor0.b)], correlate=[table($UNNEST_ROWS$1($cor0.b))], select=[a,b,_1,_2], rowType=[RecordType(INTEGER a, RecordType:peek_no_expand(INTEGER _1, VARCHAR(2147483647) _2) ARRAY b, INTEGER _1, VARCHAR(2147483647) _2)], joinType=[INNER])
    +- Calc(select=[a, b], where=[(a < 3)])
       +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b)]]], fields=[a, b])
 ]]>
@@ -154,7 +154,7 @@ LogicalProject(a=[$0], s=[$2])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, f0 AS s])
-+- Correlate(invocation=[UNNEST($cor0.set)], correlate=[table(UNNEST($cor0.set))], select=[a,set,f0], rowType=[RecordType(INTEGER a, VARCHAR(2147483647) MULTISET set, VARCHAR(2147483647) f0)], joinType=[LEFT])
++- Correlate(invocation=[$UNNEST_ROWS$1($cor0.set)], correlate=[table($UNNEST_ROWS$1($cor0.set))], select=[a,set,f0], rowType=[RecordType(INTEGER a, VARCHAR(2147483647) MULTISET set, VARCHAR(2147483647) f0)], joinType=[LEFT])
    +- GroupAggregate(groupBy=[a], select=[a, COLLECT(b) AS set])
       +- Exchange(distribution=[hash[a]])
          +- Calc(select=[a, b], where=[(a < 5)])
@@ -180,7 +180,7 @@ LogicalProject(a=[$0], s=[$3])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, f0 AS s])
-+- Correlate(invocation=[UNNEST($cor0.c)], correlate=[table(UNNEST($cor0.c))], select=[a,b,c,f0], rowType=[RecordType(INTEGER a, INTEGER ARRAY b, INTEGER ARRAY ARRAY c, INTEGER ARRAY f0)], joinType=[INNER])
++- Correlate(invocation=[$UNNEST_ROWS$1($cor0.c)], correlate=[table($UNNEST_ROWS$1($cor0.c))], select=[a,b,c,f0], rowType=[RecordType(INTEGER a, INTEGER ARRAY b, INTEGER ARRAY ARRAY c, INTEGER ARRAY f0)], joinType=[INNER])
    +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
     </Resource>
@@ -209,7 +209,7 @@ LogicalProject(b=[$0], id=[$2], point=[$3])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[b, _1 AS id, _2 AS point])
-+- Correlate(invocation=[UNNEST($cor0.set)], correlate=[table(UNNEST($cor0.set))], select=[b,set,_1,_2], rowType=[RecordType(INTEGER b, RecordType:peek_no_expand(INTEGER _1, VARCHAR(2147483647) _2) MULTISET set, INTEGER _1, VARCHAR(2147483647) _2)], joinType=[INNER])
++- Correlate(invocation=[$UNNEST_ROWS$1($cor0.set)], correlate=[table($UNNEST_ROWS$1($cor0.set))], select=[b,set,_1,_2], rowType=[RecordType(INTEGER b, RecordType:peek_no_expand(INTEGER _1, VARCHAR(2147483647) _2) MULTISET set, INTEGER _1, VARCHAR(2147483647) _2)], joinType=[INNER])
    +- GroupAggregate(groupBy=[b], select=[b, COLLECT(c) AS set])
       +- Exchange(distribution=[hash[b]])
          +- Calc(select=[b, c], where=[(b < 3)])
@@ -235,7 +235,7 @@ LogicalProject(a=[$0], b=[$1], s=[$3])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b, f0 AS s])
-+- Correlate(invocation=[UNNEST($cor0.b)], correlate=[table(UNNEST($cor0.b))], select=[a,b,c,f0], rowType=[RecordType(INTEGER a, INTEGER ARRAY b, INTEGER ARRAY ARRAY c, INTEGER f0)], joinType=[INNER])
++- Correlate(invocation=[$UNNEST_ROWS$1($cor0.b)], correlate=[table($UNNEST_ROWS$1($cor0.b))], select=[a,b,c,f0], rowType=[RecordType(INTEGER a, INTEGER ARRAY b, INTEGER ARRAY ARRAY c, INTEGER f0)], joinType=[INNER])
    +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
     </Resource>
@@ -258,7 +258,7 @@ LogicalProject(a=[$0], b=[$1], s=[$2], t=[$3])
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Correlate(invocation=[UNNEST($cor0.b)], correlate=[table(UNNEST($cor0.b))], select=[a,b,_1,_2], rowType=[RecordType(INTEGER a, RecordType:peek_no_expand(INTEGER _1, VARCHAR(2147483647) _2) ARRAY b, INTEGER _1, VARCHAR(2147483647) _2)], joinType=[INNER], condition=[>($0, 13)])
+Correlate(invocation=[$UNNEST_ROWS$1($cor0.b)], correlate=[table($UNNEST_ROWS$1($cor0.b))], select=[a,b,_1,_2], rowType=[RecordType(INTEGER a, RecordType:peek_no_expand(INTEGER _1, VARCHAR(2147483647) _2) ARRAY b, INTEGER _1, VARCHAR(2147483647) _2)], joinType=[INNER], condition=[>($0, 13)])
 +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b)]]], fields=[a, b])
 ]]>
     </Resource>
@@ -280,7 +280,7 @@ LogicalProject(a=[$0], b=[$1], _1=[$2], _2=[$3])
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Correlate(invocation=[UNNEST($cor0.b)], correlate=[table(UNNEST($cor0.b))], select=[a,b,_1,_2], rowType=[RecordType(INTEGER a, RecordType:peek_no_expand(INTEGER _1, VARCHAR(2147483647) _2) ARRAY b, INTEGER _1, VARCHAR(2147483647) _2)], joinType=[INNER], condition=[>($0, 1)])
+Correlate(invocation=[$UNNEST_ROWS$1($cor0.b)], correlate=[table($UNNEST_ROWS$1($cor0.b))], select=[a,b,_1,_2], rowType=[RecordType(INTEGER a, RecordType:peek_no_expand(INTEGER _1, VARCHAR(2147483647) _2) ARRAY b, INTEGER _1, VARCHAR(2147483647) _2)], joinType=[INNER], condition=[>($0, 1)])
 +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b)]]], fields=[a, b])
 ]]>
     </Resource>

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/BuiltInSpecializedFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/BuiltInSpecializedFunction.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.catalog.DataTypeFactory;
+import org.apache.flink.table.functions.BuiltInFunctionDefinition;
+import org.apache.flink.table.functions.FunctionKind;
+import org.apache.flink.table.functions.FunctionRequirement;
+import org.apache.flink.table.functions.SpecializedFunction;
+import org.apache.flink.table.types.inference.TypeInference;
+
+import java.util.Set;
+
+/**
+ * Base class for built-in functions that need another level of specialization via {@link
+ * BuiltInFunctionDefinition#specialize(SpecializedContext)}.
+ *
+ * <p>Subclasses can create a specific UDF runtime implementation targeted to the given (fully
+ * known) arguments and derived output type. Subclasses must provide a default constructor.
+ */
+@Internal
+public abstract class BuiltInSpecializedFunction implements SpecializedFunction {
+
+    private final BuiltInFunctionDefinition definition;
+
+    protected BuiltInSpecializedFunction(BuiltInFunctionDefinition definition) {
+        this.definition = definition;
+    }
+
+    @Override
+    public FunctionKind getKind() {
+        return definition.getKind();
+    }
+
+    @Override
+    public TypeInference getTypeInference(DataTypeFactory typeFactory) {
+        return definition.getTypeInference(typeFactory);
+    }
+
+    @Override
+    public Set<FunctionRequirement> getRequirements() {
+        return definition.getRequirements();
+    }
+
+    @Override
+    public boolean isDeterministic() {
+        return definition.isDeterministic();
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This converts UNNEST into a registered internal function that will be specialized two times until a UDF is known.

## Brief change log

Use `SpecializedFunction` to lazy instantiate a runtime implementation from an internal UDF name.

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? JavaDocs
