### PR TITLE
[FLINK-26121] Adds queue cleanup to `ZooKeeperLeaderRetrievalConnectionHandlingTest`

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/zookeeper/ZooKeeperExtension.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/zookeeper/ZooKeeperExtension.java
@@ -56,7 +56,7 @@ public class ZooKeeperExtension implements CustomExtension {
 
     private void terminateZooKeeperServer() throws IOException {
         if (zooKeeperServer != null) {
-            zooKeeperServer.stop();
+            zooKeeperServer.close();
             zooKeeperServer = null;
         }
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/zookeeper/ZooKeeperExtension.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/zookeeper/ZooKeeperExtension.java
@@ -40,12 +40,12 @@ public class ZooKeeperExtension implements CustomExtension {
     @Nullable private TestingServer zooKeeperServer;
 
     public String getConnectString() {
-        verifyIsRunning();
-        return zooKeeperServer.getConnectString();
+        return getRunningZookeeperInstanceOrFail().getConnectString();
     }
 
-    private void verifyIsRunning() {
+    private TestingServer getRunningZookeeperInstanceOrFail() {
         Preconditions.checkState(zooKeeperServer != null);
+        return zooKeeperServer;
     }
 
     @Override
@@ -71,12 +71,10 @@ public class ZooKeeperExtension implements CustomExtension {
     }
 
     public void restart() throws Exception {
-        Preconditions.checkNotNull(zooKeeperServer);
-        zooKeeperServer.restart();
+        getRunningZookeeperInstanceOrFail().restart();
     }
 
     public void stop() throws IOException {
-        Preconditions.checkNotNull(zooKeeperServer);
-        zooKeeperServer.stop();
+        getRunningZookeeperInstanceOrFail().stop();
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

We experienced some unstable ZooKeeper tests. This test belongs to the same group. See further details on the investigation effort in FLINK-26121.

## Brief change log

* Refactors test to use utility method for common functionality:
  * Instantiating the `QueueLeaderElectionListener`
  * Closing the driver
 * Add a method for cleaning up the queue after the test passed

## Verifying this change

* Nothing added to test the behavior

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
