### PR TITLE
[FLINK-26284] Introduces mark-for-deletion state in ZooKeeperStateHandleStore

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/persistence/StateHandleStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/persistence/StateHandleStore.java
@@ -106,7 +106,8 @@ public interface StateHandleStore<T extends Serializable, R extends ResourceVers
     List<Tuple2<RetrievableStateHandle<T>, String>> getAllAndLock() throws Exception;
 
     /**
-     * Return a list of all valid name for state handles.
+     * Return a list of all valid name for state handles. The result might contain nodes that are
+     * marked for deletion.
      *
      * @return List of valid state handle name. The name is key name in ConfigMap or child path name
      *     in ZooKeeper.
@@ -128,9 +129,13 @@ public interface StateHandleStore<T extends Serializable, R extends ResourceVers
     /**
      * Releases and removes all the states. Not only the state handles in the distributed
      * coordination system will be removed, but also the real state data on the distributed storage
-     * will be discarded.
+     * will be discarded. This method should be implemented in a idempotent manner, i.e. failing
+     * calls should be able to be repeated.
      *
-     * @throws Exception if releasing, removing the handles or discarding the state failed
+     * @throws Exception if releasing, removing the handles or discarding the state failed. The
+     *     removal of the states should happen independently from each other, i.e. the method call
+     *     fails if at least one removal failed. But the removal of any other state should still be
+     *     performed.
      */
     void releaseAndTryRemoveAll() throws Exception;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/zookeeper/ZooKeeperStateHandleStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/zookeeper/ZooKeeperStateHandleStore.java
@@ -408,8 +408,7 @@ public class ZooKeeperStateHandleStore<T extends Serializable>
 
     /**
      * Releases the lock for the given state node and tries to remove the state node if it is no
-     * longer locked. It returns the {@link RetrievableStateHandle} stored under the given state
-     * node if any.
+     * longer locked.
      *
      * @param pathInZooKeeper Path of state handle to remove
      * @return True if the state handle could be released
@@ -448,8 +447,6 @@ public class ZooKeeperStateHandleStore<T extends Serializable>
     /**
      * Releases all lock nodes of this ZooKeeperStateHandleStores and tries to remove all state
      * nodes which are not locked anymore.
-     *
-     * <p>The delete operation is executed asynchronously
      *
      * @throws Exception if the delete operation fails
      */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/zookeeper/ZooKeeperStateHandleStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/zookeeper/ZooKeeperStateHandleStore.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.persistence.RetrievableStateStorageHelper;
 import org.apache.flink.runtime.persistence.StateHandleStore;
 import org.apache.flink.runtime.state.RetrievableStateHandle;
 import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.function.FunctionWithException;
 
 import org.apache.flink.shaded.curator5.org.apache.curator.framework.CuratorFramework;
@@ -45,18 +46,21 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
 import static org.apache.flink.runtime.util.StateHandleStoreUtils.deserialize;
 import static org.apache.flink.runtime.util.StateHandleStoreUtils.serializeOrDiscard;
 import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * Class which stores state via the provided {@link RetrievableStateStorageHelper} and writes the
  * returned state handle to ZooKeeper. The ZooKeeper node can be locked by creating an ephemeral
- * child and only allowing the deletion of the ZooKeeper node if it does not have any children. That
- * way we protect concurrent accesses from different ZooKeeperStateHandleStore instances.
+ * child in the lock sub-path. The implementation only allows the deletion of the ZooKeeper node if
+ * the lock sub-path has no children. That way we protect concurrent accesses from different
+ * ZooKeeperStateHandleStore instances.
  *
  * <p>Added state is persisted via {@link RetrievableStateHandle RetrievableStateHandles}, which in
  * turn are written to ZooKeeper. This level of indirection is necessary to keep the amount of data
@@ -69,13 +73,15 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * <p>ZooKeeper holds the ground truth about state handles, i.e. the following holds:
  *
  * <pre>
- * State handle in ZooKeeper =&gt; State handle exists
+ * State handle in ZooKeeper and not marked for deletion =&gt; State handle exists
  * </pre>
  *
- * <p>But not:
+ * <pre>
+ * State handle in ZooKeeper and marked for deletion =&gt; State handle might or might not be deleted, yet
+ * </pre>
  *
  * <pre>
- * State handle exists =&gt; State handle in ZooKeeper
+ * State handle not in ZooKeeper =&gt; State handle does not exist
  * </pre>
  *
  * <p>There can be lingering state handles when failures happen during operation. They need to be
@@ -158,10 +164,19 @@ public class ZooKeeperStateHandleStore<T extends Serializable>
         checkNotNull(pathInZooKeeper, "Path in ZooKeeper");
         checkNotNull(state, "State");
         final String path = normalizePath(pathInZooKeeper);
-        if (exists(path).isExisting()) {
-            throw new AlreadyExistException(
-                    String.format("ZooKeeper node %s already exists.", path));
+        final Optional<Stat> maybeStat = getStat(path);
+
+        if (maybeStat.isPresent()) {
+            if (isNotMarkedForDeletion(maybeStat.get())) {
+                throw new AlreadyExistException(
+                        String.format("ZooKeeper node %s already exists.", path));
+            }
+
+            Preconditions.checkState(
+                    releaseAndTryRemove(path),
+                    "The state is marked for deletion and, therefore, should be deletable.");
         }
+
         final RetrievableStateHandle<T> storeHandle = storage.store(state);
         final byte[] serializedStoreHandle = serializeOrDiscard(storeHandle);
         try {
@@ -198,8 +213,12 @@ public class ZooKeeperStateHandleStore<T extends Serializable>
                 .forPath(path, serializedStoreHandle)
                 .and()
                 .create()
+                .withMode(CreateMode.PERSISTENT)
+                .forPath(getRootLockPath(path))
+                .and()
+                .create()
                 .withMode(CreateMode.EPHEMERAL)
-                .forPath(getLockPath(path))
+                .forPath(getInstanceLockPath(path))
                 .and()
                 .commit();
     }
@@ -211,6 +230,8 @@ public class ZooKeeperStateHandleStore<T extends Serializable>
      * @param expectedVersion Expected version of the node to replace
      * @param state The new state to replace the old one
      * @throws Exception If a ZooKeeper or state handle operation fails
+     * @throws IllegalStateException if the replace operation shall be performed on a node that is
+     *     not locked for this specific instance.
      */
     @Override
     public void replace(String pathInZooKeeper, IntegerResourceVersion expectedVersion, T state)
@@ -219,6 +240,11 @@ public class ZooKeeperStateHandleStore<T extends Serializable>
         checkNotNull(state, "State");
 
         final String path = normalizePath(pathInZooKeeper);
+
+        checkState(
+                hasLock(path),
+                "'{}' is only allowed to be replaced if the instance has a lock on this node.",
+                path);
 
         RetrievableStateHandle<T> oldStateHandle = get(path, false);
 
@@ -282,25 +308,31 @@ public class ZooKeeperStateHandleStore<T extends Serializable>
     }
 
     /**
-     * Returns the version of the node if it exists or <code>-1</code> if it doesn't.
+     * Returns the version of the node if it exists and is not marked for deletion or <code>-1
+     * </code>.
      *
      * @param pathInZooKeeper Path in ZooKeeper to check
-     * @return Version of the ZNode if the path exists, <code>-1</code> otherwise.
+     * @return Version of the ZNode if the path exists and is not marked for deletion, <code>-1
+     *     </code> otherwise.
      * @throws Exception If the ZooKeeper operation fails
      */
     @Override
     public IntegerResourceVersion exists(String pathInZooKeeper) throws Exception {
         checkNotNull(pathInZooKeeper, "Path in ZooKeeper");
 
-        final String path = normalizePath(pathInZooKeeper);
+        return getStat(pathInZooKeeper)
+                .filter(ZooKeeperStateHandleStore::isNotMarkedForDeletion)
+                .map(stat -> IntegerResourceVersion.valueOf(stat.getVersion()))
+                .orElse(IntegerResourceVersion.notExisting());
+    }
 
-        Stat stat = client.checkExists().forPath(path);
+    private static boolean isNotMarkedForDeletion(Stat stat) {
+        return stat.getNumChildren() > 0;
+    }
 
-        if (stat != null) {
-            return IntegerResourceVersion.valueOf(stat.getVersion());
-        }
-
-        return IntegerResourceVersion.notExisting();
+    private Optional<Stat> getStat(String path) throws Exception {
+        final String normalizedPath = normalizePath(path);
+        return Optional.ofNullable(client.checkExists().forPath(normalizedPath));
     }
 
     /**
@@ -318,12 +350,6 @@ public class ZooKeeperStateHandleStore<T extends Serializable>
         return get(pathInZooKeeper, true);
     }
 
-    /**
-     * Return a list of all valid paths for state handles.
-     *
-     * @return List of valid state handle paths in ZooKeeper
-     * @throws Exception if a ZooKeeper operation fails
-     */
     @Override
     public Collection<String> getAllHandles() throws Exception {
         final String path = "/";
@@ -411,7 +437,8 @@ public class ZooKeeperStateHandleStore<T extends Serializable>
      * longer locked.
      *
      * @param pathInZooKeeper Path of state handle to remove
-     * @return True if the state handle could be released
+     * @return {@code true} if the state handle could be deleted; {@code false}, if the handle is
+     *     locked by another connection.
      * @throws Exception If the ZooKeeper operation or discarding the state handle fails
      */
     @Override
@@ -431,15 +458,19 @@ public class ZooKeeperStateHandleStore<T extends Serializable>
         release(pathInZooKeeper);
 
         try {
-            client.delete().forPath(path);
+            deleteIfExists(getRootLockPath(path));
         } catch (KeeperException.NotEmptyException ignored) {
-            LOG.debug("Could not delete znode {} because it is still locked.", path);
+            LOG.debug(
+                    "Could not delete znode {} because it is still locked.", getRootLockPath(path));
             return false;
         }
 
         if (stateHandle != null) {
             stateHandle.discardState();
         }
+
+        // we can now commit the deletion by removing the parent node
+        deleteIfExists(path);
 
         return true;
     }
@@ -480,13 +511,22 @@ public class ZooKeeperStateHandleStore<T extends Serializable>
     @Override
     public void release(String pathInZooKeeper) throws Exception {
         final String path = normalizePath(pathInZooKeeper);
+        final String lockPath = getInstanceLockPath(path);
         try {
-            client.delete().forPath(getLockPath(path));
-        } catch (KeeperException.NoNodeException ignored) {
-            // we have never locked this node
+            deleteIfExists(lockPath);
         } catch (Exception e) {
-            throw new Exception(
-                    "Could not release the lock: " + getLockPath(pathInZooKeeper) + '.', e);
+            throw new Exception("Could not release the lock: " + lockPath + '.', e);
+        }
+    }
+
+    private void deleteIfExists(String path) throws Exception {
+        final String normalizedPath = normalizePath(path);
+        try {
+            client.delete().forPath(normalizedPath);
+        } catch (KeeperException.NoNodeException ignored) {
+            LOG.debug(
+                    "ZNode '{}' is already marked for deletion. Command is ignored.",
+                    normalizedPath);
         }
     }
 
@@ -536,14 +576,40 @@ public class ZooKeeperStateHandleStore<T extends Serializable>
     // ---------------------------------------------------------------------------------------------------------
 
     /**
+     * Checks whether a lock is created for this instance on the passed ZooKeeper node.
+     *
+     * @param rootPath The node that shall be checked.
+     * @return {@code true} if the lock exists; {@code false} otherwise.
+     */
+    private boolean hasLock(String rootPath) throws Exception {
+        final String normalizedRootPath = normalizePath(rootPath);
+        try {
+            return client.checkExists().forPath(getInstanceLockPath(normalizedRootPath)) != null;
+        } catch (KeeperException.NoNodeException e) {
+            // this is the case if the node is marked for deletion or already deleted
+            return false;
+        }
+    }
+
+    /**
      * Returns the path for the lock node relative to the given path.
      *
      * @param rootPath Root path under which the lock node shall be created
      * @return Path for the lock node
      */
     @VisibleForTesting
-    String getLockPath(String rootPath) {
-        return rootPath + '/' + lockNode;
+    String getInstanceLockPath(String rootPath) {
+        return getRootLockPath(rootPath) + '/' + lockNode;
+    }
+
+    /**
+     * Returns the sub-path for lock nodes of the corresponding node (referred to through the passed
+     * {@code rooPath}. The returned sub-path collects the lock nodes for the {@code rootPath}'s
+     * node. The {@code rootPath} is marked for deletion if the sub-path for lock nodes is deleted.
+     */
+    @VisibleForTesting
+    static String getRootLockPath(String rootPath) {
+        return rootPath + "/locks";
     }
 
     // ---------------------------------------------------------------------------------------------------------
@@ -567,7 +633,7 @@ public class ZooKeeperStateHandleStore<T extends Serializable>
         if (lock) {
             // try to lock the node
             try {
-                client.create().withMode(CreateMode.EPHEMERAL).forPath(getLockPath(path));
+                client.create().withMode(CreateMode.EPHEMERAL).forPath(getInstanceLockPath(path));
             } catch (KeeperException.NodeExistsException ignored) {
                 // we have already created the lock
             } catch (KeeperException.NoNodeException ex) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/zookeeper/ZooKeeperStateHandleStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/zookeeper/ZooKeeperStateHandleStoreTest.java
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.persistence.TestingLongStateHandleHelper;
 import org.apache.flink.runtime.rest.util.NoOpFatalErrorHandler;
 import org.apache.flink.runtime.state.RetrievableStateHandle;
 import org.apache.flink.runtime.util.ZooKeeperUtils;
+import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.TestLogger;
 
@@ -38,10 +39,13 @@ import org.apache.flink.shaded.guava30.com.google.common.collect.Iterables;
 import org.apache.flink.shaded.zookeeper3.org.apache.zookeeper.KeeperException;
 import org.apache.flink.shaded.zookeeper3.org.apache.zookeeper.data.Stat;
 
+import org.hamcrest.collection.IsIterableContainingInAnyOrder;
 import org.hamcrest.core.IsInstanceOf;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
+
+import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -51,10 +55,13 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 
+import static org.apache.flink.runtime.util.ZooKeeperUtils.generateZookeeperPath;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -116,14 +123,33 @@ public class ZooKeeperStateHandleStoreTest extends TestLogger {
 
         List<String> children = ZOOKEEPER.getClient().getChildren().forPath(pathInZooKeeper);
 
-        // there should be one child which is the lock
-        assertEquals(1, children.size());
-
-        stat = ZOOKEEPER.getClient().checkExists().forPath(pathInZooKeeper + '/' + children.get(0));
+        // There should be one child which is the locks subfolder
+        final String locksSubfolderChild = Iterables.getOnlyElement(children);
+        stat =
+                ZOOKEEPER
+                        .getClient()
+                        .checkExists()
+                        .forPath(generateZookeeperPath(pathInZooKeeper, locksSubfolderChild));
         assertNotNull(stat);
 
-        // check that the child is an ephemeral node
-        assertNotEquals(0, stat.getEphemeralOwner());
+        assertEquals("The lock subfolder shouldn't be ephemeral", 0, stat.getEphemeralOwner());
+
+        List<String> lockChildren =
+                ZOOKEEPER
+                        .getClient()
+                        .getChildren()
+                        .forPath(generateZookeeperPath(pathInZooKeeper, locksSubfolderChild));
+        // Only one lock is expected
+        final String lockChild = Iterables.getOnlyElement(lockChildren);
+        stat =
+                ZOOKEEPER
+                        .getClient()
+                        .checkExists()
+                        .forPath(
+                                generateZookeeperPath(
+                                        pathInZooKeeper, locksSubfolderChild, lockChild));
+
+        assertNotEquals("The lock node should be ephemeral", 0, stat.getEphemeralOwner());
 
         // Data is equal
         @SuppressWarnings("unchecked")
@@ -136,6 +162,138 @@ public class ZooKeeperStateHandleStoreTest extends TestLogger {
                         .getValue();
 
         assertEquals(state, actual);
+    }
+
+    @Test
+    public void testAddAndLockOnMarkedForDeletionNode() throws Exception {
+        final CuratorFramework client =
+                ZooKeeperUtils.useNamespaceAndEnsurePath(
+                        ZOOKEEPER.getClient(), "/testAddAndLockOnMarkedForDeletionNode");
+        final ZooKeeperStateHandleStore<TestingLongStateHandleHelper.LongStateHandle> zkStore =
+                new ZooKeeperStateHandleStore<>(client, new TestingLongStateHandleHelper());
+
+        final long oldStateValue = 1L;
+        final TestingLongStateHandleHelper.LongStateHandle oldStateHandle =
+                new TestingLongStateHandleHelper.LongStateHandle(oldStateValue);
+        final String markedForDeletionNode = "marked-for-deletion";
+        final String markedForDeletionNodePath = generateZookeeperPath(markedForDeletionNode);
+        zkStore.addAndLock(markedForDeletionNodePath, oldStateHandle);
+
+        markNodeForDeletion(client, markedForDeletionNode);
+
+        final long updatedStateValue = oldStateValue + 2;
+        final TestingLongStateHandleHelper.LongStateHandle updatedStateHandle =
+                new TestingLongStateHandleHelper.LongStateHandle(updatedStateValue);
+        zkStore.addAndLock(markedForDeletionNodePath, updatedStateHandle);
+
+        assertEquals(
+                updatedStateValue,
+                zkStore.getAndLock(markedForDeletionNodePath).retrieveState().getValue());
+        assertTrue(oldStateHandle.isDiscarded());
+        assertFalse(updatedStateHandle.isDiscarded());
+    }
+
+    @Test
+    public void testRepeatableCleanup() throws Exception {
+        final ZooKeeperStateHandleStore<TestingLongStateHandleHelper.LongStateHandle> testInstance =
+                new ZooKeeperStateHandleStore<>(
+                        ZOOKEEPER.getClient(), new TestingLongStateHandleHelper());
+
+        final String pathInZooKeeper = "/testRepeatableCleanup";
+
+        final RuntimeException expectedException =
+                new RuntimeException("Expected RuntimeException");
+        final TestingLongStateHandleHelper.LongStateHandle stateHandle =
+                new TestingLongStateHandleHelper.LongStateHandle(
+                        12354L, throwExceptionOnce(expectedException));
+
+        testInstance.addAndLock(pathInZooKeeper, stateHandle);
+
+        try {
+            testInstance.releaseAndTryRemove(pathInZooKeeper);
+            fail("Exception should have been thrown.");
+        } catch (Exception e) {
+            ExceptionUtils.assertThrowable(e, expectedException::equals);
+        }
+
+        assertThrows(
+                StateHandleStore.NotExistException.class,
+                () -> testInstance.getAndLock(pathInZooKeeper));
+        assertFalse(stateHandle.isDiscarded());
+
+        assertTrue(testInstance.releaseAndTryRemove(pathInZooKeeper));
+        assertFalse(testInstance.exists(pathInZooKeeper).isExisting());
+        assertTrue(stateHandle.isDiscarded());
+    }
+
+    @Test
+    public void testRepeatableCleanupWithLockOnNode() throws Exception {
+        final CuratorFramework client =
+                ZooKeeperUtils.useNamespaceAndEnsurePath(
+                        ZOOKEEPER.getClient(), "/testRepeatableCleanupWithLockOnNode");
+
+        final TestingLongStateHandleHelper storage = new TestingLongStateHandleHelper();
+        final ZooKeeperStateHandleStore<TestingLongStateHandleHelper.LongStateHandle>
+                storeForCreation = new ZooKeeperStateHandleStore<>(client, storage);
+        final ZooKeeperStateHandleStore<TestingLongStateHandleHelper.LongStateHandle>
+                storeForDeletion = new ZooKeeperStateHandleStore<>(client, storage);
+
+        final String pathInZooKeeper = "/testRepeatableCleanupWithLock";
+
+        final long actualValue = 12345L;
+        final RuntimeException expectedException =
+                new RuntimeException("RuntimeException for testing the failing discardState call.");
+        final TestingLongStateHandleHelper.LongStateHandle stateHandle =
+                new TestingLongStateHandleHelper.LongStateHandle(
+                        actualValue, throwExceptionOnce(expectedException));
+
+        final RetrievableStateHandle<TestingLongStateHandleHelper.LongStateHandle>
+                handleForCreation = storeForCreation.addAndLock(pathInZooKeeper, stateHandle);
+
+        final RetrievableStateHandle<TestingLongStateHandleHelper.LongStateHandle>
+                handleForDeletion = storeForDeletion.getAndLock(pathInZooKeeper);
+
+        assertEquals(handleForCreation.retrieveState().getValue(), actualValue);
+        assertEquals(handleForDeletion.retrieveState().getValue(), actualValue);
+
+        assertFalse(
+                "Deletion by the first StateHandleStore shouldn't be successful because there's still a lock from StateHandleStore #1.",
+                storeForCreation.releaseAndTryRemove(pathInZooKeeper));
+
+        assertNotNull(
+                "StateHandle should not be marked for deletion, yet.",
+                client.checkExists()
+                        .forPath(ZooKeeperStateHandleStore.getRootLockPath(pathInZooKeeper)));
+        assertNull(
+                "The lock for storeForCreation should have been removed",
+                client.checkExists()
+                        .forPath(storeForCreation.getInstanceLockPath(pathInZooKeeper)));
+        assertEquals(
+                "discardState shouldn't have been called, yet.",
+                0,
+                stateHandle.getNumberOfDiscardCalls());
+
+        try {
+            storeForDeletion.releaseAndTryRemove(pathInZooKeeper);
+            fail("Exception should have been thrown.");
+        } catch (Exception e) {
+            ExceptionUtils.assertThrowable(e, expectedException::equals);
+        }
+
+        assertNull(
+                "StateHandle should be marked for deletion.",
+                client.checkExists()
+                        .forPath(ZooKeeperStateHandleStore.getRootLockPath(pathInZooKeeper)));
+        assertNotNull(
+                "StateHandle should not be deleted, yet.",
+                client.checkExists().forPath(pathInZooKeeper));
+        assertFalse("The StateHandle should not be discarded, yet.", stateHandle.isDiscarded());
+
+        assertTrue(storeForDeletion.releaseAndTryRemove(pathInZooKeeper));
+        assertNull(
+                "The StateHandle node should have been removed",
+                client.checkExists().forPath(pathInZooKeeper));
+        assertTrue("The StateHandle should have been discarded.", stateHandle.isDiscarded());
     }
 
     /**
@@ -356,6 +514,33 @@ public class ZooKeeperStateHandleStoreTest extends TestLogger {
         assertEquals(replaceState, actual);
     }
 
+    @Test
+    public void testReplaceRequiringALock() throws Exception {
+        final CuratorFramework client =
+                ZooKeeperUtils.useNamespaceAndEnsurePath(
+                        ZOOKEEPER.getClient(), "/testReplaceOnMarkedForDeletionNode");
+        final ZooKeeperStateHandleStore<TestingLongStateHandleHelper.LongStateHandle> zkStore =
+                new ZooKeeperStateHandleStore<>(client, new TestingLongStateHandleHelper());
+
+        final long oldState = 1L;
+        final TestingLongStateHandleHelper.LongStateHandle oldStateHandle =
+                new TestingLongStateHandleHelper.LongStateHandle(oldState);
+        final String nodeName = "node";
+        final String path = generateZookeeperPath(nodeName);
+
+        zkStore.addAndLock(path, oldStateHandle);
+        zkStore.release(path);
+
+        final IntegerResourceVersion versionBeforeDeletion = zkStore.exists(path);
+        final long updatedState = oldState + 2;
+        final TestingLongStateHandleHelper.LongStateHandle updatedStateHandle =
+                new TestingLongStateHandleHelper.LongStateHandle(updatedState);
+
+        assertThrows(
+                IllegalStateException.class,
+                () -> zkStore.replace(path, versionBeforeDeletion, updatedStateHandle));
+    }
+
     /** Tests that a non existing path throws an Exception. */
     @Test(expected = Exception.class)
     public void testReplaceNonExistingPath() throws Exception {
@@ -554,6 +739,24 @@ public class ZooKeeperStateHandleStoreTest extends TestLogger {
         assertTrue(store.exists(pathInZooKeeper).getValue() >= 0);
     }
 
+    @Test
+    public void testExistsOnMarkedForDeletionNode() throws Exception {
+        final CuratorFramework client =
+                ZooKeeperUtils.useNamespaceAndEnsurePath(
+                        ZOOKEEPER.getClient(), "/testExistsOnMarkedForDeletionEntry");
+        final ZooKeeperStateHandleStore<TestingLongStateHandleHelper.LongStateHandle> zkStore =
+                new ZooKeeperStateHandleStore<>(client, new TestingLongStateHandleHelper());
+
+        final String markedForDeletionPath = "marked-for-deletion";
+        zkStore.addAndLock(
+                generateZookeeperPath(markedForDeletionPath),
+                new TestingLongStateHandleHelper.LongStateHandle(1L));
+
+        markNodeForDeletion(client, markedForDeletionPath);
+
+        assertFalse(zkStore.exists(generateZookeeperPath(markedForDeletionPath)).isExisting());
+    }
+
     /** Tests that a non existing path throws an Exception. */
     @Test(expected = Exception.class)
     public void testGetNonExistingPath() throws Exception {
@@ -746,6 +949,52 @@ public class ZooKeeperStateHandleStoreTest extends TestLogger {
         assertEquals(0, ZOOKEEPER.getClient().getChildren().forPath("/").size());
     }
 
+    @Test
+    public void testReleaseAndTryRemoveAllRepeatableAfterFailure() throws Exception {
+        // Setup
+        final TestingLongStateHandleHelper stateHandleProvider = new TestingLongStateHandleHelper();
+
+        ZooKeeperStateHandleStore<TestingLongStateHandleHelper.LongStateHandle> store =
+                new ZooKeeperStateHandleStore<>(ZOOKEEPER.getClient(), stateHandleProvider);
+
+        // Config
+        final String pathInZooKeeper = "/testDiscardAllWithFailure";
+
+        final long actualValue = 12345L;
+        final RuntimeException expectedException =
+                new RuntimeException("RuntimeException for testing the failing discardState call.");
+        final TestingLongStateHandleHelper.LongStateHandle failingStateHandle =
+                new TestingLongStateHandleHelper.LongStateHandle(
+                        actualValue, throwExceptionOnce(expectedException));
+        store.addAndLock(pathInZooKeeper + "-with-failure", failingStateHandle);
+
+        final TestingLongStateHandleHelper.LongStateHandle succeedingStateHandle =
+                TestingLongStateHandleHelper.createState(42);
+        store.addAndLock(pathInZooKeeper + "-without-failure", succeedingStateHandle);
+
+        try {
+            store.releaseAndTryRemoveAll();
+            fail("An Exception should have been thrown.");
+        } catch (Exception e) {
+            ExceptionUtils.assertThrowable(e, expectedException::equals);
+        }
+
+        assertEquals(
+                "One discardState call should have failed resulting in one node being left, still.",
+                1,
+                ZOOKEEPER.getClient().getChildren().forPath("/").size());
+        assertEquals(0, failingStateHandle.getNumberOfDiscardCalls());
+        assertEquals(1, succeedingStateHandle.getNumberOfDiscardCalls());
+
+        store.releaseAndTryRemoveAll();
+
+        assertTrue(
+                "The second removal attempt should have succeeded with no nodes left.",
+                ZOOKEEPER.getClient().getChildren().forPath("/").isEmpty());
+        assertEquals(1, failingStateHandle.getNumberOfDiscardCalls());
+        assertEquals(1, succeedingStateHandle.getNumberOfDiscardCalls());
+    }
+
     /**
      * Tests that the ZooKeeperStateHandleStore can handle corrupted data by releasing and trying to
      * remove the respective ZooKeeper ZNodes.
@@ -862,7 +1111,7 @@ public class ZooKeeperStateHandleStoreTest extends TestLogger {
         }
 
         // check that there is no lock node left
-        String lockNodePath = zkStore2.getLockPath(path);
+        String lockNodePath = zkStore2.getInstanceLockPath(path);
 
         Stat stat = ZOOKEEPER.getClient().checkExists().forPath(lockNodePath);
 
@@ -920,7 +1169,8 @@ public class ZooKeeperStateHandleStoreTest extends TestLogger {
             // check that our state node still exists
             assertNotNull(stat);
 
-            Collection<String> children = client2.getChildren().forPath(path);
+            Collection<String> children =
+                    client2.getChildren().forPath(zkStore.getRootLockPath(path));
 
             // check that the lock node has been released
             assertEquals(0, children.size());
@@ -943,7 +1193,7 @@ public class ZooKeeperStateHandleStoreTest extends TestLogger {
 
         zkStore.addAndLock(path, new TestingLongStateHandleHelper.LongStateHandle(42L));
 
-        final String lockPath = zkStore.getLockPath(path);
+        final String lockPath = zkStore.getInstanceLockPath(path);
 
         Stat stat = ZOOKEEPER.getClient().checkExists().forPath(lockPath);
 
@@ -951,7 +1201,11 @@ public class ZooKeeperStateHandleStoreTest extends TestLogger {
 
         zkStore.release(path);
 
-        stat = ZOOKEEPER.getClient().checkExists().forPath(path);
+        stat =
+                ZOOKEEPER
+                        .getClient()
+                        .checkExists()
+                        .forPath(ZooKeeperStateHandleStore.getRootLockPath(path));
 
         // release should have removed the lock child
         assertEquals("Expected no lock nodes as children", 0, stat.getNumChildren());
@@ -982,7 +1236,8 @@ public class ZooKeeperStateHandleStoreTest extends TestLogger {
         }
 
         for (String path : paths) {
-            Stat stat = ZOOKEEPER.getClient().checkExists().forPath(zkStore.getLockPath(path));
+            Stat stat =
+                    ZOOKEEPER.getClient().checkExists().forPath(zkStore.getInstanceLockPath(path));
 
             assertNotNull("Expecte and existing lock.", stat);
         }
@@ -990,7 +1245,11 @@ public class ZooKeeperStateHandleStoreTest extends TestLogger {
         zkStore.releaseAll();
 
         for (String path : paths) {
-            Stat stat = ZOOKEEPER.getClient().checkExists().forPath(path);
+            Stat stat =
+                    ZOOKEEPER
+                            .getClient()
+                            .checkExists()
+                            .forPath(ZooKeeperStateHandleStore.getRootLockPath(path));
 
             assertEquals(0, stat.getNumChildren());
         }
@@ -1013,5 +1272,50 @@ public class ZooKeeperStateHandleStoreTest extends TestLogger {
         zkStore.clearEntries();
 
         assertThat(zkStore.getAllHandles(), is(empty()));
+    }
+
+    @Test
+    public void testGetAllHandlesWithMarkedForDeletionEntries() throws Exception {
+        final CuratorFramework client =
+                ZooKeeperUtils.useNamespaceAndEnsurePath(
+                        ZOOKEEPER.getClient(), "/testGetAllHandlesWithMarkedForDeletionEntries");
+        final ZooKeeperStateHandleStore<TestingLongStateHandleHelper.LongStateHandle> zkStore =
+                new ZooKeeperStateHandleStore<>(client, new TestingLongStateHandleHelper());
+
+        final String notMarkedForDeletionNodeName = "not-marked-for-deletion";
+        final String markedForDeletionNodeName = "marked-for-deletion";
+        zkStore.addAndLock(
+                generateZookeeperPath(notMarkedForDeletionNodeName),
+                new TestingLongStateHandleHelper.LongStateHandle(1L));
+        zkStore.addAndLock(
+                generateZookeeperPath(markedForDeletionNodeName),
+                new TestingLongStateHandleHelper.LongStateHandle(2L));
+
+        markNodeForDeletion(client, markedForDeletionNodeName);
+
+        assertThat(
+                zkStore.getAllHandles(),
+                IsIterableContainingInAnyOrder.containsInAnyOrder(
+                        notMarkedForDeletionNodeName, markedForDeletionNodeName));
+    }
+
+    private static void markNodeForDeletion(CuratorFramework client, String childNodeName)
+            throws Exception {
+        client.delete()
+                .deletingChildrenIfNeeded()
+                .forPath(
+                        ZooKeeperStateHandleStore.getRootLockPath(
+                                generateZookeeperPath(childNodeName)));
+    }
+
+    private static TestingLongStateHandleHelper.PreDiscardCallback throwExceptionOnce(
+            @Nullable RuntimeException e) {
+        final AtomicReference<RuntimeException> ref = new AtomicReference<>(e);
+        return ignoredValue -> {
+            final RuntimeException actualException = ref.getAndSet(null);
+            if (actualException != null) {
+                throw actualException;
+            }
+        };
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

The `ZooKeeperStateHandleStore` cleanup is not repeatable: The ZK node is deleted removing the `StateHandle` metadata before discarding the `StateHandle` itself. If the deletion of the `StateHandle` fails, there is no way to determine the location for a subsequent cleanup anymore.

## Brief change log

We fixed this by introducing another child node collecting all the lock child nodes. A state node now has the following structure:
* `/<name>` - root node referencing the actual `StateHandle`
  * `/<name>/locks` - The locks child which contains all the lock nodes. This child node is `PERSISTENT` like the parent node to prevent the node going away automatically after all connections are cleared. We want to do the cleanup explicitly.
    * `/<name>/locks/<lock-child>` - A node referencing to a single ZK connection. This child lock is going to be `EPHEREMAL` like in the previous version and will be cleaned up automatically as soon as the ZK client is disconnected.

Removing the `/<name>/locks` means that the corresponding node is ready for deletion. Marking the node as deletable is only possible if all lock nodes are removed.

The interface contract stays the same or is hardened (for the`replace` method).

Additionally, a minor fix for FLINK-26285 was added.

## Verifying this change

`ZooKeeperStateHandleStoreTest` was extended by multiple tests covering the execution on nodes that are marked for deletion: See the individual commits for the different test cases.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
