### PR TITLE
[FLINK-26095][metrics] Respect bind-host for MQS actor system

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -386,7 +386,10 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
 
             final RpcService metricQueryServiceRpcService =
                     MetricUtils.startRemoteMetricsRpcService(
-                            configuration, commonRpcService.getAddress(), rpcSystem);
+                            configuration,
+                            commonRpcService.getAddress(),
+                            configuration.getString(JobManagerOptions.BIND_HOST),
+                            rpcSystem);
             metricRegistry.startQueryService(metricQueryServiceRpcService, null);
 
             final String hostname = RpcUtils.getHostname(commonRpcService);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/util/MetricUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/util/MetricUtils.java
@@ -42,6 +42,7 @@ import org.apache.flink.util.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import javax.management.AttributeNotFoundException;
 import javax.management.InstanceNotFoundException;
 import javax.management.MBeanException;
@@ -181,11 +182,20 @@ public class MetricUtils {
     }
 
     public static RpcService startRemoteMetricsRpcService(
-            Configuration configuration, String hostname, RpcSystem rpcSystem) throws Exception {
+            Configuration configuration,
+            String externalAddress,
+            @Nullable String bindAddress,
+            RpcSystem rpcSystem)
+            throws Exception {
         final String portRange = configuration.getString(MetricOptions.QUERY_SERVICE_PORT);
 
-        return startMetricRpcService(
-                configuration, rpcSystem.remoteServiceBuilder(configuration, hostname, portRange));
+        final RpcSystem.RpcServiceBuilder rpcServiceBuilder =
+                rpcSystem.remoteServiceBuilder(configuration, externalAddress, portRange);
+        if (bindAddress != null) {
+            rpcServiceBuilder.withBindAddress(bindAddress);
+        }
+
+        return startMetricRpcService(configuration, rpcServiceBuilder);
     }
 
     public static RpcService startLocalMetricsRpcService(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -378,6 +378,7 @@ public class MiniCluster implements AutoCloseableAsync {
                             MetricUtils.startRemoteMetricsRpcService(
                                     configuration,
                                     commonRpcService.getAddress(),
+                                    null,
                                     rpcSystem.deref());
                 }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -224,7 +224,10 @@ public class TaskManagerRunner implements FatalErrorHandler {
 
             final RpcService metricQueryServiceRpcService =
                     MetricUtils.startRemoteMetricsRpcService(
-                            configuration, rpcService.getAddress(), rpcSystem);
+                            configuration,
+                            rpcService.getAddress(),
+                            configuration.getString(TaskManagerOptions.BIND_HOST),
+                            rpcSystem);
             metricRegistry.startQueryService(metricQueryServiceRpcService, resourceId.unwrap());
 
             blobCacheService =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/util/MetricUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/util/MetricUtilsTest.java
@@ -79,7 +79,7 @@ public class MetricUtilsTest extends TestLogger {
 
         final RpcService rpcService =
                 MetricUtils.startRemoteMetricsRpcService(
-                        configuration, "localhost", RpcSystem.load());
+                        configuration, "localhost", null, RpcSystem.load());
 
         try {
             final int threadPriority =


### PR DESCRIPTION
With this PR the actor system for the MetricQueryService uses the same bind-host as the JM/TM actor systems. Previously it categorically used 0.0.0.0.