### PR TITLE
[FLINK-25987][state/changelog] Make lastAppendedSqn optional

### DIFF
--- a/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/ChangelogStorageMetricsTest.java
+++ b/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/ChangelogStorageMetricsTest.java
@@ -62,7 +62,7 @@ public class ChangelogStorageMetricsTest {
             int numUploads = 5;
             for (int i = 0; i < numUploads; i++) {
                 writer.append(0, new byte[] {0, 1, 2, 3});
-                writer.persist(writer.lastAppendedSequenceNumber()).get();
+                writer.persist(writer.lastAppendedSequenceNumber().get()).get();
             }
             assertEquals(numUploads, metrics.getUploadsCounter().getCount());
             assertTrue(metrics.getUploadLatenciesNanos().getStatistics().getMin() > 0);
@@ -81,13 +81,13 @@ public class ChangelogStorageMetricsTest {
 
             // upload single byte to infer header size
             writer.append(0, new byte[] {0});
-            writer.persist(writer.lastAppendedSequenceNumber()).get();
+            writer.persist(writer.lastAppendedSequenceNumber().get()).get();
             long headerSize = metrics.getUploadSizes().getStatistics().getMin() - 1;
 
             byte[] upload = new byte[33];
             for (int i = 0; i < 5; i++) {
                 writer.append(0, upload);
-                writer.persist(writer.lastAppendedSequenceNumber()).get();
+                writer.persist(writer.lastAppendedSequenceNumber().get()).get();
             }
             long expected = upload.length + headerSize;
             assertEquals(expected, metrics.getUploadSizes().getStatistics().getMax());
@@ -107,7 +107,7 @@ public class ChangelogStorageMetricsTest {
             for (int i = 0; i < numUploads; i++) {
                 writer.append(0, new byte[] {0, 1, 2, 3});
                 try {
-                    writer.persist(writer.lastAppendedSequenceNumber()).get();
+                    writer.persist(writer.lastAppendedSequenceNumber().get()).get();
                 } catch (IOException e) {
                     // ignore
                 }
@@ -151,7 +151,7 @@ public class ChangelogStorageMetricsTest {
                     // cause
                     // actual uploads
                     writers[writer].append(0, new byte[] {0, 1, 2, 3});
-                    writers[writer].persist(writers[writer].lastAppendedSequenceNumber());
+                    writers[writer].persist(writers[writer].lastAppendedSequenceNumber().get());
                 }
                 // now the uploads should be grouped and executed at once
                 scheduler.triggerScheduledTasks();
@@ -187,7 +187,7 @@ public class ChangelogStorageMetricsTest {
         try {
             for (int upload = 0; upload < numUploads; upload++) {
                 writer.append(0, new byte[] {0, 1, 2, 3});
-                writer.persist(writer.lastAppendedSequenceNumber()).get();
+                writer.persist(writer.lastAppendedSequenceNumber().get()).get();
             }
             HistogramStatistics histogram = metrics.getAttemptsPerUpload().getStatistics();
             assertEquals(maxAttempts, histogram.getMin());
@@ -237,7 +237,7 @@ public class ChangelogStorageMetricsTest {
             int numUploads = 11;
             for (int i = 0; i < numUploads; i++) {
                 writer.append(0, new byte[] {0});
-                writer.persist(writer.lastAppendedSequenceNumber());
+                writer.persist(writer.lastAppendedSequenceNumber().get());
             }
             assertEquals(numUploads, (int) queueSizeGauge.get().getValue());
             scheduler.triggerScheduledTasks();

--- a/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/FsStateChangelogWriterSqnTest.java
+++ b/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/FsStateChangelogWriterSqnTest.java
@@ -19,7 +19,6 @@ package org.apache.flink.changelog.fs;
 
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.changelog.SequenceNumber;
-import org.apache.flink.runtime.state.changelog.StateChangelogWriter;
 import org.apache.flink.util.function.ThrowingConsumer;
 
 import org.junit.Test;
@@ -43,10 +42,16 @@ public class FsStateChangelogWriterSqnTest {
     @Parameterized.Parameters(name = "{0}")
     public static List<WriterSqnTestSettings> getSettings() {
         return asList(
-                of(StateChangelogWriter::lastAppendedSequenceNumber, "lastAppendedSequenceNumber")
+                of(
+                                fsStateChangelogWriter1 ->
+                                        fsStateChangelogWriter1.lastAppendedSequenceNumber(),
+                                "lastAppendedSequenceNumber")
                         .withAppendCall(false)
                         .expectIncrement(false),
-                of(StateChangelogWriter::lastAppendedSequenceNumber, "lastAppendedSequenceNumber")
+                of(
+                                fsStateChangelogWriter ->
+                                        fsStateChangelogWriter.lastAppendedSequenceNumber().get(),
+                                "lastAppendedSequenceNumber")
                         .withAppendCall(true)
                         .expectIncrement(true),
                 of(FsStateChangelogWriterSqnTest::persistAll, "persist")
@@ -146,7 +151,7 @@ public class FsStateChangelogWriterSqnTest {
     }
 
     private static void truncateLast(FsStateChangelogWriter writer) {
-        writer.truncate(writer.lastAppendedSequenceNumber());
+        writer.truncate(writer.lastAppendedSequenceNumber().get());
     }
 
     private static void truncateAll(FsStateChangelogWriter writer) {

--- a/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/FsStateChangelogWriterTest.java
+++ b/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/FsStateChangelogWriterTest.java
@@ -224,7 +224,7 @@ public class FsStateChangelogWriterTest {
 
     private SequenceNumber append(FsStateChangelogWriter writer, byte[] bytes) throws IOException {
         writer.append(KEY_GROUP, bytes);
-        return writer.lastAppendedSequenceNumber();
+        return writer.lastAppendedSequenceNumber().get();
     }
 
     private byte[] getBytes() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogWriter.java
@@ -21,6 +21,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 
 import java.io.IOException;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 /** Allows to write data to the log. Scoped to a single writer (e.g. state backend). */
@@ -33,7 +34,7 @@ public interface StateChangelogWriter<Handle extends ChangelogStateHandle> exten
     /**
      * Get {@link SequenceNumber} of the last element added by {@link #append(int, byte[]) append}.
      */
-    SequenceNumber lastAppendedSequenceNumber();
+    Optional<SequenceNumber> lastAppendedSequenceNumber();
 
     /** Appends the provided data to this log. No persistency guarantees. */
     void append(int keyGroup, byte[] value) throws IOException;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/inmemory/InMemoryStateChangelogWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/inmemory/InMemoryStateChangelogWriter.java
@@ -34,6 +34,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
+import java.util.Optional;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
@@ -71,8 +72,8 @@ class InMemoryStateChangelogWriter implements StateChangelogWriter<InMemoryChang
     }
 
     @Override
-    public SequenceNumber lastAppendedSequenceNumber() {
-        return sqn;
+    public Optional<SequenceNumber> lastAppendedSequenceNumber() {
+        return sqn == INITIAL_SQN ? Optional.empty() : Optional.of(sqn);
     }
 
     @Override
@@ -109,7 +110,7 @@ class InMemoryStateChangelogWriter implements StateChangelogWriter<InMemoryChang
                 .filter(map -> !map.isEmpty())
                 .map(SortedMap::firstKey)
                 .min(Comparator.naturalOrder())
-                .orElse(lastAppendedSequenceNumber().next());
+                .orElse(sqn.next());
     }
 
     @Override

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogStateBackendTestUtils.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogStateBackendTestUtils.java
@@ -250,7 +250,7 @@ public class ChangelogStateBackendTestUtils {
             PeriodicMaterializationManager periodicMaterializationManager) {
         StateChangelogWriter<? extends ChangelogStateHandle> writer =
                 keyedBackend.getChangelogWriter();
-        SequenceNumber sqnBefore = writer.lastAppendedSequenceNumber();
+        SequenceNumber sqnBefore = writer.lastAppendedSequenceNumber().get();
         periodicMaterializationManager.triggerMaterialization();
         assertTrue(
                 "Materialization didn't truncate the changelog",

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/StateChangeLoggerTestBase.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/StateChangeLoggerTestBase.java
@@ -115,7 +115,7 @@ abstract class StateChangeLoggerTestBase<Namespace> {
         }
 
         @Override
-        public SequenceNumber lastAppendedSequenceNumber() {
+        public Optional<SequenceNumber> lastAppendedSequenceNumber() {
             throw new UnsupportedOperationException();
         }
 


### PR DESCRIPTION
## What is the purpose of the change

In a recent fix, materialization sqn is advanced by backend rather than writer
(by calling `sqn.next()`).
However, this is not enough for `FsStateChangelogWriter` because backend can't
distinguish writer initial empty state from state with some records appended.

This change makes `lastAppendedSequenceNumber` return Optional which allows
backend to decide whether or not to perform materialization or snapshot.

## Verifying this change

`ProcessingTimeWindowCheckpointingITCase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no