### PR TITLE
[FLINK-25987][state/changelog] Replace lastSqn with nextSqn()

### DIFF
--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogWriter.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogWriter.java
@@ -105,8 +105,6 @@ class FsStateChangelogWriter implements StateChangelogWriter<ChangelogStateHandl
     /** Current {@link SequenceNumber}. */
     private SequenceNumber activeSequenceNumber = INITIAL_SQN;
 
-    private SequenceNumber lastAppendedSequenceNumber = INITIAL_SQN;
-
     /**
      * {@link SequenceNumber} before which changes will NOT be requested, exclusive. Increased after
      * materialization.
@@ -173,18 +171,14 @@ class FsStateChangelogWriter implements StateChangelogWriter<ChangelogStateHandl
     }
 
     @Override
-    public SequenceNumber lastAppendedSequenceNumber() {
+    public SequenceNumber nextSequenceNumber() {
         // the returned current sequence number must be able to distinguish between the changes
         // appended before and after this call so we need to use the next sequence number
         // At the same time, we don't want to increment SQN on each append (to avoid too many
         // objects and segments in the resulting file).
         rollover();
-        LOG.trace(
-                "query {} sqn, last: {}, active: {}",
-                logId,
-                lastAppendedSequenceNumber,
-                activeSequenceNumber);
-        return lastAppendedSequenceNumber;
+        LOG.trace("query {} sqn: {}", logId, activeSequenceNumber);
+        return activeSequenceNumber;
     }
 
     @Override
@@ -290,7 +284,6 @@ class FsStateChangelogWriter implements StateChangelogWriter<ChangelogStateHandl
         notUploaded.put(
                 activeSequenceNumber,
                 new StateChangeSet(logId, activeSequenceNumber, activeChangeSet));
-        lastAppendedSequenceNumber = activeSequenceNumber;
         activeSequenceNumber = activeSequenceNumber.next();
         LOG.debug("bump active sqn to {}", activeSequenceNumber);
         activeChangeSet = new ArrayList<>();

--- a/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/FsStateChangelogWriterSqnTest.java
+++ b/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/FsStateChangelogWriterSqnTest.java
@@ -43,10 +43,10 @@ public class FsStateChangelogWriterSqnTest {
     @Parameterized.Parameters(name = "{0}")
     public static List<WriterSqnTestSettings> getSettings() {
         return asList(
-                of(StateChangelogWriter::lastAppendedSequenceNumber, "lastAppendedSequenceNumber")
+                of(StateChangelogWriter::nextSequenceNumber, "nextSequenceNumber")
                         .withAppendCall(false)
                         .expectIncrement(false),
-                of(StateChangelogWriter::lastAppendedSequenceNumber, "lastAppendedSequenceNumber")
+                of(StateChangelogWriter::nextSequenceNumber, "nextSequenceNumber")
                         .withAppendCall(true)
                         .expectIncrement(true),
                 of(FsStateChangelogWriterSqnTest::persistAll, "persist")
@@ -146,7 +146,7 @@ public class FsStateChangelogWriterSqnTest {
     }
 
     private static void truncateLast(FsStateChangelogWriter writer) {
-        writer.truncate(writer.lastAppendedSequenceNumber());
+        writer.truncate(writer.nextSequenceNumber());
     }
 
     private static void truncateAll(FsStateChangelogWriter writer) {

--- a/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/FsStateChangelogWriterTest.java
+++ b/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/FsStateChangelogWriterTest.java
@@ -223,8 +223,9 @@ public class FsStateChangelogWriterTest {
     }
 
     private SequenceNumber append(FsStateChangelogWriter writer, byte[] bytes) throws IOException {
+        SequenceNumber sequenceNumber = writer.nextSequenceNumber();
         writer.append(KEY_GROUP, bytes);
-        return writer.lastAppendedSequenceNumber();
+        return sequenceNumber;
     }
 
     private byte[] getBytes() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogWriter.java
@@ -31,9 +31,10 @@ public interface StateChangelogWriter<Handle extends ChangelogStateHandle> exten
     SequenceNumber initialSequenceNumber();
 
     /**
-     * Get {@link SequenceNumber} of the last element added by {@link #append(int, byte[]) append}.
+     * Get {@link SequenceNumber} to be used for the next element added by {@link #append(int,
+     * byte[]) append}.
      */
-    SequenceNumber lastAppendedSequenceNumber();
+    SequenceNumber nextSequenceNumber();
 
     /** Appends the provided data to this log. No persistency guarantees. */
     void append(int keyGroup, byte[] value) throws IOException;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/inmemory/InMemoryStateChangelogWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/inmemory/InMemoryStateChangelogWriter.java
@@ -61,8 +61,8 @@ class InMemoryStateChangelogWriter implements StateChangelogWriter<InMemoryChang
     public void append(int keyGroup, byte[] value) {
         Preconditions.checkState(!closed, "LogWriter is closed");
         LOG.trace("append, keyGroup={}, {} bytes", keyGroup, value.length);
-        sqn = sqn.next();
         changesByKeyGroup.computeIfAbsent(keyGroup, unused -> new TreeMap<>()).put(sqn, value);
+        sqn = sqn.next();
     }
 
     @Override
@@ -71,7 +71,7 @@ class InMemoryStateChangelogWriter implements StateChangelogWriter<InMemoryChang
     }
 
     @Override
-    public SequenceNumber lastAppendedSequenceNumber() {
+    public SequenceNumber nextSequenceNumber() {
         return sqn;
     }
 
@@ -109,7 +109,7 @@ class InMemoryStateChangelogWriter implements StateChangelogWriter<InMemoryChang
                 .filter(map -> !map.isEmpty())
                 .map(SortedMap::firstKey)
                 .min(Comparator.naturalOrder())
-                .orElse(lastAppendedSequenceNumber().next());
+                .orElse(nextSequenceNumber());
     }
 
     @Override

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
@@ -189,10 +189,9 @@ public class ChangelogKeyedStateBackend<K>
     @Nullable private SequenceNumber lastUploadedFrom;
     /**
      * {@link SequenceNumber} denoting last upload range <b>end</b>, exclusive. Updated to {@link
-     * org.apache.flink.runtime.state.changelog.StateChangelogWriter#lastAppendedSequenceNumber}
-     * when {@link #snapshot(long, long, CheckpointStreamFactory, CheckpointOptions) starting
-     * snapshot}. Used to notify {@link #stateChangelogWriter} about changelog ranges that were
-     * confirmed or aborted by JM.
+     * StateChangelogWriter#nextSequenceNumber()} when {@link #snapshot(long, long,
+     * CheckpointStreamFactory, CheckpointOptions) starting snapshot}. Used to notify {@link
+     * #stateChangelogWriter} about changelog ranges that were confirmed or aborted by JM.
      */
     @Nullable private SequenceNumber lastUploadedTo;
 
@@ -374,7 +373,7 @@ public class ChangelogKeyedStateBackend<K>
         // have to split it somehow for the former option, so the latter is used.
         lastCheckpointId = checkpointId;
         lastUploadedFrom = changelogSnapshotState.lastMaterializedTo();
-        lastUploadedTo = stateChangelogWriter.lastAppendedSequenceNumber().next();
+        lastUploadedTo = stateChangelogWriter.nextSequenceNumber();
 
         LOG.info(
                 "snapshot of {} for checkpoint {}, change range: {}..{}",
@@ -629,7 +628,7 @@ public class ChangelogKeyedStateBackend<K>
      *     SequenceNumber} identifying the latest change in the changelog
      */
     public Optional<MaterializationRunnable> initMaterialization() throws Exception {
-        SequenceNumber upTo = stateChangelogWriter.lastAppendedSequenceNumber().next();
+        SequenceNumber upTo = stateChangelogWriter.nextSequenceNumber();
         SequenceNumber lastMaterializedTo = changelogSnapshotState.lastMaterializedTo();
 
         LOG.info(

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogStateBackendTestUtils.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogStateBackendTestUtils.java
@@ -250,11 +250,11 @@ public class ChangelogStateBackendTestUtils {
             PeriodicMaterializationManager periodicMaterializationManager) {
         StateChangelogWriter<? extends ChangelogStateHandle> writer =
                 keyedBackend.getChangelogWriter();
-        SequenceNumber sqnBefore = writer.lastAppendedSequenceNumber();
+        SequenceNumber sqn = writer.nextSequenceNumber();
         periodicMaterializationManager.triggerMaterialization();
         assertTrue(
                 "Materialization didn't truncate the changelog",
-                sqnBefore.compareTo(writer.getLowestSequenceNumber()) <= 0);
+                sqn.compareTo(writer.getLowestSequenceNumber()) <= 0);
     }
 
     public static void testMaterializedRestoreForPriorityQueue(

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/StateChangeLoggerTestBase.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/StateChangeLoggerTestBase.java
@@ -115,7 +115,7 @@ abstract class StateChangeLoggerTestBase<Namespace> {
         }
 
         @Override
-        public SequenceNumber lastAppendedSequenceNumber() {
+        public SequenceNumber nextSequenceNumber() {
             throw new UnsupportedOperationException();
         }
 


### PR DESCRIPTION
## What is the purpose of the change

The current semantics of `ChangelogWriter.lastAppendedSqn` doesn't allow 
to distinguish between initial empty and non-empty states.
This results in wrong SQN passed to `truncate` and `persist` methods.

This change solves this by replacing `lastAppendedSqn` with `nextSqn`.
It essentially moves the responsibility to call `sqn.next()` on materialization
from backend to writer which has the knowledge of whether there were any changes or not. 

## Verifying this change

`ProcessingTimeWindowCheckpointingITCase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
