### PR TITLE
[FLINK-26542][hive] Hive dialect supports queries with multiple same columns in select

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/copy/HiveParserRowResolver.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/copy/HiveParserRowResolver.java
@@ -136,11 +136,8 @@ public class HiveParserRowResolver implements Serializable {
     private void keepAmbiguousInfo(String colAlias, String tabAlias) {
         // we keep track of duplicate <tab alias, col alias> so that get can check
         // for ambiguity
-        LinkedHashMap<String, String> colAliases = ambiguousColumns.get(tabAlias);
-        if (colAliases == null) {
-            colAliases = new LinkedHashMap<>();
-            ambiguousColumns.put(tabAlias, colAliases);
-        }
+        LinkedHashMap<String, String> colAliases =
+                ambiguousColumns.computeIfAbsent(tabAlias, k -> new LinkedHashMap<>());
         colAliases.put(colAlias, colAlias);
     }
 
@@ -207,8 +204,8 @@ public class HiveParserRowResolver implements Serializable {
         ColumnInfo ret = null;
 
         if (!isExprResolver && isAmbiguousReference(tabAlias, colAlias)) {
-            String tableName = tabAlias != null ? tabAlias : "";
-            String fullQualifiedName = tableName + "." + colAlias;
+            String colNamePrefix = tabAlias != null ? tabAlias + "." : "";
+            String fullQualifiedName = colNamePrefix + colAlias;
             throw new SemanticException("Ambiguous column reference: " + fullQualifiedName);
         }
 

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/copy/HiveParserRowResolver.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/copy/HiveParserRowResolver.java
@@ -49,7 +49,9 @@ public class HiveParserRowResolver implements Serializable {
      */
     private final Map<String, String[]> altInvRslvMap;
     private final Map<String, HiveParserASTNode> expressionMap;
+    private final LinkedHashMap<String, LinkedHashMap<String, String>> ambiguousColumns;
 
+    private boolean checkForAmbiguity;
     // TODO: Refactor this and do in a more object oriented manner
     private boolean isExprResolver;
 
@@ -59,12 +61,34 @@ public class HiveParserRowResolver implements Serializable {
     private HiveParserNamedJoinInfo namedJoinInfo;
 
     public HiveParserRowResolver() {
-        rowSchema = new RowSchema();
-        rslvMap = new LinkedHashMap<>();
-        invRslvMap = new HashMap<>();
-        altInvRslvMap = new HashMap<>();
-        expressionMap = new HashMap<>();
-        isExprResolver = false;
+        this(
+                new RowSchema(),
+                new LinkedHashMap<>(),
+                new HashMap<>(),
+                new HashMap<>(),
+                new HashMap<>(),
+                false,
+                new LinkedHashMap<>(),
+                false);
+    }
+
+    public HiveParserRowResolver(
+            RowSchema rowSchema,
+            LinkedHashMap<String, LinkedHashMap<String, ColumnInfo>> rslvMap,
+            HashMap<String, String[]> invRslvMap,
+            Map<String, String[]> altInvRslvMap,
+            Map<String, HiveParserASTNode> expressionMap,
+            boolean isExprResolver,
+            LinkedHashMap<String, LinkedHashMap<String, String>> ambiguousColumns,
+            boolean checkForAmbiguity) {
+        this.rowSchema = rowSchema;
+        this.rslvMap = rslvMap;
+        this.invRslvMap = invRslvMap;
+        this.altInvRslvMap = altInvRslvMap;
+        this.expressionMap = expressionMap;
+        this.isExprResolver = isExprResolver;
+        this.ambiguousColumns = ambiguousColumns;
+        this.checkForAmbiguity = checkForAmbiguity;
     }
 
     /**
@@ -109,6 +133,17 @@ public class HiveParserRowResolver implements Serializable {
         }
     }
 
+    private void keepAmbiguousInfo(String colAlias, String tabAlias) {
+        // we keep track of duplicate <tab alias, col alias> so that get can check
+        // for ambiguity
+        LinkedHashMap<String, String> colAliases = ambiguousColumns.get(tabAlias);
+        if (colAliases == null) {
+            colAliases = new LinkedHashMap<>();
+            ambiguousColumns.put(tabAlias, colAliases);
+        }
+        colAliases.put(colAlias, colAlias);
+    }
+
     public boolean addMappingOnly(String tabAlias, String colAlias, ColumnInfo colInfo) {
         if (tabAlias != null) {
             tabAlias = tabAlias.toLowerCase();
@@ -134,6 +169,7 @@ public class HiveParserRowResolver implements Serializable {
                             + oldColInfo
                             + " by "
                             + colInfo);
+            keepAmbiguousInfo(colAlias, tabAlias);
         }
 
         String[] qualifiedAlias = new String[2];
@@ -169,6 +205,12 @@ public class HiveParserRowResolver implements Serializable {
      */
     public ColumnInfo get(String tabAlias, String colAlias) throws SemanticException {
         ColumnInfo ret = null;
+
+        if (!isExprResolver && isAmbiguousReference(tabAlias, colAlias)) {
+            String tableName = tabAlias != null ? tabAlias : "";
+            String fullQualifiedName = tableName + "." + colAlias;
+            throw new SemanticException("Ambiguous column reference: " + fullQualifiedName);
+        }
 
         if (tabAlias != null) {
             tabAlias = tabAlias.toLowerCase();
@@ -390,6 +432,7 @@ public class HiveParserRowResolver implements Serializable {
         if (internalName != null) {
             existing = get(tabAlias, internalName);
             if (existing == null) {
+                keepAmbiguousInfo(colAlias, tabAlias);
                 put(tabAlias, internalName, newCI);
                 return true;
             } else if (existing.isSameColumnForRR(newCI)) {
@@ -432,11 +475,58 @@ public class HiveParserRowResolver implements Serializable {
         return combinedRR;
     }
 
+    public HiveParserRowResolver duplicate() {
+        return new HiveParserRowResolver(
+                new RowSchema(rowSchema),
+                new LinkedHashMap<>(rslvMap),
+                new HashMap<>(invRslvMap),
+                new HashMap<>(altInvRslvMap),
+                new HashMap<>(expressionMap),
+                isExprResolver,
+                new LinkedHashMap<>(ambiguousColumns),
+                checkForAmbiguity);
+    }
+
     public HiveParserNamedJoinInfo getNamedJoinInfo() {
         return namedJoinInfo;
     }
 
     public void setNamedJoinInfo(HiveParserNamedJoinInfo namedJoinInfo) {
         this.namedJoinInfo = namedJoinInfo;
+    }
+
+    private boolean isAmbiguousReference(String tableAlias, String colAlias) {
+
+        if (!getCheckForAmbiguity()) {
+            return false;
+        }
+        if (ambiguousColumns == null || ambiguousColumns.isEmpty()) {
+            return false;
+        }
+
+        if (tableAlias != null) {
+            LinkedHashMap<String, String> colAliases =
+                    ambiguousColumns.get(tableAlias.toLowerCase());
+            return colAliases != null && colAliases.containsKey(colAlias.toLowerCase());
+        } else {
+            for (Map.Entry<String, LinkedHashMap<String, String>> ambigousColsEntry :
+                    ambiguousColumns.entrySet()) {
+                LinkedHashMap<String, String> cmap = ambigousColsEntry.getValue();
+                for (Map.Entry<String, String> cmapEnt : cmap.entrySet()) {
+                    if (colAlias.equalsIgnoreCase(cmapEnt.getKey())) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    public void setCheckForAmbiguity(boolean check) {
+        this.checkForAmbiguity = check;
+    }
+
+    public boolean getCheckForAmbiguity() {
+        return this.checkForAmbiguity;
     }
 }

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectQueryITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectQueryITCase.java
@@ -74,7 +74,7 @@ public class HiveDialectQueryITCase {
 
         // create tables
         tableEnv.executeSql("create table foo (x int, y int)");
-        tableEnv.executeSql("create table bar(i int, s string)");
+        tableEnv.executeSql("create table bar(I int, s string)");
         tableEnv.executeSql("create table baz(ai array<int>, d double)");
         tableEnv.executeSql(
                 "create table employee(id int,name string,dep string,salary int,age int)");

--- a/flink-connectors/flink-connector-hive/src/test/resources/query-test/join.q
+++ b/flink-connectors/flink-connector-hive/src/test/resources/query-test/join.q
@@ -26,7 +26,7 @@ select * from foo left semi join bar on foo.y=bar.i;
 
 select * from (select a.value, a.* from (select * from src) a join (select * from src) b on a.key = b.key) t;
 
-[+I[val1, 1], +I[val2, 2], +I[val3, 3]]
+[+I[val1, 1, val1], +I[val2, 2, val2], +I[val3, 3, val3]]
 
 select f1.x,f1.y,f2.x,f2.y from (select * from foo order by x,y) f1 join (select * from foo order by x,y) f2;
 

--- a/flink-connectors/flink-connector-hive/src/test/resources/query-test/set_op.q
+++ b/flink-connectors/flink-connector-hive/src/test/resources/query-test/set_op.q
@@ -19,3 +19,7 @@ select x from foo intersect select i from bar;
 select x,y from foo union all select i,i from bar;
 
 [+I[1, 1], +I[1, 1], +I[1, 1], +I[2, 2], +I[2, 2], +I[3, 3], +I[4, 4], +I[5, 5]]
+
+select x,Y,X from foo union all select i,i,I from bar;
+
+[+I[1, 1, 1], +I[1, 1, 1], +I[1, 1, 1], +I[2, 2, 2], +I[2, 2, 2], +I[3, 3, 3], +I[4, 4, 4], +I[5, 5, 5]]

--- a/flink-connectors/flink-connector-hive/src/test/resources/query-test/set_op.q
+++ b/flink-connectors/flink-connector-hive/src/test/resources/query-test/set_op.q
@@ -15,3 +15,7 @@ select i from bar except select x from foo;
 select x from foo intersect select i from bar;
 
 [+I[1], +I[2]]
+
+select x,y from foo union all select i,i from bar;
+
+[+I[1, 1], +I[1, 1], +I[1, 1], +I[2, 2], +I[2, 2], +I[3, 3], +I[4, 4], +I[5, 5]]


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
To fix the issue that it'll throw "schema of both sides of union should match" exception when one side of union select multiple same coulmns  in `UNION ALL` statement with Hive dialect.


## Brief change log

- use method `HiveParserRowResolver#putWithCheck` to put ColumnInfo, it will try to use internal name to duplicate again after finding a duplicate.

- add check for ambiguous columns .

## Verifying this change
The added SQL statement `select x,y from foo union all select i,i from bar;`  which will fail before this fix in set_op.q


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector:  no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
