### PR TITLE
[hotfix][table-planner] Improve error reporting when serializing CatalogTable into the plan

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ContextResolvedTableJsonSerializer.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ContextResolvedTableJsonSerializer.java
@@ -68,11 +68,19 @@ class ContextResolvedTableJsonSerializer extends StdSerializer<ContextResolvedTa
         if ((contextResolvedTable.isPermanent() || contextResolvedTable.isAnonymous())
                 && planCompilationOption != CatalogPlanCompilation.IDENTIFIER) {
             jsonGenerator.writeFieldName(FIELD_NAME_CATALOG_TABLE);
-            ResolvedCatalogTableJsonSerializer.serialize(
-                    contextResolvedTable.getResolvedTable(),
-                    planCompilationOption == CatalogPlanCompilation.ALL,
-                    jsonGenerator,
-                    serializerProvider);
+            try {
+                ResolvedCatalogTableJsonSerializer.serialize(
+                        contextResolvedTable.getResolvedTable(),
+                        planCompilationOption == CatalogPlanCompilation.ALL,
+                        jsonGenerator,
+                        serializerProvider);
+            } catch (ValidationException e) {
+                throw new ValidationException(
+                        String.format(
+                                "Error when trying to serialize the table '%s'",
+                                contextResolvedTable.getIdentifier()),
+                        e);
+            }
         }
 
         jsonGenerator.writeEndObject();

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ResolvedCatalogTableJsonSerializer.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ResolvedCatalogTableJsonSerializer.java
@@ -83,7 +83,15 @@ class ResolvedCatalogTableJsonSerializer extends StdSerializer<ResolvedCatalogTa
             if (!resolvedCatalogTable.getComment().isEmpty()) {
                 jsonGenerator.writeObjectField(COMMENT, resolvedCatalogTable.getComment());
             }
-            jsonGenerator.writeObjectField(OPTIONS, resolvedCatalogTable.getOptions());
+            try {
+                jsonGenerator.writeObjectField(OPTIONS, resolvedCatalogTable.getOptions());
+            } catch (Exception e) {
+                throw new ValidationException(
+                        "The table is not serializable, as "
+                                + resolvedCatalogTable.getClass()
+                                + "#getOptions failed.",
+                        e);
+            }
         }
 
         jsonGenerator.writeEndObject();


### PR DESCRIPTION
This is a little hotfix to improve error reporting when serializing a `CatalogTable` that cannot be serialized