### PR TITLE
[FLINK-26016][hive][BP-1.14] Fix FileSystemLookupFunction does not produce correct results when hive table uses columnar storage

### DIFF
--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveLookupJoinITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveLookupJoinITCase.java
@@ -35,6 +35,7 @@ import org.apache.flink.table.filesystem.FileSystemConnectorOptions;
 import org.apache.flink.table.filesystem.FileSystemLookupFunction;
 import org.apache.flink.table.filesystem.PartitionFetcher;
 import org.apache.flink.table.filesystem.PartitionReader;
+import org.apache.flink.table.planner.factories.TestValuesTableFactory;
 import org.apache.flink.table.planner.factories.utils.TestCollectionTableFactory;
 import org.apache.flink.table.runtime.typeutils.InternalSerializers;
 import org.apache.flink.types.Row;
@@ -57,6 +58,7 @@ import static org.apache.flink.table.filesystem.FileSystemConnectorOptions.STREA
 import static org.apache.flink.table.filesystem.FileSystemConnectorOptions.STREAMING_SOURCE_PARTITION_INCLUDE;
 import static org.apache.flink.table.filesystem.FileSystemConnectorOptions.STREAMING_SOURCE_PARTITION_ORDER;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /** Test lookup join of hive tables. */
 public class HiveLookupJoinITCase {
@@ -150,6 +152,12 @@ public class HiveLookupJoinITCase {
                         STREAMING_SOURCE_ENABLE.key(),
                         STREAMING_SOURCE_PARTITION_INCLUDE.key(),
                         STREAMING_SOURCE_PARTITION_ORDER.key()));
+        // create the hive table with columnar storage.
+        tableEnv.executeSql(
+                String.format(
+                        "create table columnar_table (x string) STORED AS PARQUET "
+                                + "tblproperties ('%s'='5min')",
+                        FileSystemConnectorOptions.LOOKUP_JOIN_CACHE_TTL.key()));
         tableEnv.getConfig().setSqlDialect(SqlDialect.DEFAULT);
     }
 
@@ -349,6 +357,38 @@ public class HiveLookupJoinITCase {
         List<Row> results = CollectionUtil.iteratorToList(flinkTable.execute().collect());
         assertEquals(
                 "[+I[1, a, 101, 2020, 08, 01], +I[2, b, 122, 2020, 08, 01]]", results.toString());
+    }
+
+    @Test
+    public void testLookupJoinTableWithColumnarStorage() throws Exception {
+        // constructs test data, as the DEFAULT_SIZE of VectorizedColumnBatch is 2048, we should
+        // write as least 2048 records to the test table.
+        List<Row> testData = new ArrayList<>(4096);
+        for (int i = 0; i < 4096; i++) {
+            testData.add(Row.of(String.valueOf(i)));
+        }
+
+        // constructs test data using values table
+        TableEnvironment batchEnv = HiveTestUtils.createTableEnvInBatchMode(SqlDialect.DEFAULT);
+        batchEnv.registerCatalog(hiveCatalog.getName(), hiveCatalog);
+        batchEnv.useCatalog(hiveCatalog.getName());
+        String dataId = TestValuesTableFactory.registerData(testData);
+        batchEnv.executeSql(
+                String.format(
+                        "create table value_source(x string, p as proctime()) with ("
+                                + "'connector' = 'values', 'data-id' = '%s', 'bounded'='true')",
+                        dataId));
+        batchEnv.executeSql("insert overwrite columnar_table select x from value_source").await();
+        TableImpl flinkTable =
+                (TableImpl)
+                        tableEnv.sqlQuery(
+                                "select t.x as x1, c.x as x2 from value_source t "
+                                        + "left join columnar_table for system_time as of t.p c "
+                                        + "on t.x = c.x where c.x is null");
+        List<Row> results = CollectionUtil.iteratorToList(flinkTable.execute().collect());
+        assertTrue(
+                "All records should be able to be joined, and the final results should be empty.",
+                results.size() == 0);
     }
 
     private FileSystemLookupFunction<HiveTablePartition> getLookupFunction(String tableName)

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/filesystem/FileSystemLookupFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/filesystem/FileSystemLookupFunction.java
@@ -133,9 +133,10 @@ public class FileSystemLookupFunction<P> extends TableFunction<RowData> {
                 RowData row;
                 while ((row = partitionReader.read(reuse)) != null) {
                     count++;
-                    RowData key = extractLookupKey(row);
+                    RowData rowData = serializer.copy(row);
+                    RowData key = extractLookupKey(rowData);
                     List<RowData> rows = cache.computeIfAbsent(key, k -> new ArrayList<>());
-                    rows.add(serializer.copy(row));
+                    rows.add(rowData);
                 }
                 partitionReader.close();
                 nextLoadTime = System.currentTimeMillis() + reloadInterval.toMillis();


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*Fix lookup join bug when reading hive columnar storage tables.  *


## Brief change log

  - *When building the cache, generate cache key after copy the RowData from columnar RowData in case of different key reference the same memory*


## Verifying this change

This change added tests and can be verified as follows:

*Unit tests*
  - *Add test in [HiveLookupJoinITCase.java] to test lookup join with columnar table and make sure there is enough records to make sure the ParquetVectorizedInputFormat will read at least two batch to reproduce the error*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
