### PR TITLE
[FLINK-26358][Runtime / Coordination] Operator maxParallelism is lost during chaining

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
@@ -311,6 +311,31 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
         assertTrue(printConfig.isChainEnd());
     }
 
+    /** Verifies that the max parallelism of chained operator maintained. */
+    @Test
+    public void testChainedMaxParallelism() throws Exception {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+        // set parallelism to 2 to avoid chaining with source in case when available processors is
+        // 1.
+        env.setParallelism(2);
+
+        // fromElements -> CHAIN(Map -> Filter -> Print)
+        env.fromElements(1, 2, 3)
+                .map((MapFunction<Integer, Integer>) value -> value)
+                .filter((FilterFunction<Integer>) value -> true)
+                .setMaxParallelism(200)
+                .print();
+        JobGraph jobGraph = StreamingJobGraphGenerator.createJobGraph(env.getStreamGraph());
+
+        List<JobVertex> verticesSorted = jobGraph.getVerticesSortedTopologicallyFromSources();
+        JobVertex sourceVertex = verticesSorted.get(0);
+        JobVertex mapFilterPrintVertex = verticesSorted.get(1);
+
+        assertEquals(sourceVertex.getMaxParallelism(), -1);
+        assertEquals(mapFilterPrintVertex.getMaxParallelism(), 200);
+    }
+
     @Test
     public void testOperatorCoordinatorAddedToJobVertex() {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
FLINK-26358: https://issues.apache.org/jira/browse/FLINK-26358
This pull request fixes the maxParallelism issue in operator chaining

## Brief change log
- Add `chainedMaxParallelism` map in `StreamJobGraphGenerator` to store the max parallelism of each operator chain
- Fetch max parallelism from `chainedMaxParallelism` and config job vertex in `createJobVertex`
- Added unit test for this case


## Verifying this change

This change added tests and can be verified as follows:
  - Unit tests added in `StreamingJobGraphGeneratorTest.java`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)