### PR TITLE
[FLINK-26353] flink stop --help does not list --type option

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
@@ -149,6 +149,7 @@ public class CliFrontendParser {
 
     static final Option SAVEPOINT_FORMAT_OPTION =
             new Option(
+                    "t",
                     "type",
                     true,
                     "Describes the binary format in which a savepoint should be taken. Supported"

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
@@ -457,13 +457,15 @@ public class CliFrontendParser {
     }
 
     private static Options getStopOptionsWithoutDeprecatedOptions(Options options) {
-        return options.addOption(STOP_WITH_SAVEPOINT_PATH).addOption(STOP_AND_DRAIN);
+        return options.addOption(STOP_WITH_SAVEPOINT_PATH)
+                .addOption(STOP_AND_DRAIN)
+                .addOption(SAVEPOINT_FORMAT_OPTION);
     }
 
     private static Options getSavepointOptionsWithoutDeprecatedOptions(Options options) {
-        options.addOption(SAVEPOINT_DISPOSE_OPTION);
-        options.addOption(JAR_OPTION);
-        return options;
+        return options.addOption(SAVEPOINT_DISPOSE_OPTION)
+                .addOption(SAVEPOINT_FORMAT_OPTION)
+                .addOption(JAR_OPTION);
     }
 
     /** Prints the help for the client. */

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendSavepointTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendSavepointTest.java
@@ -182,12 +182,18 @@ public class CliFrontendSavepointTest extends CliFrontendTestBase {
         }
     }
 
-    /**
-     * Tests that a CLI call with a custom savepoint directory target is forwarded correctly to the
-     * cluster client.
-     */
     @Test
-    public void testTriggerSavepointCustomFormat() throws Exception {
+    public void testTriggerSavepointCustomFormatShortOption() throws Exception {
+        testTriggerSavepointCustomFormat("-t", SavepointFormatType.NATIVE);
+    }
+
+    @Test
+    public void testTriggerSavepointCustomFormatLongOption() throws Exception {
+        testTriggerSavepointCustomFormat("--type", SavepointFormatType.NATIVE);
+    }
+
+    private void testTriggerSavepointCustomFormat(String flag, SavepointFormatType formatType)
+            throws Exception {
         replaceStdOutAndStdErr();
 
         JobID jobId = new JobID();
@@ -200,13 +206,12 @@ public class CliFrontendSavepointTest extends CliFrontendTestBase {
             MockedCliFrontend frontend = new MockedCliFrontend(clusterClient);
 
             String[] parameters = {
-                jobId.toString(), savepointDirectory, "-type", SavepointFormatType.NATIVE.toString()
+                jobId.toString(), savepointDirectory, flag, formatType.toString()
             };
             frontend.savepoint(parameters);
 
             verify(clusterClient, times(1))
-                    .triggerSavepoint(
-                            eq(jobId), eq(savepointDirectory), eq(SavepointFormatType.NATIVE));
+                    .triggerSavepoint(eq(jobId), eq(savepointDirectory), eq(formatType));
 
             assertTrue(buffer.toString().contains(savepointDirectory));
         } finally {

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendStopWithSavepointTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendStopWithSavepointTest.java
@@ -120,11 +120,21 @@ public class CliFrontendStopWithSavepointTest extends CliFrontendTestBase {
     }
 
     @Test
-    public void testStopWithExplicitSavepointType() throws Exception {
+    public void testStopWithExplicitSavepointTypeShortOption() throws Exception {
+        testStopWithExplicitSavepointType("-t", SavepointFormatType.NATIVE);
+    }
+
+    @Test
+    public void testStopWithExplicitSavepointTypeLongOption() throws Exception {
+        testStopWithExplicitSavepointType("--type", SavepointFormatType.NATIVE);
+    }
+
+    private void testStopWithExplicitSavepointType(String flag, SavepointFormatType expectedFormat)
+            throws Exception {
         JobID jid = new JobID();
 
         String[] parameters = {
-            "-p", "test-target-dir", jid.toString(), "-type", SavepointFormatType.NATIVE.toString()
+            "-p", "test-target-dir", jid.toString(), flag, expectedFormat.toString()
         };
         OneShotLatch stopWithSavepointLatch = new OneShotLatch();
         TestingClusterClient<String> clusterClient = new TestingClusterClient<>();
@@ -133,6 +143,7 @@ public class CliFrontendStopWithSavepointTest extends CliFrontendTestBase {
                     assertThat(jobID, is(jid));
                     assertThat(advanceToEndOfEventTime, is(false));
                     assertThat(savepointDirectory, is("test-target-dir"));
+                    assertThat(formatType, is(expectedFormat));
                     stopWithSavepointLatch.trigger();
                     return CompletableFuture.completedFuture(savepointDirectory);
                 });


### PR DESCRIPTION
```
Action "savepoint" triggers savepoints for a running job or disposes existing ones.

  Syntax: savepoint [OPTIONS] <Job ID> [<target directory>]
  "savepoint" action options:
     -d,--dispose <arg>       Path of savepoint to dispose.
     -j,--jarfile <jarfile>   Flink program JAR file.
     -t,--type <arg>          Describes the binary format in which a savepoint
                              should be taken. Supported options: [canonical - a
                              common format for all state backends, allow for
                              changing state backends, native = a specific
                              format for the chosen state backend, might be
                              faster to take and restore from.
```

```
Action "stop" stops a running program with a savepoint (streaming jobs only).

  Syntax: stop [OPTIONS] <Job ID>
  "stop" action options:
     -d,--drain                           Send MAX_WATERMARK before taking the
                                          savepoint and stopping the pipelne.
     -p,--savepointPath <savepointPath>   Path to the savepoint (for example
                                          hdfs:///flink/savepoint-1537). If no
                                          directory is specified, the configured
                                          default will be used
                                          ("state.savepoints.dir").
     -t,--type <arg>                      Describes the binary format in which a
                                          savepoint should be taken. Supported
                                          options: [canonical - a common format
                                          for all state backends, allow for
                                          changing state backends, native = a
                                          specific format for the chosen state
                                          backend, might be faster to take and
                                          restore from.
```