### PR TITLE
[FLINK-25969][table-runtime] Clean up caches in CompileUtils more aggressively

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/BatchPlanner.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/BatchPlanner.scala
@@ -76,7 +76,7 @@ class BatchPlanner(
   }
 
   override protected def translateToPlan(execGraph: ExecNodeGraph): util.List[Transformation[_]] = {
-    validateAndOverrideConfiguration()
+    beforeTranslation()
     val planner = createDummyPlanner()
 
     val transformations = execGraph.getRootNodes.map {
@@ -85,7 +85,7 @@ class BatchPlanner(
         throw new TableException("Cannot generate BoundedStream due to an invalid logical plan. " +
             "This is a bug and should not happen. Please file an issue.")
     }
-    cleanupInternalConfigurations()
+    afterTranslation()
     transformations
   }
 
@@ -152,8 +152,8 @@ class BatchPlanner(
     throw new UnsupportedOperationException(
       "The compiled plan feature is not supported in batch mode.")
 
-  override def validateAndOverrideConfiguration(): Unit = {
-    super.validateAndOverrideConfiguration()
+  override def beforeTranslation(): Unit = {
+    super.beforeTranslation()
     val runtimeMode = getConfiguration.get(ExecutionOptions.RUNTIME_MODE)
     if (runtimeMode != RuntimeExecutionMode.BATCH) {
       throw new IllegalArgumentException(

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
@@ -55,6 +55,7 @@ import org.apache.flink.table.planner.sinks.DataStreamTableSink
 import org.apache.flink.table.planner.sinks.TableSinkUtils.{inferSinkPhysicalSchema, validateLogicalPhysicalTypesCompatible, validateTableSink}
 import org.apache.flink.table.planner.utils.InternalConfigOptions.{TABLE_QUERY_START_EPOCH_TIME, TABLE_QUERY_START_LOCAL_TIME}
 import org.apache.flink.table.planner.utils.JavaScalaConversionUtil.{toJava, toScala}
+import org.apache.flink.table.runtime.generated.CompileUtils
 import org.apache.flink.table.sinks.TableSink
 import org.apache.flink.table.types.utils.LegacyTypeInfoDataTypeConverter
 
@@ -183,7 +184,7 @@ abstract class PlannerBase(
 
   override def translate(
       modifyOperations: util.List[ModifyOperation]): util.List[Transformation[_]] = {
-    validateAndOverrideConfiguration()
+    beforeTranslation()
     if (modifyOperations.isEmpty) {
       return List.empty[Transformation[_]]
     }
@@ -192,7 +193,7 @@ abstract class PlannerBase(
     val optimizedRelNodes = optimize(relNodes)
     val execGraph = translateToExecNodeGraph(optimizedRelNodes)
     val transformations = translateToPlan(execGraph)
-    cleanupInternalConfigurations()
+    afterTranslation()
     transformations
   }
 
@@ -477,11 +478,7 @@ abstract class PlannerBase(
     )
   }
 
-  /**
-   * Different planner has different rules. Validate the planner and runtime mode is consistent with
-   * the configuration before planner do optimization with [[ModifyOperation]] or other works.
-   */
-  protected def validateAndOverrideConfiguration(): Unit = {
+  protected def beforeTranslation(): Unit = {
     val configuration = tableConfig.getConfiguration
 
     // Add query start time to TableConfig, these config are used internally,
@@ -504,13 +501,14 @@ abstract class PlannerBase(
     }
   }
 
-  /**
-   * Cleanup all internal configuration after plan translation finished.
-   */
-  protected def cleanupInternalConfigurations(): Unit = {
+  protected def afterTranslation(): Unit = {
+    // Cleanup all internal configuration after plan translation finished.
     val configuration = tableConfig.getConfiguration
     configuration.removeConfig(TABLE_QUERY_START_EPOCH_TIME)
     configuration.removeConfig(TABLE_QUERY_START_LOCAL_TIME)
+
+    // Clean caches that might have filled up during optimization
+    CompileUtils.cleanUp()
   }
 
   /**
@@ -519,7 +517,7 @@ abstract class PlannerBase(
   private[flink] def getExplainGraphs(operations: util.List[Operation]
       ): (mutable.Buffer[RelNode], Seq[RelNode], ExecNodeGraph, StreamGraph) = {
     require(operations.nonEmpty, "operations should not be empty")
-    validateAndOverrideConfiguration()
+    beforeTranslation()
     val sinkRelNodes = operations.map {
       case queryOperation: QueryOperation =>
         val relNode = getRelBuilder.queryOperation(queryOperation).build()
@@ -548,7 +546,7 @@ abstract class PlannerBase(
     val execGraph = translateToExecNodeGraph(optimizedRelNodes)
 
     val transformations = translateToPlan(execGraph)
-    cleanupInternalConfigurations()
+    afterTranslation()
 
     val streamGraph = executor.createPipeline(transformations, tableConfig.getConfiguration, null)
       .asInstanceOf[StreamGraph]

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/generated/CompileUtilsTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/generated/CompileUtilsTest.java
@@ -41,7 +41,8 @@ public class CompileUtilsTest {
     @Before
     public void before() {
         // cleanup cached class before tests
-        CompileUtils.COMPILED_CACHE.invalidateAll();
+        CompileUtils.COMPILED_CLASS_CACHE.invalidateAll();
+        CompileUtils.COMPILED_EXPRESSION_CACHE.invalidateAll();
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

An attempt to reduce the memory size for `CompileUtils` caching. 

## Brief change log

- Introduce timeouts of cache entires.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
