### PR TITLE
[FLINK-26484][fs] FileSystem.delete is not implemented consistently

### DIFF
--- a/flink-filesystems/flink-s3-fs-base/src/main/java/org/apache/flink/fs/s3/common/AbstractS3FileSystemFactory.java
+++ b/flink-filesystems/flink-s3-fs-base/src/main/java/org/apache/flink/fs/s3/common/AbstractS3FileSystemFactory.java
@@ -152,7 +152,7 @@ public abstract class AbstractS3FileSystemFactory implements FileSystemFactory {
             final int maxConcurrentUploads = flinkConfig.getInteger(MAX_CONCURRENT_UPLOADS);
             final S3AccessHelper s3AccessHelper = getS3AccessHelper(fs);
 
-            return new FlinkS3FileSystem(
+            return createFlinkFileSystem(
                     fs,
                     localTmpDirectory,
                     entropyInjectionKey,
@@ -165,6 +165,24 @@ public abstract class AbstractS3FileSystemFactory implements FileSystemFactory {
         } catch (Exception e) {
             throw new IOException(e.getMessage(), e);
         }
+    }
+
+    protected FileSystem createFlinkFileSystem(
+            org.apache.hadoop.fs.FileSystem fs,
+            String localTmpDirectory,
+            String entropyInjectionKey,
+            int numEntropyChars,
+            S3AccessHelper s3AccessHelper,
+            long s3minPartSize,
+            int maxConcurrentUploads) {
+        return new FlinkS3FileSystem(
+                fs,
+                localTmpDirectory,
+                entropyInjectionKey,
+                numEntropyChars,
+                s3AccessHelper,
+                s3minPartSize,
+                maxConcurrentUploads);
     }
 
     protected abstract org.apache.hadoop.fs.FileSystem createHadoopFileSystem();

--- a/flink-filesystems/flink-s3-fs-presto/src/main/java/org/apache/flink/fs/s3presto/FlinkS3PrestoFileSystem.java
+++ b/flink-filesystems/flink-s3-fs-presto/src/main/java/org/apache/flink/fs/s3presto/FlinkS3PrestoFileSystem.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.s3presto;
+
+import org.apache.flink.core.fs.FileStatus;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.fs.s3.common.FlinkS3FileSystem;
+import org.apache.flink.fs.s3.common.writer.S3AccessHelper;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.hadoop.fs.FileSystem;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.Optional;
+
+/**
+ * {@code FlinkS3PrestoFileSystem} provides custom recursive deletion functionality to work around a
+ * bug in the internally used Presto file system.
+ *
+ * <p>https://github.com/prestodb/presto/issues/17416
+ */
+public class FlinkS3PrestoFileSystem extends FlinkS3FileSystem {
+
+    public FlinkS3PrestoFileSystem(
+            FileSystem hadoopS3FileSystem,
+            String localTmpDirectory,
+            @Nullable String entropyInjectionKey,
+            int entropyLength,
+            @Nullable S3AccessHelper s3UploadHelper,
+            long s3uploadPartSize,
+            int maxConcurrentUploadsPerStream) {
+        super(
+                hadoopS3FileSystem,
+                localTmpDirectory,
+                entropyInjectionKey,
+                entropyLength,
+                s3UploadHelper,
+                s3uploadPartSize,
+                maxConcurrentUploadsPerStream);
+    }
+
+    @Override
+    public boolean delete(Path path, boolean recursive) throws IOException {
+        if (recursive) {
+            deleteRecursively(path);
+        } else {
+            deleteObject(path);
+        }
+
+        return true;
+    }
+
+    private void deleteRecursively(Path path) throws IOException {
+        final FileStatus[] containingFiles =
+                Preconditions.checkNotNull(
+                        listStatus(path),
+                        "Hadoop FileSystem.listStatus should never return null based on its contract.");
+
+        if (containingFiles.length == 0) {
+            // This if branch covers objects and empty directories. Both will be handled properly in
+            // the deleteObject method.
+            deleteObject(path);
+            return;
+        }
+
+        IOException exception = null;
+        for (FileStatus fileStatus : containingFiles) {
+            final Path childPath = fileStatus.getPath();
+
+            try {
+                if (fileStatus.isDir()) {
+                    deleteRecursively(childPath);
+                } else {
+                    deleteObject(childPath);
+                }
+            } catch (IOException e) {
+                exception = ExceptionUtils.firstOrSuppressed(e, exception);
+            }
+        }
+
+        // Presto doesn't hold placeholders for directories itself; therefore, we don't need to
+        // call deleteObject on the directory itself if there were objects with the prefix being
+        // deleted in the initial loop above. This saves us from doing some existence checks on
+        // an not-existing object (i.e. the now empty directory)
+        if (exception != null) {
+            throw exception;
+        }
+    }
+
+    /**
+     * Deletes the object referenced by the passed {@code path}. This method is used to work around
+     * the fact that Presto doesn't allow us to differentiate between deleting a non-existing object
+     * and some other errors. Therefore, a final check for existence is necessary in case of an
+     * error or false return value.
+     *
+     * @param path The path referring to the object that shall be deleted.
+     * @throws IOException if an error occurred while deleting the file other than the {@code path}
+     *     referring to a non-empty directory.
+     */
+    private void deleteObject(Path path) throws IOException {
+        boolean success = true;
+        IOException actualException = null;
+        try {
+            // empty directories will cause this method to fail as well - checking for their
+            // existence afterwards is a workaround to cover this use-case
+            success = super.delete(path, false);
+        } catch (IOException e) {
+            actualException = e;
+        }
+
+        if (!success || actualException != null) {
+            if (exists(path)) {
+                throw Optional.ofNullable(actualException)
+                        .orElse(
+                                new IOException(
+                                        path.getPath()
+                                                + " could not be deleted for unknown reasons."));
+            }
+        }
+    }
+}

--- a/flink-filesystems/flink-s3-fs-presto/src/main/java/org/apache/flink/fs/s3presto/S3FileSystemFactory.java
+++ b/flink-filesystems/flink-s3-fs-presto/src/main/java/org/apache/flink/fs/s3presto/S3FileSystemFactory.java
@@ -65,6 +65,25 @@ public class S3FileSystemFactory extends AbstractS3FileSystemFactory {
     }
 
     @Override
+    protected org.apache.flink.core.fs.FileSystem createFlinkFileSystem(
+            FileSystem fs,
+            String localTmpDirectory,
+            String entropyInjectionKey,
+            int numEntropyChars,
+            S3AccessHelper s3AccessHelper,
+            long s3minPartSize,
+            int maxConcurrentUploads) {
+        return new FlinkS3PrestoFileSystem(
+                fs,
+                localTmpDirectory,
+                entropyInjectionKey,
+                numEntropyChars,
+                s3AccessHelper,
+                s3minPartSize,
+                maxConcurrentUploads);
+    }
+
+    @Override
     protected org.apache.hadoop.fs.FileSystem createHadoopFileSystem() {
         return new PrestoS3FileSystem();
     }


### PR DESCRIPTION
## What is the purpose of the change

We've observed a bug in the `PrestoS3FileSystem.delete` implementation where the recursive delete isn't implemented properly to handle errors (see [PrestoDB issue #17416](https://github.com/prestodb/presto/issues/17416)). This prevents `BlobStore` items to be deleted as part of a repeated cleanup.

A new `PrestoS3FileSystem` is introduced that implements the recursive delete to work around the bug for now.

## Brief change log

* `PrestoS3FileSystem` adds recursive deletion logic that handles errors properly

## Verifying this change

* Adds tests for `exists` and `delete` to `FileSystemBehaviorTestSuite`
* The tests needed to run manually because they won't run on CI. For this, a Docker Minio container was started:
```
docker run \
  -p 9000:9000 \
  -p 9001:9001 \
  -v /tmp/minio/data2:/data \
  -e "MINIO_ROOT_USER=minio" \
  -e "MINIO_ROOT_PASSWORD=minio123" \
  "minio/minio:latest" server /data --console-address ":9001"
```
A new bucket has to be created through http://localhost:9001. For the `HadoopS3FileSystemBehaviorITCase.checkCredentialsAndSetup` and `PrestoS3FileSystemBehaviorITCase.checkCredentialsAndSetup`, the configuration has to be extended adding the following parameters:
```
        conf.setString("s3.path.style.access", "true");
        conf.setString("s3.endpoint", "http://localhost:9000")
```
Additionally, the following environment variables have to be set in the test's run configuration:
```
IT_CASE_S3_BUCKET=<bucket-name>
IT_CASE_S3_ACCESS_KEY=minio
IT_CASE_S3_SECRET_KEY=minio123
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: yes

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? JavaDoc
