### PR TITLE
[FLINK-25940][python] Fix the unstable test test_keyed_process_function_with_state in PyFlink

### DIFF
--- a/flink-python/pyflink/datastream/tests/test_data_stream.py
+++ b/flink-python/pyflink/datastream/tests/test_data_stream.py
@@ -632,8 +632,6 @@ class DataStreamTests(object):
                 self.map_state = runtime_context.get_map_state(map_state_descriptor)
 
             def process_element(self, value, ctx):
-                import time
-                time.sleep(1)
                 current_value = self.value_state.value()
                 self.value_state.update(value[0])
                 current_list = [_ for _ in self.list_state.get()]


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will fix the unstable test test_keyed_process_function_with_state in PyFlink*


## Brief change log

  - *Remove the `sleep(1)` to make the output results more deterministic*


## Verifying this change

This change added tests and can be verified as follows:

  - *original test `test_keyed_process_function_with_state`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
