### PR TITLE
[FLINK-26286] Introduces repeatable cleanup to KubernetesStateHandleStore

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/persistence/StateHandleStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/persistence/StateHandleStore.java
@@ -128,9 +128,13 @@ public interface StateHandleStore<T extends Serializable, R extends ResourceVers
     /**
      * Releases and removes all the states. Not only the state handles in the distributed
      * coordination system will be removed, but also the real state data on the distributed storage
-     * will be discarded.
+     * will be discarded. This method should be implemented in a idempotent manner, i.e. failing
+     * calls should be able to be repeated.
      *
-     * @throws Exception if releasing, removing the handles or discarding the state failed
+     * @throws Exception if releasing, removing the handles or discarding the state failed. The
+     *     removal of the states should happen independently from each other, i.e. the method call
+     *     fails if at least one removal failed. But the removal of any other state should still be
+     *     performed.
      */
     void releaseAndTryRemoveAll() throws Exception;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/RetrievableStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/RetrievableStateHandle.java
@@ -26,4 +26,8 @@ public interface RetrievableStateHandle<T extends Serializable> extends StateObj
 
     /** Retrieves the object that was previously written to state. */
     T retrieveState() throws IOException, ClassNotFoundException;
+
+    boolean isMarkedForDeletion();
+
+    void markForDeletion();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/RetrievableStreamStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/RetrievableStreamStateHandle.java
@@ -44,6 +44,8 @@ public class RetrievableStreamStateHandle<T extends Serializable>
     /** wrapped inner stream state handle from which we deserialize on retrieval */
     private final StreamStateHandle wrappedStreamStateHandle;
 
+    private boolean isMarkedForDeletion = false;
+
     public RetrievableStreamStateHandle(StreamStateHandle streamStateHandle) {
         this.wrappedStreamStateHandle = Preconditions.checkNotNull(streamStateHandle);
     }
@@ -59,6 +61,16 @@ public class RetrievableStreamStateHandle<T extends Serializable>
             return InstantiationUtil.deserializeObject(
                     in, Thread.currentThread().getContextClassLoader());
         }
+    }
+
+    @Override
+    public boolean isMarkedForDeletion() {
+        return isMarkedForDeletion;
+    }
+
+    @Override
+    public void markForDeletion() {
+        isMarkedForDeletion = true;
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/DefaultCompletedCheckpointStoreUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/DefaultCompletedCheckpointStoreUtilsTest.java
@@ -66,9 +66,21 @@ public class DefaultCompletedCheckpointStoreUtilsTest extends TestLogger {
 
         private static final int serialVersionUID = 1;
 
+        private boolean isMarkedForDeletion = false;
+
         @Override
         public T retrieveState() throws IOException, ClassNotFoundException {
             throw new IOException("Test exception.");
+        }
+
+        @Override
+        public boolean isMarkedForDeletion() {
+            return isMarkedForDeletion;
+        }
+
+        @Override
+        public void markForDeletion() {
+            isMarkedForDeletion = true;
         }
 
         @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/TestingRetrievableStateStorageHelper.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/TestingRetrievableStateStorageHelper.java
@@ -42,6 +42,7 @@ public final class TestingRetrievableStateStorageHelper<T extends Serializable>
         private static final long serialVersionUID = 137053380713794300L;
 
         private final T state;
+        private boolean isMarkedForDeletion = false;
 
         private TestingRetrievableStateHandle(T state) {
             this.state = state;
@@ -50,6 +51,16 @@ public final class TestingRetrievableStateStorageHelper<T extends Serializable>
         @Override
         public T retrieveState() {
             return state;
+        }
+
+        @Override
+        public boolean isMarkedForDeletion() {
+            return isMarkedForDeletion;
+        }
+
+        @Override
+        public void markForDeletion() {
+            isMarkedForDeletion = true;
         }
 
         @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreITCase.java
@@ -427,6 +427,8 @@ public class ZooKeeperCompletedCheckpointStoreITCase extends CompletedCheckpoint
 
         private final int key;
 
+        private boolean isMarkedForDeletion = false;
+
         public HeapRetrievableStateHandle(T state) {
             key = nextKey.getAndIncrement();
             stateMap.put(key, state);
@@ -436,6 +438,16 @@ public class ZooKeeperCompletedCheckpointStoreITCase extends CompletedCheckpoint
         @Override
         public T retrieveState() {
             return (T) stateMap.get(key);
+        }
+
+        @Override
+        public boolean isMarkedForDeletion() {
+            return isMarkedForDeletion;
+        }
+
+        @Override
+        public void markForDeletion() {
+            isMarkedForDeletion = true;
         }
 
         @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreITCase.java
@@ -35,6 +35,7 @@ import org.apache.flink.util.concurrent.ManuallyTriggeredScheduledExecutor;
 import org.apache.flink.shaded.curator5.org.apache.curator.framework.CuratorFramework;
 import org.apache.flink.shaded.zookeeper3.org.apache.zookeeper.data.Stat;
 
+import com.google.common.collect.Iterables;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
@@ -218,10 +219,21 @@ public class ZooKeeperCompletedCheckpointStoreITCase extends CompletedCheckpoint
         final String checkpointPath =
                 CHECKPOINT_PATH
                         + checkpointStoreUtil.checkpointIDToName(checkpoint.getCheckpointID());
-        Stat stat = client.checkExists().forPath(checkpointPath);
+        final List<String> checkpointPathChildren = client.getChildren().forPath(checkpointPath);
+        assertEquals(
+                "The checkpoint node should not be marked for deletion.",
+                1,
+                checkpointPathChildren.size());
 
-        assertNotNull("The checkpoint node should exist.", stat);
-        assertEquals("The checkpoint node should not be locked.", 0, stat.getNumChildren());
+        final String locksNodeName = Iterables.getOnlyElement(checkpointPathChildren);
+        final String locksNodePath =
+                ZooKeeperUtils.generateZookeeperPath(checkpointPath, locksNodeName);
+
+        final Stat locksStat = client.checkExists().forPath(locksNodePath);
+        assertEquals(
+                "There shouldn't be any lock node available for the checkpoint",
+                0,
+                locksStat.getNumChildren());
 
         // Recover again
         sharedStateRegistry.close();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreTest.java
@@ -206,6 +206,8 @@ public class ZooKeeperCompletedCheckpointStoreTest extends TestLogger {
         private final Function<Long, CompletedCheckpoint> checkpointSupplier;
         private final long id;
 
+        private boolean isMarkedForDeletion = false;
+
         CheckpointStateHandle(Function<Long, CompletedCheckpoint> checkpointSupplier, long id) {
             this.checkpointSupplier = checkpointSupplier;
             this.id = id;
@@ -214,6 +216,16 @@ public class ZooKeeperCompletedCheckpointStoreTest extends TestLogger {
         @Override
         public CompletedCheckpoint retrieveState() {
             return checkpointSupplier.apply(id);
+        }
+
+        @Override
+        public boolean isMarkedForDeletion() {
+            return isMarkedForDeletion;
+        }
+
+        @Override
+        public void markForDeletion() {
+            isMarkedForDeletion = true;
         }
 
         @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/persistence/TestingLongStateHandleHelper.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/persistence/TestingLongStateHandleHelper.java
@@ -22,6 +22,8 @@ import org.apache.flink.runtime.state.RetrievableStateHandle;
 import org.apache.flink.runtime.state.StateObject;
 import org.apache.flink.util.AbstractID;
 
+import javax.annotation.Nullable;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.StringJoiner;
@@ -79,8 +81,16 @@ public class TestingLongStateHandleHelper
 
         private int numberOfDiscardCalls = 0;
 
+        @Nullable private RuntimeException initialDiscardRuntimeException;
+
         public LongStateHandle(long value) {
+            this(value, null);
+        }
+
+        public LongStateHandle(
+                long value, @Nullable RuntimeException initialDiscardRuntimeException) {
             this.value = value;
+            this.initialDiscardRuntimeException = initialDiscardRuntimeException;
         }
 
         public long getValue() {
@@ -89,11 +99,21 @@ public class TestingLongStateHandleHelper
 
         @Override
         public void discardState() {
+            if (initialDiscardRuntimeException != null) {
+                final RuntimeException actualException = initialDiscardRuntimeException;
+                initialDiscardRuntimeException = null;
+                throw actualException;
+            }
+
             numberOfDiscardCalls++;
         }
 
         public int getNumberOfDiscardCalls() {
             return numberOfDiscardCalls;
+        }
+
+        public boolean isDiscarded() {
+            return numberOfDiscardCalls > 0;
         }
 
         @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/persistence/TestingLongStateHandleHelper.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/persistence/TestingLongStateHandleHelper.java
@@ -138,6 +138,8 @@ public class TestingLongStateHandleHelper
 
         private final int stateReference;
 
+        private boolean isMarkedForDeletion = false;
+
         public LongRetrievableStateHandle(int stateReference) {
             this.stateReference = stateReference;
         }
@@ -145,6 +147,16 @@ public class TestingLongStateHandleHelper
         @Override
         public LongStateHandle retrieveState() {
             return STATE_STORAGE.get(stateReference);
+        }
+
+        @Override
+        public boolean isMarkedForDeletion() {
+            return isMarkedForDeletion;
+        }
+
+        @Override
+        public void markForDeletion() {
+            isMarkedForDeletion = true;
         }
 
         @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/persistence/TestingRetrievableStateStorageHelper.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/persistence/TestingRetrievableStateStorageHelper.java
@@ -69,6 +69,8 @@ public final class TestingRetrievableStateStorageHelper<T extends Serializable>
 
         private final T state;
 
+        private boolean isMarkedForDeletion = false;
+
         private TestingRetrievableStateHandle(T state) {
             this.state = state;
         }
@@ -76,6 +78,16 @@ public final class TestingRetrievableStateStorageHelper<T extends Serializable>
         @Override
         public T retrieveState() throws IOException {
             return retrieveStateFunction.apply(state);
+        }
+
+        @Override
+        public boolean isMarkedForDeletion() {
+            return isMarkedForDeletion;
+        }
+
+        @Override
+        public void markForDeletion() {
+            isMarkedForDeletion = true;
         }
 
         @Override


### PR DESCRIPTION
This branch is based on the changes in #18869 and includes these changes as long as the upstream branch FLINK-28264 isn't merged.

## What is the purpose of the change

A new flag `markedForDeletion` is added that labels states within the `KubernetesStateHandleStore` that are in the process of deletion.

## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
