### PR TITLE
[FLINK-25648][Kubernetes] Avoid redundant to query Kubernetes deployment when creating task manager pods

### DIFF
--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesClientTestBase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesClientTestBase.java
@@ -125,6 +125,14 @@ public class KubernetesClientTestBase extends KubernetesTestBase {
         methodTypeSetter.apply(server.expect()).withPath(path).andReturn(500, configMap).always();
     }
 
+    protected void mockGetDeploymentWithError() {
+        final String path =
+                String.format(
+                        "/apis/apps/v1/namespaces/%s/deployments/%s",
+                        NAMESPACE, KubernetesTestBase.CLUSTER_ID);
+        server.expect().get().withPath(path).andReturn(500, "Expected error").always();
+    }
+
     protected Service buildExternalServiceWithLoadBalancer(
             @Nullable String hostname, @Nullable String ip) {
         final ServicePort servicePort =

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClientTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClientTest.java
@@ -223,15 +223,7 @@ public class Fabric8FlinkKubeClientTest extends KubernetesClientTestBase {
     public void testCreateFlinkTaskManagerPod() throws Exception {
         this.flinkKubeClient.createJobManagerComponent(this.kubernetesJobManagerSpecification);
 
-        final KubernetesPod kubernetesPod =
-                new KubernetesPod(
-                        new PodBuilder()
-                                .editOrNewMetadata()
-                                .withName("mock-task-manager-pod")
-                                .endMetadata()
-                                .editOrNewSpec()
-                                .endSpec()
-                                .build());
+        final KubernetesPod kubernetesPod = buildKubernetesPod("mock-task-manager-pod");
         this.flinkKubeClient.createTaskManagerPod(kubernetesPod).get();
 
         final Pod resultTaskManagerPod =
@@ -248,6 +240,31 @@ public class Fabric8FlinkKubeClientTest extends KubernetesClientTestBase {
                         .getMetadata()
                         .getUid(),
                 resultTaskManagerPod.getMetadata().getOwnerReferences().get(0).getUid());
+    }
+
+    @Test
+    public void testCreateTwoTaskManagerPods() throws Exception {
+        flinkKubeClient.createJobManagerComponent(this.kubernetesJobManagerSpecification);
+        flinkKubeClient.createTaskManagerPod(buildKubernetesPod("mock-task-manager-pod1")).get();
+        mockGetDeploymentWithError();
+        try {
+            flinkKubeClient
+                    .createTaskManagerPod(buildKubernetesPod("mock-task-manager-pod2"))
+                    .get();
+        } catch (Exception e) {
+            fail("should only get the master deployment once");
+        }
+    }
+
+    private KubernetesPod buildKubernetesPod(String name) {
+        return new KubernetesPod(
+                new PodBuilder()
+                        .editOrNewMetadata()
+                        .withName(name)
+                        .endMetadata()
+                        .editOrNewSpec()
+                        .endSpec()
+                        .build());
     }
 
     @Test
@@ -373,15 +390,7 @@ public class Fabric8FlinkKubeClientTest extends KubernetesClientTestBase {
     public void testStopAndCleanupCluster() throws Exception {
         this.flinkKubeClient.createJobManagerComponent(this.kubernetesJobManagerSpecification);
 
-        final KubernetesPod kubernetesPod =
-                new KubernetesPod(
-                        new PodBuilder()
-                                .editOrNewMetadata()
-                                .withName(TASKMANAGER_POD_NAME)
-                                .endMetadata()
-                                .editOrNewSpec()
-                                .endSpec()
-                                .build());
+        final KubernetesPod kubernetesPod = buildKubernetesPod(TASKMANAGER_POD_NAME);
         this.flinkKubeClient.createTaskManagerPod(kubernetesPod).get();
 
         assertEquals(


### PR DESCRIPTION
## What is the purpose of the change

When creating Task Manager (TM) Pod, the fabric client will query the Kubernetes deployment to set owner reference for the TM pod. However, repeating to querying the deployment each time is unnecessary which will waste a lot of time.

This change solves this problem by introducing an AtomicReference for Kubernetes deployment.


## Brief change log

Save the master deployment reference as a field of Fabric8FlinkKubeClient when the method "createTaskManagerPod()" is called for the first time and then get it directly in the following invocation.



## Verifying this change

This change can be tested by:
Fabric8FlinkKubeClientTest#testCreateTwoTaskManagerPods

This test will fail before this PR due to getting deployment more than once.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no.
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no.
  - The serializers: (yes / no / don't know) no.
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no.
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know) no.
  - The S3 file system connector: (yes / no / don't know) no.

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no.
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
