### PR TITLE
[FLINK-25856][python] Fix use of UserDefinedType in from_elements

### DIFF
--- a/flink-python/pyflink/table/types.py
+++ b/flink-python/pyflink/table/types.py
@@ -2202,12 +2202,17 @@ def _create_type_verifier(data_type: DataType, name: str = None):
         verify_value = verify_varbinary
 
     elif isinstance(data_type, UserDefinedType):
-        verifier = _create_type_verifier(data_type.sql_type(), name=name)
+        sql_type = data_type.sql_type()
+        verifier = _create_type_verifier(sql_type, name=name)
 
         def verify_udf(obj):
             if not (hasattr(obj, '__UDT__') and obj.__UDT__ == data_type):
                 raise ValueError(new_msg("%r is not an instance of type %r" % (obj, data_type)))
-            verifier(data_type.to_sql_type(obj))
+            data = data_type.to_sql_type(obj)
+            if isinstance(sql_type, RowType):
+                # remove the RowKind value in the first position.
+                data = data[1:]
+            verifier(data)
 
         verify_value = verify_udf
 


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will fix use of UserDefinedType in from_elements*

## Brief change log

  - *Fix use of UserDefinedType in from_elements*

## Verifying this change

This change added tests and can be verified as follows:

  - *`test_udt` in `test_table_environment_api.py`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
