### PR TITLE
[FLINK-26107][runtime] AdaptiveScheduler: OperatorCoordinator should …

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultOperatorCoordinatorHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultOperatorCoordinatorHandler.java
@@ -41,7 +41,6 @@ import org.apache.flink.util.IOUtils;
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -51,10 +50,10 @@ public class DefaultOperatorCoordinatorHandler implements OperatorCoordinatorHan
 
     private final Map<OperatorID, OperatorCoordinatorHolder> coordinatorMap;
 
-    private final Consumer<Throwable> globalFailureHandler;
+    private final GlobalFailureHandler globalFailureHandler;
 
     public DefaultOperatorCoordinatorHandler(
-            ExecutionGraph executionGraph, Consumer<Throwable> globalFailureHandler) {
+            ExecutionGraph executionGraph, GlobalFailureHandler globalFailureHandler) {
         this.executionGraph = executionGraph;
 
         this.coordinatorMap = createCoordinatorMap(executionGraph);
@@ -122,7 +121,7 @@ public class DefaultOperatorCoordinatorHandler implements OperatorCoordinatorHan
             coordinator.handleEventFromOperator(exec.getParallelSubtaskIndex(), evt);
         } catch (Throwable t) {
             ExceptionUtils.rethrowIfFatalErrorOrOOM(t);
-            globalFailureHandler.accept(t);
+            globalFailureHandler.handleGlobalFailure(t);
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/GlobalFailureHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/GlobalFailureHandler.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.runtime.scheduler;
+
+/**
+ * An interface for handling global failures. In context of a scheduler we distinguish between local
+ * and global failures. Global failure is the one that happens in context of the scheduler (in the
+ * JobManager process) and local failure is one that is "local" to an executing task.
+ */
+@FunctionalInterface
+public interface GlobalFailureHandler {
+
+    /**
+     * Handles a global failure.
+     *
+     * @param cause A cause that describes the global failure.
+     */
+    void handleGlobalFailure(Throwable cause);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerNG.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerNG.java
@@ -66,15 +66,13 @@ import java.util.concurrent.CompletableFuture;
  * <p>Implementations can expect that methods will not be invoked concurrently. In fact, all
  * invocations will originate from a thread in the {@link ComponentMainThreadExecutor}.
  */
-public interface SchedulerNG extends AutoCloseableAsync {
+public interface SchedulerNG extends GlobalFailureHandler, AutoCloseableAsync {
 
     void startScheduling();
 
     void cancel();
 
     CompletableFuture<JobStatus> getJobTerminationFuture();
-
-    void handleGlobalFailure(Throwable cause);
 
     default boolean updateTaskExecutionState(TaskExecutionState taskExecutionState) {
         return updateTaskExecutionState(new TaskExecutionStateTransition(taskExecutionState));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/State.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/State.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.scheduler.adaptive;
 
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
+import org.apache.flink.runtime.scheduler.GlobalFailureHandler;
 import org.apache.flink.util.function.FunctionWithException;
 import org.apache.flink.util.function.ThrowingConsumer;
 
@@ -31,7 +32,7 @@ import java.util.Optional;
  * State abstraction of the {@link AdaptiveScheduler}. This interface contains all methods every
  * state implementation must support.
  */
-interface State {
+interface State extends GlobalFailureHandler {
 
     /**
      * This method is called whenever one transitions out of this state.
@@ -64,13 +65,6 @@ interface State {
      * @return the current {@link ArchivedExecutionGraph}
      */
     ArchivedExecutionGraph getJob();
-
-    /**
-     * Handles a global failure.
-     *
-     * @param cause cause describes the global failure
-     */
-    void handleGlobalFailure(Throwable cause);
 
     /**
      * Gets the logger.

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolderTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.concurrent.ManuallyTriggeredScheduledExecutorSer
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.operators.coordination.EventReceivingTasks.EventWithSubtask;
+import org.apache.flink.runtime.scheduler.GlobalFailureHandler;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.TestLogger;
 
@@ -43,7 +44,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
-import java.util.function.Consumer;
 import java.util.function.Function;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -62,7 +62,7 @@ import static org.junit.Assert.assertTrue;
 @SuppressWarnings("serial")
 public class OperatorCoordinatorHolderTest extends TestLogger {
 
-    private final Consumer<Throwable> globalFailureHandler = (t) -> globalFailure = t;
+    private final GlobalFailureHandler globalFailureHandler = (t) -> globalFailure = t;
     private Throwable globalFailure;
 
     @After

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/CreatingExecutionGraphTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/CreatingExecutionGraphTest.java
@@ -32,9 +32,11 @@ import org.apache.flink.runtime.scheduler.OperatorCoordinatorHandler;
 import org.apache.flink.runtime.scheduler.adaptive.allocator.VertexParallelism;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.TestLoggerExtension;
 import org.apache.flink.util.concurrent.Executors;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import javax.annotation.Nullable;
 
@@ -43,17 +45,14 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for the {@link CreatingExecutionGraph} state. */
+@ExtendWith(TestLoggerExtension.class)
 public class CreatingExecutionGraphTest extends TestLogger {
 
     @Test
@@ -68,7 +67,8 @@ public class CreatingExecutionGraphTest extends TestLogger {
 
             context.setExpectFinished(
                     archivedExecutionGraph ->
-                            assertThat(archivedExecutionGraph.getState(), is(JobStatus.CANCELED)));
+                            assertThat(archivedExecutionGraph.getState())
+                                    .isEqualTo(JobStatus.CANCELED));
 
             creatingExecutionGraph.cancel();
         }
@@ -86,7 +86,8 @@ public class CreatingExecutionGraphTest extends TestLogger {
 
             context.setExpectFinished(
                     archivedExecutionGraph ->
-                            assertThat(archivedExecutionGraph.getState(), is(JobStatus.SUSPENDED)));
+                            assertThat(archivedExecutionGraph.getState())
+                                    .isEqualTo(JobStatus.SUSPENDED));
 
             creatingExecutionGraph.suspend(new FlinkException("Job has been suspended."));
         }
@@ -104,7 +105,8 @@ public class CreatingExecutionGraphTest extends TestLogger {
 
             context.setExpectFinished(
                     archivedExecutionGraph ->
-                            assertThat(archivedExecutionGraph.getState(), is(JobStatus.FAILED)));
+                            assertThat(archivedExecutionGraph.getState())
+                                    .isEqualTo(JobStatus.FAILED));
 
             creatingExecutionGraph.handleGlobalFailure(new FlinkException("Test exception"));
         }
@@ -115,16 +117,16 @@ public class CreatingExecutionGraphTest extends TestLogger {
         try (MockCreatingExecutionGraphContext context = new MockCreatingExecutionGraphContext()) {
             final CompletableFuture<CreatingExecutionGraph.ExecutionGraphWithVertexParallelism>
                     executionGraphWithVertexParallelismFuture = new CompletableFuture<>();
-            final CreatingExecutionGraph creatingExecutionGraph =
-                    new CreatingExecutionGraph(
-                            context,
-                            executionGraphWithVertexParallelismFuture,
-                            log,
-                            CreatingExecutionGraphTest::createTestingOperatorCoordinatorHandler);
+            new CreatingExecutionGraph(
+                    context,
+                    executionGraphWithVertexParallelismFuture,
+                    log,
+                    CreatingExecutionGraphTest::createTestingOperatorCoordinatorHandler);
 
             context.setExpectFinished(
                     archivedExecutionGraph ->
-                            assertThat(archivedExecutionGraph.getState(), is(JobStatus.FAILED)));
+                            assertThat(archivedExecutionGraph.getState())
+                                    .isEqualTo(JobStatus.FAILED));
 
             executionGraphWithVertexParallelismFuture.completeExceptionally(
                     new FlinkException("Test exception"));
@@ -136,12 +138,11 @@ public class CreatingExecutionGraphTest extends TestLogger {
         try (MockCreatingExecutionGraphContext context = new MockCreatingExecutionGraphContext()) {
             final CompletableFuture<CreatingExecutionGraph.ExecutionGraphWithVertexParallelism>
                     executionGraphWithVertexParallelismFuture = new CompletableFuture<>();
-            final CreatingExecutionGraph creatingExecutionGraph =
-                    new CreatingExecutionGraph(
-                            context,
-                            executionGraphWithVertexParallelismFuture,
-                            log,
-                            CreatingExecutionGraphTest::createTestingOperatorCoordinatorHandler);
+            new CreatingExecutionGraph(
+                    context,
+                    executionGraphWithVertexParallelismFuture,
+                    log,
+                    CreatingExecutionGraphTest::createTestingOperatorCoordinatorHandler);
 
             context.setTryToAssignSlotsFunction(
                     ignored -> CreatingExecutionGraph.AssignmentResult.notPossible());
@@ -157,13 +158,12 @@ public class CreatingExecutionGraphTest extends TestLogger {
     public void testSuccessfulSlotAssignmentTransitionsToExecuting() throws Exception {
         try (MockCreatingExecutionGraphContext context = new MockCreatingExecutionGraphContext()) {
             final CompletableFuture<CreatingExecutionGraph.ExecutionGraphWithVertexParallelism>
-                    executionGraphWithvertexParallelismFuture = new CompletableFuture<>();
-            final CreatingExecutionGraph creatingExecutionGraph =
-                    new CreatingExecutionGraph(
-                            context,
-                            executionGraphWithvertexParallelismFuture,
-                            log,
-                            CreatingExecutionGraphTest::createTestingOperatorCoordinatorHandler);
+                    executionGraphWithVertexParallelismFuture = new CompletableFuture<>();
+            new CreatingExecutionGraph(
+                    context,
+                    executionGraphWithVertexParallelismFuture,
+                    log,
+                    CreatingExecutionGraphTest::createTestingOperatorCoordinatorHandler);
 
             final StateTrackingMockExecutionGraph executionGraph =
                     new StateTrackingMockExecutionGraph();
@@ -171,9 +171,9 @@ public class CreatingExecutionGraphTest extends TestLogger {
             context.setTryToAssignSlotsFunction(CreatingExecutionGraphTest::successfulAssignment);
             context.setExpectedExecuting(
                     actualExecutionGraph ->
-                            assertThat(actualExecutionGraph, sameInstance(executionGraph)));
+                            assertThat(actualExecutionGraph).isEqualTo(executionGraph));
 
-            executionGraphWithvertexParallelismFuture.complete(
+            executionGraphWithVertexParallelismFuture.complete(
                     CreatingExecutionGraph.ExecutionGraphWithVertexParallelism.create(
                             executionGraph, new TestingVertexParallelism()));
         }
@@ -200,24 +200,14 @@ public class CreatingExecutionGraphTest extends TestLogger {
 
             context.setTryToAssignSlotsFunction(CreatingExecutionGraphTest::successfulAssignment);
             context.setExpectedExecuting(
-                    ignored -> {
-                        // This just lets us transition to executing.
-                    });
-
-            final AtomicBoolean contextGlobalFailureHandlerCalled = new AtomicBoolean(false);
-            context.setGlobalFailureHandler(
-                    t -> {
-                        contextGlobalFailureHandlerCalled.set(true);
-                    });
+                    actualExecutionGraph ->
+                            assertThat(actualExecutionGraph).isEqualTo(executionGraph));
 
             executionGraphWithVertexParallelismFuture.complete(
                     CreatingExecutionGraph.ExecutionGraphWithVertexParallelism.create(
                             executionGraph, new TestingVertexParallelism()));
 
-            operatorCoordinatorGlobalFailureHandlerRef
-                    .get()
-                    .handleGlobalFailure(new RuntimeException("Test."));
-            assertTrue(contextGlobalFailureHandlerCalled.get());
+            assertThat(operatorCoordinatorGlobalFailureHandlerRef.get()).isSameAs(context);
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/TestingOperatorCoordinatorHandler.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/TestingOperatorCoordinatorHandler.java
@@ -45,12 +45,12 @@ class TestingOperatorCoordinatorHandler implements OperatorCoordinatorHandler {
 
     @Override
     public void initializeOperatorCoordinators(ComponentMainThreadExecutor mainThreadExecutor) {
-        throw new UnsupportedOperationException();
+        // No-op.
     }
 
     @Override
     public void startAllOperatorCoordinators() {
-        throw new UnsupportedOperationException();
+        // No-op.
     }
 
     @Override


### PR DESCRIPTION
This fixes a regression introduced in https://github.com/apache/flink/commit/5180e83ec01236ecce47a56951daf2a34eb4a1f6, that makes several OC related tests fail with the AdaptiveScheduler (unfortunately with the CRON triggered CI).

The intuition behind the change is that the OC failure handling is tied with the global failure handler of the CreatingExecutionGraph state, but we need it to use a global failure handler of the State that is currently in effect (eg. Executing).

I've added new unit test to guard against future regression.