### PR TITLE
[hotfix][doc] add javadoc for describing ITCASE_USE_MINICLUSTER rule in details

### DIFF
--- a/flink-architecture-tests/flink-architecture-tests-test/src/main/java/org/apache/flink/architecture/rules/ITCaseRules.java
+++ b/flink-architecture-tests/flink-architecture-tests-test/src/main/java/org/apache/flink/architecture/rules/ITCaseRules.java
@@ -51,6 +51,49 @@ public class ITCaseRules {
                             .should()
                             .haveSimpleNameEndingWith("ITCase"));
 
+    /**
+     * In order to pass this violation check, As an example, ITCase test class should fulfill at
+     * least one of the following conditions.
+     *
+     * <p>1. For JUnit 5 test, both fields are required like:
+     *
+     * <pre>{@code
+     * public static final MiniClusterExtension MINI_CLUSTER_RESOURCE =
+     *         new MiniClusterExtension(
+     *                 new MiniClusterResourceConfiguration.Builder()
+     *                         .setConfiguration(getFlinkConfiguration())
+     *                         .build());
+     *
+     * @RegisterExtension
+     * public static AllCallbackWrapper allCallbackWrapper =
+     *         new AllCallbackWrapper(MINI_CLUSTER_RESOURCE);
+     * }</pre>
+     *
+     * <p>2. For JUnit 4 test via @Rule like:
+     *
+     * <pre>{@code
+     * @Rule
+     *  public final MiniClusterWithClientResource miniClusterResource =
+     *          new MiniClusterWithClientResource(
+     *                  new MiniClusterResourceConfiguration.Builder()
+     *                          .setNumberTaskManagers(1)
+     *                          .setNumberSlotsPerTaskManager(PARALLELISM)
+     *                          .setRpcServiceSharing(RpcServiceSharing.DEDICATED)
+     *                          .withHaLeadershipControl()
+     *                          .build());
+     * }</pre>
+     *
+     * <p>3. For JUnit 4 test via @ClassRule like:
+     *
+     * <pre>{@code
+     * @ClassRule
+     * public static final MiniClusterWithClientResource MINI_CLUSTER =
+     *         new MiniClusterWithClientResource(
+     *                 new MiniClusterResourceConfiguration.Builder()
+     *                         .setConfiguration(new Configuration())
+     *                         .build());
+     * }</pre>
+     */
     @ArchTest
     public static final ArchRule ITCASE_USE_MINICLUSTER =
             freeze(
@@ -76,6 +119,7 @@ public class ITCaseRules {
                                                     // JUnit 4 violation check, which should be
                                                     // removed
                                                     // after the JUnit 4->5 migration is closed.
+                                                    // Please refer to FLINK-25858.
                                                     .or(
                                                             containAnyFieldsInClassHierarchyThat(
                                                                     arePublicStaticFinalOfTypeWithAnnotation(


### PR DESCRIPTION
## What is the purpose of the change

When the developer runs into some violation checks of the ITCase rules, they may need some more information about the rule definition. Sometimes, the rule itself goes complex. It will be helpful to add details explanation for such rule so the developer knows how to fix the violations.

## Brief change log

  - add javadoc with comprehensive introduction of the rule ITCASE_USE_MINICLUSTER


## Verifying this change

This change is a trivial javadoc improvement without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
