### PR TITLE
[FLINK-26089][table-planner] Introduce TablePipeline

### DIFF
--- a/flink-python/pyflink/table/tests/test_table_completeness.py
+++ b/flink-python/pyflink/table/tests/test_table_completeness.py
@@ -40,9 +40,10 @@ class TableAPICompletenessTests(PythonAPICompletenessTestCase, PyFlinkTestCase):
         # getSchema method returns a TableSchema, the implementation of TableSchema requires a
         # complete type system, which does not exist currently. It will be implemented after
         # FLINK-12408 is merged. So we exclude this method for the time being.
+        # Also FLINK-25986 are excluded.
         return {'map', 'flatMap', 'flatAggregate',  'aggregate', 'leftOuterJoinLateral',
                 'createTemporalTableFunction', 'joinLateral', 'getQueryOperation', 'limit',
-                'getResolvedSchema'}
+                'getResolvedSchema', 'insertInto', 'printExplain'}
 
     @classmethod
     def java_method_name(cls, python_method_name):

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/bridge/java/StreamStatementSet.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/bridge/java/StreamStatementSet.java
@@ -40,26 +40,21 @@ import org.apache.flink.table.api.TablePipeline;
 @PublicEvolving
 public interface StreamStatementSet extends StatementSet {
 
-    /** {@inheritDoc} */
-    @Override
-    StreamStatementSet addInsertSql(String statement);
-
-    /** {@inheritDoc} */
     @Override
     StreamStatementSet add(TablePipeline tablePipeline);
 
-    /** {@inheritDoc} */
+    @Override
+    StreamStatementSet addInsertSql(String statement);
+
+    @Override
     StreamStatementSet addInsert(String targetPath, Table table);
 
-    /** {@inheritDoc} */
     @Override
     StreamStatementSet addInsert(String targetPath, Table table, boolean overwrite);
 
-    /** {@inheritDoc} */
     @Override
     StreamStatementSet addInsert(TableDescriptor targetDescriptor, Table table);
 
-    /** {@inheritDoc} */
     @Override
     StreamStatementSet addInsert(TableDescriptor targetDescriptor, Table table, boolean overwrite);
 
@@ -73,7 +68,6 @@ public interface StreamStatementSet extends StatementSet {
      */
     void attachAsDataStream();
 
-    /** {@inheritDoc} */
     @Override
     StreamStatementSet printExplain(ExplainDetail... extraDetails);
 }

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/bridge/java/StreamStatementSet.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/bridge/java/StreamStatementSet.java
@@ -21,9 +21,11 @@ package org.apache.flink.table.api.bridge.java;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.ExplainDetail;
 import org.apache.flink.table.api.StatementSet;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableDescriptor;
+import org.apache.flink.table.api.TablePipeline;
 
 /**
  * A {@link StatementSet} that integrates with the Java-specific {@link DataStream} API.
@@ -38,18 +40,26 @@ import org.apache.flink.table.api.TableDescriptor;
 @PublicEvolving
 public interface StreamStatementSet extends StatementSet {
 
+    /** {@inheritDoc} */
     @Override
     StreamStatementSet addInsertSql(String statement);
 
+    /** {@inheritDoc} */
     @Override
+    StreamStatementSet add(TablePipeline tablePipeline);
+
+    /** {@inheritDoc} */
     StreamStatementSet addInsert(String targetPath, Table table);
 
+    /** {@inheritDoc} */
     @Override
     StreamStatementSet addInsert(String targetPath, Table table, boolean overwrite);
 
+    /** {@inheritDoc} */
     @Override
     StreamStatementSet addInsert(TableDescriptor targetDescriptor, Table table);
 
+    /** {@inheritDoc} */
     @Override
     StreamStatementSet addInsert(TableDescriptor targetDescriptor, Table table, boolean overwrite);
 
@@ -62,4 +72,8 @@ public interface StreamStatementSet extends StatementSet {
      * <p>The added statements will be cleared after calling this method.
      */
     void attachAsDataStream();
+
+    /** {@inheritDoc} */
+    @Override
+    StreamStatementSet printExplain(ExplainDetail... extraDetails);
 }

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/bridge/java/internal/StreamStatementSetImpl.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/bridge/java/internal/StreamStatementSetImpl.java
@@ -19,8 +19,10 @@
 package org.apache.flink.table.api.bridge.java.internal;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.ExplainDetail;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableDescriptor;
+import org.apache.flink.table.api.TablePipeline;
 import org.apache.flink.table.api.bridge.java.StreamStatementSet;
 import org.apache.flink.table.api.internal.StatementSetImpl;
 
@@ -39,24 +41,37 @@ public class StreamStatementSetImpl extends StatementSetImpl<StreamTableEnvironm
     }
 
     @Override
-    public StreamStatementSet addInsert(String targetPath, Table table) {
-        return (StreamStatementSet) super.addInsert(targetPath, table);
+    public StreamStatementSet add(TablePipeline tablePipeline) {
+        return (StreamStatementSet) super.add(tablePipeline);
     }
 
+    @Override
+    public StreamStatementSet addInsert(String targetPath, Table table) {
+        return add(table.insertInto(targetPath));
+    }
+
+    /** {@inheritDoc} */
     @Override
     public StreamStatementSet addInsert(String targetPath, Table table, boolean overwrite) {
-        return (StreamStatementSet) super.addInsert(targetPath, table, overwrite);
+        return add(table.insertInto(targetPath, overwrite));
     }
 
+    /** {@inheritDoc} */
     @Override
     public StreamStatementSet addInsert(TableDescriptor targetDescriptor, Table table) {
-        return (StreamStatementSet) super.addInsert(targetDescriptor, table);
+        return add(table.insertInto(targetDescriptor));
     }
 
+    /** {@inheritDoc} */
     @Override
     public StreamStatementSet addInsert(
             TableDescriptor targetDescriptor, Table table, boolean overwrite) {
-        return (StreamStatementSet) super.addInsert(targetDescriptor, table, overwrite);
+        return add(table.insertInto(targetDescriptor, overwrite));
+    }
+
+    @Override
+    public StreamStatementSet printExplain(ExplainDetail... extraDetails) {
+        return (StreamStatementSet) super.printExplain(extraDetails);
     }
 
     @Override

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/bridge/java/internal/StreamStatementSetImpl.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/bridge/java/internal/StreamStatementSetImpl.java
@@ -36,13 +36,13 @@ public class StreamStatementSetImpl extends StatementSetImpl<StreamTableEnvironm
     }
 
     @Override
-    public StreamStatementSet addInsertSql(String statement) {
-        return (StreamStatementSet) super.addInsertSql(statement);
+    public StreamStatementSet add(TablePipeline tablePipeline) {
+        return (StreamStatementSet) super.add(tablePipeline);
     }
 
     @Override
-    public StreamStatementSet add(TablePipeline tablePipeline) {
-        return (StreamStatementSet) super.add(tablePipeline);
+    public StreamStatementSet addInsertSql(String statement) {
+        return (StreamStatementSet) super.addInsertSql(statement);
     }
 
     @Override
@@ -50,19 +50,16 @@ public class StreamStatementSetImpl extends StatementSetImpl<StreamTableEnvironm
         return add(table.insertInto(targetPath));
     }
 
-    /** {@inheritDoc} */
     @Override
     public StreamStatementSet addInsert(String targetPath, Table table, boolean overwrite) {
         return add(table.insertInto(targetPath, overwrite));
     }
 
-    /** {@inheritDoc} */
     @Override
     public StreamStatementSet addInsert(TableDescriptor targetDescriptor, Table table) {
         return add(table.insertInto(targetDescriptor));
     }
 
-    /** {@inheritDoc} */
     @Override
     public StreamStatementSet addInsert(
             TableDescriptor targetDescriptor, Table table, boolean overwrite) {

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Compilable.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Compilable.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api;
+
+import org.apache.flink.annotation.Experimental;
+
+/**
+ * This interface represents an object that can be compiled to a {@link CompiledPlan}.
+ *
+ * @see #compilePlan()
+ * @see CompiledPlan
+ */
+@Experimental
+public interface Compilable {
+
+    /**
+     * Compiles this object into a {@link CompiledPlan} that can be executed as one job.
+     *
+     * <p>Compiled plans can be persisted and reloaded across Flink versions. They describe static
+     * pipelines to ensure backwards compatibility and enable stateful streaming job upgrades. See
+     * {@link CompiledPlan} and the website documentation for more information.
+     *
+     * <p>Note: The compiled plan feature is not supported in batch mode.
+     *
+     * @throws TableException if any of the statements is invalid or if the plan cannot be
+     *     persisted.
+     */
+    @Experimental
+    CompiledPlan compilePlan() throws TableException;
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/CompiledPlan.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/CompiledPlan.java
@@ -55,7 +55,7 @@ import java.nio.file.Paths;
  * @see PlanReference
  */
 @Experimental
-public interface CompiledPlan {
+public interface CompiledPlan extends Explainable<CompiledPlan> {
 
     // --- Writer methods
 
@@ -111,23 +111,9 @@ public interface CompiledPlan {
     /** Returns the Flink version used to compile the plan. */
     String getFlinkVersion();
 
-    /**
-     * Returns the AST of the specified statement and the execution plan to compute the result of
-     * the given statement.
-     *
-     * <p>Shorthand for {@link TableEnvironment#explainPlan(CompiledPlan, ExplainDetail...)}.
-     */
-    String explain(ExplainDetail... explainDetails);
-
     /** Like {@link #asJsonString()}, but prints the result to {@link System#out}. */
     default CompiledPlan printJsonString() {
         System.out.println(this.asJsonString());
-        return this;
-    }
-
-    /** Like {@link #explain(ExplainDetail...)}, but prints the result to {@link System#out}. */
-    default CompiledPlan printExplain(ExplainDetail... explainDetails) {
-        System.out.println(this.explain(explainDetails));
         return this;
     }
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Executable.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Executable.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.api.config.TableConfigOptions;
+
+/**
+ * This interface represents an executable object.
+ *
+ * @see #execute()
+ */
+@PublicEvolving
+public interface Executable {
+
+    /**
+     * Executes this object.
+     *
+     * <p>By default, all DML operations are executed asynchronously. Use {@link
+     * TableResult#await()} or {@link TableResult#getJobClient()} to monitor the execution. Set
+     * {@link TableConfigOptions#TABLE_DML_SYNC} for always synchronous execution.
+     */
+    TableResult execute();
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Explainable.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Explainable.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+/**
+ * This interface represents the capability for an object to be explained.
+ *
+ * @see #explain(ExplainDetail...)
+ */
+@PublicEvolving
+public interface Explainable<SELF extends Explainable<SELF>> {
+
+    /**
+     * Returns the AST of this object and the execution plan to compute the result of the given
+     * statement.
+     *
+     * @param extraDetails The extra explain details which the result of this method should include,
+     *     e.g. estimated cost, changelog mode for streaming
+     * @return AST and the execution plan.
+     */
+    String explain(ExplainDetail... extraDetails);
+
+    /** Like {@link #explain(ExplainDetail...)}, but piping the result to {@link System#out}. */
+    @SuppressWarnings("unchecked")
+    default SELF printExplain(ExplainDetail... extraDetails) {
+        System.out.println(explain(extraDetails));
+        return (SELF) this;
+    }
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/StatementSet.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/StatementSet.java
@@ -18,9 +18,7 @@
 
 package org.apache.flink.table.api;
 
-import org.apache.flink.annotation.Experimental;
 import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.table.api.config.TableConfigOptions;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.types.DataType;
 
@@ -31,7 +29,7 @@ import org.apache.flink.table.types.DataType;
  * <p>The added statements will be cleared when calling the {@link #execute()} method.
  */
 @PublicEvolving
-public interface StatementSet {
+public interface StatementSet extends Explainable<StatementSet>, Compilable, Executable {
 
     /** Adds an {@code INSERT INTO} SQL statement. */
     StatementSet addInsertSql(String statement);
@@ -137,39 +135,4 @@ public interface StatementSet {
      * @param overwrite Indicates whether existing data should be overwritten.
      */
     StatementSet addInsert(TableDescriptor targetDescriptor, Table table, boolean overwrite);
-
-    /**
-     * Returns the AST and the execution plan to compute the result of the all statements.
-     *
-     * @param extraDetails The extra explain details which the explain result should include, e.g.
-     *     estimated cost, changelog mode for streaming, displaying execution plan in json format
-     * @return AST and the execution plan.
-     */
-    String explain(ExplainDetail... extraDetails);
-
-    /**
-     * Executes all statements as one job.
-     *
-     * <p>The added statements will be cleared after calling this method.
-     *
-     * <p>By default, all DML operations are executed asynchronously. Use {@link
-     * TableResult#await()} or {@link TableResult#getJobClient()} to monitor the execution. Set
-     * {@link TableConfigOptions#TABLE_DML_SYNC} for always synchronous execution.
-     */
-    TableResult execute();
-
-    /**
-     * Compiles all statements into a {@link CompiledPlan} that can be executed as one job.
-     *
-     * <p>Compiled plans can be persisted and reloaded across Flink versions. They describe static
-     * pipelines to ensure backwards compatibility and enable stateful streaming job upgrades. See
-     * {@link CompiledPlan} and the website documentation for more information.
-     *
-     * <p>Note: The compiled plan feature is not supported in batch mode.
-     *
-     * @throws TableException if any of the statements is invalid or if the plan cannot be
-     *     persisted.
-     */
-    @Experimental
-    CompiledPlan compilePlan() throws TableException;
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/StatementSet.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/StatementSet.java
@@ -29,11 +29,11 @@ import org.apache.flink.annotation.PublicEvolving;
 @PublicEvolving
 public interface StatementSet extends Explainable<StatementSet>, Compilable, Executable {
 
-    /** Adds an {@code INSERT INTO} SQL statement. */
-    StatementSet addInsertSql(String statement);
-
     /** Adds a {@link TablePipeline}. */
     StatementSet add(TablePipeline tablePipeline);
+
+    /** Adds an {@code INSERT INTO} SQL statement. */
+    StatementSet addInsertSql(String statement);
 
     /**
      * Shorthand for {@code statementSet.add(table.insertInto(targetPath))}.

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/StatementSet.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/StatementSet.java
@@ -19,8 +19,6 @@
 package org.apache.flink.table.api;
 
 import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.table.connector.sink.DynamicTableSink;
-import org.apache.flink.table.types.DataType;
 
 /**
  * A {@link StatementSet} accepts pipelines defined by DML statements or {@link Table} objects. The
@@ -34,105 +32,38 @@ public interface StatementSet extends Explainable<StatementSet>, Compilable, Exe
     /** Adds an {@code INSERT INTO} SQL statement. */
     StatementSet addInsertSql(String statement);
 
+    /** Adds a {@link TablePipeline}. */
+    StatementSet add(TablePipeline tablePipeline);
+
     /**
-     * Adds a statement that the pipeline defined by the given {@link Table} object should be
-     * written to a table (backed by a {@link DynamicTableSink}) that was registered under the
-     * specified path.
+     * Shorthand for {@code statementSet.add(table.insertInto(targetPath))}.
      *
-     * <p>See the documentation of {@link TableEnvironment#useDatabase(String)} or {@link
-     * TableEnvironment#useCatalog(String)} for the rules on the path resolution.
+     * @see #add(TablePipeline)
+     * @see Table#insertInto(String)
      */
     StatementSet addInsert(String targetPath, Table table);
 
     /**
-     * Adds a statement that the pipeline defined by the given {@link Table} object should be
-     * written to a table (backed by a {@link DynamicTableSink}) that was registered under the
-     * specified path.
+     * Shorthand for {@code statementSet.add(table.insertInto(targetPath, overwrite))}.
      *
-     * <p>See the documentation of {@link TableEnvironment#useDatabase(String)} or {@link
-     * TableEnvironment#useCatalog(String)} for the rules on the path resolution.
-     *
-     * @param overwrite Indicates whether existing data should be overwritten.
+     * @see #add(TablePipeline)
+     * @see Table#insertInto(String, boolean)
      */
     StatementSet addInsert(String targetPath, Table table, boolean overwrite);
 
     /**
-     * Adds a statement that the pipeline defined by the given {@link Table} object should be
-     * written to a table (backed by a {@link DynamicTableSink}) expressed via the given {@link
-     * TableDescriptor}.
+     * Shorthand for {@code statementSet.add(table.insertInto(targetDescriptor))}.
      *
-     * <p>The given {@link TableDescriptor descriptor} describes an anonymous table that won't be
-     * registered in the catalog. This table will be propagated directly in the operation tree,
-     * adding a statement that inserts the provided {@link Table} object's pipeline into such a
-     * table.
-     *
-     * <p>This method allows to declare a {@link Schema} for the sink descriptor. The declaration is
-     * similar to a {@code CREATE TABLE} DDL in SQL and allows to:
-     *
-     * <ul>
-     *   <li>overwrite automatically derived columns with a custom {@link DataType}
-     *   <li>add metadata columns next to the physical columns
-     *   <li>declare a primary key
-     * </ul>
-     *
-     * <p>It is possible to declare a schema without physical/regular columns. In this case, those
-     * columns will be automatically derived and implicitly put at the beginning of the schema
-     * declaration.
-     *
-     * <p>Examples:
-     *
-     * <pre>{@code
-     * StatementSet stmtSet = tEnv.createStatementSet();
-     * Table sourceTable = tEnv.from("SourceTable");
-     * TableDescriptor sinkDescriptor = TableDescriptor.forConnector("blackhole")
-     *   .schema(Schema.newBuilder()
-     *     // …
-     *     .build())
-     *   .build();
-     *
-     * stmtSet.addInsert(sinkDescriptor, sourceTable);
-     * }</pre>
+     * @see #add(TablePipeline)
+     * @see Table#insertInto(TableDescriptor)
      */
     StatementSet addInsert(TableDescriptor targetDescriptor, Table table);
 
     /**
-     * Adds a statement that the pipeline defined by the given {@link Table} object should be
-     * written to a table (backed by a {@link DynamicTableSink}) expressed via the given {@link
-     * TableDescriptor}.
+     * Shorthand for {@code statementSet.add(table.insertInto(targetDescriptor, overwrite))}.
      *
-     * <p>The given {@link TableDescriptor descriptor} won't be registered in the catalog, but it
-     * will be propagated directly in the operation tree, adding a statement to the statement set
-     * that inserts the {@link Table} object's pipeline into the anonymous table described with
-     * {@link TableDescriptor descriptor}.
-     *
-     * <p>This method allows to declare a {@link Schema} for the sink descriptor. The declaration is
-     * similar to a {@code CREATE TABLE} DDL in SQL and allows to:
-     *
-     * <ul>
-     *   <li>overwrite automatically derived columns with a custom {@link DataType}
-     *   <li>add metadata columns next to the physical columns
-     *   <li>declare a primary key
-     * </ul>
-     *
-     * <p>It is possible to declare a schema without physical/regular columns. In this case, those
-     * columns will be automatically derived and implicitly put at the beginning of the schema
-     * declaration.
-     *
-     * <p>Examples:
-     *
-     * <pre>{@code
-     * StatementSet stmtSet = tEnv.createStatementSet();
-     * Table sourceTable = tEnv.from("SourceTable");
-     * TableDescriptor sinkDescriptor = TableDescriptor.forConnector("blackhole")
-     *   .schema(Schema.newBuilder()
-     *     // …
-     *     .build())
-     *   .build();
-     *
-     * stmtSet.addInsert(sinkDescriptor, sourceTable, true);
-     * }</pre>
-     *
-     * @param overwrite Indicates whether existing data should be overwritten.
+     * @see #add(TablePipeline)
+     * @see Table#insertInto(TableDescriptor, boolean)
      */
     StatementSet addInsert(TableDescriptor targetDescriptor, Table table, boolean overwrite);
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Table.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Table.java
@@ -87,7 +87,7 @@ import org.apache.flink.table.types.DataType;
  * }</pre>
  */
 @PublicEvolving
-public interface Table {
+public interface Table extends Explainable<Table>, Executable {
 
     /**
      * Returns the schema of this table.
@@ -1454,24 +1454,4 @@ public interface Table {
      * @param overwrite Indicates whether existing data should be overwritten.
      */
     TableResult executeInsert(TableDescriptor descriptor, boolean overwrite);
-
-    /**
-     * Collects the contents of the current table local client.
-     *
-     * <pre>{@code
-     * Table table = tableEnv.sqlQuery("SELECT * FROM MyTable");
-     * TableResult tableResult = table.execute();
-     * tableResult.print();
-     * }</pre>
-     */
-    TableResult execute();
-
-    /**
-     * Returns the AST of this table and the execution plan to compute the result of this table.
-     *
-     * @param extraDetails The extra explain details which the explain result should include, e.g.
-     *     estimated cost, changelog mode for streaming
-     * @return AST and the execution plan.
-     */
-    String explain(ExplainDetail... extraDetails);
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Table.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Table.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.api;
 
 import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.table.api.config.TableConfigOptions;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.source.DynamicTableSource;
@@ -1301,8 +1300,9 @@ public interface Table extends Explainable<Table>, Executable {
 
     /**
      * Declares that the pipeline defined by the given {@link Table} object should be written to a
-     * table (backed by a {@link DynamicTableSink}) that was registered under the specified path. It
-     * executes the insert operation.
+     * table (backed by a {@link DynamicTableSink}) that was registered under the specified path.
+     * You can execute the returned {@link TablePipeline} using {@link TablePipeline#execute()}, or
+     * you can compile it to a {@link CompiledPlan} using {@link TablePipeline#compilePlan()}.
      *
      * <p>See the documentation of {@link TableEnvironment#useDatabase(String)} or {@link
      * TableEnvironment#useCatalog(String)} for the rules on the path resolution.
@@ -1311,26 +1311,24 @@ public interface Table extends Explainable<Table>, Executable {
      *
      * <pre>{@code
      * Table table = tableEnv.sqlQuery("SELECT * FROM MyTable");
-     * TableResult tableResult = table.executeInsert("MySinkTable");
+     * TablePipeline tablePipeline = table.insertInto("MySinkTable");
+     * TableResult tableResult = tablePipeline.execute();
      * tableResult.await();
      * }</pre>
      *
      * <p>If multiple pipelines should insert data into one or more sink tables as part of a single
      * execution, use a {@link StatementSet} (see {@link TableEnvironment#createStatementSet()}).
      *
-     * <p>By default, all insertion operations are executed asynchronously. Use {@link
-     * TableResult#await()} or {@link TableResult#getJobClient()} to monitor the execution. Set
-     * {@link TableConfigOptions#TABLE_DML_SYNC} for always synchronous execution.
-     *
      * @param tablePath The path of the registered table (backed by a {@link DynamicTableSink}).
-     * @return The insert operation execution result.
+     * @return The built pipeline.
      */
-    TableResult executeInsert(String tablePath);
+    TablePipeline insertInto(String tablePath);
 
     /**
      * Declares that the pipeline defined by the given {@link Table} object should be written to a
-     * table (backed by a {@link DynamicTableSink}) that was registered under the specified path. It
-     * executes the insert operation.
+     * table (backed by a {@link DynamicTableSink}) that was registered under the specified path.
+     * You can execute the returned {@link TablePipeline} using {@link TablePipeline#execute()}, or
+     * you can compile it to a {@link CompiledPlan} using {@link TablePipeline#compilePlan()}.
      *
      * <p>See the documentation of {@link TableEnvironment#useDatabase(String)} or {@link
      * TableEnvironment#useCatalog(String)} for the rules on the path resolution.
@@ -1339,27 +1337,25 @@ public interface Table extends Explainable<Table>, Executable {
      *
      * <pre>{@code
      * Table table = tableEnv.sqlQuery("SELECT * FROM MyTable");
-     * TableResult tableResult = table.executeInsert("MySinkTable", true);
+     * TablePipeline tablePipeline = table.insertInto("MySinkTable", true);
+     * TableResult tableResult = tablePipeline.execute();
      * tableResult.await();
      * }</pre>
      *
      * <p>If multiple pipelines should insert data into one or more sink tables as part of a single
      * execution, use a {@link StatementSet} (see {@link TableEnvironment#createStatementSet()}).
      *
-     * <p>By default, all insertion operations are executed asynchronously. Use {@link
-     * TableResult#await()} or {@link TableResult#getJobClient()} to monitor the execution. Set
-     * {@link TableConfigOptions#TABLE_DML_SYNC} for always synchronous execution.
-     *
      * @param tablePath The path of the registered table (backed by a {@link DynamicTableSink}).
      * @param overwrite Indicates whether existing data should be overwritten.
-     * @return The insert operation execution result.
+     * @return The built pipeline.
      */
-    TableResult executeInsert(String tablePath, boolean overwrite);
+    TablePipeline insertInto(String tablePath, boolean overwrite);
 
     /**
      * Declares that the pipeline defined by the given {@link Table} object should be written to a
      * table (backed by a {@link DynamicTableSink}) expressed via the given {@link TableDescriptor}.
-     * It executes the insert operation.
+     * You can execute the returned {@link TablePipeline} using {@link TablePipeline#execute()}, or
+     * you can compile it to a {@link CompiledPlan} using {@link TablePipeline#compilePlan()}.
      *
      * <p>The {@link TableDescriptor descriptor} won't be registered in the catalog, but it will be
      * propagated directly in the operation tree. Note that calling this method multiple times, even
@@ -1389,7 +1385,7 @@ public interface Table extends Explainable<Table>, Executable {
      *   .schema(schema)
      *   .build());
      *
-     * table.executeInsert(TableDescriptor.forConnector("blackhole")
+     * table.insertInto(TableDescriptor.forConnector("blackhole")
      *   .schema(schema)
      *   .build());
      * }</pre>
@@ -1397,18 +1393,15 @@ public interface Table extends Explainable<Table>, Executable {
      * <p>If multiple pipelines should insert data into one or more sink tables as part of a single
      * execution, use a {@link StatementSet} (see {@link TableEnvironment#createStatementSet()}).
      *
-     * <p>By default, all insertion operations are executed asynchronously. Use {@link
-     * TableResult#await()} or {@link TableResult#getJobClient()} to monitor the execution. Set
-     * {@link TableConfigOptions#TABLE_DML_SYNC} for always synchronous execution.
-     *
      * @param descriptor Descriptor describing the sink table into which data should be inserted.
      */
-    TableResult executeInsert(TableDescriptor descriptor);
+    TablePipeline insertInto(TableDescriptor descriptor);
 
     /**
      * Declares that the pipeline defined by the given {@link Table} object should be written to a
      * table (backed by a {@link DynamicTableSink}) expressed via the given {@link TableDescriptor}.
-     * It executes the insert operation.
+     * You can execute the returned {@link TablePipeline} using {@link TablePipeline#execute()}, or
+     * you can compile it to a {@link CompiledPlan} using {@link TablePipeline#compilePlan()}.
      *
      * <p>The {@link TableDescriptor descriptor} won't be registered in the catalog, but it will be
      * propagated directly in the operation tree. Note that calling this method multiple times, even
@@ -1438,7 +1431,7 @@ public interface Table extends Explainable<Table>, Executable {
      *   .schema(schema)
      *   .build());
      *
-     * table.executeInsert(TableDescriptor.forConnector("blackhole")
+     * table.insertInto(TableDescriptor.forConnector("blackhole")
      *   .schema(schema)
      *   .build(), true);
      * }</pre>
@@ -1446,12 +1439,48 @@ public interface Table extends Explainable<Table>, Executable {
      * <p>If multiple pipelines should insert data into one or more sink tables as part of a single
      * execution, use a {@link StatementSet} (see {@link TableEnvironment#createStatementSet()}).
      *
-     * <p>By default, all insertion operations are executed asynchronously. Use {@link
-     * TableResult#await()} or {@link TableResult#getJobClient()} to monitor the execution. Set
-     * {@link TableConfigOptions#TABLE_DML_SYNC} for always synchronous execution.
-     *
      * @param descriptor Descriptor describing the sink table into which data should be inserted.
      * @param overwrite Indicates whether existing data should be overwritten.
      */
-    TableResult executeInsert(TableDescriptor descriptor, boolean overwrite);
+    TablePipeline insertInto(TableDescriptor descriptor, boolean overwrite);
+
+    /**
+     * Shorthand for {@code tableEnv.insertInto(tablePath).execute()}.
+     *
+     * @see #insertInto(String)
+     * @see TablePipeline#execute()
+     */
+    default TableResult executeInsert(String tablePath) {
+        return insertInto(tablePath).execute();
+    }
+
+    /**
+     * Shorthand for {@code tableEnv.insertInto(tablePath, overwrite).execute()}.
+     *
+     * @see #insertInto(String, boolean)
+     * @see TablePipeline#execute()
+     */
+    default TableResult executeInsert(String tablePath, boolean overwrite) {
+        return insertInto(tablePath, overwrite).execute();
+    }
+
+    /**
+     * Shorthand for {@code tableEnv.insertInto(descriptor).execute()}.
+     *
+     * @see #insertInto(TableDescriptor)
+     * @see TablePipeline#execute()
+     */
+    default TableResult executeInsert(TableDescriptor descriptor) {
+        return insertInto(descriptor).execute();
+    }
+
+    /**
+     * Shorthand for {@code tableEnv.insertInto(descriptor, overwrite).execute()}.
+     *
+     * @see #insertInto(TableDescriptor, boolean)
+     * @see TablePipeline#execute()
+     */
+    default TableResult executeInsert(TableDescriptor descriptor, boolean overwrite) {
+        return insertInto(descriptor, overwrite).execute();
+    }
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TablePipeline.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TablePipeline.java
@@ -30,9 +30,6 @@ import java.util.Optional;
 @PublicEvolving
 public interface TablePipeline extends Explainable<TablePipeline>, Executable, Compilable {
 
-    /**
-     * @return the sink {@link ObjectIdentifier}, if any.
-     */
+    /** @return the sink {@link ObjectIdentifier}, if any. */
     Optional<ObjectIdentifier> getSinkIdentifier();
-
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TablePipeline.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TablePipeline.java
@@ -19,10 +19,20 @@
 package org.apache.flink.table.api;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+
+import java.util.Optional;
 
 /**
  * This interface describes a pipeline created from a single {@code INSERT INTO} statement, created
  * either using Table APIs or SQL.
  */
 @PublicEvolving
-public interface TablePipeline extends Explainable<TablePipeline>, Executable, Compilable {}
+public interface TablePipeline extends Explainable<TablePipeline>, Executable, Compilable {
+
+    /**
+     * @return the sink {@link ObjectIdentifier}, if any.
+     */
+    Optional<ObjectIdentifier> getSinkIdentifier();
+
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TablePipeline.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TablePipeline.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+/**
+ * This interface describes a pipeline created from a single {@code INSERT INTO} statement, created
+ * either using Table APIs or SQL.
+ */
+@PublicEvolving
+public interface TablePipeline extends Explainable<TablePipeline>, Executable, Compilable {}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/StatementSetImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/StatementSetImpl.java
@@ -20,24 +20,19 @@ package org.apache.flink.table.api.internal;
 
 import org.apache.flink.annotation.Experimental;
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.table.api.CompiledPlan;
 import org.apache.flink.table.api.ExplainDetail;
 import org.apache.flink.table.api.StatementSet;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableDescriptor;
 import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.api.TablePipeline;
 import org.apache.flink.table.api.TableResult;
-import org.apache.flink.table.catalog.ContextResolvedTable;
-import org.apache.flink.table.catalog.ObjectIdentifier;
-import org.apache.flink.table.catalog.ResolvedCatalogTable;
-import org.apache.flink.table.catalog.SchemaTranslator;
-import org.apache.flink.table.catalog.UnresolvedIdentifier;
 import org.apache.flink.table.operations.ModifyOperation;
 import org.apache.flink.table.operations.Operation;
-import org.apache.flink.table.operations.SinkModifyOperation;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -49,6 +44,11 @@ public class StatementSetImpl<E extends TableEnvironmentInternal> implements Sta
 
     protected StatementSetImpl(E tableEnvironment) {
         this.tableEnvironment = tableEnvironment;
+    }
+
+    @VisibleForTesting
+    public List<ModifyOperation> getOperations() {
+        return operations;
     }
 
     @Override
@@ -69,61 +69,30 @@ public class StatementSetImpl<E extends TableEnvironmentInternal> implements Sta
     }
 
     @Override
-    public StatementSet addInsert(String targetPath, Table table) {
-        return addInsert(targetPath, table, false);
-    }
-
-    @Override
-    public StatementSet addInsert(String targetPath, Table table, boolean overwrite) {
-        UnresolvedIdentifier unresolvedIdentifier =
-                tableEnvironment.getParser().parseIdentifier(targetPath);
-        ObjectIdentifier objectIdentifier =
-                tableEnvironment.getCatalogManager().qualifyIdentifier(unresolvedIdentifier);
-        ContextResolvedTable contextResolvedTable =
-                tableEnvironment.getCatalogManager().getTableOrError(objectIdentifier);
-
-        operations.add(
-                new SinkModifyOperation(
-                        contextResolvedTable,
-                        table.getQueryOperation(),
-                        Collections.emptyMap(),
-                        overwrite,
-                        Collections.emptyMap()));
-
+    public StatementSet add(TablePipeline tablePipeline) {
+        operations.add(((TablePipelineImpl) tablePipeline).getOperation());
         return this;
     }
 
     @Override
+    public StatementSet addInsert(String targetPath, Table table) {
+        return add(table.insertInto(targetPath));
+    }
+
+    @Override
+    public StatementSet addInsert(String targetPath, Table table, boolean overwrite) {
+        return add(table.insertInto(targetPath, overwrite));
+    }
+
+    @Override
     public StatementSet addInsert(TableDescriptor targetDescriptor, Table table) {
-        return addInsert(targetDescriptor, table, false);
+        return add(table.insertInto(targetDescriptor));
     }
 
     @Override
     public StatementSet addInsert(
             TableDescriptor targetDescriptor, Table table, boolean overwrite) {
-        final SchemaTranslator.ConsumingResult schemaTranslationResult =
-                SchemaTranslator.createConsumingResult(
-                        tableEnvironment.getCatalogManager().getDataTypeFactory(),
-                        table.getResolvedSchema().toSourceRowDataType(),
-                        targetDescriptor.getSchema().orElse(null),
-                        false);
-        final TableDescriptor updatedDescriptor =
-                targetDescriptor.toBuilder().schema(schemaTranslationResult.getSchema()).build();
-
-        final ResolvedCatalogTable resolvedCatalogBaseTable =
-                tableEnvironment
-                        .getCatalogManager()
-                        .resolveCatalogTable(updatedDescriptor.toCatalogTable());
-
-        operations.add(
-                new SinkModifyOperation(
-                        ContextResolvedTable.anonymous(resolvedCatalogBaseTable),
-                        table.getQueryOperation(),
-                        Collections.emptyMap(),
-                        overwrite,
-                        Collections.emptyMap()));
-
-        return this;
+        return add(table.insertInto(targetDescriptor, overwrite));
     }
 
     @Override

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/StatementSetImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/StatementSetImpl.java
@@ -52,6 +52,12 @@ public class StatementSetImpl<E extends TableEnvironmentInternal> implements Sta
     }
 
     @Override
+    public StatementSet add(TablePipeline tablePipeline) {
+        operations.add(((TablePipelineImpl) tablePipeline).getOperation());
+        return this;
+    }
+
+    @Override
     public StatementSet addInsertSql(String statement) {
         List<Operation> operations = tableEnvironment.getParser().parse(statement);
 
@@ -65,12 +71,6 @@ public class StatementSetImpl<E extends TableEnvironmentInternal> implements Sta
         } else {
             throw new TableException("Only insert statement is supported now.");
         }
-        return this;
-    }
-
-    @Override
-    public StatementSet add(TablePipeline tablePipeline) {
-        operations.add(((TablePipelineImpl) tablePipeline).getOperation());
         return this;
     }
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TablePipelineImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TablePipelineImpl.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api.internal;
+
+import org.apache.flink.table.api.CompiledPlan;
+import org.apache.flink.table.api.ExplainDetail;
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.api.TablePipeline;
+import org.apache.flink.table.api.TableResult;
+import org.apache.flink.table.operations.ModifyOperation;
+
+import static java.util.Collections.singletonList;
+
+/** Implementation of {@link TablePipeline}. */
+class TablePipelineImpl implements TablePipeline {
+
+    private final TableEnvironmentInternal tableEnvironment;
+    private final ModifyOperation operation;
+
+    TablePipelineImpl(TableEnvironmentInternal tableEnvironment, ModifyOperation operation) {
+        this.tableEnvironment = tableEnvironment;
+        this.operation = operation;
+    }
+
+    ModifyOperation getOperation() {
+        return operation;
+    }
+
+    @Override
+    public CompiledPlan compilePlan() throws TableException {
+        return tableEnvironment.compilePlan(singletonList(operation));
+    }
+
+    @Override
+    public TableResult execute() {
+        return tableEnvironment.executeInternal(operation);
+    }
+
+    @Override
+    public String explain(ExplainDetail... extraDetails) {
+        return tableEnvironment.explainInternal(singletonList(operation), extraDetails);
+    }
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TablePipelineImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TablePipelineImpl.java
@@ -23,7 +23,11 @@ import org.apache.flink.table.api.ExplainDetail;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.TablePipeline;
 import org.apache.flink.table.api.TableResult;
+import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.operations.ModifyOperation;
+import org.apache.flink.table.operations.SinkModifyOperation;
+
+import java.util.Optional;
 
 import static java.util.Collections.singletonList;
 
@@ -55,5 +59,28 @@ class TablePipelineImpl implements TablePipeline {
     @Override
     public String explain(ExplainDetail... extraDetails) {
         return tableEnvironment.explainInternal(singletonList(operation), extraDetails);
+    }
+
+    @Override
+    public Optional<ObjectIdentifier> getSinkIdentifier() {
+        if (this.operation instanceof SinkModifyOperation) {
+            SinkModifyOperation sinkModifyOperation = (SinkModifyOperation) this.operation;
+            if (!sinkModifyOperation.getContextResolvedTable().isAnonymous()) {
+                return Optional.of(sinkModifyOperation.getContextResolvedTable().getIdentifier());
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public String toString() {
+        if (this.operation instanceof SinkModifyOperation) {
+            return "TablePipeline with sink table '"
+                    + ((SinkModifyOperation) this.operation)
+                            .getContextResolvedTable()
+                            .getIdentifier()
+                    + "'";
+        }
+        return "TablePipeline with sink '" + operation.getClass().getSimpleName() + "'";
     }
 }

--- a/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/StreamStatementSet.scala
+++ b/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/StreamStatementSet.scala
@@ -20,7 +20,7 @@ package org.apache.flink.table.api.bridge.scala
 
 import org.apache.flink.annotation.PublicEvolving
 import org.apache.flink.streaming.api.scala.{DataStream, StreamExecutionEnvironment}
-import org.apache.flink.table.api.{StatementSet, Table, TableDescriptor}
+import org.apache.flink.table.api.{ExplainDetail, StatementSet, Table, TableDescriptor, TablePipeline}
 
 /**
  * A [[StatementSet]] that integrates with the Scala-specific [[DataStream]] API.
@@ -37,6 +37,8 @@ trait StreamStatementSet extends StatementSet {
 
   override def addInsertSql(statement: String): StreamStatementSet
 
+  override def add(tablePipeline: TablePipeline): StreamStatementSet
+
   override def addInsert(targetPath: String, table: Table): StreamStatementSet
 
   override def addInsert(targetPath: String, table: Table, overwrite: Boolean): StreamStatementSet
@@ -48,6 +50,8 @@ trait StreamStatementSet extends StatementSet {
       table: Table,
       overwrite: Boolean)
     : StreamStatementSet
+
+  override def printExplain(extraDetails: ExplainDetail*): StreamStatementSet
 
   /**
    * Optimizes all statements as one entity and adds them as transformations to the underlying

--- a/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/StreamStatementSet.scala
+++ b/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/StreamStatementSet.scala
@@ -35,9 +35,9 @@ import org.apache.flink.table.api.{ExplainDetail, StatementSet, Table, TableDesc
 @PublicEvolving
 trait StreamStatementSet extends StatementSet {
 
-  override def addInsertSql(statement: String): StreamStatementSet
-
   override def add(tablePipeline: TablePipeline): StreamStatementSet
+
+  override def addInsertSql(statement: String): StreamStatementSet
 
   override def addInsert(targetPath: String, table: Table): StreamStatementSet
 

--- a/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/internal/StreamStatementSetImpl.scala
+++ b/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/internal/StreamStatementSetImpl.scala
@@ -21,7 +21,7 @@ package org.apache.flink.table.api.bridge.scala.internal
 import org.apache.flink.annotation.Internal
 import org.apache.flink.table.api.bridge.scala.StreamStatementSet
 import org.apache.flink.table.api.internal.StatementSetImpl
-import org.apache.flink.table.api.{Table, TableDescriptor}
+import org.apache.flink.table.api.{ExplainDetail, Table, TableDescriptor, TablePipeline}
 
 /** Implementation for [[StreamStatementSet]]. */
 @Internal
@@ -29,32 +29,31 @@ class StreamStatementSetImpl(tableEnvironment: StreamTableEnvironmentImpl)
     extends StatementSetImpl[StreamTableEnvironmentImpl](tableEnvironment)
     with StreamStatementSet {
 
-  override def addInsertSql(statement: String): StreamStatementSet = {
+  override def addInsertSql(statement: String): StreamStatementSet =
     super.addInsertSql(statement).asInstanceOf[StreamStatementSet]
-  }
 
-  override def addInsert(targetPath: String, table: Table): StreamStatementSet = {
+  override def add(tablePipeline: TablePipeline): StreamStatementSet =
+    super.add(tablePipeline).asInstanceOf[StreamStatementSet]
+
+  override def addInsert(targetPath: String, table: Table): StreamStatementSet =
     super.addInsert(targetPath, table).asInstanceOf[StreamStatementSet]
-  }
 
-  override def addInsert(
-      targetPath: String,
-      table: Table,
-      overwrite: Boolean)
-    : StreamStatementSet = {
+  override def addInsert(targetPath: String, table: Table, overwrite: Boolean): StreamStatementSet =
     super.addInsert(targetPath, table, overwrite).asInstanceOf[StreamStatementSet]
-  }
 
-  override def addInsert(targetDescriptor: TableDescriptor, table: Table): StreamStatementSet = {
+  override def addInsert(targetDescriptor: TableDescriptor, table: Table): StreamStatementSet =
     super.addInsert(targetDescriptor, table).asInstanceOf[StreamStatementSet]
-  }
 
   override def addInsert(
-      targetDescriptor: TableDescriptor,
-      table: Table,
-      overwrite: Boolean)
-    : StreamStatementSet = {
+                          targetDescriptor: TableDescriptor,
+                          table: Table,
+                          overwrite: Boolean)
+  : StreamStatementSet =
     super.addInsert(targetDescriptor, table, overwrite).asInstanceOf[StreamStatementSet]
+
+  override def printExplain(extraDetails: ExplainDetail*): StreamStatementSet = {
+    System.out.println(super.explain(extraDetails: _*))
+    this
   }
 
   override def attachAsDataStream(): Unit = {

--- a/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/internal/StreamStatementSetImpl.scala
+++ b/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/internal/StreamStatementSetImpl.scala
@@ -29,30 +29,38 @@ class StreamStatementSetImpl(tableEnvironment: StreamTableEnvironmentImpl)
     extends StatementSetImpl[StreamTableEnvironmentImpl](tableEnvironment)
     with StreamStatementSet {
 
-  override def addInsertSql(statement: String): StreamStatementSet =
-    super.addInsertSql(statement).asInstanceOf[StreamStatementSet]
-
-  override def add(tablePipeline: TablePipeline): StreamStatementSet =
+  override def add(tablePipeline: TablePipeline): StreamStatementSet = {
     super.add(tablePipeline).asInstanceOf[StreamStatementSet]
+  }
 
-  override def addInsert(targetPath: String, table: Table): StreamStatementSet =
+  override def addInsertSql(statement: String): StreamStatementSet = {
+    super.addInsertSql(statement).asInstanceOf[StreamStatementSet]
+  }
+
+  override def addInsert(targetPath: String, table: Table): StreamStatementSet = {
     super.addInsert(targetPath, table).asInstanceOf[StreamStatementSet]
-
-  override def addInsert(targetPath: String, table: Table, overwrite: Boolean): StreamStatementSet =
-    super.addInsert(targetPath, table, overwrite).asInstanceOf[StreamStatementSet]
-
-  override def addInsert(targetDescriptor: TableDescriptor, table: Table): StreamStatementSet =
-    super.addInsert(targetDescriptor, table).asInstanceOf[StreamStatementSet]
+  }
 
   override def addInsert(
-                          targetDescriptor: TableDescriptor,
-                          table: Table,
-                          overwrite: Boolean)
-  : StreamStatementSet =
+    targetPath: String, table: Table, overwrite: Boolean)
+  : StreamStatementSet = {
+    super.addInsert(targetPath, table, overwrite).asInstanceOf[StreamStatementSet]
+  }
+
+  override def addInsert(targetDescriptor: TableDescriptor, table: Table): StreamStatementSet = {
+    super.addInsert(targetDescriptor, table).asInstanceOf[StreamStatementSet]
+  }
+
+  override def addInsert(
+    targetDescriptor: TableDescriptor,
+    table: Table,
+    overwrite: Boolean)
+  : StreamStatementSet = {
     super.addInsert(targetDescriptor, table, overwrite).asInstanceOf[StreamStatementSet]
+  }
 
   override def printExplain(extraDetails: ExplainDetail*): StreamStatementSet = {
-    System.out.println(super.explain(extraDetails: _*))
+    println(super.explain(extraDetails: _*))
     this
   }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/api/CompiledPlanITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/api/CompiledPlanITCase.java
@@ -97,14 +97,12 @@ public class CompiledPlanITCase extends JsonPlanTestBase {
 
     @Test
     public void testExecutePlanTable() throws Exception {
-        List<String> data = Arrays.asList("1,1,hi", "2,1,hello", "3,2,hello world");
-        createTestCsvSourceTable("src", data, "a bigint", "b int", "c varchar");
-        File sinkPath = createTestCsvSinkTable("sink", "a bigint", "b int", "c varchar");
+        File sinkPath = createSourceSinkTables();
 
         CompiledPlan plan = tableEnv.from("src").select($("*")).insertInto("sink").compilePlan();
         tableEnv.executePlan(plan).await();
 
-        assertResult(data, sinkPath);
+        assertResult(DATA, sinkPath);
     }
 
     @Test

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/hint/OptionsHintTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/hint/OptionsHintTest.scala
@@ -19,12 +19,13 @@
 package org.apache.flink.table.planner.plan.hint
 
 import org.apache.flink.table.api.config.TableConfigOptions
+import org.apache.flink.table.api.internal.StatementSetImpl
 import org.apache.flink.table.api.{DataTypes, TableSchema, ValidationException}
 import org.apache.flink.table.catalog.{CatalogViewImpl, ObjectPath}
 import org.apache.flink.table.planner.JHashMap
 import org.apache.flink.table.planner.plan.hint.OptionsHintTest.{IS_BOUNDED, Param}
 import org.apache.flink.table.planner.plan.nodes.calcite.LogicalLegacySink
-import org.apache.flink.table.planner.utils.{OptionsTableSink, TableTestBase, TableTestUtil, TestingStatementSet}
+import org.apache.flink.table.planner.utils.{OptionsTableSink, TableTestBase, TableTestUtil}
 
 import org.hamcrest.Matchers._
 import org.junit.Assert.{assertEquals, assertThat}
@@ -92,7 +93,7 @@ class OptionsHintTest(param: Param)
          |""".stripMargin
     val stmtSet = util.tableEnv.createStatementSet()
     stmtSet.addInsertSql(sql)
-    val testStmtSet = stmtSet.asInstanceOf[TestingStatementSet]
+    val testStmtSet = stmtSet.asInstanceOf[StatementSetImpl[_]]
     val relNodes = testStmtSet.getOperations.map(util.getPlanner.translateToRel)
     assertThat(relNodes.length, is(1))
     assert(relNodes.head.isInstanceOf[LogicalLegacySink])

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/join/JoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/join/JoinITCase.scala
@@ -25,7 +25,7 @@ import org.apache.flink.api.common.typeutils.TypeComparator
 import org.apache.flink.api.dag.Transformation
 import org.apache.flink.api.java.typeutils.{GenericTypeInfo, RowTypeInfo}
 import org.apache.flink.streaming.api.transformations.{LegacySinkTransformation, OneInputTransformation, TwoInputTransformation}
-import org.apache.flink.table.api.internal.TableEnvironmentInternal
+import org.apache.flink.table.api.internal.{StatementSetImpl, TableEnvironmentInternal}
 import org.apache.flink.table.planner.delegation.PlannerBase
 import org.apache.flink.table.planner.expressions.utils.FuncWithOpen
 import org.apache.flink.table.planner.runtime.batch.sql.join.JoinType.{BroadcastHashJoin, HashJoin, JoinType, NestedLoopJoin, SortMergeJoin}
@@ -33,7 +33,7 @@ import org.apache.flink.table.planner.runtime.utils.BatchTestBase
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
 import org.apache.flink.table.planner.runtime.utils.TestData._
 import org.apache.flink.table.planner.sinks.CollectRowTableSink
-import org.apache.flink.table.planner.utils.{TestingStatementSet, TestingTableEnvironment}
+import org.apache.flink.table.planner.utils.TestingTableEnvironment
 import org.apache.flink.table.runtime.operators.CodeGenOperatorFactory
 import org.apache.flink.types.Row
 
@@ -108,7 +108,7 @@ class JoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
       val table = tEnv.sqlQuery("SELECT c FROM SmallTable3, Table5 WHERE b = e")
       stmtSet.addInsert("outputTable", table)
       val testingTEnv = tEnv.asInstanceOf[TestingTableEnvironment]
-      val testingStmtSet = stmtSet.asInstanceOf[TestingStatementSet]
+      val testingStmtSet = stmtSet.asInstanceOf[StatementSetImpl[_]]
       val transforms = testingTEnv.getPlanner.asInstanceOf[PlannerBase]
         .translate(testingStmtSet.getOperations)
       var haveTwoOp = false

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
@@ -36,7 +36,7 @@ import org.apache.flink.table.api._
 import org.apache.flink.table.api.bridge.java.{StreamTableEnvironment => JavaStreamTableEnv}
 import org.apache.flink.table.api.bridge.scala.{StreamTableEnvironment => ScalaStreamTableEnv}
 import org.apache.flink.table.api.config.ExecutionConfigOptions
-import org.apache.flink.table.api.internal.{TableEnvironmentImpl, TableEnvironmentInternal, TableImpl}
+import org.apache.flink.table.api.internal.{StatementSetImpl, TableEnvironmentImpl, TableEnvironmentInternal, TableImpl}
 import org.apache.flink.table.catalog.{CatalogManager, FunctionCatalog, GenericInMemoryCatalog, ObjectIdentifier}
 import org.apache.flink.table.data.RowData
 import org.apache.flink.table.delegation.{Executor, ExecutorFactory}
@@ -890,7 +890,7 @@ abstract class TableTestUtilBase(test: TableTestBase, isStreamingMode: Boolean) 
       withRowType: Boolean,
       expectedPlans: Array[PlanKind],
       assertSqlEqualsOrExpandFunc: () => Unit): Unit = {
-    val testStmtSet = stmtSet.asInstanceOf[TestingStatementSet]
+    val testStmtSet = stmtSet.asInstanceOf[StatementSetImpl[_]]
 
     val relNodes = testStmtSet.getOperations.map(getPlanner.translateToRel)
     if (relNodes.isEmpty) {
@@ -1502,73 +1502,7 @@ class TestingTableEnvironment private(
     super.createTable(tableOperation)
   }
 
-  override def createStatementSet(): StatementSet = new TestingStatementSet(this)
-}
-
-class TestingStatementSet(tEnv: TestingTableEnvironment) extends StatementSet {
-
-  private val operations: util.List[ModifyOperation] = new util.ArrayList[ModifyOperation]
-
-  def getOperations: util.List[ModifyOperation] = operations
-
-  override def addInsertSql(statement: String): StatementSet = {
-    val operations = tEnv.getParser.parse(statement)
-
-    if (operations.size != 1) {
-      throw new TableException("Only single statement is supported.")
-    }
-
-    operations.get(0) match {
-      case op: ModifyOperation =>
-        this.operations.add(op)
-      case _ =>
-        throw new TableException("Only insert statement is supported now.")
-    }
-    this
-  }
-
-  override def addInsert(targetPath: String, table: Table): StatementSet = {
-    this.addInsert(targetPath, table, overwrite = false)
-  }
-
-  override def addInsert(targetPath: String, table: Table, overwrite: Boolean): StatementSet = {
-    val unresolvedIdentifier = tEnv.getParser.parseIdentifier(targetPath)
-    val objectIdentifier = tEnv.getCatalogManager.qualifyIdentifier(unresolvedIdentifier)
-    val resolvedTable = tEnv.getCatalogManager.getTable(objectIdentifier).get()
-
-    operations.add(new SinkModifyOperation(
-      resolvedTable,
-      table.getQueryOperation,
-      util.Collections.emptyMap[String, String],
-      overwrite,
-      util.Collections.emptyMap[String, String]))
-    this
-  }
-
-  override def addInsert(descriptor: TableDescriptor, table: Table): StatementSet = {
-    throw new TableException("Not implemented")
-  }
-
-  override def addInsert(
-      targetDescriptor: TableDescriptor,
-      table: Table,
-      overwrite: Boolean): StatementSet = {
-    throw new TableException("Not implemented")
-  }
-
-  override def explain(extraDetails: ExplainDetail*): String = {
-    tEnv.explainInternal(operations.map(o => o.asInstanceOf[Operation]), extraDetails: _*)
-  }
-
-  override def execute(): TableResult = {
-    try {
-      tEnv.executeInternal(operations)
-    } finally {
-      operations.clear()
-    }
-  }
-
-  override def compilePlan(): CompiledPlan = null
+  override def createStatementSet(): StatementSet = super.createStatementSet()
 }
 
 object TestingTableEnvironment {


### PR DESCRIPTION
This PR introduces a new API object called `TablePipeline` which encapsulates the description of an table pipeline, as a result of a compilation of an `INSERT INTO`. The implementation is simply a wrapper for `List<ModifyOperation>`. It also adds the method `StatementSet#add(TablePipeline)` to add a pipeline to a statement set.

In order to improve the overall design quality of our APIs, in the first commit I introduced 3 interfaces splitting the capabilities of our API components:

* `Compilable`: an object that can be compiled to a `CompiledPlan`
* `Explainable`: an object that can be explained
* `Executable`: an object that can be executed

This brings overall consistency to our APIs and improves documentation. This change is a refactoring and doesn't bring any new feature, except the fluent `printExplain` method.

The implementation of these capabilities is:

|                 | `Compilable`       | `Executable`       | `Explainable`      |
|-----------------|--------------------|--------------------|--------------------|
| `Table`         | FLINK-25843        | :heavy_check_mark: | :heavy_check_mark: |
| `StatementSet`  | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
| `CompiledPlan`  | Won't fix          | FLINK-26131   | :heavy_check_mark: |
| `TablePipeline` | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |

## Verifying this change

Added a test to verify a table pipeline can be compiled to a plan. The rest of the changes is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
