### PR TITLE
[FLINK-21439][runtime] Exception history adaptive scheduler

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraph.java
@@ -1576,4 +1576,15 @@ public class DefaultExecutionGraph implements ExecutionGraph, InternalExecutionG
     public boolean isDynamic() {
         return isDynamic;
     }
+
+    @Override
+    public Optional<String> findVertexWithAttempt(ExecutionAttemptID attemptId) {
+        return Optional.ofNullable(currentExecutions.get(attemptId))
+                .map(Execution::getVertexWithAttempt);
+    }
+
+    @Override
+    public Optional<AccessExecution> findExecution(ExecutionAttemptID attemptId) {
+        return Optional.ofNullable(currentExecutions.get(attemptId));
+    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -49,6 +49,7 @@ import javax.annotation.Nullable;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -228,4 +229,8 @@ public interface ExecutionGraph extends AccessExecutionGraph {
      * @param vertices The execution job vertices that are newly initialized.
      */
     void notifyNewlyInitializedJobVertices(List<ExecutionJobVertex> vertices);
+
+    Optional<String> findVertexWithAttempt(final ExecutionAttemptID attemptId);
+
+    Optional<AccessExecution> findExecution(final ExecutionAttemptID attemptId);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -103,7 +103,6 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -807,10 +806,7 @@ public abstract class SchedulerBase implements SchedulerNG, CheckpointScheduling
 
     @VisibleForTesting
     Iterable<RootExceptionHistoryEntry> getExceptionHistory() {
-        final Collection<RootExceptionHistoryEntry> copy = new ArrayList<>(exceptionHistory.size());
-        exceptionHistory.forEach(copy::add);
-
-        return copy;
+        return exceptionHistory.toArrayList();
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
@@ -1067,18 +1067,18 @@ public class AdaptiveScheduler
     }
 
     @Override
-    public Executing.FailureResult howToHandleFailure(Throwable failure) {
+    public FailureResult howToHandleFailure(Throwable failure) {
         if (ExecutionFailureHandler.isUnrecoverableError(failure)) {
-            return Executing.FailureResult.canNotRestart(
+            return FailureResult.canNotRestart(
                     new JobException("The failure is not recoverable", failure));
         }
 
         restartBackoffTimeStrategy.notifyFailure(failure);
         if (restartBackoffTimeStrategy.canRestart()) {
-            return Executing.FailureResult.canRestart(
+            return FailureResult.canRestart(
                     failure, Duration.ofMillis(restartBackoffTimeStrategy.getBackoffTime()));
         } else {
-            return Executing.FailureResult.canNotRestart(
+            return FailureResult.canNotRestart(
                     new JobException(
                             "Recovery is suppressed by " + restartBackoffTimeStrategy, failure));
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/CreatingExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/CreatingExecutionGraph.java
@@ -37,6 +37,7 @@ import org.slf4j.Logger;
 import javax.annotation.Nullable;
 
 import java.time.Duration;
+import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledFuture;
@@ -117,7 +118,8 @@ public class CreatingExecutionGraph implements State {
                 context.goToExecuting(
                         result.getExecutionGraph(),
                         executionGraphHandler,
-                        operatorCoordinatorHandler);
+                        operatorCoordinatorHandler,
+                        Collections.emptyList());
             } else {
                 logger.debug(
                         "Failed to reserve and assign the required slots. Waiting for new resources.");

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Executing.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Executing.java
@@ -231,56 +231,6 @@ class Executing extends StateWithExecutionGraph implements ResourceConsumer {
         ScheduledFuture<?> runIfState(State expectedState, Runnable action, Duration delay);
     }
 
-    /**
-     * The {@link FailureResult} describes how a failure shall be handled. Currently, there are two
-     * alternatives: Either restarting the job or failing it.
-     */
-    static final class FailureResult {
-        @Nullable private final Duration backoffTime;
-
-        private final Throwable failureCause;
-
-        private FailureResult(Throwable failureCause, @Nullable Duration backoffTime) {
-            this.backoffTime = backoffTime;
-            this.failureCause = failureCause;
-        }
-
-        boolean canRestart() {
-            return backoffTime != null;
-        }
-
-        Duration getBackoffTime() {
-            Preconditions.checkState(
-                    canRestart(), "Failure result must be restartable to return a backoff time.");
-            return backoffTime;
-        }
-
-        Throwable getFailureCause() {
-            return failureCause;
-        }
-
-        /**
-         * Creates a FailureResult which allows to restart the job.
-         *
-         * @param failureCause failureCause for restarting the job
-         * @param backoffTime backoffTime to wait before restarting the job
-         * @return FailureResult which allows to restart the job
-         */
-        static FailureResult canRestart(Throwable failureCause, Duration backoffTime) {
-            return new FailureResult(failureCause, backoffTime);
-        }
-
-        /**
-         * Creates FailureResult which does not allow to restart the job.
-         *
-         * @param failureCause failureCause describes the reason why the job cannot be restarted
-         * @return FailureResult which does not allow to restart the job
-         */
-        static FailureResult canNotRestart(Throwable failureCause) {
-            return new FailureResult(failureCause, null);
-        }
-    }
-
     static class Factory implements StateFactory<Executing> {
 
         private final Context context;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Executing.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Executing.java
@@ -86,23 +86,7 @@ class Executing extends StateWithExecutionGraph implements ResourceConsumer {
     }
 
     private void handleAnyFailure(Throwable cause) {
-        final FailureResult failureResult = context.howToHandleFailure(cause);
-
-        if (failureResult.canRestart()) {
-            getLogger().info("Restarting job.", failureResult.getFailureCause());
-            context.goToRestarting(
-                    getExecutionGraph(),
-                    getExecutionGraphHandler(),
-                    getOperatorCoordinatorHandler(),
-                    failureResult.getBackoffTime());
-        } else {
-            getLogger().info("Failing job.", failureResult.getFailureCause());
-            context.goToFailing(
-                    getExecutionGraph(),
-                    getExecutionGraphHandler(),
-                    getOperatorCoordinatorHandler(),
-                    failureResult.getFailureCause());
-        }
+        FailureResultUtil.restartOrFail(context.howToHandleFailure(cause), context, this);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Failing.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Failing.java
@@ -21,12 +21,14 @@ package org.apache.flink.runtime.scheduler.adaptive;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
-import org.apache.flink.runtime.executiongraph.TaskExecutionStateTransition;
 import org.apache.flink.runtime.scheduler.ExecutionGraphHandler;
 import org.apache.flink.runtime.scheduler.OperatorCoordinatorHandler;
+import org.apache.flink.runtime.scheduler.exceptionhistory.ExceptionHistoryEntry;
 import org.apache.flink.util.Preconditions;
 
 import org.slf4j.Logger;
+
+import java.util.List;
 
 /** State which describes a failing job which is currently being canceled. */
 class Failing extends StateWithExecutionGraph {
@@ -38,8 +40,17 @@ class Failing extends StateWithExecutionGraph {
             ExecutionGraphHandler executionGraphHandler,
             OperatorCoordinatorHandler operatorCoordinatorHandler,
             Logger logger,
-            Throwable failureCause) {
-        super(context, executionGraph, executionGraphHandler, operatorCoordinatorHandler, logger);
+            Throwable failureCause,
+            ClassLoader userCodeClassLoader,
+            List<ExceptionHistoryEntry> failureCollection) {
+        super(
+                context,
+                executionGraph,
+                executionGraphHandler,
+                operatorCoordinatorHandler,
+                logger,
+                userCodeClassLoader,
+                failureCollection);
         this.context = context;
 
         getExecutionGraph().failJob(failureCause, System.currentTimeMillis());
@@ -53,21 +64,15 @@ class Failing extends StateWithExecutionGraph {
     @Override
     public void cancel() {
         context.goToCanceling(
-                getExecutionGraph(), getExecutionGraphHandler(), getOperatorCoordinatorHandler());
+                getExecutionGraph(),
+                getExecutionGraphHandler(),
+                getOperatorCoordinatorHandler(),
+                getFailures());
     }
 
     @Override
-    public void handleGlobalFailure(Throwable cause) {
-        getLogger()
-                .debug(
-                        "Ignored global failure because we are already failing the job {}.",
-                        getJobId(),
-                        cause);
-    }
-
-    @Override
-    boolean updateTaskExecutionState(TaskExecutionStateTransition taskExecutionStateTransition) {
-        return getExecutionGraph().updateState(taskExecutionStateTransition);
+    void onFailure(Throwable failure) {
+        // We've already failed the execution graph, so there is noting else we can do.
     }
 
     @Override
@@ -87,6 +92,8 @@ class Failing extends StateWithExecutionGraph {
         private final ExecutionGraphHandler executionGraphHandler;
         private final OperatorCoordinatorHandler operatorCoordinatorHandler;
         private final Throwable failureCause;
+        private final ClassLoader userCodeClassLoader;
+        private final List<ExceptionHistoryEntry> failureCollection;
 
         public Factory(
                 Context context,
@@ -94,13 +101,17 @@ class Failing extends StateWithExecutionGraph {
                 ExecutionGraphHandler executionGraphHandler,
                 OperatorCoordinatorHandler operatorCoordinatorHandler,
                 Logger log,
-                Throwable failureCause) {
+                Throwable failureCause,
+                ClassLoader userCodeClassLoader,
+                List<ExceptionHistoryEntry> failureCollection) {
             this.context = context;
             this.log = log;
             this.executionGraph = executionGraph;
             this.executionGraphHandler = executionGraphHandler;
             this.operatorCoordinatorHandler = operatorCoordinatorHandler;
             this.failureCause = failureCause;
+            this.userCodeClassLoader = userCodeClassLoader;
+            this.failureCollection = failureCollection;
         }
 
         public Class<Failing> getStateClass() {
@@ -114,7 +125,9 @@ class Failing extends StateWithExecutionGraph {
                     executionGraphHandler,
                     operatorCoordinatorHandler,
                     log,
-                    failureCause);
+                    failureCause,
+                    userCodeClassLoader,
+                    failureCollection);
         }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/FailureResult.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/FailureResult.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.adaptive;
+
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nullable;
+
+import java.time.Duration;
+
+/**
+ * The {@link FailureResult} describes how a failure shall be handled. Currently, there are two
+ * alternatives: Either restarting the job or failing it.
+ */
+class FailureResult {
+    @Nullable private final Duration backoffTime;
+
+    private final Throwable failureCause;
+
+    private FailureResult(Throwable failureCause, @Nullable Duration backoffTime) {
+        this.backoffTime = backoffTime;
+        this.failureCause = failureCause;
+    }
+
+    boolean canRestart() {
+        return backoffTime != null;
+    }
+
+    Duration getBackoffTime() {
+        Preconditions.checkState(
+                canRestart(), "Failure result must be restartable to return a backoff time.");
+        return backoffTime;
+    }
+
+    Throwable getFailureCause() {
+        return failureCause;
+    }
+
+    /**
+     * Creates a FailureResult which allows to restart the job.
+     *
+     * @param failureCause failureCause for restarting the job
+     * @param backoffTime backoffTime to wait before restarting the job
+     * @return FailureResult which allows to restart the job
+     */
+    static FailureResult canRestart(Throwable failureCause, Duration backoffTime) {
+        return new FailureResult(failureCause, backoffTime);
+    }
+
+    /**
+     * Creates FailureResult which does not allow to restart the job.
+     *
+     * @param failureCause failureCause describes the reason why the job cannot be restarted
+     * @return FailureResult which does not allow to restart the job
+     */
+    static FailureResult canNotRestart(Throwable failureCause) {
+        return new FailureResult(failureCause, null);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/FailureResultUtil.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/FailureResultUtil.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.adaptive;
+
+/** {@link FailureResultUtil} contains helper methods for {@link FailureResult}. */
+public class FailureResultUtil {
+    public static <T extends StateTransitions.ToRestarting & StateTransitions.ToFailing>
+            void restartOrFail(
+                    FailureResult failureResult, T context, StateWithExecutionGraph sweg) {
+        if (failureResult.canRestart()) {
+            sweg.getLogger().info("Restarting job.", failureResult.getFailureCause());
+            context.goToRestarting(
+                    sweg.getExecutionGraph(),
+                    sweg.getExecutionGraphHandler(),
+                    sweg.getOperatorCoordinatorHandler(),
+                    failureResult.getBackoffTime(),
+                    sweg.getFailures());
+        } else {
+            sweg.getLogger().info("Failing job.", failureResult.getFailureCause());
+            context.goToFailing(
+                    sweg.getExecutionGraph(),
+                    sweg.getExecutionGraphHandler(),
+                    sweg.getOperatorCoordinatorHandler(),
+                    failureResult.getFailureCause(),
+                    sweg.getFailures());
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Restarting.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Restarting.java
@@ -20,9 +20,9 @@ package org.apache.flink.runtime.scheduler.adaptive;
 
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
-import org.apache.flink.runtime.executiongraph.TaskExecutionStateTransition;
 import org.apache.flink.runtime.scheduler.ExecutionGraphHandler;
 import org.apache.flink.runtime.scheduler.OperatorCoordinatorHandler;
+import org.apache.flink.runtime.scheduler.exceptionhistory.ExceptionHistoryEntry;
 import org.apache.flink.util.Preconditions;
 
 import org.slf4j.Logger;
@@ -30,6 +30,7 @@ import org.slf4j.Logger;
 import javax.annotation.Nullable;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.concurrent.ScheduledFuture;
 
 /** State which describes a job which is currently being restarted. */
@@ -47,8 +48,17 @@ class Restarting extends StateWithExecutionGraph {
             ExecutionGraphHandler executionGraphHandler,
             OperatorCoordinatorHandler operatorCoordinatorHandler,
             Logger logger,
-            Duration backoffTime) {
-        super(context, executionGraph, executionGraphHandler, operatorCoordinatorHandler, logger);
+            Duration backoffTime,
+            ClassLoader userCodeClassLoader,
+            List<ExceptionHistoryEntry> failureCollection) {
+        super(
+                context,
+                executionGraph,
+                executionGraphHandler,
+                operatorCoordinatorHandler,
+                logger,
+                userCodeClassLoader,
+                failureCollection);
         this.context = context;
         this.backoffTime = backoffTime;
 
@@ -72,21 +82,15 @@ class Restarting extends StateWithExecutionGraph {
     @Override
     public void cancel() {
         context.goToCanceling(
-                getExecutionGraph(), getExecutionGraphHandler(), getOperatorCoordinatorHandler());
+                getExecutionGraph(),
+                getExecutionGraphHandler(),
+                getOperatorCoordinatorHandler(),
+                getFailures());
     }
 
     @Override
-    public void handleGlobalFailure(Throwable cause) {
-        getLogger()
-                .debug(
-                        "Ignored global failure because we are already restarting the job {}.",
-                        getJobId(),
-                        cause);
-    }
-
-    @Override
-    boolean updateTaskExecutionState(TaskExecutionStateTransition taskExecutionStateTransition) {
-        return getExecutionGraph().updateState(taskExecutionStateTransition);
+    void onFailure(Throwable failure) {
+        // We've already cancelled the execution graph, so there is noting else we can do.
     }
 
     @Override
@@ -123,6 +127,8 @@ class Restarting extends StateWithExecutionGraph {
         private final ExecutionGraphHandler executionGraphHandler;
         private final OperatorCoordinatorHandler operatorCoordinatorHandler;
         private final Duration backoffTime;
+        private final ClassLoader userCodeClassLoader;
+        private final List<ExceptionHistoryEntry> failureCollection;
 
         public Factory(
                 Context context,
@@ -130,13 +136,17 @@ class Restarting extends StateWithExecutionGraph {
                 ExecutionGraphHandler executionGraphHandler,
                 OperatorCoordinatorHandler operatorCoordinatorHandler,
                 Logger log,
-                Duration backoffTime) {
+                Duration backoffTime,
+                ClassLoader userCodeClassLoader,
+                List<ExceptionHistoryEntry> failureCollection) {
             this.context = context;
             this.log = log;
             this.executionGraph = executionGraph;
             this.executionGraphHandler = executionGraphHandler;
             this.operatorCoordinatorHandler = operatorCoordinatorHandler;
             this.backoffTime = backoffTime;
+            this.userCodeClassLoader = userCodeClassLoader;
+            this.failureCollection = failureCollection;
         }
 
         public Class<Restarting> getStateClass() {
@@ -150,7 +160,9 @@ class Restarting extends StateWithExecutionGraph {
                     executionGraphHandler,
                     operatorCoordinatorHandler,
                     log,
-                    backoffTime);
+                    backoffTime,
+                    userCodeClassLoader,
+                    failureCollection);
         }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/StateTransitions.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/StateTransitions.java
@@ -23,8 +23,10 @@ import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.scheduler.ExecutionGraphHandler;
 import org.apache.flink.runtime.scheduler.OperatorCoordinatorHandler;
+import org.apache.flink.runtime.scheduler.exceptionhistory.ExceptionHistoryEntry;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -43,11 +45,13 @@ public interface StateTransitions {
          * @param executionGraphHandler executionGraphHandler to pass to the {@link Canceling} state
          * @param operatorCoordinatorHandler operatorCoordinatorHandler to pass to the {@link
          *     Canceling} state
+         * @param failureCollection collection of failures that are propagated
          */
         void goToCanceling(
                 ExecutionGraph executionGraph,
                 ExecutionGraphHandler executionGraphHandler,
-                OperatorCoordinatorHandler operatorCoordinatorHandler);
+                OperatorCoordinatorHandler operatorCoordinatorHandler,
+                List<ExceptionHistoryEntry> failureCollection);
     }
 
     /** Interface covering transition to the {@link CreatingExecutionGraph} state. */
@@ -67,11 +71,13 @@ public interface StateTransitions {
          * @param executionGraphHandler executionGraphHandler to pass to the {@link Executing} state
          * @param operatorCoordinatorHandler operatorCoordinatorHandler to pass to the {@link
          *     Executing} state
+         * @param failureCollection collection of failures that are propagated
          */
         void goToExecuting(
                 ExecutionGraph executionGraph,
                 ExecutionGraphHandler executionGraphHandler,
-                OperatorCoordinatorHandler operatorCoordinatorHandler);
+                OperatorCoordinatorHandler operatorCoordinatorHandler,
+                List<ExceptionHistoryEntry> failureCollection);
     }
 
     /** Interface covering transition to the {@link Finished} state. */
@@ -97,12 +103,14 @@ public interface StateTransitions {
          * @param operatorCoordinatorHandler operatorCoordinatorHandler to pass to the {@link
          *     Failing} state
          * @param failureCause failureCause describing why the job execution failed
+         * @param failureCollection collection of failures that are propagated
          */
         void goToFailing(
                 ExecutionGraph executionGraph,
                 ExecutionGraphHandler executionGraphHandler,
                 OperatorCoordinatorHandler operatorCoordinatorHandler,
-                Throwable failureCause);
+                Throwable failureCause,
+                List<ExceptionHistoryEntry> failureCollection);
     }
 
     /** Interface covering transition to the {@link Restarting} state. */
@@ -118,12 +126,14 @@ public interface StateTransitions {
          *     Restarting} state
          * @param backoffTime backoffTime to wait before transitioning to the {@link Restarting}
          *     state
+         * @param failureCollection collection of failures that are propagated
          */
         void goToRestarting(
                 ExecutionGraph executionGraph,
                 ExecutionGraphHandler executionGraphHandler,
                 OperatorCoordinatorHandler operatorCoordinatorHandler,
-                Duration backoffTime);
+                Duration backoffTime,
+                List<ExceptionHistoryEntry> failureCollection);
     }
 
     /** Interface covering transition to the {@link StopWithSavepoint} state. */
@@ -138,6 +148,7 @@ public interface StateTransitions {
          * @param operatorCoordinatorHandler operatorCoordinatorHandler to pass to the {@link
          *     StopWithSavepoint} state
          * @param savepointFuture Future for the savepoint to complete.
+         * @param failureCollection collection of failures that are propagated
          * @return Location of the savepoint.
          */
         CompletableFuture<String> goToStopWithSavepoint(
@@ -145,7 +156,8 @@ public interface StateTransitions {
                 ExecutionGraphHandler executionGraphHandler,
                 OperatorCoordinatorHandler operatorCoordinatorHandler,
                 CheckpointScheduling checkpointScheduling,
-                CompletableFuture<String> savepointFuture);
+                CompletableFuture<String> savepointFuture,
+                List<ExceptionHistoryEntry> failureCollection);
     }
 
     /** Interface covering transition to the {@link WaitingForResources} state. */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/StateWithExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/StateWithExecutionGraph.java
@@ -28,7 +28,9 @@ import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.AccessExecution;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ErrorInfo;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.TaskExecutionStateTransition;
@@ -48,6 +50,8 @@ import org.apache.flink.runtime.query.UnknownKvStateLocation;
 import org.apache.flink.runtime.scheduler.ExecutionGraphHandler;
 import org.apache.flink.runtime.scheduler.KvStateHandler;
 import org.apache.flink.runtime.scheduler.OperatorCoordinatorHandler;
+import org.apache.flink.runtime.scheduler.exceptionhistory.ExceptionHistoryEntry;
+import org.apache.flink.runtime.scheduler.exceptionhistory.RootExceptionHistoryEntry;
 import org.apache.flink.runtime.scheduler.stopwithsavepoint.StopWithSavepointTerminationManager;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.util.FlinkException;
@@ -58,6 +62,10 @@ import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
@@ -79,18 +87,26 @@ abstract class StateWithExecutionGraph implements State {
 
     private final Logger logger;
 
+    private final ClassLoader userCodeClassLoader;
+
+    private final List<ExceptionHistoryEntry> failureCollection;
+
     StateWithExecutionGraph(
             Context context,
             ExecutionGraph executionGraph,
             ExecutionGraphHandler executionGraphHandler,
             OperatorCoordinatorHandler operatorCoordinatorHandler,
-            Logger logger) {
+            Logger logger,
+            ClassLoader userClassCodeLoader,
+            List<ExceptionHistoryEntry> failureCollection) {
         this.context = context;
         this.executionGraph = executionGraph;
         this.executionGraphHandler = executionGraphHandler;
         this.operatorCoordinatorHandler = operatorCoordinatorHandler;
         this.kvStateHandler = new KvStateHandler(executionGraph);
         this.logger = logger;
+        this.userCodeClassLoader = userClassCodeLoader;
+        this.failureCollection = new ArrayList<>(failureCollection);
 
         FutureUtils.assertNoException(
                 executionGraph
@@ -99,7 +115,12 @@ abstract class StateWithExecutionGraph implements State {
                                 jobStatus -> {
                                     if (jobStatus.isGloballyTerminalState()) {
                                         context.runIfState(
-                                                this, () -> onGloballyTerminalState(jobStatus));
+                                                this,
+                                                () -> {
+                                                    convertFailures(this.failureCollection)
+                                                            .ifPresent(context::archiveFailure);
+                                                    onGloballyTerminalState(jobStatus);
+                                                });
                                     }
                                 },
                                 context.getMainThreadExecutor()));
@@ -304,6 +325,22 @@ abstract class StateWithExecutionGraph implements State {
                 operatorId, request);
     }
 
+    /** Transition to different state when failure occurs. Stays in the same state by default. */
+    abstract void onFailure(Throwable cause);
+
+    /**
+     * Transition to different state when the execution graph reaches a globally terminal state.
+     *
+     * @param globallyTerminalState globally terminal state which the execution graph reached
+     */
+    abstract void onGloballyTerminalState(JobStatus globallyTerminalState);
+
+    @Override
+    public void handleGlobalFailure(Throwable cause) {
+        failureCollection.add(ExceptionHistoryEntry.createGlobal(cause));
+        onFailure(cause);
+    }
+
     /**
      * Updates the execution graph with the given task execution state transition.
      *
@@ -311,15 +348,43 @@ abstract class StateWithExecutionGraph implements State {
      *     with
      * @return {@code true} if the update was successful; otherwise {@code false}
      */
-    abstract boolean updateTaskExecutionState(
-            TaskExecutionStateTransition taskExecutionStateTransition);
+    boolean updateTaskExecutionState(TaskExecutionStateTransition taskExecutionStateTransition) {
+        // collect before updateState, as updateState may deregister the execution
+        final Optional<AccessExecution> maybeExecution =
+                executionGraph.findExecution(taskExecutionStateTransition.getID());
+        final Optional<String> maybeTaskName =
+                executionGraph.findVertexWithAttempt(taskExecutionStateTransition.getID());
 
-    /**
-     * Callback which is called once the execution graph reaches a globally terminal state.
-     *
-     * @param globallyTerminalState globally terminal state which the execution graph reached
-     */
-    abstract void onGloballyTerminalState(JobStatus globallyTerminalState);
+        final ExecutionState desiredState = taskExecutionStateTransition.getExecutionState();
+        boolean successfulUpdate = getExecutionGraph().updateState(taskExecutionStateTransition);
+        if (successfulUpdate && desiredState == ExecutionState.FAILED) {
+            final AccessExecution execution =
+                    maybeExecution.orElseThrow(NoSuchElementException::new);
+            final String taskName = maybeTaskName.orElseThrow(NoSuchElementException::new);
+            final ExecutionState currentState = execution.getState();
+            if (currentState == desiredState) {
+                failureCollection.add(ExceptionHistoryEntry.create(execution, taskName));
+                onFailure(
+                        ErrorInfo.handleMissingThrowable(
+                                taskExecutionStateTransition.getError(userCodeClassLoader)));
+            }
+        }
+        return successfulUpdate;
+    }
+
+    List<ExceptionHistoryEntry> getFailures() {
+        return failureCollection;
+    }
+
+    private static Optional<RootExceptionHistoryEntry> convertFailures(
+            List<ExceptionHistoryEntry> failureCollection) {
+        if (failureCollection.isEmpty()) {
+            return Optional.empty();
+        }
+        final ExceptionHistoryEntry first = failureCollection.remove(0);
+        return Optional.of(
+                RootExceptionHistoryEntry.fromExceptionHistoryEntry(first, failureCollection));
+    }
 
     /** Context of the {@link StateWithExecutionGraph} state. */
     interface Context extends StateTransitions.ToFinished {
@@ -347,5 +412,8 @@ abstract class StateWithExecutionGraph implements State {
          * @return the main thread executor
          */
         Executor getMainThreadExecutor();
+
+        /** Archive failure. */
+        void archiveFailure(RootExceptionHistoryEntry failure);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/StateWithExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/StateWithExecutionGraph.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.scheduler.adaptive;
 
-import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.core.execution.SavepointFormatType;
@@ -106,7 +105,6 @@ abstract class StateWithExecutionGraph implements State {
                                 context.getMainThreadExecutor()));
     }
 
-    @VisibleForTesting
     ExecutionGraph getExecutionGraph() {
         return executionGraph;
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/StopWithSavepoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/StopWithSavepoint.java
@@ -180,23 +180,7 @@ class StopWithSavepoint extends StateWithExecutionGraph {
 
     private void handleAnyFailure(Throwable cause) {
         operationFailureCause = cause;
-        final FailureResult failureResult = context.howToHandleFailure(cause);
-
-        if (failureResult.canRestart()) {
-            getLogger().info("Restarting job.", failureResult.getFailureCause());
-            context.goToRestarting(
-                    getExecutionGraph(),
-                    getExecutionGraphHandler(),
-                    getOperatorCoordinatorHandler(),
-                    failureResult.getBackoffTime());
-        } else {
-            getLogger().info("Failing job.", failureResult.getFailureCause());
-            context.goToFailing(
-                    getExecutionGraph(),
-                    getExecutionGraphHandler(),
-                    getOperatorCoordinatorHandler(),
-                    failureResult.getFailureCause());
-        }
+        FailureResultUtil.restartOrFail(context.howToHandleFailure(cause), context, this);
     }
 
     CompletableFuture<String> getOperationFuture() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/StopWithSavepoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/StopWithSavepoint.java
@@ -180,7 +180,7 @@ class StopWithSavepoint extends StateWithExecutionGraph {
 
     private void handleAnyFailure(Throwable cause) {
         operationFailureCause = cause;
-        final Executing.FailureResult failureResult = context.howToHandleFailure(cause);
+        final FailureResult failureResult = context.howToHandleFailure(cause);
 
         if (failureResult.canRestart()) {
             getLogger().info("Restarting job.", failureResult.getFailureCause());
@@ -214,9 +214,9 @@ class StopWithSavepoint extends StateWithExecutionGraph {
          * Asks how to handle the failure.
          *
          * @param failure failure describing the failure cause
-         * @return {@link Executing.FailureResult} which describes how to handle the failure
+         * @return {@link FailureResult} which describes how to handle the failure
          */
-        Executing.FailureResult howToHandleFailure(Throwable failure);
+        FailureResult howToHandleFailure(Throwable failure);
 
         /**
          * Runs the given action after the specified delay if the state is the expected state at

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/exceptionhistory/ExceptionHistoryEntry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/exceptionhistory/ExceptionHistoryEntry.java
@@ -67,6 +67,12 @@ public class ExceptionHistoryEntry extends ErrorInfo {
                 failedExecution.getAssignedResourceLocation());
     }
 
+    /** Creates an {@code ExceptionHistoryEntry} that is not based on an {@code Execution}. */
+    public static ExceptionHistoryEntry createGlobal(Throwable cause) {
+        return new ExceptionHistoryEntry(
+                cause, System.currentTimeMillis(), null, (ArchivedTaskManagerLocation) null);
+    }
+
     /**
      * Instantiates a {@code ExceptionHistoryEntry}.
      *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/exceptionhistory/RootExceptionHistoryEntry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/exceptionhistory/RootExceptionHistoryEntry.java
@@ -27,7 +27,6 @@ import org.apache.flink.util.Preconditions;
 import javax.annotation.Nullable;
 
 import java.util.Collections;
-import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -39,7 +38,7 @@ public class RootExceptionHistoryEntry extends ExceptionHistoryEntry {
 
     private static final long serialVersionUID = -7647332765867297434L;
 
-    private final Set<ExceptionHistoryEntry> concurrentExceptions;
+    private final Iterable<ExceptionHistoryEntry> concurrentExceptions;
 
     /**
      * Creates a {@code RootExceptionHistoryEntry} based on the passed {@link
@@ -87,6 +86,12 @@ public class RootExceptionHistoryEntry extends ExceptionHistoryEntry {
         return createRootExceptionHistoryEntry(cause, timestamp, null, null, executions);
     }
 
+    public static RootExceptionHistoryEntry fromExceptionHistoryEntry(
+            ExceptionHistoryEntry entry, Iterable<ExceptionHistoryEntry> entries) {
+        return new RootExceptionHistoryEntry(
+                entry.getException(), entry.getTimestamp(), null, null, entries);
+    }
+
     /**
      * Creates a {@code RootExceptionHistoryEntry} based on the passed {@link ErrorInfo}. No
      * concurrent failures will be added.
@@ -122,7 +127,7 @@ public class RootExceptionHistoryEntry extends ExceptionHistoryEntry {
                                 execution ->
                                         ExceptionHistoryEntry.create(
                                                 execution, execution.getVertexWithAttempt()))
-                        .collect(Collectors.toSet()));
+                        .collect(Collectors.toList()));
     }
 
     /**
@@ -142,7 +147,7 @@ public class RootExceptionHistoryEntry extends ExceptionHistoryEntry {
             long timestamp,
             @Nullable String failingTaskName,
             @Nullable TaskManagerLocation taskManagerLocation,
-            Set<ExceptionHistoryEntry> concurrentExceptions) {
+            Iterable<ExceptionHistoryEntry> concurrentExceptions) {
         super(cause, timestamp, failingTaskName, taskManagerLocation);
         this.concurrentExceptions = concurrentExceptions;
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/BoundedFIFOQueue.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/BoundedFIFOQueue.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.util;
 import org.apache.flink.util.Preconditions;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.Queue;
@@ -64,6 +65,10 @@ public class BoundedFIFOQueue<T> implements Iterable<T>, Serializable {
         if (elements.add(element) && elements.size() > maxSize) {
             elements.poll();
         }
+    }
+
+    public ArrayList<T> toArrayList() {
+        return new ArrayList<>(elements);
     }
 
     /**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerTest.java
@@ -943,8 +943,7 @@ public class AdaptiveSchedulerTest extends TestLogger {
                         .setRestartBackoffTimeStrategy(restartBackoffTimeStrategy)
                         .build();
 
-        final Executing.FailureResult failureResult =
-                scheduler.howToHandleFailure(new Exception("test"));
+        final FailureResult failureResult = scheduler.howToHandleFailure(new Exception("test"));
 
         assertThat(failureResult.canRestart()).isTrue();
         assertThat(failureResult.getBackoffTime().toMillis())

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/CancelingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/CancelingTest.java
@@ -20,14 +20,17 @@ package org.apache.flink.runtime.scheduler.adaptive;
 
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.ErrorInfo;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.TaskExecutionStateTransition;
 import org.apache.flink.runtime.scheduler.ExecutionGraphHandler;
 import org.apache.flink.runtime.scheduler.OperatorCoordinatorHandler;
-import org.apache.flink.runtime.taskmanager.TaskExecutionState;
+import org.apache.flink.runtime.scheduler.exceptionhistory.TestingAccessExecution;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
+
+import java.util.ArrayList;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
@@ -96,17 +99,16 @@ public class CancelingTest extends TestLogger {
             StateTrackingMockExecutionGraph meg = new StateTrackingMockExecutionGraph();
             Canceling canceling = createCancelingState(ctx, meg);
             // register execution at EG
-            ExecutingTest.MockExecutionJobVertex ejv =
-                    new ExecutingTest.MockExecutionJobVertex(
-                            ExecutingTest.MockExecutionVertex::new);
+
+            Exception exception = new RuntimeException();
+            TestingAccessExecution execution =
+                    TestingAccessExecution.newBuilder()
+                            .withExecutionState(ExecutionState.FAILED)
+                            .withErrorInfo(new ErrorInfo(exception, System.currentTimeMillis()))
+                            .build();
+            meg.registerExecution(execution);
             TaskExecutionStateTransition update =
-                    new TaskExecutionStateTransition(
-                            new TaskExecutionState(
-                                    ejv.getMockExecutionVertex()
-                                            .getCurrentExecutionAttempt()
-                                            .getAttemptId(),
-                                    ExecutionState.FAILED,
-                                    new RuntimeException()));
+                    ExecutingTest.createFailingStateTransition(execution.getAttemptId(), exception);
             canceling.updateTaskExecutionState(update);
             ctx.assertNoStateTransition();
         }
@@ -150,7 +152,9 @@ public class CancelingTest extends TestLogger {
                         executionGraph,
                         executionGraphHandler,
                         operatorCoordinatorHandler,
-                        log);
+                        log,
+                        ClassLoader.getSystemClassLoader(),
+                        new ArrayList<>());
         return canceling;
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/CreatingExecutionGraphTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/CreatingExecutionGraphTest.java
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.scheduler.ExecutionGraphHandler;
 import org.apache.flink.runtime.scheduler.GlobalFailureHandler;
 import org.apache.flink.runtime.scheduler.OperatorCoordinatorHandler;
 import org.apache.flink.runtime.scheduler.adaptive.allocator.VertexParallelism;
+import org.apache.flink.runtime.scheduler.exceptionhistory.ExceptionHistoryEntry;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.TestLoggerExtension;
@@ -41,6 +42,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import javax.annotation.Nullable;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -279,7 +281,8 @@ public class CreatingExecutionGraphTest extends TestLogger {
         public void goToExecuting(
                 ExecutionGraph executionGraph,
                 ExecutionGraphHandler executionGraphHandler,
-                OperatorCoordinatorHandler operatorCoordinatorHandler) {
+                OperatorCoordinatorHandler operatorCoordinatorHandler,
+                List<ExceptionHistoryEntry> failureCollection) {
             executingStateValidator.validateInput(executionGraph);
             hadStateTransitionHappened = true;
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/ExecutingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/ExecutingTest.java
@@ -175,7 +175,7 @@ public class ExecutingTest extends TestLogger {
                         assertThat(failingArguments.getExecutionGraph(), notNullValue());
                         assertThat(failingArguments.getFailureCause().getMessage(), is(failureMsg));
                     }));
-            ctx.setHowToHandleFailure(Executing.FailureResult::canNotRestart);
+            ctx.setHowToHandleFailure(FailureResult::canNotRestart);
             exec.handleGlobalFailure(new RuntimeException(failureMsg));
         }
     }
@@ -188,7 +188,7 @@ public class ExecutingTest extends TestLogger {
             ctx.setExpectRestarting(
                     (restartingArguments ->
                             assertThat(restartingArguments.getBackoffTime(), is(duration))));
-            ctx.setHowToHandleFailure((t) -> Executing.FailureResult.canRestart(t, duration));
+            ctx.setHowToHandleFailure((t) -> FailureResult.canRestart(t, duration));
             exec.handleGlobalFailure(new RuntimeException("Recoverable error"));
         }
     }
@@ -266,7 +266,7 @@ public class ExecutingTest extends TestLogger {
                             .setExecutionGraph(returnsFailedStateExecutionGraph)
                             .build(ctx);
 
-            ctx.setHowToHandleFailure(Executing.FailureResult::canNotRestart);
+            ctx.setHowToHandleFailure(FailureResult::canNotRestart);
             ctx.setExpectFailing(assertNonNull());
 
             exec.updateTaskExecutionState(createFailingStateTransition());
@@ -283,7 +283,7 @@ public class ExecutingTest extends TestLogger {
                             .setExecutionGraph(returnsFailedStateExecutionGraph)
                             .build(ctx);
             ctx.setHowToHandleFailure(
-                    (throwable) -> Executing.FailureResult.canRestart(throwable, Duration.ZERO));
+                    (throwable) -> FailureResult.canRestart(throwable, Duration.ZERO));
             ctx.setExpectRestarting(assertNonNull());
 
             exec.updateTaskExecutionState(createFailingStateTransition());
@@ -481,7 +481,7 @@ public class ExecutingTest extends TestLogger {
         private final StateValidator<CancellingArguments> cancellingStateValidator =
                 new StateValidator<>("cancelling");
 
-        private Function<Throwable, Executing.FailureResult> howToHandleFailure;
+        private Function<Throwable, FailureResult> howToHandleFailure;
         private Supplier<Boolean> canScaleUp = () -> false;
         private StateValidator<StopWithSavepointArguments> stopWithSavepointValidator =
                 new StateValidator<>("stopWithSavepoint");
@@ -504,7 +504,7 @@ public class ExecutingTest extends TestLogger {
             stopWithSavepointValidator.expectInput(asserter);
         }
 
-        public void setHowToHandleFailure(Function<Throwable, Executing.FailureResult> function) {
+        public void setHowToHandleFailure(Function<Throwable, FailureResult> function) {
             this.howToHandleFailure = function;
         }
 
@@ -526,7 +526,7 @@ public class ExecutingTest extends TestLogger {
         }
 
         @Override
-        public Executing.FailureResult howToHandleFailure(Throwable failure) {
+        public FailureResult howToHandleFailure(Throwable failure) {
             return howToHandleFailure.apply(failure);
         }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/FailingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/FailingTest.java
@@ -20,15 +20,20 @@ package org.apache.flink.runtime.scheduler.adaptive;
 
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.ErrorInfo;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.TaskExecutionStateTransition;
 import org.apache.flink.runtime.scheduler.ExecutionGraphHandler;
 import org.apache.flink.runtime.scheduler.OperatorCoordinatorHandler;
-import org.apache.flink.runtime.taskmanager.TaskExecutionState;
+import org.apache.flink.runtime.scheduler.exceptionhistory.ExceptionHistoryEntry;
+import org.apache.flink.runtime.scheduler.exceptionhistory.RootExceptionHistoryEntry;
+import org.apache.flink.runtime.scheduler.exceptionhistory.TestingAccessExecution;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.Consumer;
 
 import static org.apache.flink.runtime.scheduler.adaptive.WaitingForResourcesTest.assertNonNull;
@@ -102,17 +107,15 @@ public class FailingTest extends TestLogger {
             StateTrackingMockExecutionGraph meg = new StateTrackingMockExecutionGraph();
             Failing failing = createFailingState(ctx, meg);
             // register execution at EG
-            ExecutingTest.MockExecutionJobVertex ejv =
-                    new ExecutingTest.MockExecutionJobVertex(
-                            ExecutingTest.MockExecutionVertex::new);
+            Exception exception = new RuntimeException();
+            TestingAccessExecution execution =
+                    TestingAccessExecution.newBuilder()
+                            .withExecutionState(ExecutionState.FAILED)
+                            .withErrorInfo(new ErrorInfo(exception, System.currentTimeMillis()))
+                            .build();
+            meg.registerExecution(execution);
             TaskExecutionStateTransition update =
-                    new TaskExecutionStateTransition(
-                            new TaskExecutionState(
-                                    ejv.getMockExecutionVertex()
-                                            .getCurrentExecutionAttempt()
-                                            .getAttemptId(),
-                                    ExecutionState.FAILED,
-                                    new RuntimeException()));
+                    ExecutingTest.createFailingStateTransition(execution.getAttemptId(), exception);
             failing.updateTaskExecutionState(update);
             ctx.assertNoStateTransition();
         }
@@ -155,7 +158,9 @@ public class FailingTest extends TestLogger {
                 executionGraphHandler,
                 operatorCoordinatorHandler,
                 log,
-                testFailureCause);
+                testFailureCause,
+                ClassLoader.getSystemClassLoader(),
+                new ArrayList<>());
     }
 
     private static class MockFailingContext extends MockStateWithExecutionGraphContext
@@ -169,10 +174,14 @@ public class FailingTest extends TestLogger {
         }
 
         @Override
+        public void archiveFailure(RootExceptionHistoryEntry failure) {}
+
+        @Override
         public void goToCanceling(
                 ExecutionGraph executionGraph,
                 ExecutionGraphHandler executionGraphHandler,
-                OperatorCoordinatorHandler operatorCoordinatorHandler) {
+                OperatorCoordinatorHandler operatorCoordinatorHandler,
+                List<ExceptionHistoryEntry> failureCollection) {
             cancellingStateValidator.validateInput(
                     new ExecutingTest.CancellingArguments(
                             executionGraph, executionGraphHandler, operatorCoordinatorHandler));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/MockStateWithExecutionGraphContext.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/MockStateWithExecutionGraphContext.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.scheduler.adaptive;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.concurrent.ManuallyTriggeredComponentMainThreadExecutor;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
+import org.apache.flink.runtime.scheduler.exceptionhistory.RootExceptionHistoryEntry;
 
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -64,6 +65,9 @@ class MockStateWithExecutionGraphContext implements StateWithExecutionGraph.Cont
     public ComponentMainThreadExecutor getMainThreadExecutor() {
         return executor;
     }
+
+    @Override
+    public void archiveFailure(RootExceptionHistoryEntry failure) {}
 
     @Override
     public void close() throws Exception {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/RestartingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/RestartingTest.java
@@ -25,11 +25,15 @@ import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.scheduler.ExecutionGraphHandler;
 import org.apache.flink.runtime.scheduler.OperatorCoordinatorHandler;
+import org.apache.flink.runtime.scheduler.exceptionhistory.ExceptionHistoryEntry;
+import org.apache.flink.runtime.scheduler.exceptionhistory.RootExceptionHistoryEntry;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
 
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.ScheduledFuture;
 import java.util.function.Consumer;
 
@@ -127,7 +131,9 @@ public class RestartingTest extends TestLogger {
                 executionGraphHandler,
                 operatorCoordinatorHandler,
                 log,
-                Duration.ZERO);
+                Duration.ZERO,
+                ClassLoader.getSystemClassLoader(),
+                new ArrayList<>());
     }
 
     public Restarting createRestartingState(MockRestartingContext ctx)
@@ -156,12 +162,16 @@ public class RestartingTest extends TestLogger {
         public void goToCanceling(
                 ExecutionGraph executionGraph,
                 ExecutionGraphHandler executionGraphHandler,
-                OperatorCoordinatorHandler operatorCoordinatorHandler) {
+                OperatorCoordinatorHandler operatorCoordinatorHandler,
+                List<ExceptionHistoryEntry> failureCollection) {
             cancellingStateValidator.validateInput(
                     new ExecutingTest.CancellingArguments(
                             executionGraph, executionGraphHandler, operatorCoordinatorHandler));
             hadStateTransition = true;
         }
+
+        @Override
+        public void archiveFailure(RootExceptionHistoryEntry failure) {}
 
         @Override
         public void goToWaitingForResources() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/StopWithSavepointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/StopWithSavepointTest.java
@@ -73,7 +73,7 @@ public class StopWithSavepointTest extends TestLogger {
                     new StateTrackingMockExecutionGraph();
             StopWithSavepoint sws = createStopWithSavepoint(ctx, mockExecutionGraph);
             ctx.setStopWithSavepoint(sws);
-            ctx.setHowToHandleFailure(Executing.FailureResult::canNotRestart);
+            ctx.setHowToHandleFailure(FailureResult::canNotRestart);
 
             ctx.setExpectFailing(
                     failingArguments -> {
@@ -102,7 +102,7 @@ public class StopWithSavepointTest extends TestLogger {
             StopWithSavepoint sws =
                     createStopWithSavepoint(ctx, mockExecutionGraph, savepointFuture);
             ctx.setStopWithSavepoint(sws);
-            ctx.setHowToHandleFailure(Executing.FailureResult::canNotRestart);
+            ctx.setHowToHandleFailure(FailureResult::canNotRestart);
 
             ctx.setExpectFailing(
                     failingArguments -> {
@@ -174,7 +174,7 @@ public class StopWithSavepointTest extends TestLogger {
             StopWithSavepoint sws = createStopWithSavepoint(ctx);
             ctx.setStopWithSavepoint(sws);
             ctx.setHowToHandleFailure(
-                    (throwable) -> Executing.FailureResult.canRestart(throwable, Duration.ZERO));
+                    (throwable) -> FailureResult.canRestart(throwable, Duration.ZERO));
 
             ctx.setExpectRestarting(assertNonNull());
 
@@ -188,7 +188,7 @@ public class StopWithSavepointTest extends TestLogger {
 
             StopWithSavepoint sws = createStopWithSavepoint(ctx);
             ctx.setStopWithSavepoint(sws);
-            ctx.setHowToHandleFailure(Executing.FailureResult::canNotRestart);
+            ctx.setHowToHandleFailure(FailureResult::canNotRestart);
 
             ctx.setExpectFailing(
                     failingArguments -> {
@@ -208,7 +208,7 @@ public class StopWithSavepointTest extends TestLogger {
             StopWithSavepoint sws =
                     createStopWithSavepoint(ctx, new StateTrackingMockExecutionGraph());
             ctx.setStopWithSavepoint(sws);
-            ctx.setHowToHandleFailure(Executing.FailureResult::canNotRestart);
+            ctx.setHowToHandleFailure(FailureResult::canNotRestart);
 
             ctx.setExpectFailing(
                     failingArguments -> {
@@ -229,7 +229,7 @@ public class StopWithSavepointTest extends TestLogger {
                     createStopWithSavepoint(ctx, new StateTrackingMockExecutionGraph());
             ctx.setStopWithSavepoint(sws);
             ctx.setHowToHandleFailure(
-                    (throwable) -> Executing.FailureResult.canRestart(throwable, Duration.ZERO));
+                    (throwable) -> FailureResult.canRestart(throwable, Duration.ZERO));
 
             ctx.setExpectRestarting(assertNonNull());
 
@@ -297,7 +297,7 @@ public class StopWithSavepointTest extends TestLogger {
             ctx.setStopWithSavepoint(sws);
 
             ctx.setHowToHandleFailure(
-                    (throwable) -> Executing.FailureResult.canRestart(throwable, Duration.ZERO));
+                    (throwable) -> FailureResult.canRestart(throwable, Duration.ZERO));
 
             ctx.setExpectRestarting(assertNonNull());
 
@@ -390,7 +390,7 @@ public class StopWithSavepointTest extends TestLogger {
     private static class MockStopWithSavepointContext extends MockStateWithExecutionGraphContext
             implements StopWithSavepoint.Context {
 
-        private Function<Throwable, Executing.FailureResult> howToHandleFailure;
+        private Function<Throwable, FailureResult> howToHandleFailure;
 
         private final StateValidator<ExecutingTest.FailingArguments> failingStateValidator =
                 new StateValidator<>("failing");
@@ -424,12 +424,12 @@ public class StopWithSavepointTest extends TestLogger {
             executingStateTransition.expectInput(asserter);
         }
 
-        public void setHowToHandleFailure(Function<Throwable, Executing.FailureResult> function) {
+        public void setHowToHandleFailure(Function<Throwable, FailureResult> function) {
             this.howToHandleFailure = function;
         }
 
         @Override
-        public Executing.FailureResult howToHandleFailure(Throwable failure) {
+        public FailureResult howToHandleFailure(Throwable failure) {
             return howToHandleFailure.apply(failure);
         }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/StopWithSavepointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/StopWithSavepointTest.java
@@ -20,15 +20,22 @@ package org.apache.flink.runtime.scheduler.adaptive;
 
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.runtime.checkpoint.CheckpointScheduling;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.ErrorInfo;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.TaskExecutionStateTransition;
 import org.apache.flink.runtime.scheduler.ExecutionGraphHandler;
 import org.apache.flink.runtime.scheduler.OperatorCoordinatorHandler;
+import org.apache.flink.runtime.scheduler.exceptionhistory.ExceptionHistoryEntry;
+import org.apache.flink.runtime.scheduler.exceptionhistory.TestingAccessExecution;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
 
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -36,7 +43,6 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 import static org.apache.flink.core.testutils.FlinkMatchers.containsCause;
-import static org.apache.flink.runtime.scheduler.adaptive.ExecutingTest.createFailingStateTransition;
 import static org.apache.flink.runtime.scheduler.adaptive.WaitingForResourcesTest.assertNonNull;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.hamcrest.CoreMatchers.is;
@@ -173,8 +179,7 @@ public class StopWithSavepointTest extends TestLogger {
         try (MockStopWithSavepointContext ctx = new MockStopWithSavepointContext()) {
             StopWithSavepoint sws = createStopWithSavepoint(ctx);
             ctx.setStopWithSavepoint(sws);
-            ctx.setHowToHandleFailure(
-                    (throwable) -> FailureResult.canRestart(throwable, Duration.ZERO));
+            ctx.setHowToHandleFailure(failure -> FailureResult.canRestart(failure, Duration.ZERO));
 
             ctx.setExpectRestarting(assertNonNull());
 
@@ -204,9 +209,8 @@ public class StopWithSavepointTest extends TestLogger {
     @Test
     public void testFailingOnUpdateTaskExecutionStateWithNoRestart() throws Exception {
         try (MockStopWithSavepointContext ctx = new MockStopWithSavepointContext()) {
-
-            StopWithSavepoint sws =
-                    createStopWithSavepoint(ctx, new StateTrackingMockExecutionGraph());
+            StateTrackingMockExecutionGraph executionGraph = new StateTrackingMockExecutionGraph();
+            StopWithSavepoint sws = createStopWithSavepoint(ctx, executionGraph);
             ctx.setStopWithSavepoint(sws);
             ctx.setHowToHandleFailure(FailureResult::canNotRestart);
 
@@ -217,23 +221,39 @@ public class StopWithSavepointTest extends TestLogger {
                                 containsCause(RuntimeException.class));
                     });
 
-            assertThat(sws.updateTaskExecutionState(createFailingStateTransition()), is(true));
+            Exception exception = new RuntimeException();
+            TestingAccessExecution execution =
+                    TestingAccessExecution.newBuilder()
+                            .withExecutionState(ExecutionState.FAILED)
+                            .withErrorInfo(new ErrorInfo(exception, System.currentTimeMillis()))
+                            .build();
+            executionGraph.registerExecution(execution);
+            TaskExecutionStateTransition taskExecutionStateTransition =
+                    ExecutingTest.createFailingStateTransition(execution.getAttemptId(), exception);
+            assertThat(sws.updateTaskExecutionState(taskExecutionStateTransition), is(true));
         }
     }
 
     @Test
     public void testRestartingOnUpdateTaskExecutionStateWithRestart() throws Exception {
         try (MockStopWithSavepointContext ctx = new MockStopWithSavepointContext()) {
-
-            StopWithSavepoint sws =
-                    createStopWithSavepoint(ctx, new StateTrackingMockExecutionGraph());
+            StateTrackingMockExecutionGraph executionGraph = new StateTrackingMockExecutionGraph();
+            StopWithSavepoint sws = createStopWithSavepoint(ctx, executionGraph);
             ctx.setStopWithSavepoint(sws);
-            ctx.setHowToHandleFailure(
-                    (throwable) -> FailureResult.canRestart(throwable, Duration.ZERO));
+            ctx.setHowToHandleFailure(failure -> FailureResult.canRestart(failure, Duration.ZERO));
 
             ctx.setExpectRestarting(assertNonNull());
 
-            assertThat(sws.updateTaskExecutionState(createFailingStateTransition()), is(true));
+            Exception exception = new RuntimeException();
+            TestingAccessExecution execution =
+                    TestingAccessExecution.newBuilder()
+                            .withExecutionState(ExecutionState.FAILED)
+                            .withErrorInfo(new ErrorInfo(exception, System.currentTimeMillis()))
+                            .build();
+            executionGraph.registerExecution(execution);
+            TaskExecutionStateTransition taskExecutionStateTransition =
+                    ExecutingTest.createFailingStateTransition(execution.getAttemptId(), exception);
+            assertThat(sws.updateTaskExecutionState(taskExecutionStateTransition), is(true));
         }
     }
 
@@ -292,12 +312,13 @@ public class StopWithSavepointTest extends TestLogger {
         try (MockStopWithSavepointContext ctx = new MockStopWithSavepointContext()) {
             CheckpointScheduling mockStopWithSavepointOperations = new MockCheckpointScheduling();
             CompletableFuture<String> savepointFuture = new CompletableFuture<>();
+            StateTrackingMockExecutionGraph executionGraph = new StateTrackingMockExecutionGraph();
             StopWithSavepoint sws =
-                    createStopWithSavepoint(ctx, mockStopWithSavepointOperations, savepointFuture);
+                    createStopWithSavepoint(
+                            ctx, mockStopWithSavepointOperations, executionGraph, savepointFuture);
             ctx.setStopWithSavepoint(sws);
 
-            ctx.setHowToHandleFailure(
-                    (throwable) -> FailureResult.canRestart(throwable, Duration.ZERO));
+            ctx.setHowToHandleFailure(failure -> FailureResult.canRestart(failure, Duration.ZERO));
 
             ctx.setExpectRestarting(assertNonNull());
 
@@ -306,7 +327,16 @@ public class StopWithSavepointTest extends TestLogger {
             ctx.triggerExecutors();
 
             // 2. fail task
-            assertThat(sws.updateTaskExecutionState(createFailingStateTransition()), is(true));
+            Exception exception = new RuntimeException();
+            TestingAccessExecution execution =
+                    TestingAccessExecution.newBuilder()
+                            .withExecutionState(ExecutionState.FAILED)
+                            .withErrorInfo(new ErrorInfo(exception, System.currentTimeMillis()))
+                            .build();
+            executionGraph.registerExecution(execution);
+            TaskExecutionStateTransition taskExecutionStateTransition =
+                    ExecutingTest.createFailingStateTransition(execution.getAttemptId(), exception);
+            assertThat(sws.updateTaskExecutionState(taskExecutionStateTransition), is(true));
         }
     }
 
@@ -384,7 +414,8 @@ public class StopWithSavepointTest extends TestLogger {
                 checkpointScheduling,
                 log,
                 ClassLoader.getSystemClassLoader(),
-                savepointFuture);
+                savepointFuture,
+                new ArrayList<>());
     }
 
     private static class MockStopWithSavepointContext extends MockStateWithExecutionGraphContext
@@ -444,7 +475,8 @@ public class StopWithSavepointTest extends TestLogger {
         public void goToCanceling(
                 ExecutionGraph executionGraph,
                 ExecutionGraphHandler executionGraphHandler,
-                OperatorCoordinatorHandler operatorCoordinatorHandler) {
+                OperatorCoordinatorHandler operatorCoordinatorHandler,
+                List<ExceptionHistoryEntry> failureCollection) {
             simulateTransitionToState(Canceling.class);
 
             cancellingStateValidator.validateInput(
@@ -458,7 +490,8 @@ public class StopWithSavepointTest extends TestLogger {
                 ExecutionGraph executionGraph,
                 ExecutionGraphHandler executionGraphHandler,
                 OperatorCoordinatorHandler operatorCoordinatorHandler,
-                Duration backoffTime) {
+                Duration backoffTime,
+                List<ExceptionHistoryEntry> failureCollection) {
             simulateTransitionToState(Restarting.class);
             restartingStateValidator.validateInput(
                     new ExecutingTest.RestartingArguments(
@@ -474,7 +507,8 @@ public class StopWithSavepointTest extends TestLogger {
                 ExecutionGraph executionGraph,
                 ExecutionGraphHandler executionGraphHandler,
                 OperatorCoordinatorHandler operatorCoordinatorHandler,
-                Throwable failureCause) {
+                Throwable failureCause,
+                List<ExceptionHistoryEntry> failureCollection) {
             simulateTransitionToState(Failing.class);
             failingStateValidator.validateInput(
                     new ExecutingTest.FailingArguments(
@@ -489,7 +523,8 @@ public class StopWithSavepointTest extends TestLogger {
         public void goToExecuting(
                 ExecutionGraph executionGraph,
                 ExecutionGraphHandler executionGraphHandler,
-                OperatorCoordinatorHandler operatorCoordinatorHandler) {
+                OperatorCoordinatorHandler operatorCoordinatorHandler,
+                List<ExceptionHistoryEntry> failureCollection) {
             simulateTransitionToState(Executing.class);
             executingStateTransition.validateInput(
                     new ExecutingTest.CancellingArguments(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/exceptionhistory/TestingAccessExecution.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/exceptionhistory/TestingAccessExecution.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.exceptionhistory;
+
+import org.apache.flink.runtime.accumulators.StringifiedAccumulatorResult;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.AccessExecution;
+import org.apache.flink.runtime.executiongraph.ErrorInfo;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.executiongraph.IOMetrics;
+import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
+import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+
+import javax.annotation.Nullable;
+
+import java.util.Optional;
+
+/** Mock of an {@link AccessExecution}. */
+public class TestingAccessExecution implements AccessExecution {
+
+    private final ExecutionAttemptID executionAttemptID;
+    private final ExecutionState state;
+    @Nullable private final ErrorInfo failureInfo;
+    @Nullable private final TaskManagerLocation taskManagerLocation;
+
+    private TestingAccessExecution(
+            ExecutionAttemptID executionAttemptID,
+            ExecutionState state,
+            @Nullable ErrorInfo failureInfo,
+            @Nullable TaskManagerLocation taskManagerLocation) {
+        this.executionAttemptID = executionAttemptID;
+        this.state = state;
+        this.failureInfo = failureInfo;
+        this.taskManagerLocation = taskManagerLocation;
+    }
+
+    @Override
+    public ExecutionAttemptID getAttemptId() {
+        return executionAttemptID;
+    }
+
+    @Override
+    public TaskManagerLocation getAssignedResourceLocation() {
+        return taskManagerLocation;
+    }
+
+    @Override
+    public Optional<ErrorInfo> getFailureInfo() {
+        return Optional.ofNullable(failureInfo);
+    }
+
+    @Override
+    public int getAttemptNumber() {
+        throw new UnsupportedOperationException("getAttemptNumber should not be called.");
+    }
+
+    @Override
+    public long[] getStateTimestamps() {
+        throw new UnsupportedOperationException("getStateTimestamps should not be called.");
+    }
+
+    @Override
+    public ExecutionState getState() {
+        return state;
+    }
+
+    @Override
+    public long getStateTimestamp(ExecutionState state) {
+        throw new UnsupportedOperationException("getStateTimestamp should not be called.");
+    }
+
+    @Override
+    public StringifiedAccumulatorResult[] getUserAccumulatorsStringified() {
+        throw new UnsupportedOperationException(
+                "getUserAccumulatorsStringified should not be called.");
+    }
+
+    @Override
+    public int getParallelSubtaskIndex() {
+        throw new UnsupportedOperationException("getParallelSubtaskIndex should not be called.");
+    }
+
+    @Override
+    public IOMetrics getIOMetrics() {
+        throw new UnsupportedOperationException("getIOMetrics should not be called.");
+    }
+
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    /** Builder for {@link TestingAccessExecution}. */
+    public static class Builder {
+
+        private ExecutionState state = ExecutionState.CREATED;
+        private ExecutionAttemptID attemptId = new ExecutionAttemptID();
+        @Nullable private ErrorInfo failureInfo = null;
+        @Nullable private TaskManagerLocation taskManagerLocation = new LocalTaskManagerLocation();
+
+        private Builder() {}
+
+        public Builder withAttemptId(ExecutionAttemptID attemptId) {
+            this.attemptId = attemptId;
+            return this;
+        }
+
+        public Builder withExecutionState(ExecutionState state) {
+            this.state = state;
+            return this;
+        }
+
+        public Builder withErrorInfo(ErrorInfo failureInfo) {
+            this.failureInfo = failureInfo;
+            return this;
+        }
+
+        public Builder withTaskManagerLocation(@Nullable TaskManagerLocation taskManagerLocation) {
+            this.taskManagerLocation = taskManagerLocation;
+            return this;
+        }
+
+        public TestingAccessExecution build() {
+            return new TestingAccessExecution(attemptId, state, failureInfo, taskManagerLocation);
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

https://issues.apache.org/jira/browse/FLINK-21439

## Brief change log

Add exception history to Adaptive Scheduler
- Add convenience methods to ExecutionGraph

## Verifying this change

This change added tests and can be verified as follows:
- AdaptiveSchedulerTest#testExceptionHistoryWithGlobalFailure
- AdaptiveSchedulerTest#testExceptionHistoryWithTaskFailure
- AdaptiveSchedulerTest#testExceptionHistoryWithTaskConcurrentFailure

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
