### PR TITLE
[FLINK-26166][runtime-web] Add auto newline detection to prettier formatter

### DIFF
--- a/flink-runtime-web/web-dashboard/.eslintrc.js
+++ b/flink-runtime-web/web-dashboard/.eslintrc.js
@@ -136,7 +136,8 @@ module.exports = {
         'prettier/prettier': [
           'error',
           {
-            parser: 'angular'
+            parser: 'angular',
+            endOfLine: 'auto'
           }
         ]
       }

--- a/flink-runtime-web/web-dashboard/.eslintrc.js
+++ b/flink-runtime-web/web-dashboard/.eslintrc.js
@@ -136,8 +136,7 @@ module.exports = {
         'prettier/prettier': [
           'error',
           {
-            parser: 'angular',
-            endOfLine: 'auto'
+            parser: 'angular'
           }
         ]
       }

--- a/flink-runtime-web/web-dashboard/.prettierrc
+++ b/flink-runtime-web/web-dashboard/.prettierrc
@@ -9,6 +9,7 @@
   "bracketSpacing": true,
   "proseWrap": "preserve",
   "trailingComma": "none",
+  "endOfLine": "auto",
   "overrides": [
     {
       "files": ".prettierrc",


### PR DESCRIPTION
## What is the purpose of the change

Normally I'm developing on linux based system but sometimes reviewing on Windows based machines. Compile blows up in the following way:
```
[INFO] d:\projects\flink\flink-runtime-web\web-dashboard\src\@types\d3-flame-graph\index.d.ts
[INFO]    1:3   error  Delete `â??`  prettier/prettier
...
```

The following git config hacks it around:
```
core.eol=lf
core.autocrlf=input
```

but it would be good to make it work out of the box so changed prettier formatter config to auto detect the newline.

Here is how auto behaves:
`"auto" - Maintain existing line endings (mixed values within one file are normalised by looking at what’s used after the first line)`

## Brief change log

Changed prettier formatter config to auto detect the newline.

## Verifying this change

Flink compile on linux + windows.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
