### PR TITLE
[FLINK-26118][connectors/common] Add support for AsyncSink to downscale with state

### DIFF
--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/sink/writer/AsyncSinkWriter.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/sink/writer/AsyncSinkWriter.java
@@ -271,7 +271,8 @@ public abstract class AsyncSinkWriter<InputT, RequestEntryT extends Serializable
                                     throw exception;
                                 },
                                 "A fatal exception occurred in the sink that cannot be recovered from or should not be retried.");
-        initialize(states);
+
+        initializeState(states);
     }
 
     private void registerCallback() {
@@ -429,17 +430,13 @@ public abstract class AsyncSinkWriter<InputT, RequestEntryT extends Serializable
         return Collections.singletonList(new BufferedRequestState<>((bufferedRequestEntries)));
     }
 
-    protected void initialize(Collection<BufferedRequestState<RequestEntryT>> states) {
-        if (states.isEmpty()) {
-            return;
+    private void initializeState(Collection<BufferedRequestState<RequestEntryT>> states) {
+        for (BufferedRequestState<RequestEntryT> state : states) {
+            initializeState(state);
         }
+    }
 
-        if (states.size() > 1) {
-            throw new IllegalStateException(
-                    "Writer failed to initialize due to multiple initial states.");
-        }
-
-        BufferedRequestState<RequestEntryT> state = states.iterator().next();
+    private void initializeState(BufferedRequestState<RequestEntryT> state) {
         this.bufferedRequestEntries.addAll(state.getBufferedRequestEntries());
 
         for (RequestEntryWrapper<RequestEntryT> wrapper : bufferedRequestEntries) {
@@ -451,7 +448,7 @@ public abstract class AsyncSinkWriter<InputT, RequestEntryT extends Serializable
             }
         }
 
-        this.bufferedRequestEntriesTotalSizeInBytes = state.getStateSize();
+        this.bufferedRequestEntriesTotalSizeInBytes += state.getStateSize();
     }
 
     @Override

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/sink/writer/AsyncSinkWriterTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/sink/writer/AsyncSinkWriterTest.java
@@ -63,13 +63,7 @@ public class AsyncSinkWriterTest {
     private void performNormalWriteOfEightyRecordsToMock()
             throws IOException, InterruptedException {
         AsyncSinkWriterImpl sink =
-                new AsyncSinkWriterImplBuilder()
-                        .context(sinkInitContext)
-                        .maxBatchSize(10)
-                        .maxInFlightRequests(1)
-                        .maxBufferedRequests(100)
-                        .simulateFailures(false)
-                        .build();
+                new AsyncSinkWriterImplBuilder().context(sinkInitContext).build();
         for (int i = 0; i < 80; i++) {
             sink.write(String.valueOf(i));
         }
@@ -98,9 +92,6 @@ public class AsyncSinkWriterTest {
                 new AsyncSinkWriterImplBuilder()
                         .context(sinkInitContext)
                         .maxBatchSize(2)
-                        .maxInFlightRequests(1)
-                        .maxBufferedRequests(100)
-                        .simulateFailures(false)
                         .delay(100)
                         .build();
         for (int i = 0; i < 4; i++) {
@@ -114,13 +105,7 @@ public class AsyncSinkWriterTest {
     public void testThatUnwrittenRecordsInBufferArePersistedWhenSnapshotIsTaken()
             throws IOException, InterruptedException {
         AsyncSinkWriterImpl sink =
-                new AsyncSinkWriterImplBuilder()
-                        .context(sinkInitContext)
-                        .maxBatchSize(10)
-                        .maxInFlightRequests(1)
-                        .maxBufferedRequests(100)
-                        .simulateFailures(false)
-                        .build();
+                new AsyncSinkWriterImplBuilder().context(sinkInitContext).build();
         for (int i = 0; i < 23; i++) {
             sink.write(String.valueOf(i));
         }
@@ -134,12 +119,8 @@ public class AsyncSinkWriterTest {
         AsyncSinkWriterImpl sink =
                 new AsyncSinkWriterImplBuilder()
                         .context(sinkInitContext)
-                        .maxBatchSize(10)
-                        .maxInFlightRequests(1)
-                        .maxBufferedRequests(100)
                         .maxBatchSizeInBytes(12)
                         .maxRecordSizeInBytes(4)
-                        .simulateFailures(false)
                         .build();
         sink.write("1"); // 4 bytes per record
         sink.write("2"); // to give 12 bytes in final flush
@@ -151,13 +132,7 @@ public class AsyncSinkWriterTest {
     public void testPreparingCommitAtSnapshotTimeEnsuresBufferedRecordsArePersistedToDestination()
             throws IOException, InterruptedException {
         AsyncSinkWriterImpl sink =
-                new AsyncSinkWriterImplBuilder()
-                        .context(sinkInitContext)
-                        .maxBatchSize(10)
-                        .maxInFlightRequests(1)
-                        .maxBufferedRequests(100)
-                        .simulateFailures(false)
-                        .build();
+                new AsyncSinkWriterImplBuilder().context(sinkInitContext).build();
         for (int i = 0; i < 23; i++) {
             sink.write(String.valueOf(i));
         }
@@ -169,13 +144,7 @@ public class AsyncSinkWriterTest {
     public void testThatMailboxYieldDoesNotBlockWhileATimerIsRegisteredAndHasYetToElapse()
             throws Exception {
         AsyncSinkWriterImpl sink =
-                new AsyncSinkWriterImplBuilder()
-                        .context(sinkInitContext)
-                        .maxBatchSize(10)
-                        .maxInFlightRequests(1)
-                        .maxBufferedRequests(100)
-                        .simulateFailures(false)
-                        .build();
+                new AsyncSinkWriterImplBuilder().context(sinkInitContext).build();
         sink.write(String.valueOf(0));
         sink.flush(true);
         assertEquals(1, res.size());
@@ -185,13 +154,7 @@ public class AsyncSinkWriterTest {
     public void testThatSnapshotsAreTakenOfBufferCorrectlyBeforeAndAfterAutomaticFlush()
             throws IOException, InterruptedException {
         AsyncSinkWriterImpl sink =
-                new AsyncSinkWriterImplBuilder()
-                        .context(sinkInitContext)
-                        .maxBatchSize(3)
-                        .maxInFlightRequests(1)
-                        .maxBufferedRequests(100)
-                        .simulateFailures(false)
-                        .build();
+                new AsyncSinkWriterImplBuilder().context(sinkInitContext).maxBatchSize(3).build();
 
         sink.write("25");
         sink.write("55");
@@ -206,13 +169,7 @@ public class AsyncSinkWriterTest {
     public void writeFiveRecordsWithOneFailingThenCallPrepareCommitWithFlushing()
             throws IOException, InterruptedException {
         AsyncSinkWriterImpl sink =
-                new AsyncSinkWriterImplBuilder()
-                        .context(sinkInitContext)
-                        .maxBatchSize(3)
-                        .maxInFlightRequests(1)
-                        .maxBufferedRequests(100)
-                        .simulateFailures(false)
-                        .build();
+                new AsyncSinkWriterImplBuilder().context(sinkInitContext).maxBatchSize(3).build();
 
         sink.write("25");
         sink.write("55");
@@ -246,8 +203,6 @@ public class AsyncSinkWriterTest {
                 new AsyncSinkWriterImplBuilder()
                         .context(sinkInitContext)
                         .maxBatchSize(3)
-                        .maxInFlightRequests(1)
-                        .maxBufferedRequests(100)
                         .simulateFailures(true)
                         .build();
 
@@ -270,8 +225,7 @@ public class AsyncSinkWriterTest {
                 new AsyncSinkWriterImplBuilder()
                         .context(sinkInitContext)
                         .maxBatchSize(3)
-                        .maxInFlightRequests(1)
-                        .maxBufferedRequests(100)
+                        .maxBatchSizeInBytes(10_000_000)
                         .simulateFailures(true)
                         .build();
 
@@ -334,8 +288,6 @@ public class AsyncSinkWriterTest {
                 new AsyncSinkWriterImplBuilder()
                         .context(sinkInitContext)
                         .maxBatchSize(3)
-                        .maxInFlightRequests(1)
-                        .maxBufferedRequests(100)
                         .simulateFailures(true)
                         .build();
 
@@ -369,10 +321,7 @@ public class AsyncSinkWriterTest {
                         () ->
                                 new AsyncSinkWriterImplBuilder()
                                         .context(sinkInitContext)
-                                        .maxBatchSize(10)
-                                        .maxInFlightRequests(1)
                                         .maxBufferedRequests(10)
-                                        .simulateFailures(false)
                                         .build());
         assertEquals(
                 "The maximum number of requests that may be buffered should be "
@@ -388,12 +337,9 @@ public class AsyncSinkWriterTest {
                         () ->
                                 new AsyncSinkWriterImplBuilder()
                                         .context(sinkInitContext)
-                                        .maxBatchSize(10)
-                                        .maxInFlightRequests(1)
                                         .maxBufferedRequests(11)
                                         .maxBatchSizeInBytes(10_000)
                                         .maxRecordSizeInBytes(10_001)
-                                        .simulateFailures(false)
                                         .build());
         assertEquals(
                 "The maximum allowed size in bytes per flush must be greater than or equal to the maximum allowed size in bytes of a single record.",
@@ -406,11 +352,9 @@ public class AsyncSinkWriterTest {
                 new AsyncSinkWriterImplBuilder()
                         .context(sinkInitContext)
                         .maxBatchSize(3)
-                        .maxInFlightRequests(1)
                         .maxBufferedRequests(11)
                         .maxBatchSizeInBytes(10_000)
                         .maxRecordSizeInBytes(3)
-                        .simulateFailures(false)
                         .build();
         Exception e = assertThrows(IllegalArgumentException.class, () -> sink.write("3"));
         assertEquals(
@@ -432,13 +376,8 @@ public class AsyncSinkWriterTest {
         AsyncSinkWriterImpl sink =
                 new AsyncSinkWriterImplBuilder()
                         .context(sinkInitContext)
-                        .maxBatchSize(10)
-                        .maxInFlightRequests(1)
-                        .maxBufferedRequests(100)
                         .maxBatchSizeInBytes(30)
-                        .maxTimeInBufferMS(1000)
                         .maxRecordSizeInBytes(30)
-                        .simulateFailures(false)
                         .build();
 
         /* Sink has flush threshold of 30 bytes, each integer is 4 bytes, therefore, flushing
@@ -457,13 +396,7 @@ public class AsyncSinkWriterTest {
     @Test
     public void prepareCommitDoesNotFlushElementsIfFlushIsSetToFalse() throws Exception {
         AsyncSinkWriterImpl sink =
-                new AsyncSinkWriterImplBuilder()
-                        .context(sinkInitContext)
-                        .maxBatchSize(10)
-                        .maxInFlightRequests(1)
-                        .maxBufferedRequests(100)
-                        .simulateFailures(false)
-                        .build();
+                new AsyncSinkWriterImplBuilder().context(sinkInitContext).build();
         sink.write(String.valueOf(0));
         sink.write(String.valueOf(1));
         sink.write(String.valueOf(2));
@@ -478,12 +411,8 @@ public class AsyncSinkWriterTest {
                 new AsyncSinkWriterImplBuilder()
                         .context(sinkInitContext)
                         .maxBatchSize(7)
-                        .maxInFlightRequests(1)
-                        .maxBufferedRequests(100)
                         .maxBatchSizeInBytes(32)
-                        .maxTimeInBufferMS(1000)
                         .maxRecordSizeInBytes(32)
-                        .simulateFailures(false)
                         .build();
 
         for (int i = 0; i < 7; i++) {
@@ -502,11 +431,6 @@ public class AsyncSinkWriterTest {
         AsyncSinkWriterImpl sink =
                 new AsyncSinkWriterImplBuilder()
                         .context(sinkInitContext)
-                        .maxBatchSize(10)
-                        .maxInFlightRequests(1)
-                        .maxBufferedRequests(100)
-                        .maxBatchSizeInBytes(110)
-                        .maxTimeInBufferMS(1000)
                         .maxRecordSizeInBytes(110)
                         .simulateFailures(true)
                         .build();
@@ -531,11 +455,7 @@ public class AsyncSinkWriterTest {
         AsyncSinkWriterImpl sink =
                 new AsyncSinkWriterImplBuilder()
                         .context(sinkInitContext)
-                        .maxBatchSize(10)
-                        .maxInFlightRequests(1)
-                        .maxBufferedRequests(100)
                         .maxBatchSizeInBytes(210)
-                        .maxTimeInBufferMS(1000)
                         .maxRecordSizeInBytes(110)
                         .simulateFailures(true)
                         .build();
@@ -564,7 +484,6 @@ public class AsyncSinkWriterTest {
                         .context(sinkInitContext)
                         .maxBatchSize(10)
                         .maxInFlightRequests(20)
-                        .maxBufferedRequests(100)
                         .maxBatchSizeInBytes(10_000)
                         .maxTimeInBufferMS(100)
                         .maxRecordSizeInBytes(10_000)
@@ -591,7 +510,6 @@ public class AsyncSinkWriterTest {
                         .context(sinkInitContext)
                         .maxBatchSize(10)
                         .maxInFlightRequests(20)
-                        .maxBufferedRequests(100)
                         .maxBatchSizeInBytes(10_000)
                         .maxTimeInBufferMS(100)
                         .maxRecordSizeInBytes(10_000)
@@ -615,7 +533,6 @@ public class AsyncSinkWriterTest {
                 new AsyncSinkWriterImplBuilder()
                         .context(sinkInitContext)
                         .maxBatchSize(3)
-                        .maxInFlightRequests(1)
                         .maxBufferedRequests(10)
                         .simulateFailures(true)
                         .build();
@@ -637,11 +554,6 @@ public class AsyncSinkWriterTest {
         AsyncSinkWriterImpl sink =
                 new AsyncSinkWriterImplBuilder()
                         .context(sinkInitContext)
-                        .maxBatchSize(10)
-                        .maxInFlightRequests(1)
-                        .maxBufferedRequests(100)
-                        .maxBatchSizeInBytes(110)
-                        .maxTimeInBufferMS(1000)
                         .maxRecordSizeInBytes(110)
                         .simulateFailures(true)
                         .build();
@@ -659,13 +571,7 @@ public class AsyncSinkWriterTest {
         AsyncSinkWriterImpl newSink =
                 new AsyncSinkWriterImplBuilder()
                         .context(sinkInitContext)
-                        .maxBatchSize(10)
-                        .maxInFlightRequests(1)
-                        .maxBufferedRequests(100)
-                        .maxBatchSizeInBytes(110)
-                        .maxTimeInBufferMS(1000)
                         .maxRecordSizeInBytes(110)
-                        .simulateFailures(false)
                         .buildWithState(states);
 
         newSink.write(String.valueOf(4)); //   Buffer:   12/15B; 3/10 elements; 0 inflight
@@ -680,11 +586,6 @@ public class AsyncSinkWriterTest {
         AsyncSinkWriterImpl sink =
                 new AsyncSinkWriterImplBuilder()
                         .context(sinkInitContext)
-                        .maxBatchSize(10)
-                        .maxInFlightRequests(1)
-                        .maxBufferedRequests(100)
-                        .maxBatchSizeInBytes(110)
-                        .maxTimeInBufferMS(1000)
                         .maxRecordSizeInBytes(110)
                         .simulateFailures(true)
                         .build();
@@ -697,13 +598,7 @@ public class AsyncSinkWriterTest {
                         () ->
                                 new AsyncSinkWriterImplBuilder()
                                         .context(sinkInitContext)
-                                        .maxBatchSize(10)
-                                        .maxInFlightRequests(1)
-                                        .maxBufferedRequests(100)
-                                        .maxBatchSizeInBytes(110)
-                                        .maxTimeInBufferMS(1000)
                                         .maxRecordSizeInBytes(15)
-                                        .simulateFailures(false)
                                         .buildWithState(states))
                 .withMessageContaining(
                         "State contains record of size 100 which exceeds sink maximum record size 15.");
@@ -716,7 +611,6 @@ public class AsyncSinkWriterTest {
                         .context(sinkInitContext)
                         .maxBatchSize(10)
                         .maxInFlightRequests(20)
-                        .maxBufferedRequests(100)
                         .maxBatchSizeInBytes(10_000)
                         .maxTimeInBufferMS(100)
                         .maxRecordSizeInBytes(10_000)
@@ -748,9 +642,6 @@ public class AsyncSinkWriterTest {
         AsyncSinkWriterImpl sink =
                 new AsyncSinkWriterImplBuilder()
                         .context(sinkInitContext)
-                        .maxBatchSize(10)
-                        .maxInFlightRequests(1)
-                        .maxBufferedRequests(100)
                         .maxBatchSizeInBytes(10_000)
                         .maxTimeInBufferMS(100)
                         .maxRecordSizeInBytes(10_000)
@@ -779,7 +670,6 @@ public class AsyncSinkWriterTest {
                         .context(sinkInitContext)
                         .maxBatchSize(10)
                         .maxInFlightRequests(20)
-                        .maxBufferedRequests(100)
                         .maxBatchSizeInBytes(10_000)
                         .maxTimeInBufferMS(100)
                         .maxRecordSizeInBytes(10_000)
@@ -802,7 +692,6 @@ public class AsyncSinkWriterTest {
                         .context(sinkInitContext)
                         .maxBatchSize(10)
                         .maxInFlightRequests(20)
-                        .maxBufferedRequests(100)
                         .maxBatchSizeInBytes(10_000)
                         .maxTimeInBufferMS(100)
                         .maxRecordSizeInBytes(10_000)
@@ -1071,14 +960,14 @@ public class AsyncSinkWriterTest {
     /** A builder for {@link AsyncSinkWriterImpl}. */
     private class AsyncSinkWriterImplBuilder {
 
-        private Boolean simulateFailures;
+        private boolean simulateFailures = false;
         private int delay = 0;
         private Sink.InitContext context;
-        private Integer maxBatchSize;
-        private Integer maxInFlightRequests;
-        private Integer maxBufferedRequests;
-        private long maxBatchSizeInBytes = 10000000;
-        private long maxTimeInBufferMS = 1000;
+        private int maxBatchSize = 10;
+        private int maxInFlightRequests = 1;
+        private int maxBufferedRequests = 100;
+        private long maxBatchSizeInBytes = 110;
+        private long maxTimeInBufferMS = 1_000;
         private long maxRecordSizeInBytes = maxBatchSizeInBytes;
 
         private AsyncSinkWriterImplBuilder context(Sink.InitContext context) {


### PR DESCRIPTION
## What is the purpose of the change

Add support for `AsyncSink` to downscale with state. `AsyncSinkWriter` can be restored from multiple `BufferedRequestState`

## Brief change log

- `AsyncSinkWriter` now handles multiple `BufferedRequestState`
- Added defaults to test `AsyncSinkWriter` to reduce complexity of test (in separate commit)

## Verifying this change

This change added tests and can be verified as follows:
- `AsyncSinkWriterTest::testRestoreFromMultipleStates`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: yes (state serializer)
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? n/a
