### PR TITLE
[FLINK-26030][yarn] Set FLINK_LIB_DIR to 'lib' under working dir in YARN containers

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -1729,6 +1729,11 @@ public final class ConfigConstants {
     /** The environment variable name which contains the location of the lib folder. */
     public static final String ENV_FLINK_LIB_DIR = "FLINK_LIB_DIR";
 
+    /**
+     * The default Flink lib directory if none has been specified via {@link #ENV_FLINK_LIB_DIR}.
+     */
+    public static final String DEFAULT_FLINK_LIB_DIR = "lib";
+
     /** The environment variable name which contains the location of the opt directory. */
     public static final String ENV_FLINK_OPT_DIR = "FLINK_OPT_DIR";
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -1825,6 +1825,8 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
                         this.flinkConfiguration));
         // set Flink app class path
         env.put(ENV_FLINK_CLASSPATH, classPathStr);
+        // Set FLINK_LIB_DIR to `lib` folder under working dir in container
+        env.put(ENV_FLINK_LIB_DIR, Path.CUR_DIR + "/" + ConfigConstants.DEFAULT_FLINK_LIB_DIR);
         // set Flink on YARN internal configuration values
         env.put(YarnConfigKeys.FLINK_DIST_JAR, localFlinkJarStr);
         env.put(YarnConfigKeys.ENV_APP_ID, appIdStr);

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -123,6 +123,7 @@ import static org.apache.flink.configuration.ConfigConstants.ENV_FLINK_LIB_DIR;
 import static org.apache.flink.runtime.entrypoint.component.FileJobGraphRetriever.JOB_GRAPH_FILE_PATH;
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.yarn.YarnConfigKeys.ENV_FLINK_CLASSPATH;
 import static org.apache.flink.yarn.YarnConfigKeys.LOCAL_RESOURCE_DESCRIPTOR_SEPARATOR;
 
 /** The descriptor with deployment information for deploying a Flink cluster on Yarn. */
@@ -1126,30 +1127,12 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
         fileUploader.close();
 
         // Setup CLASSPATH and environment variables for ApplicationMaster
-        final Map<String, String> appMasterEnv = new HashMap<>();
-        // set user specified app master environment variables
-        appMasterEnv.putAll(
-                ConfigurationUtils.getPrefixedKeyValuePairs(
-                        ResourceManagerOptions.CONTAINERIZED_MASTER_ENV_PREFIX, configuration));
-        // set Flink app class path
-        appMasterEnv.put(YarnConfigKeys.ENV_FLINK_CLASSPATH, classPathBuilder.toString());
-
-        // set Flink on YARN internal configuration values
-        appMasterEnv.put(YarnConfigKeys.FLINK_DIST_JAR, localResourceDescFlinkJar.toString());
-        appMasterEnv.put(YarnConfigKeys.ENV_APP_ID, appId.toString());
-        appMasterEnv.put(YarnConfigKeys.ENV_CLIENT_HOME_DIR, fileUploader.getHomeDir().toString());
-        appMasterEnv.put(
-                YarnConfigKeys.ENV_CLIENT_SHIP_FILES,
-                encodeYarnLocalResourceDescriptorListToString(
-                        fileUploader.getEnvShipResourceList()));
-        appMasterEnv.put(
-                YarnConfigKeys.FLINK_YARN_FILES,
-                fileUploader.getApplicationDir().toUri().toString());
-
-        // https://github.com/apache/hadoop/blob/trunk/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-site/src/site/markdown/YarnApplicationSecurity.md#identity-on-an-insecure-cluster-hadoop_user_name
-        appMasterEnv.put(
-                YarnConfigKeys.ENV_HADOOP_USER_NAME,
-                UserGroupInformation.getCurrentUser().getUserName());
+        final Map<String, String> appMasterEnv =
+                generateApplicationMasterEnv(
+                        fileUploader,
+                        classPathBuilder.toString(),
+                        localResourceDescFlinkJar.toString(),
+                        appId.toString());
 
         if (localizedKeytabPath != null) {
             appMasterEnv.put(YarnConfigKeys.LOCAL_KEYTAB_PATH, localizedKeytabPath);
@@ -1168,9 +1151,6 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
         if (remoteKrb5Path != null) {
             appMasterEnv.put(YarnConfigKeys.ENV_KRB5_PATH, remoteKrb5Path.toString());
         }
-
-        // set classpath from YARN configuration
-        Utils.setupYarnClassPath(yarnConfiguration, appMasterEnv);
 
         amContainer.setEnvironment(appMasterEnv);
 
@@ -1828,5 +1808,40 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
                         + "Note that killing Flink might not clean up all job artifacts and temporary files.",
                 yarnApplicationId,
                 yarnApplicationId);
+    }
+
+    @VisibleForTesting
+    Map<String, String> generateApplicationMasterEnv(
+            final YarnApplicationFileUploader fileUploader,
+            final String classPathStr,
+            final String localFlinkJarStr,
+            final String appIdStr)
+            throws IOException {
+        final Map<String, String> env = new HashMap<>();
+        // set user specified app master environment variables
+        env.putAll(
+                ConfigurationUtils.getPrefixedKeyValuePairs(
+                        ResourceManagerOptions.CONTAINERIZED_MASTER_ENV_PREFIX,
+                        this.flinkConfiguration));
+        // set Flink app class path
+        env.put(ENV_FLINK_CLASSPATH, classPathStr);
+        // set Flink on YARN internal configuration values
+        env.put(YarnConfigKeys.FLINK_DIST_JAR, localFlinkJarStr);
+        env.put(YarnConfigKeys.ENV_APP_ID, appIdStr);
+        env.put(YarnConfigKeys.ENV_CLIENT_HOME_DIR, fileUploader.getHomeDir().toString());
+        env.put(
+                YarnConfigKeys.ENV_CLIENT_SHIP_FILES,
+                encodeYarnLocalResourceDescriptorListToString(
+                        fileUploader.getEnvShipResourceList()));
+        env.put(
+                YarnConfigKeys.FLINK_YARN_FILES,
+                fileUploader.getApplicationDir().toUri().toString());
+        // https://github.com/apache/hadoop/blob/trunk/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-site/src/site/markdown/YarnApplicationSecurity.md#identity-on-an-insecure-cluster-hadoop_user_name
+        env.put(
+                YarnConfigKeys.ENV_HADOOP_USER_NAME,
+                UserGroupInformation.getCurrentUser().getUserName());
+        // set classpath from YARN configuration
+        Utils.setupYarnClassPath(this.yarnConfiguration, env);
+        return env;
     }
 }

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
@@ -38,8 +38,10 @@ import org.apache.flink.yarn.configuration.YarnLogConfigUtil;
 
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.service.Service;
 import org.apache.hadoop.yarn.api.ApplicationConstants;
+import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.client.api.YarnClient;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.junit.AfterClass;
@@ -829,5 +831,47 @@ public class YarnClusterDescriptorTest extends TestLogger {
                 .setYarnConfiguration(yarnConfiguration)
                 .setYarnClusterInformationRetriever(() -> YARN_MAX_VCORES)
                 .build();
+    }
+
+    @Test
+    public void testGenerateApplicationMasterEnv() throws IOException {
+        final File flinkHomeDir = temporaryFolder.newFolder();
+        final String fakeLocalFlinkJar = "./lib/flink_dist.jar";
+        final String fakeClassPath = fakeLocalFlinkJar + ":./usrlib/user.jar";
+        final ApplicationId appId = ApplicationId.newInstance(0, 0);
+        final Map<String, String> masterEnv =
+                getTestMasterEnv(flinkHomeDir, fakeLocalFlinkJar, fakeClassPath, appId);
+
+        assertEquals(appId.toString(), masterEnv.get(YarnConfigKeys.ENV_APP_ID));
+        assertEquals(
+                YarnApplicationFileUploader.getApplicationDirPath(
+                                new Path(flinkHomeDir.getPath()), appId)
+                        .toString(),
+                masterEnv.get(YarnConfigKeys.FLINK_YARN_FILES));
+        assertEquals(fakeClassPath, masterEnv.get(YarnConfigKeys.ENV_FLINK_CLASSPATH));
+        assertEquals("", masterEnv.get(YarnConfigKeys.ENV_CLIENT_SHIP_FILES));
+        assertEquals(fakeLocalFlinkJar, masterEnv.get(YarnConfigKeys.FLINK_DIST_JAR));
+        assertEquals(flinkHomeDir.getPath(), masterEnv.get(YarnConfigKeys.ENV_CLIENT_HOME_DIR));
+    }
+
+    private Map<String, String> getTestMasterEnv(
+            File flinkHomeDir, String fakeLocalFlinkJar, String fakeClassPath, ApplicationId appId)
+            throws IOException {
+        final Configuration flinkConfig = new Configuration();
+        try (final YarnClusterDescriptor yarnClusterDescriptor =
+                createYarnClusterDescriptor(flinkConfig)) {
+            final YarnApplicationFileUploader yarnApplicationFileUploader =
+                    YarnApplicationFileUploader.from(
+                            FileSystem.get(new YarnConfiguration()),
+                            new Path(flinkHomeDir.getPath()),
+                            new ArrayList<>(),
+                            appId,
+                            DFSConfigKeys.DFS_REPLICATION_DEFAULT);
+            return yarnClusterDescriptor.generateApplicationMasterEnv(
+                    yarnApplicationFileUploader,
+                    fakeClassPath,
+                    fakeLocalFlinkJar,
+                    appId.toString());
+        }
     }
 }


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
Fix the minor bug when locating `usrlib` with `ClusterEntrypointUtils#tryFindUserLibDirectory` as it will return a wrong usrlib if environment variable `FLINK_LIB_DIR` is pre-configured in the YARN cluster. To get rid of this wrong behavior, this PR sets `FLINK_LIB_DIR` to 'lib' under working dir in YARN containers for JM.


## Brief change log

  - Add a ConfigConstant `DEFAULT_FLINK_LIB_DIR`.
  - Set FLINK_LIB_DIR to 'lib' under working dir in JM containers(i.e. YARN's application master container). Note, this PR does not set such env in TM (i.e. YARN's worker containers) as `tryFindUserLibDirectory` will only be used in ClusterEntrypoint in JM containers to generate JobGraph.


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers:  no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
