### PR TITLE
[FLINK-26015] Fixes object store bug

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/fs/FileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/FileSystem.java
@@ -316,7 +316,7 @@ public abstract class FileSystem {
      * @param pluginManager optional plugin manager that is used to initialized filesystems provided
      *     as plugins.
      */
-    public static void initialize(Configuration config, PluginManager pluginManager)
+    public static void initialize(Configuration config, @Nullable PluginManager pluginManager)
             throws IllegalConfigurationException {
 
         LOCK.lock();

--- a/flink-filesystems/flink-s3-fs-base/pom.xml
+++ b/flink-filesystems/flink-s3-fs-base/pom.xml
@@ -221,6 +221,36 @@ under the License.
 				</exclusion>
 			</exclusions>
 		</dependency>
+
+		<!-- flink-runtime and curator dependencies are needed for the HAJobRunOnMinioS3StoreITCase -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-runtime</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-runtime</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.curator</groupId>
+			<artifactId>curator-test</artifactId>
+			<version>${curator.version}</version>
+			<scope>test</scope>
+			<exclusions>
+				<!-- This transitive dependency causes version conflicts on the classpath. -->
+				<exclusion>
+					<groupId>com.google.guava</groupId>
+					<artifactId>guava</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/flink-filesystems/flink-s3-fs-base/pom.xml
+++ b/flink-filesystems/flink-s3-fs-base/pom.xml
@@ -235,6 +235,18 @@ under the License.
 					<skip>true</skip>
 				</configuration>
 			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>test-jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/HAJobRunOnMinioS3StoreITCase.java
+++ b/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/HAJobRunOnMinioS3StoreITCase.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.s3.common;
+
+import org.apache.flink.api.common.time.Deadline;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.testutils.AllCallbackWrapper;
+import org.apache.flink.core.testutils.TestContainerExtension;
+import org.apache.flink.runtime.clusterframework.ApplicationStatus;
+import org.apache.flink.runtime.highavailability.AbstractHAJobRunITCase;
+import org.apache.flink.runtime.highavailability.FileSystemJobResultStore;
+import org.apache.flink.runtime.highavailability.JobResultStoreOptions;
+import org.apache.flink.runtime.testutils.CommonTestUtils;
+
+import org.apache.flink.shaded.guava30.com.google.common.collect.Iterables;
+
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.time.Duration;
+import java.util.List;
+
+import static org.apache.flink.shaded.guava30.com.google.common.base.Predicates.not;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * {@code HAJobRunOnMinioS3StoreITCase} covers a job run where the HA data is stored in Minio. The
+ * implementation verifies whether the {@code JobResult} was written into the FileSystem-backed
+ * {@code JobResultStore}.
+ */
+public abstract class HAJobRunOnMinioS3StoreITCase extends AbstractHAJobRunITCase {
+
+    private static final String CLUSTER_ID = "test-cluster";
+    private static final String JOB_RESULT_STORE_FOLDER = "jrs";
+
+    @RegisterExtension
+    private static final AllCallbackWrapper<TestContainerExtension<MinioTestContainer>>
+            MINIO_EXTENSION =
+                    new AllCallbackWrapper<>(new TestContainerExtension<>(MinioTestContainer::new));
+
+    private static MinioTestContainer getMinioContainer() {
+        return MINIO_EXTENSION.getCustomExtension().getTestContainer();
+    }
+
+    private static String createS3URIWithSubPath(String... subfolders) {
+        return getMinioContainer().getS3UriForDefaultBucket() + createSubPath(subfolders);
+    }
+
+    private static List<S3ObjectSummary> getObjectsFromJobResultStore() {
+        return getMinioContainer()
+                .getClient()
+                .listObjects(
+                        getMinioContainer().getDefaultBucketName(),
+                        createSubPath(CLUSTER_ID, JOB_RESULT_STORE_FOLDER))
+                .getObjectSummaries();
+    }
+
+    private static String createSubPath(String... subfolders) {
+        final String pathSeparator = "/";
+        return pathSeparator + StringUtils.join(subfolders, pathSeparator);
+    }
+
+    @Override
+    protected String getHAStoragePath() {
+        return createS3URIWithSubPath(CLUSTER_ID);
+    }
+
+    @Override
+    protected Configuration createConfiguration() {
+        final Configuration config = new Configuration();
+
+        getMinioContainer().setS3ConfigOptions(config);
+
+        // JobResultStore configuration
+        config.set(JobResultStoreOptions.DELETE_ON_COMMIT, Boolean.FALSE);
+        config.set(
+                JobResultStoreOptions.STORAGE_PATH,
+                createS3URIWithSubPath(CLUSTER_ID, JOB_RESULT_STORE_FOLDER));
+
+        return config;
+    }
+
+    @Override
+    protected void runAfterJobTermination() throws Exception {
+        CommonTestUtils.waitUntilCondition(
+                () -> {
+                    final List<S3ObjectSummary> objects = getObjectsFromJobResultStore();
+                    return objects.stream()
+                                    .map(S3ObjectSummary::getKey)
+                                    .anyMatch(
+                                            FileSystemJobResultStore
+                                                    ::hasValidJobResultStoreEntryExtension)
+                            && objects.stream()
+                                    .map(S3ObjectSummary::getKey)
+                                    .noneMatch(
+                                            FileSystemJobResultStore
+                                                    ::hasValidDirtyJobResultStoreEntryExtension);
+                },
+                Deadline.fromNow(Duration.ofSeconds(60)),
+                2000L,
+                "Wait for the JobResult being written to the JobResultStore.");
+
+        final S3ObjectSummary objRef = Iterables.getOnlyElement(getObjectsFromJobResultStore());
+        assertThat(objRef.getKey())
+                .matches(FileSystemJobResultStore::hasValidJobResultStoreEntryExtension)
+                .matches(not(FileSystemJobResultStore::hasValidDirtyJobResultStoreEntryExtension));
+
+        final String objContent =
+                getMinioContainer()
+                        .getClient()
+                        .getObjectAsString(objRef.getBucketName(), objRef.getKey());
+        assertThat(objContent).contains(ApplicationStatus.SUCCEEDED.name());
+    }
+}

--- a/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/MinioTestContainer.java
+++ b/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/MinioTestContainer.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.s3.common;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.util.DockerImageVersions;
+import org.apache.flink.util.Preconditions;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.github.dockerjava.api.command.InspectContainerResponse;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
+import org.testcontainers.utility.Base58;
+
+import java.time.Duration;
+import java.util.Locale;
+
+/** {@code MinioTestContainer} provides a {@code Minio} test instance. */
+public class MinioTestContainer extends GenericContainer<MinioTestContainer> {
+
+    private static final String FLINK_CONFIG_S3_ENDPOINT = "s3.endpoint";
+
+    private static final int DEFAULT_PORT = 9000;
+
+    private static final String MINIO_ACCESS_KEY = "MINIO_ROOT_USER";
+    private static final String MINIO_SECRET_KEY = "MINIO_ROOT_PASSWORD";
+
+    private static final String DEFAULT_STORAGE_DIRECTORY = "/data";
+    private static final String HEALTH_ENDPOINT = "/minio/health/ready";
+
+    private final String accessKey;
+    private final String secretKey;
+    private final String defaultBucketName;
+
+    public MinioTestContainer() {
+        this(randomString("bucket", 6));
+    }
+
+    public MinioTestContainer(String defaultBucketName) {
+        super(DockerImageVersions.MINIO);
+
+        this.accessKey = randomString("accessKey", 10);
+        // secrets must have at least 8 characters
+        this.secretKey = randomString("secret", 10);
+        this.defaultBucketName = Preconditions.checkNotNull(defaultBucketName);
+
+        withNetworkAliases(randomString("minio", 6));
+        addExposedPort(DEFAULT_PORT);
+        withEnv(MINIO_ACCESS_KEY, this.accessKey);
+        withEnv(MINIO_SECRET_KEY, this.secretKey);
+        withCommand("server", DEFAULT_STORAGE_DIRECTORY);
+        setWaitStrategy(
+                new HttpWaitStrategy()
+                        .forPort(DEFAULT_PORT)
+                        .forPath(HEALTH_ENDPOINT)
+                        .withStartupTimeout(Duration.ofMinutes(2)));
+    }
+
+    @Override
+    protected void containerIsStarted(InspectContainerResponse containerInfo) {
+        super.containerIsStarted(containerInfo);
+        createDefaultBucket();
+    }
+
+    private static String randomString(String prefix, int length) {
+        return String.format("%s-%s", prefix, Base58.randomString(length).toLowerCase(Locale.ROOT));
+    }
+
+    /** Creates {@link AmazonS3} client for accessing the {@code Minio} instance. */
+    public AmazonS3 getClient() {
+        return AmazonS3Client.builder()
+                .withCredentials(
+                        new AWSStaticCredentialsProvider(
+                                new BasicAWSCredentials(accessKey, secretKey)))
+                .withPathStyleAccessEnabled(true)
+                .withEndpointConfiguration(
+                        new AwsClientBuilder.EndpointConfiguration(
+                                getHttpEndpoint(), "unused-region"))
+                .build();
+    }
+
+    private String getHttpEndpoint() {
+        return String.format("http://%s:%s", getContainerIpAddress(), getMappedPort(DEFAULT_PORT));
+    }
+
+    /**
+     * Initializes the Minio instance (i.e. creating the default bucket and initializing Flink's
+     * FileSystems). Additionally, the passed Flink {@link Configuration} is extended by all
+     * relevant parameter to access the {@code Minio} instance.
+     */
+    public void setS3ConfigOptions(Configuration config) {
+        config.setString(FLINK_CONFIG_S3_ENDPOINT, getHttpEndpoint());
+        config.setString("s3.path.style.access", "true");
+        config.setString("s3.access.key", accessKey);
+        config.setString("s3.secret.key", secretKey);
+    }
+
+    public void initializeFileSystem(Configuration config) {
+        Preconditions.checkArgument(
+                config.containsKey(FLINK_CONFIG_S3_ENDPOINT),
+                FLINK_CONFIG_S3_ENDPOINT
+                        + " needs to be specified before initializing the FileSystems.");
+        FileSystem.initialize(config, null);
+    }
+
+    private void createDefaultBucket() {
+        getClient().createBucket(defaultBucketName);
+    }
+
+    /** Returns the internally used default bucket. */
+    public String getDefaultBucketName() {
+        return defaultBucketName;
+    }
+
+    /**
+     * Returns the S3 URI for the default bucket. This can be used to create the HA storage
+     * directory path.
+     */
+    public String getS3UriForDefaultBucket() {
+        return "s3://" + getDefaultBucketName();
+    }
+}

--- a/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/MinioTestContainerTest.java
+++ b/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/MinioTestContainerTest.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.s3.common;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.testutils.EachCallbackWrapper;
+import org.apache.flink.core.testutils.TestContainerExtension;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.Bucket;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * {@code MinioTestContainerTest} tests some basic functionality provided by {@link
+ * MinioTestContainer}.
+ */
+public class MinioTestContainerTest {
+
+    private static final String DEFAULT_BUCKET_NAME = "test-bucket";
+
+    @RegisterExtension
+    private static final EachCallbackWrapper<TestContainerExtension<MinioTestContainer>>
+            MINIO_EXTENSION =
+                    new EachCallbackWrapper<>(
+                            new TestContainerExtension<>(
+                                    () -> new MinioTestContainer(DEFAULT_BUCKET_NAME)));
+
+    private static MinioTestContainer getTestContainer() {
+        return MINIO_EXTENSION.getCustomExtension().getTestContainer();
+    }
+
+    private static AmazonS3 getClient() {
+        return getTestContainer().getClient();
+    }
+
+    @Test
+    public void testBucketCreation() {
+        final String bucketName = "other-bucket";
+        final Bucket otherBucket = getClient().createBucket(bucketName);
+
+        assertThat(otherBucket).isNotNull();
+        assertThat(otherBucket).extracting(Bucket::getName).isEqualTo(bucketName);
+
+        assertThat(getClient().listBuckets())
+                .map(Bucket::getName)
+                .containsExactlyInAnyOrder(getTestContainer().getDefaultBucketName(), bucketName);
+    }
+
+    @Test
+    public void testPutObject() throws IOException {
+        final String bucketName = "other-bucket";
+
+        getClient().createBucket(bucketName);
+        final String objectId = "test-object";
+        final String content = "test content";
+        getClient().putObject(bucketName, objectId, content);
+
+        final BufferedReader reader =
+                new BufferedReader(
+                        new InputStreamReader(
+                                getClient().getObject(bucketName, objectId).getObjectContent()));
+        assertThat(reader.readLine()).isEqualTo(content);
+    }
+
+    @Test
+    public void testSetS3ConfigOptions() {
+        final Configuration config = new Configuration();
+        getTestContainer().setS3ConfigOptions(config);
+
+        assertThat(config.containsKey("s3.endpoint")).isTrue();
+        assertThat(config.containsKey("s3.path.style.access")).isTrue();
+        assertThat(config.containsKey("s3.access.key")).isTrue();
+        assertThat(config.containsKey("s3.secret.key")).isTrue();
+    }
+
+    @Test
+    public void testGetDefaultBucketName() {
+        assertThat(getTestContainer().getDefaultBucketName()).isEqualTo(DEFAULT_BUCKET_NAME);
+    }
+
+    @Test
+    public void testDefaultBucketCreation() {
+        assertThat(getClient().listBuckets())
+                .singleElement()
+                .extracting(Bucket::getName)
+                .isEqualTo(getTestContainer().getDefaultBucketName());
+    }
+
+    @Test
+    public void testS3EndpointNeedsToBeSpecifiedBeforeInitializingFileSyste() {
+        assertThatThrownBy(() -> getTestContainer().initializeFileSystem(new Configuration()))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/flink-filesystems/flink-s3-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-s3-fs-hadoop/pom.xml
@@ -92,6 +92,44 @@ under the License.
 			<scope>test</scope>
 			<type>test-jar</type>
 		</dependency>
+
+		<!-- for the HAJobRunOnHadoopS3FileSystemITCase -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-s3-fs-base</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-runtime</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-runtime</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.curator</groupId>
+			<artifactId>curator-test</artifactId>
+			<version>${curator.version}</version>
+			<scope>test</scope>
+			<exclusions>
+				<!-- This transitive dependency causes version conflicts on the classpath. -->
+				<exclusion>
+					<groupId>com.google.guava</groupId>
+					<artifactId>guava</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/flink-filesystems/flink-s3-fs-hadoop/src/test/java/org/apache/flink/fs/s3hadoop/HAJobRunOnHadoopS3FileSystemITCase.java
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/test/java/org/apache/flink/fs/s3hadoop/HAJobRunOnHadoopS3FileSystemITCase.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.s3hadoop;
+
+import org.apache.flink.fs.s3.common.HAJobRunOnMinioS3StoreITCase;
+
+/** Runs the {@link HAJobRunOnMinioS3StoreITCase} on the Hadoop S3 file system. */
+public class HAJobRunOnHadoopS3FileSystemITCase extends HAJobRunOnMinioS3StoreITCase {}

--- a/flink-filesystems/flink-s3-fs-presto/pom.xml
+++ b/flink-filesystems/flink-s3-fs-presto/pom.xml
@@ -46,6 +46,44 @@ under the License.
 			<scope>provided</scope>
 		</dependency>
 
+		<!-- for the HAJobRunOnPrestoS3FileSystemITCase -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-runtime</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-runtime</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-s3-fs-base</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.curator</groupId>
+			<artifactId>curator-test</artifactId>
+			<version>${curator.version}</version>
+			<scope>test</scope>
+			<exclusions>
+				<!-- This transitive dependency causes version conflicts on the classpath. -->
+				<exclusion>
+					<groupId>com.google.guava</groupId>
+					<artifactId>guava</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
 		<!-- S3 base (bundled) -->
 		<dependency>
 			<groupId>org.apache.flink</groupId>

--- a/flink-filesystems/flink-s3-fs-presto/src/test/java/org/apache/flink/fs/s3presto/HAJobRunOnPrestoS3FileSystemITCase.java
+++ b/flink-filesystems/flink-s3-fs-presto/src/test/java/org/apache/flink/fs/s3presto/HAJobRunOnPrestoS3FileSystemITCase.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.s3presto;
+
+import org.apache.flink.fs.s3.common.HAJobRunOnMinioS3StoreITCase;
+
+/** Runs the {@link HAJobRunOnMinioS3StoreITCase} on the Presto S3 file system. */
+public class HAJobRunOnPrestoS3FileSystemITCase extends HAJobRunOnMinioS3StoreITCase {}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/FileSystemJobResultStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/FileSystemJobResultStore.java
@@ -166,17 +166,14 @@ public class FileSystemJobResultStore extends AbstractThreadsafeJobResultStore {
     @Override
     public Set<JobResult> getDirtyResultsInternal() throws IOException {
         final Set<JobResult> dirtyResults = new HashSet<>();
-        final FileStatus fs = fileSystem.getFileStatus(this.basePath);
-        if (fs.isDir()) {
-            FileStatus[] statuses = fileSystem.listStatus(this.basePath);
-            for (FileStatus s : statuses) {
-                if (!s.isDir()) {
-                    if (hasValidDirtyJobResultStoreEntryExtension(s.getPath().getName())) {
-                        JsonJobResultEntry jre =
-                                mapper.readValue(
-                                        fileSystem.open(s.getPath()), JsonJobResultEntry.class);
-                        dirtyResults.add(jre.getJobResult());
-                    }
+        FileStatus[] statuses = fileSystem.listStatus(this.basePath);
+        for (FileStatus s : statuses) {
+            if (!s.isDir()) {
+                if (hasValidDirtyJobResultStoreEntryExtension(s.getPath().getName())) {
+                    JsonJobResultEntry jre =
+                            mapper.readValue(
+                                    fileSystem.open(s.getPath()), JsonJobResultEntry.class);
+                    dirtyResults.add(jre.getJobResult());
                 }
             }
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/FileSystemJobResultStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/FileSystemJobResultStore.java
@@ -52,7 +52,18 @@ import static org.apache.flink.util.StringUtils.isNullOrWhitespaceOnly;
  */
 public class FileSystemJobResultStore extends AbstractThreadsafeJobResultStore {
 
-    private static final String DIRTY_SUFFIX = "_DIRTY";
+    @VisibleForTesting static final String FILE_EXTENSION = ".json";
+    @VisibleForTesting static final String DIRTY_FILE_EXTENSION = "_DIRTY" + FILE_EXTENSION;
+
+    @VisibleForTesting
+    public static boolean hasValidDirtyJobResultStoreEntryExtension(String filename) {
+        return filename.endsWith(DIRTY_FILE_EXTENSION);
+    }
+
+    @VisibleForTesting
+    public static boolean hasValidJobResultStoreEntryExtension(String filename) {
+        return filename.endsWith(FILE_EXTENSION);
+    }
 
     private final ObjectMapper mapper = new ObjectMapper();
 
@@ -103,7 +114,7 @@ public class FileSystemJobResultStore extends AbstractThreadsafeJobResultStore {
      * @return A path for a dirty entry for the given the Job ID.
      */
     private Path constructDirtyPath(JobID jobId) {
-        return new Path(this.basePath.getPath(), jobId.toString() + DIRTY_SUFFIX + ".json");
+        return new Path(this.basePath.getPath(), jobId.toString() + DIRTY_FILE_EXTENSION);
     }
 
     /**
@@ -160,8 +171,7 @@ public class FileSystemJobResultStore extends AbstractThreadsafeJobResultStore {
             FileStatus[] statuses = fileSystem.listStatus(this.basePath);
             for (FileStatus s : statuses) {
                 if (!s.isDir()) {
-                    String fileName = s.getPath().getName();
-                    if (fileName.contains(DIRTY_SUFFIX)) {
+                    if (hasValidDirtyJobResultStoreEntryExtension(s.getPath().getName())) {
                         JsonJobResultEntry jre =
                                 mapper.readValue(
                                         fileSystem.open(s.getPath()), JsonJobResultEntry.class);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/AbstractHAJobRunITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/AbstractHAJobRunITCase.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.highavailability;
+
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.api.common.time.Deadline;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.HighAvailabilityOptions;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.testutils.AllCallbackWrapper;
+import org.apache.flink.core.testutils.EachCallbackWrapper;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobGraphTestUtils;
+import org.apache.flink.runtime.minicluster.MiniCluster;
+import org.apache.flink.runtime.testutils.MiniClusterExtension;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.runtime.zookeeper.ZooKeeperExtension;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.util.TestLoggerExtension;
+import org.apache.flink.util.concurrent.FutureUtils;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * {@code AbstractHAJobRunITCase} runs a job storing in HA mode and provides {@code abstract}
+ * methods for initializing a specific {@link FileSystem}.
+ */
+@ExtendWith(TestLoggerExtension.class)
+public abstract class AbstractHAJobRunITCase {
+
+    @RegisterExtension
+    private static final AllCallbackWrapper<ZooKeeperExtension> ZOOKEEPER_EXTENSION =
+            new AllCallbackWrapper<>(new ZooKeeperExtension());
+
+    @RegisterExtension
+    private final EachCallbackWrapper<MiniClusterExtension> miniClusterExtension =
+            new EachCallbackWrapper<>(
+                    new MiniClusterExtension(
+                            new MiniClusterResourceConfiguration.Builder()
+                                    .setConfiguration(getFlinkConfiguration())
+                                    .build()));
+
+    private Configuration getFlinkConfiguration() {
+        final Configuration config = createConfiguration();
+
+        config.set(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
+        config.set(
+                HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM,
+                ZOOKEEPER_EXTENSION.getCustomExtension().getConnectString());
+        config.set(HighAvailabilityOptions.HA_STORAGE_PATH, getHAStoragePath());
+
+        // getFlinkConfiguration() is called on each new instantiation of the MiniCluster which is
+        // happening before each test run
+        FileSystem.initialize(config, null);
+
+        return config;
+    }
+
+    @AfterEach
+    public void unsetFileSystem() {
+        FileSystem.initialize(new Configuration(), null);
+    }
+
+    /**
+     * Should return the path to the HA storage which will be injected into the Flink configuration.
+     *
+     * @see HighAvailabilityOptions#HA_STORAGE_PATH
+     */
+    protected abstract String getHAStoragePath();
+
+    /** Initializes the {@link Configuration} used for the Flink cluster. */
+    protected abstract Configuration createConfiguration();
+
+    protected void runAfterJobTermination() throws Exception {}
+
+    @Test
+    public void testJobExecutionInHaMode() throws Exception {
+        final MiniCluster flinkCluster = miniClusterExtension.getCustomExtension().getMiniCluster();
+
+        final JobGraph jobGraph = JobGraphTestUtils.singleNoOpJobGraph();
+
+        // providing a timeout helps making the test fail in case some issue occurred while
+        // initializing the cluster
+        flinkCluster.submitJob(jobGraph).get(30, TimeUnit.SECONDS);
+
+        final Deadline deadline = Deadline.fromNow(Duration.ofSeconds(30));
+        final JobStatus jobStatus =
+                FutureUtils.retrySuccessfulWithDelay(
+                                () -> flinkCluster.getJobStatus(jobGraph.getJobID()),
+                                Time.milliseconds(10),
+                                deadline,
+                                status -> flinkCluster.isRunning() && status == JobStatus.FINISHED,
+                                TestingUtils.defaultScheduledExecutor())
+                        .get(deadline.timeLeft().toMillis(), TimeUnit.MILLISECONDS);
+
+        assertThat(jobStatus).isEqualTo(JobStatus.FINISHED);
+
+        runAfterJobTermination();
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/FileSystemJobResultStoreTestInternal.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/FileSystemJobResultStoreTestInternal.java
@@ -162,6 +162,7 @@ public class FileSystemJobResultStoreTestInternal {
         final FileSystemJobResultStore.JsonJobResultEntry deserializedEntry =
                 MAPPER.readValue(dirtyFile, FileSystemJobResultStore.JsonJobResultEntry.class);
         assertThat(dirtyFile).isFile().content().containsPattern("\"version\":1");
+        assertThat(deserializedEntry.getVersion()).isEqualTo(1);
     }
 
     @Test

--- a/flink-test-utils-parent/flink-test-utils-junit/pom.xml
+++ b/flink-test-utils-parent/flink-test-utils-junit/pom.xml
@@ -70,6 +70,12 @@ under the License.
 			<artifactId>log4j-core</artifactId>
 			<scope>compile</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>testcontainers</artifactId>
+			<scope>compile</scope>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/core/testutils/TestContainerExtension.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/core/testutils/TestContainerExtension.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.testutils;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.testcontainers.containers.GenericContainer;
+
+import javax.annotation.Nullable;
+
+import java.util.function.Supplier;
+
+/**
+ * {@code TestContainerExtension} provides common functionality for {@code TestContainer}
+ * implementations.
+ *
+ * @param <T> The {@link GenericContainer} that shall be managed.
+ */
+public class TestContainerExtension<T extends GenericContainer<T>> implements CustomExtension {
+
+    @Nullable private T testContainer;
+
+    private final Supplier<T> testContainerCreator;
+
+    public TestContainerExtension(Supplier<T> testContainerCreator) {
+        this.testContainerCreator = testContainerCreator;
+    }
+
+    public T getTestContainer() {
+        assert testContainer != null;
+        return testContainer;
+    }
+
+    private void terminateTestContainer() {
+        if (testContainer != null) {
+            testContainer.stop();
+            testContainer = null;
+        }
+    }
+
+    private void instantiateTestContainer() {
+        assert testContainer == null;
+        testContainer = testContainerCreator.get();
+        testContainer.start();
+    }
+
+    @Override
+    public void after(ExtensionContext context) throws Exception {
+        terminateTestContainer();
+    }
+
+    @Override
+    public void before(ExtensionContext context) throws Exception {
+        terminateTestContainer();
+        instantiateTestContainer();
+    }
+}

--- a/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/util/DockerImageVersions.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/util/DockerImageVersions.java
@@ -45,4 +45,6 @@ public class DockerImageVersions {
     public static final String PULSAR = "apachepulsar/pulsar:2.8.0";
 
     public static final String CASSANDRA_3 = "cassandra:3.0";
+
+    public static final String MINIO = "minio/minio:RELEASE.2022-02-07T08-17-33Z";
 }


### PR DESCRIPTION
## What is the purpose of the change

`FileSystem` implementations based on object stores like S3 do not support directories. `FileSystem.getFileStatus` fails with a `FileNotFoundException` in such a case. This also happens despite the fact that `FileSystem.mkdirs` doesn't fail.

Additionally, I created FLINK-26061 as a follow-up to cover the inconsistency of the `FileSystem` contract.

## Brief change log

* Removes directory check from `FileSystemJobResultStore` since it's actually obsolete
* Adds MinioTestContainer to test the change

## Verifying this change

* A ITCase was added that runs a job with HA enabled and backed by S3 using the newly added Minio TestContainer
* `MinioTestContainerTest` was added to test rudimentary functionality of the `MinioTestContainer`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: yes

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
