### PR TITLE
[FLINK-26550][checkpoint] Correct the information of checkpoint failure

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManager.java
@@ -105,7 +105,7 @@ public class CheckpointFailureManager {
         updateStatsAfterCheckpointFailed(pendingCheckpointStats, statsTracker, exception);
 
         LOG.warn(
-                "Failed to trigger checkpoint {} for job {}. ({} consecutive failed attempts so far)",
+                "Failed to trigger or complete checkpoint {} for job {}. ({} consecutive failed attempts so far)",
                 checkpointId == UNKNOWN_CHECKPOINT_ID ? "UNKNOWN_CHECKPOINT_ID" : checkpointId,
                 job,
                 continuousFailureCounter.get(),


### PR DESCRIPTION
## What is the purpose of the change

After [FLINK-26049], all failed checkpoint would print message with `Failed to trigger checkpoint...`, this is extremely strange as most failures do not happen during the trigger phase.
We could change the inforamtion to `Failed to complete checkpoint...` as the fail to trigger exception would also print in the warning message.


## Brief change log

Change the warning information.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.



## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers:  no
  - The runtime per-record code paths (performance sensitive): no 
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no 
  - The S3 file system connector:  no

## Documentation

  - Does this pull request introduce a new feature?  no
  - If yes, how is the feature documented? not applicable
