### PR TITLE
[FLINK-20454][format][debezium] Allow to read metadata for debezium-avro-confluent format

### DIFF
--- a/docs/content.zh/docs/connectors/table/formats/debezium.md
+++ b/docs/content.zh/docs/connectors/table/formats/debezium.md
@@ -174,7 +174,7 @@ metadata fields for its value format.
     <tr>
       <td><code>schema</code></td>
       <td><code>STRING NULL</code></td>
-      <td>JSON string describing the schema of the payload. Null if the schema is not included in
+      <td><i>(only available in <code>'debezium-json'</code> format.)</i> JSON string describing the schema of the payload. Null if the schema is not included in
       the Debezium record.</td>
     </tr>
     <tr>

--- a/docs/content/docs/connectors/table/formats/debezium.md
+++ b/docs/content/docs/connectors/table/formats/debezium.md
@@ -167,7 +167,7 @@ metadata fields for its value format.
     <tr>
       <td><code>schema</code></td>
       <td><code>STRING NULL</code></td>
-      <td>JSON string describing the schema of the payload. Null if the schema is not included in
+      <td><i>(only available in <code>'debezium-json'</code> format.)</i> JSON string describing the schema of the payload. Null if the schema is not included in
       the Debezium record.</td>
     </tr>
     <tr>

--- a/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroDecodingFormat.java
+++ b/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroDecodingFormat.java
@@ -61,7 +61,8 @@ public class DebeziumAvroDecodingFormat
     private final String schemaRegistryURL;
     private final Map<String, ?> optionalPropertiesMap;
 
-    public DebeziumAvroDecodingFormat(String schemaRegistryURL, Map<String, ?> optionalPropertiesMap) {
+    public DebeziumAvroDecodingFormat(
+            String schemaRegistryURL, Map<String, ?> optionalPropertiesMap) {
         this.schemaRegistryURL = schemaRegistryURL;
         this.optionalPropertiesMap = optionalPropertiesMap;
         this.metadataKeys = Collections.emptyList();
@@ -69,9 +70,7 @@ public class DebeziumAvroDecodingFormat
 
     @Override
     public DeserializationSchema<RowData> createRuntimeDecoder(
-            DynamicTableSource.Context context,
-            DataType physicalDataType,
-            int[][] projections) {
+            DynamicTableSource.Context context, DataType physicalDataType, int[][] projections) {
         physicalDataType = Projection.of(projections).project(physicalDataType);
 
         final List<ReadableMetadata> readableMetadata =
@@ -94,7 +93,11 @@ public class DebeziumAvroDecodingFormat
                 context.createTypeInformation(producedDataType);
 
         return new DebeziumAvroDeserializationSchema(
-                physicalDataType, readableMetadata, producedTypeInfo, schemaRegistryURL, optionalPropertiesMap);
+                physicalDataType,
+                readableMetadata,
+                producedTypeInfo,
+                schemaRegistryURL,
+                optionalPropertiesMap);
     }
 
     @Override
@@ -209,7 +212,9 @@ public class DebeziumAvroDecodingFormat
                         Map<StringData, StringData> result = new HashMap<>();
                         for (int i = 0; i < SOURCE_PROPERTY_FIELDS.length; i++) {
                             Object value = row.getField(i);
-                            result.put(StringData.fromString(SOURCE_PROPERTY_FIELDS[i].getName()), value == null ? null : StringData.fromString(value.toString()));
+                            result.put(
+                                    StringData.fromString(SOURCE_PROPERTY_FIELDS[i].getName()),
+                                    value == null ? null : StringData.fromString(value.toString()));
                         }
                         return new GenericMapData(result);
                     }
@@ -236,22 +241,24 @@ public class DebeziumAvroDecodingFormat
     }
 
     private static final DataTypes.Field[] SOURCE_PROPERTY_FIELDS = {
-            DataTypes.FIELD("version", DataTypes.STRING()),
-            DataTypes.FIELD("connector", DataTypes.STRING()),
-            DataTypes.FIELD("name", DataTypes.STRING()),
-            DataTypes.FIELD("ts_ms", DataTypes.TIMESTAMP(3)),
-            DataTypes.FIELD("snapshot", DataTypes.STRING().nullable()),
-            DataTypes.FIELD("db", DataTypes.STRING()),
-            DataTypes.FIELD("sequence", DataTypes.STRING().nullable()),
-            DataTypes.FIELD("schema", DataTypes.STRING()),
-            DataTypes.FIELD("table", DataTypes.STRING()),
-            DataTypes.FIELD("txId", DataTypes.STRING().nullable()),
-            DataTypes.FIELD("scn", DataTypes.STRING().nullable()),
-            DataTypes.FIELD("commit_scn", DataTypes.STRING().nullable()),
-            DataTypes.FIELD("lcr_position", DataTypes.STRING().nullable())
+        DataTypes.FIELD("version", DataTypes.STRING()),
+        DataTypes.FIELD("connector", DataTypes.STRING()),
+        DataTypes.FIELD("name", DataTypes.STRING()),
+        DataTypes.FIELD("ts_ms", DataTypes.TIMESTAMP(3)),
+        DataTypes.FIELD("snapshot", DataTypes.STRING().nullable()),
+        DataTypes.FIELD("db", DataTypes.STRING()),
+        DataTypes.FIELD("sequence", DataTypes.STRING().nullable()),
+        DataTypes.FIELD("schema", DataTypes.STRING()),
+        DataTypes.FIELD("table", DataTypes.STRING()),
+        DataTypes.FIELD("txId", DataTypes.STRING().nullable()),
+        DataTypes.FIELD("scn", DataTypes.STRING().nullable()),
+        DataTypes.FIELD("commit_scn", DataTypes.STRING().nullable()),
+        DataTypes.FIELD("lcr_position", DataTypes.STRING().nullable())
     };
-    private static final Map<String, Integer> SOURCE_PROPERTY_POSITION = IntStream
-            .range(0, SOURCE_PROPERTY_FIELDS.length).boxed()
-            .collect(Collectors.toMap(i -> SOURCE_PROPERTY_FIELDS[i].getName(), i -> i));
-    private static final DataTypes.Field SOURCE_FIELD = DataTypes.FIELD("source", DataTypes.ROW(SOURCE_PROPERTY_FIELDS));
+    private static final Map<String, Integer> SOURCE_PROPERTY_POSITION =
+            IntStream.range(0, SOURCE_PROPERTY_FIELDS.length)
+                    .boxed()
+                    .collect(Collectors.toMap(i -> SOURCE_PROPERTY_FIELDS[i].getName(), i -> i));
+    private static final DataTypes.Field SOURCE_FIELD =
+            DataTypes.FIELD("source", DataTypes.ROW(SOURCE_PROPERTY_FIELDS));
 }

--- a/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroDecodingFormat.java
+++ b/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroDecodingFormat.java
@@ -1,0 +1,257 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.avro.registry.confluent.debezium;
+
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.formats.avro.registry.confluent.debezium.DebeziumAvroDeserializationSchema.MetadataConverter;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.Projection;
+import org.apache.flink.table.connector.format.DecodingFormat;
+import org.apache.flink.table.connector.format.ProjectableDecodingFormat;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.data.GenericMapData;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.utils.DataTypeUtils;
+import org.apache.flink.types.RowKind;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+/** {@link DecodingFormat} for Debezium using Avro encoding. */
+public class DebeziumAvroDecodingFormat
+        implements ProjectableDecodingFormat<DeserializationSchema<RowData>> {
+
+    // --------------------------------------------------------------------------------------------
+    // Mutable attributes
+    // --------------------------------------------------------------------------------------------
+
+    private List<String> metadataKeys;
+
+    // --------------------------------------------------------------------------------------------
+    // Debezium-specific attributes
+    // --------------------------------------------------------------------------------------------
+
+    private final String schemaRegistryURL;
+    private final Map<String, ?> optionalPropertiesMap;
+
+    public DebeziumAvroDecodingFormat(String schemaRegistryURL, Map<String, ?> optionalPropertiesMap) {
+        this.schemaRegistryURL = schemaRegistryURL;
+        this.optionalPropertiesMap = optionalPropertiesMap;
+        this.metadataKeys = Collections.emptyList();
+    }
+
+    @Override
+    public DeserializationSchema<RowData> createRuntimeDecoder(
+            DynamicTableSource.Context context,
+            DataType physicalDataType,
+            int[][] projections) {
+        physicalDataType = Projection.of(projections).project(physicalDataType);
+
+        final List<ReadableMetadata> readableMetadata =
+                metadataKeys.stream()
+                        .map(
+                                k ->
+                                        Stream.of(ReadableMetadata.values())
+                                                .filter(rm -> rm.key.equals(k))
+                                                .findFirst()
+                                                .orElseThrow(IllegalStateException::new))
+                        .collect(Collectors.toList());
+        final List<DataTypes.Field> metadataFields =
+                readableMetadata.stream()
+                        .map(m -> DataTypes.FIELD(m.key, m.dataType))
+                        .collect(Collectors.toList());
+
+        final DataType producedDataType =
+                DataTypeUtils.appendRowFields(physicalDataType, metadataFields);
+        final TypeInformation<RowData> producedTypeInfo =
+                context.createTypeInformation(producedDataType);
+
+        return new DebeziumAvroDeserializationSchema(
+                physicalDataType, readableMetadata, producedTypeInfo, schemaRegistryURL, optionalPropertiesMap);
+    }
+
+    @Override
+    public Map<String, DataType> listReadableMetadata() {
+        final Map<String, DataType> metadataMap = new LinkedHashMap<>();
+        Stream.of(ReadableMetadata.values())
+                .forEachOrdered(m -> metadataMap.put(m.key, m.dataType));
+        return metadataMap;
+    }
+
+    @Override
+    public void applyReadableMetadata(List<String> metadataKeys) {
+        this.metadataKeys = metadataKeys;
+    }
+
+    @Override
+    public ChangelogMode getChangelogMode() {
+        return ChangelogMode.newBuilder()
+                .addContainedKind(RowKind.INSERT)
+                .addContainedKind(RowKind.UPDATE_BEFORE)
+                .addContainedKind(RowKind.UPDATE_AFTER)
+                .addContainedKind(RowKind.DELETE)
+                .build();
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Metadata handling
+    // --------------------------------------------------------------------------------------------
+
+    /** List of metadata that can be read with this format. */
+    enum ReadableMetadata {
+        INGESTION_TIMESTAMP(
+                "ingestion-timestamp",
+                DataTypes.TIMESTAMP(3).nullable(),
+                DataTypes.FIELD("ts_ms", DataTypes.TIMESTAMP(3)),
+                new MetadataConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public Object convert(GenericRowData row, int unused) {
+                        return row;
+                    }
+                }),
+
+        SOURCE_TIMESTAMP(
+                "source.timestamp",
+                DataTypes.TIMESTAMP(3).nullable(),
+                SOURCE_FIELD,
+                new MetadataConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public Object convert(GenericRowData row, int unused) {
+                        int pos = SOURCE_PROPERTY_POSITION.get("ts_ms");
+                        return row.getField(pos);
+                    }
+                }),
+
+        SOURCE_DATABASE(
+                "source.database",
+                DataTypes.STRING().nullable(),
+                SOURCE_FIELD,
+                new MetadataConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public Object convert(GenericRowData row, int unused) {
+                        int pos = SOURCE_PROPERTY_POSITION.get("db");
+                        return row.getField(pos);
+                    }
+                }),
+
+        SOURCE_SCHEMA(
+                "source.schema",
+                DataTypes.STRING().nullable(),
+                SOURCE_FIELD,
+                new MetadataConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public Object convert(GenericRowData row, int unused) {
+                        int pos = SOURCE_PROPERTY_POSITION.get("schema");
+                        return row.getField(pos);
+                    }
+                }),
+
+        SOURCE_TABLE(
+                "source.table",
+                DataTypes.STRING().nullable(),
+                SOURCE_FIELD,
+                new MetadataConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public Object convert(GenericRowData row, int unused) {
+                        int pos = SOURCE_PROPERTY_POSITION.get("table");
+                        return row.getField(pos);
+                    }
+                }),
+
+        SOURCE_PROPERTIES(
+                "source.properties",
+                // key and value of the map are nullable to make handling easier in queries
+                DataTypes.MAP(DataTypes.STRING().nullable(), DataTypes.STRING().nullable())
+                        .nullable(),
+                SOURCE_FIELD,
+                new MetadataConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public Object convert(GenericRowData row, int unused) {
+                        Map<StringData, StringData> result = new HashMap<>();
+                        for (int i = 0; i < SOURCE_PROPERTY_FIELDS.length; i++) {
+                            Object value = row.getField(i);
+                            result.put(StringData.fromString(SOURCE_PROPERTY_FIELDS[i].getName()), value == null ? null : StringData.fromString(value.toString()));
+                        }
+                        return new GenericMapData(result);
+                    }
+                });
+
+        final String key;
+
+        final DataType dataType;
+
+        final DataTypes.Field requiredAvroField;
+
+        final MetadataConverter converter;
+
+        ReadableMetadata(
+                String key,
+                DataType dataType,
+                DataTypes.Field requiredAvroField,
+                MetadataConverter converter) {
+            this.key = key;
+            this.dataType = dataType;
+            this.requiredAvroField = requiredAvroField;
+            this.converter = converter;
+        }
+    }
+
+    private static final DataTypes.Field[] SOURCE_PROPERTY_FIELDS = {
+            DataTypes.FIELD("version", DataTypes.STRING()),
+            DataTypes.FIELD("connector", DataTypes.STRING()),
+            DataTypes.FIELD("name", DataTypes.STRING()),
+            DataTypes.FIELD("ts_ms", DataTypes.TIMESTAMP(3)),
+            DataTypes.FIELD("snapshot", DataTypes.STRING().nullable()),
+            DataTypes.FIELD("db", DataTypes.STRING()),
+            DataTypes.FIELD("sequence", DataTypes.STRING().nullable()),
+            DataTypes.FIELD("schema", DataTypes.STRING()),
+            DataTypes.FIELD("table", DataTypes.STRING()),
+            DataTypes.FIELD("txId", DataTypes.STRING().nullable()),
+            DataTypes.FIELD("scn", DataTypes.STRING().nullable()),
+            DataTypes.FIELD("commit_scn", DataTypes.STRING().nullable()),
+            DataTypes.FIELD("lcr_position", DataTypes.STRING().nullable())
+    };
+    private static final Map<String, Integer> SOURCE_PROPERTY_POSITION = IntStream
+            .range(0, SOURCE_PROPERTY_FIELDS.length).boxed()
+            .collect(Collectors.toMap(i -> SOURCE_PROPERTY_FIELDS[i].getName(), i -> i));
+    private static final DataTypes.Field SOURCE_FIELD = DataTypes.FIELD("source", DataTypes.ROW(SOURCE_PROPERTY_FIELDS));
+}

--- a/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroDeserializationSchema.java
+++ b/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroDeserializationSchema.java
@@ -114,15 +114,16 @@ public final class DebeziumAvroDeserializationSchema implements DeserializationS
                                             debeziumAvroRowType
                                                     .getFieldNames()
                                                     .indexOf(m.requiredAvroField.getName());
-                                    return (MetadataConverter) (row, pos) -> {
-                                        Object result = row.getField(rootPosition);
-                                        if (result instanceof GenericRowData) {
-                                            result =
-                                                    m.converter.convert(
-                                                            (GenericRowData) result, pos);
-                                        }
-                                        return result;
-                                    };
+                                    return (MetadataConverter)
+                                            (row, pos) -> {
+                                                Object result = row.getField(rootPosition);
+                                                if (result instanceof GenericRowData) {
+                                                    result =
+                                                            m.converter.convert(
+                                                                    (GenericRowData) result, pos);
+                                                }
+                                                return result;
+                                            };
                                 })
                         .toArray(MetadataConverter[]::new);
     }

--- a/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroDeserializationSchema.java
+++ b/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroDeserializationSchema.java
@@ -25,23 +25,27 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.formats.avro.AvroRowDataDeserializationSchema;
 import org.apache.flink.formats.avro.AvroToRowDataConverters;
 import org.apache.flink.formats.avro.registry.confluent.ConfluentRegistryAvroDeserializationSchema;
+import org.apache.flink.formats.avro.registry.confluent.debezium.DebeziumAvroDecodingFormat.ReadableMetadata;
 import org.apache.flink.formats.avro.typeutils.AvroSchemaConverter;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.utils.DataTypeUtils;
 import org.apache.flink.types.RowKind;
 import org.apache.flink.util.Collector;
 
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.io.Serializable;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import static java.lang.String.format;
-import static org.apache.flink.table.types.utils.TypeConversions.fromLogicalToDataType;
 
 /**
  * Deserialization schema from Debezium Avro to Flink Table/SQL internal data structure {@link
@@ -76,13 +80,20 @@ public final class DebeziumAvroDeserializationSchema implements DeserializationS
     /** TypeInformation of the produced {@link RowData}. */
     private final TypeInformation<RowData> producedTypeInfo;
 
+    /** Flag that indicates that an additional projection is required for metadata. */
+    private final boolean hasMetadata;
+
+    /** Metadata to be extracted for every record. */
+    private final MetadataConverter[] metadataConverters;
+
     public DebeziumAvroDeserializationSchema(
-            RowType rowType,
+            DataType physicalDataType,
+            List<ReadableMetadata> requestedMetadata,
             TypeInformation<RowData> producedTypeInfo,
             String schemaRegistryUrl,
             @Nullable Map<String, ?> registryConfigs) {
         this.producedTypeInfo = producedTypeInfo;
-        RowType debeziumAvroRowType = createDebeziumAvroRowType(fromLogicalToDataType(rowType));
+        RowType debeziumAvroRowType = createDebeziumAvroRowType(physicalDataType, requestedMetadata);
 
         this.avroDeserializer =
                 new AvroRowDataDeserializationSchema(
@@ -92,6 +103,21 @@ public final class DebeziumAvroDeserializationSchema implements DeserializationS
                                 registryConfigs),
                         AvroToRowDataConverters.createRowConverter(debeziumAvroRowType),
                         producedTypeInfo);
+
+        this.hasMetadata = requestedMetadata.size() > 0;
+        this.metadataConverters = requestedMetadata.stream().map(m -> {
+            final int rootPosition = debeziumAvroRowType.getFieldNames().indexOf(m.requiredAvroField.getName());
+            return new MetadataConverter() {
+                @Override
+                public Object convert(GenericRowData row, int pos) {
+                    Object result = row.getField(rootPosition);
+                    if (result instanceof GenericRowData) {
+                        result = m.converter.convert((GenericRowData) result, pos);
+                    }
+                    return result;
+                }
+            };
+        }).toArray(MetadataConverter[]::new);
     }
 
     @VisibleForTesting
@@ -100,6 +126,8 @@ public final class DebeziumAvroDeserializationSchema implements DeserializationS
             AvroRowDataDeserializationSchema avroDeserializer) {
         this.producedTypeInfo = producedTypeInfo;
         this.avroDeserializer = avroDeserializer;
+        this.hasMetadata = false;
+        this.metadataConverters = new MetadataConverter[0];
     }
 
     @Override
@@ -128,7 +156,7 @@ public final class DebeziumAvroDeserializationSchema implements DeserializationS
             String op = row.getField(2).toString();
             if (OP_CREATE.equals(op) || OP_READ.equals(op)) {
                 after.setRowKind(RowKind.INSERT);
-                out.collect(after);
+                emitRow(row, after, out);
             } else if (OP_UPDATE.equals(op)) {
                 if (before == null) {
                     throw new IllegalStateException(
@@ -136,15 +164,15 @@ public final class DebeziumAvroDeserializationSchema implements DeserializationS
                 }
                 before.setRowKind(RowKind.UPDATE_BEFORE);
                 after.setRowKind(RowKind.UPDATE_AFTER);
-                out.collect(before);
-                out.collect(after);
+                emitRow(row, before, out);
+                emitRow(row, after, out);
             } else if (OP_DELETE.equals(op)) {
                 if (before == null) {
                     throw new IllegalStateException(
                             String.format(REPLICA_IDENTITY_EXCEPTION, "DELETE"));
                 }
                 before.setRowKind(RowKind.DELETE);
-                out.collect(before);
+                emitRow(row, before, out);
             } else {
                 throw new IOException(
                         format(
@@ -155,6 +183,32 @@ public final class DebeziumAvroDeserializationSchema implements DeserializationS
             // a big try catch to protect the processing.
             throw new IOException("Can't deserialize Debezium Avro message.", t);
         }
+    }
+
+    private void emitRow(
+            GenericRowData rootRow, GenericRowData physicalRow, Collector<RowData> out) {
+        // shortcut in case no output projection is required
+        if (!hasMetadata) {
+            out.collect(physicalRow);
+            return;
+        }
+
+        final int physicalArity = physicalRow.getArity();
+        final int metadataArity = metadataConverters.length;
+
+        final GenericRowData producedRow =
+                new GenericRowData(physicalRow.getRowKind(), physicalArity + metadataArity);
+
+        for (int physicalPos = 0; physicalPos < physicalArity; physicalPos++) {
+            producedRow.setField(physicalPos, physicalRow.getField(physicalPos));
+        }
+
+        for (int metadataPos = 0; metadataPos < metadataArity; metadataPos++) {
+            producedRow.setField(
+                    physicalArity + metadataPos, metadataConverters[metadataPos].convert(rootRow, metadataPos));
+        }
+
+        out.collect(producedRow);
     }
 
     @Override
@@ -177,22 +231,41 @@ public final class DebeziumAvroDeserializationSchema implements DeserializationS
         }
         DebeziumAvroDeserializationSchema that = (DebeziumAvroDeserializationSchema) o;
         return Objects.equals(avroDeserializer, that.avroDeserializer)
-                && Objects.equals(producedTypeInfo, that.producedTypeInfo);
+                && Objects.equals(producedTypeInfo, that.producedTypeInfo)
+                && hasMetadata == that.hasMetadata;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(avroDeserializer, producedTypeInfo);
+        return Objects.hash(avroDeserializer, producedTypeInfo, hasMetadata);
     }
 
-    public static RowType createDebeziumAvroRowType(DataType databaseSchema) {
+    public static RowType createDebeziumAvroRowType(DataType databaseSchema, List<ReadableMetadata> readableMetadata) {
         // Debezium Avro contains other information, e.g. "source", "ts_ms"
-        // but we don't need them
-        return (RowType)
+        DataType payload =
                 DataTypes.ROW(
-                                DataTypes.FIELD("before", databaseSchema.nullable()),
-                                DataTypes.FIELD("after", databaseSchema.nullable()),
-                                DataTypes.FIELD("op", DataTypes.STRING()))
-                        .getLogicalType();
+                        DataTypes.FIELD("before", databaseSchema.nullable()),
+                        DataTypes.FIELD("after", databaseSchema.nullable()),
+                        DataTypes.FIELD("op", DataTypes.STRING()));
+
+        // append fields that are required for reading metadata in the payload
+        final List<DataTypes.Field> payloadMetadataFields =
+                readableMetadata.stream()
+                        .map(m -> m.requiredAvroField)
+                        .distinct()
+                        .collect(Collectors.toList());
+        payload = DataTypeUtils.appendRowFields(payload, payloadMetadataFields);
+
+        return (RowType) payload.getLogicalType();
+    }
+
+    // --------------------------------------------------------------------------------------------
+
+    /**
+     * Converter that extracts a metadata field from the row payload that comes out of the
+     * Avro schema and converts it to the desired data type.
+     */
+    interface MetadataConverter extends Serializable {
+        Object convert(GenericRowData row, int pos);
     }
 }

--- a/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroFormatFactoryTest.java
+++ b/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroFormatFactoryTest.java
@@ -63,7 +63,8 @@ public class DebeziumAvroFormatFactoryTest extends TestLogger {
 
     private static final RowType ROW_TYPE =
             (RowType) SCHEMA.toPhysicalRowDataType().getLogicalType();
-    private static final List<ReadableMetadata> REQUESTED_METADATA = Collections.emptyList(); // Arrays.asList(ReadableMetadata.values());
+    private static final List<ReadableMetadata> REQUESTED_METADATA =
+            Collections.emptyList(); // Arrays.asList(ReadableMetadata.values());
 
     private static final String SUBJECT = "test-debezium-avro";
     private static final String REGISTRY_URL = "http://localhost:8081";
@@ -78,7 +79,11 @@ public class DebeziumAvroFormatFactoryTest extends TestLogger {
 
         DebeziumAvroDeserializationSchema expectedDeser =
                 new DebeziumAvroDeserializationSchema(
-                        fromLogicalToDataType(ROW_TYPE), REQUESTED_METADATA, InternalTypeInfo.of(ROW_TYPE), REGISTRY_URL, registryConfigs);
+                        fromLogicalToDataType(ROW_TYPE),
+                        REQUESTED_METADATA,
+                        InternalTypeInfo.of(ROW_TYPE),
+                        REGISTRY_URL,
+                        registryConfigs);
         DeserializationSchema<RowData> actualDeser = createDeserializationSchema(options);
         assertEquals(expectedDeser, actualDeser);
 

--- a/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroFormatFactoryTest.java
+++ b/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroFormatFactoryTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.formats.avro.registry.confluent.debezium;
 
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.formats.avro.registry.confluent.debezium.DebeziumAvroDecodingFormat.ReadableMetadata;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.ResolvedSchema;
@@ -38,12 +39,15 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static junit.framework.TestCase.assertEquals;
 import static org.apache.flink.table.factories.utils.FactoryMocks.createTableSink;
 import static org.apache.flink.table.factories.utils.FactoryMocks.createTableSource;
+import static org.apache.flink.table.types.utils.TypeConversions.fromLogicalToDataType;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertThat;
 
@@ -59,6 +63,7 @@ public class DebeziumAvroFormatFactoryTest extends TestLogger {
 
     private static final RowType ROW_TYPE =
             (RowType) SCHEMA.toPhysicalRowDataType().getLogicalType();
+    private static final List<ReadableMetadata> REQUESTED_METADATA = Collections.emptyList(); // Arrays.asList(ReadableMetadata.values());
 
     private static final String SUBJECT = "test-debezium-avro";
     private static final String REGISTRY_URL = "http://localhost:8081";
@@ -73,7 +78,7 @@ public class DebeziumAvroFormatFactoryTest extends TestLogger {
 
         DebeziumAvroDeserializationSchema expectedDeser =
                 new DebeziumAvroDeserializationSchema(
-                        ROW_TYPE, InternalTypeInfo.of(ROW_TYPE), REGISTRY_URL, registryConfigs);
+                        fromLogicalToDataType(ROW_TYPE), REQUESTED_METADATA, InternalTypeInfo.of(ROW_TYPE), REGISTRY_URL, registryConfigs);
         DeserializationSchema<RowData> actualDeser = createDeserializationSchema(options);
         assertEquals(expectedDeser, actualDeser);
 

--- a/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroSerDeSchemaTest.java
+++ b/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroSerDeSchemaTest.java
@@ -75,7 +75,8 @@ public class DebeziumAvroSerDeSchemaTest {
                                     FIELD("description", STRING()),
                                     FIELD("weight", DOUBLE()))
                             .getLogicalType();
-    private static final List<ReadableMetadata> requestedMetadata = Collections.emptyList(); // Arrays.asList(ReadableMetadata.values());
+    private static final List<ReadableMetadata> requestedMetadata =
+            Collections.emptyList(); // Arrays.asList(ReadableMetadata.values());
 
     private static final Schema DEBEZIUM_SCHEMA_COMPATIBLE_TEST =
             new Schema.Parser().parse(new String(readBytesFromFile("debezium-test-schema.json")));

--- a/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroSerDeSchemaTest.java
+++ b/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroSerDeSchemaTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.formats.avro.RegistryAvroDeserializationSchema;
 import org.apache.flink.formats.avro.RegistryAvroSerializationSchema;
 import org.apache.flink.formats.avro.RowDataToAvroConverters;
 import org.apache.flink.formats.avro.registry.confluent.ConfluentSchemaRegistryCoder;
+import org.apache.flink.formats.avro.registry.confluent.debezium.DebeziumAvroDecodingFormat.ReadableMetadata;
 import org.apache.flink.formats.avro.typeutils.AvroSchemaConverter;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
@@ -74,6 +75,7 @@ public class DebeziumAvroSerDeSchemaTest {
                                     FIELD("description", STRING()),
                                     FIELD("weight", DOUBLE()))
                             .getLogicalType();
+    private static final List<ReadableMetadata> requestedMetadata = Collections.emptyList(); // Arrays.asList(ReadableMetadata.values());
 
     private static final Schema DEBEZIUM_SCHEMA_COMPATIBLE_TEST =
             new Schema.Parser().parse(new String(readBytesFromFile("debezium-test-schema.json")));
@@ -85,7 +87,7 @@ public class DebeziumAvroSerDeSchemaTest {
 
         RowType rowTypeDe =
                 DebeziumAvroDeserializationSchema.createDebeziumAvroRowType(
-                        fromLogicalToDataType(rowType));
+                        fromLogicalToDataType(rowType), requestedMetadata);
         RowType rowTypeSe =
                 DebeziumAvroSerializationSchema.createDebeziumAvroRowType(
                         fromLogicalToDataType(rowType));
@@ -146,7 +148,7 @@ public class DebeziumAvroSerDeSchemaTest {
     public List<String> testDeserialization(String dataPath) throws Exception {
         RowType rowTypeDe =
                 DebeziumAvroDeserializationSchema.createDebeziumAvroRowType(
-                        fromLogicalToDataType(rowType));
+                        fromLogicalToDataType(rowType), requestedMetadata);
 
         client.register(SUBJECT, DEBEZIUM_SCHEMA_COMPATIBLE_TEST, 1, 81);
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*The metadata fields below are currently unavailable when using debezium-avro-confluent fomat. Hence, enhance this format to allow read metadata fields by exposing them as read-only (VIRTUAL) table columns*

- ingestion-timestamp
- source.timestamp
- source.database
- source.schema
- source.table
- source.properties


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
