### PR TITLE
[FLINK-26299] Reintroduce old JobClient#triggerSavepoint,stopWithSavepoint methods

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/execution/JobClient.java
+++ b/flink-core/src/main/java/org/apache/flink/core/execution/JobClient.java
@@ -52,6 +52,27 @@ public interface JobClient {
      *     MAX_WATERMARK} in the pipeline
      * @param savepointDirectory directory the savepoint should be written to
      * @return a {@link CompletableFuture} containing the path where the savepoint is located
+     * @deprecated pass the format explicitly
+     */
+    @Deprecated
+    default CompletableFuture<String> stopWithSavepoint(
+            boolean advanceToEndOfEventTime, @Nullable String savepointDirectory) {
+        return stopWithSavepoint(
+                advanceToEndOfEventTime, savepointDirectory, SavepointFormatType.DEFAULT);
+    }
+
+    /**
+     * Stops the associated job on Flink cluster.
+     *
+     * <p>Stopping works only for streaming programs. Be aware, that the job might continue to run
+     * for a while after sending the stop command, because after sources stopped to emit data all
+     * operators need to finish processing.
+     *
+     * @param advanceToEndOfEventTime flag indicating if the source should inject a {@code
+     *     MAX_WATERMARK} in the pipeline
+     * @param savepointDirectory directory the savepoint should be written to
+     * @param formatType binary format of the savepoint
+     * @return a {@link CompletableFuture} containing the path where the savepoint is located
      */
     CompletableFuture<String> stopWithSavepoint(
             boolean advanceToEndOfEventTime,
@@ -64,6 +85,21 @@ public interface JobClient {
      * org.apache.flink.configuration.CheckpointingOptions#SAVEPOINT_DIRECTORY} if it is null.
      *
      * @param savepointDirectory directory the savepoint should be written to
+     * @return a {@link CompletableFuture} containing the path where the savepoint is located
+     * @deprecated pass the format explicitly
+     */
+    @Deprecated
+    default CompletableFuture<String> triggerSavepoint(@Nullable String savepointDirectory) {
+        return triggerSavepoint(savepointDirectory, SavepointFormatType.DEFAULT);
+    }
+
+    /**
+     * Triggers a savepoint for the associated job. The savepoint will be written to the given
+     * savepoint directory, or {@link
+     * org.apache.flink.configuration.CheckpointingOptions#SAVEPOINT_DIRECTORY} if it is null.
+     *
+     * @param savepointDirectory directory the savepoint should be written to
+     * @param formatType binary format of the savepoint
      * @return a {@link CompletableFuture} containing the path where the savepoint is located
      */
     CompletableFuture<String> triggerSavepoint(


### PR DESCRIPTION

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
