### PR TITLE
[FLINK-26390] Use try resourses for CliClient#executeFile

### DIFF
--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
@@ -348,21 +348,16 @@ public class CliClient implements AutoCloseable {
         terminal.writer().println(CliStrings.messageInfo(CliStrings.MESSAGE_EXECUTE_FILE).toAnsi());
 
         // append line delimiter
-        InputStream inputStream =
-                new ByteArrayInputStream(SqlMultiLineParser.formatSqlFile(content).getBytes());
-        Terminal dumbTerminal = TerminalUtils.createDumbTerminal(inputStream, outputStream);
-        try {
+        try (InputStream inputStream =
+                        new ByteArrayInputStream(
+                                SqlMultiLineParser.formatSqlFile(content).getBytes());
+                Terminal dumbTerminal =
+                        TerminalUtils.createDumbTerminal(inputStream, outputStream)) {
             LineReader lineReader = createLineReader(dumbTerminal, false);
             return getAndExecuteStatements(lineReader, mode);
         } catch (Throwable e) {
             printExecutionException(e);
             return false;
-        } finally {
-            try {
-                dumbTerminal.close();
-            } catch (IOException e) {
-                // ignore
-            }
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change

The PR makes use of try resources for `CliClient#executeFile` and skip creation of `Completer` object in case of `CliClient#executeFile` since `Completer` makes sense only in interactive mode

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
