### PR TITLE
[FLINK-26403] SinkWriter should emit all the pending committables on endOfInput

### DIFF
--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/StreamingCompactingFileSinkITCase.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/StreamingCompactingFileSinkITCase.java
@@ -27,7 +27,6 @@ import org.apache.flink.connector.file.sink.utils.IntegerFileSinkTestDataUtils.I
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.minicluster.RpcServiceSharing;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
-import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
 
 import org.junit.Rule;
@@ -58,13 +57,6 @@ public class StreamingCompactingFileSinkITCase extends StreamingExecutionFileSin
                 .withRollingPolicy(new PartSizeAndCheckpointRollingPolicy(1024))
                 .enableCompact(createFileCompactStrategy(), createFileCompactor())
                 .build();
-    }
-
-    @Override
-    protected void configureEnvironment(StreamExecutionEnvironment env) {
-        super.configureEnvironment(env);
-        // Disable unaligned checkpoints explicitly to avoid being randomly enabled
-        env.getCheckpointConfig().enableUnalignedCheckpoints(false);
     }
 
     private static FileCompactor createFileCompactor() {

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/StreamingExecutionFileSinkITCase.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/StreamingExecutionFileSinkITCase.java
@@ -82,7 +82,6 @@ public class StreamingExecutionFileSinkITCase extends FileSinkITBase {
         env.configure(config, getClass().getClassLoader());
 
         env.enableCheckpointing(10, CheckpointingMode.EXACTLY_ONCE);
-        configureEnvironment(env);
 
         if (triggerFailover) {
             env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, Time.milliseconds(100)));
@@ -98,8 +97,6 @@ public class StreamingExecutionFileSinkITCase extends FileSinkITBase {
         StreamGraph streamGraph = env.getStreamGraph();
         return streamGraph.getJobGraph();
     }
-
-    protected void configureEnvironment(StreamExecutionEnvironment env) {}
 
     // ------------------------ Streaming mode user functions ----------------------------------
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/CommitterOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/CommitterOperatorFactory.java
@@ -42,12 +42,16 @@ public final class CommitterOperatorFactory<CommT>
                 CommittableMessage<CommT>, CommittableMessage<CommT>> {
 
     private final TwoPhaseCommittingSink<?, CommT> sink;
-    private final boolean isCheckpointingOrBatchModeEnabled;
+    private final boolean isBatchMode;
+    private final boolean isCheckpointingEnabled;
 
     public CommitterOperatorFactory(
-            TwoPhaseCommittingSink<?, CommT> sink, boolean isCheckpointingOrBatchModeEnabled) {
+            TwoPhaseCommittingSink<?, CommT> sink,
+            boolean isBatchMode,
+            boolean isCheckpointingEnabled) {
         this.sink = checkNotNull(sink);
-        this.isCheckpointingOrBatchModeEnabled = isCheckpointingOrBatchModeEnabled;
+        this.isBatchMode = isBatchMode;
+        this.isCheckpointingEnabled = isCheckpointingEnabled;
     }
 
     @Override
@@ -62,7 +66,8 @@ public final class CommitterOperatorFactory<CommT>
                             sink.getCommittableSerializer(),
                             sink.createCommitter(),
                             sink instanceof WithPostCommitTopology,
-                            isCheckpointingOrBatchModeEnabled);
+                            isBatchMode,
+                            isCheckpointingEnabled);
             committerOperator.setup(
                     parameters.getContainingTask(),
                     parameters.getStreamConfig(),

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/SinkWriterOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/SinkWriterOperatorFactory.java
@@ -45,26 +45,16 @@ public final class SinkWriterOperatorFactory<InputT, CommT>
                 YieldingOperatorFactory<CommittableMessage<CommT>> {
 
     private final Sink<InputT> sink;
-    private final boolean isBatchMode;
-    private final boolean isCheckpointingEnabled;
 
-    public SinkWriterOperatorFactory(
-            Sink<InputT> sink, boolean isBatchMode, boolean isCheckpointingEnabled) {
+    public SinkWriterOperatorFactory(Sink<InputT> sink) {
         this.sink = checkNotNull(sink);
-        this.isBatchMode = isBatchMode;
-        this.isCheckpointingEnabled = isCheckpointingEnabled;
     }
 
     public <T extends StreamOperator<CommittableMessage<CommT>>> T createStreamOperator(
             StreamOperatorParameters<CommittableMessage<CommT>> parameters) {
         try {
             final SinkWriterOperator<InputT, CommT> writerOperator =
-                    new SinkWriterOperator<>(
-                            sink,
-                            processingTimeService,
-                            getMailboxExecutor(),
-                            isBatchMode,
-                            isCheckpointingEnabled);
+                    new SinkWriterOperator<>(sink, processingTimeService, getMailboxExecutor());
             writerOperator.setup(
                     parameters.getContainingTask(),
                     parameters.getStreamConfig(),

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/SinkTransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/SinkTransformationTranslator.java
@@ -140,8 +140,7 @@ public class SinkTransformationTranslator<Input, Output>
                                 input.transform(
                                         WRITER_NAME,
                                         CommittableMessageTypeInfo.noOutput(),
-                                        new SinkWriterOperatorFactory<>(
-                                                sink, isBatchMode, isCheckpointingEnabled)));
+                                        new SinkWriterOperatorFactory<>(sink)));
             }
 
             final List<Transformation<?>> sinkTransformations =
@@ -172,8 +171,7 @@ public class SinkTransformationTranslator<Input, Output>
                                     input.transform(
                                             WRITER_NAME,
                                             typeInformation,
-                                            new SinkWriterOperatorFactory<>(
-                                                    sink, isBatchMode, isCheckpointingEnabled)));
+                                            new SinkWriterOperatorFactory<>(sink)));
 
             DataStream<CommittableMessage<CommT>> precommitted = addFailOverRegion(written);
 
@@ -193,7 +191,8 @@ public class SinkTransformationTranslator<Input, Output>
                                             typeInformation,
                                             new CommitterOperatorFactory<>(
                                                     committingSink,
-                                                    isBatchMode || isCheckpointingEnabled)));
+                                                    isBatchMode,
+                                                    isCheckpointingEnabled)));
 
             if (sink instanceof WithPostCommitTopology) {
                 DataStream<CommittableMessage<CommT>> postcommitted = addFailOverRegion(committed);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/SinkWriterOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/SinkWriterOperatorTest.java
@@ -57,18 +57,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class SinkWriterOperatorTest {
 
-    private static final boolean STREAMING_MODE = false;
-    private static final boolean CHECKPOINTING_ENABLED = true;
-
     @Test
     void testNotEmitCommittablesWithoutCommitter() throws Exception {
         final TestSink.DefaultSinkWriter<Integer> sinkWriter = new TestSink.DefaultSinkWriter<>();
         final OneInputStreamOperatorTestHarness<Integer, CommittableMessage<Integer>> testHarness =
                 new OneInputStreamOperatorTestHarness<>(
                         new SinkWriterOperatorFactory<>(
-                                TestSink.newBuilder().setWriter(sinkWriter).build().asV2(),
-                                STREAMING_MODE,
-                                CHECKPOINTING_ENABLED));
+                                TestSink.newBuilder().setWriter(sinkWriter).build().asV2()));
         testHarness.open();
         testHarness.processElement(1, 1);
 
@@ -90,9 +85,7 @@ class SinkWriterOperatorTest {
         final OneInputStreamOperatorTestHarness<Integer, CommittableMessage<Integer>> testHarness =
                 new OneInputStreamOperatorTestHarness<>(
                         new SinkWriterOperatorFactory<>(
-                                TestSink.newBuilder().setWriter(writer).build().asV2(),
-                                STREAMING_MODE,
-                                CHECKPOINTING_ENABLED));
+                                TestSink.newBuilder().setWriter(writer).build().asV2()));
         testHarness.open();
 
         testHarness.processWatermark(initialTime);
@@ -118,9 +111,7 @@ class SinkWriterOperatorTest {
                                         .setDefaultCommitter()
                                         .setWriter(new TimeBasedBufferingSinkWriter())
                                         .build()
-                                        .asV2(),
-                                STREAMING_MODE,
-                                CHECKPOINTING_ENABLED));
+                                        .asV2()));
 
         testHarness.open();
 
@@ -148,9 +139,7 @@ class SinkWriterOperatorTest {
         final OneInputStreamOperatorTestHarness<Integer, CommittableMessage<Integer>> testHarness =
                 new OneInputStreamOperatorTestHarness<>(
                         new SinkWriterOperatorFactory<>(
-                                TestSink.newBuilder().setDefaultCommitter().build().asV2(),
-                                STREAMING_MODE,
-                                CHECKPOINTING_ENABLED));
+                                TestSink.newBuilder().setDefaultCommitter().build().asV2()));
 
         testHarness.open();
         assertThat(testHarness.getOutput()).isEmpty();
@@ -169,7 +158,7 @@ class SinkWriterOperatorTest {
     void testEmitOnEndOfInputInBatchMode() throws Exception {
         final SinkWriterOperatorFactory<Integer, Integer> writerOperatorFactory =
                 new SinkWriterOperatorFactory<>(
-                        TestSink.newBuilder().setDefaultCommitter().build().asV2(), true, false);
+                        TestSink.newBuilder().setDefaultCommitter().build().asV2());
         final OneInputStreamOperatorTestHarness<Integer, CommittableMessage<Integer>> testHarness =
                 new OneInputStreamOperatorTestHarness<>(writerOperatorFactory);
 
@@ -223,7 +212,7 @@ class SinkWriterOperatorTest {
         restoredTestHarness.prepareSnapshotPreBarrier(checkpointId);
 
         if (stateful) {
-            assertBasicOutput(restoredTestHarness.getOutput(), 2, checkpointId);
+            assertBasicOutput(restoredTestHarness.getOutput(), 2, Long.MAX_VALUE);
         } else {
             assertThat(fromOutput(restoredTestHarness.getOutput()).get(0).asRecord().getValue())
                     .isInstanceOf(CommittableSummary.class)
@@ -313,9 +302,7 @@ class SinkWriterOperatorTest {
                                         .setWriter(sinkWriter)
                                         .setDefaultCommitter()
                                         .build()
-                                        .asV2(),
-                                STREAMING_MODE,
-                                isCheckpointingEnabled));
+                                        .asV2()));
         testHarness.open();
         testHarness.processElement(1, 1);
 
@@ -328,10 +315,6 @@ class SinkWriterOperatorTest {
         if (isCheckpointingEnabled) {
             testHarness.prepareSnapshotPreBarrier(1);
         }
-
-        // Ensure after the final emission no emission is possible anymore to prevent empty updates
-        testHarness.prepareSnapshotPreBarrier(2);
-        testHarness.endInput();
 
         assertEmitted(Collections.singletonList(record), testHarness.getOutput());
         assertThat(sinkWriter.elements).isEmpty();
@@ -373,8 +356,7 @@ class SinkWriterOperatorTest {
             builder.withWriterState();
         }
         final SinkWriterOperatorFactory<Integer, Integer> writerOperatorFactory =
-                new SinkWriterOperatorFactory<>(
-                        builder.build().asV2(), STREAMING_MODE, CHECKPOINTING_ENABLED);
+                new SinkWriterOperatorFactory<>(builder.build().asV2());
         return new OneInputStreamOperatorTestHarness<>(writerOperatorFactory);
     }
 
@@ -391,8 +373,7 @@ class SinkWriterOperatorTest {
             builder.withWriterState();
         }
         final SinkWriterOperatorFactory<Integer, Integer> writerOperatorFactory =
-                new SinkWriterOperatorFactory<>(
-                        builder.build().asV2(), STREAMING_MODE, CHECKPOINTING_ENABLED);
+                new SinkWriterOperatorFactory<>(builder.build().asV2());
         return new OneInputStreamOperatorTestHarness<>(writerOperatorFactory);
     }
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Currently the SinkWriterOperator not drained all the pending committables on endOfInput() and left them till final checkpoint, which would be in fact deserted. This might cause data loss or the CommitterOperator hanged on endOfInput() due to not received expected number of committables.


## Brief change log

  - SinkWriterOperator emits all the pending committables on endOfInput
  - CommitterOperator commits all committables when the final checkpoint is completed or on endOfInput if there's no final checkpoint.
  - The previous hotfix to avoid FileSinkCompactionSwitchITCase using unaligned checkpoint is reverted.


## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
