### PR TITLE
[FLINK-26072][Connectors][NiFi] Mark NiFi Source and Sink as deprecated

### DIFF
--- a/docs/content.zh/docs/connectors/datastream/nifi.md
+++ b/docs/content.zh/docs/connectors/datastream/nifi.md
@@ -26,6 +26,10 @@ under the License.
 
 # Apache NiFi 连接器
 
+{{< hint warning >}}
+The NiFi connector is deprecated and will be removed with Flink 1.16.
+{{< /hint >}}
+
 [Apache NiFi](https://nifi.apache.org/) 连接器提供了可以读取和写入的 Source 和 Sink。
 使用这个连接器，需要在工程中添加下面的依赖:
 

--- a/docs/content/docs/connectors/datastream/nifi.md
+++ b/docs/content/docs/connectors/datastream/nifi.md
@@ -26,6 +26,10 @@ under the License.
 
 # Apache NiFi Connector
 
+{{< hint warning >}}
+The NiFi connector is deprecated and will be removed with Flink 1.16.
+{{< /hint >}}
+
 This connector provides a Source and Sink that can read from and write to
 [Apache NiFi](https://nifi.apache.org/). To use this connector, add the
 following dependency to your project:

--- a/flink-connectors/flink-connector-nifi/src/main/java/org/apache/flink/streaming/connectors/nifi/NiFiSink.java
+++ b/flink-connectors/flink-connector-nifi/src/main/java/org/apache/flink/streaming/connectors/nifi/NiFiSink.java
@@ -29,7 +29,10 @@ import org.apache.nifi.remote.client.SiteToSiteClientConfig;
 /**
  * A sink that delivers data to Apache NiFi using the NiFi Site-to-Site client. The sink requires a
  * NiFiDataPacketBuilder which can create instances of NiFiDataPacket from the incoming data.
+ *
+ * @deprecated The NiFi Sink has been deprecated and will be removed in a future Flink release.
  */
+@Deprecated
 public class NiFiSink<T> extends RichSinkFunction<T> {
 
     private SiteToSiteClient client;

--- a/flink-connectors/flink-connector-nifi/src/main/java/org/apache/flink/streaming/connectors/nifi/NiFiSource.java
+++ b/flink-connectors/flink-connector-nifi/src/main/java/org/apache/flink/streaming/connectors/nifi/NiFiSource.java
@@ -38,7 +38,10 @@ import java.util.Map;
 /**
  * A source that pulls data from Apache NiFi using the NiFi Site-to-Site client. This source
  * produces NiFiDataPackets which encapsulate the content and attributes of a NiFi FlowFile.
+ *
+ * @deprecated The NiFi Source has been deprecated and will be removed in a future Flink release.
  */
+@Deprecated
 public class NiFiSource extends RichParallelSourceFunction<NiFiDataPacket> {
 
     private static final long serialVersionUID = 1L;


### PR DESCRIPTION
## What is the purpose of the change

* Mark NiFi connector as deprecated so they can be removed in the next Flink release

## Brief change log

* Added `@Deprecated` annotation to both `NiFiSource` and `NiFiSink`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
