### PR TITLE
[FLINK-26117] Adds GloballyCleanableResource to JobManagerMetricGroup

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DefaultJobManagerRunnerRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DefaultJobManagerRunnerRegistry.java
@@ -83,16 +83,7 @@ public class DefaultJobManagerRunnerRegistry implements JobManagerRunnerRegistry
     }
 
     @Override
-    public CompletableFuture<Void> globalCleanupAsync(JobID jobId, Executor unusedExecutor) {
-        return cleanup(jobId);
-    }
-
-    @Override
     public CompletableFuture<Void> localCleanupAsync(JobID jobId, Executor unusedExecutor) {
-        return cleanup(jobId);
-    }
-
-    private CompletableFuture<Void> cleanup(JobID jobId) {
         if (isRegistered(jobId)) {
             try {
                 unregister(jobId).close();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/JobManagerRunnerRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/JobManagerRunnerRegistry.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.dispatcher;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.runtime.dispatcher.cleanup.GloballyCleanableResource;
 import org.apache.flink.runtime.dispatcher.cleanup.LocallyCleanableResource;
 import org.apache.flink.runtime.jobmaster.JobManagerRunner;
 
@@ -28,8 +27,7 @@ import java.util.NoSuchElementException;
 import java.util.Set;
 
 /** {@code JobManagerRunner} collects running jobs represented by {@link JobManagerRunner}. */
-public interface JobManagerRunnerRegistry
-        extends LocallyCleanableResource, GloballyCleanableResource {
+public interface JobManagerRunnerRegistry extends LocallyCleanableResource {
 
     /**
      * Checks whether a {@link JobManagerRunner} is registered under the given {@link JobID}.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/OnMainThreadJobManagerRunnerRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/OnMainThreadJobManagerRunnerRegistry.java
@@ -84,12 +84,6 @@ public class OnMainThreadJobManagerRunnerRegistry
     }
 
     @Override
-    public CompletableFuture<Void> globalCleanupAsync(JobID jobId, Executor executor) {
-        mainThreadExecutor.assertRunningInMainThread();
-        return delegate.globalCleanupAsync(jobId, executor);
-    }
-
-    @Override
     public CompletableFuture<Void> localCleanupAsync(JobID jobId, Executor executor) {
         mainThreadExecutor.assertRunningInMainThread();
         return delegate.localCleanupAsync(jobId, executor);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/DefaultResourceCleaner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/DefaultResourceCleaner.java
@@ -111,11 +111,25 @@ public class DefaultResourceCleaner<T> implements ResourceCleaner {
             this.retryStrategy = retryStrategy;
         }
 
+        /**
+         * Prioritized cleanups run before their regular counterparts. This method enables the
+         * caller to model dependencies between cleanup tasks. The order in which cleanable
+         * resources are added matters, i.e. if two cleanable resources are added as prioritized
+         * cleanup tasks, the resource being added first will block the cleanup of the second
+         * resource. All prioritized cleanup resources will run and finish before any resource that
+         * is added using {@link #withRegularCleanup(Object)} is started.
+         */
         public Builder<T> withPrioritizedCleanup(T prioritizedCleanup) {
             this.prioritizedCleanup.add(prioritizedCleanup);
             return this;
         }
 
+        /**
+         * Regular cleanups are resources for which the cleanup is triggered after all prioritized
+         * cleanups succeeded. All added regular cleanups will run concurrently to each other.
+         *
+         * @see #withPrioritizedCleanup(Object)
+         */
         public Builder<T> withRegularCleanup(T regularCleanup) {
             this.regularCleanup.add(regularCleanup);
             return this;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/GloballyCleanableResource.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/GloballyCleanableResource.java
@@ -24,11 +24,11 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
 /**
- * {@code GloballyCleanableResource} is supposed to be used by any class that provides artifacts for
- * a given job that can be cleaned up globally. Globally available artifacts should survive a
- * JobManager failover and are, in contrast to {@link GloballyCleanableResource}, only cleaned up
- * after the corresponding job reached a globally-terminal state.
+ * {@code GloballyCleanableResource} is supposed to be implemented by any class that provides
+ * artifacts for a given job that need to be cleaned up after the job reached a global terminal
+ * state.
  *
+ * @see LocallyCleanableResource
  * @see org.apache.flink.api.common.JobStatus
  */
 @FunctionalInterface

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/LocallyCleanableResource.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/LocallyCleanableResource.java
@@ -24,11 +24,14 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
 /**
- * {@code LocallyCleanableResource} is supposed to be used by any class that provides artifacts for
- * a given job that can be cleaned up locally. Artifacts considered to be local are located on the
- * JobManager instance itself and won't survive a failover scenario. These artifacts are, in
- * contrast to {@link GloballyCleanableResource} artifacts, going to be cleaned up even after the
- * job reaches a locally-terminated state.
+ * {@code LocallyCleanableResource} is supposed to be implemented by any class that provides
+ * artifacts for a given job that need to be cleaned up after the job reached a local terminal
+ * state. Local cleanups that needs to be triggered for a global terminal state as well, need to be
+ * implemented using the {@link GloballyCleanableResource}.
+ *
+ * <p>The {@link DispatcherResourceCleanerFactory} provides a workaround to trigger some {@code
+ * LocallyCleanableResources} as globally cleanable. FLINK-26175 is created to cover a refactoring
+ * and straighten things out.
  *
  * @see org.apache.flink.api.common.JobStatus
  */

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherCleanupITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherCleanupITCase.java
@@ -203,7 +203,7 @@ public class DispatcherCleanupITCase extends AbstractDispatcherTest {
         final AtomicReference<JobManagerRunner> jobManagerRunnerEntry = new AtomicReference<>();
         final JobManagerRunnerRegistry jobManagerRunnerRegistry =
                 TestingJobManagerRunnerRegistry.newSingleJobBuilder(jobManagerRunnerEntry)
-                        .withGlobalCleanupAsyncFunction(
+                        .withLocalCleanupAsyncFunction(
                                 (actualJobId, executor) -> jobManagerRunnerCleanupFuture)
                         .build();
 


### PR DESCRIPTION
## What is the purpose of the change

I missed adding the `GloballyCleanableResource` to `JobManagerMetricGroup` and adding it to the `DispatcherResourceCleanerFactory` under global cleanup resources. This would cause the `JobManagerMetricGroup` not being cleaned up after a global cleanup.

## Brief change log

* Removes `GloballyCleanableResource` interface from `JobManagerRunnerRegistry`
* Creates utility method in `DispatcherResourceCleanerFactory` converting a local cleanup to a global cleanup and uses it for the `JobManagerRunnerRegistry`
* Adds `JobManagerMetricGroup` to `DispatcherResourceCleanerFactory`'s `ResourceCleaner` instantiation for global cleanup

## Verifying this change

* The corresponding tests `DispatcherResourceCleanerFactory` was updated to cover the functionality

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
