### PR TITLE
[FLINK-26565][TABLE][TRIGGER]use later trigger for delay window when laterTrigger is not null

### DIFF
--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/window/triggers/EventTimeTriggers.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/window/triggers/EventTimeTriggers.java
@@ -177,7 +177,10 @@ public class EventTimeTriggers {
                     // if there is no late trigger then we fire on every late element
                     // This also covers the case of recovery after a failure
                     // where the currentWatermark will be Long.MIN_VALUE
-                    return true;
+                    if (hasFired == null) {
+                        ctx.getPartitionedState(hasFiredOnTimeStateDesc).update(true);
+                    }
+                    return lateTrigger == null || lateTrigger.onElement(element, timestamp, window);
                 } else {
                     // we are in the early phase
                     ctx.registerEventTimeTimer(triggerTime(window));


### PR DESCRIPTION

## What is the purpose of the change

When a  record arrived and the  window is not exist,  it will  emit the window result  immediately.

`        if (triggerTime(window) <= ctx.getCurrentWatermark()) {
                    // we are in the late phase

                    // if there is no late trigger then we fire on every late element
                    // This also covers the case of recovery after a failure
                    // where the currentWatermark will be Long.MIN_VALUE
                    return true;
}`

I think it can use lateTrigger, if user set "table.exec.emit.late-fire.delay".



