### PR TITLE
[FLINK-26185] Update Elasticsarch E2E Tests to use new unified Sink interface

### DIFF
--- a/flink-end-to-end-tests/flink-elasticsearch6-test/src/main/java/org/apache/flink/streaming/tests/Elasticsearch6SinkExample.java
+++ b/flink-end-to-end-tests/flink-elasticsearch6-test/src/main/java/org/apache/flink/streaming/tests/Elasticsearch6SinkExample.java
@@ -18,25 +18,20 @@
 package org.apache.flink.streaming.tests;
 
 import org.apache.flink.api.common.functions.FlatMapFunction;
-import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.connector.elasticsearch.sink.Elasticsearch6SinkBuilder;
+import org.apache.flink.connector.elasticsearch.sink.ElasticsearchSink;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.connectors.elasticsearch.ActionRequestFailureHandler;
-import org.apache.flink.streaming.connectors.elasticsearch.RequestIndexer;
-import org.apache.flink.streaming.connectors.elasticsearch6.ElasticsearchSink;
 import org.apache.flink.util.Collector;
 
 import org.apache.http.HttpHost;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.client.Requests;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 /** End to end test for Elasticsearch6Sink. */
@@ -57,7 +52,7 @@ public class Elasticsearch6SinkExample {
         env.enableCheckpointing(5000);
 
         DataStream<Tuple2<String, String>> source =
-                env.generateSequence(0, parameterTool.getInt("numRecords") - 1)
+                env.fromSequence(0, parameterTool.getInt("numRecords") - 1)
                         .flatMap(
                                 new FlatMapFunction<Long, Tuple2<String, String>>() {
                                     @Override
@@ -70,79 +65,30 @@ public class Elasticsearch6SinkExample {
                                     }
                                 });
 
-        List<HttpHost> httpHosts = new ArrayList<>();
-        httpHosts.add(new HttpHost("127.0.0.1", 9200, "http"));
+        ElasticsearchSink<Tuple2<String, String>> sink =
+                new Elasticsearch6SinkBuilder<Tuple2<String, String>>()
+                        .setHosts(new HttpHost("127.0.0.1", 9200, "http"))
+                        .setEmitter(
+                                (element, ctx, indexer) -> {
+                                    indexer.add(createIndexRequest(element.f1, parameterTool));
+                                    indexer.add(createUpdateRequest(element, parameterTool));
+                                })
+                        .setBulkFlushMaxActions(1) // emit after every element, don't buffer
+                        .build();
 
-        ElasticsearchSink.Builder<Tuple2<String, String>> esSinkBuilder =
-                new ElasticsearchSink.Builder<>(
-                        httpHosts,
-                        (Tuple2<String, String> element,
-                                RuntimeContext ctx,
-                                RequestIndexer indexer) -> {
-                            indexer.add(createIndexRequest(element.f1, parameterTool));
-                            indexer.add(createUpdateRequest(element, parameterTool));
-                        });
-
-        esSinkBuilder.setFailureHandler(
-                new CustomFailureHandler(
-                        parameterTool.getRequired("index"), parameterTool.getRequired("type")));
-
-        // this instructs the sink to emit after every element, otherwise they would be buffered
-        esSinkBuilder.setBulkFlushMaxActions(1);
-
-        source.addSink(esSinkBuilder.build());
-
+        source.sinkTo(sink);
         env.execute("Elasticsearch 6.x end to end sink test example");
-    }
-
-    private static class CustomFailureHandler implements ActionRequestFailureHandler {
-
-        private static final long serialVersionUID = 942269087742453482L;
-
-        private final String index;
-        private final String type;
-
-        CustomFailureHandler(String index, String type) {
-            this.index = index;
-            this.type = type;
-        }
-
-        @Override
-        public void onFailure(
-                ActionRequest action, Throwable failure, int restStatusCode, RequestIndexer indexer)
-                throws Throwable {
-            if (action instanceof IndexRequest) {
-                Map<String, Object> json = new HashMap<>();
-                json.put("data", ((IndexRequest) action).source());
-
-                indexer.add(
-                        Requests.indexRequest()
-                                .index(index)
-                                .type(type)
-                                .id(((IndexRequest) action).id())
-                                .source(json));
-            } else {
-                throw new IllegalStateException("unexpected");
-            }
-        }
     }
 
     private static IndexRequest createIndexRequest(String element, ParameterTool parameterTool) {
         Map<String, Object> json = new HashMap<>();
         json.put("data", element);
 
-        String index;
-        String type;
-
-        if (element.startsWith("message #15")) {
-            index = ":intentional invalid index:";
-            type = ":intentional invalid type:";
-        } else {
-            index = parameterTool.getRequired("index");
-            type = parameterTool.getRequired("type");
-        }
-
-        return Requests.indexRequest().index(index).type(type).id(element).source(json);
+        return Requests.indexRequest()
+                .index(parameterTool.getRequired("index"))
+                .type(parameterTool.getRequired("type"))
+                .id(element)
+                .source(json);
     }
 
     private static UpdateRequest createUpdateRequest(


### PR DESCRIPTION
## What is the purpose of the change

We want to update the Elasticsearch E2E Tests to use the new unified Sink API instead of the old one.

## Brief change log
  - Updated ElasticsearchXExample for ES6&7
  - Minor code cleanup

## Verifying this change

This change is already covered by existing tests, such as E2E Tests (`test_streaming_elasticsearch.sh`)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no***)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable)
