### PR TITLE
[FLINK-26517][runtime] Normalize the decided parallelism to power of 2 when using adaptive batch scheduler

### DIFF
--- a/docs/layouts/shortcodes/generated/all_jobmanager_section.html
+++ b/docs/layouts/shortcodes/generated/all_jobmanager_section.html
@@ -9,10 +9,10 @@
     </thead>
     <tbody>
         <tr>
-            <td><h5>jobmanager.adaptive-batch-scheduler.data-volume-per-task</h5></td>
+            <td><h5>jobmanager.adaptive-batch-scheduler.avg-data-volume-per-task</h5></td>
             <td style="word-wrap: break-word;">1 gb</td>
             <td>MemorySize</td>
-            <td>The size of data volume to expect each task instance to process if <code class="highlighter-rouge">jobmanager.scheduler</code> has been set to <code class="highlighter-rouge">AdaptiveBatch</code></td>
+            <td>The average size of data volume to expect each task instance to process if <code class="highlighter-rouge">jobmanager.scheduler</code> has been set to <code class="highlighter-rouge">AdaptiveBatch</code>. Note that since the parallelism of the vertices is adjusted to a power of 2, the actual average size will be 0.75~1.5 times this value. It is also important to note that when data skew occurs or the decided parallelism reaches the <code class="highlighter-rouge">jobmanager.adaptive-batch-scheduler.max-parallelism</code> (due to too much data), the data actually processed by some tasks may far exceed this value.</td>
         </tr>
         <tr>
             <td><h5>jobmanager.adaptive-batch-scheduler.default-source-parallelism</h5></td>
@@ -24,13 +24,13 @@
             <td><h5>jobmanager.adaptive-batch-scheduler.max-parallelism</h5></td>
             <td style="word-wrap: break-word;">128</td>
             <td>Integer</td>
-            <td>The upper bound of allowed parallelism to set adaptively if <code class="highlighter-rouge">jobmanager.scheduler</code> has been set to <code class="highlighter-rouge">AdaptiveBatch</code></td>
+            <td>The upper bound of allowed parallelism to set adaptively if <code class="highlighter-rouge">jobmanager.scheduler</code> has been set to <code class="highlighter-rouge">AdaptiveBatch</code>. Currently, this option should be configured as a power of 2, otherwise it will also be rounded down to a power of 2 automatically.</td>
         </tr>
         <tr>
             <td><h5>jobmanager.adaptive-batch-scheduler.min-parallelism</h5></td>
             <td style="word-wrap: break-word;">1</td>
             <td>Integer</td>
-            <td>The lower bound of allowed parallelism to set adaptively if <code class="highlighter-rouge">jobmanager.scheduler</code> has been set to <code class="highlighter-rouge">AdaptiveBatch</code></td>
+            <td>The lower bound of allowed parallelism to set adaptively if <code class="highlighter-rouge">jobmanager.scheduler</code> has been set to <code class="highlighter-rouge">AdaptiveBatch</code>. Currently, this option should be configured as a power of 2, otherwise it will also be rounded up to a power of 2 automatically.</td>
         </tr>
         <tr>
             <td><h5>jobmanager.adaptive-scheduler.min-parallelism-increase</h5></td>

--- a/docs/layouts/shortcodes/generated/expert_scheduling_section.html
+++ b/docs/layouts/shortcodes/generated/expert_scheduling_section.html
@@ -27,10 +27,10 @@
             <td>Whether to convert all PIPELINE edges to BLOCKING when apply fine-grained resource management in batch jobs.</td>
         </tr>
         <tr>
-            <td><h5>jobmanager.adaptive-batch-scheduler.data-volume-per-task</h5></td>
+            <td><h5>jobmanager.adaptive-batch-scheduler.avg-data-volume-per-task</h5></td>
             <td style="word-wrap: break-word;">1 gb</td>
             <td>MemorySize</td>
-            <td>The size of data volume to expect each task instance to process if <code class="highlighter-rouge">jobmanager.scheduler</code> has been set to <code class="highlighter-rouge">AdaptiveBatch</code></td>
+            <td>The average size of data volume to expect each task instance to process if <code class="highlighter-rouge">jobmanager.scheduler</code> has been set to <code class="highlighter-rouge">AdaptiveBatch</code>. Note that since the parallelism of the vertices is adjusted to a power of 2, the actual average size will be 0.75~1.5 times this value. It is also important to note that when data skew occurs or the decided parallelism reaches the <code class="highlighter-rouge">jobmanager.adaptive-batch-scheduler.max-parallelism</code> (due to too much data), the data actually processed by some tasks may far exceed this value.</td>
         </tr>
         <tr>
             <td><h5>jobmanager.adaptive-batch-scheduler.default-source-parallelism</h5></td>
@@ -42,13 +42,13 @@
             <td><h5>jobmanager.adaptive-batch-scheduler.max-parallelism</h5></td>
             <td style="word-wrap: break-word;">128</td>
             <td>Integer</td>
-            <td>The upper bound of allowed parallelism to set adaptively if <code class="highlighter-rouge">jobmanager.scheduler</code> has been set to <code class="highlighter-rouge">AdaptiveBatch</code></td>
+            <td>The upper bound of allowed parallelism to set adaptively if <code class="highlighter-rouge">jobmanager.scheduler</code> has been set to <code class="highlighter-rouge">AdaptiveBatch</code>. Currently, this option should be configured as a power of 2, otherwise it will also be rounded down to a power of 2 automatically.</td>
         </tr>
         <tr>
             <td><h5>jobmanager.adaptive-batch-scheduler.min-parallelism</h5></td>
             <td style="word-wrap: break-word;">1</td>
             <td>Integer</td>
-            <td>The lower bound of allowed parallelism to set adaptively if <code class="highlighter-rouge">jobmanager.scheduler</code> has been set to <code class="highlighter-rouge">AdaptiveBatch</code></td>
+            <td>The lower bound of allowed parallelism to set adaptively if <code class="highlighter-rouge">jobmanager.scheduler</code> has been set to <code class="highlighter-rouge">AdaptiveBatch</code>. Currently, this option should be configured as a power of 2, otherwise it will also be rounded up to a power of 2 automatically.</td>
         </tr>
         <tr>
             <td><h5>jobmanager.adaptive-scheduler.min-parallelism-increase</h5></td>

--- a/docs/layouts/shortcodes/generated/job_manager_configuration.html
+++ b/docs/layouts/shortcodes/generated/job_manager_configuration.html
@@ -9,10 +9,10 @@
     </thead>
     <tbody>
         <tr>
-            <td><h5>jobmanager.adaptive-batch-scheduler.data-volume-per-task</h5></td>
+            <td><h5>jobmanager.adaptive-batch-scheduler.avg-data-volume-per-task</h5></td>
             <td style="word-wrap: break-word;">1 gb</td>
             <td>MemorySize</td>
-            <td>The size of data volume to expect each task instance to process if <code class="highlighter-rouge">jobmanager.scheduler</code> has been set to <code class="highlighter-rouge">AdaptiveBatch</code></td>
+            <td>The average size of data volume to expect each task instance to process if <code class="highlighter-rouge">jobmanager.scheduler</code> has been set to <code class="highlighter-rouge">AdaptiveBatch</code>. Note that since the parallelism of the vertices is adjusted to a power of 2, the actual average size will be 0.75~1.5 times this value. It is also important to note that when data skew occurs or the decided parallelism reaches the <code class="highlighter-rouge">jobmanager.adaptive-batch-scheduler.max-parallelism</code> (due to too much data), the data actually processed by some tasks may far exceed this value.</td>
         </tr>
         <tr>
             <td><h5>jobmanager.adaptive-batch-scheduler.default-source-parallelism</h5></td>
@@ -24,13 +24,13 @@
             <td><h5>jobmanager.adaptive-batch-scheduler.max-parallelism</h5></td>
             <td style="word-wrap: break-word;">128</td>
             <td>Integer</td>
-            <td>The upper bound of allowed parallelism to set adaptively if <code class="highlighter-rouge">jobmanager.scheduler</code> has been set to <code class="highlighter-rouge">AdaptiveBatch</code></td>
+            <td>The upper bound of allowed parallelism to set adaptively if <code class="highlighter-rouge">jobmanager.scheduler</code> has been set to <code class="highlighter-rouge">AdaptiveBatch</code>. Currently, this option should be configured as a power of 2, otherwise it will also be rounded down to a power of 2 automatically.</td>
         </tr>
         <tr>
             <td><h5>jobmanager.adaptive-batch-scheduler.min-parallelism</h5></td>
             <td style="word-wrap: break-word;">1</td>
             <td>Integer</td>
-            <td>The lower bound of allowed parallelism to set adaptively if <code class="highlighter-rouge">jobmanager.scheduler</code> has been set to <code class="highlighter-rouge">AdaptiveBatch</code></td>
+            <td>The lower bound of allowed parallelism to set adaptively if <code class="highlighter-rouge">jobmanager.scheduler</code> has been set to <code class="highlighter-rouge">AdaptiveBatch</code>. Currently, this option should be configured as a power of 2, otherwise it will also be rounded up to a power of 2 automatically.</td>
         </tr>
         <tr>
             <td><h5>jobmanager.adaptive-scheduler.min-parallelism-increase</h5></td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
@@ -531,7 +531,9 @@ public class JobManagerOptions {
                     .withDescription(
                             Description.builder()
                                     .text(
-                                            "The lower bound of allowed parallelism to set adaptively if %s has been set to %s",
+                                            "The lower bound of allowed parallelism to set adaptively if %s has been set to %s. "
+                                                    + "Currently, this option should be configured as a power of 2, "
+                                                    + "otherwise it will also be rounded up to a power of 2 automatically.",
                                             code(SCHEDULER.key()),
                                             code(SchedulerType.AdaptiveBatch.name()))
                                     .build());
@@ -547,7 +549,9 @@ public class JobManagerOptions {
                     .withDescription(
                             Description.builder()
                                     .text(
-                                            "The upper bound of allowed parallelism to set adaptively if %s has been set to %s",
+                                            "The upper bound of allowed parallelism to set adaptively if %s has been set to %s. "
+                                                    + "Currently, this option should be configured as a power of 2, "
+                                                    + "otherwise it will also be rounded down to a power of 2 automatically.",
                                             code(SCHEDULER.key()),
                                             code(SchedulerType.AdaptiveBatch.name()))
                                     .build());
@@ -556,16 +560,21 @@ public class JobManagerOptions {
         Documentation.Sections.EXPERT_SCHEDULING,
         Documentation.Sections.ALL_JOB_MANAGER
     })
-    public static final ConfigOption<MemorySize> ADAPTIVE_BATCH_SCHEDULER_DATA_VOLUME_PER_TASK =
-            key("jobmanager.adaptive-batch-scheduler.data-volume-per-task")
+    public static final ConfigOption<MemorySize> ADAPTIVE_BATCH_SCHEDULER_AVG_DATA_VOLUME_PER_TASK =
+            key("jobmanager.adaptive-batch-scheduler.avg-data-volume-per-task")
                     .memoryType()
                     .defaultValue(MemorySize.ofMebiBytes(1024))
                     .withDescription(
                             Description.builder()
                                     .text(
-                                            "The size of data volume to expect each task instance to process if %s has been set to %s",
+                                            "The average size of data volume to expect each task instance to process if %s has been set to %s. "
+                                                    + "Note that since the parallelism of the vertices is adjusted to a power of 2, "
+                                                    + "the actual average size will be 0.75~1.5 times this value. "
+                                                    + "It is also important to note that when data skew occurs or the decided parallelism reaches the %s (due to too much data), "
+                                                    + "the data actually processed by some tasks may far exceed this value.",
                                             code(SCHEDULER.key()),
-                                            code(SchedulerType.AdaptiveBatch.name()))
+                                            code(SchedulerType.AdaptiveBatch.name()),
+                                            code(ADAPTIVE_BATCH_SCHEDULER_MAX_PARALLELISM.key()))
                                     .build());
 
     @Documentation.Section({

--- a/flink-end-to-end-tests/test-scripts/test_tpcds.sh
+++ b/flink-end-to-end-tests/test-scripts/test_tpcds.sh
@@ -67,7 +67,7 @@ elif [ "${SCHEDULER}" == "AdaptiveBatch" ]; then
     set_config_key "taskmanager.numberOfTaskSlots" "8"
     set_config_key "parallelism.default" "-1"
     set_config_key "jobmanager.adaptive-batch-scheduler.max-parallelism" "8"
-    set_config_key "jobmanager.adaptive-batch-scheduler.data-volume-per-task" "6m"
+    set_config_key "jobmanager.adaptive-batch-scheduler.avg-data-volume-per-task" "6m"
 else
     echo "ERROR: Scheduler ${SCHEDULER} is unsupported for tpcds test. Aborting..."
     exit 1

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchScheduler.java
@@ -223,8 +223,7 @@ public class AdaptiveBatchScheduler extends DefaultScheduler implements Schedule
 
     private void changeJobVertexParallelism(ExecutionJobVertex jobVertex, int parallelism) {
         // update the JSON Plan, it's needed to enable REST APIs to return the latest parallelism of
-        // job
-        // vertices
+        // job vertices
         jobVertex.getJobVertex().setParallelism(parallelism);
         try {
             getExecutionGraph().setJsonPlan(JsonPlanGenerator.generatePlan(getJobGraph()));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchSchedulerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchSchedulerFactory.java
@@ -171,8 +171,8 @@ public class AdaptiveBatchSchedulerFactory implements SchedulerNGFactory {
                 shuffleMaster,
                 rpcTimeout,
                 DefaultVertexParallelismDecider.from(jobMasterConfiguration),
-                jobMasterConfiguration.getInteger(
-                        JobManagerOptions.ADAPTIVE_BATCH_SCHEDULER_MAX_PARALLELISM));
+                DefaultVertexParallelismDecider.getNormalizedMaxParallelism(
+                        jobMasterConfiguration));
     }
 
     private void checkAllExchangesBlocking(final JobGraph jobGraph) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchSchedulerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchSchedulerFactory.java
@@ -105,7 +105,7 @@ public class AdaptiveBatchSchedulerFactory implements SchedulerNGFactory {
                         .orElseThrow(
                                 () ->
                                         new IllegalStateException(
-                                                "The DefaultScheduler requires a SlotPool."));
+                                                "The AdaptiveBatchScheduler requires a SlotPool."));
 
         final SlotSelectionStrategy slotSelectionStrategy =
                 SlotSelectionStrategyUtils.selectSlotSelectionStrategy(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchSchedulerTest.java
@@ -174,7 +174,7 @@ public class AdaptiveBatchSchedulerTest extends TestLogger {
                         new AdaptiveBatchSchedulerTestUtils.AdaptiveBatchSchedulerBuilder(
                                         jobGraph, mainThreadExecutor)
                                 .setJobMasterConfiguration(configuration);
-        schedulerBuilder.setJobVertexParallelismDecider((ignored) -> 10);
+        schedulerBuilder.setVertexParallelismDecider((ignored) -> 10);
 
         return schedulerBuilder.build();
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchSchedulerTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchSchedulerTestUtils.java
@@ -46,9 +46,8 @@ public class AdaptiveBatchSchedulerTestUtils {
             setSchedulingStrategyFactory(new VertexwiseSchedulingStrategy.Factory());
         }
 
-        public void setJobVertexParallelismDecider(
-                VertexParallelismDecider jobVertexParallelismDecider) {
-            this.vertexParallelismDecider = jobVertexParallelismDecider;
+        public void setVertexParallelismDecider(VertexParallelismDecider vertexParallelismDecider) {
+            this.vertexParallelismDecider = vertexParallelismDecider;
         }
 
         public void setDefaultMaxParallelism(int defaultMaxParallelism) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/DefaultVertexParallelismDeciderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/DefaultVertexParallelismDeciderTest.java
@@ -41,11 +41,11 @@ public class DefaultVertexParallelismDeciderTest {
     private static final long BYTE_1_TB = 1024 * 1024 * 1024 * 1024L;
 
     private static final int MAX_PARALLELISM = 100;
-    private static final int MIN_PARALLELISM = 2;
+    private static final int MIN_PARALLELISM = 3;
     private static final int DEFAULT_SOURCE_PARALLELISM = 10;
     private static final long DATA_VOLUME_PER_TASK = 1024 * 1024 * 1024L;
 
-    private VertexParallelismDecider decider;
+    private DefaultVertexParallelismDecider decider;
 
     @Before
     public void before() throws Exception {
@@ -56,7 +56,7 @@ public class DefaultVertexParallelismDeciderTest {
         configuration.setInteger(
                 JobManagerOptions.ADAPTIVE_BATCH_SCHEDULER_MIN_PARALLELISM, MIN_PARALLELISM);
         configuration.set(
-                JobManagerOptions.ADAPTIVE_BATCH_SCHEDULER_DATA_VOLUME_PER_TASK,
+                JobManagerOptions.ADAPTIVE_BATCH_SCHEDULER_AVG_DATA_VOLUME_PER_TASK,
                 new MemorySize(DATA_VOLUME_PER_TASK));
         configuration.setInteger(
                 JobManagerOptions.ADAPTIVE_BATCH_SCHEDULER_DEFAULT_SOURCE_PARALLELISM,
@@ -66,13 +66,19 @@ public class DefaultVertexParallelismDeciderTest {
     }
 
     @Test
+    public void testNormalizedMaxAndMinParallelism() {
+        assertThat(decider.getMaxParallelism(), is(64));
+        assertThat(decider.getMinParallelism(), is(4));
+    }
+
+    @Test
     public void testSourceJobVertex() {
         int parallelism = decider.decideParallelismForVertex(Collections.emptyList());
         assertThat(parallelism, is(DEFAULT_SOURCE_PARALLELISM));
     }
 
     @Test
-    public void testDecideParallelism() {
+    public void testNormalizeParallelismDownToPowerOf2() {
         BlockingResultInfo resultInfo1 =
                 BlockingResultInfo.createFromBroadcastResult(Arrays.asList(BYTE_256_MB));
         BlockingResultInfo resultInfo2 =
@@ -82,11 +88,25 @@ public class DefaultVertexParallelismDeciderTest {
         int parallelism =
                 decider.decideParallelismForVertex(Arrays.asList(resultInfo1, resultInfo2));
 
-        assertThat(parallelism, is(11));
+        assertThat(parallelism, is(8));
     }
 
     @Test
-    public void testInitiallyDecidedParallelismIsLargerThanMaxParallelism() {
+    public void testNormalizeParallelismUpToPowerOf2() {
+        BlockingResultInfo resultInfo1 =
+                BlockingResultInfo.createFromBroadcastResult(Arrays.asList(BYTE_256_MB));
+        BlockingResultInfo resultInfo2 =
+                BlockingResultInfo.createFromNonBroadcastResult(
+                        Arrays.asList(BYTE_1_GB, BYTE_8_GB));
+
+        int parallelism =
+                decider.decideParallelismForVertex(Arrays.asList(resultInfo1, resultInfo2));
+
+        assertThat(parallelism, is(16));
+    }
+
+    @Test
+    public void testInitiallyNormalizedParallelismIsLargerThanMaxParallelism() {
         BlockingResultInfo resultInfo1 =
                 BlockingResultInfo.createFromBroadcastResult(Arrays.asList(BYTE_256_MB));
         BlockingResultInfo resultInfo2 =
@@ -96,11 +116,11 @@ public class DefaultVertexParallelismDeciderTest {
         int parallelism =
                 decider.decideParallelismForVertex(Arrays.asList(resultInfo1, resultInfo2));
 
-        assertThat(parallelism, is(MAX_PARALLELISM));
+        assertThat(parallelism, is(64));
     }
 
     @Test
-    public void testInitiallyDecidedParallelismIsSmallerThanMinParallelism() {
+    public void testInitiallyNormalizedParallelismIsSmallerThanMinParallelism() {
         BlockingResultInfo resultInfo1 =
                 BlockingResultInfo.createFromBroadcastResult(Arrays.asList(BYTE_256_MB));
         BlockingResultInfo resultInfo2 =
@@ -109,7 +129,7 @@ public class DefaultVertexParallelismDeciderTest {
         int parallelism =
                 decider.decideParallelismForVertex(Arrays.asList(resultInfo1, resultInfo2));
 
-        assertThat(parallelism, is(MIN_PARALLELISM));
+        assertThat(parallelism, is(4));
     }
 
     @Test
@@ -136,6 +156,6 @@ public class DefaultVertexParallelismDeciderTest {
         int parallelism =
                 decider.decideParallelismForVertex(Arrays.asList(resultInfo1, resultInfo2));
 
-        assertThat(parallelism, is(17));
+        assertThat(parallelism, is(16));
     }
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/scheduling/AdaptiveBatchSchedulerITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/scheduling/AdaptiveBatchSchedulerITCase.java
@@ -108,6 +108,9 @@ public class AdaptiveBatchSchedulerITCase extends TestLogger {
         configuration.setInteger(
                 JobManagerOptions.ADAPTIVE_BATCH_SCHEDULER_MAX_PARALLELISM,
                 DEFAULT_MAX_PARALLELISM);
+        configuration.set(
+                JobManagerOptions.ADAPTIVE_BATCH_SCHEDULER_AVG_DATA_VOLUME_PER_TASK,
+                MemorySize.parse("150kb"));
         configuration.set(TaskManagerOptions.MEMORY_SEGMENT_SIZE, MemorySize.parse("4kb"));
         configuration.set(TaskManagerOptions.NUM_TASK_SLOTS, 1);
 


### PR DESCRIPTION
## What is the purpose of the change

As describe in [FLINK-26330](https://issues.apache.org/jira/browse/FLINK-26330), in order to make the number of subpartitoins evenly consumed by downstream tasks, we need to normalize the decided parallelism to 2^N.

## Verifying this change
UT `DefaultVertexParallelismDeciderTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**no**)
  - The serializers: (**no**)
  - The runtime per-record code paths (performance sensitive): (**no**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**no**)
  - The S3 file system connector: (**no**)

## Documentation

  - Does this pull request introduce a new feature? (**no**)
  - If yes, how is the feature documented? (**not applicable**)
