### PR TITLE
[FLINK-25495] The deployment of application-mode support client attach

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterClientJobClientAdapter.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterClientJobClientAdapter.java
@@ -54,7 +54,7 @@ public class ClusterClientJobClientAdapter<ClusterID>
 
     private final JobID jobID;
 
-    private final ClassLoader classLoader;
+    @Nullable private ClassLoader classLoader;
 
     public ClusterClientJobClientAdapter(
             final ClusterClientProvider<ClusterID> clusterClientProvider,
@@ -63,6 +63,12 @@ public class ClusterClientJobClientAdapter<ClusterID>
         this.jobID = checkNotNull(jobID);
         this.clusterClientProvider = checkNotNull(clusterClientProvider);
         this.classLoader = classLoader;
+    }
+
+    public ClusterClientJobClientAdapter(
+            final ClusterClientProvider<ClusterID> clusterClientProvider, final JobID jobID) {
+        this.jobID = checkNotNull(jobID);
+        this.clusterClientProvider = checkNotNull(clusterClientProvider);
     }
 
     @Override

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterDescriptor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterDescriptor.java
@@ -67,7 +67,8 @@ public interface ClusterDescriptor<T> extends AutoCloseable {
      */
     ClusterClientProvider<T> deployApplicationCluster(
             final ClusterSpecification clusterSpecification,
-            final ApplicationConfiguration applicationConfiguration)
+            final ApplicationConfiguration applicationConfiguration,
+            final boolean detached)
             throws ClusterDeploymentException;
 
     /**

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/StandaloneClusterDescriptor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/StandaloneClusterDescriptor.java
@@ -64,7 +64,8 @@ public class StandaloneClusterDescriptor implements ClusterDescriptor<Standalone
     @Override
     public ClusterClientProvider<StandaloneClusterId> deployApplicationCluster(
             final ClusterSpecification clusterSpecification,
-            final ApplicationConfiguration applicationConfiguration) {
+            final ApplicationConfiguration applicationConfiguration,
+            final boolean detached) {
         throw new UnsupportedOperationException(
                 "Application Mode not supported by standalone deployments.");
     }

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/util/DummyClusterDescriptor.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/util/DummyClusterDescriptor.java
@@ -54,7 +54,8 @@ public class DummyClusterDescriptor<T> implements ClusterDescriptor<T> {
     @Override
     public ClusterClientProvider<T> deployApplicationCluster(
             final ClusterSpecification clusterSpecification,
-            final ApplicationConfiguration applicationConfiguration) {
+            final ApplicationConfiguration applicationConfiguration,
+            final boolean detached) {
         throw new UnsupportedOperationException("Application Mode not supported.");
     }
 

--- a/flink-clients/src/test/java/org/apache/flink/client/deployment/cli/ApplicationClusterDeployerTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/deployment/cli/ApplicationClusterDeployerTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.deployment.cli;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.client.deployment.application.cli.ApplicationClusterDeployer;
+import org.apache.flink.runtime.client.JobExecutionException;
+import org.apache.flink.util.TestLoggerExtension;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Test for {@link org.apache.flink.client.deployment.application.cli.ApplicationClusterDeployer}.
+ */
+@ExtendWith(TestLoggerExtension.class)
+public class ApplicationClusterDeployerTest {
+    private static final JobID TESTING_JOB_ID = new JobID();
+
+    @Test
+    public void testWaitUtilTargetStatusReached_normal() throws JobExecutionException {
+        ApplicationClusterDeployer.waitUtilTargetStatusReached(
+                TESTING_JOB_ID, () -> JobStatus.FINISHED, this::isInTargetStatus);
+
+        AtomicInteger attempt = new AtomicInteger();
+        ApplicationClusterDeployer.waitUtilTargetStatusReached(
+                TESTING_JOB_ID,
+                () -> {
+                    if (attempt.getAndIncrement() < 2) {
+                        return JobStatus.RUNNING;
+                    }
+                    return JobStatus.FINISHED;
+                },
+                this::isInTargetStatus);
+    }
+
+    @Test
+    public void testWaitUtilTargetStatusReached_executionFailed() {
+        assertThrows(
+                JobExecutionException.class,
+                () ->
+                        ApplicationClusterDeployer.waitUtilTargetStatusReached(
+                                TESTING_JOB_ID, () -> JobStatus.FAILED, this::isInTargetStatus));
+    }
+
+    @Test
+    public void testWaitUntilTargetStatusReached_statusFetchingError() {
+        assertThrows(
+                RuntimeException.class,
+                () -> {
+                    ApplicationClusterDeployer.waitUtilTargetStatusReached(
+                            TESTING_JOB_ID,
+                            () -> {
+                                throw new Exception("Failed to get job status.");
+                            },
+                            this::isInTargetStatus);
+                });
+    }
+
+    private boolean isInTargetStatus(JobStatus jobStatus) {
+        return jobStatus == JobStatus.FINISHED || jobStatus == JobStatus.FAILED;
+    }
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesClusterDescriptor.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesClusterDescriptor.java
@@ -175,7 +175,8 @@ public class KubernetesClusterDescriptor implements ClusterDescriptor<String> {
     @Override
     public ClusterClientProvider<String> deployApplicationCluster(
             final ClusterSpecification clusterSpecification,
-            final ApplicationConfiguration applicationConfiguration)
+            final ApplicationConfiguration applicationConfiguration,
+            final boolean detached)
             throws ClusterDeploymentException {
         if (client.getService(KubernetesService.ServiceType.REST_SERVICE, clusterId).isPresent()) {
             throw new ClusterDeploymentException(

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesClusterDescriptorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesClusterDescriptorTest.java
@@ -136,7 +136,7 @@ public class KubernetesClusterDescriptorTest extends KubernetesClientTestBase {
                 PipelineOptions.JARS, Collections.singletonList("local:///path/of/user.jar"));
         flinkConfig.set(DeploymentOptions.TARGET, KubernetesDeploymentTarget.APPLICATION.getName());
         try {
-            descriptor.deployApplicationCluster(clusterSpecification, appConfig);
+            descriptor.deployApplicationCluster(clusterSpecification, appConfig, false);
         } catch (Exception ignored) {
         }
 
@@ -155,7 +155,7 @@ public class KubernetesClusterDescriptorTest extends KubernetesClientTestBase {
         assertThrows(
                 "Only \"local\" is supported as schema for application mode.",
                 IllegalArgumentException.class,
-                () -> descriptor.deployApplicationCluster(clusterSpecification, appConfig));
+                () -> descriptor.deployApplicationCluster(clusterSpecification, appConfig, false));
     }
 
     @Test
@@ -167,7 +167,7 @@ public class KubernetesClusterDescriptorTest extends KubernetesClientTestBase {
         assertThrows(
                 "The Flink cluster " + CLUSTER_ID + " already exists.",
                 ClusterDeploymentException.class,
-                () -> descriptor.deployApplicationCluster(clusterSpecification, appConfig));
+                () -> descriptor.deployApplicationCluster(clusterSpecification, appConfig, false));
     }
 
     @Test
@@ -178,7 +178,7 @@ public class KubernetesClusterDescriptorTest extends KubernetesClientTestBase {
         assertThrows(
                 "Expected deployment.target=kubernetes-application",
                 ClusterDeploymentException.class,
-                () -> descriptor.deployApplicationCluster(clusterSpecification, appConfig));
+                () -> descriptor.deployApplicationCluster(clusterSpecification, appConfig, false));
     }
 
     @Test
@@ -190,7 +190,7 @@ public class KubernetesClusterDescriptorTest extends KubernetesClientTestBase {
         assertThrows(
                 "Should only have one jar",
                 IllegalArgumentException.class,
-                () -> descriptor.deployApplicationCluster(clusterSpecification, appConfig));
+                () -> descriptor.deployApplicationCluster(clusterSpecification, appConfig, false));
     }
 
     @Test
@@ -204,7 +204,7 @@ public class KubernetesClusterDescriptorTest extends KubernetesClientTestBase {
 
         final ClusterClient<String> clusterClient =
                 descriptor
-                        .deployApplicationCluster(clusterSpecification, appConfig)
+                        .deployApplicationCluster(clusterSpecification, appConfig, false)
                         .getClusterClient();
 
         final String address = CLUSTER_ID + Constants.FLINK_REST_SERVICE_SUFFIX + "." + NAMESPACE;

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNApplicationITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNApplicationITCase.java
@@ -109,7 +109,8 @@ public class YARNApplicationITCase extends YarnTestBase {
                     yarnClusterDescriptor
                             .deployApplicationCluster(
                                     clusterSpecification,
-                                    ApplicationConfiguration.fromConfiguration(configuration))
+                                    ApplicationConfiguration.fromConfiguration(configuration),
+                                    false)
                             .getClusterClient()) {
 
                 ApplicationId applicationId = clusterClient.getClusterId();

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -428,7 +428,8 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
     @Override
     public ClusterClientProvider<ApplicationId> deployApplicationCluster(
             final ClusterSpecification clusterSpecification,
-            final ApplicationConfiguration applicationConfiguration)
+            final ApplicationConfiguration applicationConfiguration,
+            final boolean detached)
             throws ClusterDeploymentException {
         checkNotNull(clusterSpecification);
         checkNotNull(applicationConfiguration);
@@ -459,7 +460,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
                     "Flink Application Cluster",
                     YarnApplicationClusterEntryPoint.class.getName(),
                     null,
-                    false);
+                    detached);
         } catch (Exception e) {
             throw new ClusterDeploymentException("Couldn't deploy Yarn Application Cluster", e);
         }
@@ -521,6 +522,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
             boolean detached)
             throws Exception {
 
+        LOG.info("In detached mode: " + detached);
         final UserGroupInformation currentUser = UserGroupInformation.getCurrentUser();
         if (HadoopUtils.isKerberosSecurityEnabled(currentUser)) {
             boolean useTicketCache =

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
@@ -765,7 +765,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
                     ClusterDeploymentException.class,
                     () ->
                             yarnClusterDescriptor.deployApplicationCluster(
-                                    clusterSpecification, appConfig));
+                                    clusterSpecification, appConfig, false));
         }
     }
 
@@ -813,7 +813,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
                     IllegalArgumentException.class,
                     () ->
                             yarnClusterDescriptor.deployApplicationCluster(
-                                    clusterSpecification, appConfig));
+                                    clusterSpecification, appConfig, false));
         }
     }
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
