### PR TITLE
[FLINK-26275][BUILD] Upgrade JLine 3.21.0

### DIFF
--- a/flink-table/flink-sql-client/pom.xml
+++ b/flink-table/flink-sql-client/pom.xml
@@ -56,13 +56,13 @@ under the License.
 		<dependency>
 			<groupId>org.jline</groupId>
 			<artifactId>jline-terminal</artifactId>
-			<version>3.9.0</version>
+			<version>3.21.0</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.jline</groupId>
 			<artifactId>jline-reader</artifactId>
-			<version>3.9.0</version>
+			<version>3.21.0</version>
 		</dependency>
 
 		<!-- configuration -->

--- a/flink-table/flink-sql-client/src/main/resources/META-INF/NOTICE
+++ b/flink-table/flink-sql-client/src/main/resources/META-INF/NOTICE
@@ -7,5 +7,5 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the BSD license.
 See bundled license files for details.
 
-- org.jline:jline-terminal:3.9.0
-- org.jline:jline-reader:3.9.0
+- org.jline:jline-terminal:3.21.0
+- org.jline:jline-reader:3.21.0


### PR DESCRIPTION
## What is the purpose of the change

JLine added JDK-17 test since  https://github.com/jline/jline3/pull/707

## Brief change log

  - Upgrade JLine 3.21.0 to support JDK 17


## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
