### PR TITLE
[FLINK-26387][connectors/kafka] Fix KafkaSourceLegacyITCase.testBrokerFailure

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerTestBase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerTestBase.java
@@ -1470,13 +1470,10 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
 
         createTestTopic(topic, parallelism, 1);
 
+        StreamExecutionEnvironment sourceEnv = StreamExecutionEnvironment.getExecutionEnvironment();
+        sourceEnv.enableCheckpointing(100);
         DataGenerators.generateRandomizedIntegerSequence(
-                StreamExecutionEnvironment.getExecutionEnvironment(),
-                kafkaServer,
-                topic,
-                parallelism,
-                numElementsPerPartition,
-                true);
+                sourceEnv, kafkaServer, topic, parallelism, numElementsPerPartition, true);
 
         // find leader to shut down
         int leaderId = kafkaServer.getLeaderToShutDown(topic);


### PR DESCRIPTION
## What is the purpose of the change

The `testBrokerFailure` test is hanging in the CI. The reason is that the `ValidatingExactlyOnceSink` does not receive all records it expects. This is caused by the Kafka producer trying to run with AT_LEAST_ONCE delivery guarantee but falling back to NONE because checkpointing is not activated. This PR enables checkpointing for this test.


## Verifying this change


This change is already covered by existing tests, such as KafkaSourceLegacyITCase.testBrokerFailure


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
