### PR TITLE
[FLINK-26119][connectors/common] AsyncSinkWriterStateSerializer to @PublicEvolving

### DIFF
--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/sink/writer/AsyncSinkWriterStateSerializer.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/sink/writer/AsyncSinkWriterStateSerializer.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.connector.base.sink.writer;
 
-import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 
 import java.io.ByteArrayInputStream;
@@ -36,7 +36,7 @@ import java.util.List;
  *
  * @param <RequestEntryT> Writer Request Entry type
  */
-@Internal
+@PublicEvolving
 public abstract class AsyncSinkWriterStateSerializer<RequestEntryT extends Serializable>
         implements SimpleVersionedSerializer<BufferedRequestState<RequestEntryT>> {
     private static final long DATA_IDENTIFIER = -1;


### PR DESCRIPTION
## What is the purpose of the change

`AsyncSinkWriterStateSerializer` is annotated `@Internal`, however downstream modules need to extend this class. Therefore it should be marked `@PublicEvolving`.

## Brief change log

- `AsyncSinkWriterStateSerializer` swtiched from `@Internal` to `@PublicEvolving`


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? n/a
