### PR TITLE
[FLINK-26547][coordination] No requirement adjustments for unmatched slots

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceProfile.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceProfile.java
@@ -73,10 +73,7 @@ public class ResourceProfile implements Serializable {
      */
     public static final ResourceProfile UNKNOWN = new ResourceProfile();
 
-    /**
-     * A ResourceProfile that indicates infinite resource that matches any resource requirement, for
-     * testability purpose only.
-     */
+    /** A ResourceProfile that indicates infinite resource that matches any resource requirement. */
     @VisibleForTesting
     public static final ResourceProfile ANY =
             newBuilder()


### PR DESCRIPTION
To allow recovered TMs to eagerly re-offer their slots we allowed the registration of slots without a matching requirement if the job is currently restarting.

All slots that the pool accepts are mapped to a certain requirement, in order to determine whether sufficient slots were received yet. If a slot is reserved for a requirement that does not coincide with the mapping the pool come up with, then the mapping and requirements are changed accordingly to ensure we still request sufficient slots.

This leads to issues with slots that were accepted without a matching requirement. Those were mapped to the actual resource profile of the slot (to fit into the book-keeping). With the above logic in place this could lead to a specific resource requirement being added, which the remaining JM components are not aware of (and thus will never get rid of).


This PR fixes the issue by mapping such slots to `ResourceProfile.ANY` as a sort of sentinel value, and skipping the requirement adjustment if such a slot is reserved.