### PR TITLE
[FLINK-25819][runtime] Reordered requesting and recycling buffers in order to avoid race condition in testIsAvailableOrNotAfterRequestAndRecycleMultiSegments

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPoolTest.java
@@ -56,6 +56,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -282,6 +283,47 @@ public class NetworkBufferPoolTest extends TestLogger {
             fail("Should throw an IOException");
         } catch (IOException e) {
             assertEquals(globalPool.getNumberOfAvailableMemorySegments(), numBuffers);
+        } finally {
+            globalPool.destroy();
+        }
+    }
+
+    /**
+     * Tests {@link NetworkBufferPool#requestUnpooledMemorySegments(int)} with the total number of
+     * allocated buffers for several requests exceeding the capacity of {@link NetworkBufferPool}.
+     */
+    @Test
+    public void testInsufficientNumberOfBuffers() throws Exception {
+        final int numberOfSegmentsToRequest = 5;
+
+        final NetworkBufferPool globalPool = new NetworkBufferPool(numberOfSegmentsToRequest, 128);
+
+        try {
+            // the global pool should be in available state initially
+            assertTrue(globalPool.getAvailableFuture().isDone());
+
+            // request 5 segments
+            List<MemorySegment> segments1 =
+                    globalPool.requestUnpooledMemorySegments(numberOfSegmentsToRequest);
+            assertFalse(globalPool.getAvailableFuture().isDone());
+            assertEquals(numberOfSegmentsToRequest, segments1.size());
+
+            // request only 1 segment
+            IOException ioException =
+                    assertThrows(
+                            IOException.class, () -> globalPool.requestUnpooledMemorySegments(1));
+
+            assertTrue(ioException.getMessage().contains("Insufficient number of network buffers"));
+
+            // recycle 5 segments
+            CompletableFuture<?> availableFuture = globalPool.getAvailableFuture();
+            globalPool.recycleUnpooledMemorySegments(segments1);
+            assertTrue(availableFuture.isDone());
+
+            List<MemorySegment> segments2 =
+                    globalPool.requestUnpooledMemorySegments(numberOfSegmentsToRequest);
+            assertFalse(globalPool.getAvailableFuture().isDone());
+            assertEquals(numberOfSegmentsToRequest, segments2.size());
         } finally {
             globalPool.destroy();
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPoolTest.java
@@ -532,9 +532,8 @@ public class NetworkBufferPoolTest extends TestLogger {
      * NetworkBufferPool#requestUnpooledMemorySegments(int)} and recycled by {@link
      * NetworkBufferPool#recycleUnpooledMemorySegments(Collection)}.
      */
-    @Test(timeout = 10000L)
-    public void testIsAvailableOrNotAfterRequestAndRecycleMultiSegments()
-            throws InterruptedException, IOException {
+    @Test
+    public void testIsAvailableOrNotAfterRequestAndRecycleMultiSegments() throws Exception {
         final int numberOfSegmentsToRequest = 5;
         final int numBuffers = 2 * numberOfSegmentsToRequest;
 
@@ -556,29 +555,14 @@ public class NetworkBufferPoolTest extends TestLogger {
             assertFalse(globalPool.getAvailableFuture().isDone());
             assertEquals(numberOfSegmentsToRequest, segments2.size());
 
-            // request another 5 segments
-            final CountDownLatch latch = new CountDownLatch(1);
-            final List<MemorySegment> segments3 = new ArrayList<>(numberOfSegmentsToRequest);
-            CheckedThread asyncRequest =
-                    new CheckedThread() {
-                        @Override
-                        public void go() throws Exception {
-                            // this request should be blocked until at least 5 segments are recycled
-                            segments3.addAll(
-                                    globalPool.requestUnpooledMemorySegments(
-                                            numberOfSegmentsToRequest));
-                            latch.countDown();
-                        }
-                    };
-            asyncRequest.start();
-
             // recycle 5 segments
             CompletableFuture<?> availableFuture = globalPool.getAvailableFuture();
             globalPool.recycleUnpooledMemorySegments(segments1);
             assertTrue(availableFuture.isDone());
 
-            // wait util the third request is fulfilled
-            latch.await();
+            // request another 5 segments
+            final List<MemorySegment> segments3 =
+                    globalPool.requestUnpooledMemorySegments(numberOfSegmentsToRequest);
             assertFalse(globalPool.getAvailableFuture().isDone());
             assertEquals(numberOfSegmentsToRequest, segments3.size());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPoolTest.java
@@ -23,10 +23,7 @@ import org.apache.flink.core.testutils.CheckedThread;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.util.TestLogger;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.Timeout;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -40,13 +37,13 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.core.IsCollectionContaining.hasItem;
 import static org.hamcrest.core.IsNot.not;
@@ -55,17 +52,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /** Tests for {@link NetworkBufferPool}. */
 public class NetworkBufferPoolTest extends TestLogger {
-
-    @Rule public ExpectedException expectedException = ExpectedException.none();
-
-    @Rule public Timeout timeout = new Timeout(10, TimeUnit.SECONDS);
 
     @Test
     public void testCreatePoolAfterDestroy() {
@@ -434,10 +426,9 @@ public class NetworkBufferPoolTest extends TestLogger {
 
         segment.free();
 
-        expectedException.expect(IllegalStateException.class);
-        expectedException.expectMessage("destroyed");
         try {
-            asyncRequest.sync();
+            Exception ex = assertThrows(IllegalStateException.class, asyncRequest::sync);
+            assertTrue(ex.getMessage().contains("destroyed"));
         } finally {
             globalPool.destroy();
         }
@@ -518,11 +509,9 @@ public class NetworkBufferPoolTest extends TestLogger {
 
         asyncRequest.start();
 
-        expectedException.expect(IOException.class);
-        expectedException.expectMessage("Timeout");
-
         try {
-            asyncRequest.sync();
+            Exception ex = assertThrows(IOException.class, asyncRequest::sync);
+            assertTrue(ex.getMessage().contains("Timeout"));
         } finally {
             globalPool.destroy();
         }
@@ -683,7 +672,7 @@ public class NetworkBufferPoolTest extends TestLogger {
             // wait until all available buffers are requested
             while (segmentsRequested.size() + segments.size() + exclusiveSegments.size()
                     < numBuffers) {
-                Thread.sleep(100);
+                Thread.sleep(10);
                 assertNull(cause.get());
             }
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

1.14 backport of https://github.com/apache/flink/pull/18865


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
