### PR TITLE
[FLINK-26548][runtime] set the source parallelism correctly when using legacy file sources with AdaptiveBatcheScheduler

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -49,6 +49,7 @@ import org.apache.flink.streaming.api.operators.OutputFormatOperatorFactory;
 import org.apache.flink.streaming.api.operators.SourceOperatorFactory;
 import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
 import org.apache.flink.streaming.api.transformations.StreamExchangeMode;
+import org.apache.flink.streaming.runtime.partitioner.ForwardForConsecutiveHashPartitioner;
 import org.apache.flink.streaming.runtime.partitioner.ForwardForUnspecifiedPartitioner;
 import org.apache.flink.streaming.runtime.partitioner.ForwardPartitioner;
 import org.apache.flink.streaming.runtime.partitioner.RebalancePartitioner;
@@ -677,7 +678,8 @@ public class StreamGraph implements Pipeline {
             partitioner = new RebalancePartitioner<Object>();
         }
 
-        if (partitioner instanceof ForwardPartitioner) {
+        if (partitioner instanceof ForwardPartitioner
+                && !(partitioner instanceof ForwardForConsecutiveHashPartitioner)) {
             if (upstreamNode.getParallelism() != downstreamNode.getParallelism()) {
                 throw new UnsupportedOperationException(
                         "Forward partitioning does not allow "


### PR DESCRIPTION
## What is the purpose of the change

As described in [FLINK-26548](https://issues.apache.org/jira/browse/FLINK-26548), when using legacy file sources with AdaptiveBatcheScheduler, the parallelism of source reader is not set correctly, this pr aims to fix it.

## Verifying this change

- covered by existed unit tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**no**)
  - The serializers: (**no**)
  - The runtime per-record code paths (performance sensitive): (**no**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**no**)
  - The S3 file system connector: (**no**)

## Documentation

  - Does this pull request introduce a new feature? (**no**)
  - If yes, how is the feature documented? (**not applicable**)
