### PR TITLE
[FLINK-26381][docs] Wrong document order of Chinese version

### DIFF
--- a/docs/content.zh/docs/learn-flink/datastream_api.md
+++ b/docs/content.zh/docs/learn-flink/datastream_api.md
@@ -1,6 +1,6 @@
 ---
 title: DataStream API 简介
-weight: 2
+weight: 3
 type: docs
 ---
 <!--

--- a/docs/content.zh/docs/learn-flink/event_driven.md
+++ b/docs/content.zh/docs/learn-flink/event_driven.md
@@ -1,6 +1,6 @@
 ---
 title: 事件驱动应用
-weight: 5
+weight: 6
 type: docs
 ---
 <!--

--- a/docs/content.zh/docs/learn-flink/fault_tolerance.md
+++ b/docs/content.zh/docs/learn-flink/fault_tolerance.md
@@ -1,6 +1,6 @@
 ---
 title: 容错处理
-weight: 6
+weight: 7
 type: docs
 ---
 <!--

--- a/docs/content.zh/docs/learn-flink/streaming_analytics.md
+++ b/docs/content.zh/docs/learn-flink/streaming_analytics.md
@@ -1,6 +1,6 @@
 ---
 title: 流式分析
-weight: 3
+weight: 5
 type: docs
 ---
 <!--


### PR DESCRIPTION
## What is the purpose of the change

Compared English with Chinese version, the orders of articles locates in TOC for docs learn Flink are different.

## Brief change log

- docs/content.zh/docs/learn-flink/datastream_api.md
- docs/content.zh/docs/learn-flink/event_driven.md
- docs/content.zh/docs/learn-flink/fault_tolerance.md
- docs/content.zh/docs/learn-flink/streaming_analytics.md

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
