### PR TITLE
[FLINK-26387][connectors/kafka] Disable testBrokerFailure in ITCase tests

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/KafkaSourceLegacyITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/KafkaSourceLegacyITCase.java
@@ -24,6 +24,7 @@ import org.apache.flink.streaming.connectors.kafka.KafkaProducerTestBase;
 import org.apache.flink.streaming.connectors.kafka.KafkaTestEnvironmentImpl;
 
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -89,6 +90,7 @@ public class KafkaSourceLegacyITCase extends KafkaConsumerTestBase {
 
     // --- broker failure ---
 
+    @Ignore("FLINK-26387")
     @Test
     public void testBrokerFailure() throws Exception {
         runBrokerFailureTest();

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaITCase.java
@@ -39,6 +39,7 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import javax.annotation.Nullable;
@@ -107,6 +108,7 @@ public class KafkaITCase extends KafkaConsumerTestBase {
 
     // --- broker failure ---
 
+    @Ignore("FLINK-26393")
     @Test(timeout = 60000)
     public void testBrokerFailure() throws Exception {
         runBrokerFailureTest();


### PR DESCRIPTION
## What is the purpose of the change

The CI failures from FLINK-26387 and FLINK-26393 are blocking many people. To prevent failure of almost all builds while we are looking for the root cause we want to disable the `testBrokerFailure` tests for now.


## Brief change log
- disabled `testBrokerFailure` in `KafkaSourceLegacyITCase` and `KafkaITCase`


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
