### PR TITLE
[FLINK-26555][runtime] Adds closing and flushing to OutputStream

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/FileSystemJobResultStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/FileSystemJobResultStore.java
@@ -131,8 +131,10 @@ public class FileSystemJobResultStore extends AbstractThreadsafeJobResultStore {
     @Override
     public void createDirtyResultInternal(JobResultEntry jobResultEntry) throws IOException {
         final Path path = constructDirtyPath(jobResultEntry.getJobId());
-        OutputStream os = fileSystem.create(path, FileSystem.WriteMode.NO_OVERWRITE);
-        mapper.writeValue(os, new JsonJobResultEntry(jobResultEntry));
+        try (OutputStream os = fileSystem.create(path, FileSystem.WriteMode.NO_OVERWRITE)) {
+            mapper.writeValue(os, new JsonJobResultEntry(jobResultEntry));
+            os.flush();
+        }
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change

The `FileSystemJobResultStore` does not close the `OutputStream` when writing the JobResult into the file. This PR fixes the issue.

## Brief change log

* Adds try block around the `OutputStream` usage

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
