### PR TITLE
[FLINK-26077][runtime] Support operators send request to Coordinator and return a response

### DIFF
--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointEnvironment.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointEnvironment.java
@@ -47,6 +47,8 @@ import org.apache.flink.runtime.jobgraph.tasks.TaskOperatorEventGateway;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
+import org.apache.flink.runtime.operators.coordination.CoordinationRequest;
+import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 import org.apache.flink.runtime.query.KvStateRegistry;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
@@ -60,6 +62,7 @@ import org.apache.flink.util.UserCodeClassLoader;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 
 import static org.apache.flink.runtime.memory.MemoryManager.DEFAULT_PAGE_SIZE;
@@ -369,5 +372,11 @@ public class SavepointEnvironment implements Environment {
         @Override
         public void sendOperatorEventToCoordinator(
                 OperatorID operator, SerializedValue<OperatorEvent> event) {}
+
+        @Override
+        public CompletableFuture<CoordinationResponse> sendRequestToCoordinator(
+                OperatorID operator, SerializedValue<CoordinationRequest> request) {
+            return CompletableFuture.completedFuture(null);
+        }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServicesUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServicesUtils.java
@@ -147,7 +147,6 @@ public class HighAvailabilityServicesUtils {
         }
     }
 
-    // this one
     public static ClientHighAvailabilityServices createClientHAService(
             Configuration configuration, FatalErrorHandler fatalErrorHandler) throws Exception {
         HighAvailabilityMode highAvailabilityMode = HighAvailabilityMode.fromConfig(configuration);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServicesUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServicesUtils.java
@@ -147,6 +147,7 @@ public class HighAvailabilityServicesUtils {
         }
     }
 
+    // this one
     public static ClientHighAvailabilityServices createClientHAService(
             Configuration configuration, FatalErrorHandler fatalErrorHandler) throws Exception {
         HighAvailabilityMode highAvailabilityMode = HighAvailabilityMode.fromConfig(configuration);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/TaskOperatorEventGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/TaskOperatorEventGateway.java
@@ -21,17 +21,21 @@ package org.apache.flink.runtime.jobgraph.tasks;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobmaster.JobMasterOperatorEventGateway;
+import org.apache.flink.runtime.operators.coordination.CoordinationRequest;
+import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
 import org.apache.flink.runtime.operators.coordination.OperatorCoordinator;
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 import org.apache.flink.util.SerializedValue;
 
+import java.util.concurrent.CompletableFuture;
+
 /**
- * Gateway to send an {@link OperatorEvent} from a Task to to the {@link OperatorCoordinator}
- * JobManager side.
+ * Gateway to send an {@link OperatorEvent} or {@link CoordinationRequest} from a Task to to the
+ * {@link OperatorCoordinator} JobManager side.
  *
- * <p>This is the first step in the chain of sending Operator Events from Operator to Coordinator.
- * Each layer adds further context, so that the inner layers do not need to know about the complete
- * context, which keeps dependencies small and makes testing easier.
+ * <p>This is the first step in the chain of sending Operator Events and Requests from Operator to
+ * Coordinator. Each layer adds further context, so that the inner layers do not need to know about
+ * the complete context, which keeps dependencies small and makes testing easier.
  *
  * <pre>
  *     <li>{@code OperatorEventGateway} takes the event, enriches the event with the {@link OperatorID}, and
@@ -48,4 +52,11 @@ public interface TaskOperatorEventGateway {
      * coordinator (identified by the same ID).
      */
     void sendOperatorEventToCoordinator(OperatorID operator, SerializedValue<OperatorEvent> event);
+
+    /**
+     * Send a request from current operator to a specified operator coordinator which is identified
+     * by the given operator ID and return the response.
+     */
+    CompletableFuture<CoordinationResponse> sendRequestToCoordinator(
+            OperatorID operator, SerializedValue<CoordinationRequest> request);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/TaskOperatorEventGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/TaskOperatorEventGateway.java
@@ -48,13 +48,13 @@ import java.util.concurrent.CompletableFuture;
 public interface TaskOperatorEventGateway {
 
     /**
-     * Send an event from the operator (identified by the given operator ID) to the operator
+     * Sends an event from the operator (identified by the given operator ID) to the operator
      * coordinator (identified by the same ID).
      */
     void sendOperatorEventToCoordinator(OperatorID operator, SerializedValue<OperatorEvent> event);
 
     /**
-     * Send a request from current operator to a specified operator coordinator which is identified
+     * Sends a request from current operator to a specified operator coordinator which is identified
      * by the given operator ID and return the response.
      */
     CompletableFuture<CoordinationResponse> sendRequestToCoordinator(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -565,6 +565,17 @@ public class JobMaster extends PermanentlyFencedRpcEndpoint<JobMasterId>
     }
 
     @Override
+    public CompletableFuture<CoordinationResponse> sendRequestToCoordinator(
+            OperatorID operatorID, SerializedValue<CoordinationRequest> serializedRequest) {
+        try {
+            final CoordinationRequest request = serializedRequest.deserializeValue(userCodeLoader);
+            return schedulerNG.deliverCoordinationRequestToCoordinator(operatorID, request);
+        } catch (Exception e) {
+            return FutureUtils.completedExceptionally(e);
+        }
+    }
+
+    @Override
     public CompletableFuture<KvStateLocation> requestKvStateLocation(
             final JobID jobId, final String registrationName) {
         try {
@@ -876,12 +887,7 @@ public class JobMaster extends PermanentlyFencedRpcEndpoint<JobMasterId>
             OperatorID operatorId,
             SerializedValue<CoordinationRequest> serializedRequest,
             Time timeout) {
-        try {
-            CoordinationRequest request = serializedRequest.deserializeValue(userCodeLoader);
-            return schedulerNG.deliverCoordinationRequestToCoordinator(operatorId, request);
-        } catch (Exception e) {
-            return FutureUtils.completedExceptionally(e);
-        }
+        return this.sendRequestToCoordinator(operatorId, serializedRequest);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterOperatorEventGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterOperatorEventGateway.java
@@ -22,6 +22,8 @@ import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.tasks.TaskOperatorEventGateway;
 import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.operators.coordination.CoordinationRequest;
+import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
 import org.apache.flink.runtime.operators.coordination.OperatorCoordinator;
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 import org.apache.flink.util.SerializedValue;
@@ -29,8 +31,8 @@ import org.apache.flink.util.SerializedValue;
 import java.util.concurrent.CompletableFuture;
 
 /**
- * Gateway to send an {@link OperatorEvent} from the Task Manager to to the {@link
- * OperatorCoordinator} on the JobManager side.
+ * Gateway to send an {@link OperatorEvent} or {@link CoordinationRequest} from the Task Manager to
+ * to the {@link OperatorCoordinator} on the JobManager side.
  *
  * <p>This is the first step in the chain of sending Operator Events from Operator to Coordinator.
  * Each layer adds further context, so that the inner layers do not need to know about the complete
@@ -48,4 +50,7 @@ public interface JobMasterOperatorEventGateway {
 
     CompletableFuture<Acknowledge> sendOperatorEventToCoordinator(
             ExecutionAttemptID task, OperatorID operatorID, SerializedValue<OperatorEvent> event);
+
+    CompletableFuture<CoordinationResponse> sendRequestToCoordinator(
+            OperatorID operatorID, SerializedValue<CoordinationRequest> request);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/CoordinationRequestHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/CoordinationRequestHandler.java
@@ -22,12 +22,12 @@ import java.util.concurrent.CompletableFuture;
 
 /**
  * Coordinator interface which can handle {@link CoordinationRequest}s and response with {@link
- * CoordinationResponse}s to the client.
+ * CoordinationResponse}s to the client or operator.
  */
 public interface CoordinationRequestHandler {
 
     /**
-     * Called when receiving a request from the client.
+     * Called when receiving a request from the client or operator.
      *
      * @param request the request received
      * @return a future containing the response from the coordinator for this request

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/rpc/RpcTaskOperatorEventGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/rpc/RpcTaskOperatorEventGateway.java
@@ -23,6 +23,8 @@ import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.tasks.TaskOperatorEventGateway;
 import org.apache.flink.runtime.jobmaster.JobMasterOperatorEventGateway;
 import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.operators.coordination.CoordinationRequest;
+import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 import org.apache.flink.util.SerializedValue;
 
@@ -63,5 +65,11 @@ public class RpcTaskOperatorEventGateway implements TaskOperatorEventGateway {
                         errorHandler.accept(exception);
                     }
                 });
+    }
+
+    @Override
+    public CompletableFuture<CoordinationResponse> sendRequestToCoordinator(
+            OperatorID operator, SerializedValue<CoordinationRequest> request) {
+        return rpcGateway.sendRequestToCoordinator(operator, request);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGateway.java
@@ -532,6 +532,12 @@ public class TestingJobMasterGateway implements JobMasterGateway {
     }
 
     @Override
+    public CompletableFuture<CoordinationResponse> sendRequestToCoordinator(
+            OperatorID operatorID, SerializedValue<CoordinationRequest> request) {
+        return deliverCoordinationRequestFunction.apply(operatorID, request);
+    }
+
+    @Override
     public CompletableFuture<CoordinationResponse> deliverCoordinationRequestToCoordinator(
             OperatorID operatorId,
             SerializedValue<CoordinationRequest> serializedRequest,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/NoOpTaskOperatorEventGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/NoOpTaskOperatorEventGateway.java
@@ -21,8 +21,12 @@ package org.apache.flink.runtime.taskmanager;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.tasks.TaskOperatorEventGateway;
 import org.apache.flink.runtime.jobmaster.JobMasterOperatorEventGateway;
+import org.apache.flink.runtime.operators.coordination.CoordinationRequest;
+import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 import org.apache.flink.util.SerializedValue;
+
+import java.util.concurrent.CompletableFuture;
 
 /** A test / mock implementation of the {@link JobMasterOperatorEventGateway}. */
 public class NoOpTaskOperatorEventGateway implements TaskOperatorEventGateway {
@@ -30,4 +34,10 @@ public class NoOpTaskOperatorEventGateway implements TaskOperatorEventGateway {
     @Override
     public void sendOperatorEventToCoordinator(
             OperatorID operatorID, SerializedValue<OperatorEvent> event) {}
+
+    @Override
+    public CompletableFuture<CoordinationResponse> sendRequestToCoordinator(
+            OperatorID operator, SerializedValue<CoordinationRequest> request) {
+        return CompletableFuture.completedFuture(null);
+    }
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Currently, the communitcation between Operator and Coordiator is sigle-way. That means, after Operator sending a message to Coordiator, it can't wait to get the response message. In some senarios, the Operator may need to retrieve some information stored in the Coordinator. Thus, it would be great if we can have a two-way communication.

## Brief change log

- Add `sendRequestToCoordinator(..)` interface to `TaskOperatorEventGateway` which accepts a request and returns a response future. The `TaskOperatorEventGateway` can be obtained by opereator used to communicate with coordinator.  
- Add `sendRequestToCoordinator` iterface to `JobMasterOperatorEventGateway` as the RPC method for Task to JM. JobMaster implement the interface to handover the request to correspond OperatorCoordinator. 
- Users' OperatorCoordinator should implement `CoordinationRequestHandler` interface (already exist) to handle the received requests. `CollectSinkOperatorCoordinator` already does it in this way.

## Verifying this change

- Added integration test in `CoordinatorEventsExactlyOnceITCase`
- Added unit test in `TaskExecutorOperatorEventHandlingTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
