### PR TITLE
[FLINK-26054][table-planner][build] Add enforcer rule to disable direct dependency on table planner

### DIFF
--- a/flink-connectors/flink-connector-cassandra/pom.xml
+++ b/flink-connectors/flink-connector-cassandra/pom.xml
@@ -45,6 +45,23 @@ under the License.
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>forbid-direct-table-planner-dependencies</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<!-- We need to depend on table planner because we rely on its internals -->
+							<skip>true</skip>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>
 					<reuseForks>true</reuseForks>

--- a/flink-connectors/flink-connector-hive/pom.xml
+++ b/flink-connectors/flink-connector-hive/pom.xml
@@ -889,6 +889,23 @@ under the License.
 	<build>
 		<plugins>
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>forbid-direct-table-planner-dependencies</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<!-- We need to depend on table planner because we rely on its internals -->
+							<skip>true</skip>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
 				<groupId>org.antlr</groupId>
 				<artifactId>antlr3-maven-plugin</artifactId>
 				<version>3.5.2</version>

--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -586,6 +586,16 @@ under the License.
 							<skip>true</skip>
 						</configuration>
 					</execution>
+					<execution>
+						<id>forbid-direct-table-planner-dependencies</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<!-- We need to depend on table planner to ship it in the /opt folder -->
+							<skip>true</skip>
+						</configuration>
+					</execution>
 				</executions>
 			</plugin>
 

--- a/flink-examples/flink-examples-table/pom.xml
+++ b/flink-examples/flink-examples-table/pom.xml
@@ -97,6 +97,23 @@ under the License.
 
 	<build>
 		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>forbid-direct-table-planner-dependencies</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<!-- See comment above on table planner dependency -->
+							<skip>true</skip>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
 			<!-- Fail compilation on deprecation warnings to prevent from showing users outdated examples. -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/flink-table/flink-table-planner-loader-bundle/pom.xml
+++ b/flink-table/flink-table-planner-loader-bundle/pom.xml
@@ -31,9 +31,9 @@
 	</parent>
 
 	<artifactId>flink-table-planner-loader-bundle</artifactId>
-	<name>Flink : Table : Planner Loader Helper</name>
+	<name>Flink : Table : Planner Loader Bundle</name>
 	<packaging>jar</packaging>
-	<description>Intermediate build artifact use by the planner-loader.</description>
+	<description>Intermediate build artifact used by the flink-table-planner-loader.</description>
 
 	<dependencies>
 		<dependency>
@@ -46,6 +46,22 @@
 
 	<build>
 		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>forbid-direct-table-planner-dependencies</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<skip>true</skip>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-deploy-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1745,6 +1745,28 @@ under the License.
 						</configuration>
 					</execution>
 					<execution>
+						<id>forbid-direct-table-planner-dependencies</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<bannedDependencies>
+									<excludes>
+										<exclude>org.apache.flink:flink-table-planner_${scala.binary.version}</exclude>
+									</excludes>
+									<includes>
+										<include>org.apache.flink:flink-table-planner_${scala.binary.version}:*:*:test</include>
+									</includes>
+									<message>
+										Direct dependencies on flink-table-planner are not allowed.
+										You should depend on either Table API modules or flink-table-planner-loader.
+									</message>
+								</bannedDependencies>
+							</rules>
+						</configuration>
+					</execution>
+					<execution>
 						<id>dependency-convergence</id>
 						<!-- disabled by default as it interacts badly with shade-plugin -->
 						<phase>none</phase>


### PR DESCRIPTION
## What is the purpose of the change

Add a maven enforcer rule to disable direct dependency on table planner. Added exclusions to modules depending directly on table planner
