### PR TITLE
[hotfix][datastream] move the change and restore of env parallelism into the adjusTransformations method.

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/SinkTransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/SinkTransformationTranslator.java
@@ -214,7 +214,7 @@ public class SinkTransformationTranslator<Input, Output>
          * either the default value or customized value. In this way, any customized value will be
          * discriminated from the default value and, for any subTransformation with the default
          * parallelism value, we will then be able to let it inherit the parallelism value from the
-         * previous sinkTransformation. After adjustment of transformations is closed, the
+         * previous sinkTransformation. After the adjustment of transformations is closed, the
          * environment parallelism will be restored back to its original value to keep the
          * customized parallelism value at environment level.
          */


### PR DESCRIPTION
## What is the purpose of the change

During the transformations adjustment, we need to keep any potential customized parallelism value. This can be achieved by setting the environment parallelism to be ExecutionConfig.PARALLELISM_DEFAULT before adjusting transformations and restoring it back after it. Considering the high cohesion from design perspective, the logic of changing the environment parallelism should be as close as possible to the transformation adjustment.

## Brief change log

  - move the logic of changing the environment parallelism into the `adjustTransformations()` method
  - add comprehensive javadoc and single line comments to describe the reason of doing it.


## Verifying this change

This change is covered by StreamGraphGeneratorTest and UpsertKafkaTableITCase.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
