### PR TITLE
[FLINK-26331] Make cleanup retry strategy configurable similar to how the task restart is configurable

### DIFF
--- a/docs/content.zh/docs/deployment/config.md
+++ b/docs/content.zh/docs/deployment/config.md
@@ -135,6 +135,20 @@ The default restart strategy will only take effect if no job specific restart st
 
 {{< generated/failure_rate_restart_strategy_configuration >}}
 
+### Retryable Cleanup
+
+After jobs reach a globally-terminal state, a cleanup of all related resources is performed. This cleanup can be retried in case of failure. Different retry strategies can be configured to change this behavior:
+
+{{< generated/cleanup_configuration >}}
+
+**Fixed-Delay Cleanup Retry Strategy**
+
+{{< generated/fixed_delay_cleanup_strategy_configuration >}}
+
+**Exponential-Delay Cleanup Retry Strategy**
+
+{{< generated/exponential_delay_cleanup_strategy_configuration >}}
+
 ### Checkpoints and State Backends
 
 These options control the basic setup of state backends and checkpointing behavior.

--- a/docs/content/docs/deployment/config.md
+++ b/docs/content/docs/deployment/config.md
@@ -136,6 +136,20 @@ The default restart strategy will only take effect if no job specific restart st
 
 {{< generated/failure_rate_restart_strategy_configuration >}}
 
+### Retryable Cleanup
+
+After jobs reach a globally-terminal state, a cleanup of all related resources is performed. This cleanup can be retried in case of failure. Different retry strategies can be configured to change this behavior:
+
+{{< generated/cleanup_configuration >}}
+
+**Fixed-Delay Cleanup Retry Strategy**
+
+{{< generated/fixed_delay_cleanup_strategy_configuration >}}
+
+**Exponential-Delay Cleanup Retry Strategy**
+
+{{< generated/exponential_delay_cleanup_strategy_configuration >}}
+
 ### Checkpoints and State Backends
 
 These options control the basic setup of state backends and checkpointing behavior.

--- a/docs/layouts/shortcodes/generated/all_jobmanager_section.html
+++ b/docs/layouts/shortcodes/generated/all_jobmanager_section.html
@@ -57,18 +57,6 @@
             <td>Dictionary for JobManager to store the archives of completed jobs.</td>
         </tr>
         <tr>
-            <td><h5>jobmanager.cleanup.max-delay</h5></td>
-            <td style="word-wrap: break-word;">1 h</td>
-            <td>Duration</td>
-            <td>The cleanup of each job is retried up to the point where it succeeds. The maximum delay marks the maximum amount of time used for a retry interval up to which the retry interval increases exponentially.</td>
-        </tr>
-        <tr>
-            <td><h5>jobmanager.cleanup.min-delay</h5></td>
-            <td style="word-wrap: break-word;">1 s</td>
-            <td>Duration</td>
-            <td>The cleanup of each job is retried up to the point where it succeeds. The minimum delay is used for the first retry of a cleanup task. The delay will increase exponentially.</td>
-        </tr>
-        <tr>
             <td><h5>jobmanager.execution.attempts-history-size</h5></td>
             <td style="word-wrap: break-word;">16</td>
             <td>Integer</td>

--- a/docs/layouts/shortcodes/generated/cleanup_configuration.html
+++ b/docs/layouts/shortcodes/generated/cleanup_configuration.html
@@ -1,0 +1,18 @@
+<table class="configuration table table-bordered">
+    <thead>
+        <tr>
+            <th class="text-left" style="width: 20%">Key</th>
+            <th class="text-left" style="width: 15%">Default</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><h5>cleanup-strategy</h5></td>
+            <td style="word-wrap: break-word;">"exponential-delay"</td>
+            <td>String</td>
+            <td>Defines the cleanup strategy to use in case of cleanup failures.<br />Accepted values are:<ul><li><code class="highlighter-rouge">none</code>, <code class="highlighter-rouge">disable</code>, <code class="highlighter-rouge">off</code>: Cleanup is only performed once. No retry will be initiated in case of failure.</li><li><code class="highlighter-rouge">fixed-delay</code>, <code class="highlighter-rouge">fixeddelay</code>: Cleanup attempts will be separated by a fixed interval up to the point where the cleanup is considered successful or a set amount of retries is reached.</li><li><code class="highlighter-rouge">exponential-delay</code>, <code class="highlighter-rouge">exponentialdelay</code>: Exponential delay restart strategy triggers the cleanup with an exponentially increasing delay up to the point where the cleanup succeeded or a set amount of retries is reached.</li></ul>The default configuration relies on an exponentially delayed retry strategy with the given default values.</td>
+        </tr>
+    </tbody>
+</table>

--- a/docs/layouts/shortcodes/generated/exponential_delay_cleanup_strategy_configuration.html
+++ b/docs/layouts/shortcodes/generated/exponential_delay_cleanup_strategy_configuration.html
@@ -1,0 +1,30 @@
+<table class="configuration table table-bordered">
+    <thead>
+        <tr>
+            <th class="text-left" style="width: 20%">Key</th>
+            <th class="text-left" style="width: 15%">Default</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><h5>cleanup-strategy.exponential-delay.attempts</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Integer</td>
+            <td>The number of times a failed cleanup is retried if <code class="highlighter-rouge">cleanup-strategy</code> has been set to <code class="highlighter-rouge">exponential-delay</code>. (no value means: infinitely).</td>
+        </tr>
+        <tr>
+            <td><h5>cleanup-strategy.exponential-delay.initial-backoff</h5></td>
+            <td style="word-wrap: break-word;">1 s</td>
+            <td>Duration</td>
+            <td>Starting duration between cleanup retries if <code class="highlighter-rouge">cleanup-strategy</code> has been set to <code class="highlighter-rouge">exponential-delay</code>. It can be specified using the following notation: "1 min", "20 s"</td>
+        </tr>
+        <tr>
+            <td><h5>cleanup-strategy.exponential-delay.max-backoff</h5></td>
+            <td style="word-wrap: break-word;">1 h</td>
+            <td>Duration</td>
+            <td>The highest possible duration between cleanup retries if <code class="highlighter-rouge">cleanup-strategy</code> has been set to <code class="highlighter-rouge">exponential-delay</code>. It can be specified using the following notation: "1 min", "20 s"</td>
+        </tr>
+    </tbody>
+</table>

--- a/docs/layouts/shortcodes/generated/fixed_delay_cleanup_strategy_configuration.html
+++ b/docs/layouts/shortcodes/generated/fixed_delay_cleanup_strategy_configuration.html
@@ -1,0 +1,24 @@
+<table class="configuration table table-bordered">
+    <thead>
+        <tr>
+            <th class="text-left" style="width: 20%">Key</th>
+            <th class="text-left" style="width: 15%">Default</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><h5>cleanup-strategy.fixed-delay.attempts</h5></td>
+            <td style="word-wrap: break-word;">1</td>
+            <td>Integer</td>
+            <td>The number of times that Flink retries the cleanup before giving up if <code class="highlighter-rouge">cleanup-strategy</code> has been set to <code class="highlighter-rouge">fixed-delay</code>.</td>
+        </tr>
+        <tr>
+            <td><h5>cleanup-strategy.fixed-delay.delay</h5></td>
+            <td style="word-wrap: break-word;">1 s</td>
+            <td>Duration</td>
+            <td>Amount of time that Flink waits before re-triggering the cleanup after a failed attempt if the <code class="highlighter-rouge">cleanup-strategy</code> is set to <code class="highlighter-rouge">fixed-delay</code>. It can be specified using the following notation: "1 min", "20 s"</td>
+        </tr>
+    </tbody>
+</table>

--- a/docs/layouts/shortcodes/generated/job_manager_configuration.html
+++ b/docs/layouts/shortcodes/generated/job_manager_configuration.html
@@ -63,18 +63,6 @@
             <td>The local address of the network interface that the job manager binds to. If not configured, '0.0.0.0' will be used.</td>
         </tr>
         <tr>
-            <td><h5>jobmanager.cleanup.max-delay</h5></td>
-            <td style="word-wrap: break-word;">1 h</td>
-            <td>Duration</td>
-            <td>The cleanup of each job is retried up to the point where it succeeds. The maximum delay marks the maximum amount of time used for a retry interval up to which the retry interval increases exponentially.</td>
-        </tr>
-        <tr>
-            <td><h5>jobmanager.cleanup.min-delay</h5></td>
-            <td style="word-wrap: break-word;">1 s</td>
-            <td>Duration</td>
-            <td>The cleanup of each job is retried up to the point where it succeeds. The minimum delay is used for the first retry of a cleanup task. The delay will increase exponentially.</td>
-        </tr>
-        <tr>
             <td><h5>jobmanager.execution.attempts-history-size</h5></td>
             <td style="word-wrap: break-word;">16</td>
             <td>Integer</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/CleanupOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CleanupOptions.java
@@ -1,0 +1,196 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.configuration;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.docs.ConfigGroup;
+import org.apache.flink.annotation.docs.ConfigGroups;
+import org.apache.flink.configuration.description.Description;
+import org.apache.flink.configuration.description.TextElement;
+
+import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableSet;
+
+import java.time.Duration;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.configuration.description.TextElement.code;
+import static org.apache.flink.configuration.description.TextElement.text;
+
+/**
+ * {@link ConfigOption} collection for the configuration of repeatable cleanup of resource cleanup
+ * after a job reached a globally-terminated state.
+ *
+ * <p>This implementation copies {@link RestartStrategyOptions} to provide similar user experience.
+ * FLINK-26359 is created to clean this up.
+ */
+@PublicEvolving
+@ConfigGroups(
+        groups = {
+            @ConfigGroup(
+                    name = "ExponentialDelayCleanupStrategy",
+                    keyPrefix = "cleanup-strategy.exponential-delay"),
+            @ConfigGroup(
+                    name = "FixedDelayCleanupStrategy",
+                    keyPrefix = "cleanup-strategy.fixed-delay"),
+        })
+public class CleanupOptions {
+
+    private static final String CLEANUP_STRATEGY_PARAM = "cleanup-strategy";
+
+    public static final String FIXED_DELAY_LABEL = "fixed-delay";
+    public static final String EXPONENTIAL_DELAY_LABEL = "exponential-delay";
+
+    public static final Set<String> NONE_PARAM_VALUES = ImmutableSet.of("none", "disable", "off");
+
+    private static String createParameterPrefix(String paramGroupKey) {
+        return CLEANUP_STRATEGY_PARAM + "." + paramGroupKey + ".";
+    }
+
+    private static String createFixedDelayParameterPrefix(String parameter) {
+        return createParameterPrefix(FIXED_DELAY_LABEL) + parameter;
+    }
+
+    private static String createExponentialBackoffParameterPrefix(String parameter) {
+        return createParameterPrefix(EXPONENTIAL_DELAY_LABEL) + parameter;
+    }
+
+    public static String extractAlphaNumericCharacters(String paramName) {
+        return paramName.replaceAll("[^a-zA-Z0-9]", "");
+    }
+
+    public static final ConfigOption<String> CLEANUP_STRATEGY =
+            ConfigOptions.key(CLEANUP_STRATEGY_PARAM)
+                    .stringType()
+                    .defaultValue(EXPONENTIAL_DELAY_LABEL)
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "Defines the cleanup strategy to use in case of cleanup failures.")
+                                    .linebreak()
+                                    .text("Accepted values are:")
+                                    .list(
+                                            text(
+                                                    NONE_PARAM_VALUES.stream()
+                                                                    .map(ignored -> "%s")
+                                                                    .collect(
+                                                                            Collectors.joining(
+                                                                                    ", "))
+                                                            + ": Cleanup is only performed once. No retry "
+                                                            + "will be initiated in case of failure.",
+                                                    NONE_PARAM_VALUES.stream()
+                                                            .map(TextElement::code)
+                                                            .collect(Collectors.toList())
+                                                            .toArray(
+                                                                    new TextElement
+                                                                            [NONE_PARAM_VALUES
+                                                                                    .size()])),
+                                            text(
+                                                    "%s, %s: Cleanup attempts will be separated by a fixed "
+                                                            + "interval up to the point where the cleanup is "
+                                                            + "considered successful or a set amount of retries "
+                                                            + "is reached.",
+                                                    code(FIXED_DELAY_LABEL),
+                                                    code(
+                                                            extractAlphaNumericCharacters(
+                                                                    FIXED_DELAY_LABEL))),
+                                            text(
+                                                    "%s, %s: Exponential delay restart strategy "
+                                                            + "triggers the cleanup with an exponentially "
+                                                            + "increasing delay up to the point where the "
+                                                            + "cleanup succeeded or a set amount of retries "
+                                                            + "is reached.",
+                                                    code(EXPONENTIAL_DELAY_LABEL),
+                                                    code(
+                                                            extractAlphaNumericCharacters(
+                                                                    EXPONENTIAL_DELAY_LABEL))))
+                                    .text(
+                                            "The default configuration relies on an exponentially delayed "
+                                                    + "retry strategy with the given default values.")
+                                    .build());
+
+    public static final ConfigOption<Integer> CLEANUP_STRATEGY_FIXED_DELAY_ATTEMPTS =
+            ConfigOptions.key(createFixedDelayParameterPrefix("attempts"))
+                    .intType()
+                    .defaultValue(1)
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "The number of times that Flink retries the cleanup "
+                                                    + "before giving up if %s has been set to %s.",
+                                            code(CLEANUP_STRATEGY_PARAM), code(FIXED_DELAY_LABEL))
+                                    .build());
+
+    public static final ConfigOption<Duration> CLEANUP_STRATEGY_FIXED_DELAY_DELAY =
+            ConfigOptions.key(createFixedDelayParameterPrefix("delay"))
+                    .durationType()
+                    .defaultValue(Duration.ofSeconds(1))
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "Amount of time that Flink waits before re-triggering "
+                                                    + "the cleanup after a failed attempt if the %s is "
+                                                    + "set to %s. It can be specified using the following "
+                                                    + "notation: \"1 min\", \"20 s\"",
+                                            code(CLEANUP_STRATEGY_PARAM), code(FIXED_DELAY_LABEL))
+                                    .build());
+
+    public static final ConfigOption<Duration> CLEANUP_STRATEGY_EXPONENTIAL_DELAY_INITIAL_BACKOFF =
+            ConfigOptions.key(createExponentialBackoffParameterPrefix("initial-backoff"))
+                    .durationType()
+                    .defaultValue(Duration.ofSeconds(1))
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "Starting duration between cleanup retries if %s has "
+                                                    + "been set to %s. It can be specified using the "
+                                                    + "following notation: \"1 min\", \"20 s\"",
+                                            code(CLEANUP_STRATEGY_PARAM),
+                                            code(EXPONENTIAL_DELAY_LABEL))
+                                    .build());
+
+    public static final ConfigOption<Duration> CLEANUP_STRATEGY_EXPONENTIAL_DELAY_MAX_BACKOFF =
+            ConfigOptions.key(createExponentialBackoffParameterPrefix("max-backoff"))
+                    .durationType()
+                    .defaultValue(Duration.ofHours(1))
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "The highest possible duration between cleanup "
+                                                    + "retries if %s has been set to %s. It can be "
+                                                    + "specified using the following notation: "
+                                                    + "\"1 min\", \"20 s\"",
+                                            code(CLEANUP_STRATEGY_PARAM),
+                                            code(EXPONENTIAL_DELAY_LABEL))
+                                    .build());
+
+    public static final ConfigOption<Integer> CLEANUP_STRATEGY_EXPONENTIAL_DELAY_MAX_ATTEMPTS =
+            ConfigOptions.key(createExponentialBackoffParameterPrefix("attempts"))
+                    .intType()
+                    .noDefaultValue()
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "The number of times a failed cleanup is retried "
+                                                    + "if %s has been set to %s. (no value means: "
+                                                    + "infinitely).",
+                                            code(CLEANUP_STRATEGY_PARAM),
+                                            code(EXPONENTIAL_DELAY_LABEL))
+                                    .build());
+}

--- a/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
@@ -287,22 +287,6 @@ public class JobManagerOptions {
                                                             "here")))
                                     .build());
 
-    /** The minimum delay for the exponentially-increasing job cleanup retry interval. */
-    @Documentation.Section(Documentation.Sections.ALL_JOB_MANAGER)
-    public static final ConfigOption<Duration> JOB_CLEANUP_MINIMUM_DELAY =
-            key("jobmanager.cleanup.min-delay")
-                    .defaultValue(Duration.ofSeconds(1))
-                    .withDescription(
-                            "The cleanup of each job is retried up to the point where it succeeds. The minimum delay is used for the first retry of a cleanup task. The delay will increase exponentially.");
-
-    /** The minimum delay for the exponentially-increasing job cleanup retry interval. */
-    @Documentation.Section(Documentation.Sections.ALL_JOB_MANAGER)
-    public static final ConfigOption<Duration> JOB_CLEANUP_MAXIMUM_DELAY =
-            key("jobmanager.cleanup.max-delay")
-                    .defaultValue(Duration.ofHours(1))
-                    .withDescription(
-                            "The cleanup of each job is retried up to the point where it succeeds. The maximum delay marks the maximum amount of time used for a retry interval up to which the retry interval increases exponentially.");
-
     /** The location where the JobManager stores the archives of completed jobs. */
     @Documentation.Section(Documentation.Sections.ALL_JOB_MANAGER)
     public static final ConfigOption<String> ARCHIVE_DIR =

--- a/flink-core/src/main/java/org/apache/flink/configuration/RestartStrategyOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/RestartStrategyOptions.java
@@ -29,7 +29,12 @@ import static org.apache.flink.configuration.description.LinkElement.link;
 import static org.apache.flink.configuration.description.TextElement.code;
 import static org.apache.flink.configuration.description.TextElement.text;
 
-/** Config options for restart strategies. */
+/**
+ * Config options for restart strategies.
+ *
+ * <p>{@link CleanupOptions} copied this collection of parameters to provide similar user
+ * experience. FLINK-26359 is created to clean this up.
+ */
 @PublicEvolving
 @ConfigGroups(
         groups = {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/CleanupRetryStrategyFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/CleanupRetryStrategyFactory.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher.cleanup;
+
+import org.apache.flink.configuration.CleanupOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.concurrent.ExponentialBackoffRetryStrategy;
+import org.apache.flink.util.concurrent.FixedRetryStrategy;
+import org.apache.flink.util.concurrent.RetryStrategy;
+
+import java.time.Duration;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * {@code CleanupRetryStrategyFactory} is used to create the {@link RetryStrategy} for the {@link
+ * DispatcherResourceCleanerFactory}. It extracts all the necessary information from the passed
+ * {@link Configuration}.
+ *
+ * @see CleanupOptions
+ */
+public enum CleanupRetryStrategyFactory {
+    INSTANCE;
+
+    /** Creates the {@link RetryStrategy} instance based on the passed {@link Configuration}. */
+    public RetryStrategy createRetryStrategy(Configuration configuration) {
+        final String configuredRetryStrategy =
+                configuration.getString(CleanupOptions.CLEANUP_STRATEGY);
+        if (isRetryStrategy(
+                CleanupOptions.FIXED_DELAY_LABEL,
+                configuration.getString(CleanupOptions.CLEANUP_STRATEGY))) {
+            return createFixedRetryStrategy(configuration);
+        } else if (isRetryStrategy(
+                CleanupOptions.EXPONENTIAL_DELAY_LABEL,
+                configuration.getString(CleanupOptions.CLEANUP_STRATEGY))) {
+            return createExponentialBackoffRetryStrategy(configuration);
+        } else if (retryingDisabled(configuredRetryStrategy)) {
+            return createNoRetryStrategy();
+        }
+
+        throw new IllegalArgumentException(
+                createInvalidCleanupStrategyErrorMessage(configuredRetryStrategy));
+    }
+
+    private static RetryStrategy createNoRetryStrategy() {
+        return new FixedRetryStrategy(0, Duration.ZERO);
+    }
+
+    private static FixedRetryStrategy createFixedRetryStrategy(Configuration configuration) {
+        final Duration delay = configuration.get(CleanupOptions.CLEANUP_STRATEGY_FIXED_DELAY_DELAY);
+        final int maxAttempts =
+                configuration.get(CleanupOptions.CLEANUP_STRATEGY_FIXED_DELAY_ATTEMPTS);
+
+        return new FixedRetryStrategy(maxAttempts, delay);
+    }
+
+    private static ExponentialBackoffRetryStrategy createExponentialBackoffRetryStrategy(
+            Configuration configuration) {
+        final Duration minDelay =
+                configuration.get(
+                        CleanupOptions.CLEANUP_STRATEGY_EXPONENTIAL_DELAY_INITIAL_BACKOFF);
+        final Duration maxDelay =
+                configuration.get(CleanupOptions.CLEANUP_STRATEGY_EXPONENTIAL_DELAY_MAX_BACKOFF);
+        final int maxAttempts =
+                configuration.getInteger(
+                        CleanupOptions.CLEANUP_STRATEGY_EXPONENTIAL_DELAY_MAX_ATTEMPTS,
+                        Integer.MAX_VALUE);
+
+        return new ExponentialBackoffRetryStrategy(maxAttempts, minDelay, maxDelay);
+    }
+
+    private static String createInvalidCleanupStrategyErrorMessage(String configuredRetryStrategy) {
+        final StringBuilder msgBuilder = new StringBuilder();
+        msgBuilder
+                .append("Unknown cleanup retry strategy '")
+                .append(configuredRetryStrategy)
+                .append("'. Valid strategies are ");
+
+        final String validOptionsStr =
+                Stream.concat(
+                                Stream.of(
+                                        CleanupOptions.EXPONENTIAL_DELAY_LABEL,
+                                        CleanupOptions.FIXED_DELAY_LABEL),
+                                CleanupOptions.NONE_PARAM_VALUES.stream())
+                        .collect(Collectors.joining(", "));
+
+        return msgBuilder.append(validOptionsStr).toString();
+    }
+
+    private static boolean retryingDisabled(String configuredRetryStrategy) {
+        final String retryStrategy = configuredRetryStrategy.toLowerCase();
+        return CleanupOptions.NONE_PARAM_VALUES.contains(retryStrategy);
+    }
+
+    private static boolean isRetryStrategy(
+            String retryStrategyLabel, String configuredRetryStrategy) {
+        final String retryStrategy = configuredRetryStrategy.toLowerCase();
+        return retryStrategy.equals(retryStrategyLabel)
+                || retryStrategy.equals(
+                        CleanupOptions.extractAlphaNumericCharacters(retryStrategyLabel));
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/cleanup/CleanupRetryStrategyFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/cleanup/CleanupRetryStrategyFactoryTest.java
@@ -1,0 +1,240 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher.cleanup;
+
+import org.apache.flink.configuration.CleanupOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.concurrent.ExponentialBackoffRetryStrategy;
+import org.apache.flink.util.concurrent.FixedRetryStrategy;
+import org.apache.flink.util.concurrent.RetryStrategy;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** {@code CleanupRetryStrategyFactoryTest} tests {@link CleanupRetryStrategyFactory}. */
+class CleanupRetryStrategyFactoryTest {
+
+    private static final CleanupRetryStrategyFactory TEST_INSTANCE =
+            CleanupRetryStrategyFactory.INSTANCE;
+
+    @ParameterizedTest
+    @ValueSource(strings = {"none", "disable", "off", "NONE", "None", "oFf"})
+    public void testNoRetryStrategyCreation(String configValue) {
+        final Configuration config = createConfigurationWithRetryStrategy(configValue);
+        final RetryStrategy retryStrategy = TEST_INSTANCE.createRetryStrategy(config);
+
+        assertThat(retryStrategy.getRetryDelay()).isZero();
+        assertThat(retryStrategy.getNumRemainingRetries()).isZero();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "random string"})
+    public void testInvalidConfiguration(String value) {
+        assertThatThrownBy(
+                () ->
+                        TEST_INSTANCE.createRetryStrategy(
+                                createConfigurationWithRetryStrategy(value)));
+    }
+
+    @Test
+    public void testDefaultStrategyCreation() {
+        testExponentialBackoffDelayRetryStrategyCreation(
+                new Configuration(),
+                CleanupOptions.CLEANUP_STRATEGY_EXPONENTIAL_DELAY_INITIAL_BACKOFF.defaultValue(),
+                CleanupOptions.CLEANUP_STRATEGY_EXPONENTIAL_DELAY_MAX_BACKOFF.defaultValue(),
+                Integer.MAX_VALUE);
+    }
+
+    private static Configuration createConfigurationWithRetryStrategy(String configValue) {
+        final Configuration config = new Configuration();
+        config.set(CleanupOptions.CLEANUP_STRATEGY, configValue);
+
+        return config;
+    }
+
+    /* *********************************************
+     * FixedDelayRetryStrategy tests
+     * *********************************************/
+
+    @Test
+    public void testFixedDelayStrategyCreationWithFixedDelayStrategyDefaultLabel() {
+        testFixedDelayStrategyWithDefaultValues(CleanupOptions.FIXED_DELAY_LABEL);
+    }
+
+    @Test
+    public void testFixedDelayStrategyCreationWithAlphaNumericFixedDelayStrategyLabel() {
+        testFixedDelayStrategyWithDefaultValues(
+                CleanupOptions.extractAlphaNumericCharacters(CleanupOptions.FIXED_DELAY_LABEL));
+    }
+
+    private static void testFixedDelayStrategyWithDefaultValues(String label) {
+        final Configuration config = createConfigurationWithRetryStrategy(label);
+        testFixedDelayStrategyCreation(
+                config,
+                CleanupOptions.CLEANUP_STRATEGY_FIXED_DELAY_DELAY.defaultValue(),
+                CleanupOptions.CLEANUP_STRATEGY_FIXED_DELAY_ATTEMPTS.defaultValue());
+    }
+
+    @Test
+    public void testFixedDelayStrategyWithCustomDelay() {
+        final Configuration config =
+                createConfigurationWithRetryStrategy(CleanupOptions.FIXED_DELAY_LABEL);
+        final Duration customDelay =
+                CleanupOptions.CLEANUP_STRATEGY_FIXED_DELAY_DELAY.defaultValue().plusMinutes(1);
+        config.set(CleanupOptions.CLEANUP_STRATEGY_FIXED_DELAY_DELAY, customDelay);
+
+        testFixedDelayStrategyCreation(
+                config,
+                customDelay,
+                CleanupOptions.CLEANUP_STRATEGY_FIXED_DELAY_ATTEMPTS.defaultValue());
+    }
+
+    @Test
+    public void testFixedDelayStrategyWithCustomMaxAttempts() {
+        final Configuration config =
+                createConfigurationWithRetryStrategy(CleanupOptions.FIXED_DELAY_LABEL);
+        final int customMaxAttempts =
+                CleanupOptions.CLEANUP_STRATEGY_FIXED_DELAY_ATTEMPTS.defaultValue() + 2;
+        config.set(CleanupOptions.CLEANUP_STRATEGY_FIXED_DELAY_ATTEMPTS, customMaxAttempts);
+
+        testFixedDelayStrategyCreation(
+                config,
+                CleanupOptions.CLEANUP_STRATEGY_FIXED_DELAY_DELAY.defaultValue(),
+                customMaxAttempts);
+    }
+
+    private static void testFixedDelayStrategyCreation(
+            Configuration config, Duration expectedDelay, int expectedMaxAttempts) {
+        final RetryStrategy retryStrategy = TEST_INSTANCE.createRetryStrategy(config);
+
+        assertThat(retryStrategy).isInstanceOf(FixedRetryStrategy.class);
+        assertThat(retryStrategy.getRetryDelay()).isEqualTo(expectedDelay);
+        assertThat(retryStrategy.getNumRemainingRetries()).isEqualTo(expectedMaxAttempts);
+    }
+    /* *********************************************
+     * ExponentialBackoffDelayRetryStrategy tests
+     * *********************************************/
+
+    @Test
+    public void
+            testExponentialBackoffDelayRetryStrategyCreationWithFixedDelayStrategyDefaultLabel() {
+        testExponentialBackoffDelayRetryStrategyWithDefaultValues(
+                CleanupOptions.EXPONENTIAL_DELAY_LABEL);
+    }
+
+    @Test
+    public void
+            testExponentialBackoffDelayRetryStrategyCreationWithAlphaNumericFixedDelayStrategyLabel() {
+        testExponentialBackoffDelayRetryStrategyWithDefaultValues(
+                CleanupOptions.extractAlphaNumericCharacters(
+                        CleanupOptions.EXPONENTIAL_DELAY_LABEL));
+    }
+
+    private static void testExponentialBackoffDelayRetryStrategyWithDefaultValues(String label) {
+        final Configuration config = createConfigurationWithRetryStrategy(label);
+        testExponentialBackoffDelayRetryStrategyCreation(
+                config,
+                CleanupOptions.CLEANUP_STRATEGY_EXPONENTIAL_DELAY_INITIAL_BACKOFF.defaultValue(),
+                CleanupOptions.CLEANUP_STRATEGY_EXPONENTIAL_DELAY_MAX_BACKOFF.defaultValue(),
+                Integer.MAX_VALUE);
+    }
+
+    @Test
+    public void testExponentialBackoffDelayRetryStrategyWithCustomMinimumDelay() {
+        final Configuration config =
+                createConfigurationWithRetryStrategy(CleanupOptions.EXPONENTIAL_DELAY_LABEL);
+        final Duration customMinDelay =
+                CleanupOptions.CLEANUP_STRATEGY_EXPONENTIAL_DELAY_INITIAL_BACKOFF
+                        .defaultValue()
+                        .plusMinutes(1);
+        config.set(
+                CleanupOptions.CLEANUP_STRATEGY_EXPONENTIAL_DELAY_INITIAL_BACKOFF, customMinDelay);
+
+        testExponentialBackoffDelayRetryStrategyCreation(
+                config,
+                customMinDelay,
+                CleanupOptions.CLEANUP_STRATEGY_EXPONENTIAL_DELAY_MAX_BACKOFF.defaultValue(),
+                Integer.MAX_VALUE);
+    }
+
+    @Test
+    public void testExponentialBackoffDelayRetryStrategyWithCustomMaximumDelay() {
+        final Configuration config =
+                createConfigurationWithRetryStrategy(CleanupOptions.EXPONENTIAL_DELAY_LABEL);
+        final Duration customMaxDelay =
+                CleanupOptions.CLEANUP_STRATEGY_EXPONENTIAL_DELAY_MAX_BACKOFF
+                        .defaultValue()
+                        .plusMinutes(1);
+        config.set(CleanupOptions.CLEANUP_STRATEGY_EXPONENTIAL_DELAY_MAX_BACKOFF, customMaxDelay);
+
+        testExponentialBackoffDelayRetryStrategyCreation(
+                config,
+                CleanupOptions.CLEANUP_STRATEGY_EXPONENTIAL_DELAY_INITIAL_BACKOFF.defaultValue(),
+                customMaxDelay,
+                Integer.MAX_VALUE);
+    }
+
+    @Test
+    public void testExponentialBackoffDelayRetryStrategyWithCustomMaxAttempts() {
+        final Configuration config =
+                createConfigurationWithRetryStrategy(CleanupOptions.EXPONENTIAL_DELAY_LABEL);
+        // 13 is the minimum we can use for this test; otherwise, assertMaxDelay would fail due to a
+        // Precondition in ExponentialBackoffRetryStrategy
+        final int customMaxAttempts = 13;
+        config.set(
+                CleanupOptions.CLEANUP_STRATEGY_EXPONENTIAL_DELAY_MAX_ATTEMPTS, customMaxAttempts);
+
+        testExponentialBackoffDelayRetryStrategyCreation(
+                config,
+                CleanupOptions.CLEANUP_STRATEGY_FIXED_DELAY_DELAY.defaultValue(),
+                CleanupOptions.CLEANUP_STRATEGY_EXPONENTIAL_DELAY_MAX_BACKOFF.defaultValue(),
+                customMaxAttempts);
+    }
+
+    private static void testExponentialBackoffDelayRetryStrategyCreation(
+            Configuration config,
+            Duration expectedMinDelay,
+            Duration expectedMaxDelay,
+            int expectedMaxAttempts) {
+        final RetryStrategy retryStrategy = TEST_INSTANCE.createRetryStrategy(config);
+
+        assertThat(retryStrategy).isInstanceOf(ExponentialBackoffRetryStrategy.class);
+        assertThat(retryStrategy.getRetryDelay()).isEqualTo(expectedMinDelay);
+        assertThat(retryStrategy.getNumRemainingRetries()).isEqualTo(expectedMaxAttempts);
+
+        assertMaxDelay(retryStrategy, expectedMaxDelay);
+    }
+
+    private static void assertMaxDelay(RetryStrategy retryStrategy, Duration expectedMaximumDelay) {
+        RetryStrategy nextInstance = retryStrategy.getNextRetryStrategy();
+        Duration currentDuration = retryStrategy.getRetryDelay();
+        while (!nextInstance.getRetryDelay().equals(currentDuration)) {
+            currentDuration = nextInstance.getRetryDelay();
+            nextInstance = nextInstance.getNextRetryStrategy();
+        }
+
+        assertThat(currentDuration).isEqualTo(expectedMaximumDelay);
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

The goal is to align the user experience for retry functionality. I created a follow-up ticket FLINK-26359 to cover the actual alignment in the code.

## Brief change log

* Introduced `CleanupOptions` similar to `RestartOptions` to give a consistent user experience.
* Adds `CleanupRetryStrategyFactory` covering the configuration extraction to create the right `RetryStrategy` instance
* Updated docs

## Verifying this change

* `CleanupRetryStrategyFactoryTest` is added to cover all different options

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? docs, JavaDoc
