### PR TITLE
[FLINK-26189][build] Remove bundling of grizzled-slf4j from rpc-akka

### DIFF
--- a/flink-rpc/flink-rpc-akka/pom.xml
+++ b/flink-rpc/flink-rpc-akka/pom.xml
@@ -104,12 +104,6 @@ under the License.
 		</dependency>
 
 		<dependency>
-			<groupId>org.clapper</groupId>
-			<artifactId>grizzled-slf4j_${scala.binary.version}</artifactId>
-			<version>1.3.2</version>
-		</dependency>
-
-		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
 			<scope>provided</scope>

--- a/flink-rpc/flink-rpc-akka/src/main/resources/META-INF/NOTICE
+++ b/flink-rpc/flink-rpc-akka/src/main/resources/META-INF/NOTICE
@@ -18,11 +18,6 @@ This project bundles the following dependencies under the Apache Software Licens
 - io.netty:netty:3.10.6.Final
 - org.agrona:agrona:1.9.0
 
-This project bundles the following dependencies under the BSD license.
-See bundled license files for details.
-
-- org.clapper:grizzled-slf4j_2.12:1.3.2
-
 The following dependencies all share the same BSD license which you find under licenses/LICENSE.scala.
 
 - org.scala-lang:scala-compiler:2.12.7

--- a/flink-rpc/flink-rpc-akka/src/main/resources/META-INF/licenses/LICENSE.scala
+++ b/flink-rpc/flink-rpc-akka/src/main/resources/META-INF/licenses/LICENSE.scala
@@ -1,0 +1,28 @@
+Copyright (c) 2002-2018 EPFL
+Copyright (c) 2011-2018 Lightbend, Inc.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+  * Neither the name of the EPFL nor the names of its contributors
+    may be used to endorse or promote products derived from this software
+    without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
Unused dependency. It was used in the past when we had actor implementations in Scala and accidentally carried it forward.