### PR TITLE
[FLINK-25225][e2e] Add e2e TPCDS tests to run against the AdaptiveBatchScheduler

### DIFF
--- a/flink-end-to-end-tests/flink-tpcds-test/src/main/java/org/apache/flink/table/tpcds/TpcdsTestProgram.java
+++ b/flink-end-to-end-tests/flink-tpcds-test/src/main/java/org/apache/flink/table/tpcds/TpcdsTestProgram.java
@@ -138,9 +138,6 @@ public class TpcdsTestProgram {
         TableEnvironment tEnv = TableEnvironment.create(environmentSettings);
 
         // config Optimizer parameters
-        tEnv.getConfig()
-                .getConfiguration()
-                .setInteger(ExecutionConfigOptions.TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM, 4);
         // TODO use the default shuffle mode of batch runtime mode once FLINK-23470 is implemented
         tEnv.getConfig()
                 .getConfiguration()

--- a/flink-end-to-end-tests/run-nightly-tests.sh
+++ b/flink-end-to-end-tests/run-nightly-tests.sh
@@ -217,6 +217,7 @@ function run_group_2 {
 
     run_test "TPC-H end-to-end test" "$END_TO_END_DIR/test-scripts/test_tpch.sh"
     run_test "TPC-DS end-to-end test" "$END_TO_END_DIR/test-scripts/test_tpcds.sh"
+    run_test "TPC-DS end-to-end test with adaptive batch scheduler" "$END_TO_END_DIR/test-scripts/test_tpcds.sh AdaptiveBatch"
 
     run_test "Heavy deployment end-to-end test" "$END_TO_END_DIR/test-scripts/test_heavy_deployment.sh" "skip_check_exceptions"
 

--- a/flink-end-to-end-tests/test-scripts/test_tpcds.sh
+++ b/flink-end-to-end-tests/test-scripts/test_tpcds.sh
@@ -54,10 +54,25 @@ cd "$END_TO_END_DIR"
 
 echo "[INFO]Preparing Flink cluster..."
 
+SCHEDULER="${1:-Ng}"
+
+set_config_key "jobmanager.scheduler" "${SCHEDULER}"
 set_config_key "taskmanager.memory.process.size" "4096m"
-set_config_key "taskmanager.numberOfTaskSlots" "4"
-set_config_key "parallelism.default" "4"
 set_config_key "taskmanager.memory.network.fraction" "0.2"
+
+if [ "${SCHEDULER}" == "Ng" ]; then
+    set_config_key "taskmanager.numberOfTaskSlots" "4"
+    set_config_key "parallelism.default" "4"
+elif [ "${SCHEDULER}" == "AdaptiveBatch" ]; then
+    set_config_key "taskmanager.numberOfTaskSlots" "8"
+    set_config_key "parallelism.default" "-1"
+    set_config_key "jobmanager.adaptive-batch-scheduler.max-parallelism" "8"
+    set_config_key "jobmanager.adaptive-batch-scheduler.data-volume-per-task" "6m"
+else
+    echo "ERROR: Scheduler ${SCHEDULER} is unsupported for tpcds test. Aborting..."
+    exit 1
+fi
+
 start_cluster
 
 


### PR DESCRIPTION
## What is the purpose of the change
Add e2e TPCDS tests to run against the AdaptiveBatchScheduler


## Verifying this change
e2e test

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**no**)
  - The serializers: (**no**)
  - The runtime per-record code paths (performance sensitive): (**no**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**no**)
  - The S3 file system connector: (**no**)

## Documentation

  - Does this pull request introduce a new feature? (**no**)
  - If yes, how is the feature documented? (**not applicable**)
