### PR TITLE
[FlINK-26112][k8s]Port getRestEndpoint method to the specific service type subclass

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesClusterDescriptor.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesClusterDescriptor.java
@@ -42,9 +42,9 @@ import org.apache.flink.kubernetes.kubeclient.Endpoint;
 import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient;
 import org.apache.flink.kubernetes.kubeclient.FlinkPod;
 import org.apache.flink.kubernetes.kubeclient.KubernetesJobManagerSpecification;
+import org.apache.flink.kubernetes.kubeclient.decorators.ExternalServiceDecorator;
 import org.apache.flink.kubernetes.kubeclient.factory.KubernetesJobManagerFactory;
 import org.apache.flink.kubernetes.kubeclient.parameters.KubernetesJobManagerParameters;
-import org.apache.flink.kubernetes.kubeclient.resources.KubernetesService;
 import org.apache.flink.kubernetes.utils.Constants;
 import org.apache.flink.kubernetes.utils.KubernetesUtils;
 import org.apache.flink.runtime.entrypoint.ClusterEntrypoint;
@@ -177,7 +177,8 @@ public class KubernetesClusterDescriptor implements ClusterDescriptor<String> {
             final ClusterSpecification clusterSpecification,
             final ApplicationConfiguration applicationConfiguration)
             throws ClusterDeploymentException {
-        if (client.getService(KubernetesService.ServiceType.REST_SERVICE, clusterId).isPresent()) {
+        if (client.getService(ExternalServiceDecorator.getExternalServiceName(clusterId))
+                .isPresent()) {
             throw new ClusterDeploymentException(
                     "The Flink cluster " + clusterId + " already exists.");
         }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/cli/KubernetesSessionCli.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/cli/KubernetesSessionCli.java
@@ -36,7 +36,7 @@ import org.apache.flink.configuration.UnmodifiableConfiguration;
 import org.apache.flink.kubernetes.executors.KubernetesSessionClusterExecutor;
 import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient;
 import org.apache.flink.kubernetes.kubeclient.FlinkKubeClientFactory;
-import org.apache.flink.kubernetes.kubeclient.resources.KubernetesService;
+import org.apache.flink.kubernetes.kubeclient.decorators.ExternalServiceDecorator;
 import org.apache.flink.runtime.security.SecurityUtils;
 import org.apache.flink.util.FlinkException;
 
@@ -109,7 +109,7 @@ public class KubernetesSessionCli {
             // Retrieve or create a session cluster.
             if (clusterId != null
                     && kubeClient
-                            .getService(KubernetesService.ServiceType.REST_SERVICE, clusterId)
+                            .getService(ExternalServiceDecorator.getExternalServiceName(clusterId))
                             .isPresent()) {
                 clusterClient = kubernetesClusterDescriptor.retrieve(clusterId).getClusterClient();
             } else {

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/entrypoint/KubernetesEntrypointUtils.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/entrypoint/KubernetesEntrypointUtils.java
@@ -32,13 +32,8 @@ import org.apache.flink.kubernetes.utils.KubernetesUtils;
 import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
 import org.apache.flink.util.Preconditions;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /** This class contains utility methods for the {@link KubernetesSessionClusterEntrypoint}. */
 class KubernetesEntrypointUtils {
-
-    private static final Logger LOG = LoggerFactory.getLogger(KubernetesEntrypointUtils.class);
 
     /**
      * For non-HA cluster, {@link JobManagerOptions#ADDRESS} has be set to Kubernetes service name

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/FlinkKubeClient.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/FlinkKubeClient.java
@@ -76,12 +76,10 @@ public interface FlinkKubeClient extends AutoCloseable {
     /**
      * Get the kubernetes service of the given flink clusterId.
      *
-     * @param serviceType Internal/Rest
-     * @param clusterId cluster id
-     * @return Return the optional rest service of the specified cluster id.
+     * @param serviceName the name of the service
+     * @return Return the optional kubernetes service of the specified name.
      */
-    Optional<KubernetesService> getService(
-            KubernetesService.ServiceType serviceType, String clusterId);
+    Optional<KubernetesService> getService(String serviceName);
 
     /**
      * Get the rest endpoint for access outside cluster.
@@ -207,16 +205,13 @@ public interface FlinkKubeClient extends AutoCloseable {
     /**
      * Update the target ports of the given Kubernetes service.
      *
-     * @param serviceType The service type which needs to be updated
+     * @param serviceName The name of the service which needs to be updated
      * @param portName The port name which needs to be updated
      * @param targetPort The updated target port
      * @return Return the update service target port future
      */
     CompletableFuture<Void> updateServiceTargetPort(
-            KubernetesService.ServiceType serviceType,
-            String clusterId,
-            String portName,
-            int targetPort);
+            String serviceName, String portName, int targetPort);
 
     /** Callback handler for kubernetes resources. */
     interface WatchCallbackHandler<T> {

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/ExternalServiceDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/ExternalServiceDecorator.java
@@ -55,7 +55,10 @@ public class ExternalServiceDecorator extends AbstractKubernetesStepDecorator {
         return clusterId + Constants.FLINK_REST_SERVICE_SUFFIX;
     }
 
-    /** Generate namespaced name of the external rest Service. */
+    /**
+     * Generate namespaced name of the external rest Service by cluster Id, This is used by other
+     * project, so do not delete it.
+     */
     public static String getNamespacedExternalServiceName(String clusterId, String namespace) {
         return getExternalServiceName(clusterId) + "." + namespace;
     }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/resources/KubernetesService.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/resources/KubernetesService.java
@@ -26,10 +26,4 @@ public class KubernetesService extends KubernetesResource<Service> {
     public KubernetesService(Service internalResource) {
         super(internalResource);
     }
-
-    /** The flink service type. */
-    public enum ServiceType {
-        REST_SERVICE,
-        INTERNAL_SERVICE,
-    }
 }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/services/ClusterIPService.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/services/ClusterIPService.java
@@ -19,9 +19,15 @@
 package org.apache.flink.kubernetes.kubeclient.services;
 
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
+import org.apache.flink.kubernetes.kubeclient.Endpoint;
 import org.apache.flink.kubernetes.kubeclient.parameters.KubernetesJobManagerParameters;
+import org.apache.flink.kubernetes.utils.KubernetesUtils;
 
 import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServicePort;
+import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
+
+import java.util.Optional;
 
 /** The service type of ClusterIP. */
 public class ClusterIPService extends ServiceType {
@@ -32,6 +38,23 @@ public class ClusterIPService extends ServiceType {
     public Service buildUpInternalService(
             KubernetesJobManagerParameters kubernetesJobManagerParameters) {
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<Endpoint> getRestEndpoint(
+            Service targetService,
+            NamespacedKubernetesClient internalClient,
+            KubernetesConfigOptions.NodePortAddressType nodePortAddressType) {
+        int restPort = getRestPortFromExternalService(targetService);
+
+        // Return the external service.namespace directly when using ClusterIP.
+        return Optional.of(
+                new Endpoint(KubernetesUtils.getNamespacedServiceName(targetService), restPort));
+    }
+
+    @Override
+    public int getRestPort(ServicePort port) {
+        return port.getPort();
     }
 
     @Override

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/services/LoadBalancerService.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/services/LoadBalancerService.java
@@ -19,13 +19,23 @@
 package org.apache.flink.kubernetes.kubeclient.services;
 
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
+import org.apache.flink.kubernetes.kubeclient.Endpoint;
 import org.apache.flink.kubernetes.kubeclient.parameters.KubernetesJobManagerParameters;
 
+import io.fabric8.kubernetes.api.model.LoadBalancerStatus;
+import io.fabric8.kubernetes.api.model.NodeAddress;
 import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServicePort;
+import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
 
 /** The service type of LoadBalancer. */
 public class LoadBalancerService extends ServiceType {
 
+    private static final Logger LOG = LoggerFactory.getLogger(LoadBalancerService.class);
     public static final LoadBalancerService INSTANCE = new LoadBalancerService();
 
     @Override
@@ -35,7 +45,89 @@ public class LoadBalancerService extends ServiceType {
     }
 
     @Override
+    public Optional<Endpoint> getRestEndpoint(
+            Service targetService,
+            NamespacedKubernetesClient internalClient,
+            KubernetesConfigOptions.NodePortAddressType nodePortAddressType) {
+        int restPort = getRestPortFromExternalService(targetService);
+        return getRestEndPointFromService(
+                internalClient, nodePortAddressType, targetService, restPort);
+    }
+
+    @Override
+    public int getRestPort(ServicePort port) {
+        return port.getPort();
+    }
+
+    @Override
     public String getType() {
         return KubernetesConfigOptions.ServiceExposedType.LoadBalancer.name();
+    }
+
+    private Optional<Endpoint> getRestEndPointFromService(
+            NamespacedKubernetesClient internalClient,
+            KubernetesConfigOptions.NodePortAddressType nodePortAddressType,
+            Service service,
+            int restPort) {
+        if (service.getStatus() == null) {
+            return Optional.empty();
+        }
+
+        LoadBalancerStatus loadBalancer = service.getStatus().getLoadBalancer();
+        boolean hasExternalIP =
+                service.getSpec() != null
+                        && service.getSpec().getExternalIPs() != null
+                        && !service.getSpec().getExternalIPs().isEmpty();
+
+        if (loadBalancer != null) {
+            return getLoadBalancerRestEndpoint(
+                    internalClient, nodePortAddressType, loadBalancer, restPort);
+        } else if (hasExternalIP) {
+            final String address = service.getSpec().getExternalIPs().get(0);
+            if (address != null && !address.isEmpty()) {
+                return Optional.of(new Endpoint(address, restPort));
+            }
+        }
+        return Optional.empty();
+    }
+
+    private Optional<Endpoint> getLoadBalancerRestEndpoint(
+            NamespacedKubernetesClient internalClient,
+            KubernetesConfigOptions.NodePortAddressType nodePortAddressType,
+            LoadBalancerStatus loadBalancer,
+            int restPort) {
+        boolean hasIngress =
+                loadBalancer.getIngress() != null && !loadBalancer.getIngress().isEmpty();
+        String address;
+        if (hasIngress) {
+            address = loadBalancer.getIngress().get(0).getIp();
+            // Use hostname when the ip address is null
+            if (address == null || address.isEmpty()) {
+                address = loadBalancer.getIngress().get(0).getHostname();
+            }
+        } else {
+            // Use node port. Node port is accessible on any node within kubernetes cluster. We'll
+            // only consider IPs with the configured address type.
+            address =
+                    internalClient.nodes().list().getItems().stream()
+                            .flatMap(node -> node.getStatus().getAddresses().stream())
+                            .filter(
+                                    nodeAddress ->
+                                            nodePortAddressType
+                                                    .name()
+                                                    .equals(nodeAddress.getType()))
+                            .map(NodeAddress::getAddress)
+                            .filter(ip -> !ip.isEmpty())
+                            .findAny()
+                            .orElse(null);
+            if (address == null) {
+                LOG.warn(
+                        "Unable to find any node ip with type [{}]. Please see [{}] config option for more details.",
+                        nodePortAddressType,
+                        KubernetesConfigOptions.REST_SERVICE_EXPOSED_NODE_PORT_ADDRESS_TYPE.key());
+            }
+        }
+        boolean noAddress = address == null || address.isEmpty();
+        return noAddress ? Optional.empty() : Optional.of(new Endpoint(address, restPort));
     }
 }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/services/NodePortService.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/services/NodePortService.java
@@ -19,13 +19,23 @@
 package org.apache.flink.kubernetes.kubeclient.services;
 
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
+import org.apache.flink.kubernetes.kubeclient.Endpoint;
 import org.apache.flink.kubernetes.kubeclient.parameters.KubernetesJobManagerParameters;
+import org.apache.flink.util.StringUtils;
 
+import io.fabric8.kubernetes.api.model.NodeAddress;
 import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServicePort;
+import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
 
 /** The service type of NodePort. */
 public class NodePortService extends ServiceType {
 
+    private static final Logger LOG = LoggerFactory.getLogger(NodePortService.class);
     public static final NodePortService INSTANCE = new NodePortService();
 
     private NodePortService() {}
@@ -34,6 +44,44 @@ public class NodePortService extends ServiceType {
     public Service buildUpInternalService(
             KubernetesJobManagerParameters kubernetesJobManagerParameters) {
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<Endpoint> getRestEndpoint(
+            Service targetService,
+            NamespacedKubernetesClient internalClient,
+            KubernetesConfigOptions.NodePortAddressType nodePortAddressType) {
+        if (targetService.getStatus() == null) {
+            return Optional.empty();
+        }
+
+        String address;
+        // Node port is accessible on any node within kubernetes cluster. We'll
+        // only consider IPs with the configured address type.
+        address =
+                internalClient.nodes().list().getItems().stream()
+                        .flatMap(node -> node.getStatus().getAddresses().stream())
+                        .filter(
+                                nodeAddress ->
+                                        nodePortAddressType.name().equals(nodeAddress.getType()))
+                        .map(NodeAddress::getAddress)
+                        .filter(ip -> !ip.isEmpty())
+                        .findAny()
+                        .orElse(null);
+        if (address == null) {
+            LOG.warn(
+                    "Unable to find any node ip with type [{}]. Please see [{}] config option for more details.",
+                    nodePortAddressType,
+                    KubernetesConfigOptions.REST_SERVICE_EXPOSED_NODE_PORT_ADDRESS_TYPE.key());
+        }
+        return StringUtils.isNullOrWhitespaceOnly(address)
+                ? Optional.empty()
+                : Optional.of(new Endpoint(address, getRestPortFromExternalService(targetService)));
+    }
+
+    @Override
+    public int getRestPort(ServicePort port) {
+        return port.getNodePort();
     }
 
     @Override

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
@@ -61,6 +61,7 @@ import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
+import io.fabric8.kubernetes.api.model.Service;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -614,6 +615,11 @@ public class KubernetesUtils {
 
     public static String extractLeaderName(String key) {
         return key.substring(LEADER_PREFIX.length());
+    }
+
+    /** Generate namespaced name of the service. */
+    public static String getNamespacedServiceName(Service service) {
+        return service.getMetadata().getName() + "." + service.getMetadata().getNamespace();
     }
 
     private KubernetesUtils() {}

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesClientTestBase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesClientTestBase.java
@@ -211,6 +211,7 @@ public class KubernetesClientTestBase extends KubernetesTestBase {
                 new ServiceBuilder()
                         .editOrNewMetadata()
                         .withName(ExternalServiceDecorator.getExternalServiceName(CLUSTER_ID))
+                        .withNamespace(NAMESPACE)
                         .endMetadata()
                         .editOrNewSpec()
                         .withType(serviceExposedType.name())

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClientTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClientTest.java
@@ -30,11 +30,11 @@ import org.apache.flink.kubernetes.configuration.KubernetesConfigOptionsInternal
 import org.apache.flink.kubernetes.configuration.KubernetesDeploymentTarget;
 import org.apache.flink.kubernetes.entrypoint.KubernetesSessionClusterEntrypoint;
 import org.apache.flink.kubernetes.kubeclient.decorators.ExternalServiceDecorator;
+import org.apache.flink.kubernetes.kubeclient.decorators.InternalServiceDecorator;
 import org.apache.flink.kubernetes.kubeclient.factory.KubernetesJobManagerFactory;
 import org.apache.flink.kubernetes.kubeclient.parameters.KubernetesJobManagerParameters;
 import org.apache.flink.kubernetes.kubeclient.resources.KubernetesConfigMap;
 import org.apache.flink.kubernetes.kubeclient.resources.KubernetesPod;
-import org.apache.flink.kubernetes.kubeclient.resources.KubernetesService;
 import org.apache.flink.kubernetes.utils.Constants;
 import org.apache.flink.runtime.persistence.PossibleInconsistentStateException;
 import org.apache.flink.util.concurrent.ExecutorThreadFactory;
@@ -172,12 +172,10 @@ public class Fabric8FlinkKubeClientTest extends KubernetesClientTestBase {
         this.flinkKubeClient.createJobManagerComponent(this.kubernetesJobManagerSpecification);
 
         final int expectedRestPort = 9081;
+        final String restServiceName = ExternalServiceDecorator.getExternalServiceName(CLUSTER_ID);
         flinkKubeClient
                 .updateServiceTargetPort(
-                        KubernetesService.ServiceType.REST_SERVICE,
-                        CLUSTER_ID,
-                        Constants.REST_PORT_NAME,
-                        expectedRestPort)
+                        restServiceName, Constants.REST_PORT_NAME, expectedRestPort)
                 .get();
         final int updatedRestPort =
                 getServiceTargetPort(
@@ -190,12 +188,11 @@ public class Fabric8FlinkKubeClientTest extends KubernetesClientTestBase {
         this.flinkKubeClient.createJobManagerComponent(this.kubernetesJobManagerSpecification);
 
         final int expectedBlobPort = 9082;
+        final String internalServiceName =
+                InternalServiceDecorator.getInternalServiceName(CLUSTER_ID);
         flinkKubeClient
                 .updateServiceTargetPort(
-                        KubernetesService.ServiceType.INTERNAL_SERVICE,
-                        CLUSTER_ID,
-                        Constants.BLOB_SERVER_PORT_NAME,
-                        expectedBlobPort)
+                        internalServiceName, Constants.BLOB_SERVER_PORT_NAME, expectedBlobPort)
                 .get();
         final int updatedBlobPort =
                 getServiceTargetPort(CLUSTER_ID, Constants.BLOB_SERVER_PORT_NAME);

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/TestingFlinkKubeClient.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/TestingFlinkKubeClient.java
@@ -138,8 +138,7 @@ public class TestingFlinkKubeClient implements FlinkKubeClient {
     }
 
     @Override
-    public Optional<KubernetesService> getService(
-            KubernetesService.ServiceType serviceType, String clusterId) {
+    public Optional<KubernetesService> getService(String serviceName) {
         throw new UnsupportedOperationException();
     }
 
@@ -211,10 +210,7 @@ public class TestingFlinkKubeClient implements FlinkKubeClient {
 
     @Override
     public CompletableFuture<Void> updateServiceTargetPort(
-            KubernetesService.ServiceType serviceType,
-            String clusterId,
-            String portName,
-            int targetPort) {
+            String serviceName, String portName, int targetPort) {
         throw new UnsupportedOperationException();
     }
 


### PR DESCRIPTION
## What is the purpose of the change

This pull request is meant to improve the implementation of `Fabric8FlinkKubeClient#getRestEndpoint`. It's mainly done threes things

- Refactor the FlinkKubeClient interface `getService` and `updateServiceTargetPort` to deal with service name directly which will eliminate the unnecessary enum of `KubernetesService.ServiceType`.
- Port `Fabric8FlinkKubeClient#getRestEndpoint` method to the specific service type subclass
- Remove the implicit behavior to use the Service externalIP as the address of the Endpoint which is the purpose of [FLINK-17232](https://issues.apache.org/jira/browse/FLINK-17232).  I think it can be safely removed as i comments in the jira. Please correct me if I'm wrong. Or If I need to create a separate pull request for that issue, please let me know.

## Verifying this change

This change is already covered by existing tests `Fabric8FlinkKubeClientTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes)
  - The S3 file system connector: (no)
