### PR TITLE
[FLINK-26064] Temporarily disable KinesisFirehoseSinkITCase.

### DIFF
--- a/flink-connectors/flink-connector-aws-kinesis-firehose/src/test/java/org/apache/flink/connector/firehose/sink/KinesisFirehoseSinkITCase.java
+++ b/flink-connectors/flink-connector-aws-kinesis-firehose/src/test/java/org/apache/flink/connector/firehose/sink/KinesisFirehoseSinkITCase.java
@@ -30,6 +30,7 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMap
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,6 +58,7 @@ import static org.apache.flink.connector.firehose.sink.testutils.KinesisFirehose
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Integration test suite for the {@code KinesisFirehoseSink} using a localstack container. */
+@Ignore("FLINK-26064")
 public class KinesisFirehoseSinkITCase {
 
     private static final Logger LOG = LoggerFactory.getLogger(KinesisFirehoseSinkITCase.class);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/FLINK-26064

Disabling the test until the underlying issues are resolved. It seems to be some combination of ThreadLocals / ServiceLoader / Classloading issues deep down in AWS SDK, so it might take some time to address.

Context:

https://github.com/apache/flink/pull/18553#discussion_r802466514