### PR TITLE
[FLINK-25893] Fix ResourceManagerServiceImpl#deregisterApplication instability

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/DispatcherResourceManagerComponent.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/DispatcherResourceManagerComponent.java
@@ -129,17 +129,7 @@ public class DispatcherResourceManagerComponent implements AutoCloseableAsync {
     public CompletableFuture<Void> stopApplication(
             final ApplicationStatus applicationStatus, final @Nullable String diagnostics) {
         return internalShutdown(
-                () ->
-                        resourceManagerService
-                                .deregisterApplication(applicationStatus, diagnostics)
-                                // suppress deregister exception because of FLINK-25893
-                                .exceptionally(
-                                        exception -> {
-                                            LOG.warn(
-                                                    "Could not properly deregister the application.",
-                                                    exception);
-                                            return null;
-                                        }));
+                () -> resourceManagerService.deregisterApplication(applicationStatus, diagnostics));
     }
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerServiceImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerServiceImpl.java
@@ -155,9 +155,8 @@ public class ResourceManagerServiceImpl implements ResourceManagerService, Leade
     }
 
     private static CompletableFuture<Void> deregisterWithoutLeaderRm() {
-        return FutureUtils.completedExceptionally(
-                new FlinkException(
-                        "Cannot deregister application. Resource manager service is not available."));
+        LOG.warn("Cannot deregister application. Resource manager service is not available.");
+        return FutureUtils.completedVoidFuture();
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerServiceImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerServiceImplTest.java
@@ -482,6 +482,16 @@ public class ResourceManagerServiceImplTest extends TestLogger {
         deregisterApplicationFuture.get(TIMEOUT.getSize(), TIMEOUT.getUnit());
     }
 
+    @Test
+    public void deregisterApplication_noLeaderRm() throws Exception {
+        createAndStartResourceManager();
+        final CompletableFuture<Void> deregisterApplicationFuture =
+                resourceManagerService.deregisterApplication(ApplicationStatus.CANCELED, null);
+
+        // should not report error
+        deregisterApplicationFuture.get(TIMEOUT.getSize(), TIMEOUT.getUnit());
+    }
+
     private static void blockOnFuture(CompletableFuture<?> future) {
         try {
             future.get();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerServiceImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerServiceImplTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.resourcemanager;
 
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
@@ -446,6 +447,39 @@ public class ResourceManagerServiceImplTest extends TestLogger {
         finishRmTerminationFuture.complete(null);
 
         closeServiceFuture.get(TIMEOUT.getSize(), TIMEOUT.getUnit());
+    }
+
+    @Test
+    public void deregisterApplication_leaderRmNotStarted() throws Exception {
+        final CompletableFuture<Void> startRmInitializationFuture = new CompletableFuture<>();
+        final CompletableFuture<Void> finishRmInitializationFuture = new CompletableFuture<>();
+
+        rmFactoryBuilder.setInitializeConsumer(
+                (ignore) -> {
+                    startRmInitializationFuture.complete(null);
+                    blockOnFuture(finishRmInitializationFuture);
+                });
+
+        createAndStartResourceManager();
+
+        // grant leadership
+        leaderElectionService.isLeader(UUID.randomUUID());
+
+        // make sure leader RM is created
+        startRmInitializationFuture.get(TIMEOUT.getSize(), TIMEOUT.getUnit());
+
+        // deregister application
+        final CompletableFuture<Void> deregisterApplicationFuture =
+                resourceManagerService.deregisterApplication(ApplicationStatus.CANCELED, null);
+
+        // RM not fully started, future shuold not complete
+        assertNotComplete(deregisterApplicationFuture);
+
+        // finish starting RM
+        finishRmInitializationFuture.complete(null);
+
+        // should perform deregistration
+        deregisterApplicationFuture.get(TIMEOUT.getSize(), TIMEOUT.getUnit());
     }
 
     private static void blockOnFuture(CompletableFuture<?> future) {


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes 2 problems in `ResourceManagerServiceImpl#deregisterApplication`:
1. `deregisterApplication` might be called on a leader RM that is not fully started
2. It should not be treated as an error that `deregisterApplication` is called when there's no leader RM


## Brief change log

- Fix the above mentioned 2 problems
- Re-enable the related error reporting, which is suppressed in FLINK-25885

## Verifying this change

- UT added / updated

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
