### PR TITLE
Reverts [hotfix][table-planner] Raw to Binary can fail if the user type ser/de fails

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/RawToBinaryCastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/RawToBinaryCastRule.java
@@ -43,11 +43,6 @@ class RawToBinaryCastRule extends AbstractNullAwareCodeGeneratorCastRule<Object,
                         .build());
     }
 
-    @Override
-    public boolean canFail() {
-        return true;
-    }
-
     /* Example generated code for BINARY(3):
 
     // legacy behavior


### PR DESCRIPTION
Reverts the `cbfca3afae5d33f9137ae97eb4f4c27ea0d82919` introduced through PR #18813 . The method is not used anywhere but introduces a compilation error on `master`:

https://dev.azure.com/mapohl/flink/_build/results?buildId=850&view=logs&j=668ee87f-c790-5715-ed85-7ccae79a5a1f&t=6703b1a5-0c3e-5043-cc7f-f6c333c30a20