### PR TITLE
[FLINK-26099][table][connector][docs] Corrected example in proctime attribute section

### DIFF
--- a/docs/content.zh/docs/connectors/table/overview.md
+++ b/docs/content.zh/docs/connectors/table/overview.md
@@ -270,7 +270,7 @@ The computed column is a virtual column which is not stored in the physical data
 CREATE TABLE MyTable (
   MyField1 INT,
   MyField2 STRING,
-  MyField3 BOOLEAN
+  MyField3 BOOLEAN,
   MyField4 AS PROCTIME() -- declares a proctime attribute
 ) WITH (
   ...

--- a/docs/content/docs/connectors/table/overview.md
+++ b/docs/content/docs/connectors/table/overview.md
@@ -272,7 +272,7 @@ The computed column is a virtual column which is not stored in the physical data
 CREATE TABLE MyTable (
   MyField1 INT,
   MyField2 STRING,
-  MyField3 BOOLEAN
+  MyField3 BOOLEAN,
   MyField4 AS PROCTIME() -- declares a proctime attribute
 ) WITH (
   ...


### PR DESCRIPTION
## What is the purpose of the change

* The example in table connector proctime [table connector](https://nightlies.apache.org/flink/flink-docs-master/docs/connectors/table/overview/#proctime-attributes) section has missing comma

```
CREATE TABLE MyTable (
  MyField1 INT,
  MyField2 STRING,
  MyField3 BOOLEAN
  MyField4 AS PROCTIME() -- declares a proctime attribute
) WITH (
```

## Brief change log

* Updated example 

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
