### PR TITLE
[FLINK-25785][BP 1.13][Connectors][JDBC] Upgrade com.h2database:h2 to 2.1.210

### DIFF
--- a/flink-connectors/flink-connector-jdbc/pom.xml
+++ b/flink-connectors/flink-connector-jdbc/pom.xml
@@ -96,7 +96,7 @@ under the License.
 		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
-			<version>2.0.206</version>
+			<version>2.1.210</version>
 			<scope>test</scope>
 		</dependency>
 


### PR DESCRIPTION
(cherry picked from commit 8488b9e110baec5ed31c3e62d72ff3eceaab721c)
Signed-off-by: martijnvisser <martijn@2symbols.com>

Backport of https://github.com/apache/flink/pull/18605
