### PR TITLE
[FLINK-26295][table] Operation strategies should allow having spaces …

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/parse/ClearOperationParseStrategy.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/parse/ClearOperationParseStrategy.java
@@ -29,7 +29,7 @@ public class ClearOperationParseStrategy extends AbstractRegexParseStrategy {
     static final ClearOperationParseStrategy INSTANCE = new ClearOperationParseStrategy();
 
     private ClearOperationParseStrategy() {
-        super(Pattern.compile("CLEAR(\\s*;)?", DEFAULT_PATTERN_FLAGS));
+        super(Pattern.compile("CLEAR\\s*;?", DEFAULT_PATTERN_FLAGS));
     }
 
     @Override

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/parse/ClearOperationParseStrategy.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/parse/ClearOperationParseStrategy.java
@@ -29,7 +29,7 @@ public class ClearOperationParseStrategy extends AbstractRegexParseStrategy {
     static final ClearOperationParseStrategy INSTANCE = new ClearOperationParseStrategy();
 
     private ClearOperationParseStrategy() {
-        super(Pattern.compile("CLEAR;?", DEFAULT_PATTERN_FLAGS));
+        super(Pattern.compile("CLEAR(\\s*;)?", DEFAULT_PATTERN_FLAGS));
     }
 
     @Override

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/parse/HelpOperationParseStrategy.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/parse/HelpOperationParseStrategy.java
@@ -29,7 +29,7 @@ public class HelpOperationParseStrategy extends AbstractRegexParseStrategy {
     static final HelpOperationParseStrategy INSTANCE = new HelpOperationParseStrategy();
 
     private HelpOperationParseStrategy() {
-        super(Pattern.compile("HELP(\\s*;)?", DEFAULT_PATTERN_FLAGS));
+        super(Pattern.compile("HELP\\s*;?", DEFAULT_PATTERN_FLAGS));
     }
 
     @Override

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/parse/HelpOperationParseStrategy.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/parse/HelpOperationParseStrategy.java
@@ -29,7 +29,7 @@ public class HelpOperationParseStrategy extends AbstractRegexParseStrategy {
     static final HelpOperationParseStrategy INSTANCE = new HelpOperationParseStrategy();
 
     private HelpOperationParseStrategy() {
-        super(Pattern.compile("HELP;?", DEFAULT_PATTERN_FLAGS));
+        super(Pattern.compile("HELP(\\s*;)?", DEFAULT_PATTERN_FLAGS));
     }
 
     @Override

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/parse/QuitOperationParseStrategy.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/parse/QuitOperationParseStrategy.java
@@ -29,7 +29,7 @@ public class QuitOperationParseStrategy extends AbstractRegexParseStrategy {
     static final QuitOperationParseStrategy INSTANCE = new QuitOperationParseStrategy();
 
     private QuitOperationParseStrategy() {
-        super(Pattern.compile("(EXIT|QUIT)\\s*;", DEFAULT_PATTERN_FLAGS));
+        super(Pattern.compile("(EXIT|QUIT)\\s*;?", DEFAULT_PATTERN_FLAGS));
     }
 
     @Override

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/parse/QuitOperationParseStrategy.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/parse/QuitOperationParseStrategy.java
@@ -39,6 +39,6 @@ public class QuitOperationParseStrategy extends AbstractRegexParseStrategy {
 
     @Override
     public String[] getHints() {
-        return new String[] {"EXIT;", "QUIT;"};
+        return new String[] {"EXIT", "QUIT"};
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/parse/QuitOperationParseStrategy.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/parse/QuitOperationParseStrategy.java
@@ -29,7 +29,7 @@ public class QuitOperationParseStrategy extends AbstractRegexParseStrategy {
     static final QuitOperationParseStrategy INSTANCE = new QuitOperationParseStrategy();
 
     private QuitOperationParseStrategy() {
-        super(Pattern.compile("(EXIT|QUIT)(\\s*;)?", DEFAULT_PATTERN_FLAGS));
+        super(Pattern.compile("(EXIT|QUIT)\\s*;", DEFAULT_PATTERN_FLAGS));
     }
 
     @Override
@@ -39,6 +39,6 @@ public class QuitOperationParseStrategy extends AbstractRegexParseStrategy {
 
     @Override
     public String[] getHints() {
-        return new String[] {"EXIT", "QUIT"};
+        return new String[] {"EXIT;", "QUIT;"};
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/parse/QuitOperationParseStrategy.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/parse/QuitOperationParseStrategy.java
@@ -29,7 +29,7 @@ public class QuitOperationParseStrategy extends AbstractRegexParseStrategy {
     static final QuitOperationParseStrategy INSTANCE = new QuitOperationParseStrategy();
 
     private QuitOperationParseStrategy() {
-        super(Pattern.compile("(EXIT|QUIT);?", DEFAULT_PATTERN_FLAGS));
+        super(Pattern.compile("(EXIT|QUIT)(\\s*;)?", DEFAULT_PATTERN_FLAGS));
     }
 
     @Override

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/parse/ResetOperationParseStrategy.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/parse/ResetOperationParseStrategy.java
@@ -31,7 +31,7 @@ public class ResetOperationParseStrategy extends AbstractRegexParseStrategy {
     static final ResetOperationParseStrategy INSTANCE = new ResetOperationParseStrategy();
 
     private ResetOperationParseStrategy() {
-        super(Pattern.compile("RESET(\\s+(?<key>[^'\\s]+)\\s*)?;?", DEFAULT_PATTERN_FLAGS));
+        super(Pattern.compile("RESET(\\s+(?<key>[^'\\s]+)\\s*)?(\\s*;)?", DEFAULT_PATTERN_FLAGS));
     }
 
     @Override

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/parse/ResetOperationParseStrategy.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/parse/ResetOperationParseStrategy.java
@@ -31,7 +31,7 @@ public class ResetOperationParseStrategy extends AbstractRegexParseStrategy {
     static final ResetOperationParseStrategy INSTANCE = new ResetOperationParseStrategy();
 
     private ResetOperationParseStrategy() {
-        super(Pattern.compile("RESET(\\s+(?<key>[^'\\s]+)\\s*)?(\\s*;)?", DEFAULT_PATTERN_FLAGS));
+        super(Pattern.compile("RESET(\\s+(?<key>[^'\\s]+)\\s*)?\\s*;?", DEFAULT_PATTERN_FLAGS));
     }
 
     @Override

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/parse/SetOperationParseStrategy.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/parse/SetOperationParseStrategy.java
@@ -35,7 +35,7 @@ public class SetOperationParseStrategy extends AbstractRegexParseStrategy {
     protected SetOperationParseStrategy() {
         super(
                 Pattern.compile(
-                        "SET(\\s+(?<key>[^'\\s]+)\\s*=\\s*('(?<quotedVal>[^']*)'|(?<val>[^;\\s]+)))?(\\s*;)?",
+                        "SET(\\s+(?<key>[^'\\s]+)\\s*=\\s*('(?<quotedVal>[^']*)'|(?<val>[^;\\s]+)))?\\s*;?",
                         DEFAULT_PATTERN_FLAGS));
     }
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/parse/SetOperationParseStrategy.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/parse/SetOperationParseStrategy.java
@@ -35,7 +35,7 @@ public class SetOperationParseStrategy extends AbstractRegexParseStrategy {
     protected SetOperationParseStrategy() {
         super(
                 Pattern.compile(
-                        "SET(\\s+(?<key>[^'\\s]+)\\s*=\\s*('(?<quotedVal>[^']*)'|(?<val>[^;\\s]+)))?;?",
+                        "SET(\\s+(?<key>[^'\\s]+)\\s*=\\s*('(?<quotedVal>[^']*)'|(?<val>[^;\\s]+)))?(\\s*;)?",
                         DEFAULT_PATTERN_FLAGS));
     }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
@@ -1666,35 +1666,48 @@ public class SqlToOperationConverterTest {
     }
 
     @Test
-    public void testSqlClientCommands() {
+    public void testHelpCommands() {
         ExtendedParser extendedParser = new ExtendedParser();
-        Map<Class<? extends Operation>, String[]> operation2commands = new HashMap<>();
-        operation2commands.put(
-                ClearOperation.class,
-                new String[] {"CLEAR", "CLEAR;", "CLEAR ;", "CLEAR\t;", "CLEAR\n;"});
-        operation2commands.put(
-                HelpOperation.class,
-                new String[] {"HELP", "HELP;", "HELP ;", "HELP\t;", "HELP\n;"});
-        operation2commands.put(
-                QuitOperation.class,
-                new String[] {"QUIT", "QUIT;", "QUIT ;", "QUIT\t;", "QUIT\n;"});
-        operation2commands.forEach(
-                (key, value) ->
-                        Stream.of(value)
-                                .forEach(
-                                        command -> {
-                                            Operation operation1 =
-                                                    extendedParser
-                                                            .parse(command)
-                                                            .orElseThrow(
-                                                                    () ->
-                                                                            new RuntimeException(
-                                                                                    "Fail to parse '"
-                                                                                            + command
-                                                                                            + "'"));
-                                            assertThat(operation1)
-                                                    .isInstanceOf(ClearOperation.class);
-                                        }));
+        Stream.of("HELP", "HELP;", "HELP ;", "HELP\t;", "HELP\n;")
+                .forEach(
+                        command -> {
+                            Operation operation1 = extendedParser
+                                    .parse(command)
+                                    .orElseThrow(() -> new RuntimeException(
+                                            "Fail to parse '" + command + "'"));
+                            assertThat(operation1).isInstanceOf(ClearOperation.class);
+                        }
+                );
+    }
+
+    @Test
+    public void testClearCommands() {
+        ExtendedParser extendedParser = new ExtendedParser();
+        Stream.of("CLEAR", "CLEAR;", "CLEAR ;", "CLEAR\t;", "CLEAR\n;")
+                .forEach(
+                        command -> {
+                            Operation operation1 = extendedParser
+                                    .parse(command)
+                                    .orElseThrow(() -> new RuntimeException(
+                                            "Fail to parse '" + command + "'"));
+                            assertThat(operation1).isInstanceOf(ClearOperation.class);
+                        }
+                );
+    }
+
+    @Test
+    public void testQuitCommands() {
+        ExtendedParser extendedParser = new ExtendedParser();
+        Stream.of("QUIT", "QUIT;", "QUIT ;", "QUIT\t;", "QUIT\n;", "EXIT", "EXIT;", "EXIT ;", "EXIT\t;", "EXIT\n;")
+                .forEach(
+                command -> {
+                    Operation operation1 = extendedParser
+                            .parse(command)
+                            .orElseThrow(() -> new RuntimeException(
+                                    "Fail to parse '" + command + "'"));
+                    assertThat(operation1).isInstanceOf(ClearOperation.class);
+                }
+        );
     }
 
     // ~ Tool Methods ----------------------------------------------------------

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
@@ -1670,27 +1670,21 @@ public class SqlToOperationConverterTest {
     @ValueSource(strings = {"SET", "SET;", "SET ;", "SET\t;", "SET\n;"})
     public void testSetCommands(String command) {
         ExtendedParser extendedParser = new ExtendedParser();
-        assertThat(extendedParser.parse(command))
-                .get()
-                .isInstanceOf(SetOperation.class);
+        assertThat(extendedParser.parse(command)).get().isInstanceOf(SetOperation.class);
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"HELP", "HELP;", "HELP ;", "HELP\t;", "HELP\n;"})
     public void testHelpCommands(String command) {
         ExtendedParser extendedParser = new ExtendedParser();
-        assertThat(extendedParser.parse(command))
-                .get()
-                .isInstanceOf(HelpOperation.class);
+        assertThat(extendedParser.parse(command)).get().isInstanceOf(HelpOperation.class);
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"CLEAR", "CLEAR;", "CLEAR ;", "CLEAR\t;", "CLEAR\n;"})
     public void testClearCommands(String command) {
         ExtendedParser extendedParser = new ExtendedParser();
-        assertThat(extendedParser.parse(command))
-                .get()
-                .isInstanceOf(ClearOperation.class);
+        assertThat(extendedParser.parse(command)).get().isInstanceOf(ClearOperation.class);
     }
 
     @ParameterizedTest
@@ -1701,9 +1695,7 @@ public class SqlToOperationConverterTest {
             })
     public void testQuitCommands(String command) {
         ExtendedParser extendedParser = new ExtendedParser();
-        assertThat(extendedParser.parse(command))
-                .get()
-                .isInstanceOf(QuitOperation.class);
+        assertThat(extendedParser.parse(command)).get().isInstanceOf(QuitOperation.class);
     }
 
     // ~ Tool Methods ----------------------------------------------------------

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
@@ -1671,13 +1671,17 @@ public class SqlToOperationConverterTest {
         Stream.of("HELP", "HELP;", "HELP ;", "HELP\t;", "HELP\n;")
                 .forEach(
                         command -> {
-                            Operation operation1 = extendedParser
-                                    .parse(command)
-                                    .orElseThrow(() -> new RuntimeException(
-                                            "Fail to parse '" + command + "'"));
-                            assertThat(operation1).isInstanceOf(ClearOperation.class);
-                        }
-                );
+                            Operation operation1 =
+                                    extendedParser
+                                            .parse(command)
+                                            .orElseThrow(
+                                                    () ->
+                                                            new RuntimeException(
+                                                                    "Fail to parse '"
+                                                                            + command
+                                                                            + "'"));
+                            assertThat(operation1).isInstanceOf(HelpOperation.class);
+                        });
     }
 
     @Test
@@ -1686,28 +1690,38 @@ public class SqlToOperationConverterTest {
         Stream.of("CLEAR", "CLEAR;", "CLEAR ;", "CLEAR\t;", "CLEAR\n;")
                 .forEach(
                         command -> {
-                            Operation operation1 = extendedParser
-                                    .parse(command)
-                                    .orElseThrow(() -> new RuntimeException(
-                                            "Fail to parse '" + command + "'"));
+                            Operation operation1 =
+                                    extendedParser
+                                            .parse(command)
+                                            .orElseThrow(
+                                                    () ->
+                                                            new RuntimeException(
+                                                                    "Fail to parse '"
+                                                                            + command
+                                                                            + "'"));
                             assertThat(operation1).isInstanceOf(ClearOperation.class);
-                        }
-                );
+                        });
     }
 
     @Test
     public void testQuitCommands() {
         ExtendedParser extendedParser = new ExtendedParser();
-        Stream.of("QUIT", "QUIT;", "QUIT ;", "QUIT\t;", "QUIT\n;", "EXIT", "EXIT;", "EXIT ;", "EXIT\t;", "EXIT\n;")
+        Stream.of(
+                        "QUIT", "QUIT;", "QUIT ;", "QUIT\t;", "QUIT\n;", "EXIT", "EXIT;", "EXIT ;",
+                        "EXIT\t;", "EXIT\n;")
                 .forEach(
-                command -> {
-                    Operation operation1 = extendedParser
-                            .parse(command)
-                            .orElseThrow(() -> new RuntimeException(
-                                    "Fail to parse '" + command + "'"));
-                    assertThat(operation1).isInstanceOf(ClearOperation.class);
-                }
-        );
+                        command -> {
+                            Operation operation1 =
+                                    extendedParser
+                                            .parse(command)
+                                            .orElseThrow(
+                                                    () ->
+                                                            new RuntimeException(
+                                                                    "Fail to parse '"
+                                                                            + command
+                                                                            + "'"));
+                            assertThat(operation1).isInstanceOf(QuitOperation.class);
+                        });
     }
 
     // ~ Tool Methods ----------------------------------------------------------

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
@@ -1667,19 +1667,30 @@ public class SqlToOperationConverterTest {
     }
 
     @ParameterizedTest
+    @ValueSource(strings = {"SET", "SET;", "SET ;", "SET\t;", "SET\n;"})
+    public void testSetCommands(String command) {
+        ExtendedParser extendedParser = new ExtendedParser();
+        assertThat(extendedParser.parse(command))
+                .get()
+                .isInstanceOf(SetOperation.class);
+    }
+
+    @ParameterizedTest
     @ValueSource(strings = {"HELP", "HELP;", "HELP ;", "HELP\t;", "HELP\n;"})
     public void testHelpCommands(String command) {
         ExtendedParser extendedParser = new ExtendedParser();
-        Operation operation1 = extendedParser.parse(command).get();
-        assertThat(operation1).isInstanceOf(HelpOperation.class);
+        assertThat(extendedParser.parse(command))
+                .get()
+                .isInstanceOf(HelpOperation.class);
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"CLEAR", "CLEAR;", "CLEAR ;", "CLEAR\t;", "CLEAR\n;"})
     public void testClearCommands(String command) {
         ExtendedParser extendedParser = new ExtendedParser();
-        Operation operation1 = extendedParser.parse(command).get();
-        assertThat(operation1).isInstanceOf(ClearOperation.class);
+        assertThat(extendedParser.parse(command))
+                .get()
+                .isInstanceOf(ClearOperation.class);
     }
 
     @ParameterizedTest
@@ -1690,8 +1701,9 @@ public class SqlToOperationConverterTest {
             })
     public void testQuitCommands(String command) {
         ExtendedParser extendedParser = new ExtendedParser();
-        Operation operation1 = extendedParser.parse(command).get();
-        assertThat(operation1).isInstanceOf(QuitOperation.class);
+        assertThat(extendedParser.parse(command))
+                .get()
+                .isInstanceOf(QuitOperation.class);
     }
 
     // ~ Tool Methods ----------------------------------------------------------


### PR DESCRIPTION
## What is the purpose of the change

The PR allows to have spaces between sql client command and semicolon like it was before https://github.com/apache/flink/pull/18363

e.g. 
```sql
HELP ;
QUIT ;
```
Now it fails as described in FLINK-26295
## Brief change log

Added spaces support in Operations

## Verifying this change
There is a new test _org.apache.flink.table.planner.operations.SqlToOperationConverterTest#testSqlClientCommands_

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no )
  - The S3 file system connector: ( no )

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
