### PR TITLE
[FLINK-26320][DOC]update hive doc for 1 m->1 min

### DIFF
--- a/docs/content.zh/docs/connectors/table/hive/hive_read_write.md
+++ b/docs/content.zh/docs/connectors/table/hive/hive_read_write.md
@@ -73,7 +73,7 @@ of new files in the folder and read new files incrementally.
         <td style="word-wrap: break-word;">None</td>
         <td>Duration</td>
         <td>Time interval for consecutively monitoring partition/file.
-            Notes: The default interval for hive streaming reading is '1 m', the default interval for hive streaming temporal join is '60 m', this is because there's one framework limitation that every TM will visit the Hive metaStore in current hive streaming temporal join implementation which may produce pressure to metaStore, this will improve in the future.</td>
+            Notes: The default interval for hive streaming reading is '1 min', the default interval for hive streaming temporal join is '60 min', this is because there's one framework limitation that every TM will visit the Hive metaStore in current hive streaming temporal join implementation which may produce pressure to metaStore, this will improve in the future.</td>
     </tr>
     <tr>
         <td><h5>streaming-source.partition-order</h5></td>

--- a/docs/content/docs/connectors/table/hive/hive_read_write.md
+++ b/docs/content/docs/connectors/table/hive/hive_read_write.md
@@ -73,7 +73,7 @@ of new files in the folder and read new files incrementally.
         <td style="word-wrap: break-word;">None</td>
         <td>Duration</td>
         <td>Time interval for consecutively monitoring partition/file.
-            Notes: The default interval for hive streaming reading is '1 m', the default interval for hive streaming temporal join is '60 m', this is because there's one framework limitation that every TM will visit the Hive metaStore in current hive streaming temporal join implementation which may produce pressure to metaStore, this will improve in the future.</td>
+            Notes: The default interval for hive streaming reading is '1 min', the default interval for hive streaming temporal join is '60 min', this is because there's one framework limitation that every TM will visit the Hive metaStore in current hive streaming temporal join implementation which may produce pressure to metaStore, this will improve in the future.</td>
     </tr>
     <tr>
         <td><h5>streaming-source.partition-order</h5></td>


### PR DESCRIPTION
## What is the purpose of the change
`Time interval unit label 'm' does not match any of the recognized units: DAYS: (d | day | days), HOURS: (h | hour | hours), MINUTES: (min | minute | minutes), SECONDS: (s | sec | secs | second | seconds), MILLISECONDS: (ms | milli | millis | millisecond | milliseconds), MICROSECONDS: (µs | micro | micros | microsecond | microseconds), NANOSECONDS: (ns | nano | nanos | nanosecond | nanoseconds)`

‘1 m’ is misleading when we used, which is not  correct.

![image](https://user-images.githubusercontent.com/18002496/155277924-4b54e3d8-5322-49d7-a96e-3536f4f1958c.png)

## Documentation

  - Does this pull request introduce a new feature? (yes )
  - If yes, how is the feature documented? ( docs / JavaDocs )
