### PR TITLE
[FLINK-26167][table-planner] Explicitly set the partitioner for the sql operators whose shuffle and sort are removed

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/InputProperty.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/InputProperty.java
@@ -269,17 +269,28 @@ public class InputProperty {
         }
     }
 
-    /** A special distribution which indicators the data distribution is the same as its input. */
+    /**
+     * A special distribution which indicators the data distribution is the same as its input. '
+     *
+     * <p>TODO This class can be removed once FLINK-21224 is finished.
+     */
     public static class KeepInputAsIsDistribution extends RequiredDistribution {
         private final RequiredDistribution inputDistribution;
+        /** whether the input distribution is strictly guaranteed. */
+        private final boolean strict;
 
-        private KeepInputAsIsDistribution(RequiredDistribution inputDistribution) {
+        private KeepInputAsIsDistribution(RequiredDistribution inputDistribution, boolean strict) {
             super(DistributionType.KEEP_INPUT_AS_IS);
             this.inputDistribution = checkNotNull(inputDistribution);
+            this.strict = strict;
         }
 
         public RequiredDistribution getInputDistribution() {
             return inputDistribution;
+        }
+
+        public boolean isStrict() {
+            return strict;
         }
 
         @Override
@@ -294,17 +305,21 @@ public class InputProperty {
                 return false;
             }
             KeepInputAsIsDistribution that = (KeepInputAsIsDistribution) o;
-            return inputDistribution.equals(that.inputDistribution);
+            return strict == that.strict && inputDistribution.equals(that.inputDistribution);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(super.hashCode(), inputDistribution);
+            return Objects.hash(super.hashCode(), strict, inputDistribution);
         }
 
         @Override
         public String toString() {
-            return "KEEP_INPUT_AS_IS(" + inputDistribution + ")";
+            if (strict) {
+                return "KEEP_INPUT_AS_IS(strict, " + inputDistribution + ")";
+            } else {
+                return "KEEP_INPUT_AS_IS(" + inputDistribution + ")";
+            }
         }
     }
 
@@ -321,10 +336,11 @@ public class InputProperty {
      * A special distribution which indicators the data distribution is the same as its input.
      *
      * @param inputDistribution the input distribution
+     * @param strict whether the input distribution is strictly guaranteed
      */
     public static KeepInputAsIsDistribution keepInputAsIsDistribution(
-            RequiredDistribution inputDistribution) {
-        return new KeepInputAsIsDistribution(inputDistribution);
+            RequiredDistribution inputDistribution, boolean strict) {
+        return new KeepInputAsIsDistribution(inputDistribution, strict);
     }
 
     /** Enumeration which describes the type of the input data distribution. */

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecOverAggregateBase.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecOverAggregateBase.java
@@ -40,7 +40,7 @@ import java.util.List;
 
 /** Batch {@link ExecNode} base class for sort-based over window aggregate. */
 public abstract class BatchExecOverAggregateBase extends ExecNodeBase<RowData>
-        implements BatchExecNode<RowData>, SingleTransformationTranslator<RowData> {
+        implements InputSortedExecNode<RowData>, SingleTransformationTranslator<RowData> {
 
     protected final OverSpec overSpec;
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecRank.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecRank.java
@@ -41,7 +41,7 @@ import java.util.Collections;
  *
  * <p>This node supports two-stage(local and global) rank to reduce data-shuffling.
  */
-public class BatchExecRank extends ExecNodeBase<RowData> implements BatchExecNode<RowData> {
+public class BatchExecRank extends ExecNodeBase<RowData> implements InputSortedExecNode<RowData> {
 
     private final int[] partitionFields;
     private final int[] sortFields;

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSortAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSortAggregate.java
@@ -47,7 +47,7 @@ import java.util.Collections;
 
 /** Batch {@link ExecNode} for (global) sort-based aggregate operator. */
 public class BatchExecSortAggregate extends ExecNodeBase<RowData>
-        implements BatchExecNode<RowData>, SingleTransformationTranslator<RowData> {
+        implements InputSortedExecNode<RowData>, SingleTransformationTranslator<RowData> {
 
     private final int[] grouping;
     private final int[] auxGrouping;

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSortWindowAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSortWindowAggregate.java
@@ -52,7 +52,7 @@ import java.util.Collections;
 
 /** Batch {@link ExecNode} for sort-based window aggregate operator. */
 public class BatchExecSortWindowAggregate extends ExecNodeBase<RowData>
-        implements BatchExecNode<RowData>, SingleTransformationTranslator<RowData> {
+        implements InputSortedExecNode<RowData>, SingleTransformationTranslator<RowData> {
 
     private final int[] grouping;
     private final int[] auxGrouping;

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/InputSortedExecNode.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/InputSortedExecNode.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * imitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.exec.batch;
+
+/**
+ * A {@link BatchExecNode} which does not sort the input data within the operator, but requires the
+ * input data is already sorted.
+ */
+public interface InputSortedExecNode<T> extends BatchExecNode<T> {}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/processor/ForwardHashExchangeProcessor.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/processor/ForwardHashExchangeProcessor.java
@@ -22,8 +22,14 @@ import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeGraph;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
+import org.apache.flink.table.planner.plan.nodes.exec.batch.BatchExecCalc;
+import org.apache.flink.table.planner.plan.nodes.exec.batch.BatchExecCorrelate;
 import org.apache.flink.table.planner.plan.nodes.exec.batch.BatchExecExchange;
 import org.apache.flink.table.planner.plan.nodes.exec.batch.BatchExecMultipleInput;
+import org.apache.flink.table.planner.plan.nodes.exec.batch.BatchExecPythonCalc;
+import org.apache.flink.table.planner.plan.nodes.exec.batch.BatchExecPythonCorrelate;
+import org.apache.flink.table.planner.plan.nodes.exec.batch.BatchExecSort;
+import org.apache.flink.table.planner.plan.nodes.exec.batch.InputSortedExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.common.CommonExecExchange;
 import org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.visitor.AbstractExecNodeExactlyOnceVisitor;
@@ -79,40 +85,46 @@ public class ForwardHashExchangeProcessor implements ExecNodeGraphProcessor {
                                     != InputProperty.DistributionType.HASH) {
                                 continue;
                             }
+
                             ExecEdge edge = node.getInputEdges().get(i);
-                            if (!isExchangeInput(edge)) {
-                                InputProperty newInputProperty =
-                                        InputProperty.builder()
-                                                .requiredDistribution(
-                                                        InputProperty.keepInputAsIsDistribution(
-                                                                requiredDistribution))
-                                                .damBehavior(inputProperty.getDamBehavior())
-                                                .priority(inputProperty.getPriority())
-                                                .build();
-                                BatchExecExchange newExchange =
-                                        new BatchExecExchange(
-                                                newInputProperty,
-                                                (RowType) edge.getOutputType(),
-                                                newInputProperty.toString());
+                            if (!hasExchangeInput(edge)) {
+                                ExecEdge newEdge;
+                                if (isInputSortedNode(node)) {
+                                    if (hasSortInputForInputSortedNode(node)) {
+                                        // add Exchange with keep_input_as_is distribution as the
+                                        // input of Sort
+                                        ExecNode<?> sort = edge.getSource();
+                                        ExecEdge newEdgeOfSort =
+                                                addExchangeAndReconnectEdge(
+                                                        sort.getInputEdges().get(0),
+                                                        inputProperty,
+                                                        false);
+                                        sort.setInputEdges(
+                                                Collections.singletonList(newEdgeOfSort));
+                                    }
 
-                                ExecEdge newEdge1 =
-                                        new ExecEdge(
-                                                edge.getSource(),
-                                                newExchange,
-                                                edge.getShuffle(),
-                                                edge.getExchangeMode());
-                                newExchange.setInputEdges(Collections.singletonList(newEdge1));
-
-                                ExecEdge newEdge2 =
-                                        new ExecEdge(
-                                                newExchange,
-                                                edge.getTarget(),
-                                                edge.getShuffle(),
-                                                edge.getExchangeMode());
-
+                                    // if operation chaining is disabled, this could mark sure the
+                                    // sort node and its output can also be connected by
+                                    // ForwardPartitioner
+                                    newEdge =
+                                            addExchangeAndReconnectEdge(edge, inputProperty, true);
+                                } else {
+                                    // add Exchange with keep_input_as_is distribution as the input
+                                    // of the node
+                                    newEdge =
+                                            addExchangeAndReconnectEdge(edge, inputProperty, false);
+                                    updateOriginalEdgeInMultipleInput(
+                                            node, i, (BatchExecExchange) newEdge.getSource());
+                                }
                                 // update the edge
-                                newEdges.set(i, newEdge2);
-                                updateOriginalEdgeInMultipleInput(node, i, newExchange);
+                                newEdges.set(i, newEdge);
+                                changed = true;
+                            } else if (hasSortInputForInputSortedNode(node)) {
+                                // if operation chaining is disabled, this could mark sure the sort
+                                // node and its output can also be connected by ForwardPartitioner
+                                ExecEdge newEdge =
+                                        addExchangeAndReconnectEdge(edge, inputProperty, true);
+                                newEdges.set(i, newEdge);
                                 changed = true;
                             }
                         }
@@ -125,8 +137,60 @@ public class ForwardHashExchangeProcessor implements ExecNodeGraphProcessor {
         return execGraph;
     }
 
-    private boolean isExchangeInput(ExecEdge edge) {
-        return edge.getSource() instanceof CommonExecExchange;
+    // TODO This implementation should be updated once FLINK-21224 is finished.
+    private ExecEdge addExchangeAndReconnectEdge(
+            ExecEdge edge, InputProperty inputProperty, boolean strict) {
+        ExecNode<?> target = edge.getTarget();
+        ExecNode<?> source = edge.getSource();
+        // only Calc and Correlate can propagate sort property and distribution property
+        if (source instanceof BatchExecCalc
+                || source instanceof BatchExecPythonCalc
+                || source instanceof BatchExecCorrelate
+                || source instanceof BatchExecPythonCorrelate) {
+            ExecEdge newEdge =
+                    addExchangeAndReconnectEdge(
+                            source.getInputEdges().get(0), inputProperty, strict);
+            source.setInputEdges(Collections.singletonList(newEdge));
+        }
+
+        BatchExecExchange exchange =
+                createExchangeWithKeepInputAsIsDistribution(
+                        inputProperty, strict, (RowType) edge.getOutputType());
+        ExecEdge newEdge =
+                new ExecEdge(source, exchange, edge.getShuffle(), edge.getExchangeMode());
+        exchange.setInputEdges(Collections.singletonList(newEdge));
+        return new ExecEdge(exchange, target, edge.getShuffle(), edge.getExchangeMode());
+    }
+
+    private BatchExecExchange createExchangeWithKeepInputAsIsDistribution(
+            InputProperty inputProperty, boolean strict, RowType outputRowType) {
+        InputProperty newInputProperty =
+                InputProperty.builder()
+                        .requiredDistribution(
+                                InputProperty.keepInputAsIsDistribution(
+                                        inputProperty.getRequiredDistribution(), strict))
+                        .damBehavior(inputProperty.getDamBehavior())
+                        .priority(inputProperty.getPriority())
+                        .build();
+        return new BatchExecExchange(newInputProperty, outputRowType, newInputProperty.toString());
+    }
+
+    private boolean hasExchangeInput(ExecEdge edge) {
+        ExecNode<?> input = edge.getSource();
+        if (hasSortInputForInputSortedNode(edge.getTarget())) {
+            // skip Sort node
+            input = input.getInputEdges().get(0).getSource();
+        }
+        return input instanceof CommonExecExchange;
+    }
+
+    private boolean hasSortInputForInputSortedNode(ExecNode<?> node) {
+        return isInputSortedNode(node)
+                && node.getInputEdges().get(0).getSource() instanceof BatchExecSort;
+    }
+
+    private boolean isInputSortedNode(ExecNode<?> node) {
+        return node instanceof InputSortedExecNode;
     }
 
     private void updateOriginalEdgeInMultipleInput(

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/processor/ForwardHashExchangeProcessor.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/processor/ForwardHashExchangeProcessor.java
@@ -157,13 +157,15 @@ public class ForwardHashExchangeProcessor implements ExecNodeGraphProcessor {
             ExecEdge edge, InputProperty inputProperty, boolean strict) {
         ExecNode<?> target = edge.getTarget();
         ExecNode<?> source = edge.getSource();
+        if (source instanceof CommonExecExchange) {
+            return edge;
+        }
         // only Calc, Correlate and Sort can propagate sort property and distribution property
-        if (!hasExchangeInput(edge)
-                && (source instanceof BatchExecCalc
-                        || source instanceof BatchExecPythonCalc
-                        || source instanceof BatchExecSort
-                        || source instanceof BatchExecCorrelate
-                        || source instanceof BatchExecPythonCorrelate)) {
+        if (source instanceof BatchExecCalc
+                || source instanceof BatchExecPythonCalc
+                || source instanceof BatchExecSort
+                || source instanceof BatchExecCorrelate
+                || source instanceof BatchExecPythonCorrelate) {
             ExecEdge newEdge =
                     addExchangeAndReconnectEdge(
                             source.getInputEdges().get(0), inputProperty, strict);

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/ForwardHashExchangeTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/ForwardHashExchangeTest.xml
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <Root>
-  <TestCase name="testHashAggWithHashJoin">
+  <TestCase name="testHashAggOnHashJoinWithHashShuffle">
     <Resource name="sql">
       <![CDATA[WITH r AS (SELECT * FROM T1, T2 WHERE a1 = a2 AND c1 LIKE 'He%')
 SELECT sum(b1) FROM r group by a1]]>
@@ -45,6 +45,33 @@ Calc(select=[EXPR$0])
                :     +- TableSourceScan(table=[[default_catalog, default_database, T1, filter=[], project=[a1, b1, c1], metadata=[]]], fields=[a1, b1, c1])
                +- Exchange(distribution=[hash[a2]])
                   +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testHashAggOnNestedLoopJoinWithGlobalShuffle">
+    <Resource name="sql">
+      <![CDATA[WITH r AS (SELECT * FROM T1 FULL OUTER JOIN T2 ON true)
+SELECT sum(b1) FROM r]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[SUM($0)])
++- LogicalProject(b1=[$1])
+   +- LogicalJoin(condition=[true], joinType=[full])
+      :- LogicalTableScan(table=[[default_catalog, default_database, T1]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, T2]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+HashAggregate(isMerge=[false], select=[SUM(b1) AS EXPR$0])
++- Exchange(distribution=[single])
+   +- Calc(select=[b1])
+      +- NestedLoopJoin(joinType=[FullOuterJoin], where=[true], select=[b1, a2], build=[left])
+         :- Exchange(distribution=[single])
+         :  +- TableSourceScan(table=[[default_catalog, default_database, T1, project=[b1], metadata=[]]], fields=[b1])
+         +- Exchange(distribution=[single])
+            +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
 ]]>
     </Resource>
   </TestCase>
@@ -182,7 +209,31 @@ MultipleInput(readOrder=[1,1,0,0], members=[\nUnion(all=[true], union=[b, sd, sy
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testOverAggWithHashAgg">
+  <TestCase name="testOverAggOnHashAggWithGlobalShuffle">
+    <Resource name="sql">
+      <![CDATA[SELECT b, RANK() OVER (ORDER BY b) FROM (SELECT SUM(b) AS b FROM T)]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(b=[$0], EXPR$1=[RANK() OVER (ORDER BY $0 NULLS FIRST)])
++- LogicalAggregate(group=[{}], b=[SUM($0)])
+   +- LogicalProject(b=[$1])
+      +- LogicalTableScan(table=[[default_catalog, default_database, T]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+OverAggregate(orderBy=[b ASC], window#0=[RANK(*) AS w0$o0 RANG BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW], select=[b, w0$o0])
++- Exchange(distribution=[forward])
+   +- Sort(orderBy=[b ASC])
+      +- Exchange(distribution=[forward])
+         +- HashAggregate(isMerge=[true], select=[Final_SUM(sum$0) AS b])
+            +- Exchange(distribution=[single])
+               +- TableSourceScan(table=[[default_catalog, default_database, T, project=[b], metadata=[], aggregates=[grouping=[], aggFunctions=[LongSumAggFunction(b)]]]], fields=[sum$0])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testOverAggOnHashAggWithHashShuffle">
     <Resource name="sql">
       <![CDATA[ SELECT
    SUM(b) sum_b,
@@ -213,39 +264,31 @@ Calc(select=[sum_b, (CASE((w0$o0 > 0), w0$o1, null:BIGINT) / w0$o0) AS avg_b, w1
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testSortAggWithSortMergeJoin">
+  <TestCase name="testOverAggOnSortAggWithGlobalShuffle">
     <Resource name="sql">
-      <![CDATA[WITH r AS (SELECT * FROM T1, T2 WHERE a1 = a2 AND c1 LIKE 'He%')
-SELECT sum(b1) FROM r group by a1]]>
+      <![CDATA[SELECT b, RANK() OVER (ORDER BY b) FROM (SELECT SUM(b) AS b FROM T)]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalProject(EXPR$0=[$1])
-+- LogicalAggregate(group=[{0}], EXPR$0=[SUM($1)])
-   +- LogicalProject(a1=[$0], b1=[$1])
-      +- LogicalFilter(condition=[AND(=($0, $4), LIKE($2, _UTF-16LE'He%'))])
-         +- LogicalJoin(condition=[true], joinType=[inner])
-            :- LogicalTableScan(table=[[default_catalog, default_database, T1]])
-            +- LogicalTableScan(table=[[default_catalog, default_database, T2]])
+LogicalProject(b=[$0], EXPR$1=[RANK() OVER (ORDER BY $0 NULLS FIRST)])
++- LogicalAggregate(group=[{}], b=[SUM($0)])
+   +- LogicalProject(b=[$1])
+      +- LogicalTableScan(table=[[default_catalog, default_database, T]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Calc(select=[EXPR$0])
-+- SortAggregate(isMerge=[false], groupBy=[a1], select=[a1, SUM(b1) AS EXPR$0])
-   +- Exchange(distribution=[forward])
-      +- Calc(select=[a1, b1])
-         +- Exchange(distribution=[forward])
-            +- SortMergeJoin(joinType=[InnerJoin], where=[(a1 = a2)], select=[a1, b1, a2])
-               :- Exchange(distribution=[hash[a1]])
-               :  +- Calc(select=[a1, b1], where=[LIKE(c1, 'He%')])
-               :     +- TableSourceScan(table=[[default_catalog, default_database, T1, filter=[], project=[a1, b1, c1], metadata=[]]], fields=[a1, b1, c1])
-               +- Exchange(distribution=[hash[a2]])
-                  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
+OverAggregate(orderBy=[b ASC], window#0=[RANK(*) AS w0$o0 RANG BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW], select=[b, w0$o0])
++- Exchange(distribution=[forward])
+   +- Sort(orderBy=[b ASC])
+      +- Exchange(distribution=[forward])
+         +- SortAggregate(isMerge=[true], select=[Final_SUM(sum$0) AS b])
+            +- Exchange(distribution=[single])
+               +- TableSourceScan(table=[[default_catalog, default_database, T, project=[b], metadata=[], aggregates=[grouping=[], aggFunctions=[LongSumAggFunction(b)]]]], fields=[sum$0])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testOverAggWithSortAgg">
+  <TestCase name="testOverAggOnSortAggWithHashShuffle">
     <Resource name="sql">
       <![CDATA[ SELECT
    SUM(b) sum_b,
@@ -276,7 +319,97 @@ Calc(select=[sum_b, (CASE((w0$o0 > 0), w0$o1, null:BIGINT) / w0$o0) AS avg_b, w1
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testRankWithHashAgg">
+  <TestCase name="testRankOnHashAggWithGlobalShuffle">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM (
+                SELECT b, RANK() OVER(ORDER BY b) rk FROM (
+                        SELECT SUM(b) AS b FROM T
+                )
+        ) WHERE rk <= 10]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(b=[$0], rk=[$1])
++- LogicalFilter(condition=[<=($1, 10)])
+   +- LogicalProject(b=[$0], rk=[RANK() OVER (ORDER BY $0 NULLS FIRST)])
+      +- LogicalAggregate(group=[{}], b=[SUM($0)])
+         +- LogicalProject(b=[$1])
+            +- LogicalTableScan(table=[[default_catalog, default_database, T]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Rank(rankType=[RANK], rankRange=[rankStart=1, rankEnd=10], partitionBy=[], orderBy=[b ASC], global=[true], select=[b, w0$o0])
++- Exchange(distribution=[forward])
+   +- Sort(orderBy=[b ASC])
+      +- Exchange(distribution=[forward])
+         +- HashAggregate(isMerge=[true], select=[Final_SUM(sum$0) AS b])
+            +- Exchange(distribution=[single])
+               +- TableSourceScan(table=[[default_catalog, default_database, T, project=[b], metadata=[], aggregates=[grouping=[], aggFunctions=[LongSumAggFunction(b)]]]], fields=[sum$0])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testRankOnHashAggWithHashShuffle">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM (
+                SELECT a, b, RANK() OVER(PARTITION BY a ORDER BY b) rk FROM (
+                        SELECT a, SUM(b) AS b FROM T GROUP BY a
+                )
+        ) WHERE rk <= 10]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], rk=[$2])
++- LogicalFilter(condition=[<=($2, 10)])
+   +- LogicalProject(a=[$0], b=[$1], rk=[RANK() OVER (PARTITION BY $0 ORDER BY $1 NULLS FIRST)])
+      +- LogicalAggregate(group=[{0}], b=[SUM($1)])
+         +- LogicalProject(a=[$0], b=[$1])
+            +- LogicalTableScan(table=[[default_catalog, default_database, T]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Rank(rankType=[RANK], rankRange=[rankStart=1, rankEnd=10], partitionBy=[a], orderBy=[b ASC], global=[true], select=[a, b, w0$o0])
++- Exchange(distribution=[forward])
+   +- Sort(orderBy=[a ASC, b ASC])
+      +- Exchange(distribution=[keep_input_as_is[hash[a]]])
+         +- HashAggregate(isMerge=[true], groupBy=[a], select=[a, Final_SUM(sum$0) AS b])
+            +- Exchange(distribution=[hash[a]])
+               +- TableSourceScan(table=[[default_catalog, default_database, T, project=[a, b], metadata=[], aggregates=[grouping=[a], aggFunctions=[LongSumAggFunction(b)]]]], fields=[a, sum$0])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testRankOnSortAggWithGlobalShuffle">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM (
+                SELECT b, RANK() OVER(ORDER BY b) rk FROM (
+                        SELECT SUM(b) AS b FROM T
+                )
+        ) WHERE rk <= 10]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(b=[$0], rk=[$1])
++- LogicalFilter(condition=[<=($1, 10)])
+   +- LogicalProject(b=[$0], rk=[RANK() OVER (ORDER BY $0 NULLS FIRST)])
+      +- LogicalAggregate(group=[{}], b=[SUM($0)])
+         +- LogicalProject(b=[$1])
+            +- LogicalTableScan(table=[[default_catalog, default_database, T]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Rank(rankType=[RANK], rankRange=[rankStart=1, rankEnd=10], partitionBy=[], orderBy=[b ASC], global=[true], select=[b, w0$o0])
++- Exchange(distribution=[forward])
+   +- Sort(orderBy=[b ASC])
+      +- Exchange(distribution=[forward])
+         +- HashAggregate(isMerge=[true], select=[Final_SUM(sum$0) AS b])
+            +- Exchange(distribution=[single])
+               +- TableSourceScan(table=[[default_catalog, default_database, T, project=[b], metadata=[], aggregates=[grouping=[], aggFunctions=[LongSumAggFunction(b)]]]], fields=[sum$0])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testRankOnSortAggWithHashShuffle">
     <Resource name="sql">
       <![CDATA[SELECT * FROM (
                 SELECT a, b, RANK() OVER(PARTITION BY a ORDER BY b) rk FROM (
@@ -349,33 +482,62 @@ SortMergeJoin(joinType=[InnerJoin], where=[(a = d2)], select=[a, d2])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testRankWithSortAgg">
+  <TestCase name="testSortAggOnNestedLoopJoinWithGlobalShuffle">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM (
-                SELECT a, b, RANK() OVER(PARTITION BY a ORDER BY b) rk FROM (
-                        SELECT a, SUM(b) AS b FROM T GROUP BY a
-                )
-        ) WHERE rk <= 10]]>
+      <![CDATA[WITH r AS (SELECT * FROM T1 FULL OUTER JOIN T2 ON true)
+SELECT sum(b1) FROM r]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalProject(a=[$0], b=[$1], rk=[$2])
-+- LogicalFilter(condition=[<=($2, 10)])
-   +- LogicalProject(a=[$0], b=[$1], rk=[RANK() OVER (PARTITION BY $0 ORDER BY $1 NULLS FIRST)])
-      +- LogicalAggregate(group=[{0}], b=[SUM($1)])
-         +- LogicalProject(a=[$0], b=[$1])
-            +- LogicalTableScan(table=[[default_catalog, default_database, T]])
+LogicalAggregate(group=[{}], EXPR$0=[SUM($0)])
++- LogicalProject(b1=[$1])
+   +- LogicalJoin(condition=[true], joinType=[full])
+      :- LogicalTableScan(table=[[default_catalog, default_database, T1]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, T2]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Rank(rankType=[RANK], rankRange=[rankStart=1, rankEnd=10], partitionBy=[a], orderBy=[b ASC], global=[true], select=[a, b, w0$o0])
-+- Exchange(distribution=[forward])
-   +- Sort(orderBy=[a ASC, b ASC])
-      +- Exchange(distribution=[keep_input_as_is[hash[a]]])
-         +- HashAggregate(isMerge=[true], groupBy=[a], select=[a, Final_SUM(sum$0) AS b])
-            +- Exchange(distribution=[hash[a]])
-               +- TableSourceScan(table=[[default_catalog, default_database, T, project=[a, b], metadata=[], aggregates=[grouping=[a], aggFunctions=[LongSumAggFunction(b)]]]], fields=[a, sum$0])
+SortAggregate(isMerge=[false], select=[SUM(b1) AS EXPR$0])
++- Exchange(distribution=[single])
+   +- Calc(select=[b1])
+      +- NestedLoopJoin(joinType=[FullOuterJoin], where=[true], select=[b1, a2], build=[left])
+         :- Exchange(distribution=[single])
+         :  +- TableSourceScan(table=[[default_catalog, default_database, T1, project=[b1], metadata=[]]], fields=[b1])
+         +- Exchange(distribution=[single])
+            +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testSortAggOnSortMergeJoinWithHashShuffle">
+    <Resource name="sql">
+      <![CDATA[WITH r AS (SELECT * FROM T1, T2 WHERE a1 = a2 AND c1 LIKE 'He%')
+SELECT sum(b1) FROM r group by a1]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(EXPR$0=[$1])
++- LogicalAggregate(group=[{0}], EXPR$0=[SUM($1)])
+   +- LogicalProject(a1=[$0], b1=[$1])
+      +- LogicalFilter(condition=[AND(=($0, $4), LIKE($2, _UTF-16LE'He%'))])
+         +- LogicalJoin(condition=[true], joinType=[inner])
+            :- LogicalTableScan(table=[[default_catalog, default_database, T1]])
+            +- LogicalTableScan(table=[[default_catalog, default_database, T2]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[EXPR$0])
++- SortAggregate(isMerge=[false], groupBy=[a1], select=[a1, SUM(b1) AS EXPR$0])
+   +- Exchange(distribution=[forward])
+      +- Calc(select=[a1, b1])
+         +- Exchange(distribution=[forward])
+            +- SortMergeJoin(joinType=[InnerJoin], where=[(a1 = a2)], select=[a1, b1, a2])
+               :- Exchange(distribution=[hash[a1]])
+               :  +- Calc(select=[a1, b1], where=[LIKE(c1, 'He%')])
+               :     +- TableSourceScan(table=[[default_catalog, default_database, T1, filter=[], project=[a1, b1, c1], metadata=[]]], fields=[a1, b1, c1])
+               +- Exchange(distribution=[hash[a2]])
+                  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/ForwardHashExchangeTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/ForwardHashExchangeTest.xml
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <Root>
-  <TestCase name="testHashAgg">
+  <TestCase name="testHashAggWithHashJoin">
     <Resource name="sql">
       <![CDATA[WITH r AS (SELECT * FROM T1, T2 WHERE a1 = a2 AND c1 LIKE 'He%')
 SELECT sum(b1) FROM r group by a1]]>
@@ -36,14 +36,15 @@ LogicalProject(EXPR$0=[$1])
       <![CDATA[
 Calc(select=[EXPR$0])
 +- HashAggregate(isMerge=[false], groupBy=[a1], select=[a1, SUM(b1) AS EXPR$0])
-   +- Exchange(distribution=[keep_input_as_is])
+   +- Exchange(distribution=[keep_input_as_is[hash[a1]]])
       +- Calc(select=[a1, b1])
-         +- HashJoin(joinType=[InnerJoin], where=[(a1 = a2)], select=[a1, b1, a2], build=[left])
-            :- Exchange(distribution=[hash[a1]])
-            :  +- Calc(select=[a1, b1], where=[LIKE(c1, 'He%')])
-            :     +- TableSourceScan(table=[[default_catalog, default_database, T1, filter=[], project=[a1, b1, c1], metadata=[]]], fields=[a1, b1, c1])
-            +- Exchange(distribution=[hash[a2]])
-               +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
+         +- Exchange(distribution=[keep_input_as_is[hash[a1]]])
+            +- HashJoin(joinType=[InnerJoin], where=[(a1 = a2)], select=[a1, b1, a2], build=[left])
+               :- Exchange(distribution=[hash[a1]])
+               :  +- Calc(select=[a1, b1], where=[LIKE(c1, 'He%')])
+               :     +- TableSourceScan(table=[[default_catalog, default_database, T1, filter=[], project=[a1, b1, c1], metadata=[]]], fields=[a1, b1, c1])
+               +- Exchange(distribution=[hash[a2]])
+                  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
 ]]>
     </Resource>
   </TestCase>
@@ -72,19 +73,21 @@ LogicalProject(a=[$0], d2=[$1])
     <Resource name="optimized exec plan">
       <![CDATA[
 HashJoin(joinType=[InnerJoin], where=[(a = d2)], select=[a, d2], build=[right])
-:- Exchange(distribution=[keep_input_as_is])
+:- Exchange(distribution=[keep_input_as_is[hash[a]]])
 :  +- Calc(select=[a])
-:     +- HashJoin(joinType=[InnerJoin], where=[(a = a1)], select=[a1, a], build=[right])
-:        :- Exchange(distribution=[hash[a1]])
-:        :  +- TableSourceScan(table=[[default_catalog, default_database, T1, project=[a1], metadata=[]]], fields=[a1])
-:        +- Exchange(distribution=[hash[a]])(reuse_id=[1])
-:           +- TableSourceScan(table=[[default_catalog, default_database, T, project=[a], metadata=[]]], fields=[a])
-+- Exchange(distribution=[keep_input_as_is])
+:     +- Exchange(distribution=[keep_input_as_is[hash[a1]]])
+:        +- HashJoin(joinType=[InnerJoin], where=[(a = a1)], select=[a1, a], build=[right])
+:           :- Exchange(distribution=[hash[a1]])
+:           :  +- TableSourceScan(table=[[default_catalog, default_database, T1, project=[a1], metadata=[]]], fields=[a1])
+:           +- Exchange(distribution=[hash[a]])(reuse_id=[1])
+:              +- TableSourceScan(table=[[default_catalog, default_database, T, project=[a], metadata=[]]], fields=[a])
++- Exchange(distribution=[keep_input_as_is[hash[d2]]])
    +- Calc(select=[d2])
-      +- HashJoin(joinType=[InnerJoin], where=[(d2 = a)], select=[a, d2], build=[right])
-         :- Reused(reference_id=[1])
-         +- Exchange(distribution=[hash[d2]])
-            +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[d2], metadata=[]]], fields=[d2])
+      +- Exchange(distribution=[keep_input_as_is[hash[a]]])
+         +- HashJoin(joinType=[InnerJoin], where=[(d2 = a)], select=[a, d2], build=[right])
+            :- Reused(reference_id=[1])
+            +- Exchange(distribution=[hash[d2]])
+               +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[d2], metadata=[]]], fields=[d2])
 ]]>
     </Resource>
   </TestCase>
@@ -158,7 +161,7 @@ MultipleInput(readOrder=[1,1,0,0], members=[\nUnion(all=[true], union=[b, sd, sy
 :        +- MultipleInput(readOrder=[0,1,0], members=[\nHashJoin(joinType=[InnerJoin], where=[(a = d)], select=[a, ny, nz, b, d], build=[right])\n:- Calc(select=[a, ny, nz, b])\n:  +- HashJoin(joinType=[LeftOuterJoin], where=[(a = a0)], select=[a, ny, nz, a0, b], build=[right])\n:     :- [#2] MultipleInput(readOrder=[0,1,0], members=[\nHashJoin(joinType=[LeftOuterJoin], where=[(a = nz)], select=[a, ny, nz], build=[right])\n:- HashJoin(joinType=[LeftOuterJoin], where=[(a = ny)], select=[a, ny], build=[right])\n:  :- [#2] Exchange(distribution=[hash[a]])\n:  +- [#3] Exchange(distribution=[hash[ny]])\n+- [#1] Exchange(distribution=[hash[nz]])\n])\n:     +- [#3] Exchange(distribution=[hash[a]])\n+- [#1] Exchange(distribution=[hash[d]])\n])
 :           :- Exchange(distribution=[hash[d]])(reuse_id=[3])
 :           :  +- TableSourceScan(table=[[default_catalog, default_database, y, project=[d], metadata=[]]], fields=[d])
-:           :- Exchange(distribution=[keep_input_as_is])
+:           :- Exchange(distribution=[keep_input_as_is[hash[a]]])
 :           :  +- MultipleInput(readOrder=[0,1,0], members=[\nHashJoin(joinType=[LeftOuterJoin], where=[(a = nz)], select=[a, ny, nz], build=[right])\n:- HashJoin(joinType=[LeftOuterJoin], where=[(a = ny)], select=[a, ny], build=[right])\n:  :- [#2] Exchange(distribution=[hash[a]])\n:  +- [#3] Exchange(distribution=[hash[ny]])\n+- [#1] Exchange(distribution=[hash[nz]])\n])(reuse_id=[2])
 :           :     :- Exchange(distribution=[hash[nz]])
 :           :     :  +- TableSourceScan(table=[[default_catalog, default_database, z, project=[nz], metadata=[]]], fields=[nz])
@@ -173,13 +176,13 @@ MultipleInput(readOrder=[1,1,0,0], members=[\nUnion(all=[true], union=[b, sd, sy
       +- Calc(select=[b, d, ny, nz])
          +- MultipleInput(readOrder=[0,1,0], members=[\nHashJoin(joinType=[InnerJoin], where=[(a = a0)], select=[a, ny, nz, d, a0, b], build=[right])\n:- HashJoin(joinType=[LeftOuterJoin], where=[(a = d)], select=[a, ny, nz, d], build=[right])\n:  :- [#2] MultipleInput(readOrder=[0,1,0], members=[\nHashJoin(joinType=[LeftOuterJoin], where=[(a = nz)], select=[a, ny, nz], build=[right])\n:- HashJoin(joinType=[LeftOuterJoin], where=[(a = ny)], select=[a, ny], build=[right])\n:  :- [#2] Exchange(distribution=[hash[a]])\n:  +- [#3] Exchange(distribution=[hash[ny]])\n+- [#1] Exchange(distribution=[hash[nz]])\n])\n:  +- [#3] Exchange(distribution=[hash[d]])\n+- [#1] Exchange(distribution=[hash[a]])\n])
             :- Reused(reference_id=[1])
-            :- Exchange(distribution=[keep_input_as_is])
+            :- Exchange(distribution=[keep_input_as_is[hash[a]]])
             :  +- Reused(reference_id=[2])
             +- Reused(reference_id=[3])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testOverAgg">
+  <TestCase name="testOverAggWithHashAgg">
     <Resource name="sql">
       <![CDATA[ SELECT
    SUM(b) sum_b,
@@ -201,15 +204,79 @@ LogicalProject(sum_b=[$1], avg_b=[/(CASE(>(COUNT($1) OVER (PARTITION BY $0), 0),
       <![CDATA[
 Calc(select=[sum_b, (CASE((w0$o0 > 0), w0$o1, null:BIGINT) / w0$o0) AS avg_b, w1$o0 AS rn, c])
 +- OverAggregate(partitionBy=[c], window#0=[COUNT(sum_b) AS w0$o0, $SUM0(sum_b) AS w0$o1 RANG BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING], window#1=[RANK(*) AS w1$o0 RANG BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW], select=[c, sum_b, w0$o0, w0$o1, w1$o0])
-   +- Exchange(distribution=[keep_input_as_is])
+   +- Exchange(distribution=[forward])
       +- Sort(orderBy=[c ASC])
-         +- HashAggregate(isMerge=[true], groupBy=[c], select=[c, Final_SUM(sum$0) AS sum_b])
-            +- Exchange(distribution=[hash[c]])
-               +- TableSourceScan(table=[[default_catalog, default_database, T, project=[c, b], metadata=[], aggregates=[grouping=[c], aggFunctions=[LongSumAggFunction(b)]]]], fields=[c, sum$0])
+         +- Exchange(distribution=[keep_input_as_is[hash[c]]])
+            +- HashAggregate(isMerge=[true], groupBy=[c], select=[c, Final_SUM(sum$0) AS sum_b])
+               +- Exchange(distribution=[hash[c]])
+                  +- TableSourceScan(table=[[default_catalog, default_database, T, project=[c, b], metadata=[], aggregates=[grouping=[c], aggFunctions=[LongSumAggFunction(b)]]]], fields=[c, sum$0])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testRank">
+  <TestCase name="testSortAggWithSortMergeJoin">
+    <Resource name="sql">
+      <![CDATA[WITH r AS (SELECT * FROM T1, T2 WHERE a1 = a2 AND c1 LIKE 'He%')
+SELECT sum(b1) FROM r group by a1]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(EXPR$0=[$1])
++- LogicalAggregate(group=[{0}], EXPR$0=[SUM($1)])
+   +- LogicalProject(a1=[$0], b1=[$1])
+      +- LogicalFilter(condition=[AND(=($0, $4), LIKE($2, _UTF-16LE'He%'))])
+         +- LogicalJoin(condition=[true], joinType=[inner])
+            :- LogicalTableScan(table=[[default_catalog, default_database, T1]])
+            +- LogicalTableScan(table=[[default_catalog, default_database, T2]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[EXPR$0])
++- SortAggregate(isMerge=[false], groupBy=[a1], select=[a1, SUM(b1) AS EXPR$0])
+   +- Exchange(distribution=[forward])
+      +- Calc(select=[a1, b1])
+         +- Exchange(distribution=[forward])
+            +- SortMergeJoin(joinType=[InnerJoin], where=[(a1 = a2)], select=[a1, b1, a2])
+               :- Exchange(distribution=[hash[a1]])
+               :  +- Calc(select=[a1, b1], where=[LIKE(c1, 'He%')])
+               :     +- TableSourceScan(table=[[default_catalog, default_database, T1, filter=[], project=[a1, b1, c1], metadata=[]]], fields=[a1, b1, c1])
+               +- Exchange(distribution=[hash[a2]])
+                  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testOverAggWithSortAgg">
+    <Resource name="sql">
+      <![CDATA[ SELECT
+   SUM(b) sum_b,
+   AVG(SUM(b)) OVER (PARTITION BY c) avg_b,
+   RANK() OVER (PARTITION BY c ORDER BY c) rn,
+   c
+ FROM T
+ GROUP BY c]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(sum_b=[$1], avg_b=[/(CASE(>(COUNT($1) OVER (PARTITION BY $0), 0), $SUM0($1) OVER (PARTITION BY $0), null:BIGINT), COUNT($1) OVER (PARTITION BY $0))], rn=[RANK() OVER (PARTITION BY $0 ORDER BY $0 NULLS FIRST)], c=[$0])
++- LogicalAggregate(group=[{0}], sum_b=[SUM($1)])
+   +- LogicalProject(c=[$2], b=[$1])
+      +- LogicalTableScan(table=[[default_catalog, default_database, T]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[sum_b, (CASE((w0$o0 > 0), w0$o1, null:BIGINT) / w0$o0) AS avg_b, w1$o0 AS rn, c])
++- OverAggregate(partitionBy=[c], window#0=[COUNT(sum_b) AS w0$o0, $SUM0(sum_b) AS w0$o1 RANG BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING], window#1=[RANK(*) AS w1$o0 RANG BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW], select=[c, sum_b, w0$o0, w0$o1, w1$o0])
+   +- Exchange(distribution=[forward])
+      +- SortAggregate(isMerge=[true], groupBy=[c], select=[c, Final_SUM(sum$0) AS sum_b])
+         +- Exchange(distribution=[forward])
+            +- Sort(orderBy=[c ASC])
+               +- Exchange(distribution=[hash[c]])
+                  +- TableSourceScan(table=[[default_catalog, default_database, T, project=[c, b], metadata=[], aggregates=[grouping=[c], aggFunctions=[LongSumAggFunction(b)]]]], fields=[c, sum$0])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testRankWithHashAgg">
     <Resource name="sql">
       <![CDATA[SELECT * FROM (
                 SELECT a, b, RANK() OVER(PARTITION BY a ORDER BY b) rk FROM (
@@ -230,11 +297,12 @@ LogicalProject(a=[$0], b=[$1], rk=[$2])
     <Resource name="optimized exec plan">
       <![CDATA[
 Rank(rankType=[RANK], rankRange=[rankStart=1, rankEnd=10], partitionBy=[a], orderBy=[b ASC], global=[true], select=[a, b, w0$o0])
-+- Exchange(distribution=[keep_input_as_is])
++- Exchange(distribution=[forward])
    +- Sort(orderBy=[a ASC, b ASC])
-      +- HashAggregate(isMerge=[true], groupBy=[a], select=[a, Final_SUM(sum$0) AS b])
-         +- Exchange(distribution=[hash[a]])
-            +- TableSourceScan(table=[[default_catalog, default_database, T, project=[a, b], metadata=[], aggregates=[grouping=[a], aggFunctions=[LongSumAggFunction(b)]]]], fields=[a, sum$0])
+      +- Exchange(distribution=[keep_input_as_is[hash[a]]])
+         +- HashAggregate(isMerge=[true], groupBy=[a], select=[a, Final_SUM(sum$0) AS b])
+            +- Exchange(distribution=[hash[a]])
+               +- TableSourceScan(table=[[default_catalog, default_database, T, project=[a, b], metadata=[], aggregates=[grouping=[a], aggFunctions=[LongSumAggFunction(b)]]]], fields=[a, sum$0])
 ]]>
     </Resource>
   </TestCase>
@@ -263,50 +331,51 @@ LogicalProject(a=[$0], d2=[$1])
     <Resource name="optimized exec plan">
       <![CDATA[
 SortMergeJoin(joinType=[InnerJoin], where=[(a = d2)], select=[a, d2])
-:- Exchange(distribution=[keep_input_as_is])
+:- Exchange(distribution=[keep_input_as_is[hash[a]]])
 :  +- Calc(select=[a])
-:     +- SortMergeJoin(joinType=[InnerJoin], where=[(a = a1)], select=[a1, a])
-:        :- Exchange(distribution=[hash[a1]])
-:        :  +- TableSourceScan(table=[[default_catalog, default_database, T1, project=[a1], metadata=[]]], fields=[a1])
-:        +- Exchange(distribution=[hash[a]])(reuse_id=[1])
-:           +- TableSourceScan(table=[[default_catalog, default_database, T, project=[a], metadata=[]]], fields=[a])
-+- Exchange(distribution=[keep_input_as_is])
+:     +- Exchange(distribution=[keep_input_as_is[hash[a1]]])
+:        +- SortMergeJoin(joinType=[InnerJoin], where=[(a = a1)], select=[a1, a])
+:           :- Exchange(distribution=[hash[a1]])
+:           :  +- TableSourceScan(table=[[default_catalog, default_database, T1, project=[a1], metadata=[]]], fields=[a1])
+:           +- Exchange(distribution=[hash[a]])(reuse_id=[1])
+:              +- TableSourceScan(table=[[default_catalog, default_database, T, project=[a], metadata=[]]], fields=[a])
++- Exchange(distribution=[keep_input_as_is[hash[d2]]])
    +- Calc(select=[d2])
-      +- SortMergeJoin(joinType=[InnerJoin], where=[(d2 = a)], select=[a, d2])
-         :- Reused(reference_id=[1])
-         +- Exchange(distribution=[hash[d2]])
-            +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[d2], metadata=[]]], fields=[d2])
+      +- Exchange(distribution=[keep_input_as_is[hash[a]]])
+         +- SortMergeJoin(joinType=[InnerJoin], where=[(d2 = a)], select=[a, d2])
+            :- Reused(reference_id=[1])
+            +- Exchange(distribution=[hash[d2]])
+               +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[d2], metadata=[]]], fields=[d2])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testSortAgg">
+  <TestCase name="testRankWithSortAgg">
     <Resource name="sql">
-      <![CDATA[WITH r AS (SELECT * FROM T1, T2 WHERE a1 = a2 AND c1 LIKE 'He%')
-SELECT sum(b1) FROM r group by a1]]>
+      <![CDATA[SELECT * FROM (
+                SELECT a, b, RANK() OVER(PARTITION BY a ORDER BY b) rk FROM (
+                        SELECT a, SUM(b) AS b FROM T GROUP BY a
+                )
+        ) WHERE rk <= 10]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalProject(EXPR$0=[$1])
-+- LogicalAggregate(group=[{0}], EXPR$0=[SUM($1)])
-   +- LogicalProject(a1=[$0], b1=[$1])
-      +- LogicalFilter(condition=[AND(=($0, $4), LIKE($2, _UTF-16LE'He%'))])
-         +- LogicalJoin(condition=[true], joinType=[inner])
-            :- LogicalTableScan(table=[[default_catalog, default_database, T1]])
-            +- LogicalTableScan(table=[[default_catalog, default_database, T2]])
+LogicalProject(a=[$0], b=[$1], rk=[$2])
++- LogicalFilter(condition=[<=($2, 10)])
+   +- LogicalProject(a=[$0], b=[$1], rk=[RANK() OVER (PARTITION BY $0 ORDER BY $1 NULLS FIRST)])
+      +- LogicalAggregate(group=[{0}], b=[SUM($1)])
+         +- LogicalProject(a=[$0], b=[$1])
+            +- LogicalTableScan(table=[[default_catalog, default_database, T]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Calc(select=[EXPR$0])
-+- SortAggregate(isMerge=[false], groupBy=[a1], select=[a1, SUM(b1) AS EXPR$0])
-   +- Exchange(distribution=[keep_input_as_is])
-      +- Calc(select=[a1, b1])
-         +- SortMergeJoin(joinType=[InnerJoin], where=[(a1 = a2)], select=[a1, b1, a2])
-            :- Exchange(distribution=[hash[a1]])
-            :  +- Calc(select=[a1, b1], where=[LIKE(c1, 'He%')])
-            :     +- TableSourceScan(table=[[default_catalog, default_database, T1, filter=[], project=[a1, b1, c1], metadata=[]]], fields=[a1, b1, c1])
-            +- Exchange(distribution=[hash[a2]])
-               +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
+Rank(rankType=[RANK], rankRange=[rankStart=1, rankEnd=10], partitionBy=[a], orderBy=[b ASC], global=[true], select=[a, b, w0$o0])
++- Exchange(distribution=[forward])
+   +- Sort(orderBy=[a ASC, b ASC])
+      +- Exchange(distribution=[keep_input_as_is[hash[a]]])
+         +- HashAggregate(isMerge=[true], groupBy=[a], select=[a, Final_SUM(sum$0) AS b])
+            +- Exchange(distribution=[hash[a]])
+               +- TableSourceScan(table=[[default_catalog, default_database, T, project=[a, b], metadata=[], aggregates=[grouping=[a], aggFunctions=[LongSumAggFunction(b)]]]], fields=[a, sum$0])
 ]]>
     </Resource>
   </TestCase>


### PR DESCRIPTION

## What is the purpose of the change

*Explicitly set the partitioner for the sql operators whose shuffle and sort are removed*


## Brief change log

  - *Introduce InputSortedExecNode*
  - *Update ForwardHashExchangeProcessor to explicitly set Exchange for the nodes whose shuffle and sort are removed *


## Verifying this change



This change added tests and can be verified as follows:

  - *Extended ForwardHashExchangeTest the verify the plan about the changes*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
