### PR TITLE
[FLINK-25982] Support idleness with watermark alignment

### DIFF
--- a/flink-core/src/test/java/org/apache/flink/api/connector/source/mocks/MockSourceReader.java
+++ b/flink-core/src/test/java/org/apache/flink/api/connector/source/mocks/MockSourceReader.java
@@ -42,6 +42,7 @@ public class MockSourceReader implements SourceReader<Integer, MockSourceSplit> 
     private int timesClosed;
     private final WaitingForSplits waitingForSplitsBehaviour;
     private SplitsAssignmentState splitsAssignmentState = SplitsAssignmentState.NO_SPLITS_ASSIGNED;
+    private boolean idle = false;
 
     enum WaitingForSplits {
         WAIT_FOR_INITIAL,
@@ -105,6 +106,9 @@ public class MockSourceReader implements SourceReader<Integer, MockSourceSplit> 
         }
         // Read from the split with available record.
         if (currentSplitIndex < assignedSplits.size()) {
+            if (idle) {
+                sourceOutput.markActive();
+            }
             sourceOutput.collect(assignedSplits.get(currentSplitIndex).getNext(false)[0]);
             return InputStatus.MORE_AVAILABLE;
         } else if (finished) {
@@ -113,6 +117,7 @@ public class MockSourceReader implements SourceReader<Integer, MockSourceSplit> 
             return InputStatus.END_OF_INPUT;
         } else {
             if (markIdleOnNoSplits) {
+                idle = true;
                 sourceOutput.markIdle();
             }
             markUnavailable();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/NoOpTimestampsAndWatermarks.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/NoOpTimestampsAndWatermarks.java
@@ -48,7 +48,7 @@ public class NoOpTimestampsAndWatermarks<T> implements TimestampsAndWatermarks<T
 
     @Override
     public ReaderOutput<T> createMainOutput(
-            PushingAsyncDataInput.DataOutput<T> output, OnWatermarkEmitted watermarkEmitted) {
+            PushingAsyncDataInput.DataOutput<T> output, WatermarkUpdateListener watermarkEmitted) {
         checkNotNull(output);
         return new TimestampsOnlyOutput<>(output, timestamps);
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/ProgressiveTimestampsAndWatermarks.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/ProgressiveTimestampsAndWatermarks.java
@@ -90,7 +90,7 @@ public class ProgressiveTimestampsAndWatermarks<T> implements TimestampsAndWater
 
     @Override
     public ReaderOutput<T> createMainOutput(
-            PushingAsyncDataInput.DataOutput<T> output, OnWatermarkEmitted watermarkEmitted) {
+            PushingAsyncDataInput.DataOutput<T> output, WatermarkUpdateListener watermarkEmitted) {
         // At the moment, we assume only one output is ever created!
         // This assumption is strict, currently, because many of the classes in this implementation
         // do not

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorAlignmentTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorAlignmentTest.java
@@ -49,9 +49,9 @@ import java.util.stream.Collectors;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** Unit test for {@link SourceOperator} watermark alignment. */
 @SuppressWarnings("serial")

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskTest.java
@@ -699,9 +699,9 @@ public class MultipleInputStreamTaskTest {
             // make source active once again, emit a watermark and go idle again.
             addSourceRecords(testHarness, 1, initialTime + 10);
 
+            expectedOutput.add(WatermarkStatus.ACTIVE); // activate source on new record
             expectedOutput.add(
                     new StreamRecord<>("" + (initialTime + 10), TimestampAssigner.NO_TIMESTAMP));
-            expectedOutput.add(WatermarkStatus.ACTIVE); // activate source on new watermark
             expectedOutput.add(new Watermark(initialTime + 10)); // forward W from source
             expectedOutput.add(WatermarkStatus.IDLE); // go idle after reading all records
             testHarness.processAll();


### PR DESCRIPTION

## What is the purpose of the change

This PR accounts for idleness when reporting the last watermark status for the alignment purposes.


## Verifying this change
Added tests for source operators and coordinators.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
