### PR TITLE
[FLINK-26505][hive] Fix IndexOutOfBoundsException for non equality condition exists in left semi join in Hive dialect

### DIFF
--- a/flink-connectors/flink-connector-hive/src/test/resources/query-test/join.q
+++ b/flink-connectors/flink-connector-hive/src/test/resources/query-test/join.q
@@ -24,6 +24,12 @@ select * from foo left semi join bar on foo.y=bar.i;
 
 [+I[1, 1], +I[2, 2]]
 
+select count(1) from (select x from foo where x = 1) foo1 left semi join (select i from bar where i = 1) bar2 on 1 = 1;
+[+I[1]]
+
+select * from foo left semi join bar on (foo.x + bar.i > 4);
+[+I[3, 3], +I[4, 4], +I[5, 5]]
+
 select * from (select a.value, a.* from (select * from src) a join (select * from src) b on a.key = b.key) t;
 
 [+I[val1, 1, val1], +I[val2, 2, val2], +I[val3, 3, val3]]


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
The pr is try to fix the `IndexOutOfBoundsException` that when there's only `1 = 1` in semi join cluster like the sql: `select * from a left semi join b on 1 = 1`.
Also, with this fix, we are also enabled to support non equality condition for left semi join which is supported in Hive [HIVE-17766](https://issues.apache.org/jira/browse/HIVE-17766).



## Brief change log
  -  Replace the method `RelOptUtil.splitJoinCondition` with `HiveRelOptUtil.splitHiveJoinCondition` for there're some bugs in `RelOptUtil.splitJoinCondition`
  -  Not to throw exception when there're some non-equality conditions for semi join.
  -  Constuct join condition with equality conditions and non-equality conditions. 


## Verifying this change

Added two sql statements involved with semijoin which are to fail before this fix in  join.q.
`select count(1) from (select x from foo where x = 1) foo1 left semi join (select i from bar where i = 1) bar2 on 1 = 1;`
`select * from foo left semi join bar on (foo.x + bar.i > 4);`


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not documented
