### PR TITLE
[FLINK-24441][source] Block SourceOperator when watermarks are out of alignment

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinator.java
@@ -587,5 +587,9 @@ public class SourceCoordinator<SplitT extends SourceSplit, EnumChkT>
         public boolean isEnabled() {
             return maxAllowedWatermarkDrift < Long.MAX_VALUE;
         }
+
+        public long getUpdateInterval() {
+            return updateInterval;
+        }
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java
@@ -39,16 +39,21 @@ import org.apache.flink.runtime.metrics.groups.InternalSourceReaderMetricGroup;
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 import org.apache.flink.runtime.operators.coordination.OperatorEventGateway;
 import org.apache.flink.runtime.operators.coordination.OperatorEventHandler;
+import org.apache.flink.runtime.source.coordinator.SourceCoordinator;
+import org.apache.flink.runtime.source.coordinator.SourceCoordinator.WatermarkAlignmentParams;
 import org.apache.flink.runtime.source.event.AddSplitEvent;
 import org.apache.flink.runtime.source.event.NoMoreSplitsEvent;
 import org.apache.flink.runtime.source.event.ReaderRegistrationEvent;
+import org.apache.flink.runtime.source.event.ReportedWatermarkEvent;
 import org.apache.flink.runtime.source.event.RequestSplitEvent;
 import org.apache.flink.runtime.source.event.SourceEventWrapper;
+import org.apache.flink.runtime.source.event.WatermarkAlignmentEvent;
 import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.runtime.state.StateSnapshotContext;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.source.TimestampsAndWatermarks;
 import org.apache.flink.streaming.api.operators.util.SimpleVersionedListState;
+import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.io.DataInputStatus;
 import org.apache.flink.streaming.runtime.io.MultipleFuturesAvailabilityHelper;
 import org.apache.flink.streaming.runtime.io.PushingAsyncDataInput;
@@ -67,6 +72,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * Base source operator only used for integrating the source reader which is proposed by FLIP-27. It
@@ -108,6 +114,8 @@ public class SourceOperator<OUT, SplitT extends SourceSplit> extends AbstractStr
     /** The factory for timestamps and watermark generators. */
     private final WatermarkStrategy<OUT> watermarkStrategy;
 
+    private final WatermarkAlignmentParams watermarkAlignmentParams;
+
     /** The Flink configuration. */
     private final Configuration configuration;
 
@@ -128,6 +136,8 @@ public class SourceOperator<OUT, SplitT extends SourceSplit> extends AbstractStr
 
     private DataOutput<OUT> lastInvokedOutput;
 
+    private long lastEmittedWatermark = Watermark.UNINITIALIZED.getTimestamp();
+
     /** The state that holds the currently assigned splits. */
     private ListState<SplitT> readerState;
 
@@ -147,6 +157,7 @@ public class SourceOperator<OUT, SplitT extends SourceSplit> extends AbstractStr
 
     private enum OperatingMode {
         READING,
+        WAITING_FOR_ALIGNMENT,
         OUTPUT_NOT_INITIALIZED,
         SOURCE_DRAINED,
         SOURCE_STOPPED,
@@ -154,6 +165,11 @@ public class SourceOperator<OUT, SplitT extends SourceSplit> extends AbstractStr
     }
 
     private InternalSourceReaderMetricGroup sourceMetricGroup;
+
+    private long currentMaxDesiredWatermark = Watermark.MAX_WATERMARK.getTimestamp();
+    /** Can be not completed only in {@link OperatingMode#WAITING_FOR_ALIGNMENT} mode. */
+    private CompletableFuture<Void> waitingForAlignmentFuture =
+            CompletableFuture.completedFuture(null);
 
     private @Nullable LatencyMarkerEmitter<OUT> latencyMarerEmitter;
 
@@ -167,11 +183,35 @@ public class SourceOperator<OUT, SplitT extends SourceSplit> extends AbstractStr
             Configuration configuration,
             String localHostname,
             boolean emitProgressiveWatermarks) {
+        this(
+                readerFactory,
+                operatorEventGateway,
+                splitSerializer,
+                watermarkStrategy,
+                timeService,
+                configuration,
+                localHostname,
+                emitProgressiveWatermarks,
+                SourceCoordinator.WATERMARK_ALIGNMENT_DISABLED);
+    }
+
+    public SourceOperator(
+            FunctionWithException<SourceReaderContext, SourceReader<OUT, SplitT>, Exception>
+                    readerFactory,
+            OperatorEventGateway operatorEventGateway,
+            SimpleVersionedSerializer<SplitT> splitSerializer,
+            WatermarkStrategy<OUT> watermarkStrategy,
+            ProcessingTimeService timeService,
+            Configuration configuration,
+            String localHostname,
+            boolean emitProgressiveWatermarks,
+            WatermarkAlignmentParams watermarkAlignmentParams) {
 
         this.readerFactory = checkNotNull(readerFactory);
         this.operatorEventGateway = checkNotNull(operatorEventGateway);
         this.splitSerializer = checkNotNull(splitSerializer);
         this.watermarkStrategy = checkNotNull(watermarkStrategy);
+        this.watermarkAlignmentParams = watermarkAlignmentParams;
         this.processingTimeService = timeService;
         this.configuration = checkNotNull(configuration);
         this.localHostname = checkNotNull(localHostname);
@@ -325,6 +365,7 @@ public class SourceOperator<OUT, SplitT extends SourceSplit> extends AbstractStr
 
     public CompletableFuture<Void> stop(StopMode mode) {
         switch (operatingMode) {
+            case WAITING_FOR_ALIGNMENT:
             case OUTPUT_NOT_INITIALIZED:
             case READING:
                 this.operatingMode =
@@ -370,7 +411,17 @@ public class SourceOperator<OUT, SplitT extends SourceSplit> extends AbstractStr
     private DataInputStatus emitNextNotReading(DataOutput<OUT> output) throws Exception {
         switch (operatingMode) {
             case OUTPUT_NOT_INITIALIZED:
-                currentMainOutput = eventTimeLogic.createMainOutput(output);
+                if (watermarkAlignmentParams.isEnabled()) {
+                    // Only wrap the output when watermark alignment is enabled, as otherwise this
+                    // introduces a small performance regression (probably because of an extra
+                    // virtual call)
+                    processingTimeService.scheduleWithFixedDelay(
+                            this::emitLatestWatermark,
+                            watermarkAlignmentParams.getUpdateInterval(),
+                            watermarkAlignmentParams.getUpdateInterval());
+                }
+                currentMainOutput =
+                        eventTimeLogic.createMainOutput(output, this::onWatermarkEmitted);
                 initializeLatencyMarkerEmitter(output);
                 lastInvokedOutput = output;
                 this.operatingMode = OperatingMode.READING;
@@ -386,6 +437,10 @@ public class SourceOperator<OUT, SplitT extends SourceSplit> extends AbstractStr
             case DATA_FINISHED:
                 sourceMetricGroup.idlingStarted();
                 return DataInputStatus.END_OF_INPUT;
+            case WAITING_FOR_ALIGNMENT:
+                checkState(!waitingForAlignmentFuture.isDone());
+                checkState(shouldWaitForAlignment());
+                return convertToInternalStatus(InputStatus.NOTHING_AVAILABLE);
             case READING:
             default:
                 throw new IllegalStateException("Unknown operating mode: " + operatingMode);
@@ -428,6 +483,12 @@ public class SourceOperator<OUT, SplitT extends SourceSplit> extends AbstractStr
         }
     }
 
+    private void emitLatestWatermark(long time) {
+        checkState(currentMainOutput != null);
+        operatorEventGateway.sendEventToCoordinator(
+                new ReportedWatermarkEvent(lastEmittedWatermark));
+    }
+
     @Override
     public void snapshotState(StateSnapshotContext context) throws Exception {
         long checkpointId = context.getCheckpointId();
@@ -438,6 +499,8 @@ public class SourceOperator<OUT, SplitT extends SourceSplit> extends AbstractStr
     @Override
     public CompletableFuture<?> getAvailableFuture() {
         switch (operatingMode) {
+            case WAITING_FOR_ALIGNMENT:
+                return availabilityHelper.update(waitingForAlignmentFuture);
             case OUTPUT_NOT_INITIALIZED:
             case READING:
                 return availabilityHelper.update(sourceReader.isAvailable());
@@ -472,7 +535,10 @@ public class SourceOperator<OUT, SplitT extends SourceSplit> extends AbstractStr
 
     @SuppressWarnings("unchecked")
     public void handleOperatorEvent(OperatorEvent event) {
-        if (event instanceof AddSplitEvent) {
+        if (event instanceof WatermarkAlignmentEvent) {
+            currentMaxDesiredWatermark = ((WatermarkAlignmentEvent) event).getMaxWatermark();
+            checkWatermarkAlignment();
+        } else if (event instanceof AddSplitEvent) {
             try {
                 sourceReader.addSplits(((AddSplitEvent<SplitT>) event).splits(splitSerializer));
             } catch (IOException e) {
@@ -485,6 +551,31 @@ public class SourceOperator<OUT, SplitT extends SourceSplit> extends AbstractStr
         } else {
             throw new IllegalStateException("Received unexpected operator event " + event);
         }
+    }
+
+    private void onWatermarkEmitted(long emittedWatermark) {
+        lastEmittedWatermark = emittedWatermark;
+        checkWatermarkAlignment();
+    }
+
+    private void checkWatermarkAlignment() {
+        if (operatingMode == OperatingMode.READING) {
+            checkState(waitingForAlignmentFuture.isDone());
+            if (shouldWaitForAlignment()) {
+                operatingMode = OperatingMode.WAITING_FOR_ALIGNMENT;
+                waitingForAlignmentFuture = new CompletableFuture<>();
+            }
+        } else if (operatingMode == OperatingMode.WAITING_FOR_ALIGNMENT) {
+            checkState(!waitingForAlignmentFuture.isDone());
+            if (!shouldWaitForAlignment()) {
+                operatingMode = OperatingMode.READING;
+                waitingForAlignmentFuture.complete(null);
+            }
+        }
+    }
+
+    private boolean shouldWaitForAlignment() {
+        return currentMaxDesiredWatermark < lastEmittedWatermark;
     }
 
     private void registerReader() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/NoOpTimestampsAndWatermarks.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/NoOpTimestampsAndWatermarks.java
@@ -47,7 +47,8 @@ public class NoOpTimestampsAndWatermarks<T> implements TimestampsAndWatermarks<T
     }
 
     @Override
-    public ReaderOutput<T> createMainOutput(PushingAsyncDataInput.DataOutput<T> output) {
+    public ReaderOutput<T> createMainOutput(
+            PushingAsyncDataInput.DataOutput<T> output, OnWatermarkEmitted watermarkEmitted) {
         checkNotNull(output);
         return new TimestampsOnlyOutput<>(output, timestamps);
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/ProgressiveTimestampsAndWatermarks.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/ProgressiveTimestampsAndWatermarks.java
@@ -89,7 +89,8 @@ public class ProgressiveTimestampsAndWatermarks<T> implements TimestampsAndWater
     // ------------------------------------------------------------------------
 
     @Override
-    public ReaderOutput<T> createMainOutput(PushingAsyncDataInput.DataOutput<T> output) {
+    public ReaderOutput<T> createMainOutput(
+            PushingAsyncDataInput.DataOutput<T> output, OnWatermarkEmitted watermarkEmitted) {
         // At the moment, we assume only one output is ever created!
         // This assumption is strict, currently, because many of the classes in this implementation
         // do not
@@ -98,7 +99,7 @@ public class ProgressiveTimestampsAndWatermarks<T> implements TimestampsAndWater
                 currentMainOutput == null && currentPerSplitOutputs == null,
                 "already created a main output");
 
-        final WatermarkOutput watermarkOutput = new WatermarkToDataOutput(output);
+        final WatermarkOutput watermarkOutput = new WatermarkToDataOutput(output, watermarkEmitted);
         final WatermarkGenerator<T> watermarkGenerator =
                 watermarksFactory.createWatermarkGenerator(watermarksContext);
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/SourceOutputWithWatermarks.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/SourceOutputWithWatermarks.java
@@ -150,26 +150,6 @@ public class SourceOutputWithWatermarks<T> implements SourceOutput<T> {
 
     /**
      * Creates a new SourceOutputWithWatermarks that emits records to the given DataOutput and
-     * watermarks to the (possibly different) WatermarkOutput.
-     */
-    public static <E> SourceOutputWithWatermarks<E> createWithSameOutputs(
-            PushingAsyncDataInput.DataOutput<E> recordsAndWatermarksOutput,
-            TimestampAssigner<E> timestampAssigner,
-            WatermarkGenerator<E> watermarkGenerator) {
-
-        final WatermarkOutput watermarkOutput =
-                new WatermarkToDataOutput(recordsAndWatermarksOutput);
-
-        return new SourceOutputWithWatermarks<>(
-                recordsAndWatermarksOutput,
-                watermarkOutput,
-                watermarkOutput,
-                timestampAssigner,
-                watermarkGenerator);
-    }
-
-    /**
-     * Creates a new SourceOutputWithWatermarks that emits records to the given DataOutput and
      * watermarks to the different WatermarkOutputs.
      */
     public static <E> SourceOutputWithWatermarks<E> createWithSeparateOutputs(

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/TimestampsAndWatermarks.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/TimestampsAndWatermarks.java
@@ -42,11 +42,18 @@ import java.time.Duration;
 @Internal
 public interface TimestampsAndWatermarks<T> {
 
+    /** Lets the owner/creator of the output know about latest emitted watermark. */
+    @Internal
+    interface OnWatermarkEmitted {
+        void watermarkEmitted(long watermark);
+    }
+
     /**
      * Creates the ReaderOutput for the source reader, than internally runs the timestamp extraction
      * and watermark generation.
      */
-    ReaderOutput<T> createMainOutput(PushingAsyncDataInput.DataOutput<T> output);
+    ReaderOutput<T> createMainOutput(
+            PushingAsyncDataInput.DataOutput<T> output, OnWatermarkEmitted watermarkCallback);
 
     /**
      * Starts emitting periodic watermarks, if this implementation produces watermarks, and if

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorAlignmentTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorAlignmentTest.java
@@ -1,0 +1,202 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package org.apache.flink.streaming.api.operators;
+
+import org.apache.flink.api.common.eventtime.Watermark;
+import org.apache.flink.api.common.eventtime.WatermarkGenerator;
+import org.apache.flink.api.common.eventtime.WatermarkOutput;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.connector.source.mocks.MockSourceSplit;
+import org.apache.flink.api.connector.source.mocks.MockSourceSplitSerializer;
+import org.apache.flink.runtime.io.network.api.StopMode;
+import org.apache.flink.runtime.operators.coordination.OperatorEvent;
+import org.apache.flink.runtime.source.coordinator.SourceCoordinator.WatermarkAlignmentParams;
+import org.apache.flink.runtime.source.event.AddSplitEvent;
+import org.apache.flink.runtime.source.event.ReportedWatermarkEvent;
+import org.apache.flink.runtime.source.event.WatermarkAlignmentEvent;
+import org.apache.flink.streaming.api.operators.source.CollectingDataOutput;
+import org.apache.flink.streaming.runtime.io.DataInputStatus;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/** Unit test for {@link SourceOperator} watermark alignment. */
+@SuppressWarnings("serial")
+public class SourceOperatorAlignmentTest {
+
+    @Nullable private SourceOperatorTestContext context;
+    @Nullable private SourceOperator<Integer, MockSourceSplit> operator;
+
+    @BeforeEach
+    public void setup() throws Exception {
+        context =
+                new SourceOperatorTestContext(
+                        false,
+                        WatermarkStrategy.forGenerator(ctx -> new PunctuatedGenerator())
+                                .withTimestampAssigner((r, t) -> r),
+                        new WatermarkAlignmentParams(100, "group1", 1));
+        operator = context.getOperator();
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        context.close();
+        context = null;
+        operator = null;
+    }
+
+    @Test
+    public void testWatermarkAlignment() throws Exception {
+        operator.initializeState(context.createStateContext());
+        operator.open();
+        MockSourceSplit newSplit = new MockSourceSplit(2);
+        int record1 = 1000;
+        int record2 = 2000;
+        int record3 = 3000;
+        newSplit.addRecord(record1);
+        newSplit.addRecord(record2);
+        newSplit.addRecord(record3);
+
+        operator.handleOperatorEvent(
+                new AddSplitEvent<>(
+                        Collections.singletonList(newSplit), new MockSourceSplitSerializer()));
+
+        CollectingDataOutput<Integer> actualOutput = new CollectingDataOutput<>();
+        List<Integer> expectedOutput = new ArrayList<>();
+
+        assertThat(operator.emitNext(actualOutput), is(DataInputStatus.MORE_AVAILABLE));
+        expectedOutput.add(record1);
+        context.getTimeService().advance(1);
+        assertLatestReportedWatermarkEvent(record1);
+        assertOutput(actualOutput, expectedOutput);
+        assertTrue(operator.isAvailable());
+
+        operator.handleOperatorEvent(new WatermarkAlignmentEvent(record1 - 1));
+
+        assertFalse(operator.isAvailable());
+        assertThat(operator.emitNext(actualOutput), is(DataInputStatus.NOTHING_AVAILABLE));
+        assertLatestReportedWatermarkEvent(record1);
+        assertOutput(actualOutput, expectedOutput);
+        assertFalse(operator.isAvailable());
+
+        operator.handleOperatorEvent(new WatermarkAlignmentEvent(record1 + 1));
+
+        assertTrue(operator.isAvailable());
+        operator.emitNext(actualOutput);
+        // Try to poll a record second time. Technically speaking previous emitNext call could have
+        // already switch the operator status to unavailable, but that's an implementation detail.
+        // However, this second call can not emit anything and should after that second call
+        // operator must be unavailable.
+        assertThat(operator.emitNext(actualOutput), is(DataInputStatus.NOTHING_AVAILABLE));
+        expectedOutput.add(record2);
+        context.getTimeService().advance(1);
+        assertLatestReportedWatermarkEvent(record2);
+        assertOutput(actualOutput, expectedOutput);
+        assertFalse(operator.isAvailable());
+    }
+
+    @Test
+    public void testStopWhileWaitingForWatermarkAlignment() throws Exception {
+        testWatermarkAlignment();
+
+        CompletableFuture<?> availableFuture = operator.getAvailableFuture();
+        assertFalse(availableFuture.isDone());
+        operator.stop(StopMode.NO_DRAIN);
+        assertTrue(availableFuture.isDone());
+        assertTrue(operator.isAvailable());
+    }
+
+    @Test
+    public void testReportedWatermarkDoNotDecrease() throws Exception {
+        operator.initializeState(context.createStateContext());
+        operator.open();
+        MockSourceSplit split1 = new MockSourceSplit(2);
+        MockSourceSplit split2 = new MockSourceSplit(3);
+        int record1 = 2000;
+        int record2 = 1000;
+        split1.addRecord(record1);
+        split2.addRecord(record2);
+
+        operator.handleOperatorEvent(
+                new AddSplitEvent<>(
+                        Collections.singletonList(split1), new MockSourceSplitSerializer()));
+
+        CollectingDataOutput<Integer> actualOutput = new CollectingDataOutput<>();
+
+        operator.emitNext(actualOutput);
+        context.getTimeService().advance(1);
+        assertLatestReportedWatermarkEvent(record1);
+
+        operator.handleOperatorEvent(
+                new AddSplitEvent<>(
+                        Collections.singletonList(split2), new MockSourceSplitSerializer()));
+
+        operator.emitNext(actualOutput);
+        context.getTimeService().advance(1);
+        assertLatestReportedWatermarkEvent(record1);
+    }
+
+    private void assertOutput(
+            CollectingDataOutput<Integer> actualOutput, List<Integer> expectedOutput) {
+        assertThat(
+                actualOutput.getEvents().stream()
+                        .filter(o -> o instanceof StreamRecord)
+                        .mapToInt(object -> ((StreamRecord<Integer>) object).getValue())
+                        .boxed()
+                        .collect(Collectors.toList()),
+                contains(expectedOutput.toArray()));
+    }
+
+    private void assertLatestReportedWatermarkEvent(long expectedWatermark) {
+        List<OperatorEvent> events =
+                context.getGateway().getEventsSent().stream()
+                        .filter(event -> event instanceof ReportedWatermarkEvent)
+                        .collect(Collectors.toList());
+
+        assertFalse(events.isEmpty());
+        assertEquals(new ReportedWatermarkEvent(expectedWatermark), events.get(events.size() - 1));
+    }
+
+    private static class PunctuatedGenerator implements WatermarkGenerator<Integer> {
+        @Override
+        public void onEvent(Integer event, long eventTimestamp, WatermarkOutput output) {
+            output.emitWatermark(new Watermark(eventTimestamp));
+        }
+
+        @Override
+        public void onPeriodicEmit(WatermarkOutput output) {}
+    }
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/source/CollectingDataOutput.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/source/CollectingDataOutput.java
@@ -47,11 +47,16 @@ public final class CollectingDataOutput<E> implements PushingAsyncDataInput.Data
 
     @Override
     public void emitRecord(StreamRecord<E> streamRecord) throws Exception {
-        events.add(streamRecord);
+        // Bypass issues with object re-use disabled by copying the record
+        events.add(streamRecord.copy(streamRecord.getValue()));
     }
 
     @Override
     public void emitLatencyMarker(LatencyMarker latencyMarker) throws Exception {
         events.add(latencyMarker);
+    }
+
+    public List<Object> getEvents() {
+        return events;
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/source/TestingSourceOperator.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/source/TestingSourceOperator.java
@@ -27,10 +27,11 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.operators.coordination.MockOperatorEventGateway;
 import org.apache.flink.runtime.operators.coordination.OperatorEventGateway;
+import org.apache.flink.runtime.source.coordinator.SourceCoordinator;
+import org.apache.flink.runtime.source.coordinator.SourceCoordinator.WatermarkAlignmentParams;
 import org.apache.flink.streaming.api.operators.SourceOperator;
 import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
-import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
 import org.apache.flink.streaming.util.MockStreamingRuntimeContext;
 
 /** A SourceOperator extension to simplify test setup. */
@@ -54,23 +55,8 @@ public class TestingSourceOperator<T> extends SourceOperator<T, MockSourceSplit>
                 new MockOperatorEventGateway(),
                 1,
                 5,
-                emitProgressiveWatermarks);
-    }
-
-    public TestingSourceOperator(
-            SourceReader<T, MockSourceSplit> reader,
-            OperatorEventGateway eventGateway,
-            int subtaskIndex,
-            boolean emitProgressiveWatermarks) {
-
-        this(
-                reader,
-                WatermarkStrategy.noWatermarks(),
-                new TestProcessingTimeService(),
-                eventGateway,
-                subtaskIndex,
-                5,
-                emitProgressiveWatermarks);
+                emitProgressiveWatermarks,
+                SourceCoordinator.WATERMARK_ALIGNMENT_DISABLED);
     }
 
     public TestingSourceOperator(
@@ -80,7 +66,8 @@ public class TestingSourceOperator<T> extends SourceOperator<T, MockSourceSplit>
             OperatorEventGateway eventGateway,
             int subtaskIndex,
             int parallelism,
-            boolean emitProgressiveWatermarks) {
+            boolean emitProgressiveWatermarks,
+            WatermarkAlignmentParams watermarkAlignmentParams) {
 
         super(
                 (context) -> reader,
@@ -90,7 +77,8 @@ public class TestingSourceOperator<T> extends SourceOperator<T, MockSourceSplit>
                 timeService,
                 new Configuration(),
                 "localhost",
-                emitProgressiveWatermarks);
+                emitProgressiveWatermarks,
+                watermarkAlignmentParams);
 
         this.subtaskIndex = subtaskIndex;
         this.parallelism = parallelism;


### PR DESCRIPTION
## What is the purpose of the change

This PR integrates with FLINK-24440 and it implements `SourceOperator` level handling of watermark alignment.

## Verifying this change

This PR adds a dedicated unit test for the `SourceOperator` changes.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
