### PR TITLE
[FLINK-26280][table-planner] Add 'table.exec.legacy-transformation-uids' to support old transformation uid generation behaviour

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
@@ -478,6 +478,19 @@ public class ExecutionConfigOptions {
                                             + "all changes to downstream just like when the mini-batch is "
                                             + "not enabled.");
 
+    @Documentation.TableOption(execMode = Documentation.ExecMode.STREAMING)
+    @Deprecated
+    public static final ConfigOption<Boolean> TABLE_EXEC_LEGACY_TRANSFORMATION_UIDS =
+            key("table.exec.legacy-transformation-uids")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "In Flink 1.15 Transformation UIDs are generated deterministically starting from the metadata available after the planning phase. "
+                                    + "This new behaviour allows a safe restore of persisted plan, remapping the plan execution graph to the correct operators state. "
+                                    + "Setting this flag to true enables the previous \"legacy\" behavior, which is generating uids from the Transformation graph topology. "
+                                    + "We strongly suggest to keep this flag disabled, as this flag is going to be removed in the next releases. "
+                                    + "If you have a pipeline relying on the old behavior, please create a new pipeline and regenerate the operators state.");
+
     // ------------------------------------------------------------------------------------------
     // Enum option types
     // ------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/ExecNodeBase.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/ExecNodeBase.java
@@ -187,7 +187,8 @@ public abstract class ExecNodeBase<T> implements ExecNode<T> {
 
     protected TransformationMetadata createTransformationMeta(
             String operatorName, ReadableConfig config) {
-        if (ExecNodeMetadataUtil.isUnsupported(this.getClass())) {
+        if (ExecNodeMetadataUtil.isUnsupported(this.getClass())
+                || config.get(ExecutionConfigOptions.TABLE_EXEC_LEGACY_TRANSFORMATION_UIDS)) {
             return new TransformationMetadata(
                     createTransformationName(config), createTransformationDescription(config));
         } else {
@@ -203,7 +204,8 @@ public abstract class ExecNodeBase<T> implements ExecNode<T> {
             String operatorName, String detailName, String simplifiedName, ReadableConfig config) {
         final String name = createFormattedTransformationName(detailName, simplifiedName, config);
         final String desc = createFormattedTransformationDescription(detailName, config);
-        if (ExecNodeMetadataUtil.isUnsupported(this.getClass())) {
+        if (ExecNodeMetadataUtil.isUnsupported(this.getClass())
+                || config.get(ExecutionConfigOptions.TABLE_EXEC_LEGACY_TRANSFORMATION_UIDS)) {
             return new TransformationMetadata(name, desc);
         } else {
             // Only classes supporting metadata util need to set the uid

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecSink.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecSink.java
@@ -441,7 +441,7 @@ public abstract class CommonExecSink extends ExecNodeBase<Object>
                             inputTransform, rowtimeFieldIndex, sinkParallelism, config);
             final DataStream<RowData> dataStream = new DataStream<>(env, sinkTransformation);
             final DataStreamSinkProvider provider = (DataStreamSinkProvider) runtimeProvider;
-            return provider.consumeDataStream(createProviderContext(), dataStream)
+            return provider.consumeDataStream(createProviderContext(config), dataStream)
                     .getTransformation();
         } else if (runtimeProvider instanceof TransformationSinkProvider) {
             final TransformationSinkProvider provider =
@@ -460,7 +460,7 @@ public abstract class CommonExecSink extends ExecNodeBase<Object>
 
                         @Override
                         public Optional<String> generateUid(String name) {
-                            return createProviderContext().generateUid(name);
+                            return createProviderContext(config).generateUid(name);
                         }
                     });
         } else if (runtimeProvider instanceof SinkFunctionProvider) {
@@ -513,9 +513,10 @@ public abstract class CommonExecSink extends ExecNodeBase<Object>
         }
     }
 
-    private ProviderContext createProviderContext() {
+    private ProviderContext createProviderContext(ReadableConfig config) {
         return name -> {
-            if (this instanceof StreamExecNode) {
+            if (this instanceof StreamExecNode
+                    && !config.get(ExecutionConfigOptions.TABLE_EXEC_LEGACY_TRANSFORMATION_UIDS)) {
                 return Optional.of(createTransformationUid(name));
             }
             return Optional.empty();

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecTableSourceScan.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecTableSourceScan.java
@@ -24,11 +24,13 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.api.connector.source.Source;
 import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.source.ParallelSourceFunction;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.api.operators.StreamSource;
 import org.apache.flink.streaming.api.transformations.LegacySourceTransformation;
+import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.flink.table.connector.ProviderContext;
 import org.apache.flink.table.connector.source.DataStreamScanProvider;
 import org.apache.flink.table.connector.source.InputFormatProvider;
@@ -131,7 +133,8 @@ public abstract class CommonExecTableSourceScan extends ExecNodeBase<RowData>
         } else if (provider instanceof DataStreamScanProvider) {
             Transformation<RowData> transformation =
                     ((DataStreamScanProvider) provider)
-                            .produceDataStream(createProviderContext(), env)
+                            .produceDataStream(
+                                    createProviderContext(planner.getConfiguration()), env)
                             .getTransformation();
             meta.fill(transformation);
             transformation.setOutputType(outputTypeInfo);
@@ -139,7 +142,8 @@ public abstract class CommonExecTableSourceScan extends ExecNodeBase<RowData>
         } else if (provider instanceof TransformationScanProvider) {
             final Transformation<RowData> transformation =
                     ((TransformationScanProvider) provider)
-                            .createTransformation(createProviderContext());
+                            .createTransformation(
+                                    createProviderContext(planner.getConfiguration()));
             meta.fill(transformation);
             transformation.setOutputType(outputTypeInfo);
             return transformation;
@@ -149,9 +153,10 @@ public abstract class CommonExecTableSourceScan extends ExecNodeBase<RowData>
         }
     }
 
-    private ProviderContext createProviderContext() {
+    private ProviderContext createProviderContext(ReadableConfig config) {
         return name -> {
-            if (this instanceof StreamExecNode) {
+            if (this instanceof StreamExecNode
+                    && !config.get(ExecutionConfigOptions.TABLE_EXEC_LEGACY_TRANSFORMATION_UIDS)) {
                 return Optional.of(createTransformationUid(name));
             }
             return Optional.empty();

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecTableSourceScan.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecTableSourceScan.java
@@ -133,8 +133,7 @@ public abstract class CommonExecTableSourceScan extends ExecNodeBase<RowData>
         } else if (provider instanceof DataStreamScanProvider) {
             Transformation<RowData> transformation =
                     ((DataStreamScanProvider) provider)
-                            .produceDataStream(
-                                    createProviderContext(planner.getConfiguration()), env)
+                            .produceDataStream(createProviderContext(config), env)
                             .getTransformation();
             meta.fill(transformation);
             transformation.setOutputType(outputTypeInfo);
@@ -142,8 +141,7 @@ public abstract class CommonExecTableSourceScan extends ExecNodeBase<RowData>
         } else if (provider instanceof TransformationScanProvider) {
             final Transformation<RowData> transformation =
                     ((TransformationScanProvider) provider)
-                            .createTransformation(
-                                    createProviderContext(planner.getConfiguration()));
+                            .createTransformation(createProviderContext(config));
             meta.fill(transformation);
             transformation.setOutputType(outputTypeInfo);
             return transformation;

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/TransformationsTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/TransformationsTest.java
@@ -99,7 +99,7 @@ class TransformationsTest {
         final StreamTableEnvironment env =
                 StreamTableEnvironment.create(
                         StreamExecutionEnvironment.getExecutionEnvironment(),
-                        EnvironmentSettings.newInstance().inStreamingMode().build());
+                        EnvironmentSettings.newInstance().inBatchMode().build());
 
         final Table table = env.fromValues(1, 2, 3);
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/TransformationsTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/TransformationsTest.java
@@ -20,32 +20,44 @@ package org.apache.flink.table.planner.plan.nodes.exec;
 
 import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.transformations.LegacySourceTransformation;
 import org.apache.flink.streaming.api.transformations.WithBoundedness;
+import org.apache.flink.table.api.CompiledPlan;
 import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.Schema;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableDescriptor;
+import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
-import org.apache.flink.table.planner.utils.JavaBatchTableTestUtil;
-import org.apache.flink.table.planner.utils.JavaStreamTableTestUtil;
-import org.apache.flink.table.planner.utils.TableTestBase;
+import org.apache.flink.table.api.config.ExecutionConfigOptions;
+import org.apache.flink.table.api.internal.TableEnvironmentImpl;
+import org.apache.flink.table.planner.delegation.PlannerBase;
+import org.apache.flink.table.planner.plan.ExecNodeGraphCompiledPlan;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import java.util.List;
+
+import static org.apache.flink.table.api.Expressions.$;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.type;
 
 /**
  * Various tests to check {@link Transformation}s that have been generated from {@link ExecNode}s.
  */
-public class TransformationsTest extends TableTestBase {
+@Execution(ExecutionMode.CONCURRENT)
+class TransformationsTest {
 
     @Test
     public void testLegacyBatchSource() {
-        final JavaBatchTableTestUtil util = javaBatchTestUtil();
-        final StreamTableEnvironment env = util.tableEnv();
+        final StreamTableEnvironment env =
+                StreamTableEnvironment.create(
+                        StreamExecutionEnvironment.getExecutionEnvironment(),
+                        EnvironmentSettings.newInstance().inBatchMode().build());
 
         final Table table =
                 env.from(
@@ -58,13 +70,15 @@ public class TransformationsTest extends TableTestBase {
                 toLegacySourceTransformation(env, table);
 
         assertBoundedness(Boundedness.BOUNDED, sourceTransform);
-        assertFalse(sourceTransform.getOperator().emitsProgressiveWatermarks());
+        assertThat(sourceTransform.getOperator().emitsProgressiveWatermarks()).isFalse();
     }
 
     @Test
     public void testLegacyStreamSource() {
-        final JavaStreamTableTestUtil util = javaStreamTestUtil();
-        final StreamTableEnvironment env = util.tableEnv();
+        final StreamTableEnvironment env =
+                StreamTableEnvironment.create(
+                        StreamExecutionEnvironment.getExecutionEnvironment(),
+                        EnvironmentSettings.newInstance().inStreamingMode().build());
 
         final Table table =
                 env.from(
@@ -77,13 +91,15 @@ public class TransformationsTest extends TableTestBase {
                 toLegacySourceTransformation(env, table);
 
         assertBoundedness(Boundedness.CONTINUOUS_UNBOUNDED, sourceTransform);
-        assertTrue(sourceTransform.getOperator().emitsProgressiveWatermarks());
+        assertThat(sourceTransform.getOperator().emitsProgressiveWatermarks()).isTrue();
     }
 
     @Test
     public void testLegacyBatchValues() {
-        final JavaBatchTableTestUtil util = javaBatchTestUtil();
-        final StreamTableEnvironment env = util.tableEnv();
+        final StreamTableEnvironment env =
+                StreamTableEnvironment.create(
+                        StreamExecutionEnvironment.getExecutionEnvironment(),
+                        EnvironmentSettings.newInstance().inStreamingMode().build());
 
         final Table table = env.fromValues(1, 2, 3);
 
@@ -91,6 +107,43 @@ public class TransformationsTest extends TableTestBase {
                 toLegacySourceTransformation(env, table);
 
         assertBoundedness(Boundedness.BOUNDED, sourceTransform);
+    }
+
+    @Test
+    public void testLegacyUid() {
+        final TableEnvironment env =
+                TableEnvironment.create(EnvironmentSettings.inStreamingMode().toConfiguration());
+        env.getConfig().set(ExecutionConfigOptions.TABLE_EXEC_LEGACY_TRANSFORMATION_UIDS, true);
+
+        env.createTemporaryTable(
+                "source_table",
+                TableDescriptor.forConnector("values")
+                        .option("bounded", "true")
+                        .schema(dummySchema())
+                        .build());
+        env.createTemporaryTable(
+                "sink_table", TableDescriptor.forConnector("values").schema(dummySchema()).build());
+
+        CompiledPlan compiledPlan =
+                env.from("source_table")
+                        .select($("i").abs())
+                        .insertInto("sink_table")
+                        .compilePlan();
+
+        // There should be 3 transformations in this list: sink -> calc -> source
+        List<Transformation<?>> transformations =
+                ((PlannerBase) ((TableEnvironmentImpl) env).getPlanner())
+                        .translateToPlan(
+                                ((ExecNodeGraphCompiledPlan) compiledPlan).getExecNodeGraph())
+                        .get(0)
+                        .getTransitivePredecessors();
+        assertThat(transformations).hasSize(3);
+
+        // As the sink and source might set the uid, we only check the calc transformation.
+        assertThat(transformations)
+                .element(1, type(Transformation.class))
+                .extracting(Transformation::getUid)
+                .isNull();
     }
 
     // --------------------------------------------------------------------------------------------
@@ -103,13 +156,15 @@ public class TransformationsTest extends TableTestBase {
         while (transform.getInputs().size() == 1) {
             transform = transform.getInputs().get(0);
         }
-        assertTrue(transform instanceof LegacySourceTransformation);
+        assertThat(transform).isInstanceOf(LegacySourceTransformation.class);
         return (LegacySourceTransformation<?>) transform;
     }
 
     private static void assertBoundedness(Boundedness boundedness, Transformation<?> transform) {
-        assertTrue(transform instanceof WithBoundedness);
-        assertEquals(boundedness, ((WithBoundedness) transform).getBoundedness());
+        assertThat(transform)
+                .asInstanceOf(type(WithBoundedness.class))
+                .extracting(WithBoundedness::getBoundedness)
+                .isEqualTo(boundedness);
     }
 
     private static Schema dummySchema() {


### PR DESCRIPTION
Per discussion here https://issues.apache.org/jira/browse/FLINK-25932