### PR TITLE
[FLINK-26474][hive] Fold exprNode to fix the issue of failing to call some hive udf required constant parameters with implicit constant passed

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveParserCalcitePlanner.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveParserCalcitePlanner.java
@@ -2307,7 +2307,8 @@ public class HiveParserCalcitePlanner {
                 } else {
                     // Case when this is an expression
                     HiveParserTypeCheckCtx typeCheckCtx =
-                            new HiveParserTypeCheckCtx(inputRR, frameworkConfig, cluster);
+                            new HiveParserTypeCheckCtx(
+                                    inputRR, true, true, frameworkConfig, cluster);
                     // We allow stateful functions in the SELECT list (but nowhere else)
                     typeCheckCtx.setAllowStatefulFunctions(true);
                     if (!qbp.getDestToGroupBy().isEmpty()) {

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectQueryITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectQueryITCase.java
@@ -788,7 +788,7 @@ public class HiveDialectQueryITCase {
                                                     timestamp))
                                     .collect());
             assertThat(results.toString())
-                    .isEqualTo(String.format("[+I[%s]]", expectTimeStampDecimal.toFormatString(8)));
+                    .isEqualTo(String.format("[+I[%s]]", expectTimeStampDecimal));
 
             // test insert timestamp type to decimal type directly
             tableEnv.executeSql("create table t1 (c1 DECIMAL(38,6))");

--- a/flink-connectors/flink-connector-hive/src/test/resources/query-test/udf.q
+++ b/flink-connectors/flink-connector-hive/src/test/resources/query-test/udf.q
@@ -1,0 +1,13 @@
+-- SORT_QUERY_RESULTS
+
+select bround(55.0, -1);
+
+[+I[60]]
+
+select round(123.45, -2);
+
+[+I[100]]
+
+select sha2('ABC', cast(null as int));
+
+[+I[null]]

--- a/flink-connectors/flink-connector-hive/src/test/resources/query-test/udf.q
+++ b/flink-connectors/flink-connector-hive/src/test/resources/query-test/udf.q
@@ -4,6 +4,10 @@ select bround(55.0, -1);
 
 [+I[60]]
 
+select bround(55.0, +1);
+
+[+I[55]]
+
 select round(123.45, -2);
 
 [+I[100]]


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
The change is to enable  ExprNode  folding  and to fold UDFOPNegative.
It's mainly to fix the issue that it'll throw the exception `BROUND second argument only takes constant` when call some hive udf requiring constant parameter with implicit constant like `-1` or `cast(null as int) `.


## Brief change log
  -   enable ExprNode  fold
  -  when the ExprNodeDesc is negative operator, try to fold it to ExprNodeConstantDesc
  -  modify the logic for `convertConstant` in `HiveParserRexNodeConverter`  for the value for the data type of `IntervalYearMonth`/`IntervalDayTimeType` will be class of `HiveIntervalYearMonth`, `HiveIntervalDayTime`.


## Verifying this change
Added `udf.q` contains the sql statements that'll fail before this fix.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
