### PR TITLE
[FLINK-22781][table-planner-blink] Fix bug that when implements the LookupFunction In SQL that indirect extends (Async)TableFunction, throw exception

### DIFF
--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/utils/ExtractionUtilsTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/utils/ExtractionUtilsTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.utils;
+
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.extraction.ExtractionUtils;
+
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+
+/** Tests for {@link org.apache.flink.table.types.extraction.ExtractionUtils}. */
+public class ExtractionUtilsTest {
+
+    @Test
+    public void testExtractSimpleGeneric() {
+        assertEquals(
+                Optional.of(RowData.class),
+                ExtractionUtils.extractSimpleGeneric(Parent.class, GrandChild.class, 0));
+        assertEquals(
+                Optional.empty(),
+                ExtractionUtils.extractSimpleGeneric(Child2.class, GrandChild2.class, 0));
+        assertEquals(
+                Optional.of(RowData.class),
+                ExtractionUtils.extractSimpleGeneric(Parent.class, Child2.class, 0));
+        assertEquals(
+                Optional.of(RowData.class),
+                ExtractionUtils.extractSimpleGeneric(Child.class, GrandChild.class, 0));
+        assertEquals(
+                Optional.empty(),
+                ExtractionUtils.extractSimpleGeneric(Parent.class, Child.class, 0));
+        assertEquals(
+                Optional.of(RowData.class),
+                ExtractionUtils.extractSimpleGeneric(Parent.class, GrandChild3.class, 0));
+    }
+
+    private static class Parent<T> {}
+
+    private static class Child<T> extends Parent<T> {}
+
+    private static class Child2 extends Parent<RowData> {}
+
+    private static class Child3<T, P> extends Parent<T> {}
+
+    private static class GrandChild extends Child<RowData> {}
+
+    private static class GrandChild2 extends Child2 {}
+
+    private static class GrandChild3 extends Child3<RowData, Boolean> {}
+}


### PR DESCRIPTION
…ookupFunction In SQL that indirect extends (Async)TableFunction, throw exception

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

when implements the LookupFunction In SQL that indirect extends (Async)TableFunction, we extract the output type class use ExtractionUtils#extractSimpleGeneric, this method will return empty when dealing with indirect extended subclasses. We need to fix this bug.

## Brief change log

  - change method ExtractionUtils#extractSimpleGeneric, traverse all the super classes to the base class until find the generic parameter in pos has real class type.



## Verifying this change

*(Please pick either of the following options)*

This change added tests and can be verified as follows:

  - Added a unit Test which verified the static method result. （org.apache.flink.table.utils.ExtractionUtilsTest）
  
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
