### PR TITLE
[FLINK-26450][fs] Adds error handling to FileStateHandle.discardState

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FileStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FileStateHandle.java
@@ -81,8 +81,26 @@ public class FileStateHandle implements StreamStateHandle {
      */
     @Override
     public void discardState() throws Exception {
-        FileSystem fs = getFileSystem();
-        fs.delete(filePath, false);
+        final FileSystem fs = getFileSystem();
+
+        IOException actualException = null;
+        boolean success = true;
+        try {
+            success = fs.delete(filePath, false);
+        } catch (IOException e) {
+            actualException = e;
+        }
+
+        if (!success || actualException != null) {
+            if (fs.exists(filePath)) {
+                throw Optional.ofNullable(actualException)
+                        .orElse(
+                                new IOException(
+                                        "Unknown error caused the file '"
+                                                + filePath
+                                                + "' to not be deleted."));
+            }
+        }
     }
 
     /**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FileStateHandleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FileStateHandleTest.java
@@ -18,35 +18,41 @@
 
 package org.apache.flink.runtime.state.filesystem;
 
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.FileSystemFactory;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.core.fs.local.LocalFileSystem;
+import org.apache.flink.core.plugin.TestingPluginManager;
+import org.apache.flink.util.TestLoggerExtension;
+import org.apache.flink.util.function.BiFunctionWithException;
+import org.apache.flink.util.function.FunctionWithException;
+import org.apache.flink.util.function.RunnableWithException;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
-import java.util.Random;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /** Tests for the {@link FileStateHandle}. */
+@ExtendWith(TestLoggerExtension.class)
 public class FileStateHandleTest {
 
-    @Rule public final TemporaryFolder tempFolder = new TemporaryFolder();
+    private static final String TEST_SCHEME = "test";
 
-    @Test
-    public void testDisposeDeletesFile() throws Exception {
-        File file = tempFolder.newFile();
-        writeTestData(file);
-        assertTrue(file.exists());
-
-        FileStateHandle handle = new FileStateHandle(Path.fromLocalFile(file), file.length());
-        handle.discardState();
-        assertFalse(file.exists());
+    private static Path resolve(String... segments) {
+        return new Path(TEST_SCHEME + "://" + String.join("/", segments));
     }
 
     /**
@@ -57,27 +63,198 @@ public class FileStateHandleTest {
      */
     @Test
     public void testDisposeDoesNotDeleteParentDirectory() throws Exception {
-        File parentDir = tempFolder.newFolder();
-        assertTrue(parentDir.exists());
+        final Path p = resolve("path", "with", "parent");
+        final List<Path> pathsToDelete = new ArrayList<>();
 
-        File file = new File(parentDir, "test");
-        writeTestData(file);
-        assertTrue(file.exists());
+        initializeFileSystem(
+                MockedLocalFileSystem.newBuilder()
+                        .setDeleteFunction(
+                                (path, ignoredRecursionMarker) -> {
+                                    pathsToDelete.add(path);
+                                    return true;
+                                })
+                        .build());
 
-        FileStateHandle handle = new FileStateHandle(Path.fromLocalFile(file), file.length());
+        final FileStateHandle handle = new FileStateHandle(p, 42);
         handle.discardState();
-        assertFalse(file.exists());
-        assertTrue(parentDir.exists());
+        assertThat(pathsToDelete)
+                .as(
+                        "Only one delete call should have happened on the actual path but not the parent.")
+                .singleElement()
+                .isEqualTo(p);
     }
 
-    private static void writeTestData(File file) throws IOException {
-        final Random rnd = new Random();
+    @Test
+    public void testDiscardStateForNonExistingFileWithoutAnErrorBeingExposedByTheFileSystem()
+            throws Exception {
+        testDiscardStateForNonExistingFile(
+                MockedLocalFileSystem.newBuilder()
+                        // deletion call was successful
+                        .setDeleteFunction((ignoredPath, ignoredRecursionMarker) -> true)
+                        .setExistsFunction(
+                                path ->
+                                        fail(
+                                                "The exists call should not have been triggered. This call "
+                                                        + "should be avoided because it might be quite "
+                                                        + "expensive in object stores."))
+                        .build());
+    }
 
-        byte[] data = new byte[rnd.nextInt(1024) + 1];
-        rnd.nextBytes(data);
+    @Test
+    public void testDiscardStateForNonExistingFileWithDeleteCallReturningFalse() throws Exception {
+        testDiscardStateForNonExistingFile(
+                MockedLocalFileSystem.newBuilder()
+                        .setDeleteFunction((ignoredPath, ignoredRecursionMarker) -> false)
+                        .setExistsFunction(path -> false)
+                        .build());
+    }
 
-        try (OutputStream out = new FileOutputStream(file)) {
-            out.write(data);
+    @Test
+    public void testDiscardStateForNonExistingFileWithEDeleteCallFailing() throws Exception {
+        testDiscardStateForNonExistingFile(
+                MockedLocalFileSystem.newBuilder()
+                        .setDeleteFunction(
+                                (ignoredPath, ignoredRecursionMarker) -> {
+                                    throw new IOException(
+                                            "Expected IOException caused by FileSystem.delete.");
+                                })
+                        .setExistsFunction(path -> false)
+                        .build());
+    }
+
+    private void testDiscardStateForNonExistingFile(FileSystem fileSystem) throws Exception {
+        runInFileSystemContext(
+                fileSystem,
+                () -> {
+                    final FileStateHandle handle =
+                            new FileStateHandle(resolve("path", "to", "state"), 0);
+                    // should not fail
+                    handle.discardState();
+                });
+    }
+
+    @Test
+    public void testDiscardStateWithDeletionFailureThroughException() throws Exception {
+        testDiscardStateFailed(
+                MockedLocalFileSystem.newBuilder()
+                        .setDeleteFunction(
+                                (ignoredPath, ignoredRecursionMarker) -> {
+                                    throw new IOException(
+                                            "Expected IOException to simulate IO error.");
+                                })
+                        .setExistsFunction(path -> true)
+                        .build());
+    }
+
+    @Test
+    public void testDiscardStateWithDeletionFailureThroughReturnValue() throws Exception {
+        testDiscardStateFailed(
+                MockedLocalFileSystem.newBuilder()
+                        .setDeleteFunction((ignoredPath, ignoredRecursionMarker) -> false)
+                        .setExistsFunction(path -> true)
+                        .build());
+    }
+
+    private static void testDiscardStateFailed(FileSystem fileSystem) throws Exception {
+        runInFileSystemContext(
+                fileSystem,
+                () -> {
+                    final FileStateHandle handle =
+                            new FileStateHandle(resolve("path", "to", "state"), 0);
+                    assertThrows(IOException.class, handle::discardState);
+                });
+    }
+
+    private static void runInFileSystemContext(
+            FileSystem fileSystem, RunnableWithException testCallback) throws Exception {
+        initializeFileSystem(fileSystem);
+
+        try {
+            testCallback.run();
+        } finally {
+            FileSystem.initialize(new Configuration(), null);
+        }
+    }
+
+    private static void initializeFileSystem(FileSystem fileSystem) {
+        final Map<Class<?>, Iterator<?>> fileSystemPlugins = new HashMap<>();
+        fileSystemPlugins.put(
+                FileSystemFactory.class,
+                Collections.singletonList(new TestingFileSystemFactory(TEST_SCHEME, fileSystem))
+                        .iterator());
+
+        FileSystem.initialize(new Configuration(), new TestingPluginManager(fileSystemPlugins));
+    }
+
+    private static class MockedLocalFileSystem extends LocalFileSystem {
+
+        private final BiFunctionWithException<Path, Boolean, Boolean, IOException> deleteFunction;
+        private final FunctionWithException<Path, Boolean, IOException> existsFunction;
+
+        public MockedLocalFileSystem(
+                BiFunctionWithException<Path, Boolean, Boolean, IOException> deleteFunction,
+                FunctionWithException<Path, Boolean, IOException> existsFunction) {
+            this.deleteFunction = deleteFunction;
+            this.existsFunction = existsFunction;
+        }
+
+        @Override
+        public boolean delete(Path f, boolean recursive) throws IOException {
+            return deleteFunction.apply(f, recursive);
+        }
+
+        @Override
+        public boolean exists(Path f) throws IOException {
+            return existsFunction.apply(f);
+        }
+
+        public static Builder newBuilder() {
+            return new Builder();
+        }
+
+        private static class Builder {
+
+            private BiFunctionWithException<Path, Boolean, Boolean, IOException> deleteFunction =
+                    (ignoredPath, ignoredRecursionMarker) -> true;
+            private FunctionWithException<Path, Boolean, IOException> existsFunction =
+                    ignoredPath -> true;
+
+            public Builder setDeleteFunction(
+                    BiFunctionWithException<Path, Boolean, Boolean, IOException> deleteFunction) {
+                this.deleteFunction = deleteFunction;
+                return this;
+            }
+
+            public Builder setExistsFunction(
+                    FunctionWithException<Path, Boolean, IOException> existsFunction) {
+                this.existsFunction = existsFunction;
+                return this;
+            }
+
+            public MockedLocalFileSystem build() {
+                return new MockedLocalFileSystem(deleteFunction, existsFunction);
+            }
+        }
+    }
+
+    private static class TestingFileSystemFactory implements FileSystemFactory {
+
+        private final String scheme;
+        private final FileSystem fileSystem;
+
+        public TestingFileSystemFactory(String scheme, FileSystem fileSystem) {
+            this.scheme = scheme;
+            this.fileSystem = fileSystem;
+        }
+
+        @Override
+        public String getScheme() {
+            return scheme;
+        }
+
+        @Override
+        public FileSystem create(URI fsUri) throws IOException {
+            return fileSystem;
         }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

`FileStateHandle.discardState` didn't handle cases where the `FileSystem` implementation used the return value to indicate an error during deletion. This made the cleanup logic not recognize the failure.

## Brief change log

* Updates `FileStateHandle.discardState` implementation

## Verifying this change

* Introduces `TestingFileSystem`
* Adds tests to `FileStateHandleTest` to cover both deletion code paths.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: yes

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
