### PR TITLE
[hotfix][docs] Fix syntax errors in java doc

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/co/ProcessJoinFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/co/ProcessJoinFunction.java
@@ -47,7 +47,7 @@ public abstract class ProcessJoinFunction<IN1, IN2, OUT> extends AbstractRichFun
      * @param left The left element of the joined pair.
      * @param right The right element of the joined pair.
      * @param ctx A context that allows querying the timestamps of the left, right and joined pair.
-     *     In addition, this context allows to emit elements on a side output.
+     *     In addition, this context allows emitting elements on a side output.
      * @param out The collector to emit resulting elements to.
      * @throws Exception This function may throw exceptions which cause the streaming program to
      *     fail and go in recovery mode.
@@ -58,7 +58,7 @@ public abstract class ProcessJoinFunction<IN1, IN2, OUT> extends AbstractRichFun
     /**
      * The context that is available during an invocation of {@link #processElement(Object, Object,
      * Context, Collector)}. It gives access to the timestamps of the left element in the joined
-     * pair, the right one, and that of the joined pair. In addition, this context allows to emit
+     * pair, the right one, and that of the joined pair. In addition, this context allows emitting
      * elements on a side output.
      */
     public abstract class Context {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/co/IntervalJoinOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/co/IntervalJoinOperator.java
@@ -327,7 +327,7 @@ public class IntervalJoinOperator<K, T1, T2, OUT>
      * ProcessJoinFunction#processElement(Object, Object, ProcessJoinFunction.Context, Collector)}.
      *
      * <p>It gives access to the timestamps of the left element in the joined pair, the right one,
-     * and that of the joined pair. In addition, this context allows to emit elements on a side
+     * and that of the joined pair. In addition, this context allows emitting elements on a side
      * output.
      */
     private final class ContextImpl extends ProcessJoinFunction<T1, T2, OUT>.Context {


### PR DESCRIPTION
## What is the purpose of the change

Fix syntax errors in java doc
for example `this context allows to emit elements on a side output.`
 -> `this context allows emitting elements on a side output.`
## Brief change log

Fix syntax errors in java doc

## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
