### PR TITLE
[FLINK-26485][state/changelog] Discard unnecessarily uploaded state

### DIFF
--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/BatchingStateChangeUploadScheduler.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/BatchingStateChangeUploadScheduler.java
@@ -46,12 +46,13 @@ import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkState;
 
 /**
- * A {@link StateChangeUploader} that waits for some configured amount of time before passing the
- * accumulated state changes to the actual store.
+ * A {@link StateChangeUploadScheduler} that waits for some configured amount of time before passing
+ * the accumulated state changes to the actual store.
  */
 @ThreadSafe
-class BatchingStateChangeUploader implements StateChangeUploader {
-    private static final Logger LOG = LoggerFactory.getLogger(BatchingStateChangeUploader.class);
+class BatchingStateChangeUploadScheduler implements StateChangeUploadScheduler {
+    private static final Logger LOG =
+            LoggerFactory.getLogger(BatchingStateChangeUploadScheduler.class);
 
     private final RetryingExecutor retryingExecutor;
     private final RetryPolicy retryPolicy;
@@ -97,7 +98,7 @@ class BatchingStateChangeUploader implements StateChangeUploader {
 
     private final Histogram uploadBatchSizes;
 
-    BatchingStateChangeUploader(
+    BatchingStateChangeUploadScheduler(
             long persistDelayMs,
             long sizeThresholdBytes,
             RetryPolicy retryPolicy,
@@ -116,7 +117,7 @@ class BatchingStateChangeUploader implements StateChangeUploader {
                 metricGroup);
     }
 
-    BatchingStateChangeUploader(
+    BatchingStateChangeUploadScheduler(
             long persistDelayMs,
             long sizeThresholdBytes,
             long maxBytesInFlight,

--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/BatchingStateChangeUploadScheduler.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/BatchingStateChangeUploadScheduler.java
@@ -228,7 +228,7 @@ class BatchingStateChangeUploadScheduler implements StateChangeUploadScheduler {
             uploadBatchSizes.update(tasks.size());
             retryingExecutor.execute(
                     retryPolicy,
-                    () -> delegate.upload(tasks),
+                    () -> delegate.upload(tasks).complete(),
                     t -> tasks.forEach(task -> task.fail(t)));
         } catch (Throwable t) {
             tasks.forEach(task -> task.fail(t));

--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogWriter.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogWriter.java
@@ -19,7 +19,7 @@ package org.apache.flink.changelog.fs;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.changelog.fs.StateChangeUploader.UploadTask;
+import org.apache.flink.changelog.fs.StateChangeUploadScheduler.UploadTask;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.changelog.ChangelogStateHandleStreamImpl;
@@ -63,9 +63,9 @@ import static org.apache.flink.util.Preconditions.checkState;
  * #persistInternal(SequenceNumber) persist} is called.
  *
  * <p>On {@link #persist(SequenceNumber) persist}, accumulated changes are sent to the {@link
- * StateChangeUploader} as an immutable {@link StateChangeUploader.UploadTask task}. An {@link
- * FsStateChangelogWriter.UploadCompletionListener upload listener} is also registered. Upon
- * notification it updates the Writer local state (for future persist calls) and completes the
+ * StateChangeUploadScheduler} as an immutable {@link StateChangeUploadScheduler.UploadTask task}.
+ * An {@link FsStateChangelogWriter.UploadCompletionListener upload listener} is also registered.
+ * Upon notification it updates the Writer local state (for future persist calls) and completes the
  * future returned to the original caller. The uploader notifies all listeners via a callback in a
  * task.
  *
@@ -91,7 +91,7 @@ class FsStateChangelogWriter implements StateChangelogWriter<ChangelogStateHandl
 
     private final UUID logId;
     private final KeyGroupRange keyGroupRange;
-    private final StateChangeUploader uploader;
+    private final StateChangeUploadScheduler uploader;
     private final long preEmptivePersistThresholdInBytes;
 
     /** Lock to synchronize handling of upload completion with new upload requests. */
@@ -143,7 +143,7 @@ class FsStateChangelogWriter implements StateChangelogWriter<ChangelogStateHandl
     FsStateChangelogWriter(
             UUID logId,
             KeyGroupRange keyGroupRange,
-            StateChangeUploader uploader,
+            StateChangeUploadScheduler uploader,
             long preEmptivePersistThresholdInBytes) {
         this.logId = logId;
         this.keyGroupRange = keyGroupRange;

--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/RetryingExecutor.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/RetryingExecutor.java
@@ -19,7 +19,6 @@ package org.apache.flink.changelog.fs;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.metrics.Histogram;
-import org.apache.flink.util.function.RunnableWithException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,7 +30,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Consumer;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.apache.flink.util.ExceptionUtils.firstOrSuppressed;
@@ -74,17 +72,11 @@ class RetryingExecutor implements AutoCloseable {
      * <p>NOTE: the action must be idempotent because multiple instances of it can be executed
      * concurrently (if the policy allows retries).
      */
-    void execute(
-            RetryPolicy retryPolicy, RetriableAction action, Consumer<Throwable> failureCallback) {
+    <T> void execute(RetryPolicy retryPolicy, RetriableAction<T> action) {
         LOG.debug("execute with retryPolicy: {}", retryPolicy);
-        RetriableTask task =
-                RetriableTask.initialize(
-                        action,
-                        retryPolicy,
-                        blockingExecutor,
-                        attemptsPerTaskHistogram,
-                        timer,
-                        failureCallback);
+        RetriableActionAttempt<T> task =
+                RetriableActionAttempt.initialize(
+                        action, retryPolicy, blockingExecutor, attemptsPerTaskHistogram, timer);
         blockingExecutor.submit(task);
     }
 
@@ -119,14 +111,43 @@ class RetryingExecutor implements AutoCloseable {
      *
      * <p>NOTE: the action must be idempotent because of potential concurrent attempts.
      */
-    interface RetriableAction extends RunnableWithException {}
+    interface RetriableAction<Result> {
+        /**
+         * Make an attempt to execute this action.
+         *
+         * @return result of execution to be used in either {@link #completeWithResult(Object)} or
+         *     {@link #discardResult(Object)}.
+         * @throws Exception any intermediate state should be cleaned up inside this method in case
+         *     of failure
+         */
+        Result tryExecute() throws Exception;
 
-    private static final class RetriableTask implements Runnable {
-        private final RetriableAction runnable;
-        private final Consumer<Throwable> failureCallback;
+        /**
+         * Complete the action with the given result, e.g. by notifying waiting parties. Called on
+         * successful execution once per action, regardless of the number of execution attempts.
+         */
+        void completeWithResult(Result result);
+
+        /**
+         * Discard the execution results, e.g. because another execution attempt has completed
+         * earlier. This result will not be passed to {@link #completeWithResult(Object)} or
+         * otherwise used.
+         */
+        void discardResult(Result result) throws Exception;
+
+        /**
+         * Handle this action failure, which means that an un-recoverable failure has occurred in
+         * {@link #tryExecute()} or retry limit has been reached. No further execution attempts will
+         * be performed.
+         */
+        void handleFailure(Throwable throwable);
+    }
+
+    private static final class RetriableActionAttempt<Result> implements Runnable {
+        private final RetriableAction<Result> action;
         private final ScheduledExecutorService blockingExecutor;
         private final ScheduledExecutorService timer;
-        private final int current;
+        private final int attemptNumber;
         private final RetryPolicy retryPolicy;
         /**
          * The flag shared across all attempts to execute the same {#link #runnable action}
@@ -146,19 +167,17 @@ class RetryingExecutor implements AutoCloseable {
 
         private final Histogram attemptsPerTaskHistogram;
 
-        private RetriableTask(
-                int current,
+        private RetriableActionAttempt(
+                int attemptNumber,
                 AtomicBoolean actionCompleted,
-                RetriableAction runnable,
+                RetriableAction<Result> action,
                 RetryPolicy retryPolicy,
                 ScheduledExecutorService blockingExecutor,
                 ScheduledExecutorService timer,
-                Consumer<Throwable> failureCallback,
                 AtomicInteger activeAttempts,
                 Histogram attemptsPerTaskHistogram) {
-            this.current = current;
-            this.runnable = runnable;
-            this.failureCallback = failureCallback;
+            this.attemptNumber = attemptNumber;
+            this.action = action;
             this.retryPolicy = retryPolicy;
             this.blockingExecutor = blockingExecutor;
             this.actionCompleted = actionCompleted;
@@ -170,21 +189,29 @@ class RetryingExecutor implements AutoCloseable {
 
         @Override
         public void run() {
-            LOG.debug("starting attempt {}", current);
-            if (!actionCompleted.get()) {
-                Optional<ScheduledFuture<?>> timeoutFuture = scheduleTimeout();
-                try {
-                    runnable.run();
-                    if (actionCompleted.compareAndSet(false, true)) {
-                        LOG.debug("succeeded with {} attempts", current);
-                        attemptsPerTaskHistogram.update(current);
+            LOG.debug("starting attempt {}", attemptNumber);
+            if (actionCompleted.get()) {
+                return;
+            }
+            Optional<ScheduledFuture<?>> timeoutFuture = scheduleTimeout();
+            try {
+                Result result = action.tryExecute();
+                if (actionCompleted.compareAndSet(false, true)) {
+                    LOG.debug("succeeded with {} attempts", attemptNumber);
+                    action.completeWithResult(result);
+                    attemptsPerTaskHistogram.update(attemptNumber);
+                } else {
+                    LOG.debug("discard unnecessarily uploaded state, attempt {}", attemptNumber);
+                    try {
+                        action.discardResult(result);
+                    } catch (Exception e) {
+                        LOG.warn("unable to discard execution attempt result", e);
                     }
-                    attemptCompleted.set(true);
-                } catch (Exception e) {
-                    handleError(e);
-                } finally {
-                    timeoutFuture.ifPresent(f -> f.cancel(true));
                 }
+            } catch (Exception e) {
+                handleError(e);
+            } finally {
+                timeoutFuture.ifPresent(f -> f.cancel(true));
             }
         }
 
@@ -194,20 +221,20 @@ class RetryingExecutor implements AutoCloseable {
                 // or another attempt completed the task
                 return;
             }
-            LOG.debug("execution attempt {} failed: {}", current, e.getMessage());
-            long nextAttemptDelay = retryPolicy.retryAfter(current, e);
+            LOG.debug("execution attempt {} failed: {}", attemptNumber, e.getMessage());
+            long nextAttemptDelay = retryPolicy.retryAfter(attemptNumber, e);
             if (nextAttemptDelay >= 0L) {
                 activeAttempts.incrementAndGet();
                 scheduleNext(nextAttemptDelay, next());
             }
             if (activeAttempts.decrementAndGet() == 0
                     && actionCompleted.compareAndSet(false, true)) {
-                LOG.info("failed with {} attempts: {}", current, e.getMessage());
-                failureCallback.accept(e);
+                LOG.info("failed with {} attempts: {}", attemptNumber, e.getMessage());
+                action.handleFailure(e);
             }
         }
 
-        private void scheduleNext(long nextAttemptDelay, RetriableTask next) {
+        private void scheduleNext(long nextAttemptDelay, RetriableActionAttempt<Result> next) {
             if (nextAttemptDelay == 0L) {
                 blockingExecutor.submit(next);
             } else if (nextAttemptDelay > 0L) {
@@ -215,40 +242,37 @@ class RetryingExecutor implements AutoCloseable {
             }
         }
 
-        private static RetriableTask initialize(
-                RetriableAction runnable,
+        private static <T> RetriableActionAttempt<T> initialize(
+                RetriableAction<T> runnable,
                 RetryPolicy retryPolicy,
                 ScheduledExecutorService blockingExecutor,
                 Histogram attemptsPerTaskHistogram,
-                ScheduledExecutorService timer,
-                Consumer<Throwable> failureCallback) {
-            return new RetriableTask(
+                ScheduledExecutorService timer) {
+            return new RetriableActionAttempt(
                     1,
                     new AtomicBoolean(false),
                     runnable,
                     retryPolicy,
                     blockingExecutor,
                     timer,
-                    failureCallback,
                     new AtomicInteger(1),
                     attemptsPerTaskHistogram);
         }
 
-        private RetriableTask next() {
-            return new RetriableTask(
-                    current + 1,
+        private RetriableActionAttempt<Result> next() {
+            return new RetriableActionAttempt<>(
+                    attemptNumber + 1,
                     actionCompleted,
-                    runnable,
+                    action,
                     retryPolicy,
                     blockingExecutor,
                     timer,
-                    failureCallback,
                     activeAttempts,
                     attemptsPerTaskHistogram);
         }
 
         private Optional<ScheduledFuture<?>> scheduleTimeout() {
-            long timeout = retryPolicy.timeoutFor(current);
+            long timeout = retryPolicy.timeoutFor(attemptNumber);
             return timeout <= 0
                     ? Optional.empty()
                     : Optional.of(
@@ -258,7 +282,7 @@ class RetryingExecutor implements AutoCloseable {
 
         private TimeoutException fmtError(long timeout) {
             return new TimeoutException(
-                    String.format("Attempt %d timed out after %dms", current, timeout));
+                    String.format("Attempt %d timed out after %dms", attemptNumber, timeout));
         }
     }
 }

--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/StateChangeFsUploader.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/StateChangeFsUploader.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.changelog.fs;
 
+import org.apache.flink.changelog.fs.StateChangeUploadScheduler.UploadTask;
 import org.apache.flink.core.fs.FSDataOutputStream;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
@@ -42,13 +43,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 import static org.apache.flink.core.fs.FileSystem.WriteMode.NO_OVERWRITE;
 
 /**
- * A synchronous {@link StateChangeUploader} implementation that uploads the changes using {@link
- * FileSystem}.
+ * A synchronous {@link StateChangeUploadScheduler} implementation that uploads the changes using
+ * {@link FileSystem}.
  */
 class StateChangeFsUploader implements StateChangeUploader {
     private static final Logger LOG = LoggerFactory.getLogger(StateChangeFsUploader.class);
@@ -74,11 +74,6 @@ class StateChangeFsUploader implements StateChangeUploader {
         this.bufferSize = bufferSize;
         this.metrics = metrics;
         this.clock = SystemClock.getInstance();
-    }
-
-    @Override
-    public void upload(UploadTask uploadTask) throws IOException {
-        upload(singletonList(uploadTask));
     }
 
     public void upload(Collection<UploadTask> tasks) throws IOException {

--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/StateChangeFsUploader.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/StateChangeFsUploader.java
@@ -23,7 +23,6 @@ import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.state.SnappyStreamCompressionDecorator;
 import org.apache.flink.runtime.state.StreamCompressionDecorator;
-import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.UncompressedStreamCompressionDecorator;
 import org.apache.flink.runtime.state.filesystem.FileStateHandle;
 import org.apache.flink.util.clock.Clock;
@@ -39,11 +38,9 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import static java.util.stream.Collectors.toList;
 import static org.apache.flink.core.fs.FileSystem.WriteMode.NO_OVERWRITE;
 
 /**
@@ -76,15 +73,13 @@ class StateChangeFsUploader implements StateChangeUploader {
         this.clock = SystemClock.getInstance();
     }
 
-    public void upload(Collection<UploadTask> tasks) throws IOException {
+    public UploadTasksResult upload(Collection<UploadTask> tasks) throws IOException {
         final String fileName = generateFileName();
         LOG.debug("upload {} tasks to {}", tasks.size(), fileName);
         Path path = new Path(basePath, fileName);
 
         try {
-            LocalResult result = uploadWithMetrics(path, tasks);
-            result.tasksOffsets.forEach(
-                    (task, offsets) -> task.complete(buildResults(result.handle, offsets)));
+            return uploadWithMetrics(path, tasks);
         } catch (IOException e) {
             metrics.getUploadFailuresCounter().inc();
             try (Closer closer = Closer.create()) {
@@ -96,19 +91,20 @@ class StateChangeFsUploader implements StateChangeUploader {
                 closer.register(() -> fileSystem.delete(path, true));
             }
         }
+        return null; // closer above throws an exception
     }
 
-    private LocalResult uploadWithMetrics(Path path, Collection<UploadTask> tasks)
+    private UploadTasksResult uploadWithMetrics(Path path, Collection<UploadTask> tasks)
             throws IOException {
         metrics.getUploadsCounter().inc();
         long start = clock.relativeTimeNanos();
-        LocalResult result = upload(path, tasks);
+        UploadTasksResult result = upload(path, tasks);
         metrics.getUploadLatenciesNanos().update(clock.relativeTimeNanos() - start);
-        metrics.getUploadSizes().update(result.handle.getStateSize());
+        metrics.getUploadSizes().update(result.getStateSize());
         return result;
     }
 
-    private LocalResult upload(Path path, Collection<UploadTask> tasks) throws IOException {
+    private UploadTasksResult upload(Path path, Collection<UploadTask> tasks) throws IOException {
         boolean wrappedStreamClosed = false;
         FSDataOutputStream fsStream = fileSystem.create(path, NO_OVERWRITE);
         try {
@@ -121,7 +117,7 @@ class StateChangeFsUploader implements StateChangeUploader {
                 FileStateHandle handle = new FileStateHandle(path, stream.getPos());
                 // WARN: streams have to be closed before returning the results
                 // otherwise JM may receive invalid handles
-                return new LocalResult(tasksOffsets, handle);
+                return new UploadTasksResult(tasksOffsets, handle);
             } finally {
                 wrappedStreamClosed = true;
             }
@@ -129,17 +125,6 @@ class StateChangeFsUploader implements StateChangeUploader {
             if (!wrappedStreamClosed) {
                 fsStream.close();
             }
-        }
-    }
-
-    private static final class LocalResult {
-        private final Map<UploadTask, Map<StateChangeSet, Long>> tasksOffsets;
-        private final StreamStateHandle handle;
-
-        public LocalResult(
-                Map<UploadTask, Map<StateChangeSet, Long>> tasksOffsets, StreamStateHandle handle) {
-            this.tasksOffsets = tasksOffsets;
-            this.handle = handle;
         }
     }
 
@@ -151,13 +136,6 @@ class StateChangeFsUploader implements StateChangeUploader {
         OutputStream compressed =
                 compression ? instance.decorateWithCompression(fsStream) : fsStream;
         return new OutputStreamWithPos(new BufferedOutputStream(compressed, bufferSize));
-    }
-
-    private List<UploadResult> buildResults(
-            StreamStateHandle handle, Map<StateChangeSet, Long> offsets) {
-        return offsets.entrySet().stream()
-                .map(e -> UploadResult.of(handle, e.getKey(), e.getValue()))
-                .collect(toList());
     }
 
     private String generateFileName() {

--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/StateChangeUploadScheduler.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/StateChangeUploadScheduler.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.changelog.fs;
+
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.io.AvailabilityProvider;
+import org.apache.flink.runtime.state.changelog.SequenceNumber;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
+import static org.apache.flink.changelog.fs.FsStateChangelogOptions.BASE_PATH;
+import static org.apache.flink.changelog.fs.FsStateChangelogOptions.COMPRESSION_ENABLED;
+import static org.apache.flink.changelog.fs.FsStateChangelogOptions.IN_FLIGHT_DATA_LIMIT;
+import static org.apache.flink.changelog.fs.FsStateChangelogOptions.NUM_UPLOAD_THREADS;
+import static org.apache.flink.changelog.fs.FsStateChangelogOptions.PERSIST_DELAY;
+import static org.apache.flink.changelog.fs.FsStateChangelogOptions.PERSIST_SIZE_THRESHOLD;
+import static org.apache.flink.changelog.fs.FsStateChangelogOptions.UPLOAD_BUFFER_SIZE;
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+// todo: consider using CheckpointStreamFactory / CheckpointStorageWorkerView
+//     Considerations:
+//     0. need for checkpointId in the current API to resolve the location
+//       option a: pass checkpointId (race condition?)
+//       option b: pass location (race condition?)
+//       option c: add FsCheckpointStorageAccess.createSharedStateStream
+//     1. different settings for materialized/changelog (e.g. timeouts)
+//     2. re-use closeAndGetHandle
+//     3. re-use in-memory handles (.metadata)
+//     4. handle in-memory handles duplication
+
+/**
+ * Schedules {@link UploadTask upload tasks} on a {@link StateChangeUploader}. In the simplest form,
+ * directly calls {@link StateChangeUploader#upload(Collection)} (UploadTask)}. Other
+ * implementations might batch the tasks for efficiency.
+ */
+interface StateChangeUploadScheduler extends AutoCloseable {
+
+    void upload(UploadTask uploadTask) throws IOException;
+
+    static StateChangeUploadScheduler directScheduler(StateChangeUploader uploader) {
+        return new StateChangeUploadScheduler() {
+            @Override
+            public void upload(UploadTask uploadTask) throws IOException {
+                uploader.upload(singletonList(uploadTask));
+            }
+
+            @Override
+            public void close() throws Exception {
+                uploader.close();
+            }
+        };
+    }
+
+    static StateChangeUploadScheduler fromConfig(
+            ReadableConfig config, ChangelogStorageMetricGroup metricGroup) throws IOException {
+        Path basePath = new Path(config.get(BASE_PATH));
+        long bytes = config.get(UPLOAD_BUFFER_SIZE).getBytes();
+        checkArgument(bytes <= Integer.MAX_VALUE);
+        int bufferSize = (int) bytes;
+        StateChangeFsUploader store =
+                new StateChangeFsUploader(
+                        basePath,
+                        basePath.getFileSystem(),
+                        config.get(COMPRESSION_ENABLED),
+                        bufferSize,
+                        metricGroup);
+        BatchingStateChangeUploadScheduler batchingStore =
+                new BatchingStateChangeUploadScheduler(
+                        config.get(PERSIST_DELAY).toMillis(),
+                        config.get(PERSIST_SIZE_THRESHOLD).getBytes(),
+                        RetryPolicy.fromConfig(config),
+                        store,
+                        config.get(NUM_UPLOAD_THREADS),
+                        config.get(IN_FLIGHT_DATA_LIMIT).getBytes(),
+                        metricGroup);
+        return batchingStore;
+    }
+
+    default AvailabilityProvider getAvailabilityProvider() {
+        return () -> AvailabilityProvider.AVAILABLE;
+    }
+
+    @ThreadSafe
+    final class UploadTask {
+        final Collection<StateChangeSet> changeSets;
+        final BiConsumer<List<SequenceNumber>, Throwable> failureCallback;
+        final Consumer<List<UploadResult>> successCallback;
+        final AtomicBoolean finished = new AtomicBoolean();
+
+        public UploadTask(
+                Collection<StateChangeSet> changeSets,
+                Consumer<List<UploadResult>> successCallback,
+                BiConsumer<List<SequenceNumber>, Throwable> failureCallback) {
+            this.changeSets = new ArrayList<>(changeSets);
+            this.failureCallback = failureCallback;
+            this.successCallback = successCallback;
+        }
+
+        public void complete(List<UploadResult> results) {
+            if (finished.compareAndSet(false, true)) {
+                successCallback.accept(results);
+            }
+        }
+
+        public void fail(Throwable error) {
+            if (finished.compareAndSet(false, true)) {
+                failureCallback.accept(
+                        changeSets.stream()
+                                .map(StateChangeSet::getSequenceNumber)
+                                .collect(toList()),
+                        error);
+            }
+        }
+
+        public long getSize() {
+            long size = 0;
+            for (StateChangeSet set : changeSets) {
+                size = set.getSize();
+            }
+            return size;
+        }
+
+        @Override
+        public String toString() {
+            return "changeSets=" + changeSets;
+        }
+    }
+}

--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/StateChangeUploadScheduler.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/StateChangeUploadScheduler.java
@@ -145,7 +145,7 @@ interface StateChangeUploadScheduler extends AutoCloseable {
         public long getSize() {
             long size = 0;
             for (StateChangeSet set : changeSets) {
-                size = set.getSize();
+                size += set.getSize();
             }
             return size;
         }

--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/StateChangeUploader.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/StateChangeUploader.java
@@ -69,5 +69,9 @@ interface StateChangeUploader extends AutoCloseable {
         public long getStateSize() {
             return handle.getStateSize();
         }
+
+        public void discard() throws Exception {
+            handle.discardState();
+        }
     }
 }

--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/StateChangeUploader.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/StateChangeUploader.java
@@ -17,129 +17,16 @@
 
 package org.apache.flink.changelog.fs;
 
-import org.apache.flink.configuration.ReadableConfig;
-import org.apache.flink.core.fs.Path;
-import org.apache.flink.runtime.io.AvailabilityProvider;
-import org.apache.flink.runtime.state.changelog.SequenceNumber;
-
-import javax.annotation.concurrent.ThreadSafe;
+import org.apache.flink.changelog.fs.StateChangeUploadScheduler.UploadTask;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
-
-import static java.util.stream.Collectors.toList;
-import static org.apache.flink.changelog.fs.FsStateChangelogOptions.BASE_PATH;
-import static org.apache.flink.changelog.fs.FsStateChangelogOptions.COMPRESSION_ENABLED;
-import static org.apache.flink.changelog.fs.FsStateChangelogOptions.IN_FLIGHT_DATA_LIMIT;
-import static org.apache.flink.changelog.fs.FsStateChangelogOptions.NUM_UPLOAD_THREADS;
-import static org.apache.flink.changelog.fs.FsStateChangelogOptions.PERSIST_DELAY;
-import static org.apache.flink.changelog.fs.FsStateChangelogOptions.PERSIST_SIZE_THRESHOLD;
-import static org.apache.flink.changelog.fs.FsStateChangelogOptions.UPLOAD_BUFFER_SIZE;
-import static org.apache.flink.util.Preconditions.checkArgument;
-
-// todo: consider using CheckpointStreamFactory / CheckpointStorageWorkerView
-//     Considerations:
-//     0. need for checkpointId in the current API to resolve the location
-//       option a: pass checkpointId (race condition?)
-//       option b: pass location (race condition?)
-//       option c: add FsCheckpointStorageAccess.createSharedStateStream
-//     1. different settings for materialized/changelog (e.g. timeouts)
-//     2. re-use closeAndGetHandle
-//     3. re-use in-memory handles (.metadata)
-//     4. handle in-memory handles duplication
 
 /**
  * The purpose of this interface is to abstract the different implementations of uploading state
- * changelog parts. It has a single {@link #upload} method with a single {@link UploadTask} argument
- * which is meant to initiate such an upload.
+ * changelog parts. It has a single {@link #upload} method with a collection of {@link UploadTask}
+ * argument which is meant to initiate such an upload.
  */
 interface StateChangeUploader extends AutoCloseable {
-
-    void upload(UploadTask uploadTask) throws IOException;
-
-    default void upload(Collection<UploadTask> tasks) throws IOException {
-        for (UploadTask task : tasks) {
-            upload(task);
-        }
-    }
-
-    static StateChangeUploader fromConfig(
-            ReadableConfig config, ChangelogStorageMetricGroup metricGroup) throws IOException {
-        Path basePath = new Path(config.get(BASE_PATH));
-        long bytes = config.get(UPLOAD_BUFFER_SIZE).getBytes();
-        checkArgument(bytes <= Integer.MAX_VALUE);
-        int bufferSize = (int) bytes;
-        StateChangeFsUploader store =
-                new StateChangeFsUploader(
-                        basePath,
-                        basePath.getFileSystem(),
-                        config.get(COMPRESSION_ENABLED),
-                        bufferSize,
-                        metricGroup);
-        BatchingStateChangeUploader batchingStore =
-                new BatchingStateChangeUploader(
-                        config.get(PERSIST_DELAY).toMillis(),
-                        config.get(PERSIST_SIZE_THRESHOLD).getBytes(),
-                        RetryPolicy.fromConfig(config),
-                        store,
-                        config.get(NUM_UPLOAD_THREADS),
-                        config.get(IN_FLIGHT_DATA_LIMIT).getBytes(),
-                        metricGroup);
-        return batchingStore;
-    }
-
-    default AvailabilityProvider getAvailabilityProvider() {
-        return () -> AvailabilityProvider.AVAILABLE;
-    }
-
-    @ThreadSafe
-    final class UploadTask {
-        final Collection<StateChangeSet> changeSets;
-        final BiConsumer<List<SequenceNumber>, Throwable> failureCallback;
-        final Consumer<List<UploadResult>> successCallback;
-        final AtomicBoolean finished = new AtomicBoolean();
-
-        public UploadTask(
-                Collection<StateChangeSet> changeSets,
-                Consumer<List<UploadResult>> successCallback,
-                BiConsumer<List<SequenceNumber>, Throwable> failureCallback) {
-            this.changeSets = new ArrayList<>(changeSets);
-            this.failureCallback = failureCallback;
-            this.successCallback = successCallback;
-        }
-
-        public void complete(List<UploadResult> results) {
-            if (finished.compareAndSet(false, true)) {
-                successCallback.accept(results);
-            }
-        }
-
-        public void fail(Throwable error) {
-            if (finished.compareAndSet(false, true)) {
-                failureCallback.accept(
-                        changeSets.stream()
-                                .map(StateChangeSet::getSequenceNumber)
-                                .collect(toList()),
-                        error);
-            }
-        }
-
-        public long getSize() {
-            long size = 0;
-            for (StateChangeSet set : changeSets) {
-                size = set.getSize();
-            }
-            return size;
-        }
-
-        @Override
-        public String toString() {
-            return "changeSets=" + changeSets;
-        }
-    }
+    void upload(Collection<UploadTask> tasks) throws IOException;
 }

--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/UploadThrottle.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/UploadThrottle.java
@@ -48,7 +48,7 @@ class UploadThrottle {
 
     /**
      * Release previously {@link #seizeCapacity(long) seized} capacity. Called by {@link
-     * BatchingStateChangeUploader} (IO thread).
+     * BatchingStateChangeUploadScheduler} (IO thread).
      */
     public void releaseCapacity(long bytes) {
         inFlightBytesCounter -= bytes;

--- a/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/BatchingStateChangeUploadSchedulerTest.java
+++ b/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/BatchingStateChangeUploadSchedulerTest.java
@@ -46,6 +46,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
@@ -298,7 +299,13 @@ public class BatchingStateChangeUploadSchedulerTest {
                 new CompletableFuture<>();
         TestScenario test =
                 (uploader, probe) -> {
-                    List<StateChangeSet> changes1 = getChanges(sizeLimit + 1);
+                    List<StateChangeSet> changes1 =
+                            // explicitly create multiple StateChangeSet
+                            // to validate size computation in UploadTask.getSize
+                            Stream.concat(
+                                            getChanges(sizeLimit / 2).stream(),
+                                            getChanges(sizeLimit / 2).stream())
+                                    .collect(Collectors.toList());
                     assertTrue(uploader.getAvailabilityProvider().isAvailable());
                     assertTrue(uploader.getAvailabilityProvider().isApproximatelyAvailable());
                     upload(uploader, changes1);

--- a/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/FsStateChangelogWriterSqnTest.java
+++ b/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/FsStateChangelogWriterSqnTest.java
@@ -84,7 +84,8 @@ public class FsStateChangelogWriterSqnTest {
                 new FsStateChangelogWriter(
                         UUID.randomUUID(),
                         KeyGroupRange.of(0, 0),
-                        new TestingStateChangeUploader(),
+                        StateChangeUploadScheduler.directScheduler(
+                                new TestingStateChangeUploader()),
                         Long.MAX_VALUE)) {
             if (test.withAppend) {
                 append(writer);

--- a/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/FsStateChangelogWriterTest.java
+++ b/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/FsStateChangelogWriterTest.java
@@ -210,7 +210,7 @@ public class FsStateChangelogWriterTest {
                 new FsStateChangelogWriter(
                         UUID.randomUUID(),
                         KeyGroupRange.of(KEY_GROUP, KEY_GROUP),
-                        uploader,
+                        StateChangeUploadScheduler.directScheduler(uploader),
                         appendPersistThreshold)) {
             test.accept(writer, uploader);
         }

--- a/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/RetryingExecutorTest.java
+++ b/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/RetryingExecutorTest.java
@@ -17,22 +17,32 @@
 
 package org.apache.flink.changelog.fs;
 
+import org.apache.flink.api.common.time.Deadline;
+import org.apache.flink.changelog.fs.RetryingExecutor.RetriableAction;
 import org.apache.flink.core.testutils.CompletedScheduledFuture;
 import org.apache.flink.runtime.testutils.DirectScheduledExecutorService;
+import org.apache.flink.util.function.RunnableWithException;
 import org.apache.flink.util.function.ThrowingConsumer;
 
 import org.junit.Test;
 
 import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
 
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
 import static org.apache.flink.changelog.fs.UnregisteredChangelogStorageMetricGroup.createUnregisteredChangelogStorageMetricGroup;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -53,6 +63,62 @@ public class RetryingExecutorTest {
     @Test
     public void testFixedRetryLimit() throws Exception {
         testPolicy(5, RetryPolicy.fixed(5, 0, 0), FAILING_TASK);
+    }
+
+    @Test
+    public void testDiscardOnTimeout() throws Exception {
+        int timeoutMs = 5;
+        int numAttempts = 7;
+        int successfulAttempt = numAttempts - 1;
+        List<Integer> completed = new CopyOnWriteArrayList<>();
+        List<Integer> discarded = new CopyOnWriteArrayList<>();
+        AtomicBoolean executionBlocked = new AtomicBoolean(true);
+        Deadline deadline = Deadline.fromNow(Duration.ofMinutes(5));
+        try (RetryingExecutor executor =
+                new RetryingExecutor(
+                        numAttempts,
+                        createUnregisteredChangelogStorageMetricGroup().getAttemptsPerUpload())) {
+            executor.execute(
+                    RetryPolicy.fixed(numAttempts, timeoutMs, 0),
+                    new RetriableAction<Integer>() {
+                        private final AtomicInteger attemptsCounter = new AtomicInteger(0);
+
+                        @Override
+                        public Integer tryExecute() throws Exception {
+                            int attempt = attemptsCounter.getAndIncrement();
+                            if (attempt < successfulAttempt) {
+                                while (executionBlocked.get()) {
+                                    Thread.sleep(10);
+                                }
+                            }
+                            return attempt;
+                        }
+
+                        @Override
+                        public void completeWithResult(Integer result) {
+                            completed.add(result);
+                        }
+
+                        @Override
+                        public void discardResult(Integer result) {
+                            discarded.add(result);
+                        }
+
+                        @Override
+                        public void handleFailure(Throwable throwable) {}
+                    });
+            while (completed.isEmpty() && deadline.hasTimeLeft()) {
+                Thread.sleep(10);
+            }
+            executionBlocked.set(false);
+            while (discarded.size() < successfulAttempt && deadline.hasTimeLeft()) {
+                Thread.sleep(10);
+            }
+        }
+        assertEquals(singletonList(successfulAttempt), completed);
+        assertEquals(
+                IntStream.range(0, successfulAttempt).boxed().collect(toList()),
+                discarded.stream().sorted().collect(toList()));
     }
 
     @Test
@@ -170,16 +236,35 @@ public class RetryingExecutorTest {
                         createUnregisteredChangelogStorageMetricGroup().getAttemptsPerUpload())) {
             executor.execute(
                     policy,
-                    () -> {
-                        try {
-                            task.accept(attemptsMade.incrementAndGet());
-                        } finally {
-                            firstAttemptCompletedLatch.countDown();
-                        }
-                    },
-                    t -> {});
+                    runnableToAction(
+                            () -> {
+                                try {
+                                    task.accept(attemptsMade.incrementAndGet());
+                                } finally {
+                                    firstAttemptCompletedLatch.countDown();
+                                }
+                            }));
             firstAttemptCompletedLatch.await(); // before closing executor
         }
         assertEquals(expectedAttempts, attemptsMade.get());
+    }
+
+    private static RetriableAction<?> runnableToAction(RunnableWithException action) {
+        return new RetriableAction<Object>() {
+            @Override
+            public Object tryExecute() throws Exception {
+                action.run();
+                return null;
+            }
+
+            @Override
+            public void completeWithResult(Object o) {}
+
+            @Override
+            public void discardResult(Object o) {}
+
+            @Override
+            public void handleFailure(Throwable throwable) {}
+        };
     }
 }

--- a/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/TestingStateChangeUploader.java
+++ b/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/TestingStateChangeUploader.java
@@ -27,6 +27,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
+import static java.util.Collections.emptyMap;
 import static java.util.stream.Collectors.toList;
 
 class TestingStateChangeUploader implements StateChangeUploader {
@@ -44,11 +45,12 @@ class TestingStateChangeUploader implements StateChangeUploader {
     }
 
     @Override
-    public void upload(Collection<UploadTask> tasks) throws IOException {
+    public UploadTasksResult upload(Collection<UploadTask> tasks) throws IOException {
         for (UploadTask uploadTask : tasks) {
             this.uploaded.addAll(uploadTask.changeSets);
             this.tasks.add(uploadTask);
         }
+        return new UploadTasksResult(emptyMap(), new ByteStreamStateHandle("", new byte[0]));
     }
 
     public Collection<StateChangeSet> getUploaded() {

--- a/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/TestingStateChangeUploader.java
+++ b/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/TestingStateChangeUploader.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.changelog.fs;
 
+import org.apache.flink.changelog.fs.StateChangeUploadScheduler.UploadTask;
 import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.changelog.StateChange;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
@@ -30,8 +31,12 @@ import static java.util.stream.Collectors.toList;
 
 class TestingStateChangeUploader implements StateChangeUploader {
     private final Collection<StateChangeSet> uploaded = new CopyOnWriteArrayList<>();
-    private final List<UploadTask> tasks = new CopyOnWriteArrayList<>();
+    private final List<UploadTask> tasks;
     private boolean closed;
+
+    TestingStateChangeUploader() {
+        tasks = new CopyOnWriteArrayList<>();
+    }
 
     @Override
     public void close() {
@@ -39,9 +44,11 @@ class TestingStateChangeUploader implements StateChangeUploader {
     }
 
     @Override
-    public void upload(UploadTask uploadTask) throws IOException {
-        uploaded.addAll(uploadTask.changeSets);
-        tasks.add(uploadTask);
+    public void upload(Collection<UploadTask> tasks) throws IOException {
+        for (UploadTask uploadTask : tasks) {
+            this.uploaded.addAll(uploadTask.changeSets);
+            this.tasks.add(uploadTask);
+        }
     }
 
     public Collection<StateChangeSet> getUploaded() {


### PR DESCRIPTION
depends on #18931

## What is the purpose of the change

When an attempt of an already completed upload task succeeds,
the uploaded state is currently not discarded.

## Verifying this change

- BatchingStateChangeUploadSchedulerTest.testRetryOnTimeout
- RetryingExecutorTest.testDiscardOnTimeout

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
