### PR TITLE
[FLINK-25217][table-planner] Replace TableConfig with PlannerConfig in FlinkContext

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/connectors/DynamicSourceUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/connectors/DynamicSourceUtils.java
@@ -21,7 +21,6 @@ package org.apache.flink.table.planner.connectors;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.streaming.api.datastream.DataStream;
-import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.api.config.ExecutionConfigOptions;
@@ -229,7 +228,7 @@ public final class DynamicSourceUtils {
     public static boolean isSourceChangeEventsDuplicate(
             ResolvedSchema resolvedSchema,
             DynamicTableSource tableSource,
-            TableConfig tableConfig) {
+            ReadableConfig plannerConfig) {
         if (!(tableSource instanceof ScanTableSource)) {
             return false;
         }
@@ -237,9 +236,7 @@ public final class DynamicSourceUtils {
         boolean isCDCSource =
                 !mode.containsOnly(RowKind.INSERT) && !isUpsertSource(resolvedSchema, tableSource);
         boolean changeEventsDuplicate =
-                tableConfig
-                        .getConfiguration()
-                        .getBoolean(ExecutionConfigOptions.TABLE_EXEC_SOURCE_CDC_EVENTS_DUPLICATE);
+                plannerConfig.get(ExecutionConfigOptions.TABLE_EXEC_SOURCE_CDC_EVENTS_DUPLICATE);
         boolean hasPrimaryKey = resolvedSchema.getPrimaryKey().isPresent();
         return isCDCSource && changeEventsDuplicate && hasPrimaryKey;
     }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/delegation/PlannerConfig.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/delegation/PlannerConfig.java
@@ -20,7 +20,9 @@ package org.apache.flink.table.planner.delegation;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.table.api.TableConfig;
 
 import java.util.Optional;
 
@@ -31,23 +33,38 @@ import java.util.Optional;
 @Internal
 public final class PlannerConfig implements ReadableConfig {
 
-    private final ReadableConfig tableConfig;
+    private final TableConfig tableConfig;
 
     private final ReadableConfig executorConfig;
 
-    PlannerConfig(ReadableConfig tableConfig, ReadableConfig executorConfig) {
+    PlannerConfig(TableConfig tableConfig, ReadableConfig executorConfig) {
         this.tableConfig = tableConfig;
         this.executorConfig = executorConfig;
     }
 
+    public static PlannerConfig of(TableConfig tableConfig) {
+        return new PlannerConfig(tableConfig, new Configuration());
+    }
+
+    public static PlannerConfig getDefault() {
+        return new PlannerConfig(TableConfig.getDefault(), new Configuration());
+    }
+
+    public TableConfig getTableConfig() {
+        return tableConfig;
+    }
+
     @Override
     public <T> T get(ConfigOption<T> option) {
-        return tableConfig.getOptional(option).orElseGet(() -> executorConfig.get(option));
+        return tableConfig
+                .getConfiguration()
+                .getOptional(option)
+                .orElseGet(() -> executorConfig.get(option));
     }
 
     @Override
     public <T> Optional<T> getOptional(ConfigOption<T> option) {
-        final Optional<T> tableValue = tableConfig.getOptional(option);
+        final Optional<T> tableValue = tableConfig.getConfiguration().getOptional(option);
         if (tableValue.isPresent()) {
             return tableValue;
         }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/delegation/PlannerContext.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/delegation/PlannerContext.java
@@ -105,18 +105,18 @@ public class PlannerContext {
 
     public PlannerContext(
             boolean isBatchMode,
-            TableConfig tableConfig,
+            PlannerConfig plannerConfig,
             ModuleManager moduleManager,
             FunctionCatalog functionCatalog,
             CatalogManager catalogManager,
             CalciteSchema rootSchema,
             List<RelTraitDef> traitDefs) {
-        this.tableConfig = tableConfig;
+        this.tableConfig = plannerConfig.getTableConfig();
 
         this.context =
                 new FlinkContextImpl(
                         isBatchMode,
-                        tableConfig,
+                        plannerConfig,
                         moduleManager,
                         functionCatalog,
                         catalogManager,

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/expressions/CallExpressionResolver.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/expressions/CallExpressionResolver.java
@@ -43,7 +43,7 @@ public class CallExpressionResolver {
         FlinkContext context = unwrapContext(relBuilder.getCluster());
         this.resolver =
                 ExpressionResolver.resolverFor(
-                                context.getTableConfig(),
+                                context.getPlannerConfig().getTableConfig(),
                                 name -> Optional.empty(),
                                 context.getFunctionCatalog()
                                         .asLookup(

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/QueryOperationConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/QueryOperationConverter.java
@@ -527,7 +527,7 @@ public class QueryOperationConverter extends QueryOperationDefaultVisitor<RelNod
                 boolean isTopLevelRecord,
                 ChangelogMode changelogMode) {
             final FlinkContext flinkContext = ShortcutUtils.unwrapContext(relBuilder);
-            final ReadableConfig config = flinkContext.getTableConfig().getConfiguration();
+            final ReadableConfig config = flinkContext.getPlannerConfig();
             return DynamicSourceUtils.convertDataStreamToRel(
                     flinkContext.isBatchMode(),
                     config,

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/source/FilterPushDownSpec.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/source/FilterPushDownSpec.java
@@ -81,7 +81,10 @@ public final class FilterPushDownSpec extends SourceAbilitySpecBase {
                             context.getSourceRowType().getFieldNames().toArray(new String[0]),
                             context.getFunctionCatalog(),
                             context.getCatalogManager(),
-                            TimeZone.getTimeZone(context.getTableConfig().getLocalTimeZone()));
+                            TimeZone.getTimeZone(
+                                    context.getPlannerConfig()
+                                            .getTableConfig()
+                                            .getLocalTimeZone()));
             List<Expression> filters =
                     predicates.stream()
                             .map(
@@ -101,7 +104,7 @@ public final class FilterPushDownSpec extends SourceAbilitySpecBase {
                             .collect(Collectors.toList());
             ExpressionResolver resolver =
                     ExpressionResolver.resolverFor(
-                                    context.getTableConfig(),
+                                    context.getPlannerConfig().getTableConfig(),
                                     name -> Optional.empty(),
                                     context.getFunctionCatalog()
                                             .asLookup(

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/source/SourceAbilityContext.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/source/SourceAbilityContext.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.table.planner.plan.abilities.source;
 
-import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.catalog.CatalogManager;
 import org.apache.flink.table.catalog.FunctionCatalog;
 import org.apache.flink.table.connector.source.DynamicTableSource;
@@ -26,6 +25,7 @@ import org.apache.flink.table.module.ModuleManager;
 import org.apache.flink.table.planner.calcite.FlinkContext;
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
 import org.apache.flink.table.planner.calcite.SqlExprToRexConverterFactory;
+import org.apache.flink.table.planner.delegation.PlannerConfig;
 import org.apache.flink.table.planner.utils.ShortcutUtils;
 import org.apache.flink.table.types.logical.RowType;
 
@@ -59,8 +59,8 @@ public class SourceAbilityContext implements FlinkContext {
     }
 
     @Override
-    public TableConfig getTableConfig() {
-        return context.getTableConfig();
+    public PlannerConfig getPlannerConfig() {
+        return context.getPlannerConfig();
     }
 
     @Override

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/source/WatermarkPushDownSpec.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/source/WatermarkPushDownSpec.java
@@ -75,11 +75,12 @@ public final class WatermarkPushDownSpec extends SourceAbilitySpecBase {
         if (tableSource instanceof SupportsWatermarkPushDown) {
             GeneratedWatermarkGenerator generatedWatermarkGenerator =
                     WatermarkGeneratorCodeGenerator.generateWatermarkGenerator(
-                            context.getTableConfig(),
+                            context.getPlannerConfig().getTableConfig(),
                             context.getSourceRowType(),
                             watermarkExpr,
                             Option.apply("context"));
-            Configuration configuration = context.getTableConfig().getConfiguration();
+            Configuration configuration =
+                    context.getPlannerConfig().getTableConfig().getConfiguration();
 
             WatermarkGeneratorSupplier<RowData> supplier =
                     new GeneratedWatermarkGeneratorSupplier(

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/SerdeContext.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/SerdeContext.java
@@ -19,7 +19,7 @@
 package org.apache.flink.table.planner.plan.nodes.exec.serde;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.table.delegation.Parser;
 import org.apache.flink.table.planner.calcite.FlinkContext;
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
@@ -71,8 +71,8 @@ public class SerdeContext {
         return parser;
     }
 
-    public Configuration getConfiguration() {
-        return flinkContext.getTableConfig().getConfiguration();
+    public ReadableConfig getConfiguration() {
+        return flinkContext.getPlannerConfig();
     }
 
     public ClassLoader getClassLoader() {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/spec/DynamicTableSinkSpec.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/spec/DynamicTableSinkSpec.java
@@ -87,7 +87,7 @@ public class DynamicTableSinkSpec extends DynamicTableSpecBase {
                             contextResolvedTable.getIdentifier(),
                             contextResolvedTable.getResolvedTable(),
                             loadOptionsFromCatalogTable(contextResolvedTable, flinkContext),
-                            flinkContext.getTableConfig().getConfiguration(),
+                            flinkContext.getPlannerConfig(),
                             flinkContext.getClassLoader(),
                             contextResolvedTable.isTemporary());
             if (sinkAbilities != null) {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/spec/DynamicTableSourceSpec.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/spec/DynamicTableSourceSpec.java
@@ -80,7 +80,7 @@ public class DynamicTableSourceSpec extends DynamicTableSpecBase {
                             contextResolvedTable.getIdentifier(),
                             contextResolvedTable.getResolvedTable(),
                             loadOptionsFromCatalogTable(contextResolvedTable, flinkContext),
-                            flinkContext.getTableConfig().getConfiguration(),
+                            flinkContext.getPlannerConfig(),
                             flinkContext.getClassLoader(),
                             contextResolvedTable.isTemporary());
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/spec/DynamicTableSpecBase.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/spec/DynamicTableSpecBase.java
@@ -39,8 +39,7 @@ class DynamicTableSpecBase {
         //  loaded from the catalog
         final TableConfigOptions.CatalogPlanRestore catalogPlanRestore =
                 flinkContext
-                        .getTableConfig()
-                        .getConfiguration()
+                        .getPlannerConfig()
                         .get(TableConfigOptions.PLAN_RESTORE_CATALOG_OBJECTS);
         if (contextResolvedTable.isAnonymous()
                 || catalogPlanRestore != TableConfigOptions.CatalogPlanRestore.ALL) {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoSourceScanRuleBase.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoSourceScanRuleBase.java
@@ -17,7 +17,6 @@
 
 package org.apache.flink.table.planner.plan.rules.logical;
 
-import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.api.config.OptimizerConfigOptions;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.connector.source.abilities.SupportsFilterPushDown;
@@ -57,12 +56,8 @@ public abstract class PushFilterIntoSourceScanRuleBase extends RelOptRule {
 
     @Override
     public boolean matches(RelOptRuleCall call) {
-        TableConfig tableConfig =
-                ShortcutUtils.unwrapContext(call.getPlanner()).getPlannerConfig().getTableConfig();
-        return tableConfig
-                .getConfiguration()
-                .getBoolean(
-                        OptimizerConfigOptions.TABLE_OPTIMIZER_SOURCE_PREDICATE_PUSHDOWN_ENABLED);
+        return ShortcutUtils.unwrapPlannerConfig(call)
+                .get(OptimizerConfigOptions.TABLE_OPTIMIZER_SOURCE_PREDICATE_PUSHDOWN_ENABLED);
     }
 
     protected List<RexNode> convertExpressionToRexNode(

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoSourceScanRuleBase.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoSourceScanRuleBase.java
@@ -57,7 +57,8 @@ public abstract class PushFilterIntoSourceScanRuleBase extends RelOptRule {
 
     @Override
     public boolean matches(RelOptRuleCall call) {
-        TableConfig tableConfig = ShortcutUtils.unwrapContext(call.getPlanner()).getTableConfig();
+        TableConfig tableConfig =
+                ShortcutUtils.unwrapContext(call.getPlanner()).getPlannerConfig().getTableConfig();
         return tableConfig
                 .getConfiguration()
                 .getBoolean(
@@ -136,7 +137,8 @@ public abstract class PushFilterIntoSourceScanRuleBase extends RelOptRule {
                         inputNames,
                         context.getFunctionCatalog(),
                         context.getCatalogManager(),
-                        TimeZone.getTimeZone(context.getTableConfig().getLocalTimeZone()));
+                        TimeZone.getTimeZone(
+                                context.getPlannerConfig().getTableConfig().getLocalTimeZone()));
 
         return RexNodeExtractor.extractConjunctiveConditions(
                 filterExpression, maxCnfNodeCount, rexBuilder, converter);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushPartitionIntoTableSourceScanRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushPartitionIntoTableSourceScanRule.java
@@ -166,7 +166,7 @@ public class PushPartitionIntoTableSourceScanRule extends RelOptRule {
         Function<List<Map<String, String>>, List<Map<String, String>>> defaultPruner =
                 partitions ->
                         PartitionPruner.prunePartitions(
-                                context.getTableConfig(),
+                                context.getPlannerConfig().getTableConfig(),
                                 partitionFieldNames.toArray(new String[0]),
                                 partitionFieldTypes,
                                 partitions,
@@ -341,7 +341,8 @@ public class PushPartitionIntoTableSourceScanRule extends RelOptRule {
                         allFieldNames.toArray(new String[0]),
                         context.getFunctionCatalog(),
                         context.getCatalogManager(),
-                        TimeZone.getTimeZone(context.getTableConfig().getLocalTimeZone()));
+                        TimeZone.getTimeZone(
+                                context.getPlannerConfig().getTableConfig().getLocalTimeZone()));
         ArrayList<Expression> partitionFilters = new ArrayList<>();
         Option<ResolvedExpression> subExpr;
         for (RexNode node : JavaConversions.seqAsJavaList(partitionPredicate)) {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushProjectIntoTableSourceScanRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushProjectIntoTableSourceScanRule.java
@@ -62,7 +62,7 @@ import java.util.stream.Stream;
 
 import static org.apache.flink.table.planner.connectors.DynamicSourceUtils.createProducedType;
 import static org.apache.flink.table.planner.connectors.DynamicSourceUtils.createRequiredMetadataKeys;
-import static org.apache.flink.table.planner.utils.ShortcutUtils.unwrapContext;
+import static org.apache.flink.table.planner.utils.ShortcutUtils.unwrapTableConfig;
 import static org.apache.flink.table.planner.utils.ShortcutUtils.unwrapTypeFactory;
 
 /**
@@ -191,7 +191,7 @@ public class PushProjectIntoTableSourceScanRule
 
     private List<RexNode> getProjections(LogicalProject project, LogicalTableScan scan) {
         final TableSourceTable source = scan.getTable().unwrap(TableSourceTable.class);
-        final TableConfig tableConfig = unwrapContext(scan).getTableConfig();
+        final TableConfig tableConfig = unwrapTableConfig(scan);
 
         final List<RexNode> projections = new ArrayList<>(project.getProjects());
         if (supportsProjectionPushDown(source.tableSource())

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushWatermarkIntoTableSourceScanAcrossCalcRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushWatermarkIntoTableSourceScanAcrossCalcRule.java
@@ -95,7 +95,7 @@ public class PushWatermarkIntoTableSourceScanAcrossCalcRule
                         watermarkAssigner,
                         newWatermarkExpr,
                         call.rel(2),
-                        ShortcutUtils.unwrapContext(calc).getTableConfig(),
+                        ShortcutUtils.unwrapTableConfig(calc),
                         false); // useWatermarkAssignerRowType
 
         FlinkTypeFactory typeFactory = ShortcutUtils.unwrapTypeFactory(calc);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushWatermarkIntoTableSourceScanRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushWatermarkIntoTableSourceScanRule.java
@@ -56,7 +56,7 @@ public class PushWatermarkIntoTableSourceScanRule extends PushWatermarkIntoTable
                         watermarkAssigner,
                         watermarkAssigner.watermarkExpr(),
                         scan,
-                        ShortcutUtils.unwrapContext(scan).getTableConfig(),
+                        ShortcutUtils.unwrapTableConfig(scan),
                         true); // useWatermarkAssignerRowType
 
         call.transformTo(newScan);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/physical/batch/PushLocalAggIntoScanRuleBase.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/physical/batch/PushLocalAggIntoScanRuleBase.java
@@ -77,7 +77,8 @@ public abstract class PushLocalAggIntoScanRuleBase extends RelOptRule {
             RelOptRuleCall call,
             BatchPhysicalGroupAggregateBase aggregate,
             BatchPhysicalTableSourceScan tableSourceScan) {
-        TableConfig tableConfig = ShortcutUtils.unwrapContext(call.getPlanner()).getTableConfig();
+        TableConfig tableConfig =
+                ShortcutUtils.unwrapContext(call.getPlanner()).getPlannerConfig().getTableConfig();
         if (!tableConfig
                 .getConfiguration()
                 .getBoolean(

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/physical/batch/PushLocalAggIntoScanRuleBase.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/physical/batch/PushLocalAggIntoScanRuleBase.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.planner.plan.rules.physical.batch;
 
-import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.table.api.config.OptimizerConfigOptions;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.connector.source.abilities.SupportsAggregatePushDown;
@@ -77,12 +77,9 @@ public abstract class PushLocalAggIntoScanRuleBase extends RelOptRule {
             RelOptRuleCall call,
             BatchPhysicalGroupAggregateBase aggregate,
             BatchPhysicalTableSourceScan tableSourceScan) {
-        TableConfig tableConfig =
-                ShortcutUtils.unwrapContext(call.getPlanner()).getPlannerConfig().getTableConfig();
-        if (!tableConfig
-                .getConfiguration()
-                .getBoolean(
-                        OptimizerConfigOptions.TABLE_OPTIMIZER_SOURCE_AGGREGATE_PUSHDOWN_ENABLED)) {
+        ReadableConfig plannerConfig = ShortcutUtils.unwrapPlannerConfig(call);
+        if (!plannerConfig.get(
+                OptimizerConfigOptions.TABLE_OPTIMIZER_SOURCE_AGGREGATE_PUSHDOWN_ENABLED)) {
             return false;
         }
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalPythonGroupWindowAggregateRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalPythonGroupWindowAggregateRule.java
@@ -127,8 +127,8 @@ public class StreamPhysicalPythonGroupWindowAggregateRule extends ConverterRule 
         RelTraitSet providedTraitSet =
                 rel.getTraitSet().replace(FlinkConventions.STREAM_PHYSICAL());
         RelNode newInput = RelOptRule.convert(input, requiredTraitSet);
-        ReadableConfig config = ShortcutUtils.unwrapPlannerConfig(rel);
-        WindowEmitStrategy emitStrategy = WindowEmitStrategy.apply(config, agg.getWindow());
+        ReadableConfig plannerConfig = ShortcutUtils.unwrapPlannerConfig(rel);
+        WindowEmitStrategy emitStrategy = WindowEmitStrategy.apply(plannerConfig, agg.getWindow());
 
         if (emitStrategy.produceUpdates()) {
             throw new TableException(

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalPythonGroupWindowAggregateRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalPythonGroupWindowAggregateRule.java
@@ -127,7 +127,7 @@ public class StreamPhysicalPythonGroupWindowAggregateRule extends ConverterRule 
         RelTraitSet providedTraitSet =
                 rel.getTraitSet().replace(FlinkConventions.STREAM_PHYSICAL());
         RelNode newInput = RelOptRule.convert(input, requiredTraitSet);
-        ReadableConfig config = ShortcutUtils.unwrapTableConfig(rel);
+        ReadableConfig config = ShortcutUtils.unwrapPlannerConfig(rel);
         WindowEmitStrategy emitStrategy = WindowEmitStrategy.apply(config, agg.getWindow());
 
         if (emitStrategy.produceUpdates()) {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/TwoStageOptimizedWindowAggregateRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/TwoStageOptimizedWindowAggregateRule.java
@@ -35,6 +35,7 @@ import org.apache.flink.table.planner.plan.trait.ModifyKindSetTrait;
 import org.apache.flink.table.planner.plan.trait.UpdateKindTrait;
 import org.apache.flink.table.planner.plan.utils.AggregateUtil;
 import org.apache.flink.table.planner.utils.AggregatePhaseStrategy;
+import org.apache.flink.table.planner.utils.ShortcutUtils;
 
 import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptRuleCall;
@@ -43,7 +44,6 @@ import org.apache.calcite.rel.RelNode;
 
 import java.util.stream.IntStream;
 
-import static org.apache.flink.table.planner.utils.ShortcutUtils.unwrapContext;
 import static org.apache.flink.table.planner.utils.TableConfigUtils.getAggPhaseStrategy;
 
 /**
@@ -81,7 +81,7 @@ public class TwoStageOptimizedWindowAggregateRule extends RelOptRule {
     public boolean matches(RelOptRuleCall call) {
         final StreamPhysicalWindowAggregate windowAgg = call.rel(0);
         final RelNode realInput = call.rel(2);
-        final TableConfig tableConfig = unwrapContext(call.getPlanner()).getTableConfig();
+        final TableConfig tableConfig = ShortcutUtils.unwrapTableConfig(call);
         final WindowingStrategy windowing = windowAgg.windowing();
 
         // the two-phase optimization must be enabled

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/TwoStageOptimizedWindowAggregateRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/TwoStageOptimizedWindowAggregateRule.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.planner.plan.rules.physical.stream;
 
-import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.table.planner.plan.logical.SliceAttachedWindowingStrategy;
 import org.apache.flink.table.planner.plan.logical.TimeAttributeWindowingStrategy;
 import org.apache.flink.table.planner.plan.logical.WindowAttachedWindowingStrategy;
@@ -81,11 +81,11 @@ public class TwoStageOptimizedWindowAggregateRule extends RelOptRule {
     public boolean matches(RelOptRuleCall call) {
         final StreamPhysicalWindowAggregate windowAgg = call.rel(0);
         final RelNode realInput = call.rel(2);
-        final TableConfig tableConfig = ShortcutUtils.unwrapTableConfig(call);
+        final ReadableConfig config = ShortcutUtils.unwrapPlannerConfig(call);
         final WindowingStrategy windowing = windowAgg.windowing();
 
         // the two-phase optimization must be enabled
-        if (getAggPhaseStrategy(tableConfig) == AggregatePhaseStrategy.ONE_PHASE) {
+        if (getAggPhaseStrategy(config) == AggregatePhaseStrategy.ONE_PHASE) {
             return false;
         }
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/schema/CatalogSourceTable.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/schema/CatalogSourceTable.java
@@ -118,7 +118,7 @@ public final class CatalogSourceTable extends FlinkPreparingTableBase {
         // prepare table source and convert to RelNode
         return DynamicSourceUtils.convertSourceToRel(
                 !schemaTable.isStreamingMode(),
-                context.getTableConfig().getConfiguration(),
+                context.getPlannerConfig(),
                 relBuilder,
                 schemaTable.getContextResolvedTable(),
                 schemaTable.getStatistic(),
@@ -132,7 +132,7 @@ public final class CatalogSourceTable extends FlinkPreparingTableBase {
         if (hintedOptions.isEmpty()) {
             return contextResolvedTable;
         }
-        final ReadableConfig config = context.getTableConfig().getConfiguration();
+        final ReadableConfig config = context.getPlannerConfig();
         if (!config.get(TableConfigOptions.TABLE_DYNAMIC_TABLE_OPTIONS_ENABLED)) {
             throw new ValidationException(
                     String.format(
@@ -154,7 +154,7 @@ public final class CatalogSourceTable extends FlinkPreparingTableBase {
 
     private DynamicTableSource createDynamicTableSource(
             FlinkContext context, ResolvedCatalogTable catalogTable) {
-        final ReadableConfig config = context.getTableConfig().getConfiguration();
+        final ReadableConfig config = context.getPlannerConfig();
 
         final Optional<DynamicTableSourceFactory> factoryFromCatalog =
                 schemaTable

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/utils/ShortcutUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/utils/ShortcutUtils.java
@@ -19,19 +19,18 @@
 package org.apache.flink.table.planner.utils;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.expressions.CallExpression;
 import org.apache.flink.table.expressions.ResolvedExpression;
 import org.apache.flink.table.functions.FunctionDefinition;
 import org.apache.flink.table.planner.calcite.FlinkContext;
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
-import org.apache.flink.table.planner.delegation.PlannerConfig;
 import org.apache.flink.table.planner.expressions.RexNodeExpression;
 import org.apache.flink.table.planner.functions.bridging.BridgingSqlFunction;
 
 import org.apache.calcite.plan.Context;
 import org.apache.calcite.plan.RelOptCluster;
-import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
@@ -78,32 +77,32 @@ public final class ShortcutUtils {
         return unwrapContext(relNode.getCluster());
     }
 
-    public static FlinkContext unwrapContext(RelOptCluster cluster) {
-        return unwrapContext(cluster.getPlanner());
+    public static FlinkContext unwrapContext(RelOptRuleCall relOptRuleCall) {
+        return unwrapContext(relOptRuleCall.getPlanner().getContext());
     }
 
-    public static FlinkContext unwrapContext(RelOptPlanner planner) {
-        return unwrapContext(planner.getContext());
+    public static FlinkContext unwrapContext(RelOptCluster cluster) {
+        return unwrapContext(cluster.getPlanner().getContext());
     }
 
     public static FlinkContext unwrapContext(Context context) {
         return context.unwrap(FlinkContext.class);
     }
 
-    public static PlannerConfig unwrapPlannerConfig(RelNode relNode) {
+    public static ReadableConfig unwrapPlannerConfig(RelNode relNode) {
         return unwrapContext(relNode).getPlannerConfig();
     }
 
-    public static PlannerConfig unwrapPlannerConfig(RelOptRuleCall relOptRuleCall) {
-        return unwrapContext(relOptRuleCall.getPlanner()).getPlannerConfig();
+    public static ReadableConfig unwrapPlannerConfig(RelOptRuleCall relOptRuleCall) {
+        return unwrapContext(relOptRuleCall).getPlannerConfig();
     }
 
     public static TableConfig unwrapTableConfig(RelNode relNode) {
-        return unwrapPlannerConfig(relNode).getTableConfig();
+        return unwrapContext(relNode).getPlannerConfig().getTableConfig();
     }
 
     public static TableConfig unwrapTableConfig(RelOptRuleCall relOptRuleCall) {
-        return unwrapPlannerConfig(relOptRuleCall).getTableConfig();
+        return unwrapContext(relOptRuleCall).getPlannerConfig().getTableConfig();
     }
 
     public static @Nullable FunctionDefinition unwrapFunctionDefinition(

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/utils/ShortcutUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/utils/ShortcutUtils.java
@@ -19,18 +19,20 @@
 package org.apache.flink.table.planner.utils;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.expressions.CallExpression;
 import org.apache.flink.table.expressions.ResolvedExpression;
 import org.apache.flink.table.functions.FunctionDefinition;
 import org.apache.flink.table.planner.calcite.FlinkContext;
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
+import org.apache.flink.table.planner.delegation.PlannerConfig;
 import org.apache.flink.table.planner.expressions.RexNodeExpression;
 import org.apache.flink.table.planner.functions.bridging.BridgingSqlFunction;
 
 import org.apache.calcite.plan.Context;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptPlanner;
+import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rex.RexCall;
@@ -88,8 +90,20 @@ public final class ShortcutUtils {
         return context.unwrap(FlinkContext.class);
     }
 
-    public static ReadableConfig unwrapTableConfig(RelNode relNode) {
-        return unwrapContext(relNode).getTableConfig().getConfiguration();
+    public static PlannerConfig unwrapPlannerConfig(RelNode relNode) {
+        return unwrapContext(relNode).getPlannerConfig();
+    }
+
+    public static PlannerConfig unwrapPlannerConfig(RelOptRuleCall relOptRuleCall) {
+        return unwrapContext(relOptRuleCall.getPlanner()).getPlannerConfig();
+    }
+
+    public static TableConfig unwrapTableConfig(RelNode relNode) {
+        return unwrapPlannerConfig(relNode).getTableConfig();
+    }
+
+    public static TableConfig unwrapTableConfig(RelOptRuleCall relOptRuleCall) {
+        return unwrapPlannerConfig(relOptRuleCall).getTableConfig();
     }
 
     public static @Nullable FunctionDefinition unwrapFunctionDefinition(

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/utils/TableConfigUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/utils/TableConfigUtils.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.planner.utils;
 
+import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.planner.calcite.CalciteConfig;
 import org.apache.flink.table.planner.calcite.CalciteConfig$;
@@ -35,12 +36,12 @@ public class TableConfigUtils {
     /**
      * Returns whether the given operator type is disabled.
      *
-     * @param tableConfig TableConfig object
+     * @param config Configuration
      * @param operatorType operator type to check
      * @return true if the given operator is disabled.
      */
-    public static boolean isOperatorDisabled(TableConfig tableConfig, OperatorType operatorType) {
-        String value = tableConfig.getConfiguration().getString(TABLE_EXEC_DISABLED_OPERATORS);
+    public static boolean isOperatorDisabled(ReadableConfig config, OperatorType operatorType) {
+        String value = config.get(TABLE_EXEC_DISABLED_OPERATORS);
         if (value == null) {
             return false;
         }
@@ -64,12 +65,11 @@ public class TableConfigUtils {
     /**
      * Returns the aggregate phase strategy configuration.
      *
-     * @param tableConfig TableConfig object
+     * @param config Configuration
      * @return the aggregate phase strategy
      */
-    public static AggregatePhaseStrategy getAggPhaseStrategy(TableConfig tableConfig) {
-        String aggPhaseConf =
-                tableConfig.getConfiguration().getString(TABLE_OPTIMIZER_AGG_PHASE_STRATEGY).trim();
+    public static AggregatePhaseStrategy getAggPhaseStrategy(ReadableConfig config) {
+        String aggPhaseConf = config.get(TABLE_OPTIMIZER_AGG_PHASE_STRATEGY).trim();
         if (aggPhaseConf.isEmpty()) {
             return AggregatePhaseStrategy.AUTO;
         } else {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/calcite/FlinkContext.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/calcite/FlinkContext.scala
@@ -18,9 +18,9 @@
 
 package org.apache.flink.table.planner.calcite
 
-import org.apache.flink.table.api.TableConfig
 import org.apache.flink.table.catalog.{CatalogManager, FunctionCatalog}
 import org.apache.flink.table.module.ModuleManager
+import org.apache.flink.table.planner.delegation.PlannerConfig
 
 import org.apache.calcite.plan.Context
 
@@ -40,8 +40,8 @@ trait FlinkContext extends Context {
     Thread.currentThread().getContextClassLoader
   }
 
-  /** Returns the [[TableConfig]] defined in [[org.apache.flink.table.api.TableEnvironment]]. */
-  def getTableConfig: TableConfig
+  /** Returns the [[org.apache.flink.table.planner.delegation.PlannerConfig]]. */
+  def getPlannerConfig: PlannerConfig
 
   /** Returns the [[FunctionCatalog]] defined in [[org.apache.flink.table.api.TableEnvironment]]. */
   def getFunctionCatalog: FunctionCatalog

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/calcite/FlinkContextImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/calcite/FlinkContextImpl.scala
@@ -18,13 +18,13 @@
 
 package org.apache.flink.table.planner.calcite
 
-import org.apache.flink.table.api.TableConfig
 import org.apache.flink.table.catalog.{CatalogManager, FunctionCatalog}
 import org.apache.flink.table.module.ModuleManager
+import org.apache.flink.table.planner.delegation.PlannerConfig
 
 class FlinkContextImpl(
     inBatchMode: Boolean,
-    tableConfig: TableConfig,
+    plannerConfig: PlannerConfig,
     moduleManager: ModuleManager,
     functionCatalog: FunctionCatalog,
     catalogManager: CatalogManager,
@@ -33,7 +33,7 @@ class FlinkContextImpl(
 
   override def isBatchMode: Boolean = inBatchMode
 
-  override def getTableConfig: TableConfig = tableConfig
+  override def getPlannerConfig: PlannerConfig = plannerConfig
 
   override def getModuleManager: ModuleManager = moduleManager
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/calcite/FlinkRelBuilder.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/calcite/FlinkRelBuilder.scala
@@ -18,13 +18,16 @@
 
 package org.apache.flink.table.planner.calcite
 
+import org.apache.flink.table.catalog.ObjectIdentifier
 import org.apache.flink.table.operations.QueryOperation
 import org.apache.flink.table.planner.calcite.FlinkRelFactories.{ExpandFactory, RankFactory}
 import org.apache.flink.table.planner.expressions.WindowProperty
+import org.apache.flink.table.planner.hint.FlinkHints
 import org.apache.flink.table.planner.plan.QueryOperationConverter
 import org.apache.flink.table.planner.plan.logical.LogicalWindow
 import org.apache.flink.table.planner.plan.nodes.calcite.{LogicalTableAggregate, LogicalWatermarkAssigner, LogicalWindowAggregate, LogicalWindowTableAggregate}
 import org.apache.flink.table.planner.plan.utils.AggregateUtil
+import org.apache.flink.table.planner.utils.ShortcutUtils
 import org.apache.flink.table.runtime.groupwindow.NamedWindowProperty
 import org.apache.flink.table.runtime.operators.rank.{RankRange, RankType}
 
@@ -39,8 +42,6 @@ import org.apache.calcite.sql.SqlKind
 import org.apache.calcite.tools.RelBuilder.{AggCall, Config, GroupKey}
 import org.apache.calcite.tools.{RelBuilder, RelBuilderFactory}
 import org.apache.calcite.util.{ImmutableBitSet, Util}
-import org.apache.flink.table.catalog.ObjectIdentifier
-import org.apache.flink.table.planner.hint.FlinkHints
 
 import java.lang.Iterable
 import java.util
@@ -64,7 +65,7 @@ class FlinkRelBuilder(
   require(context != null)
 
   private val toRelNodeConverter = {
-    new QueryOperationConverter(this, context.unwrap(classOf[FlinkContext]).isBatchMode)
+    new QueryOperationConverter(this, ShortcutUtils.unwrapContext(context).isBatchMode)
   }
 
   private val expandFactory: ExpandFactory = {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
@@ -20,7 +20,6 @@ package org.apache.flink.table.planner.delegation
 
 import org.apache.flink.annotation.VisibleForTesting
 import org.apache.flink.api.dag.Transformation
-import org.apache.flink.configuration.ReadableConfig
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.apache.flink.streaming.api.graph.StreamGraph
 import org.apache.flink.table.api._
@@ -102,15 +101,15 @@ abstract class PlannerBase(
   private var parser: Parser = _
   private var currentDialect: SqlDialect = getTableConfig.getSqlDialect
 
-  private val plannerConfiguration: ReadableConfig = new PlannerConfig(
-    tableConfig.getConfiguration,
+  private val plannerConfiguration: PlannerConfig = new PlannerConfig(
+    tableConfig,
     executor.getConfiguration)
 
   @VisibleForTesting
   private[flink] val plannerContext: PlannerContext =
     new PlannerContext(
       !isStreamingMode,
-      tableConfig,
+      plannerConfiguration,
       moduleManager,
       functionCatalog,
       catalogManager,
@@ -151,7 +150,7 @@ abstract class PlannerBase(
    *
    * This configuration should be the main source of truth in the planner module.
    */
-  def getConfiguration: ReadableConfig = plannerConfiguration
+  def getConfiguration: PlannerConfig = plannerConfiguration
 
   /**
    * @deprecated Do not use this method anymore. Use [[getConfiguration]] to access options.

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
@@ -342,7 +342,7 @@ abstract class PlannerBase(
     val shuttle = new SameRelObjectShuttle()
     val relsWithoutSameObj = optimizedRelNodes.map(_.accept(shuttle))
     // reuse subplan
-    val reusedPlan = SubplanReuser.reuseDuplicatedSubplan(relsWithoutSameObj, tableConfig)
+    val reusedPlan = SubplanReuser.reuseDuplicatedSubplan(relsWithoutSameObj, plannerConfiguration)
     // convert FlinkPhysicalRel DAG to ExecNodeGraph
     val generator = new ExecNodeGraphGenerator()
     val execGraph = generator.generate(reusedPlan.map(_.asInstanceOf[FlinkPhysicalRel]))

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdColumnNullCount.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdColumnNullCount.scala
@@ -20,7 +20,8 @@ package org.apache.flink.table.planner.plan.metadata
 
 import org.apache.flink.table.planner.plan.metadata.FlinkMetadata.ColumnNullCount
 import org.apache.flink.table.planner.plan.schema.FlinkPreparingTableBase
-import org.apache.flink.table.planner.plan.utils.{FlinkRelOptUtil, FlinkRexUtil}
+import org.apache.flink.table.planner.plan.utils.FlinkRexUtil
+import org.apache.flink.table.planner.utils.ShortcutUtils
 import org.apache.flink.table.planner.{JDouble, JList}
 import org.apache.flink.util.Preconditions
 
@@ -157,9 +158,8 @@ class FlinkRelMdColumnNullCount private extends MetadataHandler[ColumnNullCount]
       } else {
         // If predicate has $index is not null, null count of index is must be 0 after predicate.
         val rexBuilder = rel.getCluster.getRexBuilder
-        val tableConfig = FlinkRelOptUtil.getTableConfigFromContext(rel)
-        val maxCnfNodeCount = tableConfig.getConfiguration.getInteger(
-          FlinkRexUtil.TABLE_OPTIMIZER_CNF_NODES_LIMIT)
+        val plannerConfig = ShortcutUtils.unwrapPlannerConfig(rel)
+        val maxCnfNodeCount = plannerConfig.get(FlinkRexUtil.TABLE_OPTIMIZER_CNF_NODES_LIMIT)
         val cnf = FlinkRexUtil.toCnf(rexBuilder, maxCnfNodeCount, predicate)
         val conjunctions = RelOptUtil.conjunctions(cnf)
         val notNullPredicatesAtIndexField = conjunctions.exists {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdDistinctRowCount.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdDistinctRowCount.scala
@@ -22,7 +22,8 @@ import org.apache.flink.table.api.TableException
 import org.apache.flink.table.planner.plan.nodes.calcite.{Expand, Rank, WindowAggregate}
 import org.apache.flink.table.planner.plan.nodes.physical.batch._
 import org.apache.flink.table.planner.plan.schema.FlinkPreparingTableBase
-import org.apache.flink.table.planner.plan.utils.{FlinkRelMdUtil, FlinkRelOptUtil, FlinkRexUtil, RankUtil}
+import org.apache.flink.table.planner.plan.utils.{FlinkRelMdUtil, FlinkRexUtil, RankUtil}
+import org.apache.flink.table.planner.utils.ShortcutUtils
 import org.apache.flink.table.planner.{JArrayList, JDouble}
 
 import org.apache.calcite.plan.RelOptUtil
@@ -203,9 +204,8 @@ class FlinkRelMdDistinctRowCount private extends MetadataHandler[BuiltInMetadata
       null
     } else {
       val rexBuilder = rel.getCluster.getRexBuilder
-      val tableConfig = FlinkRelOptUtil.getTableConfigFromContext(rel)
-      val maxCnfNodeCount = tableConfig.getConfiguration.getInteger(
-        FlinkRexUtil.TABLE_OPTIMIZER_CNF_NODES_LIMIT)
+      val plannerConfig = ShortcutUtils.unwrapPlannerConfig(rel)
+      val maxCnfNodeCount = plannerConfig.get(FlinkRexUtil.TABLE_OPTIMIZER_CNF_NODES_LIMIT)
       val cnf = FlinkRexUtil.toCnf(rexBuilder, maxCnfNodeCount, predicate)
       val conjunctions = RelOptUtil.conjunctions(cnf)
       val conjunctionsWithoutExpandId = conjunctions.filterNot { c =>

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdDistribution.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdDistribution.scala
@@ -21,7 +21,7 @@ import org.apache.flink.table.planner.JHashMap
 import org.apache.flink.table.planner.plan.`trait`.{FlinkRelDistribution, FlinkRelDistributionTraitDef}
 import org.apache.flink.table.planner.plan.metadata.FlinkMetadata.FlinkDistribution
 import org.apache.flink.table.planner.plan.rules.physical.batch.BatchPhysicalSortRule
-import org.apache.flink.table.planner.plan.utils.FlinkRelOptUtil
+import org.apache.flink.table.planner.utils.ShortcutUtils
 
 import org.apache.calcite.rel._
 import org.apache.calcite.rel.core.{Calc, Sort, TableScan}
@@ -71,9 +71,8 @@ class FlinkRelMdDistribution private extends MetadataHandler[FlinkDistribution] 
   }
 
   def flinkDistribution(sort: Sort, mq: RelMetadataQuery): FlinkRelDistribution = {
-    val tableConfig = FlinkRelOptUtil.getTableConfigFromContext(sort)
-    val enableRangeSort = tableConfig.getConfiguration.getBoolean(
-      BatchPhysicalSortRule.TABLE_EXEC_RANGE_SORT_ENABLED)
+    val plannerConfig = ShortcutUtils.unwrapPlannerConfig(sort)
+    val enableRangeSort = plannerConfig.get(BatchPhysicalSortRule.TABLE_EXEC_RANGE_SORT_ENABLED)
     if ((sort.getCollation.getFieldCollations.nonEmpty &&
       sort.fetch == null && sort.offset == null) && enableRangeSort) {
       //If Sort is global sort, and the table config allows the range partition.

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdRowCount.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdRowCount.scala
@@ -174,10 +174,9 @@ class FlinkRelMdRowCount private extends MetadataHandler[BuiltInMetadata.RowCoun
       ndvOfGroupKeysOnGlobalAgg
     } else {
       val inputRowCnt = mq.getRowCount(input)
-      val config = ShortcutUtils.unwrapTableConfig(rel)
+      val plannerConfig = ShortcutUtils.unwrapPlannerConfig(rel)
       val parallelism = (inputRowCnt /
-          config.getConfiguration.getLong(
-            FlinkRelMdRowCount.TABLE_OPTIMIZER_ROWS_PER_LOCALAGG) + 1).toInt
+        plannerConfig.get(FlinkRelMdRowCount.TABLE_OPTIMIZER_ROWS_PER_LOCALAGG) + 1).toInt
       if (parallelism == 1) {
         ndvOfGroupKeysOnGlobalAgg
       } else if (grouping.isEmpty) {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdRowCount.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdRowCount.scala
@@ -21,13 +21,13 @@ package org.apache.flink.table.planner.plan.metadata
 import org.apache.flink.annotation.Experimental
 import org.apache.flink.configuration.ConfigOption
 import org.apache.flink.configuration.ConfigOptions.key
-import org.apache.flink.table.planner.calcite.FlinkContext
 import org.apache.flink.table.planner.plan.logical.{LogicalWindow, SlidingGroupWindow, TumblingGroupWindow}
 import org.apache.flink.table.planner.plan.nodes.calcite.{Expand, Rank, WindowAggregate}
 import org.apache.flink.table.planner.plan.nodes.physical.batch._
 import org.apache.flink.table.planner.plan.stats.ValueInterval
 import org.apache.flink.table.planner.plan.utils.AggregateUtil.{hasTimeIntervalType, toLong}
 import org.apache.flink.table.planner.plan.utils.{FlinkRelMdUtil, SortUtil}
+import org.apache.flink.table.planner.utils.ShortcutUtils
 
 import org.apache.calcite.adapter.enumerable.EnumerableLimit
 import org.apache.calcite.plan.volcano.RelSubset
@@ -174,7 +174,7 @@ class FlinkRelMdRowCount private extends MetadataHandler[BuiltInMetadata.RowCoun
       ndvOfGroupKeysOnGlobalAgg
     } else {
       val inputRowCnt = mq.getRowCount(input)
-      val config = rel.getCluster.getPlanner.getContext.unwrap(classOf[FlinkContext]).getTableConfig
+      val config = ShortcutUtils.unwrapTableConfig(rel)
       val parallelism = (inputRowCnt /
           config.getConfiguration.getLong(
             FlinkRelMdRowCount.TABLE_OPTIMIZER_ROWS_PER_LOCALAGG) + 1).toInt

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/metadata/SelectivityEstimator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/metadata/SelectivityEstimator.scala
@@ -20,7 +20,8 @@ package org.apache.flink.table.planner.plan.metadata
 
 import org.apache.flink.table.planner.plan.metadata.SelectivityEstimator._
 import org.apache.flink.table.planner.plan.stats._
-import org.apache.flink.table.planner.plan.utils.{FlinkRelOptUtil, FlinkRexUtil}
+import org.apache.flink.table.planner.plan.utils.FlinkRexUtil
+import org.apache.flink.table.planner.utils.ShortcutUtils
 import org.apache.flink.table.planner.{JArrayList, JDouble, JHashMap, JHashSet}
 
 import org.apache.calcite.avatica.util.DateTimeUtils
@@ -56,9 +57,8 @@ class SelectivityEstimator(rel: RelNode, mq: FlinkRelMetadataQuery)
   extends RexVisitorImpl[Option[Double]](true) {
 
   private val rexBuilder = rel.getCluster.getRexBuilder
-  private val tableConfig = FlinkRelOptUtil.getTableConfigFromContext(rel)
-  private val maxCnfNodeCount = tableConfig.getConfiguration.getInteger(
-    FlinkRexUtil.TABLE_OPTIMIZER_CNF_NODES_LIMIT)
+  private val plannerConfig = ShortcutUtils.unwrapPlannerConfig(rel)
+  private val maxCnfNodeCount = plannerConfig.get(FlinkRexUtil.TABLE_OPTIMIZER_CNF_NODES_LIMIT)
 
   // these default values is referred to RelMdUtil#guessSelectivity
   private[flink] val defaultComparisonSelectivity = Some(0.5d)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/logical/FlinkLogicalSort.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/logical/FlinkLogicalSort.scala
@@ -19,10 +19,10 @@
 package org.apache.flink.table.planner.plan.nodes.logical
 
 import org.apache.flink.table.api.config.ExecutionConfigOptions.TABLE_EXEC_SORT_DEFAULT_LIMIT
-import org.apache.flink.table.planner.calcite.FlinkContext
 import org.apache.flink.table.planner.plan.nodes.FlinkConventions
 import org.apache.flink.table.planner.plan.rules.physical.batch.BatchPhysicalSortRule.TABLE_EXEC_RANGE_SORT_ENABLED
 import org.apache.flink.table.planner.plan.utils.SortUtil
+import org.apache.flink.table.planner.utils.ShortcutUtils
 
 import org.apache.calcite.plan._
 import org.apache.calcite.rel.convert.ConverterRule
@@ -104,7 +104,7 @@ class FlinkLogicalSortBatchConverter extends ConverterRule(
   override def convert(rel: RelNode): RelNode = {
     val sort = rel.asInstanceOf[LogicalSort]
     val newInput = RelOptRule.convert(sort.getInput, FlinkConventions.LOGICAL)
-    val config = sort.getCluster.getPlanner.getContext.unwrap(classOf[FlinkContext]).getTableConfig
+    val config = ShortcutUtils.unwrapTableConfig(sort)
     val enableRangeSort = config.getConfiguration.getBoolean(TABLE_EXEC_RANGE_SORT_ENABLED)
     val limitValue = config.getConfiguration.getInteger(TABLE_EXEC_SORT_DEFAULT_LIMIT)
     val (offset, fetch) = if (sort.fetch == null && sort.offset == null

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/logical/FlinkLogicalSort.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/logical/FlinkLogicalSort.scala
@@ -104,9 +104,9 @@ class FlinkLogicalSortBatchConverter extends ConverterRule(
   override def convert(rel: RelNode): RelNode = {
     val sort = rel.asInstanceOf[LogicalSort]
     val newInput = RelOptRule.convert(sort.getInput, FlinkConventions.LOGICAL)
-    val config = ShortcutUtils.unwrapTableConfig(sort)
-    val enableRangeSort = config.getConfiguration.getBoolean(TABLE_EXEC_RANGE_SORT_ENABLED)
-    val limitValue = config.getConfiguration.getInteger(TABLE_EXEC_SORT_DEFAULT_LIMIT)
+    val plannerConfig = ShortcutUtils.unwrapPlannerConfig(sort)
+    val enableRangeSort = plannerConfig.get(TABLE_EXEC_RANGE_SORT_ENABLED)
+    val limitValue = plannerConfig.get(TABLE_EXEC_SORT_DEFAULT_LIMIT)
     val (offset, fetch) = if (sort.fetch == null && sort.offset == null
       && !enableRangeSort && limitValue > 0) {
       //force the sort add limit

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalExchange.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalExchange.scala
@@ -23,7 +23,7 @@ import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.plan.nodes.exec.batch.BatchExecExchange
 import org.apache.flink.table.planner.plan.nodes.exec.{ExecNode, InputProperty}
 import org.apache.flink.table.planner.plan.nodes.physical.common.CommonPhysicalExchange
-import org.apache.flink.table.planner.utils.ShortcutUtils.unwrapTableConfig
+import org.apache.flink.table.planner.utils.ShortcutUtils
 import org.apache.flink.table.planner.utils.StreamExchangeModeUtils.getBatchStreamExchangeMode
 
 import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
@@ -60,7 +60,7 @@ class BatchPhysicalExchange(
     }
 
     val exchangeMode = getBatchStreamExchangeMode(
-      unwrapTableConfig(this),
+      ShortcutUtils.unwrapPlannerConfig(this),
       StreamExchangeMode.UNDEFINED)
 
     val damBehavior = if (exchangeMode eq StreamExchangeMode.BATCH) {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalGroupAggregateBase.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalGroupAggregateBase.scala
@@ -20,9 +20,8 @@ package org.apache.flink.table.planner.plan.nodes.physical.batch
 
 import org.apache.flink.table.api.TableException
 import org.apache.flink.table.functions.UserDefinedFunction
-import org.apache.flink.table.planner.plan.utils.FlinkRelOptUtil
-import org.apache.flink.table.planner.utils.AggregatePhaseStrategy
 import org.apache.flink.table.planner.utils.TableConfigUtils.getAggPhaseStrategy
+import org.apache.flink.table.planner.utils.{AggregatePhaseStrategy, ShortcutUtils}
 
 import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
 import org.apache.calcite.rel.`type`.RelDataType
@@ -68,8 +67,7 @@ abstract class BatchPhysicalGroupAggregateBase(
   def getAggCallToAggFunction: Seq[(AggregateCall, UserDefinedFunction)] = aggCallToAggFunction
 
   protected def isEnforceTwoStageAgg: Boolean = {
-    val tableConfig = FlinkRelOptUtil.getTableConfigFromContext(this)
-    getAggPhaseStrategy(tableConfig) == AggregatePhaseStrategy.TWO_PHASE
+    val plannerConfig = ShortcutUtils.unwrapPlannerConfig(this)
+    getAggPhaseStrategy(plannerConfig) == AggregatePhaseStrategy.TWO_PHASE
   }
-
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalHashAggregate.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalHashAggregate.scala
@@ -22,9 +22,10 @@ import org.apache.flink.table.functions.UserDefinedFunction
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.plan.`trait`.{FlinkRelDistribution, FlinkRelDistributionTraitDef}
 import org.apache.flink.table.planner.plan.nodes.exec.batch.BatchExecHashAggregate
-import org.apache.flink.table.planner.plan.nodes.exec.{InputProperty, ExecNode}
+import org.apache.flink.table.planner.plan.nodes.exec.{ExecNode, InputProperty}
 import org.apache.flink.table.planner.plan.rules.physical.batch.BatchPhysicalJoinRuleBase
-import org.apache.flink.table.planner.plan.utils.{FlinkRelOptUtil, RelExplainUtil}
+import org.apache.flink.table.planner.plan.utils.RelExplainUtil
+import org.apache.flink.table.planner.utils.ShortcutUtils
 
 import org.apache.calcite.plan.{RelOptCluster, RelOptRule, RelTraitSet}
 import org.apache.calcite.rel.RelDistribution.Type.{HASH_DISTRIBUTED, SINGLETON}
@@ -109,8 +110,8 @@ class BatchPhysicalHashAggregate(
           true
         } else {
           // If partialKey is enabled, try to use partial key to satisfy the required distribution
-          val tableConfig = FlinkRelOptUtil.getTableConfigFromContext(this)
-          val partialKeyEnabled = tableConfig.getConfiguration.getBoolean(
+          val plannerConfig = ShortcutUtils.unwrapPlannerConfig(this)
+          val partialKeyEnabled = plannerConfig.get(
             BatchPhysicalJoinRuleBase.TABLE_OPTIMIZER_SHUFFLE_BY_PARTIAL_KEY_ENABLED)
           partialKeyEnabled && groupKeysList.containsAll(shuffleKeys)
         }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalOverAggregateBase.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalOverAggregateBase.scala
@@ -24,7 +24,8 @@ import org.apache.flink.table.planner.plan.`trait`.{FlinkRelDistribution, FlinkR
 import org.apache.flink.table.planner.plan.cost.{FlinkCost, FlinkCostFactory}
 import org.apache.flink.table.planner.plan.rules.physical.batch.BatchPhysicalJoinRuleBase
 import org.apache.flink.table.planner.plan.utils.OverAggregateUtil.splitOutOffsetOrInsensitiveGroup
-import org.apache.flink.table.planner.plan.utils.{FlinkRelOptUtil, OverAggregateUtil, RelExplainUtil}
+import org.apache.flink.table.planner.plan.utils.{OverAggregateUtil, RelExplainUtil}
+import org.apache.flink.table.planner.utils.ShortcutUtils
 
 import org.apache.calcite.plan._
 import org.apache.calcite.rel.RelDistribution.Type._
@@ -136,8 +137,8 @@ abstract class BatchPhysicalOverAggregateBase(
         } else {
           val isAllFieldsFromInput = requiredDistribution.getKeys.forall(_ < inputFieldCnt)
           if (isAllFieldsFromInput) {
-            val tableConfig = FlinkRelOptUtil.getTableConfigFromContext(this)
-            if (tableConfig.getConfiguration.getBoolean(
+            val plannerConfig = ShortcutUtils.unwrapPlannerConfig(this)
+            if (plannerConfig.get(
               BatchPhysicalJoinRuleBase.TABLE_OPTIMIZER_SHUFFLE_BY_PARTIAL_KEY_ENABLED)) {
               ImmutableIntList.of(partitionKeyIndices: _*).containsAll(requiredDistribution.getKeys)
             } else {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalPythonGroupAggregate.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalPythonGroupAggregate.scala
@@ -21,10 +21,11 @@ package org.apache.flink.table.planner.plan.nodes.physical.batch
 import org.apache.flink.table.functions.UserDefinedFunction
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.plan.`trait`.{FlinkRelDistribution, FlinkRelDistributionTraitDef}
-import org.apache.flink.table.planner.plan.nodes.exec.{ExecNode, InputProperty}
 import org.apache.flink.table.planner.plan.nodes.exec.batch.BatchExecPythonGroupAggregate
+import org.apache.flink.table.planner.plan.nodes.exec.{ExecNode, InputProperty}
 import org.apache.flink.table.planner.plan.rules.physical.batch.BatchPhysicalJoinRuleBase
 import org.apache.flink.table.planner.plan.utils.{FlinkRelOptUtil, RelExplainUtil}
+import org.apache.flink.table.planner.utils.ShortcutUtils
 
 import org.apache.calcite.plan.{RelOptCluster, RelOptRule, RelTraitSet}
 import org.apache.calcite.rel.RelDistribution.Type.{HASH_DISTRIBUTED, SINGLETON}
@@ -92,8 +93,8 @@ class BatchPhysicalPythonGroupAggregate(
           true
         } else {
           // If partialKey is enabled, try to use partial key to satisfy the required distribution
-          val tableConfig = FlinkRelOptUtil.getTableConfigFromContext(this)
-          val partialKeyEnabled = tableConfig.getConfiguration.getBoolean(
+          val plannerConfig = ShortcutUtils.unwrapPlannerConfig(this)
+          val partialKeyEnabled = plannerConfig.get(
             BatchPhysicalJoinRuleBase.TABLE_OPTIMIZER_SHUFFLE_BY_PARTIAL_KEY_ENABLED)
           partialKeyEnabled && groupKeysList.containsAll(shuffleKeys)
         }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalRank.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalRank.scala
@@ -23,10 +23,11 @@ import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.plan.`trait`.{FlinkRelDistribution, FlinkRelDistributionTraitDef}
 import org.apache.flink.table.planner.plan.cost.{FlinkCost, FlinkCostFactory}
 import org.apache.flink.table.planner.plan.nodes.calcite.Rank
-import org.apache.flink.table.planner.plan.nodes.exec.{ExecNode, InputProperty}
 import org.apache.flink.table.planner.plan.nodes.exec.batch.BatchExecRank
+import org.apache.flink.table.planner.plan.nodes.exec.{ExecNode, InputProperty}
 import org.apache.flink.table.planner.plan.rules.physical.batch.BatchPhysicalJoinRuleBase
 import org.apache.flink.table.planner.plan.utils.{FlinkRelOptUtil, RelExplainUtil}
+import org.apache.flink.table.planner.utils.ShortcutUtils
 import org.apache.flink.table.runtime.operators.rank.{ConstantRankRange, RankRange, RankType}
 
 import org.apache.calcite.plan._
@@ -134,8 +135,8 @@ class BatchPhysicalRank(
           true
         } else {
           // If partialKey is enabled, try to use partial key to satisfy the required distribution
-          val tableConfig = FlinkRelOptUtil.getTableConfigFromContext(this)
-          val partialKeyEnabled = tableConfig.getConfiguration.getBoolean(
+          val plannerConfig = ShortcutUtils.unwrapPlannerConfig(this)
+          val partialKeyEnabled = plannerConfig.get(
             BatchPhysicalJoinRuleBase.TABLE_OPTIMIZER_SHUFFLE_BY_PARTIAL_KEY_ENABLED)
           partialKeyEnabled && partitionKeyList.containsAll(shuffleKeys)
         }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalSortAggregate.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalSortAggregate.scala
@@ -22,9 +22,10 @@ import org.apache.flink.table.functions.UserDefinedFunction
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.plan.`trait`.{FlinkRelDistribution, FlinkRelDistributionTraitDef}
 import org.apache.flink.table.planner.plan.nodes.exec.batch.BatchExecSortAggregate
-import org.apache.flink.table.planner.plan.nodes.exec.{InputProperty, ExecNode}
+import org.apache.flink.table.planner.plan.nodes.exec.{ExecNode, InputProperty}
 import org.apache.flink.table.planner.plan.rules.physical.batch.BatchPhysicalJoinRuleBase
 import org.apache.flink.table.planner.plan.utils.{FlinkRelOptUtil, RelExplainUtil}
+import org.apache.flink.table.planner.utils.ShortcutUtils
 
 import org.apache.calcite.plan.{RelOptCluster, RelOptRule, RelTraitSet}
 import org.apache.calcite.rel.RelDistribution.Type.{HASH_DISTRIBUTED, SINGLETON}
@@ -110,8 +111,8 @@ class BatchPhysicalSortAggregate(
           true
         } else {
           // If partialKey is enabled, try to use partial key to satisfy the required distribution
-          val tableConfig = FlinkRelOptUtil.getTableConfigFromContext(this)
-          val partialKeyEnabled = tableConfig.getConfiguration.getBoolean(
+          val plannerConfig = ShortcutUtils.unwrapPlannerConfig(this)
+          val partialKeyEnabled = plannerConfig.get(
             BatchPhysicalJoinRuleBase.TABLE_OPTIMIZER_SHUFFLE_BY_PARTIAL_KEY_ENABLED)
           partialKeyEnabled && groupKeysList.containsAll(shuffleKeys)
         }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalGlobalWindowAggregate.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalGlobalWindowAggregate.scala
@@ -24,7 +24,7 @@ import org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecGlobalWin
 import org.apache.flink.table.planner.plan.nodes.exec.{ExecNode, InputProperty}
 import org.apache.flink.table.planner.plan.rules.physical.stream.TwoStageOptimizedWindowAggregateRule
 import org.apache.flink.table.planner.plan.utils.WindowUtil.checkEmitConfiguration
-import org.apache.flink.table.planner.plan.utils.{AggregateUtil, FlinkRelOptUtil, RelExplainUtil, WindowUtil}
+import org.apache.flink.table.planner.plan.utils.{AggregateUtil, RelExplainUtil, WindowUtil}
 import org.apache.flink.table.runtime.groupwindow.NamedWindowProperty
 
 import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
@@ -126,7 +126,7 @@ class StreamPhysicalGlobalWindowAggregate(
   }
 
   override def translateToExecNode(): ExecNode[_] = {
-    checkEmitConfiguration(FlinkRelOptUtil.getTableConfigFromContext(this))
+    checkEmitConfiguration(this)
     new StreamExecGlobalWindowAggregate(
       grouping,
       aggCalls.toArray,

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalLocalWindowAggregate.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalLocalWindowAggregate.scala
@@ -24,7 +24,7 @@ import org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecLocalWind
 import org.apache.flink.table.planner.plan.nodes.exec.{ExecNode, InputProperty}
 import org.apache.flink.table.planner.plan.rules.physical.stream.TwoStageOptimizedWindowAggregateRule
 import org.apache.flink.table.planner.plan.utils.WindowUtil.checkEmitConfiguration
-import org.apache.flink.table.planner.plan.utils.{AggregateUtil, FlinkRelOptUtil, RelExplainUtil, WindowUtil}
+import org.apache.flink.table.planner.plan.utils.{AggregateUtil, RelExplainUtil, WindowUtil}
 import org.apache.flink.table.runtime.groupwindow.{NamedWindowProperty, SliceEnd, WindowReference}
 
 import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
@@ -123,7 +123,7 @@ class StreamPhysicalLocalWindowAggregate(
   }
 
   override def translateToExecNode(): ExecNode[_] = {
-    checkEmitConfiguration(FlinkRelOptUtil.getTableConfigFromContext(this))
+    checkEmitConfiguration(this)
     new StreamExecLocalWindowAggregate(
       grouping,
       aggCalls.toArray,

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalWindowAggregate.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalWindowAggregate.scala
@@ -101,7 +101,7 @@ class StreamPhysicalWindowAggregate(
   }
 
   override def translateToExecNode(): ExecNode[_] = {
-    checkEmitConfiguration(FlinkRelOptUtil.getTableConfigFromContext(this))
+    checkEmitConfiguration(this)
     new StreamExecWindowAggregate(
       grouping,
       aggCalls.toArray,

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/BatchCommonSubGraphBasedOptimizer.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/BatchCommonSubGraphBasedOptimizer.scala
@@ -18,11 +18,10 @@
 
 package org.apache.flink.table.planner.plan.optimize
 
-import org.apache.flink.table.api.TableConfig
 import org.apache.flink.table.catalog.{CatalogManager, FunctionCatalog}
 import org.apache.flink.table.module.ModuleManager
 import org.apache.flink.table.planner.calcite.{FlinkContext, FlinkRelBuilder, SqlExprToRexConverterFactory}
-import org.apache.flink.table.planner.delegation.BatchPlanner
+import org.apache.flink.table.planner.delegation.{BatchPlanner, PlannerConfig}
 import org.apache.flink.table.planner.plan.nodes.calcite.{LegacySink, Sink}
 import org.apache.flink.table.planner.plan.optimize.program.{BatchOptimizeContext, FlinkBatchProgram}
 import org.apache.flink.table.planner.plan.schema.IntermediateRelTable
@@ -77,9 +76,10 @@ class BatchCommonSubGraphBasedOptimizer(planner: BatchPlanner)
     * @return The optimized [[RelNode]] tree
     */
   private def optimizeTree(relNode: RelNode): RelNode = {
-    val config = planner.getTableConfig
-    val programs = TableConfigUtils.getCalciteConfig(config).getBatchProgram
-      .getOrElse(FlinkBatchProgram.buildProgram(config.getConfiguration))
+    val plannerConfig = planner.getConfiguration
+    val tableConfig = planner.getTableConfig
+    val programs = TableConfigUtils.getCalciteConfig(tableConfig).getBatchProgram
+      .getOrElse(FlinkBatchProgram.buildProgram(plannerConfig))
     Preconditions.checkNotNull(programs)
 
     val context = relNode.getCluster.getPlanner.getContext.unwrap(classOf[FlinkContext])
@@ -88,7 +88,7 @@ class BatchCommonSubGraphBasedOptimizer(planner: BatchPlanner)
 
       override def isBatchMode: Boolean = true
 
-      override def getTableConfig: TableConfig = config
+      override def getPlannerConfig: PlannerConfig = plannerConfig
 
       override def getFunctionCatalog: FunctionCatalog = planner.functionCatalog
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/BatchCommonSubGraphBasedOptimizer.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/BatchCommonSubGraphBasedOptimizer.scala
@@ -20,12 +20,12 @@ package org.apache.flink.table.planner.plan.optimize
 
 import org.apache.flink.table.catalog.{CatalogManager, FunctionCatalog}
 import org.apache.flink.table.module.ModuleManager
-import org.apache.flink.table.planner.calcite.{FlinkContext, FlinkRelBuilder, SqlExprToRexConverterFactory}
+import org.apache.flink.table.planner.calcite.{FlinkRelBuilder, SqlExprToRexConverterFactory}
 import org.apache.flink.table.planner.delegation.{BatchPlanner, PlannerConfig}
 import org.apache.flink.table.planner.plan.nodes.calcite.{LegacySink, Sink}
 import org.apache.flink.table.planner.plan.optimize.program.{BatchOptimizeContext, FlinkBatchProgram}
 import org.apache.flink.table.planner.plan.schema.IntermediateRelTable
-import org.apache.flink.table.planner.utils.TableConfigUtils
+import org.apache.flink.table.planner.utils.{ShortcutUtils, TableConfigUtils}
 import org.apache.flink.util.Preconditions
 
 import org.apache.calcite.rel.RelNode
@@ -82,7 +82,7 @@ class BatchCommonSubGraphBasedOptimizer(planner: BatchPlanner)
       .getOrElse(FlinkBatchProgram.buildProgram(plannerConfig))
     Preconditions.checkNotNull(programs)
 
-    val context = relNode.getCluster.getPlanner.getContext.unwrap(classOf[FlinkContext])
+    val context = ShortcutUtils.unwrapContext(relNode)
 
     programs.optimize(relNode, new BatchOptimizeContext {
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/RelNodeBlock.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/RelNodeBlock.scala
@@ -29,7 +29,6 @@ import org.apache.flink.table.planner.plan.utils.{DefaultRelShuttle, ExpandTable
 import org.apache.flink.util.Preconditions
 
 import com.google.common.collect.Sets
-
 import org.apache.calcite.rel._
 import org.apache.calcite.rel.core.{Aggregate, Project, Snapshot, TableFunctionScan, Union}
 import org.apache.calcite.rex.RexNode
@@ -258,12 +257,12 @@ class RelNodeWrapper(relNode: RelNode) {
 /**
   * Builds [[RelNodeBlock]] plan
   */
-class RelNodeBlockPlanBuilder private(config: ReadableConfig) {
+class RelNodeBlockPlanBuilder private(plannerConfig: ReadableConfig) {
 
   private val node2Wrapper = new util.IdentityHashMap[RelNode, RelNodeWrapper]()
   private val node2Block = new util.IdentityHashMap[RelNode, RelNodeBlock]()
 
-  private val isUnionAllAsBreakPointEnabled = config
+  private val isUnionAllAsBreakPointEnabled = plannerConfig
     .get(RelNodeBlockPlanBuilder.TABLE_OPTIMIZER_UNIONALL_AS_BREAKPOINT_ENABLED)
 
   /**
@@ -415,7 +414,7 @@ object RelNodeBlockPlanBuilder {
     */
   def buildRelNodeBlockPlan(
       sinkNodes: Seq[RelNode],
-      config: ReadableConfig): Seq[RelNodeBlock] = {
+      plannerConfig: ReadableConfig): Seq[RelNodeBlock] = {
     require(sinkNodes.nonEmpty)
 
     // expand QueryOperationCatalogViewTable in TableScan
@@ -426,8 +425,8 @@ object RelNodeBlockPlanBuilder {
       Seq(new RelNodeBlock(convertedRelNodes.head))
     } else {
       // merge multiple RelNode trees to RelNode dag
-      val relNodeDag = reuseRelNodes(convertedRelNodes, config)
-      val builder = new RelNodeBlockPlanBuilder(config)
+      val relNodeDag = reuseRelNodes(convertedRelNodes, plannerConfig)
+      val builder = new RelNodeBlockPlanBuilder(plannerConfig)
       builder.buildRelNodeBlockPlan(relNodeDag)
     }
   }
@@ -438,8 +437,8 @@ object RelNodeBlockPlanBuilder {
     * @param relNodes RelNode trees
     * @return RelNode dag which reuse common subPlan in each tree
     */
-  private def reuseRelNodes(relNodes: Seq[RelNode], config: ReadableConfig): Seq[RelNode] = {
-    val findOpBlockWithDigest = config
+  private def reuseRelNodes(relNodes: Seq[RelNode], plannerConfig: ReadableConfig): Seq[RelNode] = {
+    val findOpBlockWithDigest = plannerConfig
       .get(RelNodeBlockPlanBuilder.TABLE_OPTIMIZER_REUSE_OPTIMIZE_BLOCK_WITH_DIGEST_ENABLED)
     if (!findOpBlockWithDigest) {
       return relNodes

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/StreamCommonSubGraphBasedOptimizer.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/StreamCommonSubGraphBasedOptimizer.scala
@@ -18,12 +18,11 @@
 
 package org.apache.flink.table.planner.plan.optimize
 
-import org.apache.flink.table.api.TableConfig
 import org.apache.flink.table.api.config.ExecutionConfigOptions
 import org.apache.flink.table.catalog.{CatalogManager, FunctionCatalog}
 import org.apache.flink.table.module.ModuleManager
 import org.apache.flink.table.planner.calcite.{FlinkContext, FlinkRelBuilder, SqlExprToRexConverterFactory}
-import org.apache.flink.table.planner.delegation.StreamPlanner
+import org.apache.flink.table.planner.delegation.{PlannerConfig, StreamPlanner}
 import org.apache.flink.table.planner.plan.`trait`.{MiniBatchInterval, MiniBatchIntervalTrait, MiniBatchIntervalTraitDef, MiniBatchMode, ModifyKindSet, ModifyKindSetTraitDef, UpdateKind, UpdateKindTraitDef}
 import org.apache.flink.table.planner.plan.metadata.FlinkRelMetadataQuery
 import org.apache.flink.table.planner.plan.nodes.calcite.{LegacySink, Sink}
@@ -153,10 +152,10 @@ class StreamCommonSubGraphBasedOptimizer(planner: StreamPlanner)
       miniBatchInterval: MiniBatchInterval,
       isSinkBlock: Boolean): RelNode = {
 
-    val config = planner.getTableConfig
-    val calciteConfig = TableConfigUtils.getCalciteConfig(config)
+    val plannerConfig = planner.getConfiguration
+    val calciteConfig = TableConfigUtils.getCalciteConfig(plannerConfig.getTableConfig)
     val programs = calciteConfig.getStreamProgram
-      .getOrElse(FlinkStreamProgram.buildProgram(config.getConfiguration))
+      .getOrElse(FlinkStreamProgram.buildProgram(plannerConfig))
     Preconditions.checkNotNull(programs)
 
     val context = relNode.getCluster.getPlanner.getContext.unwrap(classOf[FlinkContext])
@@ -165,7 +164,7 @@ class StreamCommonSubGraphBasedOptimizer(planner: StreamPlanner)
 
       override def isBatchMode: Boolean = false
 
-      override def getTableConfig: TableConfig = config
+      override def getPlannerConfig: PlannerConfig = plannerConfig
 
       override def getFunctionCatalog: FunctionCatalog = planner.functionCatalog
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkBatchProgram.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkBatchProgram.scala
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.planner.plan.optimize.program
 
-import org.apache.flink.configuration.Configuration
+import org.apache.flink.configuration.ReadableConfig
 import org.apache.flink.table.api.config.OptimizerConfigOptions
 import org.apache.flink.table.planner.plan.nodes.FlinkConventions
 import org.apache.flink.table.planner.plan.rules.FlinkBatchRuleSets
@@ -44,7 +44,7 @@ object FlinkBatchProgram {
   val PHYSICAL = "physical"
   val PHYSICAL_REWRITE = "physical_rewrite"
 
-  def buildProgram(config: Configuration): FlinkChainedProgram[BatchOptimizeContext] = {
+  def buildProgram(config: ReadableConfig): FlinkChainedProgram[BatchOptimizeContext] = {
     val chainedProgram = new FlinkChainedProgram[BatchOptimizeContext]()
 
     chainedProgram.addLast(
@@ -151,7 +151,7 @@ object FlinkBatchProgram {
         .build())
 
     // join reorder
-    if (config.getBoolean(OptimizerConfigOptions.TABLE_OPTIMIZER_JOIN_REORDER_ENABLED)) {
+    if (config.get(OptimizerConfigOptions.TABLE_OPTIMIZER_JOIN_REORDER_ENABLED)) {
       chainedProgram.addLast(
         JOIN_REORDER,
         FlinkGroupProgramBuilder.newBuilder[BatchOptimizeContext]

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkChangelogModeInferenceProgram.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkChangelogModeInferenceProgram.scala
@@ -826,11 +826,11 @@ class FlinkChangelogModeInferenceProgram extends FlinkOptimizeProgram[StreamOpti
      *  contain upsertKeys of the input update stream.
      */
     private def analyzeUpsertMaterializeStrategy(sink: StreamPhysicalSink): Boolean = {
-      val tableConfig = ShortcutUtils.unwrapTableConfig(sink)
+      val plannerConfig = ShortcutUtils.unwrapPlannerConfig(sink)
       val inputChangelogMode = ChangelogPlanUtils.getChangelogMode(
         sink.getInput.asInstanceOf[StreamPhysicalRel]).get
       val primaryKeys = sink.contextResolvedTable.getResolvedSchema.getPrimaryKeyIndexes
-      val upsertMaterialize = tableConfig.getConfiguration.get(
+      val upsertMaterialize = plannerConfig.get(
         ExecutionConfigOptions.TABLE_EXEC_SINK_UPSERT_MATERIALIZE) match {
         case UpsertMaterialize.FORCE => primaryKeys.nonEmpty
         case UpsertMaterialize.NONE => false

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkChangelogModeInferenceProgram.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkChangelogModeInferenceProgram.scala
@@ -21,8 +21,8 @@ package org.apache.flink.table.planner.plan.optimize.program
 import org.apache.flink.table.api.TableException
 import org.apache.flink.table.api.config.ExecutionConfigOptions
 import org.apache.flink.table.api.config.ExecutionConfigOptions.UpsertMaterialize
+import org.apache.flink.table.catalog.{ManagedTableListener, ResolvedCatalogBaseTable}
 import org.apache.flink.table.connector.ChangelogMode
-import org.apache.flink.table.planner.calcite.FlinkContext
 import org.apache.flink.table.planner.plan.`trait`.UpdateKindTrait.{BEFORE_AND_AFTER, ONLY_UPDATE_AFTER, beforeAfterOrNone, onlyAfterOrNone}
 import org.apache.flink.table.planner.plan.`trait`._
 import org.apache.flink.table.planner.plan.metadata.FlinkRelMetadataQuery
@@ -30,14 +30,13 @@ import org.apache.flink.table.planner.plan.nodes.physical.stream._
 import org.apache.flink.table.planner.plan.utils.RankProcessStrategy.{AppendFastStrategy, RetractStrategy, UpdateFastStrategy}
 import org.apache.flink.table.planner.plan.utils._
 import org.apache.flink.table.planner.sinks.DataStreamTableSink
-import org.apache.flink.table.planner.utils.JavaScalaConversionUtil.toScala
+import org.apache.flink.table.planner.utils.ShortcutUtils
 import org.apache.flink.table.runtime.operators.join.FlinkJoinType
 import org.apache.flink.table.sinks.{AppendStreamTableSink, RetractStreamTableSink, StreamTableSink, UpsertStreamTableSink}
 import org.apache.flink.types.RowKind
 
 import org.apache.calcite.rel.RelNode
 import org.apache.calcite.util.ImmutableBitSet
-import org.apache.flink.table.catalog.{ManagedTableListener, ResolvedCatalogBaseTable}
 
 import scala.collection.JavaConversions._
 
@@ -827,8 +826,7 @@ class FlinkChangelogModeInferenceProgram extends FlinkOptimizeProgram[StreamOpti
      *  contain upsertKeys of the input update stream.
      */
     private def analyzeUpsertMaterializeStrategy(sink: StreamPhysicalSink): Boolean = {
-      val tableConfig = sink.getCluster.getPlanner.getContext.unwrap(classOf[FlinkContext])
-          .getTableConfig
+      val tableConfig = ShortcutUtils.unwrapTableConfig(sink)
       val inputChangelogMode = ChangelogPlanUtils.getChangelogMode(
         sink.getInput.asInstanceOf[StreamPhysicalRel]).get
       val primaryKeys = sink.contextResolvedTable.getResolvedSchema.getPrimaryKeyIndexes

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkStreamProgram.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkStreamProgram.scala
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.planner.plan.optimize.program
 
-import org.apache.flink.configuration.Configuration
+import org.apache.flink.configuration.ReadableConfig
 import org.apache.flink.table.api.config.OptimizerConfigOptions
 import org.apache.flink.table.planner.plan.nodes.FlinkConventions
 import org.apache.flink.table.planner.plan.rules.FlinkStreamRuleSets
@@ -43,7 +43,7 @@ object FlinkStreamProgram {
   val PHYSICAL = "physical"
   val PHYSICAL_REWRITE = "physical_rewrite"
 
-  def buildProgram(config: Configuration): FlinkChainedProgram[StreamOptimizeContext] = {
+  def buildProgram(config: ReadableConfig): FlinkChainedProgram[StreamOptimizeContext] = {
     val chainedProgram = new FlinkChainedProgram[StreamOptimizeContext]()
 
     // rewrite sub-queries to joins
@@ -161,7 +161,7 @@ object FlinkStreamProgram {
         .build())
 
     // join reorder
-    if (config.getBoolean(OptimizerConfigOptions.TABLE_OPTIMIZER_JOIN_REORDER_ENABLED)) {
+    if (config.get(OptimizerConfigOptions.TABLE_OPTIMIZER_JOIN_REORDER_ENABLED)) {
       chainedProgram.addLast(
         JOIN_REORDER,
         FlinkGroupProgramBuilder.newBuilder[StreamOptimizeContext]

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/reuse/SubplanReuser.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/reuse/SubplanReuser.scala
@@ -18,8 +18,9 @@
 
 package org.apache.flink.table.planner.plan.reuse
 
+import org.apache.flink.configuration.ReadableConfig
+import org.apache.flink.table.api.TableException
 import org.apache.flink.table.api.config.OptimizerConfigOptions
-import org.apache.flink.table.api.{TableConfig, TableException}
 import org.apache.flink.table.planner.plan.nodes.calcite.{LegacySink, Sink}
 import org.apache.flink.table.planner.plan.nodes.logical.{FlinkLogicalLegacyTableSourceScan, FlinkLogicalTableSourceScan}
 import org.apache.flink.table.planner.plan.nodes.physical.common.{CommonPhysicalLegacyTableSourceScan, CommonPhysicalTableSourceScan}
@@ -55,12 +56,11 @@ object SubplanReuser {
   /**
     * Finds duplicated sub-plans and return the reused plan.
     */
-  def reuseDuplicatedSubplan(rels: Seq[RelNode], tableConfig: TableConfig): Seq[RelNode] = {
-    if (!tableConfig.getConfiguration.getBoolean(
-      OptimizerConfigOptions.TABLE_OPTIMIZER_REUSE_SUB_PLAN_ENABLED)) {
+  def reuseDuplicatedSubplan(rels: Seq[RelNode], plannerConfig: ReadableConfig): Seq[RelNode] = {
+    if (!plannerConfig.get(OptimizerConfigOptions.TABLE_OPTIMIZER_REUSE_SUB_PLAN_ENABLED)) {
       return rels
     }
-    val tableSourceReuseEnabled = tableConfig.getConfiguration.getBoolean(
+    val tableSourceReuseEnabled = plannerConfig.get(
       OptimizerConfigOptions.TABLE_OPTIMIZER_REUSE_SOURCE_ENABLED)
     val context = new SubplanReuseContext(tableSourceReuseEnabled, rels: _*)
     val reuseShuttle = new SubplanReuseShuttle(context)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/FlinkLogicalRankRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/FlinkLogicalRankRule.scala
@@ -18,9 +18,9 @@
 package org.apache.flink.table.planner.plan.rules.logical
 
 import org.apache.flink.table.api.TableException
-import org.apache.flink.table.planner.calcite.FlinkContext
 import org.apache.flink.table.planner.plan.nodes.logical.{FlinkLogicalCalc, FlinkLogicalOverAggregate, FlinkLogicalRank}
 import org.apache.flink.table.planner.plan.utils.RankUtil
+import org.apache.flink.table.planner.utils.ShortcutUtils
 import org.apache.flink.table.runtime.operators.rank.{ConstantRankRange, ConstantRankRangeWithoutEnd, RankType}
 
 import org.apache.calcite.plan.RelOptRule.{any, operand}
@@ -52,7 +52,7 @@ abstract class FlinkLogicalRankRuleBase
     val condition = calc.getProgram.getCondition
     val predicate = calc.getProgram.expandLocalRef(condition)
 
-    val config = calc.getCluster.getPlanner.getContext.unwrap(classOf[FlinkContext]).getTableConfig
+    val config = ShortcutUtils.unwrapTableConfig(calc)
     val (rankRange, remainingPreds) = RankUtil.extractRankRange(
       predicate,
       rankFieldIndex,
@@ -177,12 +177,7 @@ class FlinkLogicalRankRuleForRangeEnd extends FlinkLogicalRankRuleBase {
         val predicate = calc.getProgram.expandLocalRef(condition)
         // the rank function is the last field of FlinkLogicalOverAggregate
         val rankFieldIndex = window.getRowType.getFieldCount - 1
-        val config = calc
-          .getCluster
-          .getPlanner
-          .getContext
-          .unwrap(classOf[FlinkContext])
-          .getTableConfig
+        val config = ShortcutUtils.unwrapTableConfig(calc)
         val (rankRange, remainingPreds) = RankUtil.extractRankRange(
           predicate,
           rankFieldIndex,
@@ -247,12 +242,7 @@ class FlinkLogicalRankRuleForConstantRange extends FlinkLogicalRankRuleBase {
         val predicate = calc.getProgram.expandLocalRef(condition)
         // the rank function is the last field of FlinkLogicalOverAggregate
         val rankFieldIndex = window.getRowType.getFieldCount - 1
-        val config = calc
-          .getCluster
-          .getPlanner
-          .getContext
-          .unwrap(classOf[FlinkContext])
-          .getTableConfig
+        val config = ShortcutUtils.unwrapTableConfig(calc)
         val (rankRange, remainingPreds) = RankUtil.extractRankRange(
           predicate,
           rankFieldIndex,

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/FlinkLogicalRankRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/FlinkLogicalRankRule.scala
@@ -52,12 +52,12 @@ abstract class FlinkLogicalRankRuleBase
     val condition = calc.getProgram.getCondition
     val predicate = calc.getProgram.expandLocalRef(condition)
 
-    val config = ShortcutUtils.unwrapTableConfig(calc)
+    val tableConfig = ShortcutUtils.unwrapTableConfig(calc)
     val (rankRange, remainingPreds) = RankUtil.extractRankRange(
       predicate,
       rankFieldIndex,
       calc.getCluster.getRexBuilder,
-      config)
+      tableConfig)
     require(rankRange.isDefined)
 
     val cluster = window.getCluster
@@ -177,12 +177,12 @@ class FlinkLogicalRankRuleForRangeEnd extends FlinkLogicalRankRuleBase {
         val predicate = calc.getProgram.expandLocalRef(condition)
         // the rank function is the last field of FlinkLogicalOverAggregate
         val rankFieldIndex = window.getRowType.getFieldCount - 1
-        val config = ShortcutUtils.unwrapTableConfig(calc)
+        val tableConfig = ShortcutUtils.unwrapTableConfig(calc)
         val (rankRange, remainingPreds) = RankUtil.extractRankRange(
           predicate,
           rankFieldIndex,
           calc.getCluster.getRexBuilder,
-          config)
+          tableConfig)
 
         rankRange match {
           case Some(_: ConstantRankRangeWithoutEnd) =>
@@ -242,12 +242,12 @@ class FlinkLogicalRankRuleForConstantRange extends FlinkLogicalRankRuleBase {
         val predicate = calc.getProgram.expandLocalRef(condition)
         // the rank function is the last field of FlinkLogicalOverAggregate
         val rankFieldIndex = window.getRowType.getFieldCount - 1
-        val config = ShortcutUtils.unwrapTableConfig(calc)
+        val tableConfig = ShortcutUtils.unwrapTableConfig(calc)
         val (rankRange, remainingPreds) = RankUtil.extractRankRange(
           predicate,
           rankFieldIndex,
           calc.getCluster.getRexBuilder,
-          config)
+          tableConfig)
 
         // remaining predicate must not access rank field attributes
         val remainingPredsAccessRank = remainingPreds.isDefined &&

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/JoinDeriveNullFilterRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/JoinDeriveNullFilterRule.scala
@@ -22,7 +22,7 @@ import org.apache.flink.annotation.Experimental
 import org.apache.flink.configuration.ConfigOption
 import org.apache.flink.configuration.ConfigOptions.key
 import org.apache.flink.table.planner.plan.metadata.FlinkRelMetadataQuery
-import org.apache.flink.table.planner.plan.utils.FlinkRelOptUtil
+import org.apache.flink.table.planner.utils.ShortcutUtils
 
 import org.apache.calcite.plan.RelOptRule.{any, operand}
 import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall}
@@ -61,8 +61,8 @@ class JoinDeriveNullFilterRule
 
     val rexBuilder = join.getCluster.getRexBuilder
     val mq = FlinkRelMetadataQuery.reuseOrCreate(join.getCluster.getMetadataQuery)
-    val conf = FlinkRelOptUtil.getTableConfigFromContext(join)
-    val minNullCount = conf.getConfiguration.getLong(
+    val plannerConfig = ShortcutUtils.unwrapPlannerConfig(join)
+    val minNullCount = plannerConfig.get(
       JoinDeriveNullFilterRule.TABLE_OPTIMIZER_JOIN_NULL_FILTER_THRESHOLD)
 
     def createIsNotNullFilter(input: RelNode, keys: ImmutableIntList): RelNode = {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/LogicalCorrelateToJoinFromTemporalTableFunctionRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/LogicalCorrelateToJoinFromTemporalTableFunctionRule.scala
@@ -29,7 +29,7 @@ import org.apache.flink.table.planner.plan.utils.TemporalJoinUtil.{makeProcTimeT
 import org.apache.flink.table.planner.plan.utils.{ExpandTableScanShuttle, RexDefaultVisitor}
 import org.apache.flink.table.planner.utils.ShortcutUtils
 import org.apache.flink.table.types.logical.LogicalTypeRoot.{TIMESTAMP_WITHOUT_TIME_ZONE, TIMESTAMP_WITH_LOCAL_TIME_ZONE}
-import org.apache.flink.table.types.logical.utils.LogicalTypeChecks.{isProctimeAttribute}
+import org.apache.flink.table.types.logical.utils.LogicalTypeChecks.isProctimeAttribute
 import org.apache.flink.util.Preconditions.checkState
 
 import org.apache.calcite.plan.RelOptRule.{any, none, operand, some}
@@ -97,7 +97,7 @@ class LogicalCorrelateToJoinFromTemporalTableFunctionRule
           .getUnderlyingHistoryTable
         val rexBuilder = cluster.getRexBuilder
 
-        val flinkContext = ShortcutUtils.unwrapContext(call.getPlanner)
+        val flinkContext = ShortcutUtils.unwrapContext(call)
           .asInstanceOf[FlinkOptimizeContext]
         val relBuilder = flinkContext.getFlinkRelBuilder
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoLegacyTableSourceScanRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoLegacyTableSourceScanRule.scala
@@ -18,14 +18,15 @@
 
 package org.apache.flink.table.planner.plan.rules.logical
 
-import org.apache.flink.table.api.config.OptimizerConfigOptions
 import org.apache.flink.table.api.TableException
+import org.apache.flink.table.api.config.OptimizerConfigOptions
 import org.apache.flink.table.expressions.Expression
 import org.apache.flink.table.planner.calcite.FlinkContext
 import org.apache.flink.table.planner.expressions.converter.ExpressionConverter
 import org.apache.flink.table.planner.plan.schema.{FlinkPreparingTableBase, LegacyTableSourceTable}
 import org.apache.flink.table.planner.plan.stats.FlinkStatistic
 import org.apache.flink.table.planner.plan.utils.{FlinkRelOptUtil, FlinkRexUtil, RexNodeExtractor}
+import org.apache.flink.table.planner.utils.ShortcutUtils
 import org.apache.flink.table.sources.FilterableTableSource
 
 import org.apache.calcite.plan.RelOptRule.{none, operand}
@@ -48,8 +49,8 @@ class PushFilterIntoLegacyTableSourceScanRule extends RelOptRule(
   "PushFilterIntoLegacyTableSourceScanRule") {
 
   override def matches(call: RelOptRuleCall): Boolean = {
-    val config = call.getPlanner.getContext.unwrap(classOf[FlinkContext]).getTableConfig
-    if (!config.getConfiguration.getBoolean(
+    val config = ShortcutUtils.unwrapPlannerConfig(call)
+    if (!config.get(
       OptimizerConfigOptions.TABLE_OPTIMIZER_SOURCE_PREDICATE_PUSHDOWN_ENABLED)) {
       return false
     }
@@ -94,8 +95,7 @@ class PushFilterIntoLegacyTableSourceScanRule extends RelOptRule(
         relBuilder.getRexBuilder,
         context.getFunctionCatalog,
         context.getCatalogManager,
-        TimeZone.getTimeZone(scan.getCluster.getPlanner.getContext
-            .unwrap(classOf[FlinkContext]).getTableConfig.getLocalTimeZone))
+        TimeZone.getTimeZone(ShortcutUtils.unwrapTableConfig(scan).getLocalTimeZone))
 
     if (predicates.isEmpty) {
       // no condition can be translated to expression

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoLegacyTableSourceScanRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoLegacyTableSourceScanRule.scala
@@ -21,7 +21,6 @@ package org.apache.flink.table.planner.plan.rules.logical
 import org.apache.flink.table.api.TableException
 import org.apache.flink.table.api.config.OptimizerConfigOptions
 import org.apache.flink.table.expressions.Expression
-import org.apache.flink.table.planner.calcite.FlinkContext
 import org.apache.flink.table.planner.expressions.converter.ExpressionConverter
 import org.apache.flink.table.planner.plan.schema.{FlinkPreparingTableBase, LegacyTableSourceTable}
 import org.apache.flink.table.planner.plan.stats.FlinkStatistic
@@ -49,9 +48,9 @@ class PushFilterIntoLegacyTableSourceScanRule extends RelOptRule(
   "PushFilterIntoLegacyTableSourceScanRule") {
 
   override def matches(call: RelOptRuleCall): Boolean = {
-    val config = ShortcutUtils.unwrapPlannerConfig(call)
-    if (!config.get(
-      OptimizerConfigOptions.TABLE_OPTIMIZER_SOURCE_PREDICATE_PUSHDOWN_ENABLED)) {
+    val plannerConfig = ShortcutUtils.unwrapPlannerConfig(call)
+    if (!plannerConfig
+      .get(OptimizerConfigOptions.TABLE_OPTIMIZER_SOURCE_PREDICATE_PUSHDOWN_ENABLED)) {
       return false
     }
 
@@ -85,7 +84,7 @@ class PushFilterIntoLegacyTableSourceScanRule extends RelOptRule(
       relOptTable: FlinkPreparingTableBase): Unit = {
 
     val relBuilder = call.builder()
-    val context = call.getPlanner.getContext.unwrap(classOf[FlinkContext])
+    val context = ShortcutUtils.unwrapContext(call)
     val maxCnfNodeCount = FlinkRelOptUtil.getMaxCnfNodeCount(scan)
     val (predicates, unconvertedRexNodes) =
       RexNodeExtractor.extractConjunctiveConditions(

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/PushPartitionIntoLegacyTableSourceScanRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/PushPartitionIntoLegacyTableSourceScanRule.scala
@@ -23,12 +23,12 @@ import org.apache.flink.table.catalog.exceptions.PartitionNotExistException
 import org.apache.flink.table.catalog.{Catalog, CatalogPartitionSpec, ObjectIdentifier}
 import org.apache.flink.table.expressions.Expression
 import org.apache.flink.table.plan.stats.TableStats
-import org.apache.flink.table.planner.calcite.{FlinkContext, FlinkTypeFactory}
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.plan.schema.LegacyTableSourceTable
 import org.apache.flink.table.planner.plan.stats.FlinkStatistic
 import org.apache.flink.table.planner.plan.utils.{FlinkRelOptUtil, PartitionPruner, RexNodeExtractor, RexNodeToExpressionConverter}
-import org.apache.flink.table.planner.utils.CatalogTableStatisticsConverter
 import org.apache.flink.table.planner.utils.JavaScalaConversionUtil.toScala
+import org.apache.flink.table.planner.utils.{CatalogTableStatisticsConverter, ShortcutUtils}
 import org.apache.flink.table.sources.PartitionableTableSource
 
 import org.apache.calcite.plan.RelOptRule.{none, operand}
@@ -70,8 +70,8 @@ class PushPartitionIntoLegacyTableSourceScanRule extends RelOptRule(
   override def onMatch(call: RelOptRuleCall): Unit = {
     val filter: Filter = call.rel(0)
     val scan: LogicalTableScan = call.rel(1)
-    val context = call.getPlanner.getContext.unwrap(classOf[FlinkContext])
-    val config = context.getPlannerConfig.getTableConfig
+    val context = ShortcutUtils.unwrapContext(call)
+    val tableConfig = context.getPlannerConfig.getTableConfig
     val tableSourceTable = scan.getTable.unwrap(classOf[LegacyTableSourceTable[_]])
     val tableIdentifier = tableSourceTable.tableIdentifier
     val catalogOption = toScala(context.getCatalogManager.getCatalog(
@@ -132,7 +132,7 @@ class PushPartitionIntoLegacyTableSourceScanRule extends RelOptRule(
         partitionPredicate
       )
       PartitionPruner.prunePartitions(
-        config,
+        tableConfig,
         partitionFieldNames,
         partitionFieldTypes,
         allPartitions,
@@ -150,7 +150,7 @@ class PushPartitionIntoLegacyTableSourceScanRule extends RelOptRule(
               inputFields,
               context.getFunctionCatalog,
               context.getCatalogManager,
-              TimeZone.getTimeZone(config.getLocalTimeZone))
+              TimeZone.getTimeZone(tableConfig.getLocalTimeZone))
             def toExpressions: Option[Seq[Expression]] = {
               val expressions = new mutable.ArrayBuffer[Expression]()
               for (predicate <- partitionPredicates) {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/PushPartitionIntoLegacyTableSourceScanRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/PushPartitionIntoLegacyTableSourceScanRule.scala
@@ -71,7 +71,7 @@ class PushPartitionIntoLegacyTableSourceScanRule extends RelOptRule(
     val filter: Filter = call.rel(0)
     val scan: LogicalTableScan = call.rel(1)
     val context = call.getPlanner.getContext.unwrap(classOf[FlinkContext])
-    val config = context.getTableConfig
+    val config = context.getPlannerConfig.getTableConfig
     val tableSourceTable = scan.getTable.unwrap(classOf[LegacyTableSourceTable[_]])
     val tableIdentifier = tableSourceTable.tableIdentifier
     val catalogOption = toScala(context.getCatalogManager.getCatalog(

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/SplitAggregateRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/SplitAggregateRule.scala
@@ -125,10 +125,10 @@ class SplitAggregateRule extends RelOptRule(
   "SplitAggregateRule") {
 
   override def matches(call: RelOptRuleCall): Boolean = {
-    val tableConfig = ShortcutUtils.unwrapPlannerConfig(call).getTableConfig
+    val plannerConfig = ShortcutUtils.unwrapPlannerConfig(call)
     val agg: FlinkLogicalAggregate = call.rel(0)
 
-    val splitDistinctAggEnabled = tableConfig.getConfiguration.getBoolean(
+    val splitDistinctAggEnabled = plannerConfig.get(
       OptimizerConfigOptions.TABLE_OPTIMIZER_DISTINCT_AGG_SPLIT_ENABLED)
     val isAllAggSplittable = doAllAggSupportSplit(agg.getAggCallList)
 
@@ -146,7 +146,7 @@ class SplitAggregateRule extends RelOptRule(
   }
 
   override def onMatch(call: RelOptRuleCall): Unit = {
-    val tableConfig = ShortcutUtils.unwrapPlannerConfig(call).getTableConfig
+    val plannerConfig = ShortcutUtils.unwrapPlannerConfig(call)
     val originalAggregate: FlinkLogicalAggregate = call.rel(0)
     val aggCalls = originalAggregate.getAggCallList
     val input: FlinkRelNode = call.rel(1)
@@ -165,8 +165,8 @@ class SplitAggregateRule extends RelOptRule(
     }.distinct.diff(aggGroupSet).sorted.toArray
 
     val hashFieldsMap: util.Map[Int, Int] = new util.HashMap()
-    val buckets = tableConfig.getConfiguration.getInteger(
-      OptimizerConfigOptions.TABLE_OPTIMIZER_DISTINCT_AGG_SPLIT_BUCKET_NUM)
+    val buckets = plannerConfig
+      .get(OptimizerConfigOptions.TABLE_OPTIMIZER_DISTINCT_AGG_SPLIT_BUCKET_NUM)
 
     if (hashFieldIndexes.nonEmpty) {
       val projects = new util.ArrayList[RexNode](relBuilder.fields)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/SplitAggregateRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/SplitAggregateRule.scala
@@ -20,7 +20,7 @@ package org.apache.flink.table.planner.plan.rules.logical
 
 import org.apache.flink.table.api.TableException
 import org.apache.flink.table.api.config.OptimizerConfigOptions
-import org.apache.flink.table.planner.calcite.{FlinkContext, FlinkLogicalRelFactories, FlinkRelBuilder}
+import org.apache.flink.table.planner.calcite.{FlinkLogicalRelFactories, FlinkRelBuilder}
 import org.apache.flink.table.planner.functions.sql.{FlinkSqlOperatorTable, SqlFirstLastValueAggFunction}
 import org.apache.flink.table.planner.plan.PartialFinalType
 import org.apache.flink.table.planner.plan.metadata.FlinkRelMetadataQuery
@@ -28,7 +28,9 @@ import org.apache.flink.table.planner.plan.nodes.FlinkRelNode
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalAggregate
 import org.apache.flink.table.planner.plan.utils.AggregateUtil.doAllAggSupportSplit
 import org.apache.flink.table.planner.plan.utils.{AggregateUtil, ExpandUtil, WindowUtil}
+import org.apache.flink.table.planner.utils.ShortcutUtils
 
+import com.google.common.collect.ImmutableList
 import org.apache.calcite.plan.RelOptRule.{any, operand}
 import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall}
 import org.apache.calcite.rel.core.AggregateCall
@@ -37,8 +39,6 @@ import org.apache.calcite.sql.fun.SqlStdOperatorTable._
 import org.apache.calcite.sql.fun.{SqlMinMaxAggFunction, SqlStdOperatorTable}
 import org.apache.calcite.sql.{SqlAggFunction, SqlKind}
 import org.apache.calcite.util.{ImmutableBitSet, ImmutableIntList}
-
-import com.google.common.collect.ImmutableList
 
 import java.math.{BigDecimal => JBigDecimal}
 import java.util
@@ -125,7 +125,7 @@ class SplitAggregateRule extends RelOptRule(
   "SplitAggregateRule") {
 
   override def matches(call: RelOptRuleCall): Boolean = {
-    val tableConfig = call.getPlanner.getContext.unwrap(classOf[FlinkContext]).getTableConfig
+    val tableConfig = ShortcutUtils.unwrapPlannerConfig(call).getTableConfig
     val agg: FlinkLogicalAggregate = call.rel(0)
 
     val splitDistinctAggEnabled = tableConfig.getConfiguration.getBoolean(
@@ -146,7 +146,7 @@ class SplitAggregateRule extends RelOptRule(
   }
 
   override def onMatch(call: RelOptRuleCall): Unit = {
-    val tableConfig = call.getPlanner.getContext.unwrap(classOf[FlinkContext]).getTableConfig
+    val tableConfig = ShortcutUtils.unwrapPlannerConfig(call).getTableConfig
     val originalAggregate: FlinkLogicalAggregate = call.rel(0)
     val aggCalls = originalAggregate.getAggCallList
     val input: FlinkRelNode = call.rel(1)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalAggRuleBase.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalAggRuleBase.scala
@@ -17,7 +17,8 @@
  */
 package org.apache.flink.table.planner.plan.rules.physical.batch
 
-import org.apache.flink.table.api.{TableConfig, TableException}
+import org.apache.flink.configuration.ReadableConfig
+import org.apache.flink.table.api.TableException
 import org.apache.flink.table.data.binary.BinaryRowData
 import org.apache.flink.table.functions.{AggregateFunction, UserDefinedFunction}
 import org.apache.flink.table.planner.JArrayList
@@ -106,8 +107,8 @@ trait BatchPhysicalAggRuleBase {
 
   protected def isTwoPhaseAggWorkable(
       aggFunctions: Array[UserDefinedFunction],
-      tableConfig: TableConfig): Boolean = {
-    getAggPhaseStrategy(tableConfig) match {
+      plannerConfig: ReadableConfig): Boolean = {
+    getAggPhaseStrategy(plannerConfig) match {
       case AggregatePhaseStrategy.ONE_PHASE => false
       case _ => doAllSupportMerge(aggFunctions)
     }
@@ -116,8 +117,8 @@ trait BatchPhysicalAggRuleBase {
   protected def isOnePhaseAggWorkable(
       agg: Aggregate,
       aggFunctions: Array[UserDefinedFunction],
-      tableConfig: TableConfig): Boolean = {
-    getAggPhaseStrategy(tableConfig) match {
+      plannerConfig: ReadableConfig): Boolean = {
+    getAggPhaseStrategy(plannerConfig) match {
       case AggregatePhaseStrategy.ONE_PHASE => true
       case AggregatePhaseStrategy.TWO_PHASE => !doAllSupportMerge(aggFunctions)
       case AggregatePhaseStrategy.AUTO =>
@@ -142,12 +143,12 @@ trait BatchPhysicalAggRuleBase {
     aggFunctions.isEmpty || supportLocalAgg
   }
 
-  protected def isEnforceOnePhaseAgg(tableConfig: TableConfig): Boolean = {
-    getAggPhaseStrategy(tableConfig) == AggregatePhaseStrategy.ONE_PHASE
+  protected def isEnforceOnePhaseAgg(plannerConfig: ReadableConfig): Boolean = {
+    getAggPhaseStrategy(plannerConfig) == AggregatePhaseStrategy.ONE_PHASE
   }
 
-  protected def isEnforceTwoPhaseAgg(tableConfig: TableConfig): Boolean = {
-    getAggPhaseStrategy(tableConfig) == AggregatePhaseStrategy.TWO_PHASE
+  protected def isEnforceTwoPhaseAgg(plannerConfig: ReadableConfig): Boolean = {
+    getAggPhaseStrategy(plannerConfig) == AggregatePhaseStrategy.TWO_PHASE
   }
 
   protected def isAggBufferFixedLength(agg: Aggregate): Boolean = {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalHashAggRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalHashAggRule.scala
@@ -18,13 +18,14 @@
 package org.apache.flink.table.planner.plan.rules.physical.batch
 
 import org.apache.flink.table.api.config.OptimizerConfigOptions
-import org.apache.flink.table.planner.calcite.{FlinkContext, FlinkTypeFactory}
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.plan.`trait`.FlinkRelDistribution
 import org.apache.flink.table.planner.plan.nodes.FlinkConventions
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalAggregate
 import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchPhysicalHashAggregate
 import org.apache.flink.table.planner.plan.utils.PythonUtil.isPythonAggregate
 import org.apache.flink.table.planner.plan.utils.{AggregateUtil, OperatorType}
+import org.apache.flink.table.planner.utils.ShortcutUtils
 import org.apache.flink.table.planner.utils.TableConfigUtils.isOperatorDisabled
 
 import org.apache.calcite.plan.RelOptRule.{any, operand}
@@ -63,7 +64,7 @@ class BatchPhysicalHashAggRule
   with BatchPhysicalAggRuleBase {
 
   override def matches(call: RelOptRuleCall): Boolean = {
-    val tableConfig = call.getPlanner.getContext.unwrap(classOf[FlinkContext]).getTableConfig
+    val tableConfig = ShortcutUtils.unwrapPlannerConfig(call).getTableConfig
     if (isOperatorDisabled(tableConfig, OperatorType.HashAgg)) {
       return false
     }
@@ -74,7 +75,7 @@ class BatchPhysicalHashAggRule
   }
 
   override def onMatch(call: RelOptRuleCall): Unit = {
-    val tableConfig = call.getPlanner.getContext.unwrap(classOf[FlinkContext]).getTableConfig
+    val tableConfig = ShortcutUtils.unwrapPlannerConfig(call).getTableConfig
     val agg: FlinkLogicalAggregate = call.rel(0)
     val input: RelNode = call.rel(1)
     val inputRowType = input.getRowType

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalHashJoinRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalHashJoinRule.scala
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.planner.plan.rules.physical.batch
 
-import org.apache.flink.table.api.TableConfig
+import org.apache.flink.configuration.ReadableConfig
 import org.apache.flink.table.api.config.OptimizerConfigOptions
 import org.apache.flink.table.planner.JDouble
 import org.apache.flink.table.planner.plan.`trait`.FlinkRelDistribution
@@ -59,21 +59,21 @@ class BatchPhysicalHashJoinRule
       return false
     }
 
-    val tableConfig = ShortcutUtils.unwrapPlannerConfig(call).getTableConfig
-    val isShuffleHashJoinEnabled = !isOperatorDisabled(tableConfig, OperatorType.ShuffleHashJoin)
+    val plannerConfig = ShortcutUtils.unwrapPlannerConfig(call)
+    val isShuffleHashJoinEnabled = !isOperatorDisabled(plannerConfig, OperatorType.ShuffleHashJoin)
     val isBroadcastHashJoinEnabled = !isOperatorDisabled(
-      tableConfig, OperatorType.BroadcastHashJoin)
+      plannerConfig, OperatorType.BroadcastHashJoin)
 
     val leftSize = binaryRowRelNodeSize(join.getLeft)
     val rightSize = binaryRowRelNodeSize(join.getRight)
-    val (isBroadcast, _) = canBroadcast(join.getJoinType, leftSize, rightSize, tableConfig)
+    val (isBroadcast, _) = canBroadcast(join.getJoinType, leftSize, rightSize, plannerConfig)
 
     // TODO use shuffle hash join if isBroadcast is true and isBroadcastHashJoinEnabled is false ?
     if (isBroadcast) isBroadcastHashJoinEnabled else isShuffleHashJoinEnabled
   }
 
   override def onMatch(call: RelOptRuleCall): Unit = {
-    val tableConfig = ShortcutUtils.unwrapPlannerConfig(call).getTableConfig
+    val plannerConfig = ShortcutUtils.unwrapPlannerConfig(call)
     val join: Join = call.rel(0)
     val joinInfo = join.analyzeCondition
     val joinType = join.getJoinType
@@ -95,7 +95,7 @@ class BatchPhysicalHashJoinRule
     val leftSize = binaryRowRelNodeSize(left)
     val rightSize = binaryRowRelNodeSize(right)
 
-    val (isBroadcast, leftIsBroadcast) = canBroadcast(joinType, leftSize, rightSize, tableConfig)
+    val (isBroadcast, leftIsBroadcast) = canBroadcast(joinType, leftSize, rightSize, plannerConfig)
 
     val leftIsBuild = if (isBroadcast) {
       leftIsBroadcast
@@ -145,7 +145,7 @@ class BatchPhysicalHashJoinRule
         toHashTraitByColumns(joinInfo.rightKeys))
 
       // add more possibility to only shuffle by partial joinKeys, now only single one
-      val isShuffleByPartialKeyEnabled = tableConfig.getConfiguration.getBoolean(
+      val isShuffleByPartialKeyEnabled = plannerConfig.get(
         BatchPhysicalJoinRuleBase.TABLE_OPTIMIZER_SHUFFLE_BY_PARTIAL_KEY_ENABLED)
       if (isShuffleByPartialKeyEnabled && joinInfo.pairs().length > 1) {
         joinInfo.pairs().foreach { pair =>
@@ -172,13 +172,13 @@ class BatchPhysicalHashJoinRule
       joinType: JoinRelType,
       leftSize: JDouble,
       rightSize: JDouble,
-      tableConfig: TableConfig): (Boolean, Boolean) = {
+      plannerConfig: ReadableConfig): (Boolean, Boolean) = {
     // if leftSize or rightSize is unknown, cannot use broadcast
     if (leftSize == null || rightSize == null) {
       return (false, false)
     }
-    val threshold = tableConfig.getConfiguration.getLong(
-      OptimizerConfigOptions.TABLE_OPTIMIZER_BROADCAST_JOIN_THRESHOLD)
+    val threshold = plannerConfig
+      .get(OptimizerConfigOptions.TABLE_OPTIMIZER_BROADCAST_JOIN_THRESHOLD)
     joinType match {
       case JoinRelType.LEFT => (rightSize <= threshold, false)
       case JoinRelType.RIGHT => (leftSize <= threshold, true)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalHashJoinRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalHashJoinRule.scala
@@ -21,12 +21,12 @@ package org.apache.flink.table.planner.plan.rules.physical.batch
 import org.apache.flink.table.api.TableConfig
 import org.apache.flink.table.api.config.OptimizerConfigOptions
 import org.apache.flink.table.planner.JDouble
-import org.apache.flink.table.planner.calcite.FlinkContext
 import org.apache.flink.table.planner.plan.`trait`.FlinkRelDistribution
 import org.apache.flink.table.planner.plan.nodes.FlinkConventions
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalJoin
 import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchPhysicalHashJoin
 import org.apache.flink.table.planner.plan.utils.OperatorType
+import org.apache.flink.table.planner.utils.ShortcutUtils
 import org.apache.flink.table.planner.utils.TableConfigUtils.isOperatorDisabled
 
 import org.apache.calcite.plan.RelOptRule.{any, operand}
@@ -59,7 +59,7 @@ class BatchPhysicalHashJoinRule
       return false
     }
 
-    val tableConfig = call.getPlanner.getContext.unwrap(classOf[FlinkContext]).getTableConfig
+    val tableConfig = ShortcutUtils.unwrapPlannerConfig(call).getTableConfig
     val isShuffleHashJoinEnabled = !isOperatorDisabled(tableConfig, OperatorType.ShuffleHashJoin)
     val isBroadcastHashJoinEnabled = !isOperatorDisabled(
       tableConfig, OperatorType.BroadcastHashJoin)
@@ -73,7 +73,7 @@ class BatchPhysicalHashJoinRule
   }
 
   override def onMatch(call: RelOptRuleCall): Unit = {
-    val tableConfig = call.getPlanner.getContext.unwrap(classOf[FlinkContext]).getTableConfig
+    val tableConfig = ShortcutUtils.unwrapPlannerConfig(call).getTableConfig
     val join: Join = call.rel(0)
     val joinInfo = join.analyzeCondition
     val joinType = join.getJoinType

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalJoinRuleBase.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalJoinRuleBase.scala
@@ -23,7 +23,8 @@ import org.apache.flink.configuration.ConfigOption
 import org.apache.flink.configuration.ConfigOptions.key
 import org.apache.flink.table.planner.plan.nodes.FlinkConventions
 import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchPhysicalLocalHashAggregate
-import org.apache.flink.table.planner.plan.utils.{FlinkRelMdUtil, FlinkRelOptUtil}
+import org.apache.flink.table.planner.plan.utils.FlinkRelMdUtil
+import org.apache.flink.table.planner.utils.ShortcutUtils
 
 import org.apache.calcite.plan.RelOptRule
 import org.apache.calcite.rel.RelNode
@@ -54,9 +55,9 @@ trait BatchPhysicalJoinRuleBase {
   def chooseSemiBuildDistinct(
       buildRel: RelNode,
       distinctKeys: Seq[Int]): Boolean = {
-    val tableConfig = FlinkRelOptUtil.getTableConfigFromContext(buildRel)
+    val plannerConfig = ShortcutUtils.unwrapPlannerConfig(buildRel)
     val mq = buildRel.getCluster.getMetadataQuery
-    val ratioConf = tableConfig.getConfiguration.getDouble(
+    val ratioConf = plannerConfig.get(
       BatchPhysicalJoinRuleBase.TABLE_OPTIMIZER_SEMI_JOIN_BUILD_DISTINCT_NDV_RATIO)
     val inputRows = mq.getRowCount(buildRel)
     val ndvOfGroupKey = mq.getDistinctRowCount(

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalNestedLoopJoinRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalNestedLoopJoinRule.scala
@@ -41,8 +41,8 @@ class BatchPhysicalNestedLoopJoinRule
   with BatchPhysicalNestedLoopJoinRuleBase {
 
   override def matches(call: RelOptRuleCall): Boolean = {
-    val tableConfig = ShortcutUtils.unwrapPlannerConfig(call).getTableConfig
-    !isOperatorDisabled(tableConfig, OperatorType.NestedLoopJoin)
+    val plannerConfig = ShortcutUtils.unwrapPlannerConfig(call)
+    !isOperatorDisabled(plannerConfig, OperatorType.NestedLoopJoin)
   }
 
   override def onMatch(call: RelOptRuleCall): Unit = {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalNestedLoopJoinRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalNestedLoopJoinRule.scala
@@ -17,10 +17,10 @@
  */
 package org.apache.flink.table.planner.plan.rules.physical.batch
 
-import org.apache.flink.table.planner.calcite.FlinkContext
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalJoin
 import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchPhysicalNestedLoopJoin
 import org.apache.flink.table.planner.plan.utils.OperatorType
+import org.apache.flink.table.planner.utils.ShortcutUtils
 import org.apache.flink.table.planner.utils.TableConfigUtils.isOperatorDisabled
 
 import org.apache.calcite.plan.RelOptRule.{any, operand}
@@ -41,7 +41,7 @@ class BatchPhysicalNestedLoopJoinRule
   with BatchPhysicalNestedLoopJoinRuleBase {
 
   override def matches(call: RelOptRuleCall): Boolean = {
-    val tableConfig = call.getPlanner.getContext.unwrap(classOf[FlinkContext]).getTableConfig
+    val tableConfig = ShortcutUtils.unwrapPlannerConfig(call).getTableConfig
     !isOperatorDisabled(tableConfig, OperatorType.NestedLoopJoin)
   }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalSortAggRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalSortAggRule.scala
@@ -18,13 +18,14 @@
 package org.apache.flink.table.planner.plan.rules.physical.batch
 
 import org.apache.flink.table.api.config.OptimizerConfigOptions
-import org.apache.flink.table.planner.calcite.{FlinkContext, FlinkTypeFactory}
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.plan.`trait`.FlinkRelDistribution
 import org.apache.flink.table.planner.plan.nodes.FlinkConventions
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalAggregate
 import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchPhysicalSortAggregate
 import org.apache.flink.table.planner.plan.utils.PythonUtil.isPythonAggregate
 import org.apache.flink.table.planner.plan.utils.{AggregateUtil, OperatorType}
+import org.apache.flink.table.planner.utils.ShortcutUtils
 import org.apache.flink.table.planner.utils.TableConfigUtils.isOperatorDisabled
 
 import org.apache.calcite.plan.RelOptRule.{any, operand}
@@ -65,14 +66,14 @@ class BatchPhysicalSortAggRule
   with BatchPhysicalAggRuleBase {
 
   override def matches(call: RelOptRuleCall): Boolean = {
-    val tableConfig = call.getPlanner.getContext.unwrap(classOf[FlinkContext]).getTableConfig
+    val tableConfig = ShortcutUtils.unwrapPlannerConfig(call).getTableConfig
     val agg: FlinkLogicalAggregate = call.rel(0)
     !isOperatorDisabled(tableConfig, OperatorType.SortAgg) &&
       !agg.getAggCallList.exists(isPythonAggregate(_))
   }
 
   override def onMatch(call: RelOptRuleCall): Unit = {
-    val tableConfig = call.getPlanner.getContext.unwrap(classOf[FlinkContext]).getTableConfig
+    val tableConfig = ShortcutUtils.unwrapPlannerConfig(call).getTableConfig
     val agg: FlinkLogicalAggregate = call.rel(0)
     val input: RelNode = call.rel(1)
     val inputRowType = input.getRowType

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalSortMergeJoinRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalSortMergeJoinRule.scala
@@ -53,8 +53,8 @@ class BatchPhysicalSortMergeJoinRule
   override def matches(call: RelOptRuleCall): Boolean = {
     val join: Join = call.rel(0)
     val joinInfo = join.analyzeCondition
-    val tableConfig = ShortcutUtils.unwrapPlannerConfig(call).getTableConfig
-    val isSortMergeJoinEnabled = !isOperatorDisabled(tableConfig, OperatorType.SortMergeJoin)
+    val plannerConfig = ShortcutUtils.unwrapPlannerConfig(call)
+    val isSortMergeJoinEnabled = !isOperatorDisabled(plannerConfig, OperatorType.SortMergeJoin)
     !joinInfo.pairs().isEmpty && isSortMergeJoinEnabled
   }
 
@@ -108,8 +108,8 @@ class BatchPhysicalSortMergeJoinRule
       call.transformTo(newJoin)
     }
 
-    val tableConfig = ShortcutUtils.unwrapPlannerConfig(call).getTableConfig
-    val candidates = if (tableConfig.getConfiguration.getBoolean(
+    val plannerConfig = ShortcutUtils.unwrapPlannerConfig(call)
+    val candidates = if (plannerConfig.get(
       BatchPhysicalSortMergeJoinRule.TABLE_OPTIMIZER_SMJ_REMOVE_SORT_ENABLED)) {
       // add more possibility to remove redundant sort, and longer optimization time
       Array((false, false), (true, false), (false, true), (true, true))
@@ -127,7 +127,7 @@ class BatchPhysicalSortMergeJoinRule
     }
 
     // add more possibility to only shuffle by partial joinKeys, now only single one
-    val isShuffleByPartialKeyEnabled = tableConfig.getConfiguration.getBoolean(
+    val isShuffleByPartialKeyEnabled = plannerConfig.get(
       BatchPhysicalJoinRuleBase.TABLE_OPTIMIZER_SHUFFLE_BY_PARTIAL_KEY_ENABLED)
     if (isShuffleByPartialKeyEnabled && joinInfo.pairs().length > 1) {
       joinInfo.pairs().foreach { pair =>

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalSortMergeJoinRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalSortMergeJoinRule.scala
@@ -21,12 +21,12 @@ package org.apache.flink.table.planner.plan.rules.physical.batch
 import org.apache.flink.annotation.Experimental
 import org.apache.flink.configuration.ConfigOption
 import org.apache.flink.configuration.ConfigOptions.key
-import org.apache.flink.table.planner.calcite.FlinkContext
 import org.apache.flink.table.planner.plan.`trait`.FlinkRelDistribution
 import org.apache.flink.table.planner.plan.nodes.FlinkConventions
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalJoin
 import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchPhysicalSortMergeJoin
 import org.apache.flink.table.planner.plan.utils.{FlinkRelOptUtil, OperatorType}
+import org.apache.flink.table.planner.utils.ShortcutUtils
 import org.apache.flink.table.planner.utils.TableConfigUtils.isOperatorDisabled
 
 import org.apache.calcite.plan.RelOptRule.{any, operand}
@@ -53,7 +53,7 @@ class BatchPhysicalSortMergeJoinRule
   override def matches(call: RelOptRuleCall): Boolean = {
     val join: Join = call.rel(0)
     val joinInfo = join.analyzeCondition
-    val tableConfig = call.getPlanner.getContext.unwrap(classOf[FlinkContext]).getTableConfig
+    val tableConfig = ShortcutUtils.unwrapPlannerConfig(call).getTableConfig
     val isSortMergeJoinEnabled = !isOperatorDisabled(tableConfig, OperatorType.SortMergeJoin)
     !joinInfo.pairs().isEmpty && isSortMergeJoinEnabled
   }
@@ -108,7 +108,7 @@ class BatchPhysicalSortMergeJoinRule
       call.transformTo(newJoin)
     }
 
-    val tableConfig = call.getPlanner.getContext.unwrap(classOf[FlinkContext]).getTableConfig
+    val tableConfig = ShortcutUtils.unwrapPlannerConfig(call).getTableConfig
     val candidates = if (tableConfig.getConfiguration.getBoolean(
       BatchPhysicalSortMergeJoinRule.TABLE_OPTIMIZER_SMJ_REMOVE_SORT_ENABLED)) {
       // add more possibility to remove redundant sort, and longer optimization time

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalSortRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalSortRule.scala
@@ -21,11 +21,11 @@ package org.apache.flink.table.planner.plan.rules.physical.batch
 import org.apache.flink.annotation.Experimental
 import org.apache.flink.configuration.ConfigOption
 import org.apache.flink.configuration.ConfigOptions.key
-import org.apache.flink.table.planner.calcite.FlinkContext
 import org.apache.flink.table.planner.plan.`trait`.FlinkRelDistribution
 import org.apache.flink.table.planner.plan.nodes.FlinkConventions
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalSort
 import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchPhysicalSort
+import org.apache.flink.table.planner.utils.ShortcutUtils
 
 import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall}
 import org.apache.calcite.rel.RelNode
@@ -52,8 +52,8 @@ class BatchPhysicalSortRule extends ConverterRule(
   override def convert(rel: RelNode): RelNode = {
     val sort: FlinkLogicalSort = rel.asInstanceOf[FlinkLogicalSort]
     val input = sort.getInput
-    val config = sort.getCluster.getPlanner.getContext.unwrap(classOf[FlinkContext]).getTableConfig
-    val enableRangeSort = config.getConfiguration.getBoolean(
+    val plannerConfig = ShortcutUtils.unwrapPlannerConfig(sort)
+    val enableRangeSort = plannerConfig.get(
       BatchPhysicalSortRule.TABLE_EXEC_RANGE_SORT_ENABLED)
     val distribution = if (enableRangeSort) {
       FlinkRelDistribution.range(sort.getCollation.getFieldCollations)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalSortRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalSortRule.scala
@@ -53,8 +53,7 @@ class BatchPhysicalSortRule extends ConverterRule(
     val sort: FlinkLogicalSort = rel.asInstanceOf[FlinkLogicalSort]
     val input = sort.getInput
     val plannerConfig = ShortcutUtils.unwrapPlannerConfig(sort)
-    val enableRangeSort = plannerConfig.get(
-      BatchPhysicalSortRule.TABLE_EXEC_RANGE_SORT_ENABLED)
+    val enableRangeSort = plannerConfig.get(BatchPhysicalSortRule.TABLE_EXEC_RANGE_SORT_ENABLED)
     val distribution = if (enableRangeSort) {
       FlinkRelDistribution.range(sort.getCollation.getFieldCollations)
     } else {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/EnforceLocalAggRuleBase.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/EnforceLocalAggRuleBase.scala
@@ -22,8 +22,9 @@ import org.apache.flink.table.api.TableException
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.plan.`trait`.FlinkRelDistribution
 import org.apache.flink.table.planner.plan.nodes.FlinkConventions
-import org.apache.flink.table.planner.plan.nodes.physical.batch.{BatchPhysicalSortAggregate, BatchPhysicalExchange, BatchPhysicalExpand, BatchPhysicalGroupAggregateBase, BatchPhysicalHashAggregate}
-import org.apache.flink.table.planner.plan.utils.{AggregateUtil, FlinkRelOptUtil}
+import org.apache.flink.table.planner.plan.nodes.physical.batch.{BatchPhysicalExchange, BatchPhysicalExpand, BatchPhysicalGroupAggregateBase, BatchPhysicalHashAggregate, BatchPhysicalSortAggregate}
+import org.apache.flink.table.planner.plan.utils.AggregateUtil
+import org.apache.flink.table.planner.utils.ShortcutUtils
 
 import org.apache.calcite.plan.{RelOptRule, RelOptRuleOperand}
 import org.apache.calcite.rel.RelNode
@@ -46,9 +47,9 @@ abstract class EnforceLocalAggRuleBase(
   with BatchPhysicalAggRuleBase {
 
   protected def isTwoPhaseAggEnabled(agg: BatchPhysicalGroupAggregateBase): Boolean = {
-    val tableConfig = FlinkRelOptUtil.getTableConfigFromContext(agg)
+    val plannerConfig = ShortcutUtils.unwrapPlannerConfig(agg)
     val aggFunctions = agg.getAggCallToAggFunction.map(_._2).toArray
-    isTwoPhaseAggWorkable(aggFunctions, tableConfig)
+    isTwoPhaseAggWorkable(aggFunctions, plannerConfig)
   }
 
   protected def hasConstantShuffleKey(

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/IncrementalAggregateRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/IncrementalAggregateRule.scala
@@ -53,10 +53,10 @@ class IncrementalAggregateRule
     val finalLocalAgg: StreamPhysicalLocalGroupAggregate = call.rel(2)
     val partialGlobalAgg: StreamPhysicalGlobalGroupAggregate = call.rel(3)
 
-    val tableConfig = ShortcutUtils.unwrapPlannerConfig(call).getTableConfig
+    val plannerConfig = ShortcutUtils.unwrapPlannerConfig(call)
 
     // whether incremental aggregate is enabled
-    val incrementalAggEnabled = tableConfig.getConfiguration.getBoolean(
+    val incrementalAggEnabled = plannerConfig.get(
       IncrementalAggregateRule.TABLE_OPTIMIZER_INCREMENTAL_AGG_ENABLED)
 
     partialGlobalAgg.partialFinalType == PartialFinalType.PARTIAL &&

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/IncrementalAggregateRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/IncrementalAggregateRule.scala
@@ -20,10 +20,11 @@ package org.apache.flink.table.planner.plan.rules.physical.stream
 import org.apache.flink.annotation.Experimental
 import org.apache.flink.configuration.ConfigOption
 import org.apache.flink.configuration.ConfigOptions.key
-import org.apache.flink.table.planner.calcite.{FlinkContext, FlinkTypeFactory}
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.plan.PartialFinalType
 import org.apache.flink.table.planner.plan.nodes.physical.stream.{StreamPhysicalExchange, StreamPhysicalGlobalGroupAggregate, StreamPhysicalIncrementalGroupAggregate, StreamPhysicalLocalGroupAggregate}
 import org.apache.flink.table.planner.plan.utils.AggregateUtil
+import org.apache.flink.table.planner.utils.ShortcutUtils
 import org.apache.flink.util.Preconditions
 
 import org.apache.calcite.plan.RelOptRule.{any, operand}
@@ -52,7 +53,7 @@ class IncrementalAggregateRule
     val finalLocalAgg: StreamPhysicalLocalGroupAggregate = call.rel(2)
     val partialGlobalAgg: StreamPhysicalGlobalGroupAggregate = call.rel(3)
 
-    val tableConfig = call.getPlanner.getContext.unwrap(classOf[FlinkContext]).getTableConfig
+    val tableConfig = ShortcutUtils.unwrapPlannerConfig(call).getTableConfig
 
     // whether incremental aggregate is enabled
     val incrementalAggEnabled = tableConfig.getConfiguration.getBoolean(

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/MiniBatchIntervalInferRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/MiniBatchIntervalInferRule.scala
@@ -20,8 +20,9 @@ package org.apache.flink.table.planner.plan.rules.physical.stream
 
 import org.apache.flink.table.api.config.ExecutionConfigOptions
 import org.apache.flink.table.planner.plan.`trait`.{MiniBatchInterval, MiniBatchIntervalTrait, MiniBatchIntervalTraitDef, MiniBatchMode}
-import org.apache.flink.table.planner.plan.nodes.physical.stream.{StreamPhysicalGroupWindowAggregate, StreamPhysicalDataStreamScan, StreamPhysicalLegacyTableSourceScan, StreamPhysicalMiniBatchAssigner, StreamPhysicalRel, StreamPhysicalTableSourceScan, StreamPhysicalWatermarkAssigner}
+import org.apache.flink.table.planner.plan.nodes.physical.stream.{StreamPhysicalDataStreamScan, StreamPhysicalGroupWindowAggregate, StreamPhysicalLegacyTableSourceScan, StreamPhysicalMiniBatchAssigner, StreamPhysicalRel, StreamPhysicalTableSourceScan, StreamPhysicalWatermarkAssigner}
 import org.apache.flink.table.planner.plan.utils.FlinkRelOptUtil
+import org.apache.flink.table.planner.utils.ShortcutUtils
 
 import org.apache.calcite.plan.RelOptRule._
 import org.apache.calcite.plan.hep.HepRelVertex
@@ -63,9 +64,8 @@ class MiniBatchIntervalInferRule extends RelOptRule(
     val rel: StreamPhysicalRel = call.rel(0)
     val miniBatchIntervalTrait = rel.getTraitSet.getTrait(MiniBatchIntervalTraitDef.INSTANCE)
     val inputs = getInputs(rel)
-    val config = FlinkRelOptUtil.getTableConfigFromContext(rel)
-    val miniBatchEnabled = config.getConfiguration.getBoolean(
-      ExecutionConfigOptions.TABLE_EXEC_MINIBATCH_ENABLED)
+    val plannerConfig = ShortcutUtils.unwrapPlannerConfig(rel)
+    val miniBatchEnabled = plannerConfig.get(ExecutionConfigOptions.TABLE_EXEC_MINIBATCH_ENABLED)
 
     val updatedTrait = rel match {
       case _: StreamPhysicalGroupWindowAggregate =>

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalGroupWindowAggregateRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalGroupWindowAggregateRule.scala
@@ -19,7 +19,6 @@
 package org.apache.flink.table.planner.plan.rules.physical.stream
 
 import org.apache.flink.table.api.TableException
-import org.apache.flink.table.planner.calcite.FlinkContext
 import org.apache.flink.table.planner.plan.`trait`.FlinkRelDistribution
 import org.apache.flink.table.planner.plan.nodes.FlinkConventions
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalWindowAggregate
@@ -72,7 +71,7 @@ class StreamPhysicalGroupWindowAggregateRule
     val providedTraitSet = rel.getTraitSet.replace(FlinkConventions.STREAM_PHYSICAL)
     val newInput: RelNode = RelOptRule.convert(input, requiredTraitSet)
 
-    val config = ShortcutUtils.unwrapTableConfig(rel)
+    val config = ShortcutUtils.unwrapPlannerConfig(rel)
     val emitStrategy = WindowEmitStrategy(config, agg.getWindow)
 
     new StreamPhysicalGroupWindowAggregate(

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalGroupWindowAggregateRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalGroupWindowAggregateRule.scala
@@ -71,8 +71,8 @@ class StreamPhysicalGroupWindowAggregateRule
     val providedTraitSet = rel.getTraitSet.replace(FlinkConventions.STREAM_PHYSICAL)
     val newInput: RelNode = RelOptRule.convert(input, requiredTraitSet)
 
-    val config = ShortcutUtils.unwrapPlannerConfig(rel)
-    val emitStrategy = WindowEmitStrategy(config, agg.getWindow)
+    val plannerConfig = ShortcutUtils.unwrapPlannerConfig(rel)
+    val emitStrategy = WindowEmitStrategy(plannerConfig, agg.getWindow)
 
     new StreamPhysicalGroupWindowAggregate(
       cluster,

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalGroupWindowTableAggregateRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalGroupWindowTableAggregateRule.scala
@@ -70,7 +70,7 @@ class StreamPhysicalGroupWindowTableAggregateRule
     val providedTraitSet = rel.getTraitSet.replace(FlinkConventions.STREAM_PHYSICAL)
     val newInput: RelNode = RelOptRule.convert(input, requiredTraitSet)
 
-    val config = ShortcutUtils.unwrapTableConfig(rel)
+    val config = ShortcutUtils.unwrapPlannerConfig(rel)
     val emitStrategy = WindowEmitStrategy(config, agg.getWindow)
 
     new StreamPhysicalGroupWindowTableAggregate(

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalGroupWindowTableAggregateRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalGroupWindowTableAggregateRule.scala
@@ -70,8 +70,8 @@ class StreamPhysicalGroupWindowTableAggregateRule
     val providedTraitSet = rel.getTraitSet.replace(FlinkConventions.STREAM_PHYSICAL)
     val newInput: RelNode = RelOptRule.convert(input, requiredTraitSet)
 
-    val config = ShortcutUtils.unwrapPlannerConfig(rel)
-    val emitStrategy = WindowEmitStrategy(config, agg.getWindow)
+    val plannerConfig = ShortcutUtils.unwrapPlannerConfig(rel)
+    val emitStrategy = WindowEmitStrategy(plannerConfig, agg.getWindow)
 
     new StreamPhysicalGroupWindowTableAggregate(
       cluster,

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalJoinRuleBase.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalJoinRuleBase.scala
@@ -19,12 +19,14 @@
 package org.apache.flink.table.planner.plan.rules.physical.stream
 
 import org.apache.flink.table.planner.plan.`trait`.FlinkRelDistribution
-import org.apache.flink.table.planner.plan.nodes.{FlinkConventions, FlinkRelNode}
 import org.apache.flink.table.planner.plan.nodes.exec.spec.IntervalJoinSpec.WindowBounds
 import org.apache.flink.table.planner.plan.nodes.logical.{FlinkLogicalJoin, FlinkLogicalRel}
-import org.apache.flink.table.planner.plan.utils.{FlinkRelOptUtil, IntervalJoinUtil}
-import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall, RelTraitSet}
+import org.apache.flink.table.planner.plan.nodes.{FlinkConventions, FlinkRelNode}
+import org.apache.flink.table.planner.plan.utils.IntervalJoinUtil
+import org.apache.flink.table.planner.utils.ShortcutUtils
+
 import org.apache.calcite.plan.RelOptRule.{any, operand}
+import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall, RelTraitSet}
 import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rex.RexNode
 
@@ -43,7 +45,7 @@ abstract class StreamPhysicalJoinRuleBase(description: String)
 
   protected def extractWindowBounds(join: FlinkLogicalJoin):
     (Option[WindowBounds], Option[RexNode]) = {
-    val tableConfig = FlinkRelOptUtil.getTableConfigFromContext(join)
+    val tableConfig = ShortcutUtils.unwrapTableConfig(join)
     IntervalJoinUtil.extractWindowBoundsFromPredicate(
       join.getCondition,
       join.getLeft.getRowType.getFieldCount,

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalTableSourceScanRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalTableSourceScanRule.scala
@@ -63,7 +63,7 @@ class StreamPhysicalTableSourceScanRule
   def convert(rel: RelNode): RelNode = {
     val scan = rel.asInstanceOf[FlinkLogicalTableSourceScan]
     val traitSet: RelTraitSet = rel.getTraitSet.replace(FlinkConventions.STREAM_PHYSICAL)
-    val config = ShortcutUtils.unwrapTableConfig(rel)
+    val plannerConfig = ShortcutUtils.unwrapPlannerConfig(rel)
     val table = scan.getTable.asInstanceOf[TableSourceTable]
 
     val newScan = new StreamPhysicalTableSourceScan(
@@ -74,7 +74,7 @@ class StreamPhysicalTableSourceScanRule
     val resolvedSchema = table.contextResolvedTable.getResolvedSchema
 
     if (isUpsertSource(resolvedSchema, table.tableSource) ||
-        isSourceChangeEventsDuplicate(resolvedSchema, table.tableSource, config)) {
+        isSourceChangeEventsDuplicate(resolvedSchema, table.tableSource, plannerConfig)) {
       // generate changelog normalize node
       // primary key has been validated in CatalogSourceTable
       val primaryKey = resolvedSchema.getPrimaryKey.get()

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalTableSourceScanRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalTableSourceScanRule.scala
@@ -19,13 +19,13 @@
 package org.apache.flink.table.planner.plan.rules.physical.stream
 
 import org.apache.flink.table.connector.source.ScanTableSource
+import org.apache.flink.table.planner.connectors.DynamicSourceUtils.{isSourceChangeEventsDuplicate, isUpsertSource}
 import org.apache.flink.table.planner.plan.`trait`.FlinkRelDistribution
 import org.apache.flink.table.planner.plan.nodes.FlinkConventions
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalTableSourceScan
 import org.apache.flink.table.planner.plan.nodes.physical.stream.{StreamPhysicalChangelogNormalize, StreamPhysicalTableSourceScan}
 import org.apache.flink.table.planner.plan.schema.TableSourceTable
 import org.apache.flink.table.planner.plan.utils.ScanUtil
-import org.apache.flink.table.planner.connectors.DynamicSourceUtils.{isSourceChangeEventsDuplicate, isUpsertSource}
 import org.apache.flink.table.planner.utils.ShortcutUtils
 
 import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall, RelTraitSet}
@@ -63,7 +63,7 @@ class StreamPhysicalTableSourceScanRule
   def convert(rel: RelNode): RelNode = {
     val scan = rel.asInstanceOf[FlinkLogicalTableSourceScan]
     val traitSet: RelTraitSet = rel.getTraitSet.replace(FlinkConventions.STREAM_PHYSICAL)
-    val config = ShortcutUtils.unwrapContext(rel.getCluster).getTableConfig
+    val config = ShortcutUtils.unwrapTableConfig(rel)
     val table = scan.getTable.asInstanceOf[TableSourceTable]
 
     val newScan = new StreamPhysicalTableSourceScan(

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/TwoStageOptimizedAggregateRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/TwoStageOptimizedAggregateRule.scala
@@ -19,15 +19,15 @@
 package org.apache.flink.table.planner.plan.rules.physical.stream
 
 import org.apache.flink.table.api.config.ExecutionConfigOptions
-import org.apache.flink.table.planner.calcite.{FlinkContext, FlinkTypeFactory}
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.plan.`trait`.{FlinkRelDistribution, FlinkRelDistributionTraitDef, ModifyKindSetTrait, UpdateKindTrait}
 import org.apache.flink.table.planner.plan.metadata.FlinkRelMetadataQuery
 import org.apache.flink.table.planner.plan.nodes.FlinkConventions
 import org.apache.flink.table.planner.plan.nodes.physical.stream._
 import org.apache.flink.table.planner.plan.rules.physical.FlinkExpandConversionRule._
 import org.apache.flink.table.planner.plan.utils.{AggregateUtil, ChangelogPlanUtils}
-import org.apache.flink.table.planner.utils.AggregatePhaseStrategy
 import org.apache.flink.table.planner.utils.TableConfigUtils.getAggPhaseStrategy
+import org.apache.flink.table.planner.utils.{AggregatePhaseStrategy, ShortcutUtils}
 
 import org.apache.calcite.plan.RelOptRule.{any, operand}
 import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall}
@@ -58,7 +58,7 @@ class TwoStageOptimizedAggregateRule extends RelOptRule(
   "TwoStageOptimizedAggregateRule") {
 
   override def matches(call: RelOptRuleCall): Boolean = {
-    val tableConfig = call.getPlanner.getContext.unwrap(classOf[FlinkContext]).getTableConfig
+    val tableConfig = ShortcutUtils.unwrapPlannerConfig(call).getTableConfig
     val agg: StreamPhysicalGroupAggregate = call.rel(0)
     val realInput: RelNode = call.rel(2)
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/TwoStageOptimizedAggregateRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/TwoStageOptimizedAggregateRule.scala
@@ -58,7 +58,7 @@ class TwoStageOptimizedAggregateRule extends RelOptRule(
   "TwoStageOptimizedAggregateRule") {
 
   override def matches(call: RelOptRuleCall): Boolean = {
-    val tableConfig = ShortcutUtils.unwrapPlannerConfig(call).getTableConfig
+    val plannerConfig = ShortcutUtils.unwrapPlannerConfig(call)
     val agg: StreamPhysicalGroupAggregate = call.rel(0)
     val realInput: RelNode = call.rel(2)
 
@@ -76,9 +76,8 @@ class TwoStageOptimizedAggregateRule extends RelOptRule(
       needRetraction,
       isStateBackendDataViews = true)
 
-    val isMiniBatchEnabled = tableConfig.getConfiguration.getBoolean(
-      ExecutionConfigOptions.TABLE_EXEC_MINIBATCH_ENABLED)
-    val isTwoPhaseEnabled = getAggPhaseStrategy(tableConfig) != AggregatePhaseStrategy.ONE_PHASE
+    val isMiniBatchEnabled = plannerConfig.get(ExecutionConfigOptions.TABLE_EXEC_MINIBATCH_ENABLED)
+    val isTwoPhaseEnabled = getAggPhaseStrategy(plannerConfig) != AggregatePhaseStrategy.ONE_PHASE
 
     isMiniBatchEnabled && isTwoPhaseEnabled &&
       AggregateUtil.doAllSupportPartialMerge(aggInfoList.aggInfos) &&

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/schema/LegacyCatalogSourceTable.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/schema/LegacyCatalogSourceTable.scala
@@ -23,7 +23,7 @@ import org.apache.flink.table.api.TableColumn.ComputedColumn
 import org.apache.flink.table.api.config.TableConfigOptions
 import org.apache.flink.table.api.{TableException, ValidationException}
 import org.apache.flink.table.catalog.CatalogTable
-import org.apache.flink.table.factories.{TableFactoryUtil, TableSourceFactory, TableSourceFactoryContextImpl}
+import org.apache.flink.table.factories.TableFactoryUtil
 import org.apache.flink.table.planner.JMap
 import org.apache.flink.table.planner.calcite.{FlinkContext, FlinkRelBuilder, FlinkTypeFactory}
 import org.apache.flink.table.planner.catalog.CatalogSchemaTable
@@ -81,11 +81,11 @@ class LegacyCatalogSourceTable[T](
       .unwrap(classOf[FlinkContext])
     val typeFactory = cluster.getTypeFactory.asInstanceOf[FlinkTypeFactory]
 
-    val conf = flinkContext.getTableConfig.getConfiguration
+    val conf = flinkContext.getPlannerConfig
 
     val hintedOptions = FlinkHints.getHintedOptions(context.getTableHints)
     if (hintedOptions.nonEmpty
-      && !conf.getBoolean(TableConfigOptions.TABLE_DYNAMIC_TABLE_OPTIONS_ENABLED)) {
+      && !conf.get(TableConfigOptions.TABLE_DYNAMIC_TABLE_OPTIONS_ENABLED)) {
       throw new ValidationException(s"${FlinkHints.HINT_NAME_OPTIONS} hint is allowed only when "
         + s"${TableConfigOptions.TABLE_DYNAMIC_TABLE_OPTIONS_ENABLED.key} "
         + s"is set to true")

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/AggregateUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/AggregateUtil.scala
@@ -1034,8 +1034,8 @@ object AggregateUtil extends Enumeration {
   /**
     * Creates a MiniBatch trigger depends on the config.
     */
-  def createMiniBatchTrigger(config: ReadableConfig): CountBundleTrigger[RowData] = {
-    val size = config.get(ExecutionConfigOptions.TABLE_EXEC_MINIBATCH_SIZE)
+  def createMiniBatchTrigger(plannerConfig: ReadableConfig): CountBundleTrigger[RowData] = {
+    val size = plannerConfig.get(ExecutionConfigOptions.TABLE_EXEC_MINIBATCH_SIZE)
     if (size <= 0) {
       throw new IllegalArgumentException(
         ExecutionConfigOptions.TABLE_EXEC_MINIBATCH_SIZE + " must be > 0.")

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/FlinkRelOptUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/FlinkRelOptUtil.scala
@@ -18,7 +18,6 @@
 package org.apache.flink.table.planner.plan.utils
 
 import org.apache.commons.math3.util.ArithmeticUtils
-import org.apache.flink.table.api.TableConfig
 import org.apache.flink.table.planner.JBoolean
 import org.apache.flink.table.planner.calcite.{FlinkPlannerImpl, FlinkTypeFactory}
 import org.apache.flink.table.planner.plan.`trait`.{MiniBatchInterval, MiniBatchMode}
@@ -195,14 +194,9 @@ object FlinkRelOptUtil {
     new RelFieldCollation(fieldIndex, direction, nullDirection)
   }
 
-  def getTableConfigFromContext(rel: RelNode): TableConfig = {
-    ShortcutUtils.unwrapTableConfig(rel)
-  }
-
   /** Get max cnf node limit by context of rel */
   def getMaxCnfNodeCount(rel: RelNode): Int = {
-    val tableConfig = getTableConfigFromContext(rel)
-    tableConfig.getConfiguration.getInteger(FlinkRexUtil.TABLE_OPTIMIZER_CNF_NODES_LIMIT)
+    ShortcutUtils.unwrapPlannerConfig(rel).get(FlinkRexUtil.TABLE_OPTIMIZER_CNF_NODES_LIMIT)
   }
 
   /**

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/FlinkRelOptUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/FlinkRelOptUtil.scala
@@ -17,10 +17,12 @@
  */
 package org.apache.flink.table.planner.plan.utils
 
+import org.apache.commons.math3.util.ArithmeticUtils
 import org.apache.flink.table.api.TableConfig
 import org.apache.flink.table.planner.JBoolean
-import org.apache.flink.table.planner.calcite.{FlinkContext, FlinkPlannerImpl, FlinkTypeFactory}
+import org.apache.flink.table.planner.calcite.{FlinkPlannerImpl, FlinkTypeFactory}
 import org.apache.flink.table.planner.plan.`trait`.{MiniBatchInterval, MiniBatchMode}
+import org.apache.flink.table.planner.utils.ShortcutUtils
 
 import org.apache.calcite.config.NullCollation
 import org.apache.calcite.plan.RelOptUtil
@@ -30,7 +32,6 @@ import org.apache.calcite.rex.{RexBuilder, RexCall, RexInputRef, RexLiteral, Rex
 import org.apache.calcite.sql.SqlExplainLevel
 import org.apache.calcite.sql.SqlKind._
 import org.apache.calcite.sql.`type`.SqlTypeName._
-import org.apache.commons.math3.util.ArithmeticUtils
 
 import java.io.{PrintWriter, StringWriter}
 import java.math.BigDecimal
@@ -195,7 +196,7 @@ object FlinkRelOptUtil {
   }
 
   def getTableConfigFromContext(rel: RelNode): TableConfig = {
-    rel.getCluster.getPlanner.getContext.unwrap(classOf[FlinkContext]).getTableConfig
+    ShortcutUtils.unwrapTableConfig(rel)
   }
 
   /** Get max cnf node limit by context of rel */

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/IntervalJoinUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/IntervalJoinUtil.scala
@@ -25,15 +25,16 @@ import org.apache.flink.table.planner.functions.sql.FlinkSqlOperatorTable
 import org.apache.flink.table.planner.plan.nodes.exec.spec.IntervalJoinSpec.WindowBounds
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalJoin
 import org.apache.flink.table.planner.plan.schema.TimeIndicatorRelDataType
+import org.apache.flink.table.planner.utils.ShortcutUtils
 
 import org.apache.calcite.plan.RelOptUtil
-import org.apache.calcite.sql.`type`.SqlTypeName
-import org.apache.calcite.sql.fun.SqlStdOperatorTable
-import org.apache.calcite.sql.validate.SqlValidatorUtil
 import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rex._
 import org.apache.calcite.sql.SqlKind
+import org.apache.calcite.sql.`type`.SqlTypeName
+import org.apache.calcite.sql.fun.SqlStdOperatorTable
+import org.apache.calcite.sql.validate.SqlValidatorUtil
 
 import java.util
 
@@ -62,7 +63,7 @@ object IntervalJoinUtil {
     * @param  leftLogicalFieldCnt number of attributes on the left join input
     * @param  joinRowType         row type of the join result
     * @param  rexBuilder          RexBuilder
-    * @param  config              TableConfig
+    * @param  tableConfig         TableConfig
     * @return A Tuple2 of extracted window bounds and remaining predicates.
     */
   private[flink] def extractWindowBoundsFromPredicate(
@@ -468,7 +469,7 @@ object IntervalJoinUtil {
       join.getCluster.getTypeFactory,
       null,
       join.getSystemFieldList)
-    val tableConfig = FlinkRelOptUtil.getTableConfigFromContext(join)
+    val tableConfig = ShortcutUtils.unwrapTableConfig(join)
     val (windowBounds, _) = extractWindowBoundsFromPredicate(
       join.getCondition,
       newLeft.getRowType.getFieldCount,
@@ -479,7 +480,7 @@ object IntervalJoinUtil {
   }
 
   def extractWindowBounds(join: FlinkLogicalJoin): (Option[WindowBounds], Option[RexNode]) = {
-    val tableConfig = FlinkRelOptUtil.getTableConfigFromContext(join)
+    val tableConfig = ShortcutUtils.unwrapTableConfig(join)
     extractWindowBoundsFromPredicate(
       join.getCondition,
       join.getLeft.getRowType.getFieldCount,

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/WindowEmitStrategy.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/WindowEmitStrategy.scala
@@ -141,16 +141,16 @@ class WindowEmitStrategy(
 }
 
 object WindowEmitStrategy {
-  def apply(config: ReadableConfig, window: LogicalWindow): WindowEmitStrategy = {
+  def apply(plannerConfig: ReadableConfig, window: LogicalWindow): WindowEmitStrategy = {
     val isEventTime = isRowtimeAttribute(window.timeAttribute)
     val isSessionWindow = window.isInstanceOf[SessionGroupWindow]
 
-    val allowLateness = parseAllowLateness(isSessionWindow, config)
-    val enableEarlyFireDelay = config.get(TABLE_EXEC_EMIT_EARLY_FIRE_ENABLED)
-    val earlyFireDelay: Duration = config.getOptional(TABLE_EXEC_EMIT_EARLY_FIRE_DELAY)
+    val allowLateness = parseAllowLateness(isSessionWindow, plannerConfig)
+    val enableEarlyFireDelay = plannerConfig.get(TABLE_EXEC_EMIT_EARLY_FIRE_ENABLED)
+    val earlyFireDelay: Duration = plannerConfig.getOptional(TABLE_EXEC_EMIT_EARLY_FIRE_DELAY)
       .orElse(null)
-    val enableLateFireDelay = config.get(TABLE_EXEC_EMIT_LATE_FIRE_ENABLED)
-    val lateFireDelay: Duration = config.getOptional(TABLE_EXEC_EMIT_LATE_FIRE_DELAY)
+    val enableLateFireDelay = plannerConfig.get(TABLE_EXEC_EMIT_LATE_FIRE_ENABLED)
+    val lateFireDelay: Duration = plannerConfig.getOptional(TABLE_EXEC_EMIT_LATE_FIRE_DELAY)
       .orElse(null)
       new WindowEmitStrategy(
       isEventTime,
@@ -164,9 +164,9 @@ object WindowEmitStrategy {
 
   private def parseAllowLateness(
       isSessionWindow: Boolean,
-      config: ReadableConfig): Long = {
-    val enableLateFireDelay = config.get(TABLE_EXEC_EMIT_LATE_FIRE_ENABLED)
-    val emitAllowLateness: Duration = config.getOptional(TABLE_EXEC_EMIT_ALLOW_LATENESS)
+      plannerConfig: ReadableConfig): Long = {
+    val enableLateFireDelay = plannerConfig.get(TABLE_EXEC_EMIT_LATE_FIRE_ENABLED)
+    val emitAllowLateness: Duration = plannerConfig.getOptional(TABLE_EXEC_EMIT_ALLOW_LATENESS)
       .orElse(null)
     if (isSessionWindow) {
       // ignore allow lateness in session window because retraction is not supported
@@ -177,12 +177,12 @@ object WindowEmitStrategy {
     } else if (emitAllowLateness != null) {
       // return emit allow-lateness if it is set
       emitAllowLateness.toMillis
-    } else if (config.get(IDLE_STATE_RETENTION).toMillis < 0) {
+    } else if (plannerConfig.get(IDLE_STATE_RETENTION).toMillis < 0) {
       // min idle state retention time is not set, use 0L as default which means not allow lateness
       0L
     } else {
       // use min idle state retention time as allow lateness
-      config.get(IDLE_STATE_RETENTION).toMillis
+      plannerConfig.get(IDLE_STATE_RETENTION).toMillis
     }
   }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/WindowUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/WindowUtil.scala
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.planner.plan.utils
 
-import org.apache.flink.table.api.{DataTypes, TableConfig, TableException, ValidationException}
+import org.apache.flink.table.api.{DataTypes, TableException, ValidationException}
 import org.apache.flink.table.planner.JBigDecimal
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.functions.sql.{FlinkSqlOperatorTable, SqlWindowTableFunction}
@@ -28,11 +28,13 @@ import org.apache.flink.table.planner.plan.metadata.FlinkRelMetadataQuery
 import org.apache.flink.table.planner.plan.utils.AggregateUtil.inferAggAccumulatorNames
 import org.apache.flink.table.planner.plan.utils.WindowEmitStrategy.{TABLE_EXEC_EMIT_EARLY_FIRE_ENABLED, TABLE_EXEC_EMIT_LATE_FIRE_ENABLED}
 import org.apache.flink.table.planner.typeutils.RowTypeUtils
+import org.apache.flink.table.planner.utils.ShortcutUtils
 import org.apache.flink.table.runtime.groupwindow._
 import org.apache.flink.table.runtime.types.LogicalTypeDataTypeConverter.fromDataTypeToLogicalType
 import org.apache.flink.table.types.logical.TimestampType
 import org.apache.flink.table.types.logical.utils.LogicalTypeChecks.canBeTimeAttributeType
 
+import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.core.{Aggregate, AggregateCall, Calc}
 import org.apache.calcite.rex._
@@ -253,10 +255,10 @@ object WindowUtil {
    * Window TVF based aggregations don't support early-fire and late-fire,
    * throws exception when the configurations are set.
    */
-  def checkEmitConfiguration(tableConfig: TableConfig): Unit = {
-    val conf = tableConfig.getConfiguration
-    if (conf.getBoolean(TABLE_EXEC_EMIT_EARLY_FIRE_ENABLED) ||
-      conf.getBoolean(TABLE_EXEC_EMIT_LATE_FIRE_ENABLED)) {
+  def checkEmitConfiguration(relNode: RelNode): Unit = {
+    val plannerConfig = ShortcutUtils.unwrapPlannerConfig(relNode)
+    if (plannerConfig.get(TABLE_EXEC_EMIT_EARLY_FIRE_ENABLED) ||
+      plannerConfig.get(TABLE_EXEC_EMIT_LATE_FIRE_ENABLED)) {
       throw new TableException("Currently, window table function based aggregate doesn't " +
         s"support early-fire and late-fire configuration " +
         s"'${TABLE_EXEC_EMIT_EARLY_FIRE_ENABLED.key()}' and " +

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/delegation/ParserImplTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/delegation/ParserImplTest.java
@@ -20,28 +20,19 @@ package org.apache.flink.table.planner.delegation;
 
 import org.apache.flink.table.api.SqlParserEOFException;
 import org.apache.flink.table.api.SqlParserException;
-import org.apache.flink.table.api.TableConfig;
-import org.apache.flink.table.catalog.Catalog;
-import org.apache.flink.table.catalog.CatalogManager;
-import org.apache.flink.table.catalog.FunctionCatalog;
-import org.apache.flink.table.catalog.GenericInMemoryCatalog;
 import org.apache.flink.table.delegation.Parser;
-import org.apache.flink.table.module.ModuleManager;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.planner.calcite.FlinkPlannerImpl;
-import org.apache.flink.table.planner.catalog.CatalogManagerCalciteSchema;
-import org.apache.flink.table.utils.CatalogManagerMocks;
+import org.apache.flink.table.planner.utils.PlannerMocks;
 
 import org.junit.Test;
 
 import javax.annotation.Nullable;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Supplier;
 
-import static org.apache.calcite.jdbc.CalciteSchemaBuilder.asRootSchema;
 import static org.apache.flink.core.testutils.CommonTestUtils.assertThrows;
 import static org.apache.flink.table.planner.delegation.ParserImplTest.TestSpec.forStatement;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -51,36 +42,16 @@ import static org.junit.Assert.assertEquals;
 /** Test for {@link ParserImpl}. */
 public class ParserImplTest {
 
-    private final boolean isStreamingMode = false;
-    private final TableConfig tableConfig = new TableConfig();
-    private final Catalog catalog = new GenericInMemoryCatalog("MockCatalog", "default");
-    private final CatalogManager catalogManager =
-            CatalogManagerMocks.preparedCatalogManager().defaultCatalog("builtin", catalog).build();
-    private final ModuleManager moduleManager = new ModuleManager();
-    private final FunctionCatalog functionCatalog =
-            new FunctionCatalog(tableConfig, catalogManager, moduleManager);
-    private final PlannerContext plannerContext =
-            new PlannerContext(
-                    !isStreamingMode,
-                    tableConfig,
-                    moduleManager,
-                    functionCatalog,
-                    catalogManager,
-                    asRootSchema(new CatalogManagerCalciteSchema(catalogManager, isStreamingMode)),
-                    new ArrayList<>());
+    private final PlannerMocks plannerMocks = PlannerMocks.create(true);
 
-    private final Supplier<FlinkPlannerImpl> plannerSupplier =
-            () ->
-                    plannerContext.createFlinkPlanner(
-                            catalogManager.getCurrentCatalog(),
-                            catalogManager.getCurrentDatabase());
+    private final Supplier<FlinkPlannerImpl> plannerSupplier = plannerMocks::getPlanner;
 
     private final Parser parser =
             new ParserImpl(
-                    catalogManager,
+                    plannerMocks.getCatalogManager(),
                     plannerSupplier,
                     () -> plannerSupplier.get().parser(),
-                    plannerContext.getSqlExprToRexConverterFactory());
+                    plannerMocks.getPlannerContext().getSqlExprToRexConverterFactory());
 
     private static final List<TestSpec> TEST_SPECS =
             Arrays.asList(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/expressions/TypeConversionsTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/expressions/TypeConversionsTest.java
@@ -35,31 +35,31 @@ import static org.apache.flink.table.api.Expressions.lit;
 public class TypeConversionsTest extends ScalarOperatorsTestBase {
     @Test
     public void testTimestampWithLocalTimeZoneToString() {
-        config().setLocalTimeZone(ZoneOffset.ofHours(2));
+        tableConfig().setLocalTimeZone(ZoneOffset.ofHours(2));
         testTableApi(lit(Instant.EPOCH).cast(DataTypes.STRING()), "1970-01-01 02:00:00");
     }
 
     @Test
     public void testTimestampWithLocalTimeZoneToDate() {
-        config().setLocalTimeZone(ZoneOffset.ofHours(4));
+        tableConfig().setLocalTimeZone(ZoneOffset.ofHours(4));
         testTableApi(lit(Instant.EPOCH).cast(DataTypes.DATE()), "1970-01-01");
     }
 
     @Test
     public void testTimestampWithLocalTimeZoneToTime() {
-        config().setLocalTimeZone(ZoneOffset.ofHours(4));
+        tableConfig().setLocalTimeZone(ZoneOffset.ofHours(4));
         testTableApi(lit(Instant.EPOCH).cast(DataTypes.TIME(0)), "04:00:00");
     }
 
     @Test
     public void testTimestampWithLocalTimeZoneToTimestamp() {
-        config().setLocalTimeZone(ZoneOffset.ofHours(3));
+        tableConfig().setLocalTimeZone(ZoneOffset.ofHours(3));
         testTableApi(lit(Instant.EPOCH).cast(DataTypes.TIMESTAMP(0)), "1970-01-01 03:00:00");
     }
 
     @Test
     public void testStringToTimestampWithLocalTimeZone() {
-        config().setLocalTimeZone(ZoneOffset.ofHours(2));
+        tableConfig().setLocalTimeZone(ZoneOffset.ofHours(2));
         testTableApi(
                 lit("1970-01-01 00:00:00").cast(DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(0)),
                 "1970-01-01 00:00:00");
@@ -71,7 +71,7 @@ public class TypeConversionsTest extends ScalarOperatorsTestBase {
 
     @Test
     public void testTimestampToTimestampWithLocalTimeZone() {
-        config().setLocalTimeZone(ZoneOffset.ofHours(2));
+        tableConfig().setLocalTimeZone(ZoneOffset.ofHours(2));
         testTableApi(
                 lit(LocalDateTime.parse("1970-01-01T00:00:00"))
                         .cast(DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(0)),
@@ -84,7 +84,7 @@ public class TypeConversionsTest extends ScalarOperatorsTestBase {
 
     @Test
     public void testTimeToTimestampWithLocalTimeZone() {
-        config().setLocalTimeZone(ZoneOffset.ofHours(2));
+        tableConfig().setLocalTimeZone(ZoneOffset.ofHours(2));
         testTableApi(
                 lit(LocalTime.parse("12:00:00")).cast(DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(0)),
                 "1970-01-01 12:00:00");
@@ -96,7 +96,7 @@ public class TypeConversionsTest extends ScalarOperatorsTestBase {
 
     @Test
     public void testDateToTimestampWithLocalTimeZone() {
-        config().setLocalTimeZone(ZoneOffset.ofHours(2));
+        tableConfig().setLocalTimeZone(ZoneOffset.ofHours(2));
         testTableApi(
                 lit(LocalDate.parse("1970-02-01"))
                         .cast(DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(0)),

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/expressions/converter/ExpressionConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/expressions/converter/ExpressionConverterTest.java
@@ -19,20 +19,12 @@
 package org.apache.flink.table.planner.expressions.converter;
 
 import org.apache.flink.table.api.DataTypes;
-import org.apache.flink.table.api.TableConfig;
-import org.apache.flink.table.catalog.CatalogManager;
-import org.apache.flink.table.catalog.FunctionCatalog;
 import org.apache.flink.table.expressions.TimePointUnit;
-import org.apache.flink.table.module.ModuleManager;
 import org.apache.flink.table.planner.delegation.PlannerContext;
-import org.apache.flink.table.planner.plan.metadata.MetadataTestUtil;
-import org.apache.flink.table.planner.plan.trait.FlinkRelDistributionTraitDef;
+import org.apache.flink.table.planner.utils.PlannerMocks;
 import org.apache.flink.table.utils.CatalogManagerMocks;
 
 import org.apache.calcite.avatica.util.TimeUnit;
-import org.apache.calcite.jdbc.CalciteSchema;
-import org.apache.calcite.plan.ConventionTraitDef;
-import org.apache.calcite.rel.RelCollationTraitDef;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.type.SqlTypeName;
@@ -49,7 +41,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.Period;
-import java.util.Arrays;
 
 import static org.apache.flink.table.expressions.ApiExpressionUtils.valueLiteral;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -58,21 +49,8 @@ import static org.junit.Assert.assertThat;
 /** Test for {@link ExpressionConverter}. */
 public class ExpressionConverterTest {
 
-    private final TableConfig tableConfig = new TableConfig();
-    private final CatalogManager catalogManager = CatalogManagerMocks.createEmptyCatalogManager();
-    private final ModuleManager moduleManager = new ModuleManager();
-    private final PlannerContext plannerContext =
-            new PlannerContext(
-                    false,
-                    tableConfig,
-                    moduleManager,
-                    new FunctionCatalog(tableConfig, catalogManager, moduleManager),
-                    catalogManager,
-                    CalciteSchema.from(MetadataTestUtil.initRootSchema()),
-                    Arrays.asList(
-                            ConventionTraitDef.INSTANCE,
-                            FlinkRelDistributionTraitDef.INSTANCE(),
-                            RelCollationTraitDef.INSTANCE));
+    private final PlannerContext plannerContext = PlannerMocks.create().getPlannerContext();
+
     private final ExpressionConverter converter =
             new ExpressionConverter(
                     plannerContext.createRelBuilder(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
@@ -85,6 +85,7 @@ import org.apache.flink.table.operations.ddl.DropDatabaseOperation;
 import org.apache.flink.table.planner.calcite.FlinkPlannerImpl;
 import org.apache.flink.table.planner.catalog.CatalogManagerCalciteSchema;
 import org.apache.flink.table.planner.delegation.ParserImpl;
+import org.apache.flink.table.planner.delegation.PlannerConfig;
 import org.apache.flink.table.planner.delegation.PlannerContext;
 import org.apache.flink.table.planner.expressions.utils.Func0$;
 import org.apache.flink.table.planner.expressions.utils.Func1$;
@@ -127,8 +128,10 @@ import static org.assertj.core.api.InstanceOfAssertFactories.type;
 
 /** Test cases for {@link SqlToOperationConverter}. */
 public class SqlToOperationConverterTest {
+
     private final boolean isStreamingMode = false;
-    private final TableConfig tableConfig = new TableConfig();
+    private final TableConfig tableConfig = TableConfig.getDefault();
+    private final PlannerConfig plannerConfig = PlannerConfig.of(tableConfig);
     private final Catalog catalog = new GenericInMemoryCatalog("MockCatalog", "default");
     private final CatalogManager catalogManager =
             CatalogManagerMocks.preparedCatalogManager()
@@ -151,7 +154,7 @@ public class SqlToOperationConverterTest {
     private final PlannerContext plannerContext =
             new PlannerContext(
                     true,
-                    tableConfig,
+                    plannerConfig,
                     moduleManager,
                     functionCatalog,
                     catalogManager,

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/DynamicTableSinkSpecSerdeTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/DynamicTableSinkSpecSerdeTest.java
@@ -189,7 +189,7 @@ class DynamicTableSinkSpecSerdeTest {
                 false);
 
         SerdeContext serdeCtx =
-                configuredSerdeContext(catalogManager, plannerMocks.getTableConfig());
+                configuredSerdeContext(catalogManager, plannerMocks.getPlannerConfig());
 
         // Re-init the spec to be permanent with correct catalog
         spec =
@@ -248,7 +248,7 @@ class DynamicTableSinkSpecSerdeTest {
 
         // Mock the context
         SerdeContext serdeCtx =
-                configuredSerdeContext(catalogManager, plannerMocks.getTableConfig());
+                configuredSerdeContext(catalogManager, plannerMocks.getPlannerConfig());
 
         DynamicTableSinkSpec planSpec =
                 new DynamicTableSinkSpec(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/DynamicTableSourceSpecSerdeTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/DynamicTableSourceSpecSerdeTest.java
@@ -248,7 +248,7 @@ public class DynamicTableSourceSpecSerdeTest {
                 false);
 
         SerdeContext serdeCtx =
-                configuredSerdeContext(catalogManager, plannerMocks.getTableConfig());
+                configuredSerdeContext(catalogManager, plannerMocks.getPlannerConfig());
 
         // Re-init the spec to be permanent with correct catalog
         spec =
@@ -308,7 +308,7 @@ public class DynamicTableSourceSpecSerdeTest {
 
         // Mock the context
         SerdeContext serdeCtx =
-                configuredSerdeContext(catalogManager, plannerMocks.getTableConfig());
+                configuredSerdeContext(catalogManager, plannerMocks.getPlannerConfig());
 
         DynamicTableSourceSpec planSpec =
                 new DynamicTableSourceSpec(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/JsonSerdeTestUtil.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/JsonSerdeTestUtil.java
@@ -26,6 +26,7 @@ import org.apache.flink.table.module.ModuleManager;
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
 import org.apache.flink.table.planner.catalog.CatalogManagerCalciteSchema;
 import org.apache.flink.table.planner.delegation.ParserImpl;
+import org.apache.flink.table.planner.delegation.PlannerConfig;
 import org.apache.flink.table.planner.delegation.PlannerContext;
 import org.apache.flink.table.utils.CatalogManagerMocks;
 
@@ -69,14 +70,19 @@ class JsonSerdeTestUtil {
 
     static SerdeContext configuredSerdeContext(
             CatalogManager catalogManager, TableConfig tableConfig) {
+        return configuredSerdeContext(catalogManager, PlannerConfig.of(tableConfig));
+    }
+
+    static SerdeContext configuredSerdeContext(
+            CatalogManager catalogManager, PlannerConfig plannerConfig) {
         final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         final ModuleManager moduleManager = new ModuleManager();
         final FunctionCatalog functionCatalog =
-                new FunctionCatalog(tableConfig, catalogManager, moduleManager);
+                new FunctionCatalog(plannerConfig.getTableConfig(), catalogManager, moduleManager);
         final PlannerContext plannerContext =
                 new PlannerContext(
                         false,
-                        tableConfig,
+                        plannerConfig,
                         moduleManager,
                         functionCatalog,
                         catalogManager,

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LogicalWindowSerdeTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LogicalWindowSerdeTest.java
@@ -18,13 +18,8 @@
 
 package org.apache.flink.table.planner.plan.nodes.exec.serde;
 
-import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.expressions.FieldReferenceExpression;
 import org.apache.flink.table.expressions.ValueLiteralExpression;
-import org.apache.flink.table.module.ModuleManager;
-import org.apache.flink.table.planner.calcite.FlinkContextImpl;
-import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
-import org.apache.flink.table.planner.functions.sql.FlinkSqlOperatorTable;
 import org.apache.flink.table.planner.plan.logical.LogicalWindow;
 import org.apache.flink.table.planner.plan.logical.SessionGroupWindow;
 import org.apache.flink.table.planner.plan.logical.SlidingGroupWindow;
@@ -34,7 +29,6 @@ import org.apache.flink.table.types.AtomicDataType;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.TimestampKind;
 import org.apache.flink.table.types.logical.TimestampType;
-import org.apache.flink.table.utils.CatalogManagerMocks;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectReader;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectWriter;
@@ -113,20 +107,7 @@ public class LogicalWindowSerdeTest {
 
     @Test
     public void testLogicalWindowSerde() throws IOException {
-        SerdeContext serdeCtx =
-                new SerdeContext(
-                        null,
-                        new FlinkContextImpl(
-                                false,
-                                TableConfig.getDefault(),
-                                new ModuleManager(),
-                                null,
-                                CatalogManagerMocks.createEmptyCatalogManager(),
-                                null),
-                        Thread.currentThread().getContextClassLoader(),
-                        FlinkTypeFactory.INSTANCE(),
-                        FlinkSqlOperatorTable.instance());
-
+        SerdeContext serdeCtx = JsonSerdeTestUtil.configuredSerdeContext();
         ObjectReader objectReader = JsonSerdeUtil.createObjectReader(serdeCtx);
         ObjectWriter objectWriter = JsonSerdeUtil.createObjectWriter(serdeCtx);
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LookupKeySerdeTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LookupKeySerdeTest.java
@@ -18,15 +18,7 @@
 
 package org.apache.flink.table.planner.plan.nodes.exec.serde;
 
-import org.apache.flink.table.api.TableConfig;
-import org.apache.flink.table.catalog.CatalogManager;
-import org.apache.flink.table.catalog.FunctionCatalog;
-import org.apache.flink.table.catalog.GenericInMemoryCatalog;
-import org.apache.flink.table.module.ModuleManager;
-import org.apache.flink.table.planner.calcite.FlinkContext;
-import org.apache.flink.table.planner.calcite.FlinkContextImpl;
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
-import org.apache.flink.table.planner.functions.sql.FlinkSqlOperatorTable;
 import org.apache.flink.table.planner.plan.utils.LookupJoinUtil;
 import org.apache.flink.table.types.logical.BigIntType;
 
@@ -45,29 +37,7 @@ public class LookupKeySerdeTest {
 
     @Test
     public void testLookupKey() throws IOException {
-        TableConfig tableConfig = TableConfig.getDefault();
-        ModuleManager moduleManager = new ModuleManager();
-        CatalogManager catalogManager =
-                CatalogManager.newBuilder()
-                        .classLoader(Thread.currentThread().getContextClassLoader())
-                        .config(tableConfig.getConfiguration())
-                        .defaultCatalog("default_catalog", new GenericInMemoryCatalog("default_db"))
-                        .build();
-        FlinkContext flinkContext =
-                new FlinkContextImpl(
-                        false,
-                        tableConfig,
-                        moduleManager,
-                        new FunctionCatalog(tableConfig, catalogManager, moduleManager),
-                        catalogManager,
-                        null);
-        SerdeContext serdeCtx =
-                new SerdeContext(
-                        null,
-                        flinkContext,
-                        Thread.currentThread().getContextClassLoader(),
-                        FlinkTypeFactory.INSTANCE(),
-                        FlinkSqlOperatorTable.instance());
+        SerdeContext serdeCtx = JsonSerdeTestUtil.configuredSerdeContext();
         ObjectReader objectReader = JsonSerdeUtil.createObjectReader(serdeCtx);
         ObjectWriter objectWriter = JsonSerdeUtil.createObjectWriter(serdeCtx);
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RexWindowBoundSerdeTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RexWindowBoundSerdeTest.java
@@ -18,12 +18,7 @@
 
 package org.apache.flink.table.planner.plan.nodes.exec.serde;
 
-import org.apache.flink.table.api.TableConfig;
-import org.apache.flink.table.module.ModuleManager;
-import org.apache.flink.table.planner.calcite.FlinkContextImpl;
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
-import org.apache.flink.table.planner.functions.sql.FlinkSqlOperatorTable;
-import org.apache.flink.table.utils.CatalogManagerMocks;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectReader;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectWriter;
@@ -42,19 +37,7 @@ public class RexWindowBoundSerdeTest {
 
     @Test
     public void testSerde() throws IOException {
-        SerdeContext serdeCtx =
-                new SerdeContext(
-                        null,
-                        new FlinkContextImpl(
-                                false,
-                                TableConfig.getDefault(),
-                                new ModuleManager(),
-                                null,
-                                CatalogManagerMocks.createEmptyCatalogManager(),
-                                null),
-                        Thread.currentThread().getContextClassLoader(),
-                        FlinkTypeFactory.INSTANCE(),
-                        FlinkSqlOperatorTable.instance());
+        SerdeContext serdeCtx = JsonSerdeTestUtil.configuredSerdeContext();
         ObjectReader objectReader = JsonSerdeUtil.createObjectReader(serdeCtx);
         ObjectWriter objectWriter = JsonSerdeUtil.createObjectWriter(serdeCtx);
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/TemporalTableSourceSpecSerdeTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/TemporalTableSourceSpecSerdeTest.java
@@ -29,9 +29,7 @@ import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.ResolvedCatalogTable;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.connector.source.LookupTableSource;
-import org.apache.flink.table.module.ModuleManager;
 import org.apache.flink.table.planner.calcite.FlinkContext;
-import org.apache.flink.table.planner.calcite.FlinkContextImpl;
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
 import org.apache.flink.table.planner.factories.TestValuesTableFactory;
 import org.apache.flink.table.planner.plan.abilities.source.LimitPushDownSpec;
@@ -59,16 +57,11 @@ import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 /** Tests for {@link TemporalTableSourceSpec} serialization and deserialization. */
 @Execution(CONCURRENT)
 public class TemporalTableSourceSpecSerdeTest {
+
     private static final FlinkTypeFactory FACTORY = FlinkTypeFactory.INSTANCE();
 
     private static final FlinkContext FLINK_CONTEXT =
-            new FlinkContextImpl(
-                    false,
-                    TableConfig.getDefault(),
-                    new ModuleManager(),
-                    null,
-                    CatalogManagerMocks.createEmptyCatalogManager(),
-                    null);
+            JsonSerdeTestUtil.configuredSerdeContext().getFlinkContext();
 
     public static Stream<TemporalTableSourceSpec> testTemporalTableSourceSpecSerde() {
         Map<String, String> options1 = new HashMap<>();

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/codegen/WatermarkGeneratorCodeGenTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/codegen/WatermarkGeneratorCodeGenTest.scala
@@ -22,33 +22,25 @@ import org.apache.flink.api.common.eventtime.WatermarkGeneratorSupplier
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.metrics.MetricGroup
 import org.apache.flink.streaming.util.MockStreamingRuntimeContext
-import org.apache.flink.table.api.{TableConfig, TableSchema}
-import org.apache.flink.table.catalog.{CatalogManager, FunctionCatalog, ObjectIdentifier, UnresolvedIdentifier}
+import org.apache.flink.table.api.TableConfig
+import org.apache.flink.table.catalog.{ObjectIdentifier, UnresolvedIdentifier}
 import org.apache.flink.table.data.{GenericRowData, TimestampData}
-import org.apache.flink.table.delegation.Parser
-import org.apache.flink.table.module.ModuleManager
-import org.apache.flink.table.planner.calcite.{FlinkContext, FlinkPlannerImpl, FlinkTypeFactory, SqlExprToRexConverter, SqlExprToRexConverterFactory}
-import org.apache.flink.table.planner.catalog.CatalogManagerCalciteSchema
-import org.apache.flink.table.planner.delegation.{ParserImpl, PlannerContext}
-import org.apache.flink.table.planner.parse.CalciteParser
+import org.apache.flink.table.planner.calcite.{FlinkContext, FlinkPlannerImpl, FlinkTypeFactory}
 import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedScalarFunctions.JavaFunc5
+import org.apache.flink.table.planner.utils.PlannerMocks
 import org.apache.flink.table.runtime.generated.WatermarkGenerator
 import org.apache.flink.table.types.logical.{IntType, TimestampType}
 import org.apache.flink.table.utils.CatalogManagerMocks
 
-import org.apache.calcite.jdbc.CalciteSchemaBuilder.asRootSchema
 import org.apache.calcite.plan.ConventionTraitDef
-import org.apache.calcite.rel.`type`.RelDataType
+
+import org.junit.Assert.{assertEquals, assertTrue}
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 
 import java.lang.{Integer => JInt, Long => JLong}
 import java.util
-import java.util.Collections
-import java.util.function.{Function => JFunction, Supplier => JSupplier}
-
-import org.junit.Assert.{assertEquals, assertTrue}
-import org.junit.runner.RunWith
-import org.junit.runners.Parameterized
-import org.junit.Test
 
 /**
   * Tests the generated [[WatermarkGenerator]] from [[WatermarkGeneratorCodeGenerator]].
@@ -57,23 +49,9 @@ import org.junit.Test
 class WatermarkGeneratorCodeGenTest(useDefinedConstructor: Boolean) {
 
   // mock FlinkPlannerImpl to avoid discovering TableEnvironment and Executor.
-  val config = new TableConfig
-  val moduleManager = new ModuleManager
-  val catalogManager: CatalogManager = CatalogManagerMocks.createEmptyCatalogManager()
-  val functionCatalog = new FunctionCatalog(config, catalogManager, moduleManager)
-  val plannerContext = new PlannerContext(
-    false,
-    config,
-    moduleManager,
-    functionCatalog,
-    catalogManager,
-    asRootSchema(new CatalogManagerCalciteSchema(catalogManager, false)),
-    Collections.singletonList(ConventionTraitDef.INSTANCE))
-  val planner: FlinkPlannerImpl = plannerContext.createFlinkPlanner(
-    catalogManager.getCurrentCatalog,
-    catalogManager.getCurrentDatabase)
+  val plannerMocks = PlannerMocks.create()
 
-  def getPlanner: FlinkPlannerImpl = planner
+  def getPlanner: FlinkPlannerImpl = plannerMocks.getPlanner
 
   val data = List(
     GenericRowData.of(TimestampData.fromEpochMillis(1000L), JInt.valueOf(5)),
@@ -128,7 +106,7 @@ class WatermarkGeneratorCodeGenTest(useDefinedConstructor: Boolean) {
     JavaFunc5.openCalled = false
     JavaFunc5.closeCalled = false
     if (isLegacy) {
-      functionCatalog.registerTempCatalogScalarFunction(
+      plannerMocks.getFunctionCatalog.registerTempCatalogScalarFunction(
         ObjectIdentifier.of(
           CatalogManagerMocks.DEFAULT_CATALOG,
           CatalogManagerMocks.DEFAULT_DATABASE,
@@ -136,7 +114,7 @@ class WatermarkGeneratorCodeGenTest(useDefinedConstructor: Boolean) {
         new JavaFunc5
       )
     } else {
-      functionCatalog.registerTemporaryCatalogFunction(
+      plannerMocks.getFunctionCatalog.registerTemporaryCatalogFunction(
         UnresolvedIdentifier.of(CatalogManagerMocks.DEFAULT_CATALOG,
           CatalogManagerMocks.DEFAULT_DATABASE,
           "myFunc"
@@ -168,14 +146,14 @@ class WatermarkGeneratorCodeGenTest(useDefinedConstructor: Boolean) {
 
   private def generateWatermarkGenerator(expr: String,
       useDefinedConstructor: Boolean): WatermarkGenerator = {
-    val tableRowType = plannerContext.getTypeFactory.buildRelNodeRowType(
+    val tableRowType = plannerMocks.getPlannerContext.getTypeFactory.buildRelNodeRowType(
       Seq("ts", "offset"),
       Seq(
         new TimestampType(3),
         new IntType()
       ))
     val rowType = FlinkTypeFactory.toLogicalRowType(tableRowType)
-    val converter = planner.createToRelContext()
+    val converter = plannerMocks.getPlanner.createToRelContext()
         .getCluster
         .getPlanner
         .getContext

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/NonDeterministicTests.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/NonDeterministicTests.scala
@@ -79,13 +79,12 @@ class NonDeterministicTests extends ExpressionTestBase {
   @Test
   def testTemporalFunctionsInBatchMode(): Unit = {
     val zoneId = ZoneId.of("Asia/Shanghai")
-    config.setLocalTimeZone(zoneId)
-    config.set(ExecutionOptions.RUNTIME_MODE, RuntimeExecutionMode.BATCH)
+    tableConfig.setLocalTimeZone(zoneId)
+    tableConfig.getConfiguration.set(ExecutionOptions.RUNTIME_MODE, RuntimeExecutionMode.BATCH)
 
-    config.set(InternalConfigOptions.TABLE_QUERY_START_EPOCH_TIME, Long.box(1123L))
-    config.set(
-      InternalConfigOptions.TABLE_QUERY_START_LOCAL_TIME,
-      Long.box(1123L + TimeZone.getTimeZone(zoneId).getOffset(1123L)))
+    tableConfig.getConfiguration.setLong(InternalConfigOptions.TABLE_QUERY_START_EPOCH_TIME, 1123L)
+    tableConfig.getConfiguration.setLong(InternalConfigOptions.TABLE_QUERY_START_LOCAL_TIME,
+      1123L + TimeZone.getTimeZone(zoneId).getOffset(1123L))
 
     val temporalFunctions = getCodeGenFunctions(List(
       "CURRENT_DATE",
@@ -110,7 +109,7 @@ class NonDeterministicTests extends ExpressionTestBase {
 
   @Test
   def testCurrentRowTimestampFunctionsInBatchMode(): Unit = {
-    config.set(ExecutionOptions.RUNTIME_MODE, RuntimeExecutionMode.BATCH)
+    tableConfig.getConfiguration.set(ExecutionOptions.RUNTIME_MODE, RuntimeExecutionMode.BATCH)
     val temporalFunctions = getCodeGenFunctions(List("CURRENT_ROW_TIMESTAMP()"))
 
     val round1 = evaluateFunctionResult(temporalFunctions)
@@ -135,7 +134,7 @@ class NonDeterministicTests extends ExpressionTestBase {
   }
 
   private def testTemporalTimestamp(zoneId: ZoneId) :Unit = {
-    config.setLocalTimeZone(zoneId)
+    tableConfig.setLocalTimeZone(zoneId)
     val localDateTime = LocalDateTime.now(zoneId)
 
     val formattedLocalTime = localDateTime

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
@@ -213,7 +213,7 @@ class TemporalTypesTest extends ExpressionTestBase {
 
   @Test
   def testTimestampLtzCastInUTC(): Unit = {
-    config.setLocalTimeZone(ZoneId.of("UTC"))
+    tableConfig.setLocalTimeZone(ZoneId.of("UTC"))
 
     //DATE -> TIMESTAMP_LTZ
     testSqlApi(
@@ -238,7 +238,7 @@ class TemporalTypesTest extends ExpressionTestBase {
 
   @Test
   def testTimestampLtzCastInShanghai(): Unit = {
-    config.setLocalTimeZone(ZoneId.of("Asia/Shanghai"))
+    tableConfig.setLocalTimeZone(ZoneId.of("Asia/Shanghai"))
 
     // DATE -> TIMESTAMP_LTZ
     testSqlApi(
@@ -744,7 +744,7 @@ class TemporalTypesTest extends ExpressionTestBase {
 
   @Test
   def testDateFormat(): Unit = {
-    config.setLocalTimeZone(ZoneId.of("UTC"))
+    tableConfig.setLocalTimeZone(ZoneId.of("UTC"))
 
     testSqlApi(
       "DATE_FORMAT('2018-03-14 01:02:03', 'yyyy/MM/dd HH:mm:ss')",
@@ -765,7 +765,7 @@ class TemporalTypesTest extends ExpressionTestBase {
 
   @Test
   def testDateFormatShanghai(): Unit = {
-    config.setLocalTimeZone(ZoneId.of("Asia/Shanghai"))
+    tableConfig.setLocalTimeZone(ZoneId.of("Asia/Shanghai"))
 
     testSqlApi(
       "DATE_FORMAT('2018-03-14 01:02:03', 'yyyy/MM/dd HH:mm:ss')",
@@ -787,7 +787,7 @@ class TemporalTypesTest extends ExpressionTestBase {
 
   @Test
   def testDateFormatLosAngeles(): Unit = {
-    config.setLocalTimeZone(ZoneId.of("America/Los_Angeles"))
+    tableConfig.setLocalTimeZone(ZoneId.of("America/Los_Angeles"))
 
     testSqlApi(
       "DATE_FORMAT('2018-03-14 01:02:03', 'yyyy/MM/dd HH:mm:ss')",
@@ -843,7 +843,7 @@ class TemporalTypesTest extends ExpressionTestBase {
 
   @Test
   def testTemporalShanghai(): Unit = {
-    config.setLocalTimeZone(ZoneId.of("Asia/Shanghai"))
+    tableConfig.setLocalTimeZone(ZoneId.of("Asia/Shanghai"))
 
     testSqlApi(timestampLtz("2018-03-14 19:01:02.123"), "2018-03-14 19:01:02.123")
     testSqlApi(timestampLtz("2018-03-14 19:00:00.010"), "2018-03-14 19:00:00.010")
@@ -1021,7 +1021,7 @@ class TemporalTypesTest extends ExpressionTestBase {
     // due to conventions for local time zone changes such as Daylight Saving Time (DST),
     // it is possible for UNIX_TIMESTAMP() to map two values that are distinct in a non-UTC
     // time zone to the same Unix timestamp value
-    config.setLocalTimeZone(ZoneId.of("MET")) // Europe/Amsterdam
+    tableConfig.setLocalTimeZone(ZoneId.of("MET")) // Europe/Amsterdam
 
     testSqlApi("UNIX_TIMESTAMP('2005-03-27 03:00:00')", "1111885200")
     testSqlApi("UNIX_TIMESTAMP('2005-03-27 02:00:00')", "1111885200")
@@ -1031,7 +1031,7 @@ class TemporalTypesTest extends ExpressionTestBase {
   @Test
   def testHourUnitRangoonTimeZone(): Unit = {
     // Asia/Rangoon UTC Offset 6.5
-    config.setLocalTimeZone(ZoneId.of("Asia/Rangoon"))
+    tableConfig.setLocalTimeZone(ZoneId.of("Asia/Rangoon"))
 
     val t1 = timestampLtz("2018-03-20 06:10:31")
     val t2 = timestampLtz("2018-03-20 06:00:00")
@@ -1136,7 +1136,7 @@ class TemporalTypesTest extends ExpressionTestBase {
 
   @Test
   def testFromUnixTimeInTokyo(): Unit = {
-    config.setLocalTimeZone(ZoneId.of("Asia/Tokyo"))
+    tableConfig.setLocalTimeZone(ZoneId.of("Asia/Tokyo"))
     val fmt = "yy-MM-dd HH-mm-ss"
     testSqlApi(
       "from_unixtime(f21)",
@@ -1171,7 +1171,7 @@ class TemporalTypesTest extends ExpressionTestBase {
 
   @Test
   def testUnixTimestampInTokyo(): Unit = {
-    config.setLocalTimeZone(ZoneId.of("Asia/Tokyo"))
+    tableConfig.setLocalTimeZone(ZoneId.of("Asia/Tokyo"))
     testSqlApi(
       "UNIX_TIMESTAMP('2015-07-24 10:00:00')",
       "1437699600")
@@ -1357,7 +1357,7 @@ class TemporalTypesTest extends ExpressionTestBase {
 
   @Test
   def testToTimestampLtzShanghai(): Unit = {
-    config.setLocalTimeZone(ZoneId.of("Asia/Shanghai"))
+    tableConfig.setLocalTimeZone(ZoneId.of("Asia/Shanghai"))
 
     // INT -> TIMESTAMP_LTZ
     testAllApis(
@@ -1413,7 +1413,7 @@ class TemporalTypesTest extends ExpressionTestBase {
 
   @Test
   def testToTimestampLtzUTC(): Unit = {
-    config.setLocalTimeZone(ZoneId.of("UTC"))
+    tableConfig.setLocalTimeZone(ZoneId.of("UTC"))
     testAllApis(
       toTimestampLtz(100, 0),
       "TO_TIMESTAMP_LTZ(100, 0)",
@@ -1437,7 +1437,7 @@ class TemporalTypesTest extends ExpressionTestBase {
 
   @Test
   def testBoundaryForToTimestampLtz(): Unit = {
-    config.setLocalTimeZone(ZoneId.of("UTC"))
+    tableConfig.setLocalTimeZone(ZoneId.of("UTC"))
 
     // INT
     testAllApis(
@@ -1735,9 +1735,9 @@ class TemporalTypesTest extends ExpressionTestBase {
     testData.setField(21, 44L)
     testData.setField(22, 3)
     testData.setField(23, localDateTime("1970-01-01 00:00:00.123456789")
-      .atZone(config.getLocalTimeZone).toInstant)
+      .atZone(tableConfig.getLocalTimeZone).toInstant)
     testData.setField(24, localDateTime("1970-01-01 00:00:00.123456789")
-      .atZone(config.getLocalTimeZone).toInstant)
+      .atZone(tableConfig.getLocalTimeZone).toInstant)
     testData.setField(25, localDateTime("1970-01-01 00:00:00.123456789").toInstant(ZoneOffset.UTC))
     testData setField(26, new Integer(124).byteValue())
     testData

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/utils/ExpressionTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/utils/ExpressionTestBase.scala
@@ -51,6 +51,7 @@ import org.apache.calcite.rel.logical.LogicalCalc
 import org.apache.calcite.rel.rules._
 import org.apache.calcite.rex.RexNode
 import org.apache.calcite.sql.`type`.SqlTypeName.VARCHAR
+
 import org.junit.Assert.{assertEquals, assertTrue, fail}
 import org.junit.rules.ExpectedException
 import org.junit.{After, Before, Rule}
@@ -62,7 +63,7 @@ import scala.collection.mutable
 
 abstract class ExpressionTestBase {
 
-  val config = new TableConfig()
+  val tableConfig = TableConfig.getDefault()
 
   // (originalExpr, optimizedExpr, expectedResult)
   private val validExprs = mutable.ArrayBuffer[(String, RexNode, String)]()
@@ -76,7 +77,7 @@ abstract class ExpressionTestBase {
   private val setting = EnvironmentSettings.newInstance().inStreamingMode().build()
   // use impl class instead of interface class to avoid
   // "Static methods in interface require -target:jvm-1.8"
-  private val tEnv = StreamTableEnvironmentImpl.create(env, setting, config)
+  private val tEnv = StreamTableEnvironmentImpl.create(env, setting, tableConfig)
     .asInstanceOf[StreamTableEnvironmentImpl]
   private val resolvedDataType = if (containsLegacyTypes) {
     TypeConversions.fromLegacyInfoToDataType(typeInfo)
@@ -100,7 +101,7 @@ abstract class ExpressionTestBase {
 
   @Before
   def prepare(): Unit = {
-    config.set(
+    tableConfig.getConfiguration.set(
       ExecutionConfigOptions.TABLE_EXEC_LEGACY_CAST_BEHAVIOUR,
       ExecutionConfigOptions.LegacyCastBehaviour.DISABLED
     )
@@ -361,7 +362,7 @@ abstract class ExpressionTestBase {
 
   private def getCodeGenFunction(rexNodes: List[RexNode]):
     GeneratedFunction[MapFunction[RowData, BinaryRowData]] = {
-    val ctx = CodeGeneratorContext(config)
+    val ctx = CodeGeneratorContext(tableConfig)
     val inputType = if (containsLegacyTypes) {
       fromTypeInfoToLogicalType(typeInfo)
     } else {

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/metadata/AggCallSelectivityEstimatorTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/metadata/AggCallSelectivityEstimatorTest.scala
@@ -18,12 +18,11 @@
 
 package org.apache.flink.table.planner.plan.metadata
 
-import org.apache.flink.table.api.TableConfig
 import org.apache.flink.table.catalog.FunctionCatalog
 import org.apache.flink.table.module.ModuleManager
 import org.apache.flink.table.plan.stats.{ColumnStats, TableStats}
 import org.apache.flink.table.planner.calcite.{FlinkRexBuilder, FlinkTypeFactory, FlinkTypeSystem}
-import org.apache.flink.table.planner.delegation.PlannerContext
+import org.apache.flink.table.planner.delegation.{PlannerConfig, PlannerContext}
 import org.apache.flink.table.planner.plan.`trait`.FlinkRelDistributionTraitDef
 import org.apache.flink.table.planner.plan.stats.FlinkStatistic
 import org.apache.flink.table.planner.{JDouble, JLong}
@@ -45,6 +44,7 @@ import org.apache.calcite.sql.fun.SqlStdOperatorTable
 import org.apache.calcite.sql.fun.SqlStdOperatorTable._
 import org.apache.calcite.sql.{SqlAggFunction, SqlOperator}
 import org.apache.calcite.util.ImmutableBitSet
+
 import org.junit.Assert._
 import org.junit.{Before, BeforeClass, Test}
 
@@ -77,7 +77,7 @@ class AggCallSelectivityEstimatorTest {
 
   private def mockScan(
       statistic: FlinkStatistic = FlinkStatistic.UNKNOWN): TableScan = {
-    val tableConfig = new TableConfig
+    val plannerConfig = PlannerConfig.getDefault
     val moduleManager = new ModuleManager
     val catalogManager = CatalogManagerMocks.createEmptyCatalogManager()
     val rootSchema = CalciteSchema.createRootSchema(true, false).plus()
@@ -86,9 +86,9 @@ class AggCallSelectivityEstimatorTest {
     val plannerContext: PlannerContext =
       new PlannerContext(
         false,
-        tableConfig,
+        plannerConfig,
         moduleManager,
-        new FunctionCatalog(tableConfig, catalogManager, moduleManager),
+        new FunctionCatalog(plannerConfig.getTableConfig, catalogManager, moduleManager),
         catalogManager,
         CalciteSchema.from(rootSchema),
         util.Arrays.asList(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdHandlerTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdHandlerTestBase.scala
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.planner.plan.metadata
 
-import org.apache.flink.table.api.{TableConfig, TableException}
+import org.apache.flink.table.api.TableException
 import org.apache.flink.table.catalog.{CatalogManager, FunctionCatalog}
 import org.apache.flink.table.data.RowData
 import org.apache.flink.table.expressions.ApiExpressionUtils.intervalOfMillis
@@ -27,7 +27,7 @@ import org.apache.flink.table.functions.{FunctionIdentifier, UserDefinedFunction
 import org.apache.flink.table.module.ModuleManager
 import org.apache.flink.table.operations.TableSourceQueryOperation
 import org.apache.flink.table.planner.calcite.{FlinkContext, FlinkRelBuilder, FlinkTypeFactory}
-import org.apache.flink.table.planner.delegation.PlannerContext
+import org.apache.flink.table.planner.delegation.{PlannerConfig, PlannerContext}
 import org.apache.flink.table.planner.functions.sql.FlinkSqlOperatorTable
 import org.apache.flink.table.planner.functions.utils.AggSqlFunction
 import org.apache.flink.table.planner.plan.PartialFinalType
@@ -69,6 +69,7 @@ import org.apache.calcite.sql.fun.{SqlCountAggFunction, SqlStdOperatorTable}
 import org.apache.calcite.sql.parser.SqlParserPos
 import org.apache.calcite.sql.{SqlAggFunction, SqlWindow}
 import org.apache.calcite.util._
+
 import org.junit.{Before, BeforeClass}
 
 import java.math.BigDecimal
@@ -80,7 +81,8 @@ import scala.collection.JavaConversions._
 
 class FlinkRelMdHandlerTestBase {
 
-  val tableConfig = new TableConfig()
+  val plannerConfig = PlannerConfig.getDefault
+  val tableConfig = plannerConfig.getTableConfig
   val rootSchema: SchemaPlus = MetadataTestUtil.initRootSchema()
 
   val catalogManager: CatalogManager = CatalogManagerMocks.createEmptyCatalogManager()
@@ -91,7 +93,7 @@ class FlinkRelMdHandlerTestBase {
   val plannerContext: PlannerContext =
   new PlannerContext(
     false,
-    tableConfig,
+    plannerConfig,
     moduleManager,
     new FunctionCatalog(tableConfig, catalogManager, moduleManager),
     catalogManager,

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/metadata/MetadataTestUtil.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/metadata/MetadataTestUtil.scala
@@ -19,13 +19,14 @@
 package org.apache.flink.table.planner.plan.metadata
 
 import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, SqlTimeTypeInfo}
-import org.apache.flink.table.api.{DataTypes, TableConfig, TableException, TableSchema}
+import org.apache.flink.table.api.{DataTypes, TableException, TableSchema}
 import org.apache.flink.table.catalog.{CatalogTable, Column, ContextResolvedTable, ObjectIdentifier, ResolvedCatalogTable, ResolvedSchema, UniqueConstraint}
 import org.apache.flink.table.connector.ChangelogMode
 import org.apache.flink.table.connector.source.{DynamicTableSource, ScanTableSource}
 import org.apache.flink.table.module.ModuleManager
 import org.apache.flink.table.plan.stats.{ColumnStats, TableStats}
 import org.apache.flink.table.planner.calcite.{FlinkContext, FlinkContextImpl, FlinkTypeFactory, FlinkTypeSystem}
+import org.apache.flink.table.planner.delegation.PlannerConfig
 import org.apache.flink.table.planner.plan.schema.{FlinkPreparingTableBase, TableSourceTable}
 import org.apache.flink.table.planner.plan.stats.FlinkStatistic
 import org.apache.flink.table.runtime.types.TypeInfoLogicalTypeConverter.fromTypeInfoToLogicalType
@@ -252,9 +253,11 @@ object MetadataTestUtil {
     getMetadataTable(fieldNames, fieldTypes, new FlinkStatistic(tableStats))
   }
 
+  val plannerConfig: PlannerConfig = PlannerConfig.getDefault
+
   private val flinkContext = new FlinkContextImpl(
     false,
-    TableConfig.getDefault,
+    plannerConfig,
     new ModuleManager,
     null,
     CatalogManagerMocks.createEmptyCatalogManager,

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/metadata/SelectivityEstimatorTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/metadata/SelectivityEstimatorTest.scala
@@ -18,12 +18,11 @@
 
 package org.apache.flink.table.planner.plan.metadata
 
-import org.apache.flink.table.api.TableConfig
 import org.apache.flink.table.catalog.FunctionCatalog
 import org.apache.flink.table.module.ModuleManager
 import org.apache.flink.table.plan.stats.{ColumnStats, TableStats}
 import org.apache.flink.table.planner.calcite.{FlinkRexBuilder, FlinkTypeFactory, FlinkTypeSystem}
-import org.apache.flink.table.planner.delegation.PlannerContext
+import org.apache.flink.table.planner.delegation.{PlannerConfig, PlannerContext}
 import org.apache.flink.table.planner.plan.`trait`.FlinkRelDistributionTraitDef
 import org.apache.flink.table.planner.plan.stats.FlinkStatistic
 import org.apache.flink.table.planner.{JDouble, JLong}
@@ -42,6 +41,7 @@ import org.apache.calcite.sql.`type`.SqlTypeName._
 import org.apache.calcite.sql.fun.SqlStdOperatorTable
 import org.apache.calcite.sql.fun.SqlStdOperatorTable._
 import org.apache.calcite.util.{DateString, TimeString, TimestampString}
+
 import org.junit.Assert._
 import org.junit.{Before, BeforeClass, Test}
 
@@ -78,7 +78,7 @@ class SelectivityEstimatorTest {
 
   private def mockScan(
       statistic: FlinkStatistic = FlinkStatistic.UNKNOWN,
-      tableConfig: TableConfig = TableConfig.getDefault): TableScan = {
+      plannerConfig: PlannerConfig = PlannerConfig.getDefault): TableScan = {
     val moduleManager = new ModuleManager
     val catalogManager = CatalogManagerMocks.createEmptyCatalogManager()
     val rootSchema = CalciteSchema.createRootSchema(true, false).plus()
@@ -87,9 +87,9 @@ class SelectivityEstimatorTest {
     val plannerContext: PlannerContext =
       new PlannerContext(
         false,
-        tableConfig,
+        plannerConfig,
         moduleManager,
-        new FunctionCatalog(tableConfig, catalogManager, moduleManager),
+        new FunctionCatalog(plannerConfig.getTableConfig, catalogManager, moduleManager),
         catalogManager,
         CalciteSchema.from(rootSchema),
         util.Arrays.asList(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/nodes/calcite/RelNodeTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/nodes/calcite/RelNodeTestBase.scala
@@ -18,24 +18,18 @@
 
 package org.apache.flink.table.planner.plan.nodes.calcite
 
-import org.apache.flink.table.api.TableConfig
-import org.apache.flink.table.catalog.{CatalogManager, FunctionCatalog}
-import org.apache.flink.table.module.ModuleManager
 import org.apache.flink.table.planner.calcite.{FlinkRelBuilder, FlinkTypeFactory, FlinkTypeSystem}
 import org.apache.flink.table.planner.delegation.PlannerContext
 import org.apache.flink.table.planner.plan.metadata.MockMetaTable
 import org.apache.flink.table.planner.plan.stats.FlinkStatistic
-import org.apache.flink.table.planner.plan.`trait`.FlinkRelDistributionTraitDef
+import org.apache.flink.table.planner.utils.PlannerMocks
 import org.apache.flink.table.types.logical.LogicalType
-import org.apache.flink.table.utils.CatalogManagerMocks
 
-import org.apache.calcite.jdbc.CalciteSchema
-import org.apache.calcite.plan.{Convention, ConventionTraitDef, RelOptCluster, RelTraitSet}
+import org.apache.calcite.plan.{Convention, RelOptCluster, RelTraitSet}
 import org.apache.calcite.rel.hint.RelHint
 import org.apache.calcite.rel.logical.LogicalTableScan
-import org.apache.calcite.rel.RelCollationTraitDef
 import org.apache.calcite.rex.RexBuilder
-import org.apache.calcite.schema.SchemaPlus
+
 import org.junit.Before
 
 import java.util
@@ -45,26 +39,8 @@ import java.util
  * TODO refactor the metadata test to extract the common logic for all related tests.
  */
 class RelNodeTestBase {
-  val tableConfig = new TableConfig()
-  val rootSchema: SchemaPlus = CalciteSchema.createRootSchema(true, false).plus()
-  val catalogManager: CatalogManager = CatalogManagerMocks.createEmptyCatalogManager()
-  val moduleManager = new ModuleManager
 
-  val plannerContext: PlannerContext = new PlannerContext(
-    false,
-    tableConfig,
-    moduleManager,
-    new FunctionCatalog(tableConfig, catalogManager, moduleManager),
-    catalogManager,
-    CalciteSchema.from(rootSchema),
-    util.Arrays.asList(
-      ConventionTraitDef.INSTANCE,
-      FlinkRelDistributionTraitDef.INSTANCE,
-      RelCollationTraitDef.INSTANCE
-      )
-    )
-
-  val typeFactory: FlinkTypeFactory = plannerContext.getTypeFactory
+  val plannerContext: PlannerContext = PlannerMocks.create().getPlannerContext
   var relBuilder: FlinkRelBuilder = _
   var rexBuilder: RexBuilder = _
   var cluster: RelOptCluster = _

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/rules/physical/batch/EnforceLocalHashAggRuleTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/rules/physical/batch/EnforceLocalHashAggRuleTest.scala
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.planner.plan.rules.physical.batch
 
-import org.apache.flink.table.api.TableConfig
+import org.apache.flink.configuration.ReadableConfig
 import org.apache.flink.table.api.config.{ExecutionConfigOptions, OptimizerConfigOptions}
 import org.apache.flink.table.functions.UserDefinedFunction
 import org.apache.flink.table.planner.calcite.CalciteConfig
@@ -27,6 +27,7 @@ import org.apache.flink.table.planner.utils.TableConfigUtils
 
 import org.apache.calcite.rel.core.Aggregate
 import org.apache.calcite.tools.RuleSets
+
 import org.junit.Before
 
 
@@ -66,10 +67,10 @@ class EnforceLocalHashAggRuleTest extends EnforceLocalAggRuleTestBase {
  */
 class BatchPhysicalHashAggRuleForOnePhase extends BatchPhysicalHashAggRule {
   override protected def isTwoPhaseAggWorkable(
-      aggFunctions: Array[UserDefinedFunction], tableConfig: TableConfig): Boolean = false
+      aggFunctions: Array[UserDefinedFunction], plannerConfig: ReadableConfig): Boolean = false
 
   override protected def isOnePhaseAggWorkable(agg: Aggregate,
-      aggFunctions: Array[UserDefinedFunction], tableConfig: TableConfig): Boolean = true
+      aggFunctions: Array[UserDefinedFunction], plannerConfig: ReadableConfig): Boolean = true
 }
 
 object BatchPhysicalHashAggRuleForOnePhase {

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/rules/physical/batch/EnforceLocalSortAggRuleTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/rules/physical/batch/EnforceLocalSortAggRuleTest.scala
@@ -19,7 +19,7 @@
 package org.apache.flink.table.planner.plan.rules.physical.batch
 
 import org.apache.flink.api.scala._
-import org.apache.flink.table.api.TableConfig
+import org.apache.flink.configuration.ReadableConfig
 import org.apache.flink.table.api.config.{ExecutionConfigOptions, OptimizerConfigOptions}
 import org.apache.flink.table.functions.UserDefinedFunction
 import org.apache.flink.table.planner.calcite.CalciteConfig
@@ -29,6 +29,7 @@ import org.apache.flink.table.planner.utils.TableConfigUtils
 
 import org.apache.calcite.rel.core.Aggregate
 import org.apache.calcite.tools.RuleSets
+
 import org.junit.{Before, Test}
 
 
@@ -84,10 +85,10 @@ class EnforceLocalSortAggRuleTest extends EnforceLocalAggRuleTestBase {
   */
 class BatchExecSortAggRuleForOnePhase extends BatchPhysicalSortAggRule {
   override protected def isTwoPhaseAggWorkable(
-      aggFunctions: Array[UserDefinedFunction], tableConfig: TableConfig): Boolean = false
+      aggFunctions: Array[UserDefinedFunction], plannerConfig: ReadableConfig): Boolean = false
 
   override protected def isOnePhaseAggWorkable(agg: Aggregate,
-      aggFunctions: Array[UserDefinedFunction], tableConfig: TableConfig): Boolean = true
+      aggFunctions: Array[UserDefinedFunction], plannerConfig: ReadableConfig): Boolean = true
 }
 
 object BatchExecSortAggRuleForOnePhase {

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/utils/PartitionPrunerTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/utils/PartitionPrunerTest.scala
@@ -24,14 +24,14 @@ import org.apache.flink.table.planner.functions.utils.ScalarSqlFunction
 
 import org.apache.calcite.rex.RexUtil
 import org.apache.calcite.sql.`type`.SqlTypeName
-import org.apache.calcite.sql.`type`.SqlTypeName.DATE
 import org.apache.calcite.sql.fun.SqlStdOperatorTable
 import org.apache.calcite.util.{DateString, TimeString, TimestampString}
+
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
 import java.math.BigDecimal
-import java.time.{ZoneId, ZoneOffset}
+import java.time.ZoneOffset
 import java.util.{List => JList, Map => JMap}
 
 import scala.collection.JavaConversions._
@@ -67,9 +67,9 @@ class PartitionPrunerTest extends RexNodeTestBase {
       Map("amount" -> "200", "name" -> "Test3", "flag" -> "false").asJava
     ).asJava
 
-    val config = new TableConfig
+    val tableConfig = new TableConfig
     val prunedPartitions = PartitionPruner.prunePartitions(
-      config,
+      tableConfig,
       partitionFieldNames,
       partitionFieldTypes,
       allPartitions,
@@ -106,9 +106,9 @@ class PartitionPrunerTest extends RexNodeTestBase {
       Map("amount" -> "200", "name" -> "Test3").asJava
     ).asJava
 
-    val config = new TableConfig
+    val tableConfig = new TableConfig
     val prunedPartitions = PartitionPruner.prunePartitions(
-      config,
+      tableConfig,
       partitionFieldNames,
       partitionFieldTypes,
       allPartitions,
@@ -176,10 +176,10 @@ class PartitionPrunerTest extends RexNodeTestBase {
         "f3" -> "2018-08-06 12:08:06.124").asJava
     ).asJava
 
-    val config = new TableConfig
-    config.setLocalTimeZone(ZoneOffset.ofHours(0))
+    val tableConfig = new TableConfig
+    tableConfig.setLocalTimeZone(ZoneOffset.ofHours(0))
     val prunedPartitions = PartitionPruner.prunePartitions(
-      config,
+      tableConfig,
       partitionFieldNames,
       partitionFieldTypes,
       allPartitions,

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/harness/GroupAggregateHarnessTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/harness/GroupAggregateHarnessTest.scala
@@ -56,8 +56,7 @@ class GroupAggregateHarnessTest(mode: StateBackendMode, miniBatch: MiniBatchMode
   override def before(): Unit = {
     super.before()
     val setting = EnvironmentSettings.newInstance().inStreamingMode().build()
-    val config = new TestTableConfig
-    this.tEnv = StreamTableEnvironmentImpl.create(env, setting, config)
+    this.tEnv = StreamTableEnvironmentImpl.create(env, setting, new TestTableConfig)
     // set mini batch
     val tableConfig = tEnv.getConfig
     miniBatch match {

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/harness/OverAggregateHarnessTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/harness/OverAggregateHarnessTest.scala
@@ -49,8 +49,7 @@ class OverAggregateHarnessTest(mode: StateBackendMode) extends HarnessTestBase(m
   override def before(): Unit = {
     super.before()
     val setting = EnvironmentSettings.newInstance().inStreamingMode().build()
-    val config = new TestTableConfig
-    this.tEnv = StreamTableEnvironmentImpl.create(env, setting, config)
+    this.tEnv = StreamTableEnvironmentImpl.create(env, setting, new TestTableConfig)
   }
 
   @Test

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/harness/RankHarnessTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/harness/RankHarnessTest.scala
@@ -49,8 +49,7 @@ class RankHarnessTest(mode: StateBackendMode) extends HarnessTestBase(mode) {
   override def before(): Unit = {
     super.before()
     val setting = EnvironmentSettings.newInstance().inStreamingMode().build()
-    val config = new TestTableConfig
-    this.tEnv = StreamTableEnvironmentImpl.create(env, setting, config)
+    this.tEnv = StreamTableEnvironmentImpl.create(env, setting, new TestTableConfig)
   }
 
   @Test

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/harness/TableAggregateHarnessTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/harness/TableAggregateHarnessTest.scala
@@ -49,8 +49,7 @@ class TableAggregateHarnessTest(mode: StateBackendMode) extends HarnessTestBase(
   override def before(): Unit = {
     super.before()
     val setting = EnvironmentSettings.newInstance().inStreamingMode().build()
-    val config = new TestTableConfig
-    this.tEnv = StreamTableEnvironmentImpl.create(env, setting, config)
+    this.tEnv = StreamTableEnvironmentImpl.create(env, setting, new TestTableConfig)
   }
 
   val data = new mutable.MutableList[(Int, Int)]

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/generated/GeneratedWatermarkGenerator.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/generated/GeneratedWatermarkGenerator.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.runtime.generated;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ReadableConfig;
 
 /** Describes a generated {@link WatermarkGenerator}. */
 public class GeneratedWatermarkGenerator extends GeneratedClass<WatermarkGenerator> {
@@ -30,7 +31,7 @@ public class GeneratedWatermarkGenerator extends GeneratedClass<WatermarkGenerat
     }
 
     public GeneratedWatermarkGenerator(
-            String className, String code, Object[] references, Configuration conf) {
+            String className, String code, Object[] references, ReadableConfig conf) {
         super(className, code, references, conf);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Replace `TableConfig` with `PlannerConfig` in `FlinkContext` so that all consumers
get the merged config (executor config + table config) instead of just
the table config.


## Brief change log

  - Replace `TableConfig` with `PlannerConfig` in `FlinkContext`
  - Try to use PlannerMocks and JsonSerdeTestUtil to avoid boilerplate code to instantiate PlannerContext for test purposes.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
