### PR TITLE
[FLINK-26418][runtime][test] Use java.io.tmpdir for tmpWorkingDir

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/TestingTaskManagerRuntimeInfo.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/TestingTaskManagerRuntimeInfo.java
@@ -38,7 +38,8 @@ public class TestingTaskManagerRuntimeInfo implements TaskManagerRuntimeInfo {
     public TestingTaskManagerRuntimeInfo() {
         this(
                 new Configuration(),
-                System.getProperty("java.io.tmpdir").split(",|" + File.pathSeparator));
+                EnvironmentInformation.getTemporaryFileDirectory()
+                        .split(",|" + File.pathSeparator));
     }
 
     public TestingTaskManagerRuntimeInfo(Configuration configuration) {
@@ -62,7 +63,9 @@ public class TestingTaskManagerRuntimeInfo implements TaskManagerRuntimeInfo {
                 configuration,
                 tmpDirectories,
                 InetAddress.getLoopbackAddress().getHostAddress(),
-                new File("tmp_" + UUID.randomUUID()));
+                new File(
+                        EnvironmentInformation.getTemporaryFileDirectory(),
+                        "tmp_" + UUID.randomUUID()));
     }
 
     public TestingTaskManagerRuntimeInfo(


### PR DESCRIPTION
Previously, the tmpWorkingDirectory was created in the current working
directory, and as a result there were directories created in the root
directories of the modules, i.e. `flink-table/flink-table-planner` which
were not cleaned up with `mvn clean`.

The behavior was introduced with: https://github.com/apache/flink/pull/18083
`EmbeddedRocksDBStateBackend#lazyInitializeForJob`:
```
if (localRocksDbDirectories == null) {
    initializedDbBasePaths = new File[] {env.getTaskManagerInfo().getTmpWorkingDirectory()};
} else {
....
```
