### PR TITLE
[hotfix]fix method name typos

### DIFF
--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
@@ -283,7 +283,7 @@ class TemporalTypesTest extends ExpressionTestBase {
   }
 
   @Test
-  def tesInvalidCastBetweenNumericAndTimestampLtz(): Unit = {
+  def testInvalidCastBetweenNumericAndTimestampLtz(): Unit = {
     val castFromTimestampLtzExceptionMsg = "The cast from TIMESTAMP_LTZ type to" +
       " NUMERIC type is not allowed."
 
@@ -363,7 +363,7 @@ class TemporalTypesTest extends ExpressionTestBase {
   }
 
   @Test
-  def tesInvalidCastBetweenNumericAndTimestamp(): Unit = {
+  def testInvalidCastBetweenNumericAndTimestamp(): Unit = {
     val castFromTimestampExceptionMsg = "The cast from TIMESTAMP type to NUMERIC type" +
       " is not allowed. It's recommended to use" +
       " UNIX_TIMESTAMP(CAST(timestamp_col AS STRING)) instead."


### PR DESCRIPTION
## What is the purpose of the change

fix method name typos

## Brief change log

tesInvalidCastBetweenNumericAndTimestampLtz -> testInvalidCastBetweenNumericAndTimestampLtz
tesInvalidCastBetweenNumericAndTimestamp -> testInvalidCastBetweenNumericAndTimestamp


## Verifying this change

no

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
