### PR TITLE
[FLINK-24607] Make OperatorCoordinator closing sequence more robust.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/ComponentClosingUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/ComponentClosingUtils.java
@@ -18,16 +18,22 @@ limitations under the License.
 
 package org.apache.flink.runtime.operators.coordination;
 
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.time.Deadline;
+import org.apache.flink.util.clock.Clock;
+import org.apache.flink.util.clock.SystemClock;
 import org.apache.flink.util.concurrent.FutureUtils;
 import org.apache.flink.util.function.ThrowingRunnable;
 
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 /** A util class to help with a clean component shutdown. */
 public class ComponentClosingUtils {
+    private static Clock clock = SystemClock.getInstance();
 
     /** Utility class, not meant to be instantiated. */
     private ComponentClosingUtils() {}
@@ -95,8 +101,91 @@ public class ComponentClosingUtils {
         return future;
     }
 
-    static void abortThread(Thread t) {
-        // the abortion strategy is pretty simple here...
-        t.interrupt();
+    /**
+     * A util method that tries to shut down an {@link ExecutorService} elegantly within the given
+     * timeout. If the executor has not been shut down before it hits timeout or the thread is
+     * interrupted when waiting for the termination, a forceful shutdown will be attempted on the
+     * executor.
+     *
+     * @param executor the {@link ExecutorService} to shut down.
+     * @param timeout the timeout duration.
+     * @return true if the given executor has been successfully closed, false otherwise.
+     */
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    public static boolean tryShutdownExecutorElegantly(ExecutorService executor, Duration timeout) {
+        try {
+            executor.shutdown();
+            executor.awaitTermination(timeout.toMillis(), TimeUnit.MILLISECONDS);
+        } catch (InterruptedException ie) {
+            // Let it go.
+        }
+        if (!executor.isTerminated()) {
+            shutdownExecutorForcefully(executor, Duration.ZERO, false);
+        }
+        return executor.isTerminated();
+    }
+
+    /**
+     * Shutdown the given executor forcefully within the given timeout. The method returns if it is
+     * interrupted.
+     *
+     * @param executor the executor to shut down.
+     * @param timeout the timeout duration.
+     * @return true if the given executor is terminated, false otherwise.
+     */
+    public static boolean shutdownExecutorForcefully(ExecutorService executor, Duration timeout) {
+        return shutdownExecutorForcefully(executor, timeout, true);
+    }
+
+    /**
+     * Shutdown the given executor forcefully within the given timeout.
+     *
+     * @param executor the executor to shut down.
+     * @param timeout the timeout duration.
+     * @param interruptable when set to true, the method can be interrupted. Each interruption to
+     *     the thread results in another {@code ExecutorService.shutdownNow()} call to the shutting
+     *     down executor.
+     * @return true if the given executor is terminated, false otherwise.
+     */
+    public static boolean shutdownExecutorForcefully(
+            ExecutorService executor, Duration timeout, boolean interruptable) {
+        Deadline deadline = Deadline.fromNowWithClock(timeout, clock);
+        boolean isInterrupted = false;
+        do {
+            executor.shutdownNow();
+            try {
+                executor.awaitTermination(deadline.timeLeft().toMillis(), TimeUnit.MILLISECONDS);
+            } catch (InterruptedException e) {
+                isInterrupted = interruptable;
+            }
+        } while (!isInterrupted && deadline.hasTimeLeft() && !executor.isTerminated());
+        return executor.isTerminated();
+    }
+
+    private static void abortThread(Thread t) {
+        // Try our best here to ensure the thread is aborted. Keep interrupting the
+        // thread for 10 times with 10 ms intervals. This helps handle the case
+        // where the shutdown sequence consists of a bunch of closeQuietly() calls
+        // that will swallow the InterruptedException so the thread to be aborted
+        // may block multiple times. If the thread is still alive after all the
+        // attempts, just let it go. The caller of closeAsyncWithTimeout() should
+        // have received a TimeoutException in this case.
+        int i = 0;
+        while (t.isAlive() && i < 10) {
+            t.interrupt();
+            i++;
+            try {
+                Thread.sleep(10);
+            } catch (InterruptedException e) {
+                // Let it go.
+            }
+        }
+    }
+
+    // ========= Method visible for testing ========
+
+    @VisibleForTesting
+    static void setClock(Clock clock) {
+        ComponentClosingUtils.clock = clock;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/RecreateOnResetOperatorCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/RecreateOnResetOperatorCoordinator.java
@@ -128,8 +128,16 @@ public class RecreateOnResetOperatorCoordinator implements OperatorCoordinator {
         // capture the status whether the coordinator was started when this method was called
         final boolean wasStarted = this.started;
 
-        closingFuture.thenRun(
-                () -> {
+        closingFuture.whenComplete(
+                (ignored, e) -> {
+                    if (e != null) {
+                        LOG.warn(
+                                String.format(
+                                        "Received exception when closing "
+                                                + "operator coordinator for %s.",
+                                        oldCoordinator.operatorId),
+                                e);
+                    }
                     if (!closed) {
                         // The previous coordinator has closed. Create a new one.
                         newCoordinator.createNewInternalCoordinator(context, provider);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/ExecutorNotifier.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/ExecutorNotifier.java
@@ -25,23 +25,20 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 
 /**
  * This class is used to coordinate between two components, where one component has an executor
  * following the mailbox model and the other component notifies it when needed.
  */
-public class ExecutorNotifier implements AutoCloseable {
+public class ExecutorNotifier {
     private static final Logger LOG = LoggerFactory.getLogger(ExecutorNotifier.class);
     private final ScheduledExecutorService workerExecutor;
     private final Executor executorToNotify;
-    private final AtomicBoolean closed;
 
     public ExecutorNotifier(ScheduledExecutorService workerExecutor, Executor executorToNotify) {
         this.executorToNotify = executorToNotify;
         this.workerExecutor = workerExecutor;
-        this.closed = new AtomicBoolean(false);
     }
 
     /**
@@ -139,21 +136,5 @@ public class ExecutorNotifier implements AutoCloseable {
                 initialDelayMs,
                 periodMs,
                 TimeUnit.MILLISECONDS);
-    }
-
-    /**
-     * Close the executor notifier. This is a blocking call which waits for all the async calls to
-     * finish before it returns.
-     *
-     * @throws InterruptedException when interrupted during closure.
-     */
-    public void close() throws InterruptedException {
-        if (!closed.compareAndSet(false, true)) {
-            LOG.debug("The executor notifier has been closed.");
-            return;
-        }
-        // Shutdown the worker executor, so no more worker tasks can run.
-        workerExecutor.shutdownNow();
-        workerExecutor.awaitTermination(Long.MAX_VALUE, TimeUnit.SECONDS);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContext.java
@@ -42,6 +42,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -50,11 +51,11 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
+
+import static org.apache.flink.runtime.operators.coordination.ComponentClosingUtils.shutdownExecutorForcefully;
 
 /**
  * A context class for the {@link OperatorCoordinator}. Compared with {@link SplitEnumeratorContext}
@@ -82,7 +83,8 @@ public class SourceCoordinatorContext<SplitT extends SourceSplit>
 
     private static final Logger LOG = LoggerFactory.getLogger(SourceCoordinatorContext.class);
 
-    private final ExecutorService coordinatorExecutor;
+    private final ScheduledExecutorService workerExecutor;
+    private final ScheduledExecutorService coordinatorExecutor;
     private final ExecutorNotifier notifier;
     private final OperatorCoordinator.Context operatorCoordinatorContext;
     private final SimpleVersionedSerializer<SplitT> splitSerializer;
@@ -95,13 +97,12 @@ public class SourceCoordinatorContext<SplitT extends SourceSplit>
     private volatile boolean closed;
 
     public SourceCoordinatorContext(
-            ExecutorService coordinatorExecutor,
             SourceCoordinatorProvider.CoordinatorExecutorThreadFactory coordinatorThreadFactory,
             int numWorkerThreads,
             OperatorCoordinator.Context operatorCoordinatorContext,
             SimpleVersionedSerializer<SplitT> splitSerializer) {
         this(
-                coordinatorExecutor,
+                Executors.newScheduledThreadPool(1, coordinatorThreadFactory),
                 Executors.newScheduledThreadPool(
                         numWorkerThreads,
                         new ExecutorThreadFactory(
@@ -115,12 +116,13 @@ public class SourceCoordinatorContext<SplitT extends SourceSplit>
     // Package private method for unit test.
     @VisibleForTesting
     SourceCoordinatorContext(
-            ExecutorService coordinatorExecutor,
+            ScheduledExecutorService coordinatorExecutor,
             ScheduledExecutorService workerExecutor,
             SourceCoordinatorProvider.CoordinatorExecutorThreadFactory coordinatorThreadFactory,
             OperatorCoordinator.Context operatorCoordinatorContext,
             SimpleVersionedSerializer<SplitT> splitSerializer,
             SplitAssignmentTracker<SplitT> splitAssignmentTracker) {
+        this.workerExecutor = workerExecutor;
         this.coordinatorExecutor = coordinatorExecutor;
         this.coordinatorThreadFactory = coordinatorThreadFactory;
         this.operatorCoordinatorContext = operatorCoordinatorContext;
@@ -171,6 +173,10 @@ public class SourceCoordinatorContext<SplitT extends SourceSplit>
                     return null;
                 },
                 String.format("Failed to send event %s to subtask %d", event, subtaskId));
+    }
+
+    ScheduledExecutorService getCoordinatorExecutor() {
+        return coordinatorExecutor;
     }
 
     @Override
@@ -259,9 +265,9 @@ public class SourceCoordinatorContext<SplitT extends SourceSplit>
     @Override
     public void close() throws InterruptedException {
         closed = true;
-        notifier.close();
-        coordinatorExecutor.shutdown();
-        coordinatorExecutor.awaitTermination(Long.MAX_VALUE, TimeUnit.MILLISECONDS);
+        // Close quietly so the closing sequence will be executed completely.
+        shutdownExecutorForcefully(workerExecutor, Duration.ofNanos(Long.MAX_VALUE));
+        shutdownExecutorForcefully(coordinatorExecutor, Duration.ofNanos(Long.MAX_VALUE));
     }
 
     // --------- Package private additional methods for the SourceCoordinator ------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorProvider.java
@@ -31,8 +31,6 @@ import org.apache.flink.util.FatalExitExceptionHandler;
 import javax.annotation.Nullable;
 
 import java.util.concurrent.Callable;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.function.BiConsumer;
 
@@ -75,20 +73,13 @@ public class SourceCoordinatorProvider<SplitT extends SourceSplit>
         CoordinatorExecutorThreadFactory coordinatorThreadFactory =
                 new CoordinatorExecutorThreadFactory(
                         coordinatorThreadName, context.getUserCodeClassloader());
-        ScheduledExecutorService coordinatorExecutor =
-                Executors.newScheduledThreadPool(1, coordinatorThreadFactory);
 
         SimpleVersionedSerializer<SplitT> splitSerializer = source.getSplitSerializer();
         SourceCoordinatorContext<SplitT> sourceCoordinatorContext =
                 new SourceCoordinatorContext<>(
-                        coordinatorExecutor,
-                        coordinatorThreadFactory,
-                        numWorkerThreads,
-                        context,
-                        splitSerializer);
+                        coordinatorThreadFactory, numWorkerThreads, context, splitSerializer);
         return new SourceCoordinator<>(
                 operatorName,
-                coordinatorExecutor,
                 source,
                 sourceCoordinatorContext,
                 context.getCoordinatorStore(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/ComponentClosingUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/ComponentClosingUtilsTest.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.operators.coordination;
+
+import org.apache.flink.core.testutils.ManuallyTriggeredScheduledExecutorService;
+import org.apache.flink.util.clock.ManualClock;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/** The unit test class for {@link ComponentClosingUtils}. */
+public class ComponentClosingUtilsTest {
+    private ManualClock clock;
+
+    @Before
+    public void setup() {
+        clock = new ManualClock();
+        ComponentClosingUtils.setClock(clock);
+    }
+
+    @Test
+    public void testTryShutdownExecutorElegantlyWithoutForcefulShutdown() {
+        MockExecutorService executor = new MockExecutorService(0);
+        assertTrue(
+                ComponentClosingUtils.tryShutdownExecutorElegantly(executor, Duration.ofDays(1)));
+        assertEquals(0, executor.forcefullyShutdownCount);
+    }
+
+    @Test
+    public void testTryShutdownExecutorElegantlyWithForcefulShutdown() {
+        MockExecutorService executor = new MockExecutorService(5);
+        assertFalse(
+                ComponentClosingUtils.tryShutdownExecutorElegantly(executor, Duration.ofDays(1)));
+        assertEquals(1, executor.forcefullyShutdownCount);
+    }
+
+    @Test
+    public void testTryShutdownExecutorElegantlyTimeoutWithForcefulShutdown() {
+        MockExecutorService executor = new MockExecutorService(5);
+        executor.timeoutAfterNumForcefulShutdown(clock, 0);
+        assertFalse(
+                ComponentClosingUtils.tryShutdownExecutorElegantly(executor, Duration.ofDays(1)));
+        assertEquals(1, executor.forcefullyShutdownCount);
+    }
+
+    @Test
+    public void testTryShutdownExecutorElegantlyInterruptedWithForcefulShutdown() {
+        MockExecutorService executor = new MockExecutorService(5);
+        executor.interruptAfterNumForcefulShutdown(0);
+        assertFalse(
+                ComponentClosingUtils.tryShutdownExecutorElegantly(executor, Duration.ofDays(1)));
+        assertEquals(1, executor.forcefullyShutdownCount);
+    }
+
+    @Test
+    public void testShutdownExecutorForcefully() {
+        MockExecutorService executor = new MockExecutorService(5);
+        assertTrue(
+                ComponentClosingUtils.shutdownExecutorForcefully(
+                        executor, Duration.ofDays(1), false));
+        assertEquals(5, executor.forcefullyShutdownCount);
+    }
+
+    @Test
+    public void testShutdownExecutorForcefullyReachesTimeout() {
+        MockExecutorService executor = new MockExecutorService(5);
+        executor.timeoutAfterNumForcefulShutdown(clock, 1);
+        assertFalse(
+                ComponentClosingUtils.shutdownExecutorForcefully(
+                        executor, Duration.ofDays(1), false));
+        assertEquals(1, executor.forcefullyShutdownCount);
+    }
+
+    @Test
+    public void testShutdownExecutorForcefullyNotInterruptable() {
+        MockExecutorService executor = new MockExecutorService(5);
+        executor.interruptAfterNumForcefulShutdown(1);
+        assertTrue(
+                ComponentClosingUtils.shutdownExecutorForcefully(
+                        executor, Duration.ofDays(1), false));
+        assertEquals(5, executor.forcefullyShutdownCount);
+    }
+
+    @Test
+    public void testShutdownExecutorForcefullyInterruptable() {
+        MockExecutorService executor = new MockExecutorService(5);
+        executor.interruptAfterNumForcefulShutdown(1);
+        assertFalse(
+                ComponentClosingUtils.shutdownExecutorForcefully(
+                        executor, Duration.ofDays(1), true));
+        assertEquals(1, executor.forcefullyShutdownCount);
+    }
+
+    // ============== private class for testing ===============
+
+    /** An executor class that behaves in an orchestrated way. */
+    private static final class MockExecutorService
+            extends ManuallyTriggeredScheduledExecutorService {
+        private final int numRequiredForcefullyShutdown;
+        private ManualClock clock;
+        private int forcefullyShutdownCount;
+        private int interruptAfterNumForcefulShutdown = Integer.MAX_VALUE;
+        private int timeoutAfterNumForcefulShutdown = Integer.MAX_VALUE;
+
+        private MockExecutorService(int numRequiredForcefullyShutdown) {
+            this.numRequiredForcefullyShutdown = numRequiredForcefullyShutdown;
+            forcefullyShutdownCount = 0;
+        }
+
+        @Override
+        public @NotNull List<Runnable> shutdownNow() {
+            forcefullyShutdownCount++;
+            return super.shutdownNow();
+        }
+
+        @Override
+        public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+            if (forcefullyShutdownCount < numRequiredForcefullyShutdown) {
+                if (forcefullyShutdownCount >= timeoutAfterNumForcefulShutdown) {
+                    clock.advanceTime(Duration.ofDays(100));
+                }
+                if (forcefullyShutdownCount >= interruptAfterNumForcefulShutdown) {
+                    throw new InterruptedException();
+                }
+            }
+            return super.awaitTermination(timeout, unit) && reachedForcefulShutdownCount();
+        }
+
+        @Override
+        public boolean isTerminated() {
+            return super.isTerminated() && reachedForcefulShutdownCount();
+        }
+
+        public void interruptAfterNumForcefulShutdown(int interruptAfterNumForcefulShutdown) {
+            this.interruptAfterNumForcefulShutdown = interruptAfterNumForcefulShutdown;
+        }
+
+        public void timeoutAfterNumForcefulShutdown(
+                ManualClock clock, int timeoutAfterNumForcefulShutdown) {
+            this.clock = clock;
+            this.timeoutAfterNumForcefulShutdown = timeoutAfterNumForcefulShutdown;
+        }
+
+        private boolean reachedForcefulShutdownCount() {
+            return forcefullyShutdownCount >= numRequiredForcefullyShutdown;
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorTestBase.java
@@ -161,7 +161,6 @@ public abstract class SourceCoordinatorTestBase {
 
         return new SourceCoordinator<>(
                 OPERATOR_NAME,
-                coordinatorExecutor,
                 mockSource,
                 getNewSourceCoordinatorContext(),
                 new CoordinatorStoreImpl(),

--- a/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/core/testutils/ManuallyTriggeredScheduledExecutorService.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/core/testutils/ManuallyTriggeredScheduledExecutorService.java
@@ -113,7 +113,7 @@ public class ManuallyTriggeredScheduledExecutorService implements ScheduledExecu
     }
 
     @Override
-    public boolean awaitTermination(long timeout, TimeUnit unit) {
+    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
         return true;
     }
 


### PR DESCRIPTION
## What is the purpose of the change
Currently the closing sequence of the `OperatorCoordinator` does not swallow the exceptions thrown in the middle. So when exception is thrown in the middle, the rest of the closing sequence will be skipped. This patch makes the closing sequence of `OperatorCoordinator` more robust by swallowing the exception thrown in the middle, and also retries interrupting the threads in case the the closing sequence is blocked multiple times.

Some of the methods, such as `closeQuietly()`, in the `IOUtils` seem better to be put in `ComponentClosingUtils`. Will do that in a separate PR. 

## Brief change log
0dfe9b7 Add util methods to shutdown executor services.
1cb9f56 Make OperatorCoordinator closure more robust.

## Verifying this change
This change added the following unit tests:

1. `ComponentClosingUtilsTest` class.
2. `SourceCoordinatorTest.testBlockOnClose()` test method.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
