### PR TITLE
[FLINK-24586][table-planner] JSON_VALUE should return STRING instead of VARCHAR(2000)

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
@@ -1140,7 +1140,7 @@ public class FlinkSqlOperatorTable extends ReflectiveSqlOperatorTable {
 
     // JSON FUNCTIONS
     public static final SqlFunction JSON_EXISTS = SqlStdOperatorTable.JSON_EXISTS;
-    public static final SqlFunction JSON_VALUE = SqlStdOperatorTable.JSON_VALUE;
+    public static final SqlFunction JSON_VALUE = new SqlJsonValueFunctionWrapper("JSON_VALUE");
     public static final SqlFunction JSON_QUERY = new SqlJsonQueryFunctionWrapper();
     public static final SqlFunction JSON_OBJECT = new SqlJsonObjectFunctionWrapper();
     public static final SqlAggFunction JSON_OBJECTAGG_NULL_ON_NULL =

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/SqlJsonValueFunctionWrapper.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/SqlJsonValueFunctionWrapper.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.functions.sql;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.sql.SqlJsonValueReturning;
+import org.apache.calcite.sql.SqlOperatorBinding;
+import org.apache.calcite.sql.fun.SqlJsonValueFunction;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlReturnTypeInference;
+import org.apache.calcite.sql.type.SqlTypeTransforms;
+
+import java.util.Optional;
+
+import static org.apache.flink.table.planner.plan.type.FlinkReturnTypes.VARCHAR_FORCE_NULLABLE;
+
+/**
+ * This class is a wrapper class for the {@link SqlJsonValueFunction} but using the {@code
+ * VARCHAR_FORCE_NULLABLE} return type inference by default. It also supports specifying return type
+ * with the RETURNING keyword just like the original {@link SqlJsonValueFunction}.
+ */
+public class SqlJsonValueFunctionWrapper extends SqlJsonValueFunction {
+
+    private final SqlReturnTypeInference returnTypeInference;
+
+    public SqlJsonValueFunctionWrapper(String name) {
+        super(name);
+        this.returnTypeInference =
+                ReturnTypes.cascade(
+                                SqlJsonValueFunctionWrapper::explicitTypeSpec,
+                                SqlTypeTransforms.FORCE_NULLABLE)
+                        .orElse(VARCHAR_FORCE_NULLABLE);
+    }
+
+    @Override
+    public RelDataType inferReturnType(SqlOperatorBinding opBinding) {
+        RelDataType returnType = returnTypeInference.inferReturnType(opBinding);
+        if (returnType == null) {
+            throw new IllegalArgumentException(
+                    "Cannot infer return type for "
+                            + opBinding.getOperator()
+                            + "; operand types: "
+                            + opBinding.collectOperandTypes());
+        }
+        return returnType;
+    }
+
+    @Override
+    public SqlReturnTypeInference getReturnTypeInference() {
+        return returnTypeInference;
+    }
+
+    /**
+     * Copied and modified from the original {@link SqlJsonValueFunction}.
+     *
+     * <p>Changes: Instead of returning {@link Optional} this method returns null directly.
+     */
+    private static RelDataType explicitTypeSpec(SqlOperatorBinding opBinding) {
+        if (opBinding.getOperandCount() > 2
+                && opBinding.isOperandLiteral(2, false)
+                && opBinding.getOperandLiteralValue(2, Object.class)
+                        instanceof SqlJsonValueReturning) {
+            return opBinding.getOperandType(3);
+        }
+        return null;
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/SqlJsonValueFunctionWrapper.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/SqlJsonValueFunctionWrapper.java
@@ -35,11 +35,11 @@ import static org.apache.flink.table.planner.plan.type.FlinkReturnTypes.VARCHAR_
  * VARCHAR_FORCE_NULLABLE} return type inference by default. It also supports specifying return type
  * with the RETURNING keyword just like the original {@link SqlJsonValueFunction}.
  */
-public class SqlJsonValueFunctionWrapper extends SqlJsonValueFunction {
+class SqlJsonValueFunctionWrapper extends SqlJsonValueFunction {
 
     private final SqlReturnTypeInference returnTypeInference;
 
-    public SqlJsonValueFunctionWrapper(String name) {
+    SqlJsonValueFunctionWrapper(String name) {
         super(name);
         this.returnTypeInference =
                 ReturnTypes.cascade(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/JsonFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/JsonFunctionsITCase.java
@@ -57,7 +57,6 @@ import static org.apache.flink.table.api.DataTypes.STRING;
 import static org.apache.flink.table.api.DataTypes.TIMESTAMP;
 import static org.apache.flink.table.api.DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE;
 import static org.apache.flink.table.api.DataTypes.VARBINARY;
-import static org.apache.flink.table.api.DataTypes.VARCHAR;
 import static org.apache.flink.table.api.Expressions.$;
 import static org.apache.flink.table.api.Expressions.call;
 import static org.apache.flink.table.api.Expressions.jsonArray;
@@ -183,7 +182,7 @@ public class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                                 "JSON_VALUE(CAST(NULL AS STRING), 'lax $')",
                                 null,
                                 STRING(),
-                                VARCHAR(2000)),
+                                STRING()),
 
                         // RETURNING + Supported Data Types
                         resultSpec(
@@ -191,7 +190,7 @@ public class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                                 "JSON_VALUE(f0, '$.type')",
                                 "account",
                                 STRING(),
-                                VARCHAR(2000)),
+                                STRING()),
                         resultSpec(
                                 $("f0").jsonValue("$.activated", BOOLEAN()),
                                 "JSON_VALUE(f0, '$.activated' RETURNING BOOLEAN)",
@@ -220,7 +219,7 @@ public class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                                 "JSON_VALUE(f0, 'lax $.invalid' NULL ON EMPTY ERROR ON ERROR)",
                                 null,
                                 STRING(),
-                                VARCHAR(2000)),
+                                STRING()),
                         resultSpec(
                                 $("f0").jsonValue(
                                                 "lax $.invalid",
@@ -243,7 +242,7 @@ public class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                                 "JSON_VALUE(f0, 'strict $.invalid' ERROR ON EMPTY NULL ON ERROR)",
                                 null,
                                 STRING(),
-                                VARCHAR(2000)),
+                                STRING()),
                         resultSpec(
                                 $("f0").jsonValue(
                                                 "strict $.invalid",


### PR DESCRIPTION
## What is the purpose of the change

#17691 changes the return type of some functions from `VARCHAR(2000)` to `STRING`, however it missed out `JSON_VALUE`. This PR fixes this issue.

## Brief change log

 - Change default return type of `JSON_VALUE` from `VARCHAR(2000)` to `STRING`.

## Verifying this change

This change modifies `JsonFunctionsITCase` and can be verified by running the test case.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
