### PR TITLE
[FLINK-25651][docs]  Modify the instance method variable in kafka.md of branch release-1.14

### DIFF
--- a/docs/content/docs/connectors/datastream/kafka.md
+++ b/docs/content/docs/connectors/datastream/kafka.md
@@ -103,7 +103,7 @@ Kafka message value as string:
 import org.apache.kafka.common.serialization.StringDeserializer;
 
 KafkaSource.<String>builder()
-        .setDeserializer(KafkaRecordDeserializationSchema.valueOnly(StringSerializer.class));
+        .setDeserializer(KafkaRecordDeserializationSchema.valueOnly(StringDeserializer.class));
 ```
 
 ### Starting Offset


### PR DESCRIPTION
Modify KafkaRecordDeserializationSchema. ValueOnly method's parameters

## What is the purpose of the change

The official documentation DataStream Connectors kafka Deserializer module, introduces the KafkaRecordDeserializationSchema. ValueOnly, used the wrong parameters

## Brief change log

Example Change StringSerializer. Class to StringDeserializer. Class


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
