### PR TITLE
[hotfix][test] add support for field assignability

### DIFF
--- a/flink-architecture-tests/flink-architecture-tests-base/src/main/java/org/apache/flink/architecture/common/JavaFieldPredicates.java
+++ b/flink-architecture-tests/flink-architecture-tests-base/src/main/java/org/apache/flink/architecture/common/JavaFieldPredicates.java
@@ -84,6 +84,19 @@ public class JavaFieldPredicates {
     }
 
     /**
+     * Match the {@link Class} of the {@link JavaField}'s assignability.
+     *
+     * @param clazz the Class type to check for assignability
+     * @return a {@link DescribedPredicate} that returns {@code true}, if the respective {@link
+     *     JavaField} is assignable to the supplied {@code clazz}.
+     */
+    public static DescribedPredicate<JavaField> isAssignableTo(Class<?> clazz) {
+        return DescribedPredicate.describe(
+                "is assignable to " + clazz.getSimpleName(),
+                field -> field.getRawType().isAssignableTo(clazz));
+    }
+
+    /**
      * Match the single Annotation of the {@link JavaField}.
      *
      * @return A {@link DescribedPredicate} returning true, if and only if the tested {@link

--- a/flink-architecture-tests/flink-architecture-tests-base/src/main/java/org/apache/flink/architecture/common/Predicates.java
+++ b/flink-architecture-tests/flink-architecture-tests-base/src/main/java/org/apache/flink/architecture/common/Predicates.java
@@ -32,9 +32,11 @@ import java.util.Set;
 
 import static com.tngtech.archunit.lang.conditions.ArchPredicates.is;
 import static org.apache.flink.architecture.common.JavaFieldPredicates.annotatedWith;
+import static org.apache.flink.architecture.common.JavaFieldPredicates.isAssignableTo;
 import static org.apache.flink.architecture.common.JavaFieldPredicates.isFinal;
 import static org.apache.flink.architecture.common.JavaFieldPredicates.isNotStatic;
 import static org.apache.flink.architecture.common.JavaFieldPredicates.isPublic;
+import static org.apache.flink.architecture.common.JavaFieldPredicates.isStatic;
 import static org.apache.flink.architecture.common.JavaFieldPredicates.ofType;
 
 /** Common predicates for architecture tests. */
@@ -88,6 +90,14 @@ public class Predicates {
      */
     public static DescribedPredicate<JavaField> arePublicFinalOfType(Class<?> clazz) {
         return is(ofType(clazz)).and(isPublic()).and(isFinal()).and(isNotStatic());
+    }
+
+    /**
+     * Tests that the given field is {@code public static final} and is assignable to the given type
+     * {@code clazz} .
+     */
+    public static DescribedPredicate<JavaField> arePublicStaticFinalAssignableTo(Class<?> clazz) {
+        return is(isAssignableTo(clazz)).and(isPublic()).and(isStatic()).and(isFinal());
     }
 
     /**


### PR DESCRIPTION
## What is the purpose of the change

add support for JavaField assignability


## Brief change log

  - new method in JavaFieldPredicates: isAssignableTo(Class<?> clazz)
  - new method in Predicates: arePublicStaticFinalAssignableTo(Class<?> clazz)


## Verifying this change

This change is a trivial work to add assignability support in the test infra without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
