### PR TITLE
[hotfix][javadoc] Misprint in javadoc at QuadFunction.java

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/function/QuadFunction.java
+++ b/flink-core/src/main/java/org/apache/flink/util/function/QuadFunction.java
@@ -39,7 +39,7 @@ public interface QuadFunction<S, T, U, V, R> {
      * @param s the first function argument
      * @param t the second function argument
      * @param u the third function argument
-     * @oaram v the fourth function argument
+     * @param v the fourth function argument
      * @return the function result
      */
     R apply(S s, T t, U u, V v);


### PR DESCRIPTION


## What is the purpose of the change
This is a trivial PR fixing a misprint at `flink-core/src/main/java/org/apache/flink/util/function/QuadFunction.java`
`@oaram` => `@param`

## Verifying this change
This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no )
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
