### PR TITLE
[FLINK-26492][metric] deprecate umRecordsOutErrorsCounter

### DIFF
--- a/docs/content/docs/ops/metrics.md
+++ b/docs/content/docs/ops/metrics.md
@@ -1616,7 +1616,15 @@ Please refer to [Kafka monitoring]({{< ref "docs/connectors/datastream/kafka" >}
   <tbody>
     <tr>
       <th rowspan="1">Operator</th>
-      <td>numRecordsOutErrors</td>
+      <td>numRecordsOutErrors (deprecated, please use numRecordsSendErrors)</td>
+      <td>Number of rejected record writes.</td>
+      <td>Counter</td>
+    </tr>
+  </tbody>
+  <tbody>
+    <tr>
+      <th rowspan="1">Operator</th>
+      <td>numRecordsSendErrors</td>
       <td>Number of rejected record writes.</td>
       <td>Counter</td>
     </tr>

--- a/flink-connectors/flink-connector-aws-kinesis-firehose/src/main/java/org/apache/flink/connector/firehose/sink/KinesisFirehoseSinkWriter.java
+++ b/flink-connectors/flink-connector-aws-kinesis-firehose/src/main/java/org/apache/flink/connector/firehose/sink/KinesisFirehoseSinkWriter.java
@@ -95,8 +95,11 @@ class KinesisFirehoseSinkWriter<InputT> extends AsyncSinkWriter<InputT, Record> 
                     RESOURCE_NOT_FOUND_EXCEPTION_CLASSIFIER,
                     getSdkClientMisconfiguredExceptionClassifier());
 
+    // deprecated, use numRecordsSendErrorsCounter instead.
+    @Deprecated private final Counter numRecordsOutErrorsCounter;
+
     /* A counter for the total number of records that have encountered an error during put */
-    private final Counter numRecordsOutErrorsCounter;
+    private final Counter numRecordsSendErrorsCounter;
 
     /* Name of the delivery stream in Kinesis Data Firehose */
     private final String deliveryStreamName;
@@ -167,6 +170,7 @@ class KinesisFirehoseSinkWriter<InputT> extends AsyncSinkWriter<InputT, Record> 
         this.deliveryStreamName = deliveryStreamName;
         this.metrics = context.metricGroup();
         this.numRecordsOutErrorsCounter = metrics.getNumRecordsOutErrorsCounter();
+        this.numRecordsSendErrorsCounter = metrics.getNumRecordsSendErrorsCounter();
         this.httpClient = createHttpClient(firehoseClientProperties);
         this.firehoseClient = createFirehoseClient(firehoseClientProperties, httpClient);
     }
@@ -216,6 +220,7 @@ class KinesisFirehoseSinkWriter<InputT> extends AsyncSinkWriter<InputT, Record> 
                 requestEntries.get(0).toString(),
                 err);
         numRecordsOutErrorsCounter.inc(requestEntries.size());
+        numRecordsSendErrorsCounter.inc(requestEntries.size());
 
         if (isRetryable(err)) {
             requestResult.accept(requestEntries);
@@ -231,6 +236,7 @@ class KinesisFirehoseSinkWriter<InputT> extends AsyncSinkWriter<InputT, Record> 
                 requestEntries.size(),
                 requestEntries.get(0).toString());
         numRecordsOutErrorsCounter.inc(response.failedPutCount());
+        numRecordsSendErrorsCounter.inc(response.failedPutCount());
 
         if (failOnError) {
             getFatalExceptionCons()

--- a/flink-connectors/flink-connector-aws-kinesis-firehose/src/test/java/org/apache/flink/connector/firehose/sink/KinesisFirehoseSinkWriterTest.java
+++ b/flink-connectors/flink-connector-aws-kinesis-firehose/src/test/java/org/apache/flink/connector/firehose/sink/KinesisFirehoseSinkWriterTest.java
@@ -101,5 +101,6 @@ public class KinesisFirehoseSinkWriterTest {
                 .withMessageContaining(
                         "Unable to execute HTTP request: Connection refused: localhost/127.0.0.1:443");
         assertThat(ctx.metricGroup().getNumRecordsOutErrorsCounter().getCount()).isEqualTo(12);
+        assertThat(ctx.metricGroup().getNumRecordsSendErrorsCounter().getCount()).isEqualTo(12);
     }
 }

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/KafkaWriter.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/KafkaWriter.java
@@ -95,7 +95,9 @@ class KafkaWriter<IN>
     private final boolean disabledMetrics;
     private final Counter numRecordsSendCounter;
     private final Counter numBytesSendCounter;
-    private final Counter numRecordsOutErrorsCounter;
+    // deprecated, use numRecordsSendErrorsCounter instead.
+    @Deprecated private final Counter numRecordsOutErrorsCounter;
+    private final Counter numRecordsSendErrorsCounter;
     private final ProcessingTimeService timeService;
 
     // Number of outgoing bytes at the latest metric sync
@@ -156,6 +158,7 @@ class KafkaWriter<IN>
         this.numBytesSendCounter = metricGroup.getNumBytesSendCounter();
         this.numRecordsSendCounter = metricGroup.getNumRecordsSendCounter();
         this.numRecordsOutErrorsCounter = metricGroup.getNumRecordsOutErrorsCounter();
+        this.numRecordsSendErrorsCounter = metricGroup.getNumRecordsSendErrorsCounter();
         this.kafkaSinkContext =
                 new DefaultKafkaSinkContext(
                         sinkInitContext.getSubtaskId(),
@@ -414,6 +417,7 @@ class KafkaWriter<IN>
                 mailboxExecutor.execute(
                         () -> {
                             numRecordsOutErrorsCounter.inc();
+                            numRecordsSendErrorsCounter.inc();
                             throwException(metadata, exception, producer);
                         },
                         "Failed to send data to Kafka");

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaWriterITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaWriterITCase.java
@@ -143,14 +143,17 @@ public class KafkaWriterITCase {
             final Counter numBytesSend = metricGroup.getNumBytesSendCounter();
             final Counter numRecordsSend = metricGroup.getNumRecordsSendCounter();
             final Counter numRecordsWrittenErrors = metricGroup.getNumRecordsOutErrorsCounter();
+            final Counter numRecordsSendErrors = metricGroup.getNumRecordsSendErrorsCounter();
             assertThat(numBytesSend.getCount()).isEqualTo(0L);
             assertThat(numRecordsSend.getCount()).isEqualTo(0);
             assertThat(numRecordsWrittenErrors.getCount()).isEqualTo(0);
+            assertThat(numRecordsSendErrors.getCount()).isEqualTo(0);
 
             writer.write(1, SINK_WRITER_CONTEXT);
             timeService.trigger();
             assertThat(numRecordsSend.getCount()).isEqualTo(1);
             assertThat(numRecordsWrittenErrors.getCount()).isEqualTo(0);
+            assertThat(numRecordsSendErrors.getCount()).isEqualTo(0);
             assertThat(numBytesSend.getCount()).isGreaterThan(0L);
         }
     }
@@ -195,10 +198,13 @@ public class KafkaWriterITCase {
                 createWriterWithConfiguration(
                         properties, DeliveryGuarantee.EXACTLY_ONCE, metricGroup)) {
             final Counter numRecordsOutErrors = metricGroup.getNumRecordsOutErrorsCounter();
+            final Counter numRecordsSendErrors = metricGroup.getNumRecordsSendErrorsCounter();
             assertThat(numRecordsOutErrors.getCount()).isEqualTo(0L);
+            assertThat(numRecordsSendErrors.getCount()).isEqualTo(0L);
 
             writer.write(1, SINK_WRITER_CONTEXT);
             assertThat(numRecordsOutErrors.getCount()).isEqualTo(0L);
+            assertThat(numRecordsSendErrors.getCount()).isEqualTo(0L);
 
             final String transactionalId = writer.getCurrentProducer().getTransactionalId();
 
@@ -215,6 +221,7 @@ public class KafkaWriterITCase {
             writer.flush(false);
             writer.prepareCommit();
             assertThat(numRecordsOutErrors.getCount()).isEqualTo(1L);
+            assertThat(numRecordsSendErrors.getCount()).isEqualTo(1L);
         }
     }
 

--- a/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/groups/SinkWriterMetricGroup.java
+++ b/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/groups/SinkWriterMetricGroup.java
@@ -28,8 +28,13 @@ import org.apache.flink.metrics.Gauge;
  */
 @PublicEvolving
 public interface SinkWriterMetricGroup extends OperatorMetricGroup {
-    /** The total number of records failed to send. */
+
+    /** @deprecated use {@link #getNumRecordsSendErrorsCounter()} instead. */
+    @Deprecated
     Counter getNumRecordsOutErrorsCounter();
+
+    /** The total number of records failed to send. */
+    Counter getNumRecordsSendErrorsCounter();
 
     /**
      * The total number of records have been sent to the downstream system.
@@ -38,7 +43,7 @@ public interface SinkWriterMetricGroup extends OperatorMetricGroup {
      * perspective, these records have been sent to the downstream system, but the downstream system
      * may have issue to perform the persistence action within its scope. Therefore, this count may
      * include the number of records that are failed to write by the downstream system, which should
-     * be counted by {@link #getNumRecordsOutErrorsCounter()}.
+     * be counted by {@link #getNumRecordsSendErrorsCounter()}.
      */
     Counter getNumRecordsSendCounter();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
@@ -84,7 +84,9 @@ public class MetricNames {
     public static final String DEBLOATED_BUFFER_SIZE = "debloatedBufferSize";
 
     // FLIP-33 sink
-    public static final String NUM_RECORDS_OUT_ERRORS = "numRecordsOutErrors";
+    // deprecated use NUM_RECORDS_SEND_ERRORS instead.
+    @Deprecated public static final String NUM_RECORDS_OUT_ERRORS = "numRecordsOutErrors";
+    public static final String NUM_RECORDS_SEND_ERRORS = "numRecordsSendErrors";
     public static final String CURRENT_SEND_TIME = "currentSendTime";
     public static final String NUM_RECORDS_SEND = "numRecordsSend";
     public static final String NUM_BYTES_SEND = "numBytesSend";

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/InternalSinkWriterMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/InternalSinkWriterMetricGroup.java
@@ -34,7 +34,9 @@ import org.apache.flink.runtime.metrics.MetricNames;
 public class InternalSinkWriterMetricGroup extends ProxyMetricGroup<MetricGroup>
         implements SinkWriterMetricGroup {
 
-    private final Counter numRecordsOutErrors;
+    // deprecated, use numRecordsSendErrors instead.
+    @Deprecated private final Counter numRecordsOutErrors;
+    private final Counter numRecordsSendErrors;
     private final Counter numRecordsWritten;
     private final Counter numBytesWritten;
     private final OperatorIOMetricGroup operatorIOMetricGroup;
@@ -43,6 +45,7 @@ public class InternalSinkWriterMetricGroup extends ProxyMetricGroup<MetricGroup>
             MetricGroup parentMetricGroup, OperatorIOMetricGroup operatorIOMetricGroup) {
         super(parentMetricGroup);
         numRecordsOutErrors = parentMetricGroup.counter(MetricNames.NUM_RECORDS_OUT_ERRORS);
+        numRecordsSendErrors = parentMetricGroup.counter(MetricNames.NUM_RECORDS_SEND_ERRORS);
         numRecordsWritten = parentMetricGroup.counter(MetricNames.NUM_RECORDS_SEND);
         numBytesWritten = parentMetricGroup.counter(MetricNames.NUM_BYTES_SEND);
         this.operatorIOMetricGroup = operatorIOMetricGroup;
@@ -70,9 +73,15 @@ public class InternalSinkWriterMetricGroup extends ProxyMetricGroup<MetricGroup>
         return operatorIOMetricGroup;
     }
 
+    @Deprecated
     @Override
     public Counter getNumRecordsOutErrorsCounter() {
         return numRecordsOutErrors;
+    }
+
+    @Override
+    public Counter getNumRecordsSendErrorsCounter() {
+        return numRecordsSendErrors;
     }
 
     @Override

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkMetricsITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkMetricsITCase.java
@@ -149,6 +149,9 @@ public class SinkMetricsITCase extends TestLogger {
             assertThat(
                     metrics.get(MetricNames.NUM_RECORDS_OUT_ERRORS),
                     isCounter(equalTo((processedRecordsPerSubtask + 1) / 2)));
+            assertThat(
+                    metrics.get(MetricNames.NUM_RECORDS_SEND_ERRORS),
+                    isCounter(equalTo((processedRecordsPerSubtask + 1) / 2)));
             // check if the latest send time is fetched
             assertThat(
                     metrics.get(MetricNames.CURRENT_SEND_TIME),
@@ -179,6 +182,7 @@ public class SinkMetricsITCase extends TestLogger {
             metricGroup.getNumRecordsSendCounter().inc();
             if (element % 2 == 0) {
                 metricGroup.getNumRecordsOutErrorsCounter().inc();
+                metricGroup.getNumRecordsSendErrorsCounter().inc();
             }
             metricGroup.getNumBytesSendCounter().inc(RECORD_SIZE_IN_BYTES);
         }


### PR DESCRIPTION
## What is the purpose of the change

After introducing new metrics in SinkWriterMetricGroup that all include the word Send it makes sense to also rename the numRecordsOutErrors to the numRecordsSendErrors.

The best way would be probably to deprecate numRecordsOutError and introduce numRecordsSendError. So we can remove numRecordsOutError with 1.16.


## Brief change log

  - introduce new metric `numRecordsSendErrorsCounter`, deprecate `numRecordsOutErrorsCounter`.
  - deprecate `numRecordsOutErrorsCounter`, replace it with `numRecordsSendErrorsCounter` in Kafka, Kinesis firehose, Kinesis connectors.


## Verifying this change

This change is already covered by existing tests, such as `SinkMetricsITCase`,  `KafkaWriterITCase`, `KinesisFirehoseSinkWriterTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)