### PR TITLE
[FLINK-25528][state-processor-api] state processor api do not support increment checkpoint

### DIFF
--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/SnapshotUtils.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/SnapshotUtils.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.runtime.checkpoint.SavepointType;
 import org.apache.flink.runtime.checkpoint.SnapshotType;
@@ -33,6 +34,7 @@ import org.apache.flink.streaming.api.operators.OperatorSnapshotFinalizer;
 import org.apache.flink.streaming.api.operators.OperatorSnapshotFutures;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.util.MathUtils;
+import org.apache.flink.util.Preconditions;
 
 import java.io.IOException;
 
@@ -56,6 +58,10 @@ public final class SnapshotUtils {
             Path savepointPath,
             SnapshotType snapshotType)
             throws Exception {
+
+        Preconditions.checkArgument(
+                snapshotType.isSavepoint() || CheckpointType.FULL_CHECKPOINT.equals(snapshotType),
+                "the snapshot type require savepoint type or full checkpoint type.");
 
         CheckpointOptions options =
                 CheckpointOptions.forConfig(

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/SnapshotUtils.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/SnapshotUtils.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.runtime.checkpoint.SavepointType;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
@@ -57,7 +58,7 @@ public final class SnapshotUtils {
 
         CheckpointOptions options =
                 CheckpointOptions.forConfig(
-                        SavepointType.savepoint(SavepointFormatType.CANONICAL),
+                        CheckpointType.CHECKPOINT,
                         AbstractFsCheckpointStorageAccess.encodePathAsReference(savepointPath),
                         isExactlyOnceMode,
                         isUnalignedCheckpoint,

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/SnapshotUtils.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/SnapshotUtils.java
@@ -23,10 +23,8 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
-import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.runtime.checkpoint.SavepointType;
-import org.apache.flink.runtime.checkpoint.SnapshotType;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
 import org.apache.flink.runtime.state.filesystem.AbstractFsCheckpointStorageAccess;
 import org.apache.flink.runtime.state.filesystem.FsCheckpointStorageLocation;
@@ -34,7 +32,6 @@ import org.apache.flink.streaming.api.operators.OperatorSnapshotFinalizer;
 import org.apache.flink.streaming.api.operators.OperatorSnapshotFutures;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.util.MathUtils;
-import org.apache.flink.util.Preconditions;
 
 import java.io.IOException;
 
@@ -56,16 +53,12 @@ public final class SnapshotUtils {
             boolean isUnalignedCheckpoint,
             Configuration configuration,
             Path savepointPath,
-            SnapshotType snapshotType)
+            SavepointFormatType savepointFormatType)
             throws Exception {
-
-        Preconditions.checkArgument(
-                snapshotType.isSavepoint() || CheckpointType.FULL_CHECKPOINT.equals(snapshotType),
-                "the snapshot type require savepoint type or full checkpoint type.");
 
         CheckpointOptions options =
                 CheckpointOptions.forConfig(
-                        snapshotType,
+                        SavepointType.savepoint(savepointFormatType),
                         AbstractFsCheckpointStorageAccess.encodePathAsReference(savepointPath),
                         isExactlyOnceMode,
                         isUnalignedCheckpoint,
@@ -103,7 +96,7 @@ public final class SnapshotUtils {
                 isUnalignedCheckpoint,
                 configuration,
                 savepointPath,
-                SavepointType.savepoint(SavepointFormatType.CANONICAL));
+                SavepointFormatType.DEFAULT);
     }
 
     private static CheckpointStreamFactory createStreamFactory(

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/output/SnapshotUtilsTest.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/output/SnapshotUtilsTest.java
@@ -56,8 +56,17 @@ public class SnapshotUtilsTest {
     private static SnapshotType actualSnapshotType;
 
     @Test
-    public void testSnapshotUtilsLifecycle() throws Exception {
+    public void testSnapshotUtilsLifecycleWithDefaultSavepointFormatType() throws Exception {
         testSnapshotUtilsLifecycleWithSavepointFormatType(SavepointFormatType.DEFAULT);
+    }
+
+    @Test
+    public void testSnapshotUtilsLifecycleWithCanonicalSavepointFormatType() throws Exception {
+        testSnapshotUtilsLifecycleWithSavepointFormatType(SavepointFormatType.CANONICAL);
+    }
+
+    @Test
+    public void testSnapshotUtilsLifecycleWithNativeSavepointFormatType() throws Exception {
         testSnapshotUtilsLifecycleWithSavepointFormatType(SavepointFormatType.NATIVE);
     }
 

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/output/SnapshotUtilsTest.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/output/SnapshotUtilsTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.metrics.groups.OperatorMetricGroup;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
 import org.apache.flink.streaming.api.operators.OperatorSnapshotFutures;
@@ -52,10 +53,30 @@ public class SnapshotUtilsTest {
 
     @Test
     public void testSnapshotUtilsLifecycle() throws Exception {
+        ACTUAL_ORDER_TRACKING.clear();
         StreamOperator<Void> operator = new LifecycleOperator();
         Path path = new Path(folder.newFolder().getAbsolutePath());
 
         SnapshotUtils.snapshot(operator, 0, 0L, true, false, new Configuration(), path);
+
+        Assert.assertEquals(EXPECTED_CALL_OPERATOR_SNAPSHOT, ACTUAL_ORDER_TRACKING);
+    }
+
+    @Test
+    public void testSnapshotUtilsLifecycleWithFullCheckpoint() throws Exception {
+        ACTUAL_ORDER_TRACKING.clear();
+        StreamOperator<Void> operator = new LifecycleOperator();
+        Path path = new Path(folder.newFolder().getAbsolutePath());
+
+        SnapshotUtils.snapshot(
+                operator,
+                0,
+                0L,
+                true,
+                false,
+                new Configuration(),
+                path,
+                CheckpointType.FULL_CHECKPOINT);
 
         Assert.assertEquals(EXPECTED_CALL_OPERATOR_SNAPSHOT, ACTUAL_ORDER_TRACKING);
     }

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/output/SnapshotUtilsTest.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/output/SnapshotUtilsTest.java
@@ -19,10 +19,10 @@
 package org.apache.flink.state.api.output;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.metrics.groups.OperatorMetricGroup;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
-import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
 import org.apache.flink.streaming.api.operators.OperatorSnapshotFutures;
@@ -63,7 +63,7 @@ public class SnapshotUtilsTest {
     }
 
     @Test
-    public void testSnapshotUtilsLifecycleWithFullCheckpoint() throws Exception {
+    public void testSnapshotUtilsLifecycleWithNativeSavepoint() throws Exception {
         ACTUAL_ORDER_TRACKING.clear();
         StreamOperator<Void> operator = new LifecycleOperator();
         Path path = new Path(folder.newFolder().getAbsolutePath());
@@ -76,7 +76,7 @@ public class SnapshotUtilsTest {
                 false,
                 new Configuration(),
                 path,
-                CheckpointType.FULL_CHECKPOINT);
+                SavepointFormatType.NATIVE);
 
         Assert.assertEquals(EXPECTED_CALL_OPERATOR_SNAPSHOT, ACTUAL_ORDER_TRACKING);
     }


### PR DESCRIPTION
## What is the purpose of the change

Make state-processor-api support increment checkpoint write.

## Brief change log


## Verifying this change

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
