### PR TITLE
[FLINK-24474] Bind Jobmanager and Taskmanager RPC host addresses to localhost by default

### DIFF
--- a/flink-dist/src/main/resources/flink-conf.yaml
+++ b/flink-dist/src/main/resources/flink-conf.yaml
@@ -36,6 +36,14 @@ jobmanager.rpc.address: localhost
 
 jobmanager.rpc.port: 6123
 
+# The host interface the JobManager will bind to. My default, this is localhost, and will prevent
+# the JobManager from communicating outside the machine/container it is running on.
+#
+# To enable this, set the bind-host address to one that has access to an outside facing network
+# interface, such as 0.0.0.0.
+
+jobmanager.bind-host: localhost
+
 
 # The total process memory size for the JobManager.
 #
@@ -43,6 +51,13 @@ jobmanager.rpc.port: 6123
 
 jobmanager.memory.process.size: 1600m
 
+# The host interface the TaskManager will bind to. My default, this is localhost, and will prevent
+# the TaskManager from communicating outside the machine/container it is running on.
+#
+# To enable this, set the bind-host address to one that has access to an outside facing network
+# interface, such as 0.0.0.0.
+
+taskmanager.bind-host: localhost
 
 # The total process memory size for the TaskManager.
 #

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/container/FlinkContainersBuilder.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/container/FlinkContainersBuilder.java
@@ -165,6 +165,9 @@ public class FlinkContainersBuilder {
                 CHECKPOINT_PATH.toAbsolutePath().toUri().toString());
         this.conf.set(RestOptions.BIND_ADDRESS, "0.0.0.0");
 
+        this.conf.set(JobManagerOptions.BIND_HOST, "0.0.0.0");
+        this.conf.set(TaskManagerOptions.BIND_HOST, "0.0.0.0");
+
         // Create temporary directory for building Flink image
         final Path imageBuildingTempDir;
         try {

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/FlinkConfMountDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/FlinkConfMountDecorator.java
@@ -21,7 +21,9 @@ package org.apache.flink.kubernetes.kubeclient.decorators;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.DeploymentOptionsInternal;
+import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.kubeclient.FlinkPod;
 import org.apache.flink.kubernetes.kubeclient.parameters.AbstractKubernetesParameters;
@@ -158,6 +160,8 @@ public class FlinkConfMountDecorator extends AbstractKubernetesStepDecorator {
         clusterSideConfig.removeConfig(KubernetesConfigOptions.KUBE_CONFIG_FILE);
         clusterSideConfig.removeConfig(DeploymentOptionsInternal.CONF_DIR);
         clusterSideConfig.removeConfig(RestOptions.BIND_ADDRESS);
+        clusterSideConfig.removeConfig(JobManagerOptions.BIND_HOST);
+        clusterSideConfig.removeConfig(TaskManagerOptions.BIND_HOST);
         return clusterSideConfig.toMap();
     }
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnEntrypointUtils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnEntrypointUtils.java
@@ -25,6 +25,7 @@ import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.ResourceManagerOptions;
 import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.configuration.SecurityOptions;
+import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.configuration.WebOptions;
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
 import org.apache.flink.util.Preconditions;
@@ -64,6 +65,8 @@ public class YarnEntrypointUtils {
                 ApplicationConstants.Environment.NM_HOST.key());
 
         configuration.setString(JobManagerOptions.ADDRESS, hostname);
+        configuration.removeConfig(JobManagerOptions.BIND_HOST);
+        configuration.removeConfig(TaskManagerOptions.BIND_HOST);
         configuration.setString(RestOptions.ADDRESS, hostname);
         configuration.setString(RestOptions.BIND_ADDRESS, hostname);
 


### PR DESCRIPTION
## What is the purpose of the change

The purpose of this change is to configure Flink, by default, to bind the RPC endpoints for the TM/JM to localhost rather than an externally facing network interface, for security reasons.

This PR depends on https://github.com/apache/flink-docker/pull/103, hence the odd addition here: https://github.com/apache/flink/commit/2aa4a2360b8e89744bb4f97f43f3a645c0eb4681#diff-f61beaac8a23a775d8b61a4e8348998c219a3ea080ff6a0ef14fdb088fd27b16R51 which will be removed if/when that PR is merged.

## Brief change log

  - *Bound the JobManager and TaskManager host-addresses in flink-conf.yaml to localhost*

## Verifying this change

This change is a trivial rework

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
