### PR TITLE
[FLINK-26231][state/changelog] Fix ChangelogStateBackendHandle constructor

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/ChangelogStateBackendHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/ChangelogStateBackendHandle.java
@@ -73,8 +73,8 @@ public interface ChangelogStateBackendHandle extends KeyedStateHandle {
                     materialized,
                     nonMaterialized,
                     keyGroupRange,
-                    persistedSizeOfThisCheckpoint,
                     materializationID,
+                    persistedSizeOfThisCheckpoint,
                     StateHandleID.randomStateHandleId());
         }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/changelog/ChangelogStateBackendHandleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/changelog/ChangelogStateBackendHandleTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.changelog;
+
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.changelog.ChangelogStateBackendHandle.ChangelogStateBackendHandleImpl;
+
+import org.junit.Test;
+
+import static java.util.Collections.emptyList;
+import static org.apache.flink.runtime.state.StateHandleID.randomStateHandleId;
+import static org.junit.Assert.assertEquals;
+
+public class ChangelogStateBackendHandleTest {
+
+    @Test
+    public void testPublicConstructor() {
+        long materializationID = 1L;
+        long size = 2L;
+        validateHandle(
+                materializationID,
+                size,
+                new ChangelogStateBackendHandleImpl(
+                        emptyList(), emptyList(), KeyGroupRange.of(1, 2), materializationID, size));
+    }
+
+    @Test
+    public void testRestore() {
+        long materializationID = 1L;
+        long size = 2L;
+        validateHandle(
+                materializationID,
+                size,
+                ChangelogStateBackendHandleImpl.restore(
+                        emptyList(),
+                        emptyList(),
+                        KeyGroupRange.of(1, 2),
+                        materializationID,
+                        size,
+                        randomStateHandleId()));
+    }
+
+    private void validateHandle(
+            long materializationID, long size, ChangelogStateBackendHandleImpl handle) {
+        assertEquals(materializationID, handle.getMaterializationID());
+        assertEquals(size, handle.getCheckpointedSize());
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

In `ChangelogStateBackendHandleImpl` constructor, `materializationID` and `persistedSizeOfThisCheckpoint` are mixed up.

## Verifying this change

Added `ChangelogStateBackendHandleTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
