### PR TITLE
[FLINK-26592][state/changelog] Schedule uploads outside synchronized block

### DIFF
--- a/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/BatchingStateChangeUploadSchedulerTest.java
+++ b/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/BatchingStateChangeUploadSchedulerTest.java
@@ -429,7 +429,7 @@ public class BatchingStateChangeUploadSchedulerTest {
         return Tuple2.of(thread, future);
     }
 
-    private static final class BlockingUploader implements StateChangeUploader {
+    static final class BlockingUploader implements StateChangeUploader {
         private final AtomicBoolean blocking = new AtomicBoolean(true);
         private final AtomicInteger uploadsCounter = new AtomicInteger();
 
@@ -449,7 +449,7 @@ public class BatchingStateChangeUploadSchedulerTest {
         @Override
         public void close() {}
 
-        private void unblock() {
+        void unblock() {
             blocking.set(false);
         }
 

--- a/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/FsStateChangelogStorageTest.java
+++ b/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/FsStateChangelogStorageTest.java
@@ -17,14 +17,21 @@
 
 package org.apache.flink.changelog.fs;
 
+import org.apache.flink.changelog.fs.BatchingStateChangeUploadSchedulerTest.BlockingUploader;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.changelog.StateChangelogStorage;
+import org.apache.flink.runtime.state.changelog.StateChangelogWriter;
 import org.apache.flink.runtime.state.changelog.inmemory.StateChangelogStorageTest;
 
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 
 import static org.apache.flink.changelog.fs.UnregisteredChangelogStorageMetricGroup.createUnregisteredChangelogStorageMetricGroup;
 
@@ -45,5 +52,58 @@ public class FsStateChangelogStorageTest extends StateChangelogStorageTest {
                 compression,
                 1024 * 1024 * 10,
                 createUnregisteredChangelogStorageMetricGroup());
+    }
+
+    /**
+     * Provoke a deadlock between task and uploader threads which might happen during waiting for
+     * capacity and upload completion.
+     */
+    @Test
+    public void testDeadlockOnUploadCompletion() throws Throwable {
+        int capacity = 10; // in bytes, allow the first two uploads without waiting (see below)
+        CountDownLatch remainingUploads = new CountDownLatch(3);
+        BlockingUploader blockingUploader = new BlockingUploader();
+        CompletableFuture<Void> unblockFuture = new CompletableFuture<>();
+        new Thread(
+                        () -> {
+                            try {
+                                remainingUploads.await();
+                                blockingUploader.unblock();
+                                unblockFuture.complete(null);
+                            } catch (Throwable e) {
+                                unblockFuture.completeExceptionally(e);
+                            }
+                        })
+                .start();
+        try (BatchingStateChangeUploadScheduler scheduler =
+                        new BatchingStateChangeUploadScheduler(
+                                0, // schedule immediately
+                                0, // schedule immediately
+                                RetryPolicy.NONE,
+                                blockingUploader,
+                                1,
+                                capacity,
+                                createUnregisteredChangelogStorageMetricGroup()) {
+                            @Override
+                            public void upload(UploadTask uploadTask) throws IOException {
+                                remainingUploads.countDown();
+                                super.upload(uploadTask);
+                            }
+                        };
+                StateChangelogWriter<?> writer =
+                        new FsStateChangelogStorage(scheduler, 0 /* persist immediately */)
+                                .createWriter(
+                                        new OperatorID().toString(), KeyGroupRange.of(0, 0)); ) {
+            // 1. start with 1-byte request - releasing only it will NOT allow proceeding in 3, but
+            // still involves completion callback, which can deadlock
+            writer.append(0, new byte[1]);
+            // 2. exceed capacity
+            writer.append(0, new byte[capacity]);
+            // 3. current thread will block until both previous requests are completed
+            // verify that completion can proceed while this thread is waiting
+            writer.append(0, new byte[1]);
+        }
+        // check unblocking thread exit status
+        unblockFuture.join();
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

```
When a task thread tries to schedule an upload, it might wait for available capacity.
Capacity is released by the uploading thread on upload completion.  After releasing,
it must notify the task thread about the completion.
Both task and uploading thread acquire FsStateChangelogWriter.lock. That causes
a deadlock if uploader releases capacity insufficient for task thread to proceed.

This change makes task thread to schedule uploads after releasing the lock.
```

## Verifying this change

`FsStateChangelogStorageTest.testDeadlockOnUploadCompletion`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
