### PR TITLE
[FLINK-26490][checkpoint] Adjust the MaxParallelism when operator state don't contain keyed state.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -42,6 +42,7 @@ import org.apache.flink.runtime.state.CheckpointStorage;
 import org.apache.flink.runtime.state.CheckpointStorageCoordinatorView;
 import org.apache.flink.runtime.state.CheckpointStorageLocation;
 import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
+import org.apache.flink.runtime.state.StateUtil;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkRuntimeException;
@@ -1776,6 +1777,8 @@ public class CheckpointCoordinator {
                         allowNonRestored,
                         checkpointProperties,
                         restoreSettings.getRestoreMode());
+
+        StateUtil.updateCheckpointMaxParallelismIfNeed(savepoint, tasks);
 
         // register shared state - even before adding the checkpoint to the store
         // because the latter might trigger subsumption so the ref counts must be up-to-date

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/Checkpoints.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/Checkpoints.java
@@ -34,6 +34,7 @@ import org.apache.flink.runtime.state.CheckpointStorageLoader;
 import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.StateBackendLoader;
+import org.apache.flink.runtime.state.StateUtil;
 import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.hashmap.HashMapStateBackend;
 import org.apache.flink.runtime.state.storage.JobManagerCheckpointStorage;
@@ -169,19 +170,22 @@ public class Checkpoints {
                                 operatorState.getMaxParallelism())) {
                     operatorStates.put(operatorState.getOperatorID(), operatorState);
                 } else {
-                    String msg =
-                            String.format(
-                                    "Failed to rollback to checkpoint/savepoint %s. "
-                                            + "Max parallelism mismatch between checkpoint/savepoint state and new program. "
-                                            + "Cannot map operator %s with max parallelism %d to new program with "
-                                            + "max parallelism %d. This indicates that the program has been changed "
-                                            + "in a non-compatible way after the checkpoint/savepoint.",
-                                    checkpointMetadata,
-                                    operatorState.getOperatorID(),
-                                    operatorState.getMaxParallelism(),
-                                    executionJobVertex.getMaxParallelism());
+                    boolean hasKeyedState = StateUtil.hasKeyedState(operatorState);
+                    if (hasKeyedState) {
+                        String msg =
+                                String.format(
+                                        "Failed to rollback to checkpoint/savepoint %s. "
+                                                + "Max parallelism mismatch between checkpoint/savepoint state and new program. "
+                                                + "Cannot map operator %s with max parallelism %d to new program with "
+                                                + "max parallelism %d. This indicates that the program has been changed "
+                                                + "in a non-compatible way after the checkpoint/savepoint.",
+                                        checkpointMetadata,
+                                        operatorState.getOperatorID(),
+                                        operatorState.getMaxParallelism(),
+                                        executionJobVertex.getMaxParallelism());
 
-                    throw new IllegalStateException(msg);
+                        throw new IllegalStateException(msg);
+                    }
                 }
             } else if (allowNonRestoredState) {
                 LOG.info(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateUtil.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateUtil.java
@@ -19,13 +19,24 @@
 package org.apache.flink.runtime.state;
 
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.OperatorIDPair;
+import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
+import org.apache.flink.runtime.checkpoint.OperatorState;
+import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
+import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.util.LambdaUtil;
 
 import org.apache.flink.shaded.guava30.com.google.common.base.Joiner;
 
+import org.apache.flink.util.Preconditions;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.Future;
 import java.util.concurrent.RunnableFuture;
 
@@ -146,5 +157,51 @@ public class StateUtil {
                         + ". "
                         + "This can mostly happen when a different StateBackend from the one "
                         + "that was used for taking a checkpoint/savepoint is used when restoring.");
+    }
+
+    public static boolean hasKeyedState(OperatorState operatorState) {
+        Preconditions.checkState(operatorState != null);
+
+        for (OperatorSubtaskState subtaskState : operatorState.getStates()) {
+            if (subtaskState.getManagedKeyedState().hasState() ||
+                    subtaskState.getRawKeyedState().hasState()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public static OperatorState generatorNewOperatorStateWithNewMaxParallelism(OperatorState operatorState,
+                                                                               int maxParallelism) {
+        OperatorState newOperatorState = new OperatorState(operatorState.getOperatorID(),
+                operatorState.getParallelism(), maxParallelism);
+
+        for (Map.Entry<Integer, OperatorSubtaskState> operatorSubtaskState : operatorState.getSubtaskStates().entrySet()) {
+            newOperatorState.putState(operatorSubtaskState.getKey(), operatorSubtaskState.getValue());
+        }
+
+        newOperatorState.setCoordinatorState(operatorState.getCoordinatorState());
+        return newOperatorState;
+    }
+
+    public static void updateCheckpointMaxParallelismIfNeed(CompletedCheckpoint savepoint, Map<JobVertexID, ExecutionJobVertex> tasks) {
+        Map<OperatorID, Integer> operator2Parallelism = new HashMap<>();
+        for (ExecutionJobVertex task : tasks.values()) {
+            for (OperatorIDPair operatorIDPair : task.getOperatorIDs()) {
+                operator2Parallelism.put(operatorIDPair.getGeneratedOperatorID(), task.getParallelism());
+                operatorIDPair.getUserDefinedOperatorID().ifPresent(id -> operator2Parallelism.put(id, task.getParallelism()));
+            }
+        }
+
+        for (Map.Entry<OperatorID, OperatorState> operatorIDOperatorState : savepoint.getOperatorStates().entrySet()) {
+            int executionParallelism = operator2Parallelism.get(operatorIDOperatorState.getKey());
+            if (!StateUtil.hasKeyedState(operatorIDOperatorState.getValue()) &&
+                    operatorIDOperatorState.getValue().getMaxParallelism() < executionParallelism) {
+                operatorIDOperatorState.setValue(
+                        StateUtil.generatorNewOperatorStateWithNewMaxParallelism(operatorIDOperatorState.getValue(),
+                                KeyGroupRangeAssignment.computeDefaultMaxParallelism(executionParallelism)));
+            }
+        }
     }
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Since Flink introduce key group and MaxParallelism, Flink can rescale with less cost.
But when we want to update the job parallelism bigger than the MaxParallelism, it 's impossible cause there are so many MaxParallelism check that require new parallelism should not bigger than MaxParallelism. 

Actually, when an operator which don't contain keyed state, there should be no problem when update the parallelism bigger than the MaxParallelism,, cause only keyed state need MaxParallelism and key group.

So should we remove this check or auto adjust the MaxParallelism when we restore an operator state that don't contain keyed state?

It can make job restore from checkpoint easier.


## Brief change log


## Verifying this change


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
