### PR TITLE
[FLINK-26296] Add missing documentation for JobResultStore and repeatable resource cleanup strategy

### DIFF
--- a/docs/content.zh/docs/concepts/glossary.md
+++ b/docs/content.zh/docs/concepts/glossary.md
@@ -87,6 +87,13 @@ Flink JobManager 是 [Flink Cluster](#flink-cluster) 的主节点。它包含三
 
 JobMaster 是在 [Flink JobManager](#flink-jobmanager) 运行中的组件之一。JobManager 负责监督单个作业 [Task](#task) 的执行。以前，整个 [Flink JobManager](#flink-jobmanager) 都叫做 JobManager。
 
+#### JobResultStore
+
+The JobResultStore is a Flink component that persists the results of globally terminated
+(i.e. finished, cancelled or failed) jobs to a filesystem, allowing the results to outlive
+a finished job. These results are then used by Flink to determine whether jobs should
+be subject to recovery in highly-available clusters.
+
 #### Logical Graph
 
 A logical graph is a directed graph where the nodes are  [Operators](#operator)

--- a/docs/content.zh/docs/deployment/ha/overview.md
+++ b/docs/content.zh/docs/deployment/ha/overview.md
@@ -73,3 +73,17 @@ Flink 提供了两种高可用服务实现：
 为了恢复提交的作业，Flink 持久化元数据和 job 组件。高可用数据将一直保存，直到相应的作业执行成功、被取消或最终失败。当这些情况发生时，将删除所有高可用数据，包括存储在高可用服务中的元数据。
 
 {{< top >}}
+
+## JobResultStore
+
+In order to preserve a job's scheduling status across failover events and prevent erroneous
+re-execution of globally terminated (i.e. finished, cancelled or failed) jobs, Flink persists
+status of terminated jobs to a filesystem using the JobResultStore.
+The JobResultStore allows job results to outlive a finished job, and can be used by
+Flink components involved in the recovery of a highly-available cluster in order to
+determine whether a job should be subject to recovery.
+
+The JobResultStore has sensible defaults for its behaviour, such as result storage
+location, but these can be [configured]({{< ref "docs/deployment/config#high-availability" >}}).
+
+{{< top >}}

--- a/docs/content.zh/docs/deployment/overview.md
+++ b/docs/content.zh/docs/deployment/overview.md
@@ -152,7 +152,12 @@ When deploying Flink, there are often multiple options available for each buildi
     </tbody>
 </table>
 
+### Repeatable Resource Cleanup
 
+Once a job has reached a globally terminal state of either finished, failed or cancelled, the
+external component resources associated with the job are then cleaned up. In the event of a
+failure when cleaning up a resource, Flink will attempt to retry the cleanup. You can
+[configure]({{< ref "docs/deployment/config#retryable-cleanup" >}}) the retry strategy used.
 
 ## Deployment Modes
 

--- a/docs/content/docs/concepts/glossary.md
+++ b/docs/content/docs/concepts/glossary.md
@@ -104,6 +104,13 @@ per running [Flink Job](#flink-job).
 JobMasters are one of the components running in the [JobManager](#flink-jobmanager). A JobMaster is
 responsible for supervising the execution of the [Tasks](#task) of a single job.
 
+#### JobResultStore
+
+The JobResultStore is a Flink component that persists the results of globally terminated
+(i.e. finished, cancelled or failed) jobs to a filesystem, allowing the results to outlive
+a finished job. These results are then used by Flink to determine whether jobs should
+be subject to recovery in highly-available clusters.
+
 #### Logical Graph
 
 A logical graph is a directed graph where the nodes are  [Operators](#operator)

--- a/docs/content/docs/deployment/ha/overview.md
+++ b/docs/content/docs/deployment/ha/overview.md
@@ -79,3 +79,17 @@ The HA data will be kept until the respective job either succeeds, is cancelled 
 Once this happens, all the HA data, including the metadata stored in the HA services, will be deleted.  
 
 {{< top >}}
+
+## JobResultStore
+
+In order to preserve a job's scheduling status across failover events and prevent erroneous
+re-execution of globally terminated (i.e. finished, cancelled or failed) jobs, Flink persists
+status of terminated jobs to a filesystem using the JobResultStore.
+The JobResultStore allows job results to outlive a finished job, and can be used by
+Flink components involved in the recovery of a highly-available cluster in order to
+determine whether a job should be subject to recovery.
+
+The JobResultStore has sensible defaults for its behaviour, such as result storage
+location, but these can be [configured]({{< ref "docs/deployment/config#high-availability" >}}).
+
+{{< top >}}

--- a/docs/content/docs/deployment/overview.md
+++ b/docs/content/docs/deployment/overview.md
@@ -153,6 +153,12 @@ When deploying Flink, there are often multiple options available for each buildi
 </table>
 
 
+### Repeatable Resource Cleanup
+
+Once a job has reached a globally terminal state of either finished, failed or cancelled, the
+external component resources associated with the job are then cleaned up. In the event of a
+failure when cleaning up a resource, Flink will attempt to retry the cleanup. You can
+[configure]({{< ref "docs/deployment/config#retryable-cleanup" >}}) the retry strategy used.
 
 ## Deployment Modes
 


### PR DESCRIPTION
## What is the purpose of the change

*Adds some extra documentation for the new JobResultStore (used for persisting globally terminated job results) and the new repeatable resource cleanup behavior.*


## Brief change log

  - *Updated documentation to include description of JobResultStore and repeatable resource cleanup.*

## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

- code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)

