### PR TITLE
[FLINK-26302][build] Upgrade rat-plugin to 1.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1364,7 +1364,7 @@ under the License.
 			<plugin>
 				<groupId>org.apache.rat</groupId>
 				<artifactId>apache-rat-plugin</artifactId>
-				<version>0.12</version><!--$NO-MVN-MAN-VER$-->
+				<version>0.13</version>
 				<inherited>false</inherited>
 				<executions>
 					<execution>


### PR DESCRIPTION
Skips the logging of exclusions, making the plugin less verbose.