### PR TITLE
[FLINK-26233] FileSinkCompactionSwitchITCase.testSwitchingCompaction() fails in CI

### DIFF
--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/FileSink.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/FileSink.java
@@ -206,7 +206,7 @@ public class FileSink<IN>
                             committableStream
                                     .forward()
                                     .transform(
-                                            "CompactorCoordinator",
+                                            "CompactorCoordinatorPlaceHolder",
                                             new EitherTypeInfo<>(
                                                     committableStream.getType(),
                                                     new CompactorRequestTypeInfo(
@@ -220,7 +220,7 @@ public class FileSink<IN>
             return coordinatorOp
                     .forward()
                     .transform(
-                            "CompactorOperator",
+                            "CompactorOperatorPlaceHolder",
                             committableStream.getType(),
                             new CompactorOperatorStateHandlerFactory(
                                     bucketsBuilder::getCommittableSerializer,

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/FileSinkCommittableSerializerMigrationTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/FileSinkCommittableSerializerMigrationTest.java
@@ -29,6 +29,7 @@ import org.apache.flink.streaming.api.functions.sink.filesystem.BucketWriter;
 import org.apache.flink.streaming.api.functions.sink.filesystem.OutputStreamBasedPartFileWriter.OutputStreamBasedInProgressFileRecoverable;
 import org.apache.flink.streaming.api.functions.sink.filesystem.OutputStreamBasedPartFileWriter.OutputStreamBasedPendingFileRecoverable;
 import org.apache.flink.streaming.api.functions.sink.filesystem.RowWiseBucketWriter;
+import org.apache.flink.util.TestLogger;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -50,7 +51,7 @@ import java.util.Collections;
  * serialized by the previous versions.
  */
 @RunWith(Parameterized.class)
-public class FileSinkCommittableSerializerMigrationTest {
+public class FileSinkCommittableSerializerMigrationTest extends TestLogger {
 
     private static final int CURRENT_VERSION = 1;
 

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/FileSinkCompactionSwitchITCase.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/FileSinkCompactionSwitchITCase.java
@@ -52,6 +52,7 @@ import org.apache.flink.streaming.api.graph.StreamGraph;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
 import org.apache.flink.testutils.junit.SharedObjects;
 import org.apache.flink.testutils.junit.SharedReference;
+import org.apache.flink.util.TestLogger;
 
 import org.junit.After;
 import org.junit.Before;
@@ -84,7 +85,7 @@ import static org.junit.Assert.assertTrue;
 
 /** Tests of switching on or off compaction for the {@link FileSink}. */
 @RunWith(Parameterized.class)
-public class FileSinkCompactionSwitchITCase {
+public class FileSinkCompactionSwitchITCase extends TestLogger {
 
     private static final int PARALLELISM = 4;
 

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/FileSinkCompactionSwitchITCase.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/FileSinkCompactionSwitchITCase.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.configuration.StateChangelogOptions;
 import org.apache.flink.connector.file.sink.FileSink.DefaultRowFormatBuilder;
 import org.apache.flink.connector.file.sink.compactor.DecoderBasedReader;
 import org.apache.flink.connector.file.sink.compactor.FileCompactStrategy;
@@ -43,6 +44,8 @@ import org.apache.flink.runtime.minicluster.RpcServiceSharing;
 import org.apache.flink.runtime.state.CheckpointListener;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
+import org.apache.flink.runtime.state.hashmap.HashMapStateBackend;
+import org.apache.flink.runtime.state.storage.FileSystemCheckpointStorage;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.streaming.api.CheckpointingMode;
 import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
@@ -137,11 +140,12 @@ public class FileSinkCompactionSwitchITCase extends TestLogger {
     @Test
     public void testSwitchingCompaction() throws Exception {
         String path = TEMPORARY_FOLDER.newFolder().getAbsolutePath();
+        String cpPath = "file://" + TEMPORARY_FOLDER.newFolder().getAbsolutePath();
 
         SharedReference<ConcurrentHashMap<Integer, Integer>> sendCountMap =
                 sharedObjects.add(new ConcurrentHashMap<>());
-        JobGraph jobGraph = createJobGraph(path, isOnToOff, false, sendCountMap);
-        JobGraph restoringJobGraph = createJobGraph(path, !isOnToOff, true, sendCountMap);
+        JobGraph jobGraph = createJobGraph(path, cpPath, isOnToOff, false, sendCountMap);
+        JobGraph restoringJobGraph = createJobGraph(path, cpPath, !isOnToOff, true, sendCountMap);
 
         final Configuration config = new Configuration();
         config.setString(RestOptions.BIND_PORT, "18081-19000");
@@ -181,16 +185,21 @@ public class FileSinkCompactionSwitchITCase extends TestLogger {
 
     private JobGraph createJobGraph(
             String path,
+            String cpPath,
             boolean compactionEnabled,
             boolean isFinite,
             SharedReference<ConcurrentHashMap<Integer, Integer>> sendCountMap) {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         Configuration config = new Configuration();
         config.set(ExecutionOptions.RUNTIME_MODE, RuntimeExecutionMode.STREAMING);
+        // disable changelog state in case it's randomly enabled, since it will fail the savepoint
+        config.set(StateChangelogOptions.ENABLE_STATE_CHANGE_LOG, false);
         env.configure(config, getClass().getClassLoader());
 
         env.enableCheckpointing(100, CheckpointingMode.EXACTLY_ONCE);
         env.setRestartStrategy(RestartStrategies.noRestart());
+        env.getCheckpointConfig().setCheckpointStorage(new FileSystemCheckpointStorage(cpPath));
+        env.setStateBackend(new HashMapStateBackend());
 
         env.addSource(new CountingTestSource(latchId, NUM_RECORDS, isFinite, sendCountMap))
                 .setParallelism(NUM_SOURCES)
@@ -357,10 +366,15 @@ public class FileSinkCompactionSwitchITCase extends TestLogger {
             latch.await();
         }
 
-        private void sendRecordsUntil(int targetNumber, SourceContext<Integer> ctx) {
+        private void sendRecordsUntil(int targetNumber, SourceContext<Integer> ctx)
+                throws InterruptedException {
             while (!isCanceled && nextValue < targetNumber) {
                 synchronized (ctx.getCheckpointLock()) {
                     ctx.collect(nextValue++);
+                    if (!isFinite && nextValue % 100 == 0) {
+                        // slow down the source in case too many records are sent
+                        Thread.sleep(1);
+                    }
                 }
             }
         }

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/compactor/AbstractCompactTestBase.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/compactor/AbstractCompactTestBase.java
@@ -19,6 +19,7 @@
 package org.apache.flink.connector.file.sink.compactor;
 
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.util.TestLogger;
 
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -29,7 +30,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 
 /** Test base for compact operators. */
-public abstract class AbstractCompactTestBase {
+public abstract class AbstractCompactTestBase extends TestLogger {
 
     @ClassRule public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
 

--- a/flink-connectors/flink-file-sink-common/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/OutputStreamBasedPartFileRecoverableMigrationTest.java
+++ b/flink-connectors/flink-file-sink-common/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/OutputStreamBasedPartFileRecoverableMigrationTest.java
@@ -30,6 +30,7 @@ import org.apache.flink.streaming.api.functions.sink.filesystem.OutputStreamBase
 import org.apache.flink.streaming.api.functions.sink.filesystem.OutputStreamBasedPartFileWriter.OutputStreamBasedInProgressFileRecoverableSerializer;
 import org.apache.flink.streaming.api.functions.sink.filesystem.OutputStreamBasedPartFileWriter.OutputStreamBasedPendingFileRecoverable;
 import org.apache.flink.streaming.api.functions.sink.filesystem.OutputStreamBasedPartFileWriter.OutputStreamBasedPendingFileRecoverableSerializer;
+import org.apache.flink.util.TestLogger;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -52,7 +53,7 @@ import java.util.Collections;
  * serialized by the previous versions.
  */
 @RunWith(Parameterized.class)
-public class OutputStreamBasedPartFileRecoverableMigrationTest {
+public class OutputStreamBasedPartFileRecoverableMigrationTest extends TestLogger {
 
     private static final int CURRENT_VERSION = 1;
 

--- a/flink-formats/flink-hadoop-bulk/src/test/java/org/apache/flink/formats/hadoop/bulk/HadoopPathBasedPendingFileRecoverableSerializerMigrationTest.java
+++ b/flink-formats/flink-hadoop-bulk/src/test/java/org/apache/flink/formats/hadoop/bulk/HadoopPathBasedPendingFileRecoverableSerializerMigrationTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.formats.hadoop.bulk;
 
 import org.apache.flink.formats.hadoop.bulk.HadoopPathBasedPartFileWriter.HadoopPathBasedPendingFileRecoverable;
 import org.apache.flink.formats.hadoop.bulk.HadoopPathBasedPartFileWriter.HadoopPathBasedPendingFileRecoverableSerializer;
+import org.apache.flink.util.TestLogger;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -40,7 +41,7 @@ import java.util.Collections;
  * read the recoverable serialized by the previous versions.
  */
 @RunWith(Parameterized.class)
-public class HadoopPathBasedPendingFileRecoverableSerializerMigrationTest {
+public class HadoopPathBasedPendingFileRecoverableSerializerMigrationTest extends TestLogger {
 
     private static final int CURRENT_VERSION = 1;
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This PR fixes the instability of FileSinkCompactionSwitchITCase.testSwitchingCompaction. The test might fail because the state of committer could be too large when the compaction is switch from on to off.

## Brief change log

  - Slow down the speed of source, in case too many records are sent, producing too many pending files.
  - Use FileSystemCheckpointStorage to ensure the state size is supported.
  - Some other hotfixes in the compactor tests.



## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)