### PR TITLE
[FLINK-26504][python] Fix the incorrect type error in unbounded Python UDAF

### DIFF
--- a/flink-python/pyflink/fn_execution/table/operations.py
+++ b/flink-python/pyflink/fn_execution/table/operations.py
@@ -365,7 +365,11 @@ class AbstractStreamGroupAggregateOperation(BaseStatefulOperation):
                 row = input_data[1]
             self.group_agg_function.process_element(row)
         else:
-            self.group_agg_function.on_timer(input_data[3])
+            if has_cython:
+                timer = InternalRow.from_row(input_data[3])
+            else:
+                timer = input_data[3]
+            self.group_agg_function.on_timer(timer)
 
     @abc.abstractmethod
     def create_process_function(self, user_defined_aggs, input_extractors, filter_args,


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will fix the incorrect type error in unbounded Python UDAF*

## Brief change log

  - *Fix the incorrect type error in unbounded Python UDAF*

## Verifying this change

This change added tests and can be verified as follows:

  - *`test_clean_state` in `test_udaf.py`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
