### PR TITLE
[BP-1.14][FLINK-26352][runtime-web] Add missing license headers to WebUI source files

### DIFF
--- a/flink-runtime-web/web-dashboard/src/@types/d3-tip/index.d.ts
+++ b/flink-runtime-web/web-dashboard/src/@types/d3-tip/index.d.ts
@@ -1,1 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 declare module 'd3-tip';


### PR DESCRIPTION
## What is the purpose of the change

This backport for #18951 was necessary despite the rat plugin update not being backported to `release-1.14` because we still should have all `*.ts` files with the proper Apache header.

## Brief change log

Cherry-picked from the parent #18951 :
```
$ git cherry-pick 932934aabb55a048da390ee804f4e55ab974ff2e
```

## Verifying this change

Manually verified that there are no other `*.ts` files without the Apache header in `flink-runtime-web/web-dashboard/src`:
```
find flink-runtime-web/web-dashboard/src -name "*.ts" -exec sh -c 'echo '{}'; grep -c "Licensed to the Apache Software Foundation (ASF) under one" '{} \; | grep -B1 0
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
