### PR TITLE
[FLINK-26279][runtime] Add mailbox delay and throughput metrics

### DIFF
--- a/docs/content.zh/docs/ops/metrics.md
+++ b/docs/content.zh/docs/ops/metrics.md
@@ -1333,7 +1333,7 @@ Note that the metrics are only available via reporters.
       <td>Histogram</td>
     </tr>
     <tr>
-      <th rowspan="20"><strong>Task</strong></th>
+      <th rowspan="23"><strong>Task</strong></th>
       <td>numBytesInLocal</td>
       <td><span class="label label-danger">Attention:</span> deprecated, use <a href="{{< ref "docs/ops/metrics" >}}#default-shuffle-service">Default shuffle service metrics</a>.</td>
       <td>Counter</td>
@@ -1431,6 +1431,21 @@ Note that the metrics are only available via reporters.
     <tr>
       <td>maxHardBackPressuredTimeMs</td>
       <td>Maximum recorded duration of a single consecutive period of the task being in the hard back pressure state in the last sampling period. Please check softBackPressuredTimeMsPerSecond and hardBackPressuredTimeMsPerSecond for more information.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>mailboxMailsPerSecond</td>
+      <td>The number of actions processed from the task's mailbox per second which includes all actions, e.g., checkpointing, timer, or cancellation actions.</td>
+      <td>Meter</td>
+    </tr>
+    <tr>
+      <td>mailboxLatencyMs</td>
+      <td>The latency is the time that actions spend waiting in the task's mailbox before being processed. The metric is a statistic of the latency in milliseconds that is measured approximately once every second and includes the last 60 measurements.</td>
+      <td>Histogram</td>
+    </tr>
+    <tr>
+      <td>mailboxQueueSize</td>
+      <td>The number of actions in the task's mailbox that are waiting to be processed.</td>
       <td>Gauge</td>
     </tr>
     <tr>

--- a/docs/content/docs/ops/metrics.md
+++ b/docs/content/docs/ops/metrics.md
@@ -1326,7 +1326,7 @@ Note that the metrics are only available via reporters.
       <td>Histogram</td>
     </tr>
     <tr>
-      <th rowspan="20"><strong>Task</strong></th>
+      <th rowspan="23"><strong>Task</strong></th>
       <td>numBytesInLocal</td>
       <td><span class="label label-danger">Attention:</span> deprecated, use <a href="{{< ref "docs/ops/metrics" >}}#default-shuffle-service">Default shuffle service metrics</a>.</td>
       <td>Counter</td>
@@ -1424,6 +1424,21 @@ Note that the metrics are only available via reporters.
     <tr>
       <td>maxHardBackPressuredTimeMs</td>
       <td>Maximum recorded duration of a single consecutive period of the task being in the hard back pressure state in the last sampling period. Please check softBackPressuredTimeMsPerSecond and hardBackPressuredTimeMsPerSecond for more information.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>mailboxMailsPerSecond</td>
+      <td>The number of actions processed from the task's mailbox per second which includes all actions, e.g., checkpointing, timer, or cancellation actions.</td>
+      <td>Meter</td>
+    </tr>
+    <tr>
+      <td>mailboxLatencyMs</td>
+      <td>The latency is the time that actions spend waiting in the task's mailbox before being processed. The metric is a statistic of the latency in milliseconds that is measured approximately once every second and includes the last 60 measurements.</td>
+      <td>Histogram</td>
+    </tr>
+    <tr>
+      <td>mailboxQueueSize</td>
+      <td>The number of actions in the task's mailbox that are waiting to be processed.</td>
       <td>Gauge</td>
     </tr>
     <tr>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/DescriptiveStatisticsHistogram.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/DescriptiveStatisticsHistogram.java
@@ -28,8 +28,7 @@ import java.io.Serializable;
  * The {@link DescriptiveStatisticsHistogram} use a DescriptiveStatistics {@link
  * DescriptiveStatistics} as a Flink {@link Histogram}.
  */
-public class DescriptiveStatisticsHistogram
-        implements org.apache.flink.metrics.Histogram, Serializable {
+public class DescriptiveStatisticsHistogram implements Histogram, Serializable {
     private static final long serialVersionUID = 1L;
 
     private final CircularDoubleArray descriptiveStatistics;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
@@ -102,4 +102,8 @@ public class MetricNames {
 
     // FLIP-182 (watermark alignment)
     public static final String WATERMARK_ALIGNMENT_DRIFT = "watermarkAlignmentDrift";
+
+    public static final String MAILBOX_THROUGHPUT = "mailboxMailsPerSecond";
+    public static final String MAILBOX_LATENCY = "mailboxLatencyMs";
+    public static final String MAILBOX_SIZE = "mailboxQueueSize";
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskIOMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskIOMetricGroup.java
@@ -20,11 +20,13 @@ package org.apache.flink.runtime.metrics.groups;
 
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.Histogram;
 import org.apache.flink.metrics.Meter;
 import org.apache.flink.metrics.MeterView;
 import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.runtime.executiongraph.IOMetrics;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
+import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
 import org.apache.flink.runtime.metrics.MetricNames;
 import org.apache.flink.runtime.metrics.TimerGauge;
 
@@ -44,6 +46,7 @@ public class TaskIOMetricGroup extends ProxyMetricGroup<TaskMetricGroup> {
     private final SumCounter numRecordsIn;
     private final SumCounter numRecordsOut;
     private final Counter numBuffersOut;
+    private final Counter numMailsProcessed;
 
     private final Meter numBytesInRate;
     private final Meter numBytesOutRate;
@@ -57,6 +60,9 @@ public class TaskIOMetricGroup extends ProxyMetricGroup<TaskMetricGroup> {
     private final TimerGauge hardBackPressuredTimePerSecond;
     private final Gauge<Long> maxSoftBackPressuredTime;
     private final Gauge<Long> maxHardBackPressuredTime;
+    private final Meter mailboxThroughput;
+    private final Histogram mailboxLatency;
+    private final SizeGauge mailboxSize;
 
     private volatile boolean busyTimeEnabled;
 
@@ -100,6 +106,13 @@ public class TaskIOMetricGroup extends ProxyMetricGroup<TaskMetricGroup> {
                         hardBackPressuredTimePerSecond::getMaxSingleMeasurement);
 
         this.busyTimePerSecond = gauge(MetricNames.TASK_BUSY_TIME, this::getBusyTimePerSecond);
+
+        this.numMailsProcessed = new SimpleCounter();
+        this.mailboxThroughput =
+                meter(MetricNames.MAILBOX_THROUGHPUT, new MeterView(numMailsProcessed));
+        this.mailboxLatency =
+                histogram(MetricNames.MAILBOX_LATENCY, new DescriptiveStatisticsHistogram(60));
+        this.mailboxSize = gauge(MetricNames.MAILBOX_SIZE, new SizeGauge());
     }
 
     public IOMetrics createSnapshot() {
@@ -135,6 +148,10 @@ public class TaskIOMetricGroup extends ProxyMetricGroup<TaskMetricGroup> {
         return numBuffersOut;
     }
 
+    public Counter getNumMailsProcessedCounter() {
+        return numMailsProcessed;
+    }
+
     public TimerGauge getIdleTimeMsPerSecond() {
         return idleTimePerSecond;
     }
@@ -161,6 +178,18 @@ public class TaskIOMetricGroup extends ProxyMetricGroup<TaskMetricGroup> {
         return busyTimeEnabled ? 1000.0 - Math.min(busyTime, 1000.0) : Double.NaN;
     }
 
+    public Meter getMailboxThroughput() {
+        return mailboxThroughput;
+    }
+
+    public Histogram getMailboxLatency() {
+        return mailboxLatency;
+    }
+
+    public Gauge<Integer> getMailboxSize() {
+        return mailboxSize;
+    }
+
     // ============================================================================================
     // Metric Reuse
     // ============================================================================================
@@ -175,6 +204,10 @@ public class TaskIOMetricGroup extends ProxyMetricGroup<TaskMetricGroup> {
     public void registerNumBytesProducedCounterForPartition(
             IntermediateResultPartitionID resultPartitionId, Counter numBytesProducedCounter) {
         this.numBytesProducedOfPartitions.put(resultPartitionId, numBytesProducedCounter);
+    }
+
+    public void registerMailboxSizeSupplier(SizeGauge.SizeSupplier<Integer> supplier) {
+        this.mailboxSize.registerSupplier(supplier);
     }
 
     /**
@@ -197,6 +230,28 @@ public class TaskIOMetricGroup extends ProxyMetricGroup<TaskMetricGroup> {
                 sum += counter.getCount();
             }
             return sum;
+        }
+    }
+
+    private static class SizeGauge implements Gauge<Integer> {
+        private SizeSupplier<Integer> supplier;
+
+        @FunctionalInterface
+        public interface SizeSupplier<R> {
+            R get();
+        }
+
+        public void registerSupplier(SizeSupplier<Integer> supplier) {
+            this.supplier = supplier;
+        }
+
+        @Override
+        public Integer getValue() {
+            if (supplier != null) {
+                return supplier.get();
+            } else {
+                return 0; // return "assumed" empty queue size
+            }
         }
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/TaskMailbox.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/TaskMailbox.java
@@ -228,6 +228,14 @@ public interface TaskMailbox {
     State getState();
 
     /**
+     * Returns the current number of mails in this mailbox. (This includes mails in the batch not
+     * processed yet.)
+     *
+     * @return number of mails in the mailbox.
+     */
+    int size();
+
+    /**
      * Runs the given code exclusively on this mailbox. No synchronized operations can be run
      * concurrently to the given runnable (e.g., {@link #put(Mail)} or modifying lifecycle methods).
      *

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/TaskMailboxImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/TaskMailboxImpl.java
@@ -96,7 +96,7 @@ public class TaskMailboxImpl implements TaskMailbox {
         return !batch.isEmpty() || hasNewMail;
     }
 
-    @VisibleForTesting
+    @Override
     public int size() {
         final ReentrantLock lock = this.lock;
         lock.lock();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -31,6 +31,8 @@ import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.core.fs.FSDataInputStream;
 import org.apache.flink.core.testutils.OneShotLatch;
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.Histogram;
 import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
@@ -191,6 +193,7 @@ import static org.apache.flink.runtime.state.CheckpointStorageLocationReference.
 import static org.apache.flink.streaming.runtime.tasks.mailbox.TaskMailbox.MAX_PRIORITY;
 import static org.apache.flink.streaming.util.StreamTaskUtil.waitTaskIsRunning;
 import static org.apache.flink.util.Preconditions.checkState;
+import static org.hamcrest.CoreMatchers.both;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
@@ -200,6 +203,7 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -1760,6 +1764,111 @@ public class StreamTaskTest extends TestLogger {
             assertThat(
                     getCurrentBufferSize(inputGates[1]),
                     equalTo((int) throughputGate2 / inputChannelsGate2));
+        }
+    }
+
+    /**
+     * Tests mailbox metrics latency and queue size and verifies that (1) latency measurement is
+     * executed initially once and at least once triggered by timer, (2) latency max value is
+     * greater than zero and (3) mailbox size is greater than zero for some time and eventually
+     * equals to zero.
+     *
+     * @throws Exception on {@link MockEnvironmentBuilder#build()} failure.
+     */
+    @Test
+    public void testMailboxMetricsScheduling() throws Exception {
+        try (MockEnvironment mockEnvironment = new MockEnvironmentBuilder().build()) {
+            Gauge<Integer> mailboxSizeMetric =
+                    mockEnvironment.getMetricGroup().getIOMetricGroup().getMailboxSize();
+            Histogram mailboxLatencyMetric =
+                    mockEnvironment.getMetricGroup().getIOMetricGroup().getMailboxLatency();
+            AtomicInteger maxMailboxSize = new AtomicInteger(-1);
+            final int minMeasurements = 2;
+            SupplierWithException<StreamTask, Exception> task =
+                    () ->
+                            new StreamTask<Object, StreamOperator<Object>>(mockEnvironment) {
+                                @Override
+                                protected void init() {
+                                    this.mailboxMetricsInterval = 2;
+                                }
+
+                                @Override
+                                protected void processInput(
+                                        MailboxDefaultAction.Controller controller)
+                                        throws Exception {
+                                    if (mailboxLatencyMetric.getCount() < minMeasurements) {
+                                        mailboxProcessor
+                                                .getMainMailboxExecutor()
+                                                .execute(() -> {}, "mail");
+                                        // The actual delay here is irrelevant for the test but
+                                        // delay should be at least once 10 ms to reach a measurable
+                                        // delay >~ 8 ms.
+                                        Thread.sleep(mailboxLatencyMetric.getCount() == 0 ? 10 : 1);
+                                    } else {
+                                        controller.suspendDefaultAction();
+                                        mailboxProcessor.suspend();
+                                    }
+                                    maxMailboxSize.set(
+                                            Math.max(
+                                                    maxMailboxSize.get(),
+                                                    mailboxSizeMetric.getValue()));
+                                }
+                            };
+
+            runTask(task::get).waitForTaskCompletion(false);
+
+            assertThat(
+                    mailboxLatencyMetric.getCount(),
+                    greaterThanOrEqualTo(new Long(minMeasurements)));
+            assertThat(mailboxLatencyMetric.getStatistics().getMax(), greaterThan(0L));
+            assertThat(maxMailboxSize.get(), greaterThan(0));
+            assertThat(mailboxSizeMetric.getValue(), equalTo(0));
+        }
+    }
+
+    @Test
+    public void testMailboxMetricsMeasurement() throws Exception {
+        final int numMails = 10, sleepTime = 5;
+        StreamTaskMailboxTestHarnessBuilder<Integer> builder =
+                new StreamTaskMailboxTestHarnessBuilder<>(
+                                OneInputStreamTask::new, BasicTypeInfo.INT_TYPE_INFO)
+                        .addInput(BasicTypeInfo.INT_TYPE_INFO)
+                        .setupOutputForSingletonOperatorChain(
+                                new TestBoundedOneInputStreamOperator());
+        try (StreamTaskMailboxTestHarness<Integer> harness = builder.build()) {
+            Histogram mailboxLatencyMetric =
+                    harness.streamTask
+                            .getEnvironment()
+                            .getMetricGroup()
+                            .getIOMetricGroup()
+                            .getMailboxLatency();
+            Gauge<Integer> mailboxSizeMetric =
+                    harness.streamTask
+                            .getEnvironment()
+                            .getMetricGroup()
+                            .getIOMetricGroup()
+                            .getMailboxSize();
+            long startTime = SystemClock.getInstance().relativeTimeMillis();
+            harness.streamTask.measureMailboxLatency();
+            for (int i = 0; i < numMails; ++i) {
+                harness.streamTask.mainMailboxExecutor.execute(
+                        () -> Thread.sleep(sleepTime), "add value");
+            }
+            harness.streamTask.measureMailboxLatency();
+
+            assertThat(mailboxSizeMetric.getValue(), greaterThanOrEqualTo(numMails));
+            assertThat(mailboxLatencyMetric.getCount(), equalTo(0L));
+
+            harness.processAll();
+            long endTime = SystemClock.getInstance().relativeTimeMillis();
+
+            assertThat(mailboxSizeMetric.getValue(), equalTo(0));
+            assertThat(mailboxLatencyMetric.getCount(), equalTo(2L));
+            assertThat(
+                    mailboxLatencyMetric.getStatistics().getMax(),
+                    is(
+                            both(greaterThanOrEqualTo(new Long(sleepTime * numMails)))
+                                    .and(lessThanOrEqualTo(endTime - startTime))));
         }
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/mailbox/TaskMailboxProcessorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/mailbox/TaskMailboxProcessorTest.java
@@ -33,6 +33,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -102,10 +104,12 @@ public class TaskMailboxProcessorTest {
     @Test
     public void testRunDefaultActionAndMails() throws Exception {
         AtomicBoolean stop = new AtomicBoolean(false);
+        AtomicInteger counter = new AtomicInteger();
         MailboxThread mailboxThread =
                 new MailboxThread() {
                     @Override
                     public void runDefaultAction(Controller controller) throws Exception {
+                        counter.incrementAndGet();
                         if (stop.get()) {
                             controller.allActionsCompleted();
                         } else {
@@ -117,6 +121,8 @@ public class TaskMailboxProcessorTest {
         MailboxProcessor mailboxProcessor = start(mailboxThread);
         mailboxProcessor.getMailboxExecutor(DEFAULT_PRIORITY).execute(() -> stop.set(true), "stop");
         mailboxThread.join();
+        assertThat(counter.get(), greaterThan(0));
+        assertThat(mailboxProcessor.getNumMailsProcessedCounter().getCount(), greaterThan(0L));
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

* Add the following metrics to TaskIOMetricGroup:
  * mailbox latency metric backed by DescriptiveStatisticsHistogram
  * throughput metric backed by a MeterView
  * mailbox size metric backed by Gauge

## Brief change log

* Added metrics to TaskIOMetricGroup
* Extended StreamTask to schedule mailbox latency measurements using a timer
* Extended MailboxProcessor to count processed mails for throughput measurement
* Added size method to TaskMailbox interface

## Verifying this change

This change added tests and can be verified as follows:

- Extended existing test method TaskMailboxProcessorTest#testRunDefaultActionAndMails to verify mail/throughput counting
- Added test method StreamTaskTest#testMailboxMetrics to verify timer-based latency measurement and queue size metric
- The change has been verified manually/visually in Web UI:
  ![Screenshot from 2022-03-09 21-29-33](https://user-images.githubusercontent.com/7805104/157533248-fa083a66-8fd1-4b71-8e51-e42e072de9d5.png)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / __no__)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / __no__)
  - The serializers: (yes / __no__ / don't know)
  - The runtime per-record code paths (performance sensitive): (__yes__ / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / __no__ / don't know)
  - The S3 file system connector: (yes / __no__ / don't know)

## Documentation

  - Does this pull request introduce a new feature? (__yes__ / no)
  - If yes, how is the feature documented? (not applicable / __docs__ / __JavaDocs__ / not documented)

~__Note:__ This PR is based on https://github.com/apache/flink/pull/18984 which is a hotfix.~
