### PR TITLE
[FLINK-26494][runtime] Cleanup does not reveal exceptions

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/DispatcherResourceCleanerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/DispatcherResourceCleanerFactory.java
@@ -43,6 +43,12 @@ import java.util.concurrent.Executor;
  */
 public class DispatcherResourceCleanerFactory implements ResourceCleanerFactory {
 
+    private static final String JOB_MANAGER_RUNNER_REGISTRY_LABEL = "JobManagerRunnerRegistry";
+    private static final String JOB_GRAPH_STORE_LABEL = "JobGraphStore";
+    private static final String BLOB_SERVER_LABEL = "BlobServer";
+    private static final String HA_SERVICES_LABEL = "HighAvailabilityServices";
+    private static final String JOB_MANAGER_METRIC_GROUP_LABEL = "JobManagerMetricGroup";
+
     private final Executor cleanupExecutor;
     private final RetryStrategy retryStrategy;
 
@@ -89,10 +95,10 @@ public class DispatcherResourceCleanerFactory implements ResourceCleanerFactory 
             ComponentMainThreadExecutor mainThreadExecutor) {
         return DefaultResourceCleaner.forLocallyCleanableResources(
                         mainThreadExecutor, cleanupExecutor, retryStrategy)
-                .withPrioritizedCleanup(jobManagerRunnerRegistry)
-                .withRegularCleanup(jobGraphWriter)
-                .withRegularCleanup(blobServer)
-                .withRegularCleanup(jobManagerMetricGroup)
+                .withPrioritizedCleanup(JOB_MANAGER_RUNNER_REGISTRY_LABEL, jobManagerRunnerRegistry)
+                .withRegularCleanup(JOB_GRAPH_STORE_LABEL, jobGraphWriter)
+                .withRegularCleanup(BLOB_SERVER_LABEL, blobServer)
+                .withRegularCleanup(JOB_MANAGER_METRIC_GROUP_LABEL, jobManagerMetricGroup)
                 .build();
     }
 
@@ -101,11 +107,14 @@ public class DispatcherResourceCleanerFactory implements ResourceCleanerFactory 
             ComponentMainThreadExecutor mainThreadExecutor) {
         return DefaultResourceCleaner.forGloballyCleanableResources(
                         mainThreadExecutor, cleanupExecutor, retryStrategy)
-                .withPrioritizedCleanup(ofLocalResource(jobManagerRunnerRegistry))
-                .withRegularCleanup(jobGraphWriter)
-                .withRegularCleanup(blobServer)
-                .withRegularCleanup(highAvailabilityServices)
-                .withRegularCleanup(ofLocalResource(jobManagerMetricGroup))
+                .withPrioritizedCleanup(
+                        JOB_MANAGER_RUNNER_REGISTRY_LABEL,
+                        ofLocalResource(jobManagerRunnerRegistry))
+                .withRegularCleanup(JOB_GRAPH_STORE_LABEL, jobGraphWriter)
+                .withRegularCleanup(BLOB_SERVER_LABEL, blobServer)
+                .withRegularCleanup(HA_SERVICES_LABEL, highAvailabilityServices)
+                .withRegularCleanup(
+                        JOB_MANAGER_METRIC_GROUP_LABEL, ofLocalResource(jobManagerMetricGroup))
                 .build();
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/FileSystemJobResultStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/FileSystemJobResultStore.java
@@ -167,8 +167,13 @@ public class FileSystemJobResultStore extends AbstractThreadsafeJobResultStore {
 
     @Override
     public Set<JobResult> getDirtyResultsInternal() throws IOException {
+        final FileStatus[] statuses = fileSystem.listStatus(this.basePath);
+
+        Preconditions.checkState(
+                statuses != null,
+                "The base directory of the JobResultStore isn't accessible. No dirty JobResults can be restored.");
+
         final Set<JobResult> dirtyResults = new HashSet<>();
-        FileStatus[] statuses = fileSystem.listStatus(this.basePath);
         for (FileStatus s : statuses) {
             if (!s.isDir()) {
                 if (hasValidDirtyJobResultStoreEntryExtension(s.getPath().getName())) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/cleanup/DefaultResourceCleanerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/cleanup/DefaultResourceCleanerTest.java
@@ -22,11 +22,13 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.core.testutils.FlinkAssertions;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
 import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.TestLoggerExtension;
 import org.apache.flink.util.concurrent.Executors;
 import org.apache.flink.util.concurrent.FutureUtils;
 import org.apache.flink.util.concurrent.RetryStrategy;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -42,6 +44,7 @@ import static org.apache.flink.core.testutils.FlinkAssertions.STREAM_THROWABLE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** {@code DefaultResourceCleanerTest} tests {@link DefaultResourceCleaner}. */
+@ExtendWith(TestLoggerExtension.class)
 public class DefaultResourceCleanerTest {
 
     // runs with retry utilizes the ComponentMainThreadExecutor which adds concurrency despite using

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/cleanup/DefaultResourceCleanerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/cleanup/DefaultResourceCleanerTest.java
@@ -34,6 +34,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -61,8 +62,8 @@ public class DefaultResourceCleanerTest {
 
         final CompletableFuture<Void> cleanupResult =
                 createTestInstanceBuilder()
-                        .withRegularCleanup(cleanup0)
-                        .withRegularCleanup(cleanup1)
+                        .withRegularCleanup("Reg #0", cleanup0)
+                        .withRegularCleanup("Reg #1", cleanup1)
                         .build()
                         .cleanupAsync(JOB_ID);
 
@@ -84,8 +85,8 @@ public class DefaultResourceCleanerTest {
 
         final CompletableFuture<Void> cleanupResult =
                 createTestInstanceBuilder()
-                        .withRegularCleanup(cleanup0)
-                        .withRegularCleanup(cleanup1)
+                        .withRegularCleanup("Reg #0", cleanup0)
+                        .withRegularCleanup("Reg #1", cleanup1)
                         .build()
                         .cleanupAsync(JOB_ID);
 
@@ -105,6 +106,7 @@ public class DefaultResourceCleanerTest {
                 .hasExactlyElementsOfTypes(
                         ExecutionException.class,
                         FutureUtils.RetryException.class,
+                        CompletionException.class,
                         expectedException.getClass())
                 .last()
                 .isEqualTo(expectedException);
@@ -117,8 +119,8 @@ public class DefaultResourceCleanerTest {
 
         final CompletableFuture<Void> cleanupResult =
                 createTestInstanceBuilder()
-                        .withRegularCleanup(cleanup0)
-                        .withRegularCleanup(cleanup1)
+                        .withRegularCleanup("Reg #0", cleanup0)
+                        .withRegularCleanup("Reg #1", cleanup1)
                         .build()
                         .cleanupAsync(JOB_ID);
 
@@ -138,6 +140,7 @@ public class DefaultResourceCleanerTest {
                 .hasExactlyElementsOfTypes(
                         ExecutionException.class,
                         FutureUtils.RetryException.class,
+                        CompletionException.class,
                         expectedException.getClass())
                 .last()
                 .isEqualTo(expectedException);
@@ -154,10 +157,10 @@ public class DefaultResourceCleanerTest {
 
         final DefaultResourceCleaner<CleanupCallback> testInstance =
                 createTestInstanceBuilder()
-                        .withPrioritizedCleanup(highPriorityCleanup)
-                        .withPrioritizedCleanup(lowerThanHighPriorityCleanup)
-                        .withRegularCleanup(noPriorityCleanup0)
-                        .withRegularCleanup(noPriorityCleanup1)
+                        .withPrioritizedCleanup("Prio #0", highPriorityCleanup)
+                        .withPrioritizedCleanup("Prio #1", lowerThanHighPriorityCleanup)
+                        .withRegularCleanup("Reg #0", noPriorityCleanup0)
+                        .withRegularCleanup("Reg #1", noPriorityCleanup1)
                         .build();
 
         final CompletableFuture<Void> overallCleanupResult = testInstance.cleanupAsync(JOB_ID);
@@ -189,10 +192,10 @@ public class DefaultResourceCleanerTest {
 
         final DefaultResourceCleaner<CleanupCallback> testInstance =
                 createTestInstanceBuilder()
-                        .withPrioritizedCleanup(highPriorityCleanup)
-                        .withPrioritizedCleanup(lowerThanHighPriorityCleanup)
-                        .withRegularCleanup(noPriorityCleanup0)
-                        .withRegularCleanup(noPriorityCleanup1)
+                        .withPrioritizedCleanup("Prio #0", highPriorityCleanup)
+                        .withPrioritizedCleanup("Prio #1", lowerThanHighPriorityCleanup)
+                        .withRegularCleanup("Reg #0", noPriorityCleanup0)
+                        .withRegularCleanup("Reg #1", noPriorityCleanup1)
                         .build();
 
         assertThat(highPriorityCleanup.isDone()).isFalse();
@@ -224,8 +227,8 @@ public class DefaultResourceCleanerTest {
 
         final CompletableFuture<Void> compositeCleanupResult =
                 createTestInstanceBuilder(TestingRetryStrategies.createWithNumberOfRetries(2))
-                        .withRegularCleanup(cleanupWithRetries)
-                        .withRegularCleanup(oneRunCleanup)
+                        .withRegularCleanup("Reg #0", cleanupWithRetries)
+                        .withRegularCleanup("Reg #1", oneRunCleanup)
                         .build()
                         .cleanupAsync(JOB_ID);
 
@@ -246,9 +249,9 @@ public class DefaultResourceCleanerTest {
 
         final CompletableFuture<Void> compositeCleanupResult =
                 createTestInstanceBuilder(TestingRetryStrategies.createWithNumberOfRetries(1))
-                        .withPrioritizedCleanup(cleanupWithRetry)
-                        .withPrioritizedCleanup(oneRunHigherPriorityCleanup)
-                        .withRegularCleanup(oneRunCleanup)
+                        .withPrioritizedCleanup("Prio #0", cleanupWithRetry)
+                        .withPrioritizedCleanup("Prio #1", oneRunHigherPriorityCleanup)
+                        .withRegularCleanup("Reg #0", oneRunCleanup)
                         .build()
                         .cleanupAsync(JOB_ID);
 


### PR DESCRIPTION
## What is the purpose of the change

The retryable cleanup works but does not reveal the actual error which makes it harder to identify the error. This PR fixes it.

## Brief change log

* `DefaultResourceCleaner.Builder` method signatures for adding cleanups are extended to also require a label that is passed. The label should be unique to make each cleanup identifyable in the logs.

## Verifying this change

* A test was added to check the uniqueness of the label
* The logging was verified manually by running the `DefaultResourceCleanerTest` methods with logging enabled

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? JavaDoc
