### PR TITLE
[FLINK-26249][table-planner] Run BuiltInFunctionsTestBase and BuiltInAggregateFunctionsTestBase in parallel

### DIFF
--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/BuiltInAggregateFunctionTestBase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/BuiltInAggregateFunctionTestBase.java
@@ -20,7 +20,6 @@ package org.apache.flink.table.planner.functions;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.StateChangelogOptions;
-import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.Schema;
@@ -35,58 +34,49 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.functions.BuiltInFunctionDefinition;
 import org.apache.flink.table.planner.factories.TableFactoryHarness;
 import org.apache.flink.table.types.DataType;
-import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.apache.flink.test.junit5.MiniClusterExtension;
 import org.apache.flink.types.Row;
 import org.apache.flink.types.RowKind;
 import org.apache.flink.util.CloseableIterator;
 import org.apache.flink.util.Preconditions;
 
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.annotation.Nullable;
 
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
-import static org.apache.flink.table.types.DataType.getFieldCount;
+import static org.apache.flink.table.test.TableAssertions.assertThat;
 import static org.apache.flink.table.types.DataType.getFieldDataTypes;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test base for testing aggregate {@link BuiltInFunctionDefinition built-in functions}. */
-@RunWith(Parameterized.class)
-public class BuiltInAggregateFunctionTestBase {
+@Execution(ExecutionMode.CONCURRENT)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(MiniClusterExtension.class)
+abstract class BuiltInAggregateFunctionTestBase {
 
-    @ClassRule
-    public static MiniClusterWithClientResource miniClusterResource =
-            new MiniClusterWithClientResource(
-                    new MiniClusterResourceConfiguration.Builder()
-                            .setNumberTaskManagers(1)
-                            .setNumberSlotsPerTaskManager(1)
-                            .build());
+    abstract Stream<TestSpec> getTestCaseSpecs();
 
-    @Parameter public TestSpec testSpec;
+    final Stream<BuiltInFunctionTestBase.TestCase> getTestCases() {
+        return this.getTestCaseSpecs().flatMap(TestSpec::getTestCases);
+    }
 
-    @Test
-    public void testFunction() throws Exception {
-        final TableEnvironment tEnv =
-                TableEnvironment.create(EnvironmentSettings.inStreamingMode());
-        Configuration configuration = tEnv.getConfig().getConfiguration();
-        // see https://issues.apache.org/jira/browse/FLINK-26092
-        configuration.set(StateChangelogOptions.ENABLE_STATE_CHANGE_LOG, false);
-        final Table sourceTable = asTable(tEnv, testSpec.sourceRowType, testSpec.sourceRows);
-
-        for (final TestItem testItem : testSpec.testItems) {
-            testItem.execute(tEnv, sourceTable);
-        }
+    @ParameterizedTest
+    @MethodSource("getTestCases")
+    final void test(BuiltInFunctionTestBase.TestCase testCase) throws Throwable {
+        testCase.execute();
     }
 
     protected static Table asTable(TableEnvironment tEnv, DataType sourceRowType, List<Row> rows) {
@@ -121,23 +111,6 @@ public class BuiltInAggregateFunctionTestBase {
                 return SourceFunctionProvider.of(new Source(rows, converter), true);
             }
         };
-    }
-
-    protected static void assertRows(List<Row> expectedRows, TableResult tableResult) {
-        final List<Row> actualRows =
-                materializeResult(tableResult).stream()
-                        .sorted(Comparator.comparing(Objects::toString))
-                        .collect(Collectors.toList());
-        final List<Row> sortedExpectedRows =
-                expectedRows.stream()
-                        .sorted(Comparator.comparing(Objects::toString))
-                        .collect(Collectors.toList());
-
-        assertThat(actualRows)
-                .as(
-                        String.format(
-                                "%n%nExpected:%n%s%n%nActual:%n%s", sortedExpectedRows, actualRows))
-                .isEqualTo(sortedExpectedRows);
     }
 
     private static List<Row> materializeResult(TableResult tableResult) {
@@ -232,6 +205,29 @@ public class BuiltInAggregateFunctionTestBase {
             return this;
         }
 
+        private Executable createTestItemExecutable(TestItem testItem) {
+            return () -> {
+                final TableEnvironment tEnv =
+                        TableEnvironment.create(EnvironmentSettings.inStreamingMode());
+                Configuration configuration = tEnv.getConfig().getConfiguration();
+                // see
+                // https://issues.apache.org/jira/browse/FLINK-26092
+                configuration.set(StateChangelogOptions.ENABLE_STATE_CHANGE_LOG, false);
+                final Table sourceTable = asTable(tEnv, sourceRowType, sourceRows);
+
+                testItem.execute(tEnv, sourceTable);
+            };
+        }
+
+        Stream<BuiltInFunctionTestBase.TestCase> getTestCases() {
+            return testItems.stream()
+                    .map(
+                            testItem ->
+                                    new BuiltInFunctionTestBase.TestCase(
+                                            testItem.toString(),
+                                            createTestItemExecutable(testItem)));
+        }
+
         @Override
         public String toString() {
             final StringBuilder bob = new StringBuilder();
@@ -267,13 +263,15 @@ public class BuiltInAggregateFunctionTestBase {
                 final DataType actualRowType =
                         tableResult.getResolvedSchema().toSourceRowDataType();
 
-                assertThat(getFieldCount(actualRowType)).isEqualTo(getFieldCount(expectedRowType));
-                assertThat(getFieldDataTypes(actualRowType))
-                        .isEqualTo(getFieldDataTypes(expectedRowType));
+                assertThat(actualRowType)
+                        .getChildren()
+                        .containsExactlyElementsOf(getFieldDataTypes(expectedRowType));
             }
 
             if (expectedRows != null) {
-                assertRows(expectedRows, tableResult);
+                final List<Row> actualRows = materializeResult(tableResult);
+
+                assertThat(actualRows).containsExactlyInAnyOrderElementsOf(expectedRows);
             }
         }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/BuiltInFunctionTestBase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/BuiltInFunctionTestBase.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.planner.functions;
 
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.Table;
@@ -33,15 +32,17 @@ import org.apache.flink.table.functions.BuiltInFunctionDefinition;
 import org.apache.flink.table.functions.UserDefinedFunction;
 import org.apache.flink.table.types.AbstractDataType;
 import org.apache.flink.table.types.DataType;
-import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.apache.flink.test.junit5.MiniClusterExtension;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.Preconditions;
 
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.annotation.Nullable;
 
@@ -52,6 +53,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import static java.util.Collections.singletonList;
 import static org.apache.flink.core.testutils.FlinkAssertions.anyCauseMatches;
@@ -60,127 +62,68 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
 /**
- * Test base for testing {@link BuiltInFunctionDefinition}.
+ * Test interface implementing the logic to execute tests for {@link BuiltInFunctionDefinition}.
+ *
+ * <p>To create a new set of test cases, just create a subclass and implement the method {@link
+ * #getTestCaseSpecs()}.
  *
  * <p>Note: This test base is not the most efficient one. It currently checks the full pipeline
  * end-to-end. If the testing time is too long, we can change the underlying implementation easily
- * without touching the defined {@link TestSpec}s.
+ * without touching the defined {@link TestSetSpec}s.
  */
-@RunWith(Parameterized.class)
-public abstract class BuiltInFunctionTestBase {
+@Execution(ExecutionMode.CONCURRENT)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(MiniClusterExtension.class)
+abstract class BuiltInFunctionTestBase {
 
-    @ClassRule
-    public static MiniClusterWithClientResource miniClusterResource =
-            new MiniClusterWithClientResource(
-                    new MiniClusterResourceConfiguration.Builder()
-                            .setNumberTaskManagers(1)
-                            .setNumberSlotsPerTaskManager(1)
-                            .build());
-
-    @Parameter public TestSpec testSpec;
-
-    protected Configuration configuration() {
+    Configuration getConfiguration() {
         return new Configuration();
     }
 
-    @Test
-    public void testFunction() {
-        final TableEnvironment env =
-                TableEnvironment.create(EnvironmentSettings.newInstance().build());
-        env.getConfig().addConfiguration(configuration());
+    abstract Stream<TestSetSpec> getTestCaseSpecs();
 
-        testSpec.functions.forEach(f -> env.createTemporarySystemFunction(f.getSimpleName(), f));
+    final Stream<TestCase> getTestCases() {
+        return this.getTestCaseSpecs()
+                .flatMap(testSpec -> testSpec.getTestCases(this.getConfiguration()));
+    }
 
-        final DataTypeFactory dataTypeFactory =
-                ((TableEnvironmentInternal) env).getCatalogManager().getDataTypeFactory();
-
-        final Table inputTable;
-        if (testSpec.fieldDataTypes == null) {
-            inputTable = env.fromValues(Row.of(testSpec.fieldData));
-        } else {
-            final DataTypes.UnresolvedField[] fields =
-                    IntStream.range(0, testSpec.fieldDataTypes.length)
-                            .mapToObj(i -> DataTypes.FIELD("f" + i, testSpec.fieldDataTypes[i]))
-                            .toArray(DataTypes.UnresolvedField[]::new);
-            inputTable = env.fromValues(DataTypes.ROW(fields), Row.of(testSpec.fieldData));
-        }
-
-        for (TestItem testItem : testSpec.testItems) {
-            try {
-                if (testItem instanceof ResultTestItem<?>) {
-                    testResult(dataTypeFactory, env, inputTable, (ResultTestItem<?>) testItem);
-                } else if (testItem instanceof ErrorTestItem<?>) {
-                    testError(env, inputTable, (ErrorTestItem<?>) testItem);
-                }
-            } catch (Throwable t) {
-                throw new AssertionError("Failing test item: " + testItem, t);
-            }
-        }
+    @ParameterizedTest
+    @MethodSource("getTestCases")
+    final void test(TestCase testCase) throws Throwable {
+        testCase.execute();
     }
 
     // --------------------------------------------------------------------------------------------
-    // Test utilities
+    // Test model
     // --------------------------------------------------------------------------------------------
-    private static void testResult(
-            DataTypeFactory dataTypeFactory,
-            TableEnvironment env,
-            Table inputTable,
-            ResultTestItem<?> testItem) {
 
-        final Table resultTable = testItem.query(env, inputTable);
+    /** Single test case. */
+    static class TestCase implements Executable {
 
-        final List<DataType> expectedDataTypes =
-                createDataTypes(dataTypeFactory, testItem.dataTypes);
-        final TableResult result = resultTable.execute();
-        final Iterator<Row> iterator = result.collect();
+        private final String name;
+        private final Executable executable;
 
-        assertThat(iterator).hasNext();
-
-        final Row row = iterator.next();
-
-        assertThat(iterator).as("No more rows expected.").isExhausted();
-
-        for (int i = 0; i < row.getArity(); i++) {
-            assertThat(result.getResolvedSchema().getColumnDataTypes().get(i).getLogicalType())
-                    .as("Logical type for spec [%d] of test [%s] doesn't match.", i, testItem)
-                    .isEqualTo(expectedDataTypes.get(i).getLogicalType());
-
-            assertThat(Row.of(row.getField(i)))
-                    .as("Result for spec [%d] of test [%s] doesn't match.", i, testItem)
-                    .isEqualTo(
-                            // Use Row.equals() to enable equality for complex structure, i.e.
-                            // byte[]
-                            Row.of(testItem.results.get(i)));
-        }
-    }
-
-    private static void testError(
-            TableEnvironment env, Table inputTable, ErrorTestItem<?> testItem) {
-        AtomicReference<TableResult> tableResult = new AtomicReference<>();
-
-        Throwable t =
-                catchThrowable(() -> tableResult.set(testItem.query(env, inputTable).execute()));
-
-        if (testItem.expectedDuringValidation) {
-            assertThat(t)
-                    .as("Expected a validation exception")
-                    .isNotNull()
-                    .satisfies(testItem.errorMatcher());
-            return;
-        } else {
-            assertThat(t).as("Error while validating the query").isNull();
+        TestCase(String name, Executable executable) {
+            this.name = name;
+            this.executable = executable;
         }
 
-        assertThatThrownBy(() -> tableResult.get().await())
-                .isNotNull()
-                .satisfies(testItem.errorMatcher());
+        @Override
+        public void execute() throws Throwable {
+            this.executable.execute();
+        }
+
+        @Override
+        public String toString() {
+            return name;
+        }
     }
 
     /**
      * Test specification for executing a {@link BuiltInFunctionDefinition} with different
      * parameters on a set of fields.
      */
-    protected static class TestSpec {
+    static class TestSetSpec {
 
         private final @Nullable BuiltInFunctionDefinition definition;
 
@@ -194,48 +137,48 @@ public abstract class BuiltInFunctionTestBase {
 
         private @Nullable AbstractDataType<?>[] fieldDataTypes;
 
-        private TestSpec(BuiltInFunctionDefinition definition, @Nullable String description) {
+        private TestSetSpec(BuiltInFunctionDefinition definition, @Nullable String description) {
             this.definition = definition;
             this.description = description;
             this.functions = new ArrayList<>();
             this.testItems = new ArrayList<>();
         }
 
-        static TestSpec forFunction(BuiltInFunctionDefinition definition) {
+        static TestSetSpec forFunction(BuiltInFunctionDefinition definition) {
             return forFunction(definition, null);
         }
 
-        static TestSpec forFunction(BuiltInFunctionDefinition definition, String description) {
-            return new TestSpec(Preconditions.checkNotNull(definition), description);
+        static TestSetSpec forFunction(BuiltInFunctionDefinition definition, String description) {
+            return new TestSetSpec(Preconditions.checkNotNull(definition), description);
         }
 
-        static TestSpec forExpression(String description) {
-            return new TestSpec(null, Preconditions.checkNotNull(description));
+        static TestSetSpec forExpression(String description) {
+            return new TestSetSpec(null, Preconditions.checkNotNull(description));
         }
 
-        TestSpec onFieldsWithData(Object... fieldData) {
+        TestSetSpec onFieldsWithData(Object... fieldData) {
             this.fieldData = fieldData;
             return this;
         }
 
-        TestSpec andDataTypes(AbstractDataType<?>... fieldDataType) {
+        TestSetSpec andDataTypes(AbstractDataType<?>... fieldDataType) {
             this.fieldDataTypes = fieldDataType;
             return this;
         }
 
-        TestSpec withFunction(Class<? extends UserDefinedFunction> functionClass) {
+        TestSetSpec withFunction(Class<? extends UserDefinedFunction> functionClass) {
             // the function will be registered under the class simple name
             this.functions.add(functionClass);
             return this;
         }
 
-        TestSpec testTableApiResult(
+        TestSetSpec testTableApiResult(
                 Expression expression, Object result, AbstractDataType<?> dataType) {
             return testTableApiResult(
                     singletonList(expression), singletonList(result), singletonList(dataType));
         }
 
-        TestSpec testTableApiResult(
+        TestSetSpec testTableApiResult(
                 List<Expression> expression,
                 List<Object> result,
                 List<AbstractDataType<?>> dataType) {
@@ -243,53 +186,54 @@ public abstract class BuiltInFunctionTestBase {
             return this;
         }
 
-        TestSpec testTableApiValidationError(Expression expression, String errorMessage) {
+        TestSetSpec testTableApiValidationError(Expression expression, String errorMessage) {
             testItems.add(
                     new TableApiErrorTestItem(
                             expression, ValidationException.class, errorMessage, true));
             return this;
         }
 
-        TestSpec testTableApiRuntimeError(Expression expression, String errorMessage) {
+        TestSetSpec testTableApiRuntimeError(Expression expression, String errorMessage) {
             testItems.add(
                     new TableApiErrorTestItem(expression, Throwable.class, errorMessage, false));
             return this;
         }
 
-        TestSpec testTableApiRuntimeError(
+        TestSetSpec testTableApiRuntimeError(
                 Expression expression, Class<? extends Throwable> exceptionError) {
             testItems.add(new TableApiErrorTestItem(expression, exceptionError, null, false));
             return this;
         }
 
-        TestSpec testSqlResult(String expression, Object result, AbstractDataType<?> dataType) {
+        TestSetSpec testSqlResult(String expression, Object result, AbstractDataType<?> dataType) {
             return testSqlResult(expression, singletonList(result), singletonList(dataType));
         }
 
-        TestSpec testSqlResult(
+        TestSetSpec testSqlResult(
                 String expression, List<Object> result, List<AbstractDataType<?>> dataType) {
             testItems.add(new SqlResultTestItem(expression, result, dataType));
             return this;
         }
 
-        TestSpec testSqlValidationError(String expression, String errorMessage) {
+        TestSetSpec testSqlValidationError(String expression, String errorMessage) {
             testItems.add(
                     new SqlErrorTestItem(
                             expression, ValidationException.class, errorMessage, true));
             return this;
         }
 
-        TestSpec testSqlRuntimeError(String expression, String errorMessage) {
+        TestSetSpec testSqlRuntimeError(String expression, String errorMessage) {
             testItems.add(new SqlErrorTestItem(expression, Throwable.class, errorMessage, false));
             return this;
         }
 
-        TestSpec testSqlRuntimeError(String expression, Class<? extends Throwable> exceptionError) {
+        TestSetSpec testSqlRuntimeError(
+                String expression, Class<? extends Throwable> exceptionError) {
             testItems.add(new SqlErrorTestItem(expression, exceptionError, null, false));
             return this;
         }
 
-        TestSpec testResult(
+        TestSetSpec testResult(
                 Expression expression,
                 String sqlExpression,
                 Object result,
@@ -297,7 +241,7 @@ public abstract class BuiltInFunctionTestBase {
             return testResult(expression, sqlExpression, result, dataType, dataType);
         }
 
-        TestSpec testResult(ResultSpec... resultSpecs) {
+        TestSetSpec testResult(ResultSpec... resultSpecs) {
             final int cols = resultSpecs.length;
             final List<Expression> expressions = new ArrayList<>(cols);
             final List<String> sqlExpressions = new ArrayList<>(cols);
@@ -316,7 +260,7 @@ public abstract class BuiltInFunctionTestBase {
                     expressions, sqlExpressions, results, tableApiDataTypes, sqlDataTypes);
         }
 
-        TestSpec testResult(
+        TestSetSpec testResult(
                 Expression expression,
                 String sqlExpression,
                 Object result,
@@ -330,7 +274,7 @@ public abstract class BuiltInFunctionTestBase {
                     singletonList(sqlDataType));
         }
 
-        TestSpec testResult(
+        TestSetSpec testResult(
                 List<Expression> expression,
                 List<String> sqlExpression,
                 List<Object> result,
@@ -342,6 +286,41 @@ public abstract class BuiltInFunctionTestBase {
             return this;
         }
 
+        Stream<TestCase> getTestCases(Configuration configuration) {
+            return testItems.stream().map(testItem -> getTestCase(configuration, testItem));
+        }
+
+        private TestCase getTestCase(Configuration configuration, TestItem testItem) {
+            return new TestCase(
+                    testItem.toString(),
+                    () -> {
+                        final TableEnvironmentInternal env =
+                                (TableEnvironmentInternal)
+                                        TableEnvironment.create(
+                                                EnvironmentSettings.newInstance().build());
+                        env.getConfig().addConfiguration(configuration);
+
+                        functions.forEach(
+                                f -> env.createTemporarySystemFunction(f.getSimpleName(), f));
+
+                        final Table inputTable;
+                        if (fieldDataTypes == null) {
+                            inputTable = env.fromValues(Row.of(fieldData));
+                        } else {
+                            final DataTypes.UnresolvedField[] fields =
+                                    IntStream.range(0, fieldDataTypes.length)
+                                            .mapToObj(
+                                                    i ->
+                                                            DataTypes.FIELD(
+                                                                    "f" + i, fieldDataTypes[i]))
+                                            .toArray(DataTypes.UnresolvedField[]::new);
+                            inputTable = env.fromValues(DataTypes.ROW(fields), Row.of(fieldData));
+                        }
+
+                        testItem.test(env, inputTable);
+                    });
+        }
+
         @Override
         public String toString() {
             return (definition != null ? definition.getName() : "Expression")
@@ -349,11 +328,11 @@ public abstract class BuiltInFunctionTestBase {
         }
     }
 
-    private interface TestItem {
-        // marker interface
+    interface TestItem {
+        void test(TableEnvironmentInternal env, Table inputTable);
     }
 
-    private abstract static class ResultTestItem<T> implements TestItem {
+    abstract static class ResultTestItem<T> implements TestItem {
         final T expression;
         final List<Object> results;
         final List<AbstractDataType<?>> dataTypes;
@@ -365,9 +344,38 @@ public abstract class BuiltInFunctionTestBase {
         }
 
         abstract Table query(TableEnvironment env, Table inputTable);
+
+        @Override
+        public void test(TableEnvironmentInternal env, Table inputTable) {
+            final Table resultTable = this.query(env, inputTable);
+
+            final List<DataType> expectedDataTypes =
+                    createDataTypes(env.getCatalogManager().getDataTypeFactory(), this.dataTypes);
+            final TableResult result = resultTable.execute();
+            final Iterator<Row> iterator = result.collect();
+
+            assertThat(iterator).hasNext();
+
+            final Row row = iterator.next();
+
+            assertThat(iterator).as("No more rows expected.").isExhausted();
+
+            for (int i = 0; i < row.getArity(); i++) {
+                assertThat(result.getResolvedSchema().getColumnDataTypes().get(i).getLogicalType())
+                        .as("Logical type for spec [%d] of test [%s] doesn't match.", i, this)
+                        .isEqualTo(expectedDataTypes.get(i).getLogicalType());
+
+                assertThat(Row.of(row.getField(i)))
+                        .as("Result for spec [%d] of test [%s] doesn't match.", i, this)
+                        .isEqualTo(
+                                // Use Row.equals() to enable equality for complex structure, i.e.
+                                // byte[]
+                                Row.of(this.results.get(i)));
+            }
+        }
     }
 
-    private abstract static class ErrorTestItem<T> implements TestItem {
+    abstract static class ErrorTestItem<T> implements TestItem {
         final T expression;
         final Class<? extends Throwable> errorClass;
         final String errorMessage;
@@ -396,9 +404,31 @@ public abstract class BuiltInFunctionTestBase {
             }
             return anyCauseMatches(errorClass);
         }
+
+        @Override
+        public void test(TableEnvironmentInternal env, Table inputTable) {
+            AtomicReference<TableResult> tableResult = new AtomicReference<>();
+
+            Throwable t =
+                    catchThrowable(() -> tableResult.set(this.query(env, inputTable).execute()));
+
+            if (this.expectedDuringValidation) {
+                assertThat(t)
+                        .as("Expected a validation exception")
+                        .isNotNull()
+                        .satisfies(this.errorMatcher());
+                return;
+            } else {
+                assertThat(t).as("Error while validating the query").isNull();
+            }
+
+            assertThatThrownBy(() -> tableResult.get().await())
+                    .isNotNull()
+                    .satisfies(this.errorMatcher());
+        }
     }
 
-    private static class TableApiResultTestItem extends ResultTestItem<List<Expression>> {
+    static class TableApiResultTestItem extends ResultTestItem<List<Expression>> {
 
         TableApiResultTestItem(
                 List<Expression> expressions,
@@ -421,7 +451,7 @@ public abstract class BuiltInFunctionTestBase {
         }
     }
 
-    private static class TableApiErrorTestItem extends ErrorTestItem<Expression> {
+    static class TableApiErrorTestItem extends ErrorTestItem<Expression> {
 
         TableApiErrorTestItem(
                 Expression expression,
@@ -442,7 +472,7 @@ public abstract class BuiltInFunctionTestBase {
         }
     }
 
-    private static class SqlResultTestItem extends ResultTestItem<String> {
+    static class SqlResultTestItem extends ResultTestItem<String> {
 
         SqlResultTestItem(
                 String sqlExpression, List<Object> result, List<AbstractDataType<?>> dataType) {
@@ -460,7 +490,7 @@ public abstract class BuiltInFunctionTestBase {
         }
     }
 
-    private static class SqlErrorTestItem extends ErrorTestItem<String> {
+    static class SqlErrorTestItem extends ErrorTestItem<String> {
 
         private SqlErrorTestItem(
                 String expression,
@@ -481,13 +511,13 @@ public abstract class BuiltInFunctionTestBase {
         }
     }
 
-    private static List<DataType> createDataTypes(
+    static List<DataType> createDataTypes(
             DataTypeFactory dataTypeFactory, List<AbstractDataType<?>> dataTypes) {
         return dataTypes.stream().map(dataTypeFactory::createDataType).collect(Collectors.toList());
     }
 
     /** Helper POJO to store test parameters. */
-    public static class ResultSpec {
+    static class ResultSpec {
 
         final Expression tableApiExpression;
         final String sqlExpression;

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/BuiltInFunctionTestBase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/BuiltInFunctionTestBase.java
@@ -65,7 +65,7 @@ import static org.assertj.core.api.Assertions.catchThrowable;
  * Test interface implementing the logic to execute tests for {@link BuiltInFunctionDefinition}.
  *
  * <p>To create a new set of test cases, just create a subclass and implement the method {@link
- * #getTestCaseSpecs()}.
+ * #getTestSetSpecs()}.
  *
  * <p>Note: This test base is not the most efficient one. It currently checks the full pipeline
  * end-to-end. If the testing time is too long, we can change the underlying implementation easily
@@ -80,10 +80,10 @@ abstract class BuiltInFunctionTestBase {
         return new Configuration();
     }
 
-    abstract Stream<TestSetSpec> getTestCaseSpecs();
+    abstract Stream<TestSetSpec> getTestSetSpecs();
 
-    final Stream<TestCase> getTestCases() {
-        return this.getTestCaseSpecs()
+    private Stream<TestCase> getTestCases() {
+        return this.getTestSetSpecs()
                 .flatMap(testSpec -> testSpec.getTestCases(this.getConfiguration()));
     }
 
@@ -328,11 +328,11 @@ abstract class BuiltInFunctionTestBase {
         }
     }
 
-    interface TestItem {
+    private interface TestItem {
         void test(TableEnvironmentInternal env, Table inputTable);
     }
 
-    abstract static class ResultTestItem<T> implements TestItem {
+    private abstract static class ResultTestItem<T> implements TestItem {
         final T expression;
         final List<Object> results;
         final List<AbstractDataType<?>> dataTypes;
@@ -375,7 +375,7 @@ abstract class BuiltInFunctionTestBase {
         }
     }
 
-    abstract static class ErrorTestItem<T> implements TestItem {
+    private abstract static class ErrorTestItem<T> implements TestItem {
         final T expression;
         final Class<? extends Throwable> errorClass;
         final String errorMessage;
@@ -428,7 +428,7 @@ abstract class BuiltInFunctionTestBase {
         }
     }
 
-    static class TableApiResultTestItem extends ResultTestItem<List<Expression>> {
+    private static class TableApiResultTestItem extends ResultTestItem<List<Expression>> {
 
         TableApiResultTestItem(
                 List<Expression> expressions,
@@ -451,7 +451,7 @@ abstract class BuiltInFunctionTestBase {
         }
     }
 
-    static class TableApiErrorTestItem extends ErrorTestItem<Expression> {
+    private static class TableApiErrorTestItem extends ErrorTestItem<Expression> {
 
         TableApiErrorTestItem(
                 Expression expression,
@@ -472,7 +472,7 @@ abstract class BuiltInFunctionTestBase {
         }
     }
 
-    static class SqlResultTestItem extends ResultTestItem<String> {
+    private static class SqlResultTestItem extends ResultTestItem<String> {
 
         SqlResultTestItem(
                 String sqlExpression, List<Object> result, List<AbstractDataType<?>> dataType) {
@@ -490,7 +490,7 @@ abstract class BuiltInFunctionTestBase {
         }
     }
 
-    static class SqlErrorTestItem extends ErrorTestItem<String> {
+    private static class SqlErrorTestItem extends ErrorTestItem<String> {
 
         private SqlErrorTestItem(
                 String expression,

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
@@ -116,7 +116,7 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
     private static final int[] DEFAULT_ARRAY = new int[] {0, 1, 2};
 
     @Override
-    public Configuration getConfiguration() {
+    Configuration getConfiguration() {
         return new Configuration()
                 .set(TableConfigOptions.LOCAL_TIME_ZONE, TEST_TZ.getId())
                 .set(
@@ -125,7 +125,7 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
     }
 
     @Override
-    public Stream<TestSetSpec> getTestCaseSpecs() {
+    Stream<TestSetSpec> getTestSetSpecs() {
         final List<TestSetSpec> specs = new ArrayList<>();
         specs.addAll(allTypesBasic());
         specs.addAll(toStringCasts());
@@ -135,7 +135,7 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
         return specs.stream();
     }
 
-    public static List<TestSetSpec> allTypesBasic() {
+    private static List<TestSetSpec> allTypesBasic() {
         return Arrays.asList(
                 CastTestSpecBuilder.testCastTo(BOOLEAN())
                         .fromCase(BOOLEAN(), null, null)
@@ -960,7 +960,7 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                 );
     }
 
-    public static List<TestSetSpec> toStringCasts() {
+    private static List<TestSetSpec> toStringCasts() {
         return Arrays.asList(
                 CastTestSpecBuilder.testCastTo(CHAR(3))
                         .fromCase(CHAR(5), null, null)
@@ -1089,7 +1089,7 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         .build());
     }
 
-    public static List<TestSetSpec> decimalCasts() {
+    private static List<TestSetSpec> decimalCasts() {
         return Collections.singletonList(
                 CastTestSpecBuilder.testCastTo(DECIMAL(8, 4))
                         .fromCase(STRING(), null, null)
@@ -1105,7 +1105,7 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
     }
 
     @SuppressWarnings("NumericOverflow")
-    public static List<TestSetSpec> numericBounds() {
+    private static List<TestSetSpec> numericBounds() {
         return Arrays.asList(
                 CastTestSpecBuilder.testCastTo(TINYINT())
                         .fromCase(TINYINT(), Byte.MIN_VALUE, Byte.MIN_VALUE)
@@ -1160,7 +1160,7 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         .build());
     }
 
-    public static List<TestSetSpec> constructedTypes() {
+    private static List<TestSetSpec> constructedTypes() {
         return Arrays.asList(
                 CastTestSpecBuilder.testCastTo(MAP(STRING(), STRING()))
                         .fromCase(MAP(FLOAT(), DOUBLE()), null, null)
@@ -1217,7 +1217,7 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         .build());
     }
 
-    static class CastTestSpecBuilder {
+    private static class CastTestSpecBuilder {
         private TestSetSpec testSetSpec;
         private DataType targetType;
         private final List<Object> columnData = new ArrayList<>();

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
@@ -31,8 +31,6 @@ import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.types.logical.utils.LogicalTypeCasts;
 import org.apache.flink.types.Row;
 
-import org.junit.runners.Parameterized;
-
 import java.math.BigDecimal;
 import java.time.DateTimeException;
 import java.time.Duration;
@@ -48,6 +46,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Stream;
 
 import static org.apache.flink.table.api.DataTypes.ARRAY;
 import static org.apache.flink.table.api.DataTypes.BIGINT;
@@ -117,26 +116,26 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
     private static final int[] DEFAULT_ARRAY = new int[] {0, 1, 2};
 
     @Override
-    protected Configuration configuration() {
-        return super.configuration()
+    public Configuration getConfiguration() {
+        return new Configuration()
                 .set(TableConfigOptions.LOCAL_TIME_ZONE, TEST_TZ.getId())
                 .set(
                         ExecutionConfigOptions.TABLE_EXEC_LEGACY_CAST_BEHAVIOUR,
                         LegacyCastBehaviour.DISABLED);
     }
 
-    @Parameterized.Parameters(name = "{index}: {0}")
-    public static List<TestSpec> testData() {
-        final List<TestSpec> specs = new ArrayList<>();
+    @Override
+    public Stream<TestSetSpec> getTestCaseSpecs() {
+        final List<TestSetSpec> specs = new ArrayList<>();
         specs.addAll(allTypesBasic());
         specs.addAll(toStringCasts());
         specs.addAll(decimalCasts());
         specs.addAll(numericBounds());
         specs.addAll(constructedTypes());
-        return specs;
+        return specs.stream();
     }
 
-    public static List<TestSpec> allTypesBasic() {
+    public static List<TestSetSpec> allTypesBasic() {
         return Arrays.asList(
                 CastTestSpecBuilder.testCastTo(BOOLEAN())
                         .fromCase(BOOLEAN(), null, null)
@@ -961,7 +960,7 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                 );
     }
 
-    public static List<TestSpec> toStringCasts() {
+    public static List<TestSetSpec> toStringCasts() {
         return Arrays.asList(
                 CastTestSpecBuilder.testCastTo(CHAR(3))
                         .fromCase(CHAR(5), null, null)
@@ -1090,7 +1089,7 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         .build());
     }
 
-    public static List<TestSpec> decimalCasts() {
+    public static List<TestSetSpec> decimalCasts() {
         return Collections.singletonList(
                 CastTestSpecBuilder.testCastTo(DECIMAL(8, 4))
                         .fromCase(STRING(), null, null)
@@ -1106,7 +1105,7 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
     }
 
     @SuppressWarnings("NumericOverflow")
-    public static List<TestSpec> numericBounds() {
+    public static List<TestSetSpec> numericBounds() {
         return Arrays.asList(
                 CastTestSpecBuilder.testCastTo(TINYINT())
                         .fromCase(TINYINT(), Byte.MIN_VALUE, Byte.MIN_VALUE)
@@ -1161,7 +1160,7 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         .build());
     }
 
-    public static List<TestSpec> constructedTypes() {
+    public static List<TestSetSpec> constructedTypes() {
         return Arrays.asList(
                 CastTestSpecBuilder.testCastTo(MAP(STRING(), STRING()))
                         .fromCase(MAP(FLOAT(), DOUBLE()), null, null)
@@ -1219,7 +1218,7 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
     }
 
     static class CastTestSpecBuilder {
-        private TestSpec testSpec;
+        private TestSetSpec testSetSpec;
         private DataType targetType;
         private final List<Object> columnData = new ArrayList<>();
         private final List<DataType> columnTypes = new ArrayList<>();
@@ -1237,8 +1236,8 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
         private static CastTestSpecBuilder testCastTo(DataType targetType) {
             CastTestSpecBuilder tsb = new CastTestSpecBuilder();
             tsb.targetType = targetType;
-            tsb.testSpec =
-                    TestSpec.forFunction(
+            tsb.testSetSpec =
+                    TestSetSpec.forFunction(
                             BuiltInFunctionDefinitions.CAST, "To " + targetType.toString());
             return tsb;
         }
@@ -1285,7 +1284,7 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
             return this;
         }
 
-        private TestSpec build() {
+        private TestSetSpec build() {
             List<ResultSpec> testSpecs = new ArrayList<>(columnData.size());
             // expectedValues may contain less elements if there are also error test cases
             int idxOffset = 0;
@@ -1304,14 +1303,15 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                                                         + ", "
                                                         + targetType.toString()
                                                         + ")"));
-                        testSpec.testTableApiValidationError($(colName).cast(targetType), errorMsg);
+                        testSetSpec.testTableApiValidationError(
+                                $(colName).cast(targetType), errorMsg);
                         idxOffset++;
                         break;
                     case ERROR_SQL:
                         errorMsg =
                                 specificErrorMsg(
                                         colType, "Cast function cannot convert value of type ");
-                        testSpec.testSqlValidationError(
+                        testSetSpec.testSqlValidationError(
                                 "CAST(" + colName + " AS " + targetType.toString() + ")", errorMsg);
                         idxOffset++;
                         break;
@@ -1319,10 +1319,10 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         @SuppressWarnings("unchecked")
                         Class<? extends Throwable> throwableClazz =
                                 (Class<? extends Throwable>) expectedValues.get(i - idxOffset);
-                        testSpec.testSqlRuntimeError(
+                        testSetSpec.testSqlRuntimeError(
                                 "CAST(" + colName + " AS " + targetType.toString() + ")",
                                 throwableClazz);
-                        testSpec.testTableApiRuntimeError(
+                        testSetSpec.testTableApiRuntimeError(
                                 $(colName).cast(targetType), throwableClazz);
                         break;
                     case RESULT:
@@ -1335,10 +1335,11 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         break;
                 }
             }
-            testSpec.onFieldsWithData(columnData.toArray())
+            testSetSpec
+                    .onFieldsWithData(columnData.toArray())
                     .andDataTypes(columnTypes.toArray(new AbstractDataType<?>[] {}))
                     .testResult(testSpecs.toArray(new ResultSpec[0]));
-            return testSpec;
+            return testSetSpec;
         }
 
         private String specificErrorMsg(LogicalType colType, String defaultMsg) {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionMiscITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionMiscITCase.java
@@ -27,13 +27,10 @@ import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 import org.apache.flink.table.functions.ScalarFunction;
 import org.apache.flink.types.Row;
 
-import org.junit.runners.Parameterized;
-
 import java.nio.ByteBuffer;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.util.Arrays;
-import java.util.List;
+import java.util.stream.Stream;
 
 import static org.apache.flink.table.api.DataTypes.BIGINT;
 import static org.apache.flink.table.api.DataTypes.BINARY;
@@ -55,20 +52,20 @@ import static org.apache.flink.util.CollectionUtil.map;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link BuiltInFunctionDefinitions#CAST} regarding {@link DataTypes#ROW}. */
-public class CastFunctionMiscITCase extends BuiltInFunctionTestBase {
+class CastFunctionMiscITCase extends BuiltInFunctionTestBase {
 
     @Override
-    protected Configuration configuration() {
-        return super.configuration()
+    public Configuration getConfiguration() {
+        return new Configuration()
                 .set(
                         ExecutionConfigOptions.TABLE_EXEC_LEGACY_CAST_BEHAVIOUR,
                         ExecutionConfigOptions.LegacyCastBehaviour.DISABLED);
     }
 
-    @Parameterized.Parameters(name = "{index}: {0}")
-    public static List<TestSpec> testData() {
-        return Arrays.asList(
-                TestSpec.forFunction(
+    @Override
+    public Stream<TestSetSpec> getTestCaseSpecs() {
+        return Stream.of(
+                TestSetSpec.forFunction(
                                 BuiltInFunctionDefinitions.CAST,
                                 "implicit with different field names")
                         .onFieldsWithData(Row.of(12, "Hello"))
@@ -76,13 +73,14 @@ public class CastFunctionMiscITCase extends BuiltInFunctionTestBase {
                         .withFunction(RowToFirstField.class)
                         .testResult(
                                 call("RowToFirstField", $("f0")), "RowToFirstField(f0)", 12, INT()),
-                TestSpec.forFunction(BuiltInFunctionDefinitions.CAST, "implicit with type widening")
+                TestSetSpec.forFunction(
+                                BuiltInFunctionDefinitions.CAST, "implicit with type widening")
                         .onFieldsWithData(Row.of((byte) 12, "Hello"))
                         .andDataTypes(DataTypes.of("ROW<i TINYINT, s STRING>"))
                         .withFunction(RowToFirstField.class)
                         .testResult(
                                 call("RowToFirstField", $("f0")), "RowToFirstField(f0)", 12, INT()),
-                TestSpec.forFunction(
+                TestSetSpec.forFunction(
                                 BuiltInFunctionDefinitions.CAST,
                                 "implicit with nested type widening")
                         .onFieldsWithData(Row.of(Row.of(12, 42), "Hello"))
@@ -93,7 +91,7 @@ public class CastFunctionMiscITCase extends BuiltInFunctionTestBase {
                                 "NestedRowToFirstField(f0)",
                                 Row.of(12, 42.0),
                                 DataTypes.of("ROW<i INT, d DOUBLE>")),
-                TestSpec.forFunction(
+                TestSetSpec.forFunction(
                                 BuiltInFunctionDefinitions.CAST,
                                 "explicit with nested rows and implicit nullability change")
                         .onFieldsWithData(Row.of(Row.of(12, 42, null), "Hello"))
@@ -114,7 +112,7 @@ public class CastFunctionMiscITCase extends BuiltInFunctionTestBase {
                                 // nullable and the cast does not allow setting the outer
                                 // nullability but derives it from the source operand
                                 DataTypes.of("ROW<r ROW<s STRING, b BOOLEAN, i INT>, s STRING>")),
-                TestSpec.forFunction(
+                TestSetSpec.forFunction(
                                 BuiltInFunctionDefinitions.CAST,
                                 "explicit with nested rows and explicit nullability change")
                         .onFieldsWithData(Row.of(Row.of(12, 42, null), "Hello"))
@@ -134,7 +132,7 @@ public class CastFunctionMiscITCase extends BuiltInFunctionTestBase {
                                 Row.of(Row.of("12", true, null), "Hello"),
                                 DataTypes.of(
                                         "ROW<r ROW<s STRING NOT NULL, b BOOLEAN, i INT>, s STRING>")),
-                TestSpec.forFunction(
+                TestSetSpec.forFunction(
                                 BuiltInFunctionDefinitions.CAST,
                                 "implicit between structured type and row")
                         .onFieldsWithData(12, "Ingo")
@@ -147,7 +145,7 @@ public class CastFunctionMiscITCase extends BuiltInFunctionTestBase {
                                 "RowToFirstField(StructuredTypeConstructor((f0, f1)))",
                                 12,
                                 INT()),
-                TestSpec.forFunction(
+                TestSetSpec.forFunction(
                                 BuiltInFunctionDefinitions.CAST,
                                 "explicit between structured type and row")
                         .onFieldsWithData(12, "Ingo")
@@ -157,7 +155,7 @@ public class CastFunctionMiscITCase extends BuiltInFunctionTestBase {
                                         .cast(ROW(BIGINT(), STRING())),
                                 Row.of(12L, "Ingo"),
                                 ROW(BIGINT(), STRING())),
-                TestSpec.forFunction(
+                TestSetSpec.forFunction(
                                 BuiltInFunctionDefinitions.CAST,
                                 "cast from RAW(Integer) to BINARY(3)")
                         .onFieldsWithData(123456)
@@ -167,7 +165,7 @@ public class CastFunctionMiscITCase extends BuiltInFunctionTestBase {
                                 call("IntegerToRaw", $("f0")).cast(BINARY(3)),
                                 new byte[] {0, 1, -30},
                                 BINARY(3)),
-                TestSpec.forFunction(
+                TestSetSpec.forFunction(
                                 BuiltInFunctionDefinitions.CAST, "cast from RAW(Integer) to BYTES")
                         .onFieldsWithData(123456)
                         .andDataTypes(INT())
@@ -176,7 +174,7 @@ public class CastFunctionMiscITCase extends BuiltInFunctionTestBase {
                                 call("IntegerToRaw", $("f0")).cast(BYTES()),
                                 new byte[] {0, 1, -30, 64},
                                 BYTES()),
-                TestSpec.forFunction(
+                TestSetSpec.forFunction(
                                 BuiltInFunctionDefinitions.CAST,
                                 "cast from RAW(Integer) to BINARY(6)")
                         .onFieldsWithData(123456)
@@ -186,7 +184,7 @@ public class CastFunctionMiscITCase extends BuiltInFunctionTestBase {
                                 call("IntegerToRaw", $("f0")).cast(BINARY(6)),
                                 new byte[] {0, 1, -30, 64, 0, 0},
                                 BINARY(6)),
-                TestSpec.forFunction(
+                TestSetSpec.forFunction(
                                 BuiltInFunctionDefinitions.CAST,
                                 "cast from RAW(UserPojo) to VARBINARY")
                         .onFieldsWithData(123456, "Flink")
@@ -202,21 +200,22 @@ public class CastFunctionMiscITCase extends BuiltInFunctionTestBase {
                                         .cast(VARBINARY(50)),
                                 new byte[] {0, 1, -30, 64, 0, 70, 0, 108, 0, 105, 0, 110, 0, 107},
                                 VARBINARY(50)),
-                TestSpec.forFunction(
+                TestSetSpec.forFunction(
                                 BuiltInFunctionDefinitions.CAST, "test the x'....' binary syntax")
                         .onFieldsWithData("foo")
                         .testSqlResult(
                                 "CAST(CAST(x'68656C6C6F20636F6465' AS BINARY(10)) AS VARCHAR)",
                                 "68656c6c6f20636f6465",
                                 STRING().notNull()),
-                TestSpec.forFunction(
+                TestSetSpec.forFunction(
                                 BuiltInFunctionDefinitions.CAST, "test the x'....' binary syntax")
                         .onFieldsWithData("foo")
                         .testSqlResult(
                                 "CAST(CAST(x'68656C6C6F2063617374' AS BINARY(10)) AS VARCHAR)",
                                 "68656c6c6f2063617374",
                                 STRING().notNull()),
-                TestSpec.forFunction(BuiltInFunctionDefinitions.CAST, "cast STRUCTURED to STRING")
+                TestSetSpec.forFunction(
+                                BuiltInFunctionDefinitions.CAST, "cast STRUCTURED to STRING")
                         .onFieldsWithData(123456, "Flink")
                         .andDataTypes(INT(), STRING())
                         .withFunction(StructuredTypeConstructor.class)
@@ -225,7 +224,7 @@ public class CastFunctionMiscITCase extends BuiltInFunctionTestBase {
                                         .cast(STRING()),
                                 "(i=123456, s=Flink)",
                                 STRING()),
-                TestSpec.forFunction(BuiltInFunctionDefinitions.CAST, "cast MULTISET to STRING")
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.CAST, "cast MULTISET to STRING")
                         .onFieldsWithData(map(entry("a", 1), entry("b", 2)))
                         .andDataTypes(MAP(STRING(), INT()))
                         .withFunction(JsonFunctionsITCase.CreateMultiset.class)
@@ -233,7 +232,7 @@ public class CastFunctionMiscITCase extends BuiltInFunctionTestBase {
                                 call("CreateMultiset", $("f0")).cast(STRING()),
                                 "{a=1, b=2}",
                                 STRING()),
-                TestSpec.forFunction(BuiltInFunctionDefinitions.CAST, "cast RAW to STRING")
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.CAST, "cast RAW to STRING")
                         .onFieldsWithData("2020-11-11T18:08:01.123")
                         .andDataTypes(STRING())
                         .withFunction(LocalDateTimeToRaw.class)
@@ -241,7 +240,7 @@ public class CastFunctionMiscITCase extends BuiltInFunctionTestBase {
                                 call("LocalDateTimeToRaw", $("f0")).cast(STRING()),
                                 "2020-11-11T18:08:01.123",
                                 STRING()),
-                TestSpec.forFunction(
+                TestSetSpec.forFunction(
                                 BuiltInFunctionDefinitions.TRY_CAST, "try cast from STRING to TIME")
                         .onFieldsWithData("Flink", "12:34:56")
                         .andDataTypes(STRING(), STRING())
@@ -255,7 +254,7 @@ public class CastFunctionMiscITCase extends BuiltInFunctionTestBase {
                                 "TRY_CAST(f1 AS TIME)",
                                 LocalTime.of(12, 34, 56, 0),
                                 TIME().nullable()),
-                TestSpec.forFunction(
+                TestSetSpec.forFunction(
                                 BuiltInFunctionDefinitions.TRY_CAST,
                                 "try cast from TIME NOT NULL to STRING NOT NULL")
                         .onFieldsWithData(LocalTime.parse("12:34:56"))
@@ -265,7 +264,7 @@ public class CastFunctionMiscITCase extends BuiltInFunctionTestBase {
                                 "TRY_CAST(f0 AS STRING)",
                                 "12:34:56",
                                 STRING().nullable()),
-                TestSpec.forFunction(
+                TestSetSpec.forFunction(
                                 BuiltInFunctionDefinitions.TRY_CAST,
                                 "try cast from ROW<INT, STRING> to ROW<TINYINT, TIME>")
                         .onFieldsWithData(Row.of(1, "abc"), Row.of(1, "12:34:56"))

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionMiscITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionMiscITCase.java
@@ -55,7 +55,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class CastFunctionMiscITCase extends BuiltInFunctionTestBase {
 
     @Override
-    public Configuration getConfiguration() {
+    Configuration getConfiguration() {
         return new Configuration()
                 .set(
                         ExecutionConfigOptions.TABLE_EXEC_LEGACY_CAST_BEHAVIOUR,
@@ -63,7 +63,7 @@ class CastFunctionMiscITCase extends BuiltInFunctionTestBase {
     }
 
     @Override
-    public Stream<TestSetSpec> getTestCaseSpecs() {
+    Stream<TestSetSpec> getTestSetSpecs() {
         return Stream.of(
                 TestSetSpec.forFunction(
                                 BuiltInFunctionDefinitions.CAST,

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CoalesceFunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CoalesceFunctionITCase.java
@@ -20,10 +20,7 @@ package org.apache.flink.table.planner.functions;
 
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 
-import org.junit.runners.Parameterized;
-
-import java.util.Collections;
-import java.util.List;
+import java.util.stream.Stream;
 
 import static org.apache.flink.table.api.DataTypes.BIGINT;
 import static org.apache.flink.table.api.DataTypes.INT;
@@ -31,12 +28,12 @@ import static org.apache.flink.table.api.Expressions.$;
 import static org.apache.flink.table.api.Expressions.coalesce;
 
 /** Test {@link BuiltInFunctionDefinitions#COALESCE} and its return type. */
-public class CoalesceFunctionITCase extends BuiltInFunctionTestBase {
+class CoalesceFunctionITCase extends BuiltInFunctionTestBase {
 
-    @Parameterized.Parameters(name = "{index}: {0}")
-    public static List<TestSpec> testData() {
-        return Collections.singletonList(
-                TestSpec.forFunction(BuiltInFunctionDefinitions.COALESCE)
+    @Override
+    public Stream<TestSetSpec> getTestCaseSpecs() {
+        return Stream.of(
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.COALESCE)
                         .onFieldsWithData(null, null, 1)
                         .andDataTypes(BIGINT().nullable(), INT().nullable(), INT().notNull())
                         .testResult(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CoalesceFunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CoalesceFunctionITCase.java
@@ -37,28 +37,23 @@ class CoalesceFunctionITCase extends BuiltInFunctionTestBase {
                         .onFieldsWithData(null, null, 1)
                         .andDataTypes(BIGINT().nullable(), INT().nullable(), INT().notNull())
                         .testResult(
-                                resultSpec(
-                                        coalesce($("f0"), $("f1")),
-                                        "COALESCE(f0, f1)",
-                                        null,
-                                        BIGINT().nullable()),
-                                resultSpec(
-                                        coalesce($("f0"), $("f2")),
-                                        "COALESCE(f0, f2)",
-                                        1L,
-                                        BIGINT().notNull()),
-                                resultSpec(
-                                        coalesce($("f1"), $("f2")),
-                                        "COALESCE(f1, f2)",
-                                        1,
-                                        INT().notNull()),
-                                resultSpec(
-                                        coalesce($("f0"), 1),
-                                        "COALESCE(f0, 1)",
-                                        1L,
-                                        // In this case, the return type is not null because we have
-                                        // a
-                                        // constant in the function invocation
-                                        BIGINT().notNull())));
+                                coalesce($("f0"), $("f1")),
+                                "COALESCE(f0, f1)",
+                                null,
+                                BIGINT().nullable())
+                        .testResult(
+                                coalesce($("f0"), $("f2")),
+                                "COALESCE(f0, f2)",
+                                1L,
+                                BIGINT().notNull())
+                        .testResult(
+                                coalesce($("f1"), $("f2")), "COALESCE(f1, f2)", 1, INT().notNull())
+                        .testResult(
+                                coalesce($("f0"), 1),
+                                "COALESCE(f0, 1)",
+                                1L,
+                                // In this case, the return type is not null because we have a
+                                // constant in the function invocation
+                                BIGINT().notNull()));
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CoalesceFunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CoalesceFunctionITCase.java
@@ -31,7 +31,7 @@ import static org.apache.flink.table.api.Expressions.coalesce;
 class CoalesceFunctionITCase extends BuiltInFunctionTestBase {
 
     @Override
-    public Stream<TestSetSpec> getTestCaseSpecs() {
+    Stream<TestSetSpec> getTestSetSpecs() {
         return Stream.of(
                 TestSetSpec.forFunction(BuiltInFunctionDefinitions.COALESCE)
                         .onFieldsWithData(null, null, 1)

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/FieldAccessFromTableITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/FieldAccessFromTableITCase.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.functions;
+
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.types.Row;
+
+import java.util.stream.Stream;
+
+import static java.util.Collections.singletonMap;
+import static org.apache.flink.table.api.DataTypes.ARRAY;
+import static org.apache.flink.table.api.DataTypes.BIGINT;
+import static org.apache.flink.table.api.DataTypes.FIELD;
+import static org.apache.flink.table.api.DataTypes.MAP;
+import static org.apache.flink.table.api.DataTypes.ROW;
+import static org.apache.flink.table.api.DataTypes.STRING;
+import static org.apache.flink.table.api.Expressions.$;
+
+/**
+ * Regular tests. See also {@link ConstructedAccessFunctionsITCase} for tests that access a nested
+ * field of an expression or for {@link BuiltInFunctionDefinitions#FLATTEN} which produces multiple
+ * columns from a single one.
+ */
+class FieldAccessFromTableITCase extends BuiltInFunctionTestBase {
+
+    @Override
+    public Stream<TestSetSpec> getTestCaseSpecs() {
+        return Stream.of(
+
+                // Actually in case of SQL it does not use the GET method, but
+                // a custom logic for accessing nested fields of a Table.
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.GET)
+                        .onFieldsWithData(null, Row.of(1))
+                        .andDataTypes(
+                                ROW(FIELD("nested", BIGINT().notNull())).nullable(),
+                                ROW(FIELD("nested", BIGINT().notNull())).notNull())
+                        .testResult(
+                                resultSpec(
+                                        $("f0").get("nested"),
+                                        "f0.nested",
+                                        null,
+                                        BIGINT().nullable()),
+                                resultSpec(
+                                        $("f1").get("nested"),
+                                        "f1.nested",
+                                        1L,
+                                        BIGINT().notNull())),
+
+                // In Calcite it maps to FlinkSqlOperatorTable.ITEM
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.AT)
+                        .onFieldsWithData(
+                                null,
+                                new int[] {1},
+                                null,
+                                singletonMap("nested", 1),
+                                null,
+                                Row.of(1))
+                        .andDataTypes(
+                                ARRAY(BIGINT().notNull()).nullable(),
+                                ARRAY(BIGINT().notNull()).notNull(),
+                                MAP(STRING(), BIGINT().notNull()).nullable(),
+                                MAP(STRING(), BIGINT().notNull()).notNull(),
+                                ROW(FIELD("nested", BIGINT().notNull())).nullable(),
+                                ROW(FIELD("nested", BIGINT().notNull())).notNull())
+                        // accessing elements of MAP or ARRAY is a runtime operations,
+                        // we do not know about the size or contents during the inference
+                        // therefore the results are always nullable
+                        .testResult(
+                                resultSpec($("f0").at(1), "f0[1]", null, BIGINT().nullable()),
+                                resultSpec($("f1").at(1), "f1[1]", 1L, BIGINT().nullable()),
+                                resultSpec(
+                                        $("f2").at("nested"),
+                                        "f2['nested']",
+                                        null,
+                                        BIGINT().nullable()),
+                                resultSpec(
+                                        $("f3").at("nested"),
+                                        "f3['nested']",
+                                        1L,
+                                        BIGINT().nullable()),
+
+                                // we know all the fields of a type up front, therefore we can
+                                // derive more accurate types during the inference
+                                resultSpec(
+                                        $("f4").get("nested"),
+                                        "f4['nested']",
+                                        null,
+                                        BIGINT().nullable()),
+                                resultSpec(
+                                        $("f5").get("nested"),
+                                        "f5['nested']",
+                                        1L,
+                                        BIGINT().notNull())));
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/FieldAccessFromTableITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/FieldAccessFromTableITCase.java
@@ -50,17 +50,8 @@ class FieldAccessFromTableITCase extends BuiltInFunctionTestBase {
                         .andDataTypes(
                                 ROW(FIELD("nested", BIGINT().notNull())).nullable(),
                                 ROW(FIELD("nested", BIGINT().notNull())).notNull())
-                        .testResult(
-                                resultSpec(
-                                        $("f0").get("nested"),
-                                        "f0.nested",
-                                        null,
-                                        BIGINT().nullable()),
-                                resultSpec(
-                                        $("f1").get("nested"),
-                                        "f1.nested",
-                                        1L,
-                                        BIGINT().notNull())),
+                        .testResult($("f0").get("nested"), "f0.nested", null, BIGINT().nullable())
+                        .testResult($("f1").get("nested"), "f1.nested", 1L, BIGINT().notNull()),
 
                 // In Calcite it maps to FlinkSqlOperatorTable.ITEM
                 TestSetSpec.forFunction(BuiltInFunctionDefinitions.AT)
@@ -81,31 +72,15 @@ class FieldAccessFromTableITCase extends BuiltInFunctionTestBase {
                         // accessing elements of MAP or ARRAY is a runtime operations,
                         // we do not know about the size or contents during the inference
                         // therefore the results are always nullable
-                        .testResult(
-                                resultSpec($("f0").at(1), "f0[1]", null, BIGINT().nullable()),
-                                resultSpec($("f1").at(1), "f1[1]", 1L, BIGINT().nullable()),
-                                resultSpec(
-                                        $("f2").at("nested"),
-                                        "f2['nested']",
-                                        null,
-                                        BIGINT().nullable()),
-                                resultSpec(
-                                        $("f3").at("nested"),
-                                        "f3['nested']",
-                                        1L,
-                                        BIGINT().nullable()),
+                        .testResult($("f0").at(1), "f0[1]", null, BIGINT().nullable())
+                        .testResult($("f1").at(1), "f1[1]", 1L, BIGINT().nullable())
+                        .testResult($("f2").at("nested"), "f2['nested']", null, BIGINT().nullable())
+                        .testResult($("f3").at("nested"), "f3['nested']", 1L, BIGINT().nullable())
 
-                                // we know all the fields of a type up front, therefore we can
-                                // derive more accurate types during the inference
-                                resultSpec(
-                                        $("f4").get("nested"),
-                                        "f4['nested']",
-                                        null,
-                                        BIGINT().nullable()),
-                                resultSpec(
-                                        $("f5").get("nested"),
-                                        "f5['nested']",
-                                        1L,
-                                        BIGINT().notNull())));
+                        // we know all the fields of a type up front, therefore we can
+                        // derive more accurate types during the inference
+                        .testResult(
+                                $("f4").get("nested"), "f4['nested']", null, BIGINT().nullable())
+                        .testResult($("f5").get("nested"), "f5['nested']", 1L, BIGINT().notNull()));
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/FieldAccessFromTableITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/FieldAccessFromTableITCase.java
@@ -40,7 +40,7 @@ import static org.apache.flink.table.api.Expressions.$;
 class FieldAccessFromTableITCase extends BuiltInFunctionTestBase {
 
     @Override
-    public Stream<TestSetSpec> getTestCaseSpecs() {
+    Stream<TestSetSpec> getTestSetSpecs() {
         return Stream.of(
 
                 // Actually in case of SQL it does not use the GET method, but

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/GreatestLeastFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/GreatestLeastFunctionsITCase.java
@@ -21,23 +21,20 @@ package org.apache.flink.table.planner.functions;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 
-import org.junit.runners.Parameterized;
-
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
-import java.util.Arrays;
-import java.util.List;
+import java.util.stream.Stream;
 
 import static org.apache.flink.table.api.Expressions.$;
 import static org.apache.flink.table.api.Expressions.call;
 
 /** Tests for GREATEST, LEAST functions {@link BuiltInFunctionDefinitions}. */
-public class GreatestLeastFunctionsITCase extends BuiltInFunctionTestBase {
+class GreatestLeastFunctionsITCase extends BuiltInFunctionTestBase {
 
-    @Parameterized.Parameters(name = "{index}: {0}")
-    public static List<TestSpec> testData() {
-        return Arrays.asList(
-                TestSpec.forFunction(BuiltInFunctionDefinitions.GREATEST)
+    @Override
+    public Stream<TestSetSpec> getTestCaseSpecs() {
+        return Stream.of(
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.GREATEST)
                         .onFieldsWithData(
                                 null,
                                 1,
@@ -86,7 +83,7 @@ public class GreatestLeastFunctionsITCase extends BuiltInFunctionTestBase {
                                 "GREATEST(f5, f6)",
                                 "SQL validation failed. Invalid function call:\n"
                                         + "GREATEST(STRING NOT NULL, TIMESTAMP(3) NOT NULL)"),
-                TestSpec.forFunction(BuiltInFunctionDefinitions.LEAST)
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.LEAST)
                         .onFieldsWithData(null, 1, 2, 3.14, "hello", "world")
                         .andDataTypes(
                                 DataTypes.INT().nullable(),

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/GreatestLeastFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/GreatestLeastFunctionsITCase.java
@@ -58,27 +58,26 @@ class GreatestLeastFunctionsITCase extends BuiltInFunctionTestBase {
                                 "SQL validation failed. Invalid function call:\n"
                                         + "GREATEST(INT NOT NULL, STRING NOT NULL)")
                         .testResult(
-                                resultSpec(
-                                        call("GREATEST", $("f1"), $("f3"), $("f2"))
-                                                .cast(DataTypes.DECIMAL(3, 2)),
-                                        "CAST(GREATEST(f1, f3, f2) AS DECIMAL(3, 2))",
-                                        BigDecimal.valueOf(3.14),
-                                        DataTypes.DECIMAL(3, 2).notNull()),
-                                resultSpec(
-                                        call("GREATEST", $("f0"), $("f1"), $("f2")),
-                                        "GREATEST(f0, f1, f2)",
-                                        null,
-                                        DataTypes.INT()),
-                                resultSpec(
-                                        call("GREATEST", $("f4"), $("f5")),
-                                        "GREATEST(f4, f5)",
-                                        "world",
-                                        DataTypes.STRING().notNull()),
-                                resultSpec(
-                                        call("GREATEST", $("f6"), $("f7")),
-                                        "GREATEST(f6, f7)",
-                                        LocalDateTime.parse("1970-01-01T00:00:03.001"),
-                                        DataTypes.TIMESTAMP(3).notNull()))
+                                call("GREATEST", $("f1"), $("f3"), $("f2"))
+                                        .cast(DataTypes.DECIMAL(3, 2)),
+                                "CAST(GREATEST(f1, f3, f2) AS DECIMAL(3, 2))",
+                                BigDecimal.valueOf(3.14),
+                                DataTypes.DECIMAL(3, 2).notNull())
+                        .testResult(
+                                call("GREATEST", $("f0"), $("f1"), $("f2")),
+                                "GREATEST(f0, f1, f2)",
+                                null,
+                                DataTypes.INT())
+                        .testResult(
+                                call("GREATEST", $("f4"), $("f5")),
+                                "GREATEST(f4, f5)",
+                                "world",
+                                DataTypes.STRING().notNull())
+                        .testResult(
+                                call("GREATEST", $("f6"), $("f7")),
+                                "GREATEST(f6, f7)",
+                                LocalDateTime.parse("1970-01-01T00:00:03.001"),
+                                DataTypes.TIMESTAMP(3).notNull())
                         .testSqlValidationError(
                                 "GREATEST(f5, f6)",
                                 "SQL validation failed. Invalid function call:\n"
@@ -97,21 +96,20 @@ class GreatestLeastFunctionsITCase extends BuiltInFunctionTestBase {
                                 "SQL validation failed. Invalid function call:\n"
                                         + "LEAST(INT NOT NULL, STRING NOT NULL)")
                         .testResult(
-                                resultSpec(
-                                        call("LEAST", $("f1"), $("f3"), $("f2"))
-                                                .cast(DataTypes.DECIMAL(3, 2)),
-                                        "CAST(LEAST(f1, f3, f2) AS DECIMAL(3, 2))",
-                                        BigDecimal.valueOf(100, 2),
-                                        DataTypes.DECIMAL(3, 2).notNull()),
-                                resultSpec(
-                                        call("LEAST", $("f0"), $("f1")),
-                                        "LEAST(f0, f1)",
-                                        null,
-                                        DataTypes.INT()),
-                                resultSpec(
-                                        call("LEAST", $("f4"), $("f5")),
-                                        "LEAST(f4, f5)",
-                                        "hello",
-                                        DataTypes.STRING().notNull())));
+                                call("LEAST", $("f1"), $("f3"), $("f2"))
+                                        .cast(DataTypes.DECIMAL(3, 2)),
+                                "CAST(LEAST(f1, f3, f2) AS DECIMAL(3, 2))",
+                                BigDecimal.valueOf(100, 2),
+                                DataTypes.DECIMAL(3, 2).notNull())
+                        .testResult(
+                                call("LEAST", $("f0"), $("f1")),
+                                "LEAST(f0, f1)",
+                                null,
+                                DataTypes.INT())
+                        .testResult(
+                                call("LEAST", $("f4"), $("f5")),
+                                "LEAST(f4, f5)",
+                                "hello",
+                                DataTypes.STRING().notNull()));
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/GreatestLeastFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/GreatestLeastFunctionsITCase.java
@@ -32,7 +32,7 @@ import static org.apache.flink.table.api.Expressions.call;
 class GreatestLeastFunctionsITCase extends BuiltInFunctionTestBase {
 
     @Override
-    public Stream<TestSetSpec> getTestCaseSpecs() {
+    Stream<TestSetSpec> getTestSetSpecs() {
         return Stream.of(
                 TestSetSpec.forFunction(BuiltInFunctionDefinitions.GREATEST)
                         .onFieldsWithData(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/ImplicitConversionEqualsFunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/ImplicitConversionEqualsFunctionITCase.java
@@ -23,13 +23,12 @@ import org.apache.flink.table.types.AbstractDataType;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
 
-import org.junit.runners.Parameterized;
-
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Stream;
 
 import static org.apache.flink.table.api.DataTypes.BIGINT;
 import static org.apache.flink.table.api.DataTypes.BOOLEAN;
@@ -49,7 +48,7 @@ import static org.apache.flink.table.api.DataTypes.TINYINT;
  * between numeric and (var)char fields and throw an exception because it will produce wrong result.
  * SEE [FLINK-24914].
  */
-public class ImplicitConversionEqualsFunctionITCase extends BuiltInFunctionTestBase {
+class ImplicitConversionEqualsFunctionITCase extends BuiltInFunctionTestBase {
 
     // numeric data
     private static final byte TINY_INT_DATA = (byte) 1;
@@ -71,16 +70,16 @@ public class ImplicitConversionEqualsFunctionITCase extends BuiltInFunctionTestB
     private static final String STRING_DATA_EQUALS_TIME = "00:00:00";
     private static final String STRING_DATA_EQUALS_TIMESTAMP = "2001-01-01 00:00:00";
 
-    @Parameterized.Parameters(name = "{index}: {0}")
-    public static List<TestSpec> testData() {
-        final List<TestSpec> specs = new ArrayList<>();
+    @Override
+    public Stream<TestSetSpec> getTestCaseSpecs() {
+        final List<TestSetSpec> specs = new ArrayList<>();
         specs.addAll(implicitConversionBetweenNumeric());
         specs.addAll(implicitConversionBetweenTimeAndString());
         specs.addAll(unsupportedImplicitConversionBetweenNumericAndString());
-        return specs;
+        return specs.stream();
     }
 
-    private static List<TestSpec> implicitConversionBetweenNumeric() {
+    private static List<TestSetSpec> implicitConversionBetweenNumeric() {
         return Arrays.asList(
                 TypeConversionTestBuilder.left(TINYINT(), TINY_INT_DATA)
                         .right(TINYINT(), TINY_INT_DATA)
@@ -123,7 +122,7 @@ public class ImplicitConversionEqualsFunctionITCase extends BuiltInFunctionTestB
                         .build());
     }
 
-    private static List<TestSpec> implicitConversionBetweenTimeAndString() {
+    private static List<TestSetSpec> implicitConversionBetweenTimeAndString() {
         return Arrays.asList(
                 TypeConversionTestBuilder.left(DATE(), DATE_DATA)
                         .right(DATE(), DATE_DATA)
@@ -138,7 +137,7 @@ public class ImplicitConversionEqualsFunctionITCase extends BuiltInFunctionTestB
     }
 
     // unsupported temporarily
-    private static List<TestSpec> unsupportedImplicitConversionBetweenNumericAndString() {
+    private static List<TestSetSpec> unsupportedImplicitConversionBetweenNumericAndString() {
         return Collections.singletonList(
                 TypeConversionTestBuilder.left(STRING(), STRING_DATA_EQUALS_NUMERIC)
                         .right(STRING(), STRING_DATA_EQUALS_NUMERIC)
@@ -179,13 +178,13 @@ public class ImplicitConversionEqualsFunctionITCase extends BuiltInFunctionTestB
             return this;
         }
 
-        private TestSpec build() {
+        private TestSetSpec build() {
             int columnBaseIdx = 0;
             String leftColumnName = "f" + columnBaseIdx;
             columnBaseIdx++;
 
-            TestSpec testSpec =
-                    TestSpec.forFunction(
+            TestSetSpec testSetSpec =
+                    TestSetSpec.forFunction(
                             BuiltInFunctionDefinitions.EQUALS, "left: " + leftType.toString());
 
             final List<Object> allData = new ArrayList<>();
@@ -198,14 +197,15 @@ public class ImplicitConversionEqualsFunctionITCase extends BuiltInFunctionTestB
             allTypes.addAll(rightTypesOnSuccess);
             allTypes.addAll(rightTypesOnFailure);
 
-            testSpec.onFieldsWithData(allData.toArray())
+            testSetSpec
+                    .onFieldsWithData(allData.toArray())
                     .andDataTypes(allTypes.toArray(new AbstractDataType<?>[] {}));
 
             // test successful cases
             for (int i = 0; i < rightTypesOnSuccess.size(); i++) {
                 String rightColumnName = "f" + (i + columnBaseIdx);
                 DataType rightType = rightTypesOnSuccess.get(i);
-                testSpec.testSqlResult(
+                testSetSpec.testSqlResult(
                         String.format(
                                 "CAST(%s AS %s) = CAST(%s AS %s)",
                                 leftColumnName, leftType.toString(), rightColumnName, rightType),
@@ -221,13 +221,13 @@ public class ImplicitConversionEqualsFunctionITCase extends BuiltInFunctionTestB
                 String exceptionMsg =
                         getImplicitConversionFromStringExceptionMsg(
                                 rightType.getLogicalType().getTypeRoot());
-                testSpec.testSqlValidationError(
+                testSetSpec.testSqlValidationError(
                         String.format(
                                 "CAST(%s AS %s) = CAST(%s AS %s)",
                                 leftColumnName, leftType.toString(), rightColumnName, rightType),
                         exceptionMsg);
             }
-            return testSpec;
+            return testSetSpec;
         }
 
         private String getImplicitConversionFromStringExceptionMsg(LogicalTypeRoot rightType) {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/ImplicitConversionEqualsFunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/ImplicitConversionEqualsFunctionITCase.java
@@ -71,7 +71,7 @@ class ImplicitConversionEqualsFunctionITCase extends BuiltInFunctionTestBase {
     private static final String STRING_DATA_EQUALS_TIMESTAMP = "2001-01-01 00:00:00";
 
     @Override
-    public Stream<TestSetSpec> getTestCaseSpecs() {
+    Stream<TestSetSpec> getTestSetSpecs() {
         final List<TestSetSpec> specs = new ArrayList<>();
         specs.addAll(implicitConversionBetweenNumeric());
         specs.addAll(implicitConversionBetweenTimeAndString());

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/JsonAggregationFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/JsonAggregationFunctionsITCase.java
@@ -22,11 +22,9 @@ import org.apache.flink.table.api.JsonOnNull;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 import org.apache.flink.types.Row;
 
-import org.junit.runners.Parameterized;
-
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
+import java.util.stream.Stream;
 
 import static org.apache.flink.table.api.DataTypes.INT;
 import static org.apache.flink.table.api.DataTypes.ROW;
@@ -39,11 +37,11 @@ import static org.apache.flink.types.RowKind.DELETE;
 import static org.apache.flink.types.RowKind.INSERT;
 
 /** Tests for built-in JSON aggregation functions. */
-public class JsonAggregationFunctionsITCase extends BuiltInAggregateFunctionTestBase {
+class JsonAggregationFunctionsITCase extends BuiltInAggregateFunctionTestBase {
 
-    @Parameterized.Parameters(name = "{index}: {0}")
-    public static List<TestSpec> testData() throws Exception {
-        return Arrays.asList(
+    @Override
+    public Stream<TestSpec> getTestCaseSpecs() {
+        return Stream.of(
                 // JSON_OBJECTAGG
                 TestSpec.forFunction(BuiltInFunctionDefinitions.JSON_OBJECTAGG_NULL_ON_NULL)
                         .withDescription("Basic Aggregation")

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/JsonFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/JsonFunctionsITCase.java
@@ -78,7 +78,7 @@ import static org.apache.flink.table.api.JsonQueryWrapper.WITHOUT_ARRAY;
 class JsonFunctionsITCase extends BuiltInFunctionTestBase {
 
     @Override
-    public Stream<TestSetSpec> getTestCaseSpecs() {
+    Stream<TestSetSpec> getTestSetSpecs() {
         final List<TestSetSpec> testCases = new ArrayList<>();
         testCases.add(jsonExistsSpec());
         testCases.add(jsonValueSpec());

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/JsonFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/JsonFunctionsITCase.java
@@ -96,74 +96,71 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
         return TestSetSpec.forFunction(BuiltInFunctionDefinitions.JSON_EXISTS)
                 .onFieldsWithData(jsonValue)
                 .andDataTypes(STRING())
+
+                // NULL
                 .testResult(
-                        // NULL
-                        resultSpec(
-                                nullOf(STRING()).jsonExists("lax $"),
-                                "JSON_EXISTS(CAST(NULL AS STRING), 'lax $')",
-                                null,
-                                BOOLEAN()),
+                        nullOf(STRING()).jsonExists("lax $"),
+                        "JSON_EXISTS(CAST(NULL AS STRING), 'lax $')",
+                        null,
+                        BOOLEAN())
 
-                        // Path variants
-                        resultSpec(
-                                $("f0").jsonExists("lax $"),
-                                "JSON_EXISTS(f0, 'lax $')",
-                                true,
-                                BOOLEAN()),
-                        resultSpec(
-                                $("f0").jsonExists("lax $.type"),
-                                "JSON_EXISTS(f0, 'lax $.type')",
-                                true,
-                                BOOLEAN()),
-                        resultSpec(
-                                $("f0").jsonExists("lax $.author.address.city"),
-                                "JSON_EXISTS(f0, 'lax $.author.address.city')",
-                                true,
-                                BOOLEAN()),
-                        resultSpec(
-                                $("f0").jsonExists("lax $.metadata.tags[0]"),
-                                "JSON_EXISTS(f0, 'lax $.metadata.tags[0]')",
-                                true,
-                                BOOLEAN()),
-                        resultSpec(
-                                $("f0").jsonExists("lax $.metadata.tags[3]"),
-                                "JSON_EXISTS(f0, 'lax $.metadata.tags[3]')",
-                                false,
-                                BOOLEAN()),
-                        // This should pass, but is broken due to
-                        // https://issues.apache.org/jira/browse/CALCITE-4717.
-                        // new TestSpecColumn(
-                        //        $("f0").jsonExists("lax $.metadata.references.url"),
-                        //        "JSON_EXISTS(f0, 'lax $.metadata.references.url')",
-                        //        true,
-                        //        DataTypes.BOOLEAN())
-                        resultSpec(
-                                $("f0").jsonExists("lax $.metadata.references[0].url"),
-                                "JSON_EXISTS(f0, 'lax $.metadata.references[0].url')",
-                                true,
-                                BOOLEAN()),
-                        resultSpec(
-                                $("f0").jsonExists("lax $.metadata.references[0].invalid"),
-                                "JSON_EXISTS(f0, 'lax $.metadata.references[0].invalid')",
-                                false,
-                                BOOLEAN()),
+                // Path variants
+                .testResult(
+                        $("f0").jsonExists("lax $"), "JSON_EXISTS(f0, 'lax $')", true, BOOLEAN())
+                .testResult(
+                        $("f0").jsonExists("lax $.type"),
+                        "JSON_EXISTS(f0, 'lax $.type')",
+                        true,
+                        BOOLEAN())
+                .testResult(
+                        $("f0").jsonExists("lax $.author.address.city"),
+                        "JSON_EXISTS(f0, 'lax $.author.address.city')",
+                        true,
+                        BOOLEAN())
+                .testResult(
+                        $("f0").jsonExists("lax $.metadata.tags[0]"),
+                        "JSON_EXISTS(f0, 'lax $.metadata.tags[0]')",
+                        true,
+                        BOOLEAN())
+                .testResult(
+                        $("f0").jsonExists("lax $.metadata.tags[3]"),
+                        "JSON_EXISTS(f0, 'lax $.metadata.tags[3]')",
+                        false,
+                        BOOLEAN())
+                // This should pass, but is broken due to
+                // https://issues.apache.org/jira/browse/CALCITE-4717.
+                // new TestSpecColumn(
+                //        $("f0").jsonExists("lax $.metadata.references.url"),
+                //        "JSON_EXISTS(f0, 'lax $.metadata.references.url')",
+                //        true,
+                //        DataTypes.BOOLEAN())
+                .testResult(
+                        $("f0").jsonExists("lax $.metadata.references[0].url"),
+                        "JSON_EXISTS(f0, 'lax $.metadata.references[0].url')",
+                        true,
+                        BOOLEAN())
+                .testResult(
+                        $("f0").jsonExists("lax $.metadata.references[0].invalid"),
+                        "JSON_EXISTS(f0, 'lax $.metadata.references[0].invalid')",
+                        false,
+                        BOOLEAN())
 
-                        // ON ERROR
-                        resultSpec(
-                                $("f0").jsonExists("strict $.invalid", JsonExistsOnError.TRUE),
-                                "JSON_EXISTS(f0, 'strict $.invalid' TRUE ON ERROR)",
-                                true,
-                                BOOLEAN()),
-                        resultSpec(
-                                $("f0").jsonExists("strict $.invalid", JsonExistsOnError.FALSE),
-                                "JSON_EXISTS(f0, 'strict $.invalid' FALSE ON ERROR)",
-                                false,
-                                BOOLEAN()),
-                        resultSpec(
-                                $("f0").jsonExists("strict $.invalid", JsonExistsOnError.UNKNOWN),
-                                "JSON_EXISTS(f0, 'strict $.invalid' UNKNOWN ON ERROR)",
-                                null,
-                                BOOLEAN()))
+                // ON ERROR
+                .testResult(
+                        $("f0").jsonExists("strict $.invalid", JsonExistsOnError.TRUE),
+                        "JSON_EXISTS(f0, 'strict $.invalid' TRUE ON ERROR)",
+                        true,
+                        BOOLEAN())
+                .testResult(
+                        $("f0").jsonExists("strict $.invalid", JsonExistsOnError.FALSE),
+                        "JSON_EXISTS(f0, 'strict $.invalid' FALSE ON ERROR)",
+                        false,
+                        BOOLEAN())
+                .testResult(
+                        $("f0").jsonExists("strict $.invalid", JsonExistsOnError.UNKNOWN),
+                        "JSON_EXISTS(f0, 'strict $.invalid' UNKNOWN ON ERROR)",
+                        null,
+                        BOOLEAN())
                 .testSqlRuntimeError(
                         "JSON_EXISTS(f0, 'strict $.invalid' ERROR ON ERROR)",
                         "No results for path: $['invalid']")
@@ -177,85 +174,85 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
         return TestSetSpec.forFunction(BuiltInFunctionDefinitions.JSON_VALUE)
                 .onFieldsWithData(jsonValue)
                 .andDataTypes(STRING())
+
+                // NULL and invalid types
                 .testResult(
-                        // NULL and invalid types
-                        resultSpec(
-                                lit(null, STRING()).jsonValue("lax $"),
-                                "JSON_VALUE(CAST(NULL AS STRING), 'lax $')",
-                                null,
-                                STRING(),
-                                VARCHAR(2000)),
+                        lit(null, STRING()).jsonValue("lax $"),
+                        "JSON_VALUE(CAST(NULL AS STRING), 'lax $')",
+                        null,
+                        STRING(),
+                        VARCHAR(2000))
 
-                        // RETURNING + Supported Data Types
-                        resultSpec(
-                                $("f0").jsonValue("$.type"),
-                                "JSON_VALUE(f0, '$.type')",
-                                "account",
-                                STRING(),
-                                VARCHAR(2000)),
-                        resultSpec(
-                                $("f0").jsonValue("$.activated", BOOLEAN()),
-                                "JSON_VALUE(f0, '$.activated' RETURNING BOOLEAN)",
-                                true,
-                                BOOLEAN()),
-                        resultSpec(
-                                $("f0").jsonValue("$.age", INT()),
-                                "JSON_VALUE(f0, '$.age' RETURNING INT)",
-                                42,
-                                INT()),
-                        resultSpec(
-                                $("f0").jsonValue("$.balance", DOUBLE()),
-                                "JSON_VALUE(f0, '$.balance' RETURNING DOUBLE)",
-                                13.37,
-                                DOUBLE()),
+                // RETURNING + Supported Data Types
+                .testResult(
+                        $("f0").jsonValue("$.type"),
+                        "JSON_VALUE(f0, '$.type')",
+                        "account",
+                        STRING(),
+                        VARCHAR(2000))
+                .testResult(
+                        $("f0").jsonValue("$.activated", BOOLEAN()),
+                        "JSON_VALUE(f0, '$.activated' RETURNING BOOLEAN)",
+                        true,
+                        BOOLEAN())
+                .testResult(
+                        $("f0").jsonValue("$.age", INT()),
+                        "JSON_VALUE(f0, '$.age' RETURNING INT)",
+                        42,
+                        INT())
+                .testResult(
+                        $("f0").jsonValue("$.balance", DOUBLE()),
+                        "JSON_VALUE(f0, '$.balance' RETURNING DOUBLE)",
+                        13.37,
+                        DOUBLE())
 
-                        // ON EMPTY / ON ERROR
-                        resultSpec(
-                                $("f0").jsonValue(
-                                                "lax $.invalid",
-                                                STRING(),
-                                                JsonValueOnEmptyOrError.NULL,
-                                                null,
-                                                JsonValueOnEmptyOrError.ERROR,
-                                                null),
-                                "JSON_VALUE(f0, 'lax $.invalid' NULL ON EMPTY ERROR ON ERROR)",
-                                null,
-                                STRING(),
-                                VARCHAR(2000)),
-                        resultSpec(
-                                $("f0").jsonValue(
-                                                "lax $.invalid",
-                                                INT(),
-                                                JsonValueOnEmptyOrError.DEFAULT,
-                                                42,
-                                                JsonValueOnEmptyOrError.ERROR,
-                                                null),
-                                "JSON_VALUE(f0, 'lax $.invalid' RETURNING INTEGER DEFAULT 42 ON EMPTY ERROR ON ERROR)",
-                                42,
-                                INT()),
-                        resultSpec(
-                                $("f0").jsonValue(
-                                                "strict $.invalid",
-                                                STRING(),
-                                                JsonValueOnEmptyOrError.ERROR,
-                                                null,
-                                                JsonValueOnEmptyOrError.NULL,
-                                                null),
-                                "JSON_VALUE(f0, 'strict $.invalid' ERROR ON EMPTY NULL ON ERROR)",
-                                null,
-                                STRING(),
-                                VARCHAR(2000)),
-                        resultSpec(
-                                $("f0").jsonValue(
-                                                "strict $.invalid",
-                                                INT(),
-                                                JsonValueOnEmptyOrError.NULL,
-                                                null,
-                                                JsonValueOnEmptyOrError.DEFAULT,
-                                                42),
-                                "JSON_VALUE(f0, 'strict $.invalid' RETURNING INTEGER NULL ON EMPTY DEFAULT 42 ON ERROR)",
-                                42,
-                                INT()));
+                // ON EMPTY / ON ERROR
+                .testResult(
+                        $("f0").jsonValue(
+                                        "lax $.invalid",
+                                        STRING(),
+                                        JsonValueOnEmptyOrError.NULL,
+                                        null,
+                                        JsonValueOnEmptyOrError.ERROR,
+                                        null),
+                        "JSON_VALUE(f0, 'lax $.invalid' NULL ON EMPTY ERROR ON ERROR)",
+                        null,
+                        STRING(),
+                        VARCHAR(2000))
+                .testResult(
+                        $("f0").jsonValue(
+                                        "lax $.invalid",
+                                        INT(),
+                                        JsonValueOnEmptyOrError.DEFAULT,
+                                        42,
+                                        JsonValueOnEmptyOrError.ERROR,
+                                        null),
+                        "JSON_VALUE(f0, 'lax $.invalid' RETURNING INTEGER DEFAULT 42 ON EMPTY ERROR ON ERROR)",
+                        42,
+                        INT())
+                .testResult(
+                        $("f0").jsonValue(
+                                        "strict $.invalid",
+                                        STRING(),
+                                        JsonValueOnEmptyOrError.ERROR,
+                                        null,
+                                        JsonValueOnEmptyOrError.NULL,
+                                        null),
+                        "JSON_VALUE(f0, 'strict $.invalid' ERROR ON EMPTY NULL ON ERROR)",
+                        null,
+                        STRING(),
+                        VARCHAR(2000))
+                .testResult(
+                        $("f0").jsonValue(
+                                        "strict $.invalid",
+                                        INT(),
+                                        JsonValueOnEmptyOrError.NULL,
+                                        null,
+                                        JsonValueOnEmptyOrError.DEFAULT,
+                                        42),
+                        "JSON_VALUE(f0, 'strict $.invalid' RETURNING INTEGER NULL ON EMPTY DEFAULT 42 ON ERROR)",
+                        42,
+                        INT());
     }
 
     private static List<TestSetSpec> isJsonSpec() {
@@ -281,55 +278,51 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                 TestSetSpec.forFunction(BuiltInFunctionDefinitions.IS_JSON)
                         .onFieldsWithData("\"a\"")
                         .andDataTypes(STRING())
+                        .testResult($("f0").isJson(), "f0 IS JSON", true, BOOLEAN().notNull())
                         .testResult(
-                                resultSpec(
-                                        $("f0").isJson(), "f0 IS JSON", true, BOOLEAN().notNull()),
-                                resultSpec(
-                                        $("f0").isJson(JsonType.VALUE),
-                                        "f0 IS JSON VALUE",
-                                        true,
-                                        BOOLEAN().notNull()),
-                                resultSpec(
-                                        $("f0").isJson(JsonType.SCALAR),
-                                        "f0 IS JSON SCALAR",
-                                        true,
-                                        BOOLEAN().notNull()),
-                                resultSpec(
-                                        $("f0").isJson(JsonType.ARRAY),
-                                        "f0 IS JSON ARRAY",
-                                        false,
-                                        BOOLEAN().notNull()),
-                                resultSpec(
-                                        $("f0").isJson(JsonType.OBJECT),
-                                        "f0 IS JSON OBJECT",
-                                        false,
-                                        BOOLEAN().notNull())),
+                                $("f0").isJson(JsonType.VALUE),
+                                "f0 IS JSON VALUE",
+                                true,
+                                BOOLEAN().notNull())
+                        .testResult(
+                                $("f0").isJson(JsonType.SCALAR),
+                                "f0 IS JSON SCALAR",
+                                true,
+                                BOOLEAN().notNull())
+                        .testResult(
+                                $("f0").isJson(JsonType.ARRAY),
+                                "f0 IS JSON ARRAY",
+                                false,
+                                BOOLEAN().notNull())
+                        .testResult(
+                                $("f0").isJson(JsonType.OBJECT),
+                                "f0 IS JSON OBJECT",
+                                false,
+                                BOOLEAN().notNull()),
                 TestSetSpec.forFunction(BuiltInFunctionDefinitions.IS_JSON)
                         .onFieldsWithData("{}")
                         .andDataTypes(STRING())
+                        .testResult($("f0").isJson(), "f0 IS JSON", true, BOOLEAN().notNull())
                         .testResult(
-                                resultSpec(
-                                        $("f0").isJson(), "f0 IS JSON", true, BOOLEAN().notNull()),
-                                resultSpec(
-                                        $("f0").isJson(JsonType.VALUE),
-                                        "f0 IS JSON VALUE",
-                                        true,
-                                        BOOLEAN().notNull()),
-                                resultSpec(
-                                        $("f0").isJson(JsonType.SCALAR),
-                                        "f0 IS JSON SCALAR",
-                                        false,
-                                        BOOLEAN().notNull()),
-                                resultSpec(
-                                        $("f0").isJson(JsonType.ARRAY),
-                                        "f0 IS JSON ARRAY",
-                                        false,
-                                        BOOLEAN().notNull()),
-                                resultSpec(
-                                        $("f0").isJson(JsonType.OBJECT),
-                                        "f0 IS JSON OBJECT",
-                                        true,
-                                        BOOLEAN().notNull())));
+                                $("f0").isJson(JsonType.VALUE),
+                                "f0 IS JSON VALUE",
+                                true,
+                                BOOLEAN().notNull())
+                        .testResult(
+                                $("f0").isJson(JsonType.SCALAR),
+                                "f0 IS JSON SCALAR",
+                                false,
+                                BOOLEAN().notNull())
+                        .testResult(
+                                $("f0").isJson(JsonType.ARRAY),
+                                "f0 IS JSON ARRAY",
+                                false,
+                                BOOLEAN().notNull())
+                        .testResult(
+                                $("f0").isJson(JsonType.OBJECT),
+                                "f0 IS JSON OBJECT",
+                                true,
+                                BOOLEAN().notNull()));
     }
 
     private static List<TestSetSpec> jsonQuerySpec() {
@@ -476,76 +469,59 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                                 VARBINARY(4).notNull(),
                                 ROW(ARRAY(ROW(INT(), INT()))).notNull())
                         .testResult(
-                                resultSpec(
-                                        jsonString($("f0")),
-                                        "JSON_STRING(f0)",
-                                        "\"V\"",
-                                        STRING().notNull()),
-                                resultSpec(
-                                        jsonString($("f1")),
-                                        "JSON_STRING(f1)",
-                                        "true",
-                                        STRING().notNull()),
-                                resultSpec(
-                                        jsonString($("f2")),
-                                        "JSON_STRING(f2)",
-                                        "1",
-                                        STRING().notNull()),
-                                resultSpec(
-                                        jsonString($("f3")),
-                                        "JSON_STRING(f3)",
-                                        "1.23",
-                                        STRING().notNull()),
-                                resultSpec(
-                                        jsonString($("f4")),
-                                        "JSON_STRING(f4)",
-                                        "1.23",
-                                        STRING().notNull()),
-                                resultSpec(
-                                        jsonString($("f5")),
-                                        "JSON_STRING(f5)",
-                                        "\"1990-06-02T13:37:42.001\"",
-                                        STRING().notNull()),
-                                resultSpec(
-                                        jsonString($("f6")),
-                                        "JSON_STRING(f6)",
-                                        "\"1990-06-02T13:37:42.001Z\"",
-                                        STRING().notNull()),
-                                resultSpec(
-                                        jsonString($("f7")),
-                                        "JSON_STRING(f7)",
-                                        "[\"A1\",\"A2\",\"A3\"]",
-                                        STRING().notNull()),
-                                resultSpec(
-                                        jsonString($("f8")),
-                                        "JSON_STRING(f8)",
-                                        "{\"f0\":\"R1\",\"f1\":\"1990-06-02T13:37:42.001Z\"}",
-                                        STRING().notNull()),
-                                resultSpec(
-                                        jsonString($("f9")),
-                                        "JSON_STRING(f9)",
-                                        "{\"M1\":\"V1\",\"M2\":\"V2\"}",
-                                        STRING().notNull()),
-                                resultSpec(
-                                        jsonString($("f10")),
-                                        "JSON_STRING(f10)",
-                                        "{\"M1\":1,\"M2\":2}",
-                                        STRING().notNull()),
-                                resultSpec(
-                                        jsonString($("f11")),
-                                        "JSON_STRING(f11)",
-                                        "\"VGVzdA==\"",
-                                        STRING().notNull()),
-                                resultSpec(
-                                        jsonString($("f12")),
-                                        "JSON_STRING(f12)",
-                                        "\"VGVzdA==\"",
-                                        STRING().notNull()),
-                                resultSpec(
-                                        jsonString($("f13")),
-                                        "JSON_STRING(f13)",
-                                        "{\"f0\":[{\"f0\":1,\"f1\":2}]}",
-                                        STRING().notNull())));
+                                jsonString($("f0")), "JSON_STRING(f0)", "\"V\"", STRING().notNull())
+                        .testResult(
+                                jsonString($("f1")), "JSON_STRING(f1)", "true", STRING().notNull())
+                        .testResult(jsonString($("f2")), "JSON_STRING(f2)", "1", STRING().notNull())
+                        .testResult(
+                                jsonString($("f3")), "JSON_STRING(f3)", "1.23", STRING().notNull())
+                        .testResult(
+                                jsonString($("f4")), "JSON_STRING(f4)", "1.23", STRING().notNull())
+                        .testResult(
+                                jsonString($("f5")),
+                                "JSON_STRING(f5)",
+                                "\"1990-06-02T13:37:42.001\"",
+                                STRING().notNull())
+                        .testResult(
+                                jsonString($("f6")),
+                                "JSON_STRING(f6)",
+                                "\"1990-06-02T13:37:42.001Z\"",
+                                STRING().notNull())
+                        .testResult(
+                                jsonString($("f7")),
+                                "JSON_STRING(f7)",
+                                "[\"A1\",\"A2\",\"A3\"]",
+                                STRING().notNull())
+                        .testResult(
+                                jsonString($("f8")),
+                                "JSON_STRING(f8)",
+                                "{\"f0\":\"R1\",\"f1\":\"1990-06-02T13:37:42.001Z\"}",
+                                STRING().notNull())
+                        .testResult(
+                                jsonString($("f9")),
+                                "JSON_STRING(f9)",
+                                "{\"M1\":\"V1\",\"M2\":\"V2\"}",
+                                STRING().notNull())
+                        .testResult(
+                                jsonString($("f10")),
+                                "JSON_STRING(f10)",
+                                "{\"M1\":1,\"M2\":2}",
+                                STRING().notNull())
+                        .testResult(
+                                jsonString($("f11")),
+                                "JSON_STRING(f11)",
+                                "\"VGVzdA==\"",
+                                STRING().notNull())
+                        .testResult(
+                                jsonString($("f12")),
+                                "JSON_STRING(f12)",
+                                "\"VGVzdA==\"",
+                                STRING().notNull())
+                        .testResult(
+                                jsonString($("f13")),
+                                "JSON_STRING(f13)",
+                                "{\"f0\":[{\"f0\":1,\"f1\":2}]}",
+                                STRING().notNull()));
     }
 
     private static List<TestSetSpec> jsonObjectSpec() {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/MathFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/MathFunctionsITCase.java
@@ -21,21 +21,18 @@ package org.apache.flink.table.planner.functions;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 
-import org.junit.runners.Parameterized.Parameters;
-
 import java.math.BigDecimal;
-import java.util.Arrays;
-import java.util.List;
+import java.util.stream.Stream;
 
 import static org.apache.flink.table.api.Expressions.$;
 
 /** Tests for math {@link BuiltInFunctionDefinitions} that fully use the new type system. */
-public class MathFunctionsITCase extends BuiltInFunctionTestBase {
+class MathFunctionsITCase extends BuiltInFunctionTestBase {
 
-    @Parameters(name = "{index}: {0}")
-    public static List<TestSpec> testData() {
-        return Arrays.asList(
-                TestSpec.forFunction(BuiltInFunctionDefinitions.PLUS)
+    @Override
+    public Stream<TestSetSpec> getTestCaseSpecs() {
+        return Stream.of(
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.PLUS)
                         .onFieldsWithData(new BigDecimal("1514356320000"))
                         .andDataTypes(DataTypes.DECIMAL(19, 0).notNull())
                         .testResult(
@@ -51,7 +48,7 @@ public class MathFunctionsITCase extends BuiltInFunctionTestBase {
                                         "f0 + f0",
                                         new BigDecimal("3028712640000"),
                                         DataTypes.DECIMAL(20, 0).notNull())),
-                TestSpec.forFunction(BuiltInFunctionDefinitions.MINUS)
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.MINUS)
                         .onFieldsWithData(new BigDecimal("1514356320000"))
                         .andDataTypes(DataTypes.DECIMAL(19, 0))
                         .testResult(
@@ -67,7 +64,7 @@ public class MathFunctionsITCase extends BuiltInFunctionTestBase {
                                         "f0 - f0",
                                         new BigDecimal("0"),
                                         DataTypes.DECIMAL(20, 0))),
-                TestSpec.forFunction(BuiltInFunctionDefinitions.DIVIDE)
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.DIVIDE)
                         .onFieldsWithData(new BigDecimal("1514356320000"))
                         .andDataTypes(DataTypes.DECIMAL(19, 0).notNull())
                         .testResult(
@@ -84,7 +81,7 @@ public class MathFunctionsITCase extends BuiltInFunctionTestBase {
                                         "f0 / f0",
                                         new BigDecimal("1.0000000000000000000"),
                                         DataTypes.DECIMAL(38, 19).notNull())),
-                TestSpec.forFunction(BuiltInFunctionDefinitions.TIMES)
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.TIMES)
                         .onFieldsWithData(new BigDecimal("1514356320000"))
                         .andDataTypes(DataTypes.DECIMAL(19, 0))
                         .testResult(
@@ -100,7 +97,7 @@ public class MathFunctionsITCase extends BuiltInFunctionTestBase {
                                         "f0 * f0",
                                         new BigDecimal("2293275063923942400000000"),
                                         DataTypes.DECIMAL(38, 0))),
-                TestSpec.forFunction(BuiltInFunctionDefinitions.MOD)
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.MOD)
                         .onFieldsWithData(new BigDecimal("1514356320000"), 44L, 3)
                         .andDataTypes(DataTypes.DECIMAL(19, 0), DataTypes.BIGINT(), DataTypes.INT())
                         .testResult(
@@ -116,7 +113,7 @@ public class MathFunctionsITCase extends BuiltInFunctionTestBase {
                                 // BIGINT(19, 0) % INT(10, 0) => INT(10, 0)
                                 resultSpec(
                                         $("f1").mod($("f2")), "MOD(f1, f2)", 2, DataTypes.INT())),
-                TestSpec.forFunction(BuiltInFunctionDefinitions.ROUND)
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.ROUND)
                         .onFieldsWithData(new BigDecimal("12345.12345"))
                         .testResult(
                                 // ROUND(DECIMAL(10, 5) NOT NULL, 2) => DECIMAL(8, 2) NOT NULL
@@ -125,7 +122,7 @@ public class MathFunctionsITCase extends BuiltInFunctionTestBase {
                                         "ROUND(f0, 2)",
                                         new BigDecimal("12345.12"),
                                         DataTypes.DECIMAL(8, 2).notNull())),
-                TestSpec.forFunction(BuiltInFunctionDefinitions.TRUNCATE)
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.TRUNCATE)
                         .onFieldsWithData(new BigDecimal("123.456"))
                         .testResult(
                                 // TRUNCATE(DECIMAL(6, 3) NOT NULL, 2) => DECIMAL(6, 2) NOT NULL

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/MathFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/MathFunctionsITCase.java
@@ -30,7 +30,7 @@ import static org.apache.flink.table.api.Expressions.$;
 class MathFunctionsITCase extends BuiltInFunctionTestBase {
 
     @Override
-    public Stream<TestSetSpec> getTestCaseSpecs() {
+    Stream<TestSetSpec> getTestSetSpecs() {
         return Stream.of(
                 TestSetSpec.forFunction(BuiltInFunctionDefinitions.PLUS)
                         .onFieldsWithData(new BigDecimal("1514356320000"))

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/MathFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/MathFunctionsITCase.java
@@ -35,101 +35,91 @@ class MathFunctionsITCase extends BuiltInFunctionTestBase {
                 TestSetSpec.forFunction(BuiltInFunctionDefinitions.PLUS)
                         .onFieldsWithData(new BigDecimal("1514356320000"))
                         .andDataTypes(DataTypes.DECIMAL(19, 0).notNull())
+                        // DECIMAL(19, 0) + INT(10, 0) => DECIMAL(20, 0)
                         .testResult(
-                                // DECIMAL(19, 0) + INT(10, 0) => DECIMAL(20, 0)
-                                resultSpec(
-                                        $("f0").plus(6),
-                                        "f0 + 6",
-                                        new BigDecimal("1514356320006"),
-                                        DataTypes.DECIMAL(20, 0).notNull()),
-                                // DECIMAL(19, 0) + DECIMAL(19, 0) => DECIMAL(20, 0)
-                                resultSpec(
-                                        $("f0").plus($("f0")),
-                                        "f0 + f0",
-                                        new BigDecimal("3028712640000"),
-                                        DataTypes.DECIMAL(20, 0).notNull())),
+                                $("f0").plus(6),
+                                "f0 + 6",
+                                new BigDecimal("1514356320006"),
+                                DataTypes.DECIMAL(20, 0).notNull())
+                        // DECIMAL(19, 0) + DECIMAL(19, 0) => DECIMAL(20, 0)
+                        .testResult(
+                                $("f0").plus($("f0")),
+                                "f0 + f0",
+                                new BigDecimal("3028712640000"),
+                                DataTypes.DECIMAL(20, 0).notNull()),
                 TestSetSpec.forFunction(BuiltInFunctionDefinitions.MINUS)
                         .onFieldsWithData(new BigDecimal("1514356320000"))
                         .andDataTypes(DataTypes.DECIMAL(19, 0))
+                        // DECIMAL(19, 0) - INT(10, 0) => DECIMAL(20, 0)
                         .testResult(
-                                // DECIMAL(19, 0) - INT(10, 0) => DECIMAL(20, 0)
-                                resultSpec(
-                                        $("f0").minus(6),
-                                        "f0 - 6",
-                                        new BigDecimal("1514356319994"),
-                                        DataTypes.DECIMAL(20, 0)),
-                                // DECIMAL(19, 0) - DECIMAL(19, 0) => DECIMAL(20, 0)
-                                resultSpec(
-                                        $("f0").minus($("f0")),
-                                        "f0 - f0",
-                                        new BigDecimal("0"),
-                                        DataTypes.DECIMAL(20, 0))),
+                                $("f0").minus(6),
+                                "f0 - 6",
+                                new BigDecimal("1514356319994"),
+                                DataTypes.DECIMAL(20, 0))
+                        // DECIMAL(19, 0) - DECIMAL(19, 0) => DECIMAL(20, 0)
+                        .testResult(
+                                $("f0").minus($("f0")),
+                                "f0 - f0",
+                                new BigDecimal("0"),
+                                DataTypes.DECIMAL(20, 0)),
                 TestSetSpec.forFunction(BuiltInFunctionDefinitions.DIVIDE)
                         .onFieldsWithData(new BigDecimal("1514356320000"))
                         .andDataTypes(DataTypes.DECIMAL(19, 0).notNull())
+                        // DECIMAL(19, 0) / INT(10, 0) => DECIMAL(30, 11)
                         .testResult(
-                                // DECIMAL(19, 0) / INT(10, 0) => DECIMAL(30, 11)
-                                resultSpec(
-                                        $("f0").dividedBy(6),
-                                        "f0 / 6",
-                                        new BigDecimal("252392720000.00000000000"),
-                                        DataTypes.DECIMAL(30, 11).notNull()),
-                                // DECIMAL(19, 0) / DECIMAL(19, 0) => DECIMAL(39, 20) => DECIMAL(38,
-                                // 19)
-                                resultSpec(
-                                        $("f0").dividedBy($("f0")),
-                                        "f0 / f0",
-                                        new BigDecimal("1.0000000000000000000"),
-                                        DataTypes.DECIMAL(38, 19).notNull())),
+                                $("f0").dividedBy(6),
+                                "f0 / 6",
+                                new BigDecimal("252392720000.00000000000"),
+                                DataTypes.DECIMAL(30, 11).notNull())
+                        // DECIMAL(19, 0) / DECIMAL(19, 0) => DECIMAL(39, 20) => DECIMAL(38, 19)
+                        .testResult(
+                                $("f0").dividedBy($("f0")),
+                                "f0 / f0",
+                                new BigDecimal("1.0000000000000000000"),
+                                DataTypes.DECIMAL(38, 19).notNull()),
                 TestSetSpec.forFunction(BuiltInFunctionDefinitions.TIMES)
                         .onFieldsWithData(new BigDecimal("1514356320000"))
                         .andDataTypes(DataTypes.DECIMAL(19, 0))
+                        // DECIMAL(19, 0) * INT(10, 0) => DECIMAL(29, 0)
                         .testResult(
-                                // DECIMAL(19, 0) * INT(10, 0) => DECIMAL(29, 0)
-                                resultSpec(
-                                        $("f0").times(6),
-                                        "f0 * 6",
-                                        new BigDecimal("9086137920000"),
-                                        DataTypes.DECIMAL(30, 0)),
-                                // DECIMAL(19, 0) * DECIMAL(19, 0) => DECIMAL(38, 0)
-                                resultSpec(
-                                        $("f0").times($("f0")),
-                                        "f0 * f0",
-                                        new BigDecimal("2293275063923942400000000"),
-                                        DataTypes.DECIMAL(38, 0))),
+                                $("f0").times(6),
+                                "f0 * 6",
+                                new BigDecimal("9086137920000"),
+                                DataTypes.DECIMAL(30, 0))
+                        // DECIMAL(19, 0) * DECIMAL(19, 0) => DECIMAL(38, 0)
+                        .testResult(
+                                $("f0").times($("f0")),
+                                "f0 * f0",
+                                new BigDecimal("2293275063923942400000000"),
+                                DataTypes.DECIMAL(38, 0)),
                 TestSetSpec.forFunction(BuiltInFunctionDefinitions.MOD)
                         .onFieldsWithData(new BigDecimal("1514356320000"), 44L, 3)
                         .andDataTypes(DataTypes.DECIMAL(19, 0), DataTypes.BIGINT(), DataTypes.INT())
+                        // DECIMAL(19, 0) % DECIMAL(19, 0) => DECIMAL(19, 0)
                         .testResult(
-                                // DECIMAL(19, 0) % DECIMAL(19, 0) => DECIMAL(19, 0)
-                                resultSpec(
-                                        $("f0").mod($("f0")),
-                                        "MOD(f0, f0)",
-                                        new BigDecimal(0),
-                                        DataTypes.DECIMAL(19, 0)),
-
-                                // DECIMAL(19, 0) % INT(10, 0) => INT(10, 0)
-                                resultSpec($("f0").mod(6), "MOD(f0, 6)", 0, DataTypes.INT()),
-                                // BIGINT(19, 0) % INT(10, 0) => INT(10, 0)
-                                resultSpec(
-                                        $("f1").mod($("f2")), "MOD(f1, f2)", 2, DataTypes.INT())),
+                                $("f0").mod($("f0")),
+                                "MOD(f0, f0)",
+                                new BigDecimal(0),
+                                DataTypes.DECIMAL(19, 0))
+                        // DECIMAL(19, 0) % INT(10, 0) => INT(10, 0)
+                        .testResult($("f0").mod(6), "MOD(f0, 6)", 0, DataTypes.INT())
+                        // BIGINT(19, 0) % INT(10, 0) => INT(10, 0)
+                        .testResult($("f1").mod($("f2")), "MOD(f1, f2)", 2, DataTypes.INT()),
                 TestSetSpec.forFunction(BuiltInFunctionDefinitions.ROUND)
                         .onFieldsWithData(new BigDecimal("12345.12345"))
+                        // ROUND(DECIMAL(10, 5) NOT NULL, 2) => DECIMAL(8, 2) NOT NULL
                         .testResult(
-                                // ROUND(DECIMAL(10, 5) NOT NULL, 2) => DECIMAL(8, 2) NOT NULL
-                                resultSpec(
-                                        $("f0").round(2),
-                                        "ROUND(f0, 2)",
-                                        new BigDecimal("12345.12"),
-                                        DataTypes.DECIMAL(8, 2).notNull())),
+                                $("f0").round(2),
+                                "ROUND(f0, 2)",
+                                new BigDecimal("12345.12"),
+                                DataTypes.DECIMAL(8, 2).notNull()),
                 TestSetSpec.forFunction(BuiltInFunctionDefinitions.TRUNCATE)
                         .onFieldsWithData(new BigDecimal("123.456"))
+                        // TRUNCATE(DECIMAL(6, 3) NOT NULL, 2) => DECIMAL(6, 2) NOT NULL
                         .testResult(
-                                // TRUNCATE(DECIMAL(6, 3) NOT NULL, 2) => DECIMAL(6, 2) NOT NULL
-                                resultSpec(
-                                        $("f0").truncate(2),
-                                        "TRUNCATE(f0, 2)",
-                                        new BigDecimal("123.45"),
-                                        DataTypes.DECIMAL(6, 2).notNull())));
+                                $("f0").truncate(2),
+                                "TRUNCATE(f0, 2)",
+                                new BigDecimal("123.45"),
+                                DataTypes.DECIMAL(6, 2).notNull()));
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/MiscFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/MiscFunctionsITCase.java
@@ -22,23 +22,20 @@ import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 import org.apache.flink.table.functions.ScalarFunction;
 
-import org.junit.runners.Parameterized;
-
 import java.math.BigDecimal;
-import java.util.Arrays;
-import java.util.List;
+import java.util.stream.Stream;
 
 import static org.apache.flink.table.api.Expressions.$;
 import static org.apache.flink.table.api.Expressions.call;
 import static org.apache.flink.table.api.Expressions.callSql;
 
 /** Tests for miscellaneous {@link BuiltInFunctionDefinitions}. */
-public class MiscFunctionsITCase extends BuiltInFunctionTestBase {
+class MiscFunctionsITCase extends BuiltInFunctionTestBase {
 
-    @Parameterized.Parameters(name = "{index}: {0}")
-    public static List<TestSpec> testData() {
-        return Arrays.asList(
-                TestSpec.forFunction(BuiltInFunctionDefinitions.TYPE_OF)
+    @Override
+    public Stream<TestSetSpec> getTestCaseSpecs() {
+        return Stream.of(
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.TYPE_OF)
                         .onFieldsWithData(12, "Hello world", false)
                         .testResult(
                                 call("TYPEOF", $("f0")),
@@ -57,7 +54,7 @@ public class MiscFunctionsITCase extends BuiltInFunctionTestBase {
                                 "CHAR(11) NOT NULL",
                                 DataTypes.STRING())
                         .testSqlResult("TYPEOF(NULL)", "NULL", DataTypes.STRING()),
-                TestSpec.forFunction(BuiltInFunctionDefinitions.IF_NULL)
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.IF_NULL)
                         .onFieldsWithData(null, new BigDecimal("123.45"))
                         .andDataTypes(DataTypes.INT().nullable(), DataTypes.DECIMAL(5, 2).notNull())
                         .withFunction(TakesNotNull.class)
@@ -90,7 +87,7 @@ public class MiscFunctionsITCase extends BuiltInFunctionTestBase {
                                 "TakesNotNull(IFNULL(f0, 12))",
                                 12,
                                 DataTypes.INT().notNull()),
-                TestSpec.forExpression("SQL call")
+                TestSetSpec.forExpression("SQL call")
                         .onFieldsWithData(null, 12, "Hello World")
                         .andDataTypes(
                                 DataTypes.INT().nullable(),

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/MiscFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/MiscFunctionsITCase.java
@@ -59,21 +59,20 @@ class MiscFunctionsITCase extends BuiltInFunctionTestBase {
                         .andDataTypes(DataTypes.INT().nullable(), DataTypes.DECIMAL(5, 2).notNull())
                         .withFunction(TakesNotNull.class)
                         .testResult(
-                                resultSpec(
-                                        $("f0").ifNull($("f0")),
-                                        "IFNULL(f0, f0)",
-                                        null,
-                                        DataTypes.INT().nullable()),
-                                resultSpec(
-                                        $("f0").ifNull($("f1")),
-                                        "IFNULL(f0, f1)",
-                                        new BigDecimal("123.45"),
-                                        DataTypes.DECIMAL(12, 2).notNull()),
-                                resultSpec(
-                                        $("f1").ifNull($("f0")),
-                                        "IFNULL(f1, f0)",
-                                        new BigDecimal("123.45"),
-                                        DataTypes.DECIMAL(12, 2).notNull()))
+                                $("f0").ifNull($("f0")),
+                                "IFNULL(f0, f0)",
+                                null,
+                                DataTypes.INT().nullable())
+                        .testResult(
+                                $("f0").ifNull($("f1")),
+                                "IFNULL(f0, f1)",
+                                new BigDecimal("123.45"),
+                                DataTypes.DECIMAL(12, 2).notNull())
+                        .testResult(
+                                $("f1").ifNull($("f0")),
+                                "IFNULL(f1, f0)",
+                                new BigDecimal("123.45"),
+                                DataTypes.DECIMAL(12, 2).notNull())
                         .testSqlValidationError(
                                 "IFNULL(SUBSTR(''), f0)",
                                 "Invalid number of arguments to function 'SUBSTR'.")

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/MiscFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/MiscFunctionsITCase.java
@@ -33,7 +33,7 @@ import static org.apache.flink.table.api.Expressions.callSql;
 class MiscFunctionsITCase extends BuiltInFunctionTestBase {
 
     @Override
-    public Stream<TestSetSpec> getTestCaseSpecs() {
+    Stream<TestSetSpec> getTestSetSpecs() {
         return Stream.of(
                 TestSetSpec.forFunction(BuiltInFunctionDefinitions.TYPE_OF)
                         .onFieldsWithData(12, "Hello world", false)

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/RowFunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/RowFunctionITCase.java
@@ -24,22 +24,19 @@ import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 import org.apache.flink.table.functions.ScalarFunction;
 import org.apache.flink.types.Row;
 
-import org.junit.runners.Parameterized.Parameters;
-
-import java.util.Arrays;
-import java.util.List;
+import java.util.stream.Stream;
 
 import static org.apache.flink.table.api.Expressions.$;
 import static org.apache.flink.table.api.Expressions.call;
 import static org.apache.flink.table.api.Expressions.row;
 
 /** Tests for different combinations around {@link BuiltInFunctionDefinitions#ROW}. */
-public class RowFunctionITCase extends BuiltInFunctionTestBase {
+class RowFunctionITCase extends BuiltInFunctionTestBase {
 
-    @Parameters(name = "{index}: {0}")
-    public static List<TestSpec> testData() {
-        return Arrays.asList(
-                TestSpec.forFunction(BuiltInFunctionDefinitions.ROW, "with field access")
+    @Override
+    public Stream<TestSetSpec> getTestCaseSpecs() {
+        return Stream.of(
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.ROW, "with field access")
                         .onFieldsWithData(12, "Hello world")
                         .andDataTypes(DataTypes.INT(), DataTypes.STRING())
                         .testTableApiResult(
@@ -56,7 +53,7 @@ public class RowFunctionITCase extends BuiltInFunctionTestBase {
                                                 DataTypes.FIELD("EXPR$0", DataTypes.INT()),
                                                 DataTypes.FIELD("EXPR$1", DataTypes.STRING()))
                                         .notNull()),
-                TestSpec.forFunction(BuiltInFunctionDefinitions.ROW, "within function call")
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.ROW, "within function call")
                         .onFieldsWithData(12, "Hello world")
                         .andDataTypes(DataTypes.INT(), DataTypes.STRING())
                         .withFunction(TakesRow.class)
@@ -67,7 +64,7 @@ public class RowFunctionITCase extends BuiltInFunctionTestBase {
                                 DataTypes.ROW(
                                         DataTypes.FIELD("i", DataTypes.INT()),
                                         DataTypes.FIELD("s", DataTypes.STRING()))),
-                TestSpec.forFunction(BuiltInFunctionDefinitions.ROW, "within cast")
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.ROW, "within cast")
                         .onFieldsWithData(1)
                         .testResult(
                                 row($("f0").plus(12), "Hello world")

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/RowFunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/RowFunctionITCase.java
@@ -34,7 +34,7 @@ import static org.apache.flink.table.api.Expressions.row;
 class RowFunctionITCase extends BuiltInFunctionTestBase {
 
     @Override
-    public Stream<TestSetSpec> getTestCaseSpecs() {
+    Stream<TestSetSpec> getTestSetSpecs() {
         return Stream.of(
                 TestSetSpec.forFunction(BuiltInFunctionDefinitions.ROW, "with field access")
                         .onFieldsWithData(12, "Hello world")

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/StringFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/StringFunctionsITCase.java
@@ -21,21 +21,19 @@ package org.apache.flink.table.planner.functions;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 
-import org.junit.runners.Parameterized;
-
-import java.util.Arrays;
-import java.util.List;
+import java.util.stream.Stream;
 
 import static org.apache.flink.table.api.Expressions.$;
 import static org.apache.flink.table.api.Expressions.call;
 
 /** Test String functions correct behaviour. */
-public class StringFunctionsITCase extends BuiltInFunctionTestBase {
+class StringFunctionsITCase extends BuiltInFunctionTestBase {
 
-    @Parameterized.Parameters(name = "{index}: {0}")
-    public static List<TestSpec> testData() {
-        return Arrays.asList(
-                TestSpec.forFunction(BuiltInFunctionDefinitions.REGEXP_EXTRACT, "Check return type")
+    @Override
+    public Stream<TestSetSpec> getTestCaseSpecs() {
+        return Stream.of(
+                TestSetSpec.forFunction(
+                                BuiltInFunctionDefinitions.REGEXP_EXTRACT, "Check return type")
                         .onFieldsWithData("22", "ABC")
                         .testResult(
                                 resultSpec(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/StringFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/StringFunctionsITCase.java
@@ -30,7 +30,7 @@ import static org.apache.flink.table.api.Expressions.call;
 class StringFunctionsITCase extends BuiltInFunctionTestBase {
 
     @Override
-    public Stream<TestSetSpec> getTestCaseSpecs() {
+    Stream<TestSetSpec> getTestSetSpecs() {
         return Stream.of(
                 TestSetSpec.forFunction(
                                 BuiltInFunctionDefinitions.REGEXP_EXTRACT, "Check return type")

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/StringFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/StringFunctionsITCase.java
@@ -36,15 +36,14 @@ class StringFunctionsITCase extends BuiltInFunctionTestBase {
                                 BuiltInFunctionDefinitions.REGEXP_EXTRACT, "Check return type")
                         .onFieldsWithData("22", "ABC")
                         .testResult(
-                                resultSpec(
-                                        call("regexpExtract", $("f0"), "[A-Z]+"),
-                                        "REGEXP_EXTRACT(f0,'[A-Z]+')",
-                                        null,
-                                        DataTypes.STRING().nullable()),
-                                resultSpec(
-                                        call("regexpExtract", $("f1"), "[A-Z]+"),
-                                        "REGEXP_EXTRACT(f1, '[A-Z]+')",
-                                        "ABC",
-                                        DataTypes.STRING().nullable())));
+                                call("regexpExtract", $("f0"), "[A-Z]+"),
+                                "REGEXP_EXTRACT(f0,'[A-Z]+')",
+                                null,
+                                DataTypes.STRING().nullable())
+                        .testResult(
+                                call("regexpExtract", $("f1"), "[A-Z]+"),
+                                "REGEXP_EXTRACT(f1, '[A-Z]+')",
+                                "ABC",
+                                DataTypes.STRING().nullable()));
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/FunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/FunctionITCase.java
@@ -40,7 +40,6 @@ import org.apache.flink.table.functions.ScalarFunction;
 import org.apache.flink.table.functions.SpecializedFunction;
 import org.apache.flink.table.functions.TableFunction;
 import org.apache.flink.table.planner.factories.utils.TestCollectionTableFactory;
-import org.apache.flink.table.planner.functions.BuiltInFunctionTestBase;
 import org.apache.flink.table.planner.runtime.utils.StreamingTestBase;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.inference.TypeInference;
@@ -72,7 +71,8 @@ import static org.assertj.core.api.Assertions.fail;
  * Tests for catalog and system functions in a table environment.
  *
  * <p>Note: This class is meant for testing the core function support. Use {@link
- * BuiltInFunctionTestBase} for testing individual function implementations.
+ * org.apache.flink.table.planner.functions.BuiltInFunctionTestBase} for testing individual function
+ * implementations.
  */
 public class FunctionITCase extends StreamingTestBase {
 


### PR DESCRIPTION
This PR includes two commits to port `BuiltInFunctionsTestBase` and `BuiltInAggregateFunctionsTestBase` to JUnit 5 and run those tests in parallel.

On my machine running the whole `functions` package and subpackage tests with non-parallel execution takes 55 secs, while with parallel it takes around ~25 secs