### PR TITLE
[FLINK-26495][table-planner] Prohibit hints(dynamic table options) on view

### DIFF
--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientITCase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientITCase.java
@@ -136,7 +136,7 @@ public class CliClientITCase extends AbstractTestBase {
                 testSqlStatements.stream().map(s -> s.sql).collect(Collectors.toList());
         List<Result> actualResults = runSqlStatements(sqlStatements);
         String out = transformOutput(testSqlStatements, actualResults);
-        assertThat(in).isEqualTo(out);
+        assertThat(out).isEqualTo(in);
     }
 
     /**

--- a/flink-table/flink-sql-client/src/test/resources/sql/view.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/view.q
@@ -46,6 +46,12 @@ create temporary view if not exists v1 as select * from orders;
 [INFO] Execute statement succeed.
 !info
 
+# test query a view with hint
+select * from v1 /*+ OPTIONS('number-of-rows' = '1') */;
+[ERROR] Could not execute SQL statement. Reason:
+org.apache.flink.table.api.ValidationException: View '`default_catalog`.`default_database`.`v1`' cannot be enriched with new options. Hints can only be applied to tables.
+!error
+
 # test create a view reference another view
 create temporary view if not exists v2 as select * from v1;
 [INFO] Execute statement succeed.

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/schema/ExpandingPreparingTable.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/schema/ExpandingPreparingTable.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.table.planner.plan.schema;
 
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.planner.plan.stats.FlinkStatistic;
 
 import org.apache.calcite.plan.RelOptSchema;
@@ -56,6 +58,15 @@ public abstract class ExpandingPreparingTable extends FlinkPreparingTableBase {
     }
 
     private RelNode expand(RelOptTable.ToRelContext context) {
+        // view with hints is prohibited
+        if (context.getTableHints().size() > 0) {
+            throw new ValidationException(
+                    String.format(
+                            "View '%s' cannot be enriched with new options. "
+                                    + "Hints can only be applied to tables.",
+                            ObjectIdentifier.of(
+                                    super.names.get(0), super.names.get(1), super.names.get(2))));
+        }
         final RelNode rel = convertToRel(context);
         // Expand any views
         return rel.accept(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
@@ -345,6 +345,28 @@ class TableEnvironmentTest {
   }
 
   @Test
+  def testQueryViewWithHints(): Unit = {
+    val statement =
+      """
+        |CREATE TABLE MyTable (
+        |  a bigint,
+        |  b int,
+        |  c varchar
+        |) WITH (
+        |  'connector' = 'COLLECTION'
+        |)
+      """.stripMargin
+    tableEnv.executeSql(statement)
+    tableEnv.executeSql("CREATE TEMPORARY VIEW my_view AS SELECT a, c FROM MyTable")
+
+    assertThatThrownBy(
+      () => tableEnv.executeSql("SELECT c FROM my_view /*+ OPTIONS('is-bounded' = 'true') */"))
+      .hasMessageContaining("View '`default_catalog`.`default_database`.`my_view`' " +
+      "cannot be enriched with new options. Hints can only be applied to tables.")
+      .isInstanceOf(classOf[ValidationException])
+  }
+
+  @Test
   def testAlterTableCompactOnManagedTableUnderStreamingMode(): Unit = {
     val statement =
       """

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
@@ -364,6 +364,24 @@ class TableEnvironmentTest {
       .hasMessageContaining("View '`default_catalog`.`default_database`.`my_view`' " +
       "cannot be enriched with new options. Hints can only be applied to tables.")
       .isInstanceOf(classOf[ValidationException])
+
+    assertThatThrownBy(
+      () => tableEnv.executeSql(
+      "CREATE TEMPORARY VIEW your_view AS " +
+        "SELECT c FROM my_view /*+ OPTIONS('is-bounded' = 'true') */"))
+      .hasMessageContaining("View '`default_catalog`.`default_database`.`my_view`' " +
+      "cannot be enriched with new options. Hints can only be applied to tables.")
+      .isInstanceOf(classOf[ValidationException])
+
+    tableEnv.executeSql(
+      "CREATE TEMPORARY VIEW your_view AS SELECT c FROM my_view ")
+
+    assertThatThrownBy(
+      () => tableEnv.executeSql("SELECT * FROM your_view /*+ OPTIONS('is-bounded' = 'true') */"))
+      .hasMessageContaining("View '`default_catalog`.`default_database`.`your_view`' " +
+      "cannot be enriched with new options. Hints can only be applied to tables.")
+      .isInstanceOf(classOf[ValidationException])
+
   }
 
   @Test

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/hint/OptionsHintTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/hint/OptionsHintTest.scala
@@ -27,6 +27,7 @@ import org.apache.flink.table.planner.plan.hint.OptionsHintTest.{IS_BOUNDED, Par
 import org.apache.flink.table.planner.plan.nodes.calcite.LogicalLegacySink
 import org.apache.flink.table.planner.utils.{OptionsTableSink, TableTestBase, TableTestUtil}
 
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.hamcrest.Matchers._
 import org.junit.Assert.{assertEquals, assertThat}
 import org.junit.runner.RunWith
@@ -142,9 +143,12 @@ class OptionsHintTest(param: Param)
   def testOptionsHintOnTableApiView(): Unit = {
     val view1 = util.tableEnv.sqlQuery("select * from t1 join t2 on t1.a = t2.d")
     util.tableEnv.createTemporaryView("view1", view1)
-    // The table hints on view expect to be ignored.
+    // The table hints on view expect to be prohibited
     val sql = "select * from view1/*+ OPTIONS(k1='#v1', k2='#v2', k3='#v3', k4='#v4') */"
-    util.verifyExecPlan(sql)
+    assertThatThrownBy(() =>  util.verifyExecPlan(sql))
+      .hasMessageContaining("View '`default_catalog`.`default_database`.`view1`' " +
+      "cannot be enriched with new options. Hints can only be applied to tables.")
+      .isInstanceOf[ValidationException]
   }
 
   @Test
@@ -175,9 +179,12 @@ class OptionsHintTest(param: Param)
       new ObjectPath(util.tableEnv.getCurrentDatabase, "view1"),
       view1,
       false)
-    // The table hints on view expect to be ignored.
+    // The table hints on view expect to be prohibited
     val sql = "select * from view1/*+ OPTIONS(k1='#v1', k2='#v2', k3='#v3', k4='#v4') */"
-    util.verifyExecPlan(sql)
+    assertThatThrownBy(() =>  util.verifyExecPlan(sql))
+      .hasMessageContaining("View '`default_catalog`.`default_database`.`view1`' " +
+      "cannot be enriched with new options. Hints can only be applied to tables.")
+      .isInstanceOf[ValidationException]
   }
 }
 


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to throw an explicit exception when querying a view with hints to improve user experience. Currently, the hints on view are swallowed quietly during the planning phase without any trace, and users complain that the hints don't work on view. 

## Brief changelog

  - Add check on `ExpandingPreparingTable` to throw a `ValidationException`
  - A monitor fix for `CliClientITCase` to correct the assertion order for expected and actual

## Verifying this change

This change added tests and can be verified as follows:

  - `TableEnvironmentTest#testQueryViewWithHints`
  - `OptionHintsTest#testOptionsHintOnTableApiView` and `#testOptionsHintOnSQLView`
  -  Add test case in `view.q`, which can be verified by running `CliClientITCase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
