### PR TITLE
[hotfix][docs] Unified variable naming

### DIFF
--- a/docs/content.zh/docs/dev/datastream/operators/joining.md
+++ b/docs/content.zh/docs/dev/datastream/operators/joining.md
@@ -254,8 +254,8 @@ orangeStream
     .process (new ProcessJoinFunction<Integer, Integer, String(){
 
         @Override
-        public void processElement(Integer left, Integer right, Context ctx, Collector<String> out) {
-            out.collect(left + "," + right);
+        public void processElement(Integer first, Integer second, Context ctx, Collector<String> out) {
+            out.collect(first + "," + second);
         }
     });
 ```
@@ -277,8 +277,8 @@ orangeStream
     .intervalJoin(greenStream.keyBy(elem => /* select key */))
     .between(Time.milliseconds(-2), Time.milliseconds(1))
     .process(new ProcessJoinFunction[Integer, Integer, String] {
-        override def processElement(left: Integer, right: Integer, ctx: ProcessJoinFunction[Integer, Integer, String]#Context, out: Collector[String]): Unit = {
-            out.collect(left + "," + right)
+        override def processElement(first: Integer, second: Integer, ctx: ProcessJoinFunction[Integer, Integer, String]#Context, out: Collector[String]): Unit = {
+            out.collect(first + "," + second)
         }
     })
 

--- a/docs/content/docs/dev/datastream/operators/joining.md
+++ b/docs/content/docs/dev/datastream/operators/joining.md
@@ -254,8 +254,8 @@ orangeStream
     .process (new ProcessJoinFunction<Integer, Integer, String(){
 
         @Override
-        public void processElement(Integer left, Integer right, Context ctx, Collector<String> out) {
-            out.collect(left + "," + right);
+        public void processElement(Integer first, Integer second, Context ctx, Collector<String> out) {
+            out.collect(first + "," + second);
         }
     });
 ```
@@ -277,8 +277,8 @@ orangeStream
     .intervalJoin(greenStream.keyBy(elem => /* select key */))
     .between(Time.milliseconds(-2), Time.milliseconds(1))
     .process(new ProcessJoinFunction[Integer, Integer, String] {
-        override def processElement(left: Integer, right: Integer, ctx: ProcessJoinFunction[Integer, Integer, String]#Context, out: Collector[String]): Unit = {
-            out.collect(left + "," + right)
+        override def processElement(first: Integer, second: Integer, ctx: ProcessJoinFunction[Integer, Integer, String]#Context, out: Collector[String]): Unit = {
+            out.collect(first + "," + second)
         }
     })
 


### PR DESCRIPTION
## What is the purpose of the change

In page [joining](https://nightlies.apache.org/flink/flink-docs-release-1.14/docs/dev/datastream/operators/joining/#interval-join), the variable names are named `first` and `second`, but in the example of `Interval Join`, the variable names are named `left` and `right`, we should unified variable naming


## Brief change log
Unified variable naming on page joining

## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
