### PR TITLE
[FLINK-24474] set default for taskmanager.host

### DIFF
--- a/flink-dist/src/main/resources/flink-conf.yaml
+++ b/flink-dist/src/main/resources/flink-conf.yaml
@@ -51,13 +51,25 @@ jobmanager.bind-host: localhost
 
 jobmanager.memory.process.size: 1600m
 
-# The host interface the TaskManager will bind to. My default, this is localhost, and will prevent
+# The host interface the TaskManager will bind to. By default, this is localhost, and will prevent
 # the TaskManager from communicating outside the machine/container it is running on.
 #
 # To enable this, set the bind-host address to one that has access to an outside facing network
 # interface, such as 0.0.0.0.
 
 taskmanager.bind-host: localhost
+
+# The address of the host on which the TaskManager runs and can be reached by the JobManager and
+# other TaskManagers. If not specified, the TaskManager will try different strategies to identify
+# the address.
+#
+# Note this address needs to be reachable by the JobManager and forward traffic to one of
+# the interfaces the TaskManager is bound to (see 'taskmanager.bind-host').
+#
+# Note also that unless all TaskManagers are running on the same machine, this address needs to be
+# configured separately for each TaskManager.
+
+taskmanager.host: localhost
 
 # The total process memory size for the TaskManager.
 #

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/container/FlinkContainersBuilder.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/container/FlinkContainersBuilder.java
@@ -167,6 +167,7 @@ public class FlinkContainersBuilder {
 
         this.conf.set(JobManagerOptions.BIND_HOST, "0.0.0.0");
         this.conf.set(TaskManagerOptions.BIND_HOST, "0.0.0.0");
+        this.conf.removeConfig(TaskManagerOptions.HOST);
 
         // Create temporary directory for building Flink image
         final Path imageBuildingTempDir;

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/FlinkConfMountDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/FlinkConfMountDecorator.java
@@ -162,6 +162,7 @@ public class FlinkConfMountDecorator extends AbstractKubernetesStepDecorator {
         clusterSideConfig.removeConfig(RestOptions.BIND_ADDRESS);
         clusterSideConfig.removeConfig(JobManagerOptions.BIND_HOST);
         clusterSideConfig.removeConfig(TaskManagerOptions.BIND_HOST);
+        clusterSideConfig.removeConfig(TaskManagerOptions.HOST);
         return clusterSideConfig.toMap();
     }
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnEntrypointUtils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnEntrypointUtils.java
@@ -67,6 +67,7 @@ public class YarnEntrypointUtils {
         configuration.setString(JobManagerOptions.ADDRESS, hostname);
         configuration.removeConfig(JobManagerOptions.BIND_HOST);
         configuration.removeConfig(TaskManagerOptions.BIND_HOST);
+        configuration.removeConfig(TaskManagerOptions.HOST);
         configuration.setString(RestOptions.ADDRESS, hostname);
         configuration.setString(RestOptions.BIND_ADDRESS, hostname);
 


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/FLINK-24474

As we have changed the `taskmanager.bind-host` to `localhost`, we also need to set the `taskmanager.host` (the advertised address) to `localhost`.