### PR TITLE
[FLINK-26278][table-api-java] Add Expressions.col to Table API

### DIFF
--- a/flink-python/pyflink/table/expressions.py
+++ b/flink-python/pyflink/table/expressions.py
@@ -84,7 +84,7 @@ def _add_version_doc():
 
 def col(name: str) -> Expression:
     """
-    Creates an expression which refers to a table's field.
+    Creates an expression which refers to a table's column.
 
     Example:
     ::
@@ -93,7 +93,7 @@ def col(name: str) -> Expression:
 
     :param name: the field name to refer to
     """
-    return _unary_op("$", name)
+    return _unary_op("col", name)
 
 
 def lit(v, data_type: DataType = None) -> Expression:

--- a/flink-python/pyflink/table/tests/test_expressions_completeness.py
+++ b/flink-python/pyflink/table/tests/test_expressions_completeness.py
@@ -41,6 +41,12 @@ class ExpressionsCompletenessTests(PythonAPICompletenessTestCase, PyFlinkTestCas
                 'range_': 'range',
                 'map_': 'map'}.get(python_method_name, python_method_name)
 
+    @classmethod
+    def excluded_methods(cls):
+        return {
+            '$'
+        }
+
 
 if __name__ == '__main__':
     import unittest

--- a/flink-python/pyflink/table/tests/test_expressions_completeness.py
+++ b/flink-python/pyflink/table/tests/test_expressions_completeness.py
@@ -39,7 +39,6 @@ class ExpressionsCompletenessTests(PythonAPICompletenessTestCase, PyFlinkTestCas
                 'or_': 'or',
                 'not_': 'not',
                 'range_': 'range',
-                'col': '$',
                 'map_': 'map'}.get(python_method_name, python_method_name)
 
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Expressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Expressions.java
@@ -60,7 +60,7 @@ import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.JSON_S
  * API entities that are further translated into {@link ResolvedExpression ResolvedExpressions}
  * under the hood.
  *
- * <p>For fluent definition of expressions and easier readability, we recommend to add a star import
+ * <p>For fluent definition of expressions and easier readability, we recommend adding a star import
  * to the methods of this class:
  *
  * <pre>
@@ -72,20 +72,39 @@ import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.JSON_S
  */
 @PublicEvolving
 public final class Expressions {
+
     /**
-     * Creates an unresolved reference to a table's field.
+     * Creates an unresolved reference to a table's column.
      *
      * <p>Example:
      *
      * <pre>{@code
      * tab.select($("key"), $("value"))
      * }</pre>
+     *
+     * @see #col(String)
      */
     // CHECKSTYLE.OFF: MethodName
     public static ApiExpression $(String name) {
         return new ApiExpression(unresolvedRef(name));
     }
     // CHECKSTYLE.ON: MethodName
+
+    /**
+     * Creates an unresolved reference to a table's column.
+     *
+     * <p>Because {@link #$(String)} is not supported by every JVM language due to the dollar sign,
+     * this method provides a synonym with the same behavior.
+     *
+     * <p>Example:
+     *
+     * <pre>{@code
+     * tab.select(col("key"), col("value"))
+     * }</pre>
+     */
+    public static ApiExpression col(String name) {
+        return new ApiExpression(unresolvedRef(name));
+    }
 
     /**
      * Creates a SQL literal.

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/expressions/resolver/ExpressionResolverTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/expressions/resolver/ExpressionResolverTest.java
@@ -60,6 +60,7 @@ import java.util.Optional;
 
 import static org.apache.flink.table.api.Expressions.$;
 import static org.apache.flink.table.api.Expressions.call;
+import static org.apache.flink.table.api.Expressions.col;
 import static org.apache.flink.table.api.Expressions.range;
 import static org.apache.flink.table.api.Expressions.withColumns;
 import static org.apache.flink.table.expressions.ApiExpressionUtils.valueLiteral;
@@ -98,7 +99,7 @@ public class ExpressionResolverTest {
                                                         DataTypes.FIELD("n0", DataTypes.BIGINT()),
                                                         DataTypes.FIELD("n1", DataTypes.STRING())))
                                         .build())
-                        .select($("f0").flatten())
+                        .select(col("f0").flatten())
                         .equalTo(
                                 CallExpression.permanent(
                                         BuiltInFunctionDefinitions.GET,

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/expressions/resolver/ExpressionResolverTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/expressions/resolver/ExpressionResolverTest.java
@@ -99,7 +99,7 @@ public class ExpressionResolverTest {
                                                         DataTypes.FIELD("n0", DataTypes.BIGINT()),
                                                         DataTypes.FIELD("n1", DataTypes.STRING())))
                                         .build())
-                        .select(col("f0").flatten())
+                        .select($("f0").flatten())
                         .equalTo(
                                 CallExpression.permanent(
                                         BuiltInFunctionDefinitions.GET,
@@ -249,7 +249,11 @@ public class ExpressionResolverTest {
                                                         "f0", DataTypes.INT(), 0, 0),
                                                 new FieldReferenceExpression(
                                                         "f1", DataTypes.STRING(), 0, 1)),
-                                        DataTypes.INT().notNull().bridgedTo(int.class))));
+                                        DataTypes.INT().notNull().bridgedTo(int.class))),
+                TestSpec.test("Test field reference with col()")
+                        .inputSchemas(TableSchema.builder().field("i", DataTypes.INT()).build())
+                        .select(col("i"))
+                        .equalTo(new FieldReferenceExpression("i", DataTypes.INT(), 0, 0)));
     }
 
     @Parameterized.Parameter public TestSpec testSpec;

--- a/flink-table/flink-table-api-scala/src/main/scala/org/apache/flink/table/api/ImplicitExpressionConversions.scala
+++ b/flink-table/flink-table-api-scala/src/main/scala/org/apache/flink/table/api/ImplicitExpressionConversions.scala
@@ -217,7 +217,7 @@ trait ImplicitExpressionConversions {
   implicit class FieldExpression(val sc: StringContext) {
 
     /**
-     * Creates an unresolved reference to a table's field.
+     * Creates an unresolved reference to a table's column.
      *
      * Example:
      * {{{
@@ -374,7 +374,7 @@ trait ImplicitExpressionConversions {
   // ----------------------------------------------------------------------------------------------
 
   /**
-   * Creates an unresolved reference to a table's field.
+   * Creates an unresolved reference to a table's column.
    *
    * For example:
    *
@@ -386,6 +386,20 @@ trait ImplicitExpressionConversions {
    * using string interpolation like `$"key"` would be inconvenient.
    */
   def $(name: String): Expression = Expressions.$(name)
+
+  /**
+   * Creates an unresolved reference to a table's column.
+   *
+   * For example:
+   *
+   * ```
+   * tab.select(col("key"), col("value"))
+   * ```
+   *
+   * This method is a synonym of [[$(String)]] for cases where a method name containing a dollar
+   * sign would be inconvenient.
+   */
+  def col(name: String): Expression = Expressions.col(name)
 
   /**
    * Creates a SQL literal.


### PR DESCRIPTION
## What is the purpose of the change

Adds synonyms `Expressions.col` to Java and Scala (for completeness) Table API.

## Brief change log

Synonym added.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? JavaDocs
