### PR TITLE
[FLINK-26148][runtime] Change the format of adaptive batch scheduler config option to jobmanager.adaptive-batch-scheduler.XXX

### DIFF
--- a/docs/layouts/shortcodes/generated/all_jobmanager_section.html
+++ b/docs/layouts/shortcodes/generated/all_jobmanager_section.html
@@ -9,6 +9,30 @@
     </thead>
     <tbody>
         <tr>
+            <td><h5>jobmanager.adaptive-batch-scheduler.data-volume-per-task</h5></td>
+            <td style="word-wrap: break-word;">1 gb</td>
+            <td>MemorySize</td>
+            <td>The size of data volume to expect each task instance to process if <code class="highlighter-rouge">jobmanager.scheduler</code> has been set to <code class="highlighter-rouge">AdaptiveBatch</code></td>
+        </tr>
+        <tr>
+            <td><h5>jobmanager.adaptive-batch-scheduler.default-source-parallelism</h5></td>
+            <td style="word-wrap: break-word;">1</td>
+            <td>Integer</td>
+            <td>The default parallelism of source vertices if <code class="highlighter-rouge">jobmanager.scheduler</code> has been set to <code class="highlighter-rouge">AdaptiveBatch</code></td>
+        </tr>
+        <tr>
+            <td><h5>jobmanager.adaptive-batch-scheduler.max-parallelism</h5></td>
+            <td style="word-wrap: break-word;">128</td>
+            <td>Integer</td>
+            <td>The upper bound of allowed parallelism to set adaptively if <code class="highlighter-rouge">jobmanager.scheduler</code> has been set to <code class="highlighter-rouge">AdaptiveBatch</code></td>
+        </tr>
+        <tr>
+            <td><h5>jobmanager.adaptive-batch-scheduler.min-parallelism</h5></td>
+            <td style="word-wrap: break-word;">1</td>
+            <td>Integer</td>
+            <td>The lower bound of allowed parallelism to set adaptively if <code class="highlighter-rouge">jobmanager.scheduler</code> has been set to <code class="highlighter-rouge">AdaptiveBatch</code></td>
+        </tr>
+        <tr>
             <td><h5>jobmanager.adaptive-scheduler.min-parallelism-increase</h5></td>
             <td style="word-wrap: break-word;">1</td>
             <td>Integer</td>
@@ -91,30 +115,6 @@
             <td style="word-wrap: break-word;">6123</td>
             <td>Integer</td>
             <td>The config parameter defining the network port to connect to for communication with the job manager. Like jobmanager.rpc.address, this value is only interpreted in setups where a single JobManager with static name/address and port exists (simple standalone setups, or container setups with dynamic service name resolution). This config option is not used in many high-availability setups, when a leader-election service (like ZooKeeper) is used to elect and discover the JobManager leader from potentially multiple standby JobManagers.</td>
-        </tr>
-        <tr>
-            <td><h5>jobmanager.scheduler.adaptive-batch.data-volume-per-task</h5></td>
-            <td style="word-wrap: break-word;">1 gb</td>
-            <td>MemorySize</td>
-            <td>The size of data volume to expect each task instance to process if <code class="highlighter-rouge">jobmanager.scheduler</code> has been set to <code class="highlighter-rouge">AdaptiveBatch</code></td>
-        </tr>
-        <tr>
-            <td><h5>jobmanager.scheduler.adaptive-batch.max-parallelism</h5></td>
-            <td style="word-wrap: break-word;">128</td>
-            <td>Integer</td>
-            <td>The upper bound of allowed parallelism to set adaptively if <code class="highlighter-rouge">jobmanager.scheduler</code> has been set to <code class="highlighter-rouge">AdaptiveBatch</code></td>
-        </tr>
-        <tr>
-            <td><h5>jobmanager.scheduler.adaptive-batch.min-parallelism</h5></td>
-            <td style="word-wrap: break-word;">1</td>
-            <td>Integer</td>
-            <td>The lower bound of allowed parallelism to set adaptively if <code class="highlighter-rouge">jobmanager.scheduler</code> has been set to <code class="highlighter-rouge">AdaptiveBatch</code></td>
-        </tr>
-        <tr>
-            <td><h5>jobmanager.scheduler.adaptive-batch.source-parallelism.default</h5></td>
-            <td style="word-wrap: break-word;">1</td>
-            <td>Integer</td>
-            <td>The default parallelism of source vertices if <code class="highlighter-rouge">jobmanager.scheduler</code> has been set to <code class="highlighter-rouge">AdaptiveBatch</code></td>
         </tr>
         <tr>
             <td><h5>jobstore.cache-size</h5></td>

--- a/docs/layouts/shortcodes/generated/expert_scheduling_section.html
+++ b/docs/layouts/shortcodes/generated/expert_scheduling_section.html
@@ -27,6 +27,30 @@
             <td>Whether to convert all PIPELINE edges to BLOCKING when apply fine-grained resource management in batch jobs.</td>
         </tr>
         <tr>
+            <td><h5>jobmanager.adaptive-batch-scheduler.data-volume-per-task</h5></td>
+            <td style="word-wrap: break-word;">1 gb</td>
+            <td>MemorySize</td>
+            <td>The size of data volume to expect each task instance to process if <code class="highlighter-rouge">jobmanager.scheduler</code> has been set to <code class="highlighter-rouge">AdaptiveBatch</code></td>
+        </tr>
+        <tr>
+            <td><h5>jobmanager.adaptive-batch-scheduler.default-source-parallelism</h5></td>
+            <td style="word-wrap: break-word;">1</td>
+            <td>Integer</td>
+            <td>The default parallelism of source vertices if <code class="highlighter-rouge">jobmanager.scheduler</code> has been set to <code class="highlighter-rouge">AdaptiveBatch</code></td>
+        </tr>
+        <tr>
+            <td><h5>jobmanager.adaptive-batch-scheduler.max-parallelism</h5></td>
+            <td style="word-wrap: break-word;">128</td>
+            <td>Integer</td>
+            <td>The upper bound of allowed parallelism to set adaptively if <code class="highlighter-rouge">jobmanager.scheduler</code> has been set to <code class="highlighter-rouge">AdaptiveBatch</code></td>
+        </tr>
+        <tr>
+            <td><h5>jobmanager.adaptive-batch-scheduler.min-parallelism</h5></td>
+            <td style="word-wrap: break-word;">1</td>
+            <td>Integer</td>
+            <td>The lower bound of allowed parallelism to set adaptively if <code class="highlighter-rouge">jobmanager.scheduler</code> has been set to <code class="highlighter-rouge">AdaptiveBatch</code></td>
+        </tr>
+        <tr>
             <td><h5>jobmanager.adaptive-scheduler.min-parallelism-increase</h5></td>
             <td style="word-wrap: break-word;">1</td>
             <td>Integer</td>
@@ -43,30 +67,6 @@
             <td style="word-wrap: break-word;">5 min</td>
             <td>Duration</td>
             <td>The maximum time the JobManager will wait to acquire all required resources after a job submission or restart. Once elapsed it will try to run the job with a lower parallelism, or fail if the minimum amount of resources could not be acquired.<br />Increasing this value will make the cluster more resilient against temporary resources shortages (e.g., there is more time for a failed TaskManager to be restarted).<br />Setting a negative duration will disable the resource timeout: The JobManager will wait indefinitely for resources to appear.<br />If <code class="highlighter-rouge">scheduler-mode</code> is configured to <code class="highlighter-rouge">REACTIVE</code>, this configuration value will default to a negative value to disable the resource timeout.</td>
-        </tr>
-        <tr>
-            <td><h5>jobmanager.scheduler.adaptive-batch.data-volume-per-task</h5></td>
-            <td style="word-wrap: break-word;">1 gb</td>
-            <td>MemorySize</td>
-            <td>The size of data volume to expect each task instance to process if <code class="highlighter-rouge">jobmanager.scheduler</code> has been set to <code class="highlighter-rouge">AdaptiveBatch</code></td>
-        </tr>
-        <tr>
-            <td><h5>jobmanager.scheduler.adaptive-batch.max-parallelism</h5></td>
-            <td style="word-wrap: break-word;">128</td>
-            <td>Integer</td>
-            <td>The upper bound of allowed parallelism to set adaptively if <code class="highlighter-rouge">jobmanager.scheduler</code> has been set to <code class="highlighter-rouge">AdaptiveBatch</code></td>
-        </tr>
-        <tr>
-            <td><h5>jobmanager.scheduler.adaptive-batch.min-parallelism</h5></td>
-            <td style="word-wrap: break-word;">1</td>
-            <td>Integer</td>
-            <td>The lower bound of allowed parallelism to set adaptively if <code class="highlighter-rouge">jobmanager.scheduler</code> has been set to <code class="highlighter-rouge">AdaptiveBatch</code></td>
-        </tr>
-        <tr>
-            <td><h5>jobmanager.scheduler.adaptive-batch.source-parallelism.default</h5></td>
-            <td style="word-wrap: break-word;">1</td>
-            <td>Integer</td>
-            <td>The default parallelism of source vertices if <code class="highlighter-rouge">jobmanager.scheduler</code> has been set to <code class="highlighter-rouge">AdaptiveBatch</code></td>
         </tr>
         <tr>
             <td><h5>scheduler-mode</h5></td>

--- a/docs/layouts/shortcodes/generated/job_manager_configuration.html
+++ b/docs/layouts/shortcodes/generated/job_manager_configuration.html
@@ -9,6 +9,30 @@
     </thead>
     <tbody>
         <tr>
+            <td><h5>jobmanager.adaptive-batch-scheduler.data-volume-per-task</h5></td>
+            <td style="word-wrap: break-word;">1 gb</td>
+            <td>MemorySize</td>
+            <td>The size of data volume to expect each task instance to process if <code class="highlighter-rouge">jobmanager.scheduler</code> has been set to <code class="highlighter-rouge">AdaptiveBatch</code></td>
+        </tr>
+        <tr>
+            <td><h5>jobmanager.adaptive-batch-scheduler.default-source-parallelism</h5></td>
+            <td style="word-wrap: break-word;">1</td>
+            <td>Integer</td>
+            <td>The default parallelism of source vertices if <code class="highlighter-rouge">jobmanager.scheduler</code> has been set to <code class="highlighter-rouge">AdaptiveBatch</code></td>
+        </tr>
+        <tr>
+            <td><h5>jobmanager.adaptive-batch-scheduler.max-parallelism</h5></td>
+            <td style="word-wrap: break-word;">128</td>
+            <td>Integer</td>
+            <td>The upper bound of allowed parallelism to set adaptively if <code class="highlighter-rouge">jobmanager.scheduler</code> has been set to <code class="highlighter-rouge">AdaptiveBatch</code></td>
+        </tr>
+        <tr>
+            <td><h5>jobmanager.adaptive-batch-scheduler.min-parallelism</h5></td>
+            <td style="word-wrap: break-word;">1</td>
+            <td>Integer</td>
+            <td>The lower bound of allowed parallelism to set adaptively if <code class="highlighter-rouge">jobmanager.scheduler</code> has been set to <code class="highlighter-rouge">AdaptiveBatch</code></td>
+        </tr>
+        <tr>
             <td><h5>jobmanager.adaptive-scheduler.min-parallelism-increase</h5></td>
             <td style="word-wrap: break-word;">1</td>
             <td>Integer</td>
@@ -157,30 +181,6 @@
             <td style="word-wrap: break-word;">6123</td>
             <td>Integer</td>
             <td>The config parameter defining the network port to connect to for communication with the job manager. Like jobmanager.rpc.address, this value is only interpreted in setups where a single JobManager with static name/address and port exists (simple standalone setups, or container setups with dynamic service name resolution). This config option is not used in many high-availability setups, when a leader-election service (like ZooKeeper) is used to elect and discover the JobManager leader from potentially multiple standby JobManagers.</td>
-        </tr>
-        <tr>
-            <td><h5>jobmanager.scheduler.adaptive-batch.data-volume-per-task</h5></td>
-            <td style="word-wrap: break-word;">1 gb</td>
-            <td>MemorySize</td>
-            <td>The size of data volume to expect each task instance to process if <code class="highlighter-rouge">jobmanager.scheduler</code> has been set to <code class="highlighter-rouge">AdaptiveBatch</code></td>
-        </tr>
-        <tr>
-            <td><h5>jobmanager.scheduler.adaptive-batch.max-parallelism</h5></td>
-            <td style="word-wrap: break-word;">128</td>
-            <td>Integer</td>
-            <td>The upper bound of allowed parallelism to set adaptively if <code class="highlighter-rouge">jobmanager.scheduler</code> has been set to <code class="highlighter-rouge">AdaptiveBatch</code></td>
-        </tr>
-        <tr>
-            <td><h5>jobmanager.scheduler.adaptive-batch.min-parallelism</h5></td>
-            <td style="word-wrap: break-word;">1</td>
-            <td>Integer</td>
-            <td>The lower bound of allowed parallelism to set adaptively if <code class="highlighter-rouge">jobmanager.scheduler</code> has been set to <code class="highlighter-rouge">AdaptiveBatch</code></td>
-        </tr>
-        <tr>
-            <td><h5>jobmanager.scheduler.adaptive-batch.source-parallelism.default</h5></td>
-            <td style="word-wrap: break-word;">1</td>
-            <td>Integer</td>
-            <td>The default parallelism of source vertices if <code class="highlighter-rouge">jobmanager.scheduler</code> has been set to <code class="highlighter-rouge">AdaptiveBatch</code></td>
         </tr>
         <tr>
             <td><h5>jobstore.cache-size</h5></td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
@@ -541,7 +541,7 @@ public class JobManagerOptions {
         Documentation.Sections.ALL_JOB_MANAGER
     })
     public static final ConfigOption<Integer> ADAPTIVE_BATCH_SCHEDULER_MIN_PARALLELISM =
-            key("jobmanager.scheduler.adaptive-batch.min-parallelism")
+            key("jobmanager.adaptive-batch-scheduler.min-parallelism")
                     .intType()
                     .defaultValue(1)
                     .withDescription(
@@ -557,7 +557,7 @@ public class JobManagerOptions {
         Documentation.Sections.ALL_JOB_MANAGER
     })
     public static final ConfigOption<Integer> ADAPTIVE_BATCH_SCHEDULER_MAX_PARALLELISM =
-            key("jobmanager.scheduler.adaptive-batch.max-parallelism")
+            key("jobmanager.adaptive-batch-scheduler.max-parallelism")
                     .intType()
                     .defaultValue(128)
                     .withDescription(
@@ -573,7 +573,7 @@ public class JobManagerOptions {
         Documentation.Sections.ALL_JOB_MANAGER
     })
     public static final ConfigOption<MemorySize> ADAPTIVE_BATCH_SCHEDULER_DATA_VOLUME_PER_TASK =
-            key("jobmanager.scheduler.adaptive-batch.data-volume-per-task")
+            key("jobmanager.adaptive-batch-scheduler.data-volume-per-task")
                     .memoryType()
                     .defaultValue(MemorySize.ofMebiBytes(1024))
                     .withDescription(
@@ -589,7 +589,7 @@ public class JobManagerOptions {
         Documentation.Sections.ALL_JOB_MANAGER
     })
     public static final ConfigOption<Integer> ADAPTIVE_BATCH_SCHEDULER_DEFAULT_SOURCE_PARALLELISM =
-            key("jobmanager.scheduler.adaptive-batch.source-parallelism.default")
+            key("jobmanager.adaptive-batch-scheduler.default-source-parallelism")
                     .intType()
                     .defaultValue(1)
                     .withDescription(


### PR DESCRIPTION
## What is the purpose of the change

Change the format of adaptive batch scheduler config option to jobmanager.adaptive-batch-scheduler.XXX to align the format with the existing scheduler option (For example, jobmanager.adaptive-scheduler.min-parallelism-increase).

## Verifying this change

This change is already covered by existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**no**)
  - The serializers: (**no**)
  - The runtime per-record code paths (performance sensitive): (**no**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**no**)
  - The S3 file system connector: (**no**)

## Documentation

  - Does this pull request introduce a new feature? (**no**)
  - If yes, how is the feature documented? (**not applicable**)
