### PR TITLE
[FLINK-26455][state/changelog] Don't fail on materialization cancellation

### DIFF
--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/PeriodicMaterializationManager.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/PeriodicMaterializationManager.java
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
 import java.util.Optional;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -166,6 +167,10 @@ class PeriodicMaterializationManager implements Closeable {
                                         subtaskName,
                                         upTo);
 
+                                scheduleNextMaterialization();
+                            } else if (throwable instanceof CancellationException) {
+                                // can happen e.g. due to task cancellation
+                                LOG.info("materialization cancelled", throwable);
                                 scheduleNextMaterialization();
                             } else {
                                 // if failed


### PR DESCRIPTION
## What is the purpose of the change

When the task is cancelled, AsyncCheckpointRunnables are cancelled as well.
Cancellation exception can reach PeriodicMaterializationManager.
When the failure limit is reached, it invokes asyncExceptionHandler.handleAsyncException, which fails the job.

## Verifying this change

ChangelogITCase (FLINK-25143)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
