### PR TITLE
[FLINK-25046][runtime] Convert unspecified edge to rescale when using adapive batch scheduler

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -49,6 +49,7 @@ import org.apache.flink.streaming.api.operators.OutputFormatOperatorFactory;
 import org.apache.flink.streaming.api.operators.SourceOperatorFactory;
 import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
 import org.apache.flink.streaming.api.transformations.StreamExchangeMode;
+import org.apache.flink.streaming.runtime.partitioner.ForwardForUnspecifiedPartitioner;
 import org.apache.flink.streaming.runtime.partitioner.ForwardPartitioner;
 import org.apache.flink.streaming.runtime.partitioner.RebalancePartitioner;
 import org.apache.flink.streaming.runtime.partitioner.StreamPartitioner;
@@ -667,7 +668,10 @@ public class StreamGraph implements Pipeline {
         // operator matches use forward partitioning, use rebalance otherwise.
         if (partitioner == null
                 && upstreamNode.getParallelism() == downstreamNode.getParallelism()) {
-            partitioner = new ForwardPartitioner<Object>();
+            partitioner =
+                    executionConfig.isDynamicGraph()
+                            ? new ForwardForUnspecifiedPartitioner<>()
+                            : new ForwardPartitioner<>();
         } else if (partitioner == null) {
             partitioner = new RebalancePartitioner<Object>();
         }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/ForwardForConsecutiveHashPartitioner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/ForwardForConsecutiveHashPartitioner.java
@@ -54,7 +54,8 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
  *
  * }</pre>
  *
- * <p>his partitioner will be converted to following partitioners after the operator chain creation:
+ * <p>This partitioner will be converted to following partitioners after the operator chain
+ * creation:
  *
  * <p>1. Be converted to {@link ForwardPartitioner} if this partitioner is intra-chain.
  *

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/ForwardForUnspecifiedPartitioner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/ForwardForUnspecifiedPartitioner.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.partitioner;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.runtime.io.network.api.writer.SubtaskStateMapper;
+import org.apache.flink.runtime.plugable.SerializationDelegate;
+import org.apache.flink.streaming.api.graph.StreamGraph;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+/**
+ * When the parallelism of both upstream and downstream is {@link
+ * ExecutionConfig#PARALLELISM_DEFAULT} and the edge's partitioner is not specified
+ * (partitioner==null), the edge's partitioner will be set to FORWARD by default(See {@link
+ * StreamGraph#createActualEdge} method for details). When using the AdaptiveBatchScheduler, this
+ * will result in the parallelism of many job vertices is not calculated based on the amount of data
+ * but has to align with the parallelism of their upstream vertices due to forward edges, which is
+ * contrary to the original intention of the AdaptiveBatchScheduler.
+ *
+ * <p>To solve it, we introduce the {@link ForwardForUnspecifiedPartitioner}. This partitioner will
+ * be set for unspecified edges(partitioner==null), and then the runtime framework will change it to
+ * FORWARD/RESCALE after the operator chain creation:
+ *
+ * <p>1. Convert to {@link ForwardPartitioner} if the partitioner is intra-chain.
+ *
+ * <p>2. Convert to {@link RescalePartitioner} if the partitioner is inter-chain.
+ *
+ * <p>This partitioner should only be used when using AdaptiveBatchScheduler.
+ *
+ * @param <T> Type of the elements in the Stream
+ */
+@Internal
+public class ForwardForUnspecifiedPartitioner<T> extends ForwardPartitioner<T> {
+
+    @Override
+    public StreamPartitioner<T> copy() {
+        throw new RuntimeException(
+                "ForwardForUnspecifiedPartitioner is a intermediate partitioner in optimization phase, "
+                        + "should be converted to a ForwardPartitioner/RescalePartitioner.");
+    }
+
+    @Override
+    public SubtaskStateMapper getDownstreamSubtaskStateMapper() {
+        throw new RuntimeException(
+                "ForwardForUnspecifiedPartitioner is a intermediate partitioner in optimization phase, "
+                        + "should be converted to a ForwardPartitioner/RescalePartitioner.");
+    }
+
+    @Override
+    public int selectChannel(SerializationDelegate<StreamRecord<T>> record) {
+        throw new RuntimeException(
+                "ForwardForUnspecifiedPartitioner is a intermediate partitioner in optimization phase, "
+                        + "should be converted to a ForwardPartitioner/RescalePartitioner.");
+    }
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/partitioner/ForwardForUnspecifiedPartitionerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/partitioner/ForwardForUnspecifiedPartitionerTest.java
@@ -31,17 +31,14 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-/** Test for {@link ForwardForConsecutiveHashPartitioner}. */
-public class ForwardForConsecutiveHashPartitionerTest extends TestLogger {
+/** Test for {@link ForwardForUnspecifiedPartitioner}. */
+public class ForwardForUnspecifiedPartitionerTest extends TestLogger {
 
     @Test
     public void testConvertToForwardPartitioner() {
         JobGraph jobGraph =
                 StreamPartitionerTestUtils.createJobGraph(
-                        "group1",
-                        "group1",
-                        new ForwardForConsecutiveHashPartitioner<>(
-                                new KeyGroupStreamPartitioner<>(record -> 0L, 100)));
+                        "group1", "group1", new ForwardForUnspecifiedPartitioner<>());
         List<JobVertex> jobVertices = jobGraph.getVerticesSortedTopologicallyFromSources();
         assertThat(jobVertices.size(), is(1));
         JobVertex vertex = jobGraph.getVerticesSortedTopologicallyFromSources().get(0);
@@ -52,19 +49,16 @@ public class ForwardForConsecutiveHashPartitionerTest extends TestLogger {
     }
 
     @Test
-    public void testConvertToHashPartitioner() {
+    public void testConvertToRescalePartitioner() {
         JobGraph jobGraph =
                 StreamPartitionerTestUtils.createJobGraph(
-                        "group1",
-                        "group2",
-                        new ForwardForConsecutiveHashPartitioner<>(
-                                new KeyGroupStreamPartitioner<>(record -> 0L, 100)));
+                        "group1", "group2", new ForwardForUnspecifiedPartitioner<>());
         List<JobVertex> jobVertices = jobGraph.getVerticesSortedTopologicallyFromSources();
         assertThat(jobVertices.size(), is(2));
         JobVertex sourceVertex = jobGraph.getVerticesSortedTopologicallyFromSources().get(0);
 
         StreamConfig sourceConfig = new StreamConfig(sourceVertex.getConfiguration());
         StreamEdge edge = sourceConfig.getNonChainedOutputs(getClass().getClassLoader()).get(0);
-        assertThat(edge.getPartitioner(), instanceOf(KeyGroupStreamPartitioner.class));
+        assertThat(edge.getPartitioner(), instanceOf(RescalePartitioner.class));
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/partitioner/StreamPartitionerTestUtils.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/partitioner/StreamPartitionerTestUtils.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.partitioner;
+
+import org.apache.flink.api.common.RuntimeExecutionMode;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.streaming.api.transformations.PartitionTransformation;
+
+/** Utility class to test {@link StreamPartitioner}. */
+public class StreamPartitionerTestUtils {
+
+    public static JobGraph createJobGraph(
+            String sourceSlotSharingGroup,
+            String sinkSlotSharingGroup,
+            StreamPartitioner<Long> streamPartitioner) {
+
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setRuntimeMode(RuntimeExecutionMode.BATCH);
+        env.getConfig().setDynamicGraph(true);
+
+        final DataStream<Long> source =
+                env.fromSequence(0, 99).slotSharingGroup(sourceSlotSharingGroup).name("source");
+
+        setPartitioner(source, streamPartitioner)
+                .addSink(new DiscardingSink<>())
+                .slotSharingGroup(sinkSlotSharingGroup)
+                .name("sink");
+
+        return env.getStreamGraph().getJobGraph();
+    }
+
+    private static <T> DataStream<T> setPartitioner(
+            DataStream<T> dataStream, StreamPartitioner<T> partitioner) {
+        return new DataStream<T>(
+                dataStream.getExecutionEnvironment(),
+                new PartitionTransformation<T>(dataStream.getTransformation(), partitioner));
+    }
+
+    /** Utility class, should not be instantiated. */
+    private StreamPartitionerTestUtils() {}
+}


### PR DESCRIPTION
## What is the purpose of the change

Currently, unspecified edges(partitioner == null) will be setted to FORWARD when the parallelism of both upstream and downstream is -1. This may cause many job vertices whose parallelism is not calculated based on data volume, but is aligned with their upstream vertices' parallelism because of forward edges, which is contrary to the original intention of our adaptive batch scheduler.

For this problem, we will convert the unspecfied edges between OperatorChains to RESCALE edges(instead of FORWARD edges) after OperatorChains' creation.

## Verifying this change
UT `ForwardForUnspecifiedPartitionerTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**no**)
  - The serializers: (**no**)
  - The runtime per-record code paths (performance sensitive): (**no**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**no**)
  - The S3 file system connector: (**no**)

## Documentation

  - Does this pull request introduce a new feature? (**no**)
  - If yes, how is the feature documented? (**not applicable**)
