### PR TITLE
[FLINK-26199] Annotate StatementSet#compilePlan as experimental.

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/StatementSet.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/StatementSet.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.api;
 
+import org.apache.flink.annotation.Experimental;
 import org.apache.flink.annotation.PublicEvolving;
 
 /**
@@ -84,5 +85,6 @@ public interface StatementSet extends Explainable<StatementSet>, Compilable, Exe
      * one job.
      */
     @Override
+    @Experimental
     CompiledPlan compilePlan() throws TableException;
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/FLINK-26199

Fixes the archunit tests for TableAPI.

- We assume that the class annotated as `@PublicEvolving` needs to have all return types / parameters `@PublicEvolving` or @Public unless explicitly noted otherwise.
- By annotating `compilePlan` as `@Experimental` we allow it to return the `CompiledPlan` which is also annotated as `@Experimental`