### PR TITLE
[FLINK-26125][docs][table] Add new documentation for the CAST changes in 1.15

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/RawToBinaryCastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/RawToBinaryCastRule.java
@@ -43,6 +43,11 @@ class RawToBinaryCastRule extends AbstractNullAwareCodeGeneratorCastRule<Object,
                         .build());
     }
 
+    @Override
+    public boolean canFail() {
+        return true;
+    }
+
     /* Example generated code for BINARY(3):
 
     // legacy behavior


### PR DESCRIPTION
## What is the purpose of the change

This PR adds documentation for the new TRY_CAST and describes the various changes related to casting in 1.15, including a matrix of the supported cast tuples.