### PR TITLE
[FLINK-26430][FLINK-26429][runtime-web] Bump Karma and follow-redirects to address security findings

### DIFF
--- a/flink-runtime-web/web-dashboard/package-lock.json
+++ b/flink-runtime-web/web-dashboard/package-lock.json
@@ -57,7 +57,7 @@
         "husky": "^7.0.4",
         "jasmine-core": "^4.0.0",
         "jasmine-spec-reporter": "^7.0.0",
-        "karma": "~6.3.7",
+        "karma": "~6.3.14",
         "karma-chrome-launcher": "~3.1.0",
         "karma-coverage": "^2.1.0",
         "karma-jasmine": "~4.0.1",
@@ -10649,9 +10649,9 @@
       }
     },
     "node_modules/karma": {
-      "version": "6.3.11",
-      "resolved": "https://registry.npmjs.org/karma/-/karma-6.3.11.tgz",
-      "integrity": "sha512-QGUh4yXgizzDNPLB5nWTvP+wysKexngbyLVWFOyikB661hpa2RZLf5anZQzqliWtAQuYVep0ot0D1U7UQKpsxQ==",
+      "version": "6.3.14",
+      "resolved": "https://registry.npmjs.org/karma/-/karma-6.3.14.tgz",
+      "integrity": "sha512-SDFoU5F4LdosEiUVWUDRPCV/C1zQRNtIakx7rWkigf7R4sxGADlSEeOma4S1f/js7YAzvqLW92ByoiQptg+8oQ==",
       "dev": true,
       "dependencies": {
         "body-parser": "^1.19.0",
@@ -10666,7 +10666,7 @@
         "http-proxy": "^1.18.1",
         "isbinaryfile": "^4.0.8",
         "lodash": "^4.17.21",
-        "log4js": "^6.3.0",
+        "log4js": "^6.4.1",
         "mime": "^2.5.2",
         "minimatch": "^3.0.4",
         "qjobs": "^1.2.0",
@@ -11395,10 +11395,9 @@
       }
     },
     "node_modules/log4js": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.4.0.tgz",
-      "integrity": "sha512-ysc/XUecZJuN8NoKOssk3V0cQ29xY4fra6fnigZa5VwxFsCsvdqsdnEuAxNN89LlHpbE4KUD3zGcn+kFqonSVQ==",
-      "dev": true,
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.4.1.tgz",
+      "integrity": "sha512-iUiYnXqAmNKiIZ1XSAitQ4TmNs8CdZYTAWINARF3LjnsLN8tY5m0vRwd6uuWj/yNY0YHxeZodnbmxKFUOM2rMg==",      "dev": true,
       "dependencies": {
         "date-format": "^4.0.3",
         "debug": "^4.3.3",
@@ -25178,10 +25177,9 @@
       }
     },
     "karma": {
-      "version": "6.3.11",
-      "resolved": "https://registry.npmjs.org/karma/-/karma-6.3.11.tgz",
-      "integrity": "sha512-QGUh4yXgizzDNPLB5nWTvP+wysKexngbyLVWFOyikB661hpa2RZLf5anZQzqliWtAQuYVep0ot0D1U7UQKpsxQ==",
-      "dev": true,
+      "version": "6.3.14",
+      "resolved": "https://registry.npmjs.org/karma/-/karma-6.3.14.tgz",
+      "integrity": "sha512-SDFoU5F4LdosEiUVWUDRPCV/C1zQRNtIakx7rWkigf7R4sxGADlSEeOma4S1f/js7YAzvqLW92ByoiQptg+8oQ==",      "dev": true,
       "requires": {
         "body-parser": "^1.19.0",
         "braces": "^3.0.2",
@@ -25195,7 +25193,7 @@
         "http-proxy": "^1.18.1",
         "isbinaryfile": "^4.0.8",
         "lodash": "^4.17.21",
-        "log4js": "^6.3.0",
+        "log4js": "^6.4.1",
         "mime": "^2.5.2",
         "minimatch": "^3.0.4",
         "qjobs": "^1.2.0",
@@ -25735,10 +25733,9 @@
       }
     },
     "log4js": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.4.0.tgz",
-      "integrity": "sha512-ysc/XUecZJuN8NoKOssk3V0cQ29xY4fra6fnigZa5VwxFsCsvdqsdnEuAxNN89LlHpbE4KUD3zGcn+kFqonSVQ==",
-      "dev": true,
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.4.1.tgz",
+      "integrity": "sha512-iUiYnXqAmNKiIZ1XSAitQ4TmNs8CdZYTAWINARF3LjnsLN8tY5m0vRwd6uuWj/yNY0YHxeZodnbmxKFUOM2rMg==",      "dev": true,
       "requires": {
         "date-format": "^4.0.3",
         "debug": "^4.3.3",

--- a/flink-runtime-web/web-dashboard/package-lock.json
+++ b/flink-runtime-web/web-dashboard/package-lock.json
@@ -8767,9 +8767,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.7",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
+      "version": "1.14.8",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
+      "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==",
       "dev": true,
       "funding": [
         {
@@ -23763,9 +23763,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.14.7",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
+      "version": "1.14.8",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
+      "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==",
       "dev": true
     },
     "forever-agent": {

--- a/flink-runtime-web/web-dashboard/package.json
+++ b/flink-runtime-web/web-dashboard/package.json
@@ -64,7 +64,7 @@
     "husky": "^7.0.4",
     "jasmine-core": "^4.0.0",
     "jasmine-spec-reporter": "^7.0.0",
-    "karma": "~6.3.7",
+    "karma": "~6.3.14",
     "karma-chrome-launcher": "~3.1.0",
     "karma-coverage": "^2.1.0",
     "karma-jasmine": "~4.0.1",


### PR DESCRIPTION
## What is the purpose of the change

* This PR updates two Javascript packages `karma` and `follow-redirects` to a later version to address security findings in those. To avoid unnecessary PRs, I've created one PR to update both of them at the same time, via two separate commits. 

## Brief change log

* 76e29ad6a7da6add1acab5d57813986b61e9ea80 updates karma
* f2dfe92d769bdbba5ca9407f35bed8505ae71cd3 updates follow-redirects

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
