### PR TITLE
[FLINK-26531][kafka] KafkaWriterITCase.testMetadataPublisher failed on azure

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaWriterITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaWriterITCase.java
@@ -232,7 +232,7 @@ public class KafkaWriterITCase {
                 writer.write(1, SINK_WRITER_CONTEXT);
                 expected.add("testMetadataPublisher-0@" + i);
             }
-            writer.prepareCommit();
+            writer.flush(false);
             assertThat(metadataList).usingRecursiveComparison().isEqualTo(expected);
         }
     }


### PR DESCRIPTION
## What is the purpose of the change

Fix unstable case: `KafkaWriterITCase.testMetadataPublisher`

## Brief change log

After the sink v2 refactoring, `precommit` is divided into two separate methods: `flush` and `precommit`.
In this test, we should call `flush` instead of `precommit`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)