### PR TITLE
[FLINK-26093][tests] Adjust SavepointFormatITCase for ChangelogStateBackend

### DIFF
--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/streaming/util/TestStreamEnvironment.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/streaming/util/TestStreamEnvironment.java
@@ -123,8 +123,10 @@ public class TestStreamEnvironment extends StreamExecutionEnvironment {
         // randomize ITTests for enabling state change log
         if (isConfigurationSupportedByChangelog(miniCluster.getConfiguration())) {
             if (STATE_CHANGE_LOG_CONFIG.equalsIgnoreCase(STATE_CHANGE_LOG_CONFIG_ON)) {
-                conf.set(StateChangelogOptions.ENABLE_STATE_CHANGE_LOG, true);
-                miniCluster.overrideRestoreModeForRandomizedChangelogStateBackend();
+                if (!conf.contains(StateChangelogOptions.ENABLE_STATE_CHANGE_LOG)) {
+                    conf.set(StateChangelogOptions.ENABLE_STATE_CHANGE_LOG, true);
+                    miniCluster.overrideRestoreModeForRandomizedChangelogStateBackend();
+                }
             } else if (STATE_CHANGE_LOG_CONFIG.equalsIgnoreCase(STATE_CHANGE_LOG_CONFIG_RAND)) {
                 boolean enabled =
                         randomize(conf, StateChangelogOptions.ENABLE_STATE_CHANGE_LOG, true, false);


### PR DESCRIPTION
## What is the purpose of the change

The test vaildates corrects types of state handles created by savepoint. For NATIVE savepoints, it expects IncrementalRemoteKeyedStateHandle and KeyGroupsStateHandle.

However, with changelog those will be wrapped into ChangelogStateBackendHandle and the test fails.

This change explicitly controls whether changelog is enabled or disabled and adjusts expectations accordingly.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
