### PR TITLE
[FLINK-26018][connector/common] Create per-split output on split addition in SourceOperator

### DIFF
--- a/flink-connectors/flink-connector-base/pom.xml
+++ b/flink-connectors/flink-connector-base/pom.xml
@@ -72,6 +72,14 @@
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-streaming-java</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+			<type>test-jar</type>
+		</dependency>
+
 		<!-- ArchUit test dependencies -->
 
 		<dependency>

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SourceReaderBase.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SourceReaderBase.java
@@ -324,6 +324,9 @@ public abstract class SourceReaderBase<E, T, SplitT extends SourceSplit, SplitSt
 
         SourceOutput<T> getOrCreateSplitOutput(ReaderOutput<T> mainOutput) {
             if (sourceOutput == null) {
+                // The split output should have been created when AddSplitsEvent was processed in
+                // SourceOperator. Here we just use this method to get the previously created
+                // output.
                 sourceOutput = mainOutput.createOutputForSplit(splitId);
             }
             return sourceOutput;

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/splitreader/SplitReader.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/splitreader/SplitReader.java
@@ -50,6 +50,11 @@ public interface SplitReader<E, SplitT extends SourceSplit> {
     /**
      * Handle the split changes. This call should be non-blocking.
      *
+     * <p>For the consistency of internal state in SourceReaderBase, if an invalid split is added to
+     * the reader (for example splits without any records), it should be put back into {@link
+     * RecordsWithSplitIds} as finished splits so that SourceReaderBase could be able to clean up
+     * resources created for it.
+     *
      * @param splitsChanges the split changes that the SplitReader needs to handle.
      */
     void handleSplitsChanges(SplitsChange<SplitT> splitsChanges);

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/SourceReaderBaseTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/SourceReaderBaseTest.java
@@ -18,10 +18,14 @@
 
 package org.apache.flink.connector.base.source.reader;
 
+import org.apache.flink.api.common.eventtime.WatermarkGenerator;
+import org.apache.flink.api.common.eventtime.WatermarkOutput;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.api.connector.source.SourceReader;
 import org.apache.flink.api.connector.source.SourceSplit;
 import org.apache.flink.api.connector.source.mocks.MockSourceSplit;
+import org.apache.flink.api.connector.source.mocks.MockSourceSplitSerializer;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.base.source.reader.fetcher.SingleThreadFetcherManager;
 import org.apache.flink.connector.base.source.reader.mocks.MockSourceReader;
@@ -37,9 +41,22 @@ import org.apache.flink.connector.testutils.source.reader.SourceReaderTestBase;
 import org.apache.flink.connector.testutils.source.reader.TestingReaderContext;
 import org.apache.flink.connector.testutils.source.reader.TestingReaderOutput;
 import org.apache.flink.core.io.InputStatus;
+import org.apache.flink.core.testutils.CommonTestUtils;
+import org.apache.flink.runtime.source.event.AddSplitEvent;
+import org.apache.flink.streaming.api.operators.SourceOperator;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.io.PushingAsyncDataInput;
+import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -48,11 +65,14 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
+import static org.apache.flink.streaming.api.operators.source.TestingSourceOperator.createTestOperator;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** A unit test class for {@link SourceReaderBase}. */
 public class SourceReaderBaseTest extends SourceReaderTestBase<MockSourceSplit> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SourceReaderBaseTest.class);
 
     @Test
     void testExceptionInSplitReader() {
@@ -239,6 +259,83 @@ public class SourceReaderBaseTest extends SourceReaderTestBase<MockSourceSplit> 
                 .isEqualTo(InputStatus.MORE_AVAILABLE);
     }
 
+    @ParameterizedTest(name = "Emit record before split addition: {0}")
+    @ValueSource(booleans = {true, false})
+    void testPerSplitWatermark(boolean emitRecordBeforeSplitAddition) throws Exception {
+        MockSplitReader mockSplitReader =
+                MockSplitReader.newBuilder()
+                        .setNumRecordsPerSplitPerFetch(3)
+                        .setBlockingFetch(true)
+                        .build();
+
+        MockSourceReader reader =
+                new MockSourceReader(
+                        new FutureCompletingBlockingQueue<>(),
+                        () -> mockSplitReader,
+                        new Configuration(),
+                        new TestingReaderContext());
+
+        SourceOperator<Integer, MockSourceSplit> sourceOperator =
+                createTestOperator(
+                        reader,
+                        WatermarkStrategy.forGenerator(
+                                (context) -> new OnEventWatermarkGenerator()),
+                        true);
+
+        MockSourceSplit splitA = new MockSourceSplit(0, 0, 3);
+        splitA.addRecord(100);
+        splitA.addRecord(200);
+        splitA.addRecord(300);
+
+        MockSourceSplit splitB = new MockSourceSplit(1, 0, 3);
+        splitB.addRecord(150);
+        splitB.addRecord(250);
+        splitB.addRecord(350);
+
+        WatermarkCollectingDataOutput output = new WatermarkCollectingDataOutput();
+
+        if (emitRecordBeforeSplitAddition) {
+            sourceOperator.emitNext(output);
+        }
+
+        AddSplitEvent<MockSourceSplit> addSplitsEvent =
+                new AddSplitEvent<>(Arrays.asList(splitA, splitB), new MockSourceSplitSerializer());
+        sourceOperator.handleOperatorEvent(addSplitsEvent);
+
+        // First 3 records from split A should not generate any watermarks
+        CommonTestUtils.waitUtil(
+                () -> {
+                    try {
+                        sourceOperator.emitNext(output);
+                    } catch (Exception e) {
+                        LOG.warn("Exception caught at emitting records", e);
+                        return false;
+                    }
+                    return output.numRecords == 3;
+                },
+                Duration.ofSeconds(10),
+                String.format(
+                        "%d out of 3 records are received within timeout", output.numRecords));
+        assertThat(output.watermarks).isEmpty();
+
+        CommonTestUtils.waitUtil(
+                () -> {
+                    try {
+                        sourceOperator.emitNext(output);
+                    } catch (Exception e) {
+                        LOG.warn("Exception caught at emitting records", e);
+                        return false;
+                    }
+                    return output.numRecords == 6;
+                },
+                Duration.ofSeconds(10),
+                String.format(
+                        "%d out of 6 records are received within timeout", output.numRecords));
+
+        assertThat(output.watermarks).hasSize(3);
+        assertThat(output.watermarks).containsExactly(150L, 250L, 300L);
+    }
+
     // ---------------- helper methods -----------------
 
     @Override
@@ -378,5 +475,38 @@ public class SourceReaderBaseTest extends SourceReaderTestBase<MockSourceSplit> 
                 }
             }
         }
+    }
+
+    private static class OnEventWatermarkGenerator implements WatermarkGenerator<Integer> {
+
+        @Override
+        public void onEvent(Integer event, long eventTimestamp, WatermarkOutput output) {
+            output.emitWatermark(new org.apache.flink.api.common.eventtime.Watermark(event));
+        }
+
+        @Override
+        public void onPeriodicEmit(WatermarkOutput output) {}
+    }
+
+    private static class WatermarkCollectingDataOutput
+            implements PushingAsyncDataInput.DataOutput<Integer> {
+        int numRecords = 0;
+        final List<Long> watermarks = new ArrayList<>();
+
+        @Override
+        public void emitRecord(StreamRecord<Integer> streamRecord) {
+            numRecords++;
+        }
+
+        @Override
+        public void emitWatermark(Watermark watermark) throws Exception {
+            watermarks.add(watermark.getTimestamp());
+        }
+
+        @Override
+        public void emitWatermarkStatus(WatermarkStatus watermarkStatus) {}
+
+        @Override
+        public void emitLatencyMarker(LatencyMarker latencyMarker) {}
     }
 }

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/KafkaSourceITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/KafkaSourceITCase.java
@@ -20,6 +20,9 @@ package org.apache.flink.connector.kafka.source;
 
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.accumulators.ListAccumulator;
+import org.apache.flink.api.common.eventtime.Watermark;
+import org.apache.flink.api.common.eventtime.WatermarkGenerator;
+import org.apache.flink.api.common.eventtime.WatermarkOutput;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
@@ -38,6 +41,7 @@ import org.apache.flink.connector.testframe.testsuites.SourceTestSuiteBase;
 import org.apache.flink.streaming.api.CheckpointingMode;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.ProcessFunction;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
 import org.apache.flink.streaming.api.operators.StreamMap;
@@ -70,11 +74,13 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.apache.flink.connector.kafka.testutils.KafkaSourceExternalContext.SplitMappingMode.PARTITION;
 import static org.apache.flink.connector.kafka.testutils.KafkaSourceExternalContext.SplitMappingMode.TOPIC;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /** Unite test class for {@link KafkaSource}. */
@@ -256,6 +262,53 @@ public class KafkaSourceITCase {
                             "testBasicReadWithoutGroupId");
             executeAndVerify(env, stream);
         }
+
+        @Test
+        public void testPerPartitionWatermark() throws Throwable {
+            String watermarkTopic = "watermarkTestTopic-" + UUID.randomUUID();
+            KafkaSourceTestEnv.createTestTopic(watermarkTopic, 2, 1);
+            List<ProducerRecord<String, Integer>> records =
+                    Arrays.asList(
+                            new ProducerRecord<>(watermarkTopic, 0, 100L, null, 100),
+                            new ProducerRecord<>(watermarkTopic, 0, 200L, null, 200),
+                            new ProducerRecord<>(watermarkTopic, 0, 300L, null, 300),
+                            new ProducerRecord<>(watermarkTopic, 1, 150L, null, 150),
+                            new ProducerRecord<>(watermarkTopic, 1, 250L, null, 250),
+                            new ProducerRecord<>(watermarkTopic, 1, 350L, null, 350));
+            KafkaSourceTestEnv.produceToKafka(records);
+            KafkaSource<PartitionAndValue> source =
+                    KafkaSource.<PartitionAndValue>builder()
+                            .setBootstrapServers(KafkaSourceTestEnv.brokerConnectionStrings)
+                            .setTopics(watermarkTopic)
+                            .setGroupId("watermark-test")
+                            .setDeserializer(new TestingKafkaRecordDeserializationSchema(false))
+                            .setStartingOffsets(OffsetsInitializer.earliest())
+                            .setBounded(OffsetsInitializer.latest())
+                            .build();
+            StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+            env.setParallelism(1);
+            env.fromSource(
+                            source,
+                            WatermarkStrategy.forGenerator(
+                                    (context) -> new OnEventWatermarkGenerator()),
+                            "testPerPartitionWatermark")
+                    .process(
+                            new ProcessFunction<PartitionAndValue, Long>() {
+                                @Override
+                                public void processElement(
+                                        PartitionAndValue value,
+                                        ProcessFunction<PartitionAndValue, Long>.Context ctx,
+                                        Collector<Long> out) {
+                                    assertThat(ctx.timestamp())
+                                            .as(
+                                                    "Event time should never behind watermark "
+                                                            + "because of per-split watermark multiplexing logic")
+                                            .isGreaterThanOrEqualTo(
+                                                    ctx.timerService().currentWatermark());
+                                }
+                            });
+            env.execute();
+        }
     }
 
     /** Integration test based on connector testing framework. */
@@ -399,5 +452,16 @@ public class KafkaSourceITCase {
                                         "The %d-th value for partition %s should be %d", i, tp, i));
                     }
                 });
+    }
+
+    private static class OnEventWatermarkGenerator
+            implements WatermarkGenerator<PartitionAndValue> {
+        @Override
+        public void onEvent(PartitionAndValue event, long eventTimestamp, WatermarkOutput output) {
+            output.emitWatermark(new Watermark(eventTimestamp));
+        }
+
+        @Override
+        public void onPeriodicEmit(WatermarkOutput output) {}
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java
@@ -170,7 +170,7 @@ public class SourceOperator<OUT, SplitT extends SourceSplit> extends AbstractStr
     private CompletableFuture<Void> waitingForAlignmentFuture =
             CompletableFuture.completedFuture(null);
 
-    private @Nullable LatencyMarkerEmitter<OUT> latencyMarerEmitter;
+    private @Nullable LatencyMarkerEmitter<OUT> latencyMarkerEmitter;
 
     public SourceOperator(
             FunctionWithException<SourceReaderContext, SourceReader<OUT, SplitT>, Exception>
@@ -334,8 +334,8 @@ public class SourceOperator<OUT, SplitT extends SourceSplit> extends AbstractStr
         if (eventTimeLogic != null) {
             eventTimeLogic.stopPeriodicWatermarkEmits();
         }
-        if (latencyMarerEmitter != null) {
-            latencyMarerEmitter.close();
+        if (latencyMarkerEmitter != null) {
+            latencyMarkerEmitter.close();
         }
     }
 
@@ -433,7 +433,7 @@ public class SourceOperator<OUT, SplitT extends SourceSplit> extends AbstractStr
                                 .getConfiguration()
                                 .getLong(MetricOptions.LATENCY_INTERVAL);
         if (latencyTrackingInterval > 0) {
-            latencyMarerEmitter =
+            latencyMarkerEmitter =
                     new LatencyMarkerEmitter<>(
                             getProcessingTimeService(),
                             output::emitLatencyMarker,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/source/SourceOperatorEventTimeTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/source/SourceOperatorEventTimeTest.java
@@ -18,30 +18,17 @@
 
 package org.apache.flink.streaming.api.operators.source;
 
-import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
-import org.apache.flink.api.common.state.OperatorStateStore;
 import org.apache.flink.api.connector.source.ReaderOutput;
 import org.apache.flink.api.connector.source.SourceReader;
 import org.apache.flink.api.connector.source.mocks.MockSourceSplit;
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.core.fs.CloseableRegistry;
+import org.apache.flink.api.connector.source.mocks.MockSourceSplitSerializer;
 import org.apache.flink.core.io.InputStatus;
-import org.apache.flink.runtime.operators.testutils.MockEnvironmentBuilder;
-import org.apache.flink.runtime.operators.testutils.MockInputSplitProvider;
-import org.apache.flink.runtime.state.StateInitializationContext;
-import org.apache.flink.runtime.state.StateInitializationContextImpl;
-import org.apache.flink.runtime.state.TestTaskStateManager;
-import org.apache.flink.runtime.state.memory.MemoryStateBackend;
+import org.apache.flink.runtime.source.event.AddSplitEvent;
 import org.apache.flink.streaming.api.operators.SourceOperator;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.io.DataInputStatus;
-import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
-import org.apache.flink.streaming.runtime.tasks.SourceOperatorStreamTask;
-import org.apache.flink.streaming.runtime.tasks.StreamMockEnvironment;
 import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
-import org.apache.flink.streaming.util.MockOutput;
-import org.apache.flink.streaming.util.MockStreamConfig;
 
 import org.apache.flink.shaded.guava30.com.google.common.collect.Lists;
 
@@ -52,13 +39,13 @@ import org.junit.runners.Parameterized;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.streaming.api.operators.source.TestingSourceOperator.createTestOperator;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertThat;
@@ -159,6 +146,35 @@ public class SourceOperatorEventTimeTest {
                 result, new Watermark(100L), new Watermark(150L), new Watermark(200L));
     }
 
+    @Test
+    public void testCreatingPerSplitOutputOnSplitAddition() throws Exception {
+        final WatermarkStrategy<Integer> watermarkStrategy =
+                WatermarkStrategy.forGenerator((ctx) -> new OnEventTestWatermarkGenerator<>());
+
+        InterpretingSourceReader reader =
+                new InterpretingSourceReader(
+                        // No watermark (no record from split 2, whose watermark is Long.MIN_VALUE)
+                        (output) -> output.createOutputForSplit("1").collect(0, 100L),
+                        (output) -> output.createOutputForSplit("1").collect(0, 200L),
+                        (output) -> output.createOutputForSplit("1").collect(0, 300L),
+                        // Emit watermark 150 (from the 1st record of split 2)
+                        (output) -> output.createOutputForSplit("2").collect(0, 150L),
+                        // Emit watermark 300 (from the 3rd record in split 1)
+                        (output) -> output.createOutputForSplit("2").collect(0, 400L));
+        SourceOperator<Integer, MockSourceSplit> sourceOperator =
+                createTestOperator(reader, watermarkStrategy, emitProgressiveWatermarks);
+
+        // Add two splits to SourceOperator. Output for two splits should be created during event
+        // handling.
+        sourceOperator.handleOperatorEvent(
+                new AddSplitEvent<>(
+                        Arrays.asList(new MockSourceSplit(1), new MockSourceSplit(2)),
+                        new MockSourceSplitSerializer()));
+
+        final List<Watermark> result = testSequenceOfWatermarks(sourceOperator);
+        assertWatermarksOrEmpty(result, new Watermark(150L), new Watermark(300L));
+    }
+
     // ------------------------------------------------------------------------
     //   test execution helpers
     // ------------------------------------------------------------------------
@@ -186,9 +202,18 @@ public class SourceOperatorEventTimeTest {
             final WatermarkStrategy<Integer> watermarkStrategy,
             final Consumer<ReaderOutput<Integer>>... actions)
             throws Exception {
+        final SourceReader<Integer, MockSourceSplit> reader = new InterpretingSourceReader(actions);
+        final SourceOperator<Integer, MockSourceSplit> sourceOperator =
+                createTestOperator(reader, watermarkStrategy, emitProgressiveWatermarks);
 
-        final List<Object> allEvents =
-                testSequenceOfEvents(emitProgressiveWatermarks, watermarkStrategy, actions);
+        return testSequenceOfWatermarks(sourceOperator);
+    }
+
+    @SuppressWarnings("FinalPrivateMethod")
+    private final List<Watermark> testSequenceOfWatermarks(
+            SourceOperator<Integer, MockSourceSplit> sourceOperator) throws Exception {
+
+        final List<Object> allEvents = testSequenceOfEvents(sourceOperator);
 
         return allEvents.stream()
                 .filter((evt) -> evt instanceof Watermark)
@@ -197,73 +222,19 @@ public class SourceOperatorEventTimeTest {
     }
 
     @SuppressWarnings("FinalPrivateMethod")
-    @SafeVarargs
     private final List<Object> testSequenceOfEvents(
-            final boolean emitProgressiveWatermarks,
-            final WatermarkStrategy<Integer> watermarkStrategy,
-            final Consumer<ReaderOutput<Integer>>... actions)
-            throws Exception {
+            final SourceOperator<Integer, MockSourceSplit> sourceOperator) throws Exception {
 
         final CollectingDataOutput<Integer> out = new CollectingDataOutput<>();
 
-        final TestProcessingTimeService timeService = new TestProcessingTimeService();
-        timeService.setCurrentTime(Integer.MAX_VALUE); // start somewhere that is not zero
-
-        final SourceReader<Integer, MockSourceSplit> reader = new InterpretingSourceReader(actions);
-
-        final SourceOperator<Integer, MockSourceSplit> sourceOperator =
-                createTestOperator(
-                        reader, watermarkStrategy, timeService, emitProgressiveWatermarks);
+        final TestProcessingTimeService timeService =
+                ((TestProcessingTimeService) sourceOperator.getProcessingTimeService());
 
         while (sourceOperator.emitNext(out) != DataInputStatus.END_OF_INPUT) {
             timeService.setCurrentTime(timeService.getCurrentProcessingTime() + 100);
         }
 
         return out.events;
-    }
-
-    // ------------------------------------------------------------------------
-    //   test setup helpers
-    // ------------------------------------------------------------------------
-
-    private static <T> SourceOperator<T, MockSourceSplit> createTestOperator(
-            SourceReader<T, MockSourceSplit> reader,
-            WatermarkStrategy<T> watermarkStrategy,
-            ProcessingTimeService timeService,
-            boolean emitProgressiveWatermarks)
-            throws Exception {
-
-        final OperatorStateStore operatorStateStore =
-                new MemoryStateBackend()
-                        .createOperatorStateBackend(
-                                new MockEnvironmentBuilder().build(),
-                                "test-operator",
-                                Collections.emptyList(),
-                                new CloseableRegistry());
-
-        final StateInitializationContext stateContext =
-                new StateInitializationContextImpl(null, operatorStateStore, null, null, null);
-
-        final SourceOperator<T, MockSourceSplit> sourceOperator =
-                new TestingSourceOperator<>(
-                        reader, watermarkStrategy, timeService, emitProgressiveWatermarks);
-
-        sourceOperator.setup(
-                new SourceOperatorStreamTask<Integer>(
-                        new StreamMockEnvironment(
-                                new Configuration(),
-                                new Configuration(),
-                                new ExecutionConfig(),
-                                1L,
-                                new MockInputSplitProvider(),
-                                1,
-                                new TestTaskStateManager())),
-                new MockStreamConfig(new Configuration(), 1),
-                new MockOutput<>(new ArrayList<>()));
-        sourceOperator.initializeState(stateContext);
-        sourceOperator.open();
-
-        return sourceOperator;
     }
 
     // ------------------------------------------------------------------------

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/source/TestingSourceOperator.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/source/TestingSourceOperator.java
@@ -20,17 +20,33 @@ package org.apache.flink.streaming.api.operators.source;
 
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.state.OperatorStateStore;
 import org.apache.flink.api.connector.source.SourceReader;
 import org.apache.flink.api.connector.source.mocks.MockSourceSplit;
 import org.apache.flink.api.connector.source.mocks.MockSourceSplitSerializer;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.operators.coordination.MockOperatorEventGateway;
 import org.apache.flink.runtime.operators.coordination.OperatorEventGateway;
+import org.apache.flink.runtime.operators.testutils.MockEnvironmentBuilder;
+import org.apache.flink.runtime.operators.testutils.MockInputSplitProvider;
+import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.runtime.state.StateInitializationContextImpl;
+import org.apache.flink.runtime.state.TestTaskStateManager;
+import org.apache.flink.runtime.state.hashmap.HashMapStateBackend;
 import org.apache.flink.streaming.api.operators.SourceOperator;
 import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
+import org.apache.flink.streaming.runtime.tasks.SourceOperatorStreamTask;
+import org.apache.flink.streaming.runtime.tasks.StreamMockEnvironment;
+import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
+import org.apache.flink.streaming.util.MockOutput;
+import org.apache.flink.streaming.util.MockStreamConfig;
 import org.apache.flink.streaming.util.MockStreamingRuntimeContext;
+
+import java.util.ArrayList;
+import java.util.Collections;
 
 /** A SourceOperator extension to simplify test setup. */
 public class TestingSourceOperator<T> extends SourceOperator<T, MockSourceSplit> {
@@ -99,5 +115,47 @@ public class TestingSourceOperator<T> extends SourceOperator<T, MockSourceSplit>
         ExecutionConfig cfg = new ExecutionConfig();
         cfg.setAutoWatermarkInterval(100);
         return cfg;
+    }
+
+    public static <T> SourceOperator<T, MockSourceSplit> createTestOperator(
+            SourceReader<T, MockSourceSplit> reader,
+            WatermarkStrategy<T> watermarkStrategy,
+            boolean emitProgressiveWatermarks)
+            throws Exception {
+
+        final OperatorStateStore operatorStateStore =
+                new HashMapStateBackend()
+                        .createOperatorStateBackend(
+                                new MockEnvironmentBuilder().build(),
+                                "test-operator",
+                                Collections.emptyList(),
+                                new CloseableRegistry());
+
+        final StateInitializationContext stateContext =
+                new StateInitializationContextImpl(null, operatorStateStore, null, null, null);
+
+        TestProcessingTimeService timeService = new TestProcessingTimeService();
+        timeService.setCurrentTime(Integer.MAX_VALUE); // start somewhere that is not zero
+
+        final SourceOperator<T, MockSourceSplit> sourceOperator =
+                new TestingSourceOperator<>(
+                        reader, watermarkStrategy, timeService, emitProgressiveWatermarks);
+
+        sourceOperator.setup(
+                new SourceOperatorStreamTask<Integer>(
+                        new StreamMockEnvironment(
+                                new Configuration(),
+                                new Configuration(),
+                                new ExecutionConfig(),
+                                1L,
+                                new MockInputSplitProvider(),
+                                1,
+                                new TestTaskStateManager())),
+                new MockStreamConfig(new Configuration(), 1),
+                new MockOutput<>(new ArrayList<>()));
+        sourceOperator.initializeState(stateContext);
+        sourceOperator.open();
+
+        return sourceOperator;
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes a bug when multiple splits are assigned to a source operator, records from the first fetch of the first split might mistakenly push watermark forward so that records from other splits are treated as late event. 


## Brief change log

  - Fix typo of variable in SourceOperator
  - Create per-split output on split addition in SourceOperator

## Verifying this change

This change added tests and can be verified as follows:

- Added unit test for per-split watermark in source operator
- Added IT case for testing `SourceReaderBase` working together with `SourceOperator` on per-split watermark
- Added IT case for KafkaSource for testing per-split watermark

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
