### PR TITLE
[hotfix][avro] Add comments to explain why projection pushdown works for avro bulk format

### DIFF
--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroFileFormatFactory.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroFileFormatFactory.java
@@ -121,6 +121,12 @@ public class AvroFileFormatFactory implements BulkReaderFormatFactory, BulkWrite
                 DynamicTableSource.Context context,
                 DataType physicalDataType,
                 int[][] projections) {
+            // avro is a file format that keeps schemas in file headers,
+            // if the schema given to the reader is not equal to the schema in header,
+            // reader will automatically map the fields and give back records with our desired
+            // schema
+            //
+            // for detailed discussion see comments in https://github.com/apache/flink/pull/18657
             DataType producedDataType = Projection.of(projections).project(physicalDataType);
             return new AvroGenericRecordBulkFormat(
                     context, (RowType) producedDataType.getLogicalType().copy(false));


### PR DESCRIPTION
## What is the purpose of the change

As discussed with @slinkydeveloper in #18657 , this hotfix add comments to explain why current implementation of projection pushdown works for avro bulk format.

## Brief change log

 - Add comments to explain why projection pushdown works for avro bulk format

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
