### PR TITLE
[FLINK-25971][table-planner] Hide JsonSerdeUtil#getObjectMapper

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/JsonSerdeUtil.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/JsonSerdeUtil.java
@@ -109,8 +109,14 @@ public class JsonSerdeUtil {
         OBJECT_MAPPER_INSTANCE.registerModule(createFlinkTableJacksonModule());
     }
 
-    /** Get the {@link ObjectMapper} instance. */
-    public static ObjectMapper getObjectMapper() {
+    /**
+     * Get the {@link ObjectMapper} instance.
+     *
+     * <p>This is not exposed outside this package to avoid bad usages, like adding new modules. If
+     * you need to read and write json, just use {@link #createObjectWriter(SerdeContext)} and
+     * {@link #createObjectReader(SerdeContext)}.
+     */
+    static ObjectMapper getObjectMapper() {
         return OBJECT_MAPPER_INSTANCE;
     }
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/JsonSerdeUtil.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/JsonSerdeUtil.java
@@ -91,6 +91,10 @@ public class JsonSerdeUtil {
     /**
      * Object mapper shared instance to serialize and deserialize the plan. Note that creating and
      * copying of object mappers is expensive and should be avoided.
+     *
+     * <p>This is not exposed to avoid bad usages, like adding new modules. If you need to read and
+     * write json persisted plans, use {@link #createObjectWriter(SerdeContext)} and {@link
+     * #createObjectReader(SerdeContext)}.
      */
     private static final ObjectMapper OBJECT_MAPPER_INSTANCE;
 
@@ -107,17 +111,6 @@ public class JsonSerdeUtil {
         OBJECT_MAPPER_INSTANCE.registerModule(new Jdk8Module().configureAbsentsAsNulls(true));
         OBJECT_MAPPER_INSTANCE.registerModule(new JavaTimeModule());
         OBJECT_MAPPER_INSTANCE.registerModule(createFlinkTableJacksonModule());
-    }
-
-    /**
-     * Get the {@link ObjectMapper} instance.
-     *
-     * <p>This is not exposed outside this package to avoid bad usages, like adding new modules. If
-     * you need to read and write json, just use {@link #createObjectWriter(SerdeContext)} and
-     * {@link #createObjectReader(SerdeContext)}.
-     */
-    static ObjectMapper getObjectMapper() {
-        return OBJECT_MAPPER_INSTANCE;
     }
 
     public static ObjectReader createObjectReader(SerdeContext serdeContext) {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ChangelogModeJsonSerdeTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ChangelogModeJsonSerdeTest.java
@@ -21,23 +21,20 @@ package org.apache.flink.table.planner.plan.nodes.exec.serde;
 import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.types.RowKind;
 
-import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonGenerator;
-import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
-
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 import java.io.IOException;
-import java.io.StringWriter;
 
-import static org.junit.Assert.assertEquals;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeTestUtil.testJsonRoundTrip;
 
 /** Tests for {@link ChangelogMode} serialization and deserialization. */
-public class ChangelogModeJsonSerdeTest {
+@Execution(ExecutionMode.CONCURRENT)
+class ChangelogModeJsonSerdeTest {
 
     @Test
-    public void testChangelogModeSerde() throws IOException {
-        ObjectMapper mapper = JsonSerdeUtil.getObjectMapper();
-
+    void testChangelogModeSerde() throws IOException {
         ChangelogMode changelogMode =
                 ChangelogMode.newBuilder()
                         .addContainedKind(RowKind.INSERT)
@@ -46,12 +43,6 @@ public class ChangelogModeJsonSerdeTest {
                         .addContainedKind(RowKind.UPDATE_BEFORE)
                         .build();
 
-        StringWriter writer = new StringWriter(100);
-        try (JsonGenerator gen = mapper.getFactory().createGenerator(writer)) {
-            gen.writeObject(changelogMode);
-        }
-        String json = writer.toString();
-        ChangelogMode actual = mapper.readValue(json, ChangelogMode.class);
-        assertEquals(changelogMode, actual);
+        testJsonRoundTrip(changelogMode, ChangelogMode.class);
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ContextResolvedTableSerdeTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ContextResolvedTableSerdeTest.java
@@ -36,6 +36,7 @@ import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.utils.CatalogManagerMocks;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectReader;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -55,7 +56,6 @@ import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeTest
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeTestUtil.assertThatJsonDoesNotContain;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeUtil.createObjectReader;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeUtil.createObjectWriter;
-import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeUtil.getObjectMapper;
 import static org.apache.flink.table.utils.CatalogManagerMocks.DEFAULT_CATALOG;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -632,13 +632,13 @@ public class ContextResolvedTableSerdeTest {
 
     private Tuple2<JsonNode, ContextResolvedTable> serDe(
             SerdeContext serdeCtx, ContextResolvedTable contextResolvedTable) throws Exception {
-        // Serialize/Deserialize test
         final byte[] actualSerialized =
                 createObjectWriter(serdeCtx).writeValueAsBytes(contextResolvedTable);
-        final JsonNode middleDeserialized = getObjectMapper().readTree(actualSerialized);
+
+        final ObjectReader objectReader = createObjectReader(serdeCtx);
+        final JsonNode middleDeserialized = objectReader.readTree(actualSerialized);
         final ContextResolvedTable actualDeserialized =
-                createObjectReader(serdeCtx)
-                        .readValue(actualSerialized, ContextResolvedTable.class);
+                objectReader.readValue(actualSerialized, ContextResolvedTable.class);
 
         return Tuple2.of(middleDeserialized, actualDeserialized);
     }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/FlinkVersionJsonSerdeTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/FlinkVersionJsonSerdeTest.java
@@ -45,9 +45,11 @@ final class FlinkVersionJsonSerdeTest {
 
     @Test
     void testManualString() throws IOException {
+        final SerdeContext ctx = configuredSerdeContext();
+
         final String flinkVersion = "1.15";
 
-        assertThat(toJson(configuredSerdeContext(), FlinkVersion.v1_15))
-                .isEqualTo(JsonSerdeUtil.getObjectMapper().writeValueAsString(flinkVersion));
+        assertThat(toJson(ctx, FlinkVersion.v1_15))
+                .isEqualTo(JsonSerdeUtil.createObjectWriter(ctx).writeValueAsString(flinkVersion));
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/InputPropertySerdeTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/InputPropertySerdeTest.java
@@ -20,41 +20,28 @@ package org.apache.flink.table.planner.plan.nodes.exec.serde;
 
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
 
-import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonGenerator;
-import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
-
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
-import java.io.StringWriter;
-import java.util.Arrays;
-import java.util.List;
+import java.util.stream.Stream;
 
-import static org.junit.Assert.assertEquals;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeTestUtil.testJsonRoundTrip;
 
 /** Tests for {@link InputProperty} serialization and deserialization. */
-@RunWith(Parameterized.class)
-public class InputPropertySerdeTest {
-    @Parameterized.Parameter public InputProperty inputProperty;
+@Execution(ExecutionMode.CONCURRENT)
+class InputPropertySerdeTest {
 
-    @Test
-    public void testExecEdgeSerde() throws IOException {
-        ObjectMapper mapper = JsonSerdeUtil.getObjectMapper();
-
-        StringWriter writer = new StringWriter(100);
-        try (JsonGenerator gen = mapper.getFactory().createGenerator(writer)) {
-            gen.writeObject(inputProperty);
-        }
-        String json = writer.toString();
-        InputProperty actual = mapper.readValue(json, InputProperty.class);
-        assertEquals(inputProperty, actual);
+    @ParameterizedTest
+    @MethodSource("testExecEdgeSerde")
+    void testExecEdgeSerde(InputProperty inputProperty) throws IOException {
+        testJsonRoundTrip(inputProperty, InputProperty.class);
     }
 
-    @Parameterized.Parameters(name = "{0}")
-    public static List<InputProperty> testData() {
-        return Arrays.asList(
+    public static Stream<InputProperty> testExecEdgeSerde() {
+        return Stream.of(
                 InputProperty.DEFAULT,
                 InputProperty.builder()
                         .requiredDistribution(InputProperty.hashDistribution(new int[] {0, 1}))

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/IntervalJoinSpecJsonSerdeTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/IntervalJoinSpecJsonSerdeTest.java
@@ -22,28 +22,21 @@ import org.apache.flink.table.planner.plan.nodes.exec.spec.IntervalJoinSpec;
 import org.apache.flink.table.planner.plan.nodes.exec.spec.JoinSpec;
 import org.apache.flink.table.runtime.operators.join.FlinkJoinType;
 
-import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
-
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertEquals;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeTestUtil.testJsonRoundTrip;
 
 /** Tests for {@link IntervalJoinSpec} serialization and deserialization. */
 public class IntervalJoinSpecJsonSerdeTest {
-
-    private final ObjectMapper mapper = JsonSerdeUtil.getObjectMapper();
 
     @Test
     public void testWindowBoundsSerde() throws IOException {
         IntervalJoinSpec.WindowBounds windowBounds =
                 new IntervalJoinSpec.WindowBounds(true, 0L, 10L, 1, 2);
-        assertEquals(
-                windowBounds,
-                mapper.readValue(
-                        mapper.writeValueAsString(windowBounds),
-                        IntervalJoinSpec.WindowBounds.class));
+
+        testJsonRoundTrip(windowBounds, IntervalJoinSpec.WindowBounds.class);
     }
 
     @Test
@@ -58,8 +51,7 @@ public class IntervalJoinSpecJsonSerdeTest {
         IntervalJoinSpec.WindowBounds windowBounds =
                 new IntervalJoinSpec.WindowBounds(true, 0L, 10L, 1, 2);
         IntervalJoinSpec actual = new IntervalJoinSpec(joinSpec, windowBounds);
-        assertEquals(
-                actual,
-                mapper.readValue(mapper.writeValueAsString(actual), IntervalJoinSpec.class));
+
+        testJsonRoundTrip(actual, IntervalJoinSpec.class);
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/IntervalJoinSpecJsonSerdeTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/IntervalJoinSpecJsonSerdeTest.java
@@ -23,12 +23,15 @@ import org.apache.flink.table.planner.plan.nodes.exec.spec.JoinSpec;
 import org.apache.flink.table.runtime.operators.join.FlinkJoinType;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 import java.io.IOException;
 
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeTestUtil.testJsonRoundTrip;
 
 /** Tests for {@link IntervalJoinSpec} serialization and deserialization. */
+@Execution(ExecutionMode.CONCURRENT)
 public class IntervalJoinSpecJsonSerdeTest {
 
     @Test

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/JoinSpecJsonSerdeTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/JoinSpecJsonSerdeTest.java
@@ -21,23 +21,20 @@ package org.apache.flink.table.planner.plan.nodes.exec.serde;
 import org.apache.flink.table.planner.plan.nodes.exec.spec.JoinSpec;
 import org.apache.flink.table.runtime.operators.join.FlinkJoinType;
 
-import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonGenerator;
-import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
-
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 import java.io.IOException;
-import java.io.StringWriter;
 
-import static org.junit.Assert.assertEquals;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeTestUtil.testJsonRoundTrip;
 
 /** Tests for {@link JoinSpec} serialization and deserialization. */
-public class JoinSpecJsonSerdeTest {
-
-    private final ObjectMapper mapper = JsonSerdeUtil.getObjectMapper();
+@Execution(ExecutionMode.CONCURRENT)
+class JoinSpecJsonSerdeTest {
 
     @Test
-    public void testJoinSpecSerde() throws IOException {
+    void testJoinSpecSerde() throws IOException {
         JoinSpec joinSpec =
                 new JoinSpec(
                         FlinkJoinType.ANTI,
@@ -46,12 +43,6 @@ public class JoinSpecJsonSerdeTest {
                         new boolean[] {true},
                         null);
 
-        StringWriter writer = new StringWriter(100);
-        try (JsonGenerator gen = mapper.getFactory().createGenerator(writer)) {
-            gen.writeObject(joinSpec);
-        }
-        String json = writer.toString();
-        JoinSpec actual = mapper.readValue(json, JoinSpec.class);
-        assertEquals(joinSpec, actual);
+        testJsonRoundTrip(joinSpec, JoinSpec.class);
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RexNodeJsonSerdeTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RexNodeJsonSerdeTest.java
@@ -88,7 +88,6 @@ import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeTest
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeTestUtil.toJson;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeUtil.createObjectReader;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeUtil.createObjectWriter;
-import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeUtil.getObjectMapper;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.RexNodeJsonSerializer.FIELD_NAME_CLASS;
 import static org.apache.flink.table.utils.CatalogManagerMocks.DEFAULT_CATALOG;
 import static org.apache.flink.table.utils.CatalogManagerMocks.DEFAULT_DATABASE;
@@ -760,7 +759,7 @@ public class RexNodeJsonSerdeTest {
         final byte[] actualSerialized =
                 createObjectWriter(serdeContext)
                         .writeValueAsBytes(createFunctionCall(serdeContext, PERMANENT_FUNCTION));
-        return getObjectMapper().readTree(actualSerialized);
+        return createObjectReader(serdeContext).readTree(actualSerialized);
     }
 
     private ContextResolvedFunction deserialize(SerdeContext serdeContext, JsonNode node)

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/utils/JsonTestUtils.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/utils/JsonTestUtils.java
@@ -19,9 +19,9 @@
 package org.apache.flink.table.planner.utils;
 
 import org.apache.flink.FlinkVersion;
-import org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeUtil;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.ObjectNode;
 
 import java.io.IOException;
@@ -29,15 +29,17 @@ import java.io.IOException;
 /** This class contains a collection of generic utilities to deal with JSON in tests. */
 public final class JsonTestUtils {
 
+    private static final ObjectMapper OBJECT_MAPPER_INSTANCE = new ObjectMapper();
+
     private JsonTestUtils() {}
 
     public static JsonNode readFromResource(String path) throws IOException {
-        return JsonSerdeUtil.getObjectMapper().readTree(JsonTestUtils.class.getResource(path));
+        return OBJECT_MAPPER_INSTANCE.readTree(JsonTestUtils.class.getResource(path));
     }
 
     public static JsonNode setFlinkVersion(JsonNode target, FlinkVersion flinkVersion) {
         return ((ObjectNode) target)
-                .set("flinkVersion", JsonSerdeUtil.getObjectMapper().valueToTree(flinkVersion));
+                .set("flinkVersion", OBJECT_MAPPER_INSTANCE.valueToTree(flinkVersion.toString()));
     }
 
     public static JsonNode clearFlinkVersion(JsonNode target) {


### PR DESCRIPTION
The only possible way a user classloader leak can happen is if a wrong usage of JsonSerdeUtil.getObjectMapper() leads to registering in this global object mapper a user serializer/deserializer. In order to be on the safe side and completely disallow it, this PR hides the `getObjectMapper` method.

The only usage of `JsonSerdeUtil#getObjectMapper` outside its package was `JsonTestUtils`, which is doing something different and doesn't require the `JsonSerdeUtil` `ObjectMapper` global instance.