### PR TITLE
[FLINK-25941][streaming] Only emit committables with Long.MAX_VALUE as checkpoint id in batch mode

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/connector/sink2/GlobalCommitterOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/connector/sink2/GlobalCommitterOperator.java
@@ -114,15 +114,6 @@ class GlobalCommitterOperator<CommT> extends AbstractStreamOperator<Void>
         commit(lastCompletedCheckpointId);
     }
 
-    private Collection<? extends CheckpointCommittableManager<CommT>> getCommittables() {
-        final Collection<? extends CheckpointCommittableManager<CommT>> committables =
-                committableCollector.getEndOfInputCommittables();
-        if (committables == null) {
-            return Collections.emptyList();
-        }
-        return committables;
-    }
-
     private Collection<? extends CheckpointCommittableManager<CommT>> getCommittables(
             long checkpointId) {
         final Collection<? extends CheckpointCommittableManager<CommT>> committables =
@@ -142,11 +133,13 @@ class GlobalCommitterOperator<CommT> extends AbstractStreamOperator<Void>
 
     @Override
     public void endInput() throws Exception {
-        do {
-            for (CommittableManager<CommT> committable : getCommittables()) {
-                committable.commit(false, committer);
-            }
-        } while (!committableCollector.isFinished());
+        final CommittableManager<CommT> endOfInputCommittable =
+                committableCollector.getEndOfInputCommittable();
+        if (endOfInputCommittable != null) {
+            do {
+                endOfInputCommittable.commit(false, committer);
+            } while (!committableCollector.isFinished());
+        }
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/CommitterOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/CommitterOperatorFactory.java
@@ -42,9 +42,12 @@ public final class CommitterOperatorFactory<CommT>
                 CommittableMessage<CommT>, CommittableMessage<CommT>> {
 
     private final TwoPhaseCommittingSink<?, CommT> sink;
+    private final boolean isCheckpointingOrBatchModeEnabled;
 
-    public CommitterOperatorFactory(TwoPhaseCommittingSink<?, CommT> sink) {
+    public CommitterOperatorFactory(
+            TwoPhaseCommittingSink<?, CommT> sink, boolean isCheckpointingOrBatchModeEnabled) {
         this.sink = checkNotNull(sink);
+        this.isCheckpointingOrBatchModeEnabled = isCheckpointingOrBatchModeEnabled;
     }
 
     @Override
@@ -58,7 +61,8 @@ public final class CommitterOperatorFactory<CommT>
                             processingTimeService,
                             sink.getCommittableSerializer(),
                             sink.createCommitter(),
-                            sink instanceof WithPostCommitTopology);
+                            sink instanceof WithPostCommitTopology,
+                            isCheckpointingOrBatchModeEnabled);
             committerOperator.setup(
                     parameters.getContainingTask(),
                     parameters.getStreamConfig(),

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/SinkWriterOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/SinkWriterOperatorFactory.java
@@ -45,16 +45,26 @@ public final class SinkWriterOperatorFactory<InputT, CommT>
                 YieldingOperatorFactory<CommittableMessage<CommT>> {
 
     private final Sink<InputT> sink;
+    private final boolean isBatchMode;
+    private final boolean isCheckpointingEnabled;
 
-    public SinkWriterOperatorFactory(Sink<InputT> sink) {
+    public SinkWriterOperatorFactory(
+            Sink<InputT> sink, boolean isBatchMode, boolean isCheckpointingEnabled) {
         this.sink = checkNotNull(sink);
+        this.isBatchMode = isBatchMode;
+        this.isCheckpointingEnabled = isCheckpointingEnabled;
     }
 
     public <T extends StreamOperator<CommittableMessage<CommT>>> T createStreamOperator(
             StreamOperatorParameters<CommittableMessage<CommT>> parameters) {
         try {
             final SinkWriterOperator<InputT, CommT> writerOperator =
-                    new SinkWriterOperator<>(sink, processingTimeService, getMailboxExecutor());
+                    new SinkWriterOperator<>(
+                            sink,
+                            processingTimeService,
+                            getMailboxExecutor(),
+                            isBatchMode,
+                            isCheckpointingEnabled);
             writerOperator.setup(
                     parameters.getContainingTask(),
                     parameters.getStreamConfig(),

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommittableCollector.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommittableCollector.java
@@ -144,13 +144,14 @@ public class CommittableCollector<CommT> {
     }
 
     /**
-     * Returns all {@link CheckpointCommittableManager} that are currently hold by the collector.
+     * Returns {@link CheckpointCommittableManager} that is currently hold by the collector and
+     * associated with the {@link CommittableCollector#EOI} checkpoint id.
      *
-     * @return collection of {@link CheckpointCommittableManager}
+     * @return {@link CheckpointCommittableManager}
      */
     @Nullable
-    public Collection<? extends CheckpointCommittableManager<CommT>> getEndOfInputCommittables() {
-        return getCheckpointCommittablesUpTo(EOI);
+    public CommittableManager<CommT> getEndOfInputCommittable() {
+        return checkpointCommittables.get(EOI);
     }
 
     /**

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/connector/sink2/CommittableSummaryAssert.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/connector/sink2/CommittableSummaryAssert.java
@@ -20,6 +20,8 @@ package org.apache.flink.streaming.api.connector.sink2;
 
 import org.assertj.core.api.AbstractAssert;
 
+import javax.annotation.Nullable;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Custom assertions for {@link CommittableSummary}. */
@@ -57,6 +59,16 @@ public class CommittableSummaryAssert
     public CommittableSummaryAssert hasFailedCommittables(int committableNumber) {
         isNotNull();
         assertThat(actual.getNumberOfFailedCommittables()).isEqualTo(committableNumber);
+        return this;
+    }
+
+    public CommittableSummaryAssert hasCheckpointId(@Nullable Long checkpointId) {
+        isNotNull();
+        if (checkpointId == null) {
+            assertThat(actual.getCheckpointId()).isEmpty();
+        } else {
+            assertThat(actual.getCheckpointId()).hasValue(checkpointId);
+        }
         return this;
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/committables/CheckpointCommittableManagerImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/committables/CheckpointCommittableManagerImplTest.java
@@ -35,7 +35,7 @@ class CheckpointCommittableManagerImplTest {
     @Test
     void testAddSummary() {
         final CheckpointCommittableManagerImpl<Integer> checkpointCommittables =
-                new CheckpointCommittableManagerImpl<>(2, 1, 1);
+                new CheckpointCommittableManagerImpl<>(2, 1, 1L);
         assertThat(checkpointCommittables.getSubtaskCommittableManagers()).isEmpty();
 
         final CommittableSummary<Integer> first = new CommittableSummary<>(1, 1, 1L, 1, 0, 0);
@@ -59,7 +59,7 @@ class CheckpointCommittableManagerImplTest {
     @Test
     void testCommit() throws IOException, InterruptedException {
         final CheckpointCommittableManagerImpl<Integer> checkpointCommittables =
-                new CheckpointCommittableManagerImpl<Integer>(1, 1, 1);
+                new CheckpointCommittableManagerImpl<>(1, 1, 1L);
         checkpointCommittables.upsertSummary(new CommittableSummary<>(1, 1, 1L, 1, 0, 0));
         checkpointCommittables.upsertSummary(new CommittableSummary<>(2, 1, 1L, 2, 0, 0));
         checkpointCommittables.addCommittable(new CommittableWithLineage<>(3, 1L, 1));
@@ -83,7 +83,7 @@ class CheckpointCommittableManagerImplTest {
     @Test
     void testUpdateCommittableSummary() {
         final CheckpointCommittableManagerImpl<Integer> checkpointCommittables =
-                new CheckpointCommittableManagerImpl<Integer>(1, 1, 1);
+                new CheckpointCommittableManagerImpl<>(1, 1, 1L);
         checkpointCommittables.upsertSummary(new CommittableSummary<>(1, 1, 1L, 1, 0, 0));
         assertThatThrownBy(
                         () ->

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommittableCollectorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommittableCollectorTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.runtime.operators.sink.committables;
 
 import org.apache.flink.streaming.api.connector.sink2.CommittableSummary;
+import org.apache.flink.streaming.api.connector.sink2.SinkV2Assertions;
 
 import org.junit.jupiter.api.Test;
 
@@ -37,6 +38,19 @@ class CommittableCollectorTest {
 
         assertThat(committableCollector.getCheckpointCommittablesUpTo(2)).hasSize(2);
 
-        assertThat(committableCollector.getEndOfInputCommittables()).hasSize(3);
+        assertThat(committableCollector.getEndOfInputCommittable()).isNull();
+    }
+
+    @Test
+    void testGetEndOfInputCommittable() {
+        final CommittableCollector<Integer> committableCollector = new CommittableCollector<>(1, 1);
+        CommittableSummary<Integer> first = new CommittableSummary<>(1, 1, null, 1, 0, 0);
+        committableCollector.addMessage(first);
+
+        CommittableManager<Integer> endOfInputCommittable =
+                committableCollector.getEndOfInputCommittable();
+        assertThat(endOfInputCommittable).isNotNull();
+        SinkV2Assertions.assertThat(endOfInputCommittable.getSummary())
+                .hasCheckpointId(Long.MAX_VALUE);
     }
 }


### PR DESCRIPTION




<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Before this commit the SinkWriter and Committer operators emitted
committables on endInput. This was troublesome because by doing so the
checkpointId was set to effectively null/Long.MAX_VALUE because
the emission was not part of any checkpoint. With the completion of
FLIP-143 all jobs in streaming mode have a final checkpoint when they
transition to finish so we can rely on the normal checkpoint mechanism
and only need endInput for the batch execution.


## Brief change log

- CommitterOperator **only** emit on notifyCheckpointComplete in streaming mode
- GlobalCommitter **only** emit on notifyCheckpointComplete in streaming mode
- SinkWriter **only** emit on preSnapshotBarrier  in streaming mode

## Verifying this change

- Adjusted existing tests to verify the behaviour
- KafkaSinkITCase is now stable (ran 20 times locally without failure, previously it was failing every 2-3 runs)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
