### PR TITLE
[FLINK-26543][python] Fix the issue that exceptions generated during startup are lost in Python loopback mode

### DIFF
--- a/flink-python/pyflink/fn_execution/beam/beam_boot.py
+++ b/flink-python/pyflink/fn_execution/beam/beam_boot.py
@@ -86,7 +86,9 @@ if __name__ == "__main__":
                 worker_id=worker_id,
                 provision_endpoint=ApiServiceDescriptor(url=provision_endpoint),
                 params=params)
-            client.StartWorker(request)
+            response = client.StartWorker(request)
+            if response.error:
+                raise RuntimeError("Error starting worker: %s" % response.error)
     else:
         logging.info("Starting up Python harness in a standalone process.")
         metadata = [("worker_id", worker_id)]


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will fix the issue that exceptions generated in startup are missed in Python loopback mode*


## Brief change log

  - *Fix the issue that exceptions generated in startup are missed in Python loopback mode*


## Verifying this change

This change added tests and can be verified as follows:

  - *Manual Tests and original tests*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
