### PR TITLE
[FLINK-18356][tests] Enable fork-reuse for table-planner

### DIFF
--- a/flink-table/flink-table-planner/pom.xml
+++ b/flink-table/flink-table-planner/pom.xml
@@ -434,8 +434,7 @@ under the License.
 								<include>**/*ITCase.*</include>
 							</includes>
 							<!-- override reuseForks to true to reduce testing time -->
-							<!-- temporarily set to false because the test consume too many resources -->
-							<reuseForks>false</reuseForks>
+							<reuseForks>true</reuseForks>
 						</configuration>
 					</execution>
 				</executions>


### PR DESCRIPTION
## What is the purpose of the change

* Re-enable fork-reuse for table-planner. This should be re-enabled since https://issues.apache.org/jira/browse/FLINK-25969 is now merged which should improve/resolve the situation

## Brief change log

* Re-enabled fork-reuse

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
