### PR TITLE
[FLINK-26151][streaming]Avoid inprogressfileRecoverable not be clean up after restoring the bucket

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/Bucket.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/Bucket.java
@@ -142,6 +142,7 @@ public class Bucket<IN, BucketID> {
                             bucketId,
                             inProgressFileRecoverable,
                             state.getInProgressFileCreationTime());
+            inProgressFileRecoverablesPerCheckpoint.put(Long.MIN_VALUE, inProgressFileRecoverable);
         } else {
             // if the writer does not support resume, then we close the
             // in-progress part and commit it, as done in the case of pending files.


### PR DESCRIPTION
## What is the purpose of the change

Avoid inprogressfileRecoverable not be clean up after restoring the bucket

## Brief change log

  inProgressFileRecoverable is added to inProgressFileRecoverablesPerCheckpoint when calling restoreInProgressFile


## Verifying this change

Added shouldCleanupOutdatedResumablesAfterResumed to cover this

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable