### PR TITLE
[FLINK-26354] -restoreMode should be --restoreMode and should have a shorthand

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
@@ -134,6 +134,7 @@ public class CliFrontendParser {
 
     public static final Option SAVEPOINT_RESTORE_MODE =
             new Option(
+                    "rm",
                     "restoreMode",
                     true,
                     "Defines how should we restore from the given savepoint. Supported options: "

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendRunTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendRunTest.java
@@ -133,50 +133,37 @@ public class CliFrontendRunTest extends CliFrontendTestBase {
 
     @Test
     public void testClaimRestoreModeParsing() throws Exception {
-        // test configure savepoint with claim mode
-        String[] parameters = {
-            "-s", "expectedSavepointPath", "-n", "-restoreMode", "claim", getTestJarPath()
-        };
-
-        CommandLine commandLine =
-                CliFrontendParser.parse(CliFrontendParser.RUN_OPTIONS, parameters, true);
-        ProgramOptions programOptions = ProgramOptions.create(commandLine);
-        ExecutionConfigAccessor executionOptions =
-                ExecutionConfigAccessor.fromProgramOptions(programOptions, Collections.emptyList());
-
-        SavepointRestoreSettings savepointSettings = executionOptions.getSavepointRestoreSettings();
-        assertTrue(savepointSettings.restoreSavepoint());
-        assertEquals(RestoreMode.CLAIM, savepointSettings.getRestoreMode());
-        assertEquals("expectedSavepointPath", savepointSettings.getRestorePath());
-        assertTrue(savepointSettings.allowNonRestoredState());
+        testRestoreMode("-rm", "claim", RestoreMode.CLAIM);
     }
 
     @Test
     public void testLegacyRestoreModeParsing() throws Exception {
-        // test configure savepoint with claim mode
-        String[] parameters = {
-            "-s", "expectedSavepointPath", "-n", "-restoreMode", "legacy", getTestJarPath()
-        };
-
-        CommandLine commandLine =
-                CliFrontendParser.parse(CliFrontendParser.RUN_OPTIONS, parameters, true);
-        ProgramOptions programOptions = ProgramOptions.create(commandLine);
-        ExecutionConfigAccessor executionOptions =
-                ExecutionConfigAccessor.fromProgramOptions(programOptions, Collections.emptyList());
-
-        SavepointRestoreSettings savepointSettings = executionOptions.getSavepointRestoreSettings();
-        assertTrue(savepointSettings.restoreSavepoint());
-        assertEquals(RestoreMode.LEGACY, savepointSettings.getRestoreMode());
-        assertEquals("expectedSavepointPath", savepointSettings.getRestorePath());
-        assertTrue(savepointSettings.allowNonRestoredState());
+        testRestoreMode("-rm", "legacy", RestoreMode.LEGACY);
     }
 
     @Test
     public void testNoClaimRestoreModeParsing() throws Exception {
-        // test configure savepoint with claim mode
-        String[] parameters = {
-            "-s", "expectedSavepointPath", "-n", "-restoreMode", "no_claim", getTestJarPath()
-        };
+        testRestoreMode("-rm", "no_claim", RestoreMode.NO_CLAIM);
+    }
+
+    @Test
+    public void testClaimRestoreModeParsingLongOption() throws Exception {
+        testRestoreMode("--restoreMode", "claim", RestoreMode.CLAIM);
+    }
+
+    @Test
+    public void testLegacyRestoreModeParsingLongOption() throws Exception {
+        testRestoreMode("--restoreMode", "legacy", RestoreMode.LEGACY);
+    }
+
+    @Test
+    public void testNoClaimRestoreModeParsingLongOption() throws Exception {
+        testRestoreMode("--restoreMode", "no_claim", RestoreMode.NO_CLAIM);
+    }
+
+    private void testRestoreMode(String flag, String arg, RestoreMode expectedMode)
+            throws Exception {
+        String[] parameters = {"-s", "expectedSavepointPath", "-n", flag, arg, getTestJarPath()};
 
         CommandLine commandLine =
                 CliFrontendParser.parse(CliFrontendParser.RUN_OPTIONS, parameters, true);
@@ -186,7 +173,7 @@ public class CliFrontendRunTest extends CliFrontendTestBase {
 
         SavepointRestoreSettings savepointSettings = executionOptions.getSavepointRestoreSettings();
         assertTrue(savepointSettings.restoreSavepoint());
-        assertEquals(RestoreMode.NO_CLAIM, savepointSettings.getRestoreMode());
+        assertEquals(expectedMode, savepointSettings.getRestoreMode());
         assertEquals("expectedSavepointPath", savepointSettings.getRestorePath());
         assertTrue(savepointSettings.allowNonRestoredState());
     }


### PR DESCRIPTION

## What is the purpose of the change
Add shorthand option for restoreMode

## Verifying this change

```
     -rm,--restoreMode <arg>                    Defines how should we restore
                                                from the given savepoint.
                                                Supported options: [claim -
                                                claim ownership of the savepoint
                                                and delete once it is subsumed,
                                                no_claim (default) - do not
                                                claim ownership, the first
                                                checkpoint will not reuse any
                                                files from the restored one,
                                                legacy - the old behaviour, do
                                                not assume ownership of the
                                                savepoint files, but can reuse
                                                some shared files.

```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
