### PR TITLE
[FLINK-26101][changelog] Avoid shared state registry to discard multi-registered identical changelog state

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/IncrementalRemoteKeyedStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/IncrementalRemoteKeyedStateHandle.java
@@ -408,7 +408,7 @@ public class IncrementalRemoteKeyedStateHandle implements IncrementalKeyedStateH
         return "IncrementalRemoteKeyedStateHandle{"
                 + "backendIdentifier="
                 + backendIdentifier
-                + "stateHandleId="
+                + ", stateHandleId="
                 + stateHandleId
                 + ", keyGroupRange="
                 + keyGroupRange

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/ChangelogStateBackendHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/ChangelogStateBackendHandle.java
@@ -247,12 +247,19 @@ public interface ChangelogStateBackendHandle extends KeyedStateHandle {
                     return false;
                 }
                 StreamStateHandleWrapper that = (StreamStateHandleWrapper) o;
-                return Objects.equals(keyedStateHandle, that.keyedStateHandle);
+                return Objects.equals(
+                        keyedStateHandle.getStateHandleId(),
+                        that.keyedStateHandle.getStateHandleId());
             }
 
             @Override
             public int hashCode() {
-                return Objects.hash(keyedStateHandle);
+                return Objects.hash(keyedStateHandle.getStateHandleId());
+            }
+
+            @Override
+            public String toString() {
+                return "Wrapped{" + keyedStateHandle + '}';
             }
         }
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/ChangelogStateBackendHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/ChangelogStateBackendHandle.java
@@ -237,6 +237,23 @@ public interface ChangelogStateBackendHandle extends KeyedStateHandle {
             public Optional<byte[]> asBytesIfInMemory() {
                 throw new UnsupportedOperationException("Should not call here.");
             }
+
+            @Override
+            public boolean equals(Object o) {
+                if (this == o) {
+                    return true;
+                }
+                if (o == null || getClass() != o.getClass()) {
+                    return false;
+                }
+                StreamStateHandleWrapper that = (StreamStateHandleWrapper) o;
+                return Objects.equals(keyedStateHandle, that.keyedStateHandle);
+            }
+
+            @Override
+            public int hashCode() {
+                return Objects.hash(keyedStateHandle);
+            }
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ChangelogTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ChangelogTestUtils.java
@@ -89,8 +89,18 @@ public class ChangelogTestUtils {
             return isDiscarded;
         }
 
-        IncrementalStateHandleWrapper copy() {
+        IncrementalStateHandleWrapper deserialize() {
             return new IncrementalStateHandleWrapper(stateHandle.copy());
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            // override original IncrementalRemoteKeyedStateHandle#equals() method via comparing
+            // the memory address directly. This is to ensure state handle generated via
+            // #deserialize is different from the original one, which let the
+            // SharedStateRegistryImpl treat them are different via Objects#equals.
+            // More information can refer to FLINK-26101.
+            return (this == o);
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/SharedStateRegistryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/SharedStateRegistryTest.java
@@ -112,8 +112,8 @@ public class SharedStateRegistryTest {
         ChangelogTestUtils.IncrementalStateHandleWrapper materializedStateBase1 =
                 createDummyIncrementalStateHandle(materializationId1);
 
-        // we copy the state handle due to FLINK-25479 to mock on JM side
-        IncrementalStateHandleWrapper materializedState1 = materializedStateBase1.copy();
+        // we deserialize the state handle due to FLINK-25479 to mock on JM side
+        IncrementalStateHandleWrapper materializedState1 = materializedStateBase1.deserialize();
         ChangelogStateHandleWrapper nonMaterializedState1 = createDummyChangelogStateHandle(1, 2);
         long materializationId = 1L;
         long checkpointId1 = 41;
@@ -128,7 +128,7 @@ public class SharedStateRegistryTest {
         sharedStateRegistry.checkpointCompleted(checkpointId1);
         sharedStateRegistry.unregisterUnusedState(checkpointId1);
 
-        IncrementalStateHandleWrapper materializedState2 = materializedStateBase1.copy();
+        IncrementalStateHandleWrapper materializedState2 = materializedStateBase1.deserialize();
         ChangelogStateHandleWrapper nonMaterializedState2 = createDummyChangelogStateHandle(2, 3);
         long checkpointId2 = 42;
         ChangelogStateBackendHandleImpl changelogStateBackendHandle2 =
@@ -153,7 +153,7 @@ public class SharedStateRegistryTest {
         IncrementalStateHandleWrapper materializedStateBase2 =
                 createDummyIncrementalStateHandle(materializationId2);
 
-        IncrementalStateHandleWrapper materializedState3 = materializedStateBase2.copy();
+        IncrementalStateHandleWrapper materializedState3 = materializedStateBase2.deserialize();
         long checkpointId3 = 43L;
         ChangelogStateBackendHandleImpl changelogStateBackendHandle3 =
                 new ChangelogStateBackendHandleImpl(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/SharedStateRegistryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/SharedStateRegistryTest.java
@@ -145,6 +145,8 @@ public class SharedStateRegistryTest {
         // the 1st materialized state would not be discarded since the 2nd changelog state backend
         // handle still use it.
         assertFalse(materializedState1.isDiscarded());
+        // FLINK-26101, check whether the multi registered state not discarded.
+        assertFalse(materializedState2.isDiscarded());
         assertTrue(nonMaterializedState1.isDiscarded());
 
         long materializationId2 = 2L;


### PR DESCRIPTION
## What is the purpose of the change

Avoid shared state registry to discard multi-registered identical changelog state.


## Brief change log

Add `#equals` and `#hashCode` for `StreamStateHandleWrapper` within `ChangelogStateBackendHandle`


## Verifying this change

`SharedStateRegistryTest#testRegisterChangelogStateBackendHandles`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
