### PR TITLE
[FLINK-26289][runtime] AdaptiveScheduler: Allow exception history to …

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobExceptionsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobExceptionsHandler.java
@@ -119,7 +119,9 @@ public class JobExceptionsHandler
         final ArchivedExecutionGraph executionGraph =
                 executionGraphInfo.getArchivedExecutionGraph();
         if (executionGraph.getFailureInfo() == null) {
-            return new JobExceptionsInfoWithHistory();
+            return new JobExceptionsInfoWithHistory(
+                    createJobExceptionHistory(
+                            executionGraphInfo.getExceptionHistory(), exceptionToReportMaxSize));
         }
 
         List<JobExceptionsInfo.ExecutionExceptionInfo> taskExceptionList = new ArrayList<>();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobExceptionsInfoWithHistory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobExceptionsInfoWithHistory.java
@@ -58,13 +58,8 @@ public class JobExceptionsInfoWithHistory extends JobExceptionsInfo implements R
         this.exceptionHistory = exceptionHistory;
     }
 
-    public JobExceptionsInfoWithHistory() {
-        this(
-                null,
-                null,
-                Collections.emptyList(),
-                false,
-                new JobExceptionHistory(Collections.emptyList(), false));
+    public JobExceptionsInfoWithHistory(JobExceptionHistory exceptionHistory) {
+        this(null, null, Collections.emptyList(), false, exceptionHistory);
     }
 
     @JsonIgnore

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobExceptionsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobExceptionsHandlerTest.java
@@ -131,6 +131,26 @@ public class JobExceptionsHandlerTest extends TestLogger {
     }
 
     @Test
+    public void testOnlyExceptionHistory() throws HandlerRequestException {
+        final RuntimeException rootThrowable = new RuntimeException("exception #0");
+        final long rootTimestamp = System.currentTimeMillis();
+        final RootExceptionHistoryEntry rootEntry = fromGlobalFailure(rootThrowable, rootTimestamp);
+        final ExecutionGraphInfo executionGraphInfo =
+                createExecutionGraphInfoWithoutFailureCause(rootEntry);
+        final HandlerRequest<EmptyRequestBody> request =
+                createRequest(executionGraphInfo.getJobId(), 10);
+        final JobExceptionsInfoWithHistory response =
+                testInstance.handleRequest(request, executionGraphInfo);
+
+        assertThat(response.getRootException(), is(nullValue()));
+        assertThat(response.getRootTimestamp(), is(nullValue()));
+
+        assertThat(
+                response.getExceptionHistory().getEntries(),
+                contains(historyContainsGlobalFailure(rootThrowable, rootTimestamp)));
+    }
+
+    @Test
     public void testWithExceptionHistory() throws HandlerRequestException {
         final RootExceptionHistoryEntry rootCause =
                 fromGlobalFailure(new RuntimeException("exception #0"), System.currentTimeMillis());
@@ -348,12 +368,22 @@ public class JobExceptionsHandlerTest extends TestLogger {
 
     private static ExecutionGraphInfo createExecutionGraphInfo(
             RootExceptionHistoryEntry... historyEntries) {
+        return createExecutionGraphInfo(true, historyEntries);
+    }
+
+    private static ExecutionGraphInfo createExecutionGraphInfoWithoutFailureCause(
+            RootExceptionHistoryEntry... historyEntries) {
+        return createExecutionGraphInfo(false, historyEntries);
+    }
+
+    private static ExecutionGraphInfo createExecutionGraphInfo(
+            boolean setFailureCause, RootExceptionHistoryEntry... historyEntries) {
         final ArchivedExecutionGraphBuilder executionGraphBuilder =
                 new ArchivedExecutionGraphBuilder();
         final List<RootExceptionHistoryEntry> historyEntryCollection = new ArrayList<>();
 
         for (int i = 0; i < historyEntries.length; i++) {
-            if (i == 0) {
+            if (i == 0 && setFailureCause) {
                 // first entry is root cause
                 executionGraphBuilder.setFailureCause(
                         new ErrorInfo(


### PR DESCRIPTION
https://issues.apache.org/jira/browse/FLINK-26289

In [FLINK-21439](https://issues.apache.org/jira/browse/FLINK-21439), we've started collecting a history of exceptions in the Adaptive Scheduler. We have a good coverage that this part works properly, but we've missed the part that exposes the history via REST API.

The problematic part is that execution graph attached with the `ExecutionGraphInfo` does no longer contain a failure info.

This is covered by a new integration test.