### PR TITLE
[FLINK-26464][metrics] Make the meaning of lastCheckpointSize stay as before

### DIFF
--- a/docs/content.zh/docs/ops/metrics.md
+++ b/docs/content.zh/docs/ops/metrics.md
@@ -1207,7 +1207,12 @@ Note that for failed checkpoints, metrics are updated on a best efforts basis an
     </tr>
     <tr>
       <td>lastCheckpointSize</td>
-      <td>The total size of the last checkpoint (in bytes).</td>
+      <td>The checkpointed size of the last checkpoint (in bytes), this metric could be different from lastCheckpointFullSize if incremental checkpoint or changelog is enabled.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>lastCheckpointFullSize</td>
+      <td>The full size of the last checkpoint (in bytes).</td>
       <td>Gauge</td>
     </tr>
     <tr>

--- a/docs/content/docs/ops/metrics.md
+++ b/docs/content/docs/ops/metrics.md
@@ -1200,7 +1200,12 @@ Note that for failed checkpoints, metrics are updated on a best efforts basis an
     </tr>
     <tr>
       <td>lastCheckpointSize</td>
-      <td>The total size of the last checkpoint (in bytes).</td>
+      <td>The checkpointed size of the last checkpoint (in bytes), this metric could be different from lastCheckpointFullSize if incremental checkpoint or changelog is enabled.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>lastCheckpointFullSize</td>
+      <td>The full size of the last checkpoint (in bytes).</td>
       <td>Gauge</td>
     </tr>
     <tr>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointStatsTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointStatsTracker.java
@@ -295,6 +295,9 @@ public class CheckpointStatsTracker {
     static final String LATEST_COMPLETED_CHECKPOINT_SIZE_METRIC = "lastCheckpointSize";
 
     @VisibleForTesting
+    static final String LATEST_COMPLETED_CHECKPOINT_FULL_SIZE_METRIC = "lastCheckpointFullSize";
+
+    @VisibleForTesting
     static final String LATEST_COMPLETED_CHECKPOINT_DURATION_METRIC = "lastCheckpointDuration";
 
     @VisibleForTesting
@@ -326,6 +329,9 @@ public class CheckpointStatsTracker {
                 new LatestRestoredCheckpointTimestampGauge());
         metricGroup.gauge(
                 LATEST_COMPLETED_CHECKPOINT_SIZE_METRIC, new LatestCompletedCheckpointSizeGauge());
+        metricGroup.gauge(
+                LATEST_COMPLETED_CHECKPOINT_FULL_SIZE_METRIC,
+                new LatestCompletedCheckpointFullSizeGauge());
         metricGroup.gauge(
                 LATEST_COMPLETED_CHECKPOINT_DURATION_METRIC,
                 new LatestCompletedCheckpointDurationGauge());
@@ -381,6 +387,18 @@ public class CheckpointStatsTracker {
     }
 
     private class LatestCompletedCheckpointSizeGauge implements Gauge<Long> {
+        @Override
+        public Long getValue() {
+            CompletedCheckpointStats completed = latestCompletedCheckpoint;
+            if (completed != null) {
+                return completed.getCheckpointedSize();
+            } else {
+                return -1L;
+            }
+        }
+    }
+
+    private class LatestCompletedCheckpointFullSizeGauge implements Gauge<Long> {
         @Override
         public Long getValue() {
             CompletedCheckpointStats completed = latestCompletedCheckpoint;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStatsTrackerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStatsTrackerTest.java
@@ -289,6 +289,7 @@ public class CheckpointStatsTrackerTest {
                                 CheckpointStatsTracker.NUMBER_OF_FAILED_CHECKPOINTS_METRIC,
                                 CheckpointStatsTracker.LATEST_RESTORED_CHECKPOINT_TIMESTAMP_METRIC,
                                 CheckpointStatsTracker.LATEST_COMPLETED_CHECKPOINT_SIZE_METRIC,
+                                CheckpointStatsTracker.LATEST_COMPLETED_CHECKPOINT_FULL_SIZE_METRIC,
                                 CheckpointStatsTracker.LATEST_COMPLETED_CHECKPOINT_DURATION_METRIC,
                                 CheckpointStatsTracker
                                         .LATEST_COMPLETED_CHECKPOINT_PROCESSED_DATA_METRIC,
@@ -296,7 +297,7 @@ public class CheckpointStatsTrackerTest {
                                         .LATEST_COMPLETED_CHECKPOINT_PERSISTED_DATA_METRIC,
                                 CheckpointStatsTracker
                                         .LATEST_COMPLETED_CHECKPOINT_EXTERNAL_PATH_METRIC)));
-        assertEquals(10, registeredGaugeNames.size());
+        assertEquals(11, registeredGaugeNames.size());
     }
 
     /**
@@ -327,7 +328,7 @@ public class CheckpointStatsTrackerTest {
         CheckpointStatsTracker stats = new CheckpointStatsTracker(0, metricGroup);
 
         // Make sure to adjust this test if metrics are added/removed
-        assertEquals(10, registeredGauges.size());
+        assertEquals(11, registeredGauges.size());
 
         // Check initial values
         Gauge<Long> numCheckpoints =
@@ -353,6 +354,11 @@ public class CheckpointStatsTrackerTest {
                 (Gauge<Long>)
                         registeredGauges.get(
                                 CheckpointStatsTracker.LATEST_COMPLETED_CHECKPOINT_SIZE_METRIC);
+        Gauge<Long> latestCompletedFullSize =
+                (Gauge<Long>)
+                        registeredGauges.get(
+                                CheckpointStatsTracker
+                                        .LATEST_COMPLETED_CHECKPOINT_FULL_SIZE_METRIC);
         Gauge<Long> latestCompletedDuration =
                 (Gauge<Long>)
                         registeredGauges.get(
@@ -379,6 +385,7 @@ public class CheckpointStatsTrackerTest {
         assertEquals(Long.valueOf(0), numFailedCheckpoints.getValue());
         assertEquals(Long.valueOf(-1), latestRestoreTimestamp.getValue());
         assertEquals(Long.valueOf(-1), latestCompletedSize.getValue());
+        assertEquals(Long.valueOf(-1), latestCompletedFullSize.getValue());
         assertEquals(Long.valueOf(-1), latestCompletedDuration.getValue());
         assertEquals(Long.valueOf(-1), latestProcessedData.getValue());
         assertEquals(Long.valueOf(-1), latestPersistedData.getValue());
@@ -399,7 +406,8 @@ public class CheckpointStatsTrackerTest {
         assertEquals(Long.valueOf(0), numFailedCheckpoints.getValue());
 
         long ackTimestamp = 11231230L;
-        long stateSize = 12381238L;
+        long checkpointedSize = 123L;
+        long fullCheckpointSize = 12381238L;
         long processedData = 4242L;
         long persistedData = 4444L;
         long ignored = 0;
@@ -409,8 +417,8 @@ public class CheckpointStatsTrackerTest {
                 new SubtaskStateStats(
                         0,
                         ackTimestamp,
-                        stateSize,
-                        stateSize,
+                        checkpointedSize,
+                        fullCheckpointSize,
                         ignored,
                         ignored,
                         processedData,
@@ -430,7 +438,8 @@ public class CheckpointStatsTrackerTest {
         assertEquals(Long.valueOf(1), numCompletedCheckpoints.getValue());
         assertEquals(Long.valueOf(0), numFailedCheckpoints.getValue());
         assertEquals(Long.valueOf(-1), latestRestoreTimestamp.getValue());
-        assertEquals(Long.valueOf(stateSize), latestCompletedSize.getValue());
+        assertEquals(Long.valueOf(checkpointedSize), latestCompletedSize.getValue());
+        assertEquals(Long.valueOf(fullCheckpointSize), latestCompletedFullSize.getValue());
         assertEquals(Long.valueOf(processedData), latestProcessedData.getValue());
         assertEquals(Long.valueOf(persistedData), latestPersistedData.getValue());
         assertEquals(Long.valueOf(ackTimestamp), latestCompletedDuration.getValue());


### PR DESCRIPTION
## What is the purpose of the change

After [FLINK-25557](https://issues.apache.org/jira/browse/FLINK-25557), the meaning of previous metric lastCheckpointSize has been changed to last completed full checkpoint size. We could introduce another metric `lastCheckpointFullSize` to represent the meaning of last completed full checkpoint size and let lastCheckpointSize stay as it was.

## Brief change log

  - Make the meaning of lastCheckpointSize stay as before.
  - Introduce a new `lastCheckpointFullSize`


## Verifying this change


This change added tests and can be verified as follows:

`CheckpointStatsTrackerTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
