### PR TITLE
[hotfix] Fix deprecated method call in the docs

### DIFF
--- a/docs/content.zh/docs/dev/datastream/fault-tolerance/checkpointing.md
+++ b/docs/content.zh/docs/dev/datastream/fault-tolerance/checkpointing.md
@@ -96,7 +96,7 @@ env.getCheckpointConfig().setTolerableCheckpointFailureNumber(2)
 env.getCheckpointConfig().setMaxConcurrentCheckpoints(1);
 
 // 使用 externalized checkpoints，这样 checkpoint 在作业取消后仍就会被保留
-env.getCheckpointConfig().enableExternalizedCheckpoints(
+env.getCheckpointConfig().setExternalizedCheckpointCleanup(
         ExternalizedCheckpointCleanup.RETAIN_ON_CANCELLATION);
 
 // 开启实验性的 unaligned checkpoints
@@ -128,7 +128,7 @@ env.getCheckpointConfig().setTolerableCheckpointFailureNumber(2)
 env.getCheckpointConfig.setMaxConcurrentCheckpoints(1)
 
 // 使用 externalized checkpoints，这样 checkpoint 在作业取消后仍就会被保留
-env.getCheckpointConfig().enableExternalizedCheckpoints(
+env.getCheckpointConfig().setExternalizedCheckpointCleanup(
   ExternalizedCheckpointCleanup.RETAIN_ON_CANCELLATION)
 
 // 开启实验性的 unaligned checkpoints

--- a/docs/content.zh/docs/ops/state/checkpoints.md
+++ b/docs/content.zh/docs/ops/state/checkpoints.md
@@ -37,7 +37,7 @@ Checkpoint 在默认的情况下仅用于恢复失败的作业，并不保留，
 
 ```java
 CheckpointConfig config = env.getCheckpointConfig();
-config.enableExternalizedCheckpoints(ExternalizedCheckpointCleanup.RETAIN_ON_CANCELLATION);
+config.setExternalizedCheckpointCleanup(ExternalizedCheckpointCleanup.RETAIN_ON_CANCELLATION);
 ```
 
 `ExternalizedCheckpointCleanup` 配置项定义了当作业取消时，对作业 checkpoint 的操作：

--- a/docs/content/docs/dev/datastream/fault-tolerance/checkpointing.md
+++ b/docs/content/docs/dev/datastream/fault-tolerance/checkpointing.md
@@ -112,7 +112,7 @@ env.getCheckpointConfig().setMaxConcurrentCheckpoints(1);
 
 // enable externalized checkpoints which are retained
 // after job cancellation
-env.getCheckpointConfig().enableExternalizedCheckpoints(
+env.getCheckpointConfig().setExternalizedCheckpointCleanup(
     ExternalizedCheckpointCleanup.RETAIN_ON_CANCELLATION);
 
 // enables the unaligned checkpoints
@@ -153,7 +153,7 @@ env.getCheckpointConfig.setMaxConcurrentCheckpoints(1)
 
 // enable externalized checkpoints which are retained 
 // after job cancellation
-env.getCheckpointConfig().enableExternalizedCheckpoints(
+env.getCheckpointConfig().setExternalizedCheckpointCleanup(
     ExternalizedCheckpointCleanup.RETAIN_ON_CANCELLATION)
 
 // enables the unaligned checkpoints

--- a/docs/content/docs/ops/state/checkpoints.md
+++ b/docs/content/docs/ops/state/checkpoints.md
@@ -98,7 +98,7 @@ This way, you will have a checkpoint around to resume from if your job fails.
 
 ```java
 CheckpointConfig config = env.getCheckpointConfig();
-config.enableExternalizedCheckpoints(ExternalizedCheckpointCleanup.RETAIN_ON_CANCELLATION);
+config.setExternalizedCheckpointCleanup(ExternalizedCheckpointCleanup.RETAIN_ON_CANCELLATION);
 ```
 
 The `ExternalizedCheckpointCleanup` mode configures what happens with checkpoints when you cancel the job:


### PR DESCRIPTION
Trivial docs fix: `enableExternalizedCheckpoints` was deprecated in favor of `setExternalizedCheckpointCleanup`.
