### PR TITLE
[BP-1.14][FLINK-23843][runtime] Properly fail the job when SplitEnumeratorContext.runInCoordinatorThread() throws an exception.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContext.java
@@ -240,9 +240,18 @@ public class SourceCoordinatorContext<SplitT extends SourceSplit>
         notifier.notifyReadyAsync(callable, handler);
     }
 
+    /** {@inheritDoc} If the runnable throws an Exception, the corresponding job is failed. */
     @Override
     public void runInCoordinatorThread(Runnable runnable) {
-        coordinatorExecutor.execute(runnable);
+        // when using a ScheduledThreadPool, uncaught exception handler catches only
+        // exceptions thrown by the threadPool, so manually call it when the exception is
+        // thrown by the runnable
+        coordinatorExecutor.execute(
+                new ThrowableCatchingRunnable(
+                        throwable ->
+                                coordinatorThreadFactory.uncaughtException(
+                                        Thread.currentThread(), throwable),
+                        runnable));
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorProvider.java
@@ -18,14 +18,15 @@ limitations under the License.
 
 package org.apache.flink.runtime.source.coordinator;
 
-import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.connector.source.Source;
 import org.apache.flink.api.connector.source.SourceSplit;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.operators.coordination.OperatorCoordinator;
 import org.apache.flink.runtime.operators.coordination.RecreateOnResetOperatorCoordinator;
-import org.apache.flink.util.FatalExitExceptionHandler;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
@@ -67,8 +68,7 @@ public class SourceCoordinatorProvider<SplitT extends SourceSplit>
     public OperatorCoordinator getCoordinator(OperatorCoordinator.Context context) {
         final String coordinatorThreadName = "SourceCoordinator-" + operatorName;
         CoordinatorExecutorThreadFactory coordinatorThreadFactory =
-                new CoordinatorExecutorThreadFactory(
-                        coordinatorThreadName, context.getUserCodeClassloader());
+                new CoordinatorExecutorThreadFactory(coordinatorThreadName, context);
 
         SimpleVersionedSerializer<SplitT> splitSerializer = source.getSplitSerializer();
         SourceCoordinatorContext<SplitT> sourceCoordinatorContext =
@@ -81,6 +81,7 @@ public class SourceCoordinatorProvider<SplitT extends SourceSplit>
     public static class CoordinatorExecutorThreadFactory
             implements ThreadFactory, Thread.UncaughtExceptionHandler {
 
+        private static final Logger LOG = LoggerFactory.getLogger(SourceCoordinatorProvider.class);
         private final String coordinatorThreadName;
         private final ClassLoader cl;
         private final Thread.UncaughtExceptionHandler errorHandler;
@@ -88,11 +89,19 @@ public class SourceCoordinatorProvider<SplitT extends SourceSplit>
         @Nullable private Thread t;
 
         CoordinatorExecutorThreadFactory(
-                final String coordinatorThreadName, final ClassLoader contextClassLoader) {
-            this(coordinatorThreadName, contextClassLoader, FatalExitExceptionHandler.INSTANCE);
+                final String coordinatorThreadName, final OperatorCoordinator.Context context) {
+            this(
+                    coordinatorThreadName,
+                    context.getUserCodeClassloader(),
+                    (t, e) -> {
+                        LOG.error(
+                                "Thread '{}' produced an uncaught exception. Failing the job.",
+                                t.getName(),
+                                e);
+                        context.failJob(e);
+                    });
         }
 
-        @VisibleForTesting
         CoordinatorExecutorThreadFactory(
                 final String coordinatorThreadName,
                 final ClassLoader contextClassLoader,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/MockOperatorCoordinatorContext.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/MockOperatorCoordinatorContext.java
@@ -20,6 +20,8 @@ package org.apache.flink.runtime.operators.coordination;
 
 import org.apache.flink.runtime.jobgraph.OperatorID;
 
+import java.util.concurrent.CompletableFuture;
+
 /** A simple implementation of {@link OperatorCoordinator.Context} for testing purposes. */
 public class MockOperatorCoordinatorContext implements OperatorCoordinator.Context {
 
@@ -29,6 +31,7 @@ public class MockOperatorCoordinatorContext implements OperatorCoordinator.Conte
 
     private boolean jobFailed;
     private Throwable jobFailureReason;
+    private final CompletableFuture<Void> jobFailedFuture = new CompletableFuture<>();
 
     public MockOperatorCoordinatorContext(OperatorID operatorID, int numSubtasks) {
         this(operatorID, numSubtasks, MockOperatorCoordinatorContext.class.getClassLoader());
@@ -56,6 +59,7 @@ public class MockOperatorCoordinatorContext implements OperatorCoordinator.Conte
     public void failJob(Throwable cause) {
         jobFailed = true;
         jobFailureReason = cause;
+        jobFailedFuture.complete(null);
     }
 
     @Override
@@ -76,5 +80,9 @@ public class MockOperatorCoordinatorContext implements OperatorCoordinator.Conte
 
     public Throwable getJobFailureReason() {
         return jobFailureReason;
+    }
+
+    public CompletableFuture<Void> getJobFailedFuture() {
+        return jobFailedFuture;
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorTestBase.java
@@ -76,7 +76,7 @@ public abstract class SourceCoordinatorTestBase {
         String coordinatorThreadName = TEST_OPERATOR_ID.toHexString();
         coordinatorThreadFactory =
                 new SourceCoordinatorProvider.CoordinatorExecutorThreadFactory(
-                        coordinatorThreadName, getClass().getClassLoader());
+                        coordinatorThreadName, operatorCoordinatorContext);
 
         coordinatorExecutor = Executors.newSingleThreadScheduledExecutor(coordinatorThreadFactory);
         sourceCoordinator = getNewSourceCoordinator();


### PR DESCRIPTION
This serves as a 1.14 backport of PR #18610. Only minor import conflicts during the cherry-picking of [02d9bec](https://github.com/apache/flink/commit/02d9bec4d251c09a1e75eb4d5c6edb751293c54e)
```
git cherry-pick 02d9bec4d251c09a1e75eb4d5c6edb751293c54e
```