### PR TITLE
[FLINK-26063][state/changelog] Compute keys of the removed PQ elements

### DIFF
--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/AbstractStateChangeLogger.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/AbstractStateChangeLogger.java
@@ -145,9 +145,17 @@ abstract class AbstractStateChangeLogger<Key, Value, Ns>
             @Nullable ThrowingConsumer<DataOutputViewStreamWrapper, IOException> dataWriter,
             Ns ns)
             throws IOException {
+        log(op, dataWriter, ns, keyContext.getCurrentKeyGroupIndex());
+    }
+
+    protected void log(
+            StateChangeOperation op,
+            @Nullable ThrowingConsumer<DataOutputViewStreamWrapper, IOException> dataWriter,
+            Ns ns,
+            int keyGroup)
+            throws IOException {
         logMetaIfNeeded();
-        stateChangelogWriter.append(
-                keyContext.getCurrentKeyGroupIndex(), serialize(op, ns, dataWriter));
+        stateChangelogWriter.append(keyGroup, serialize(op, ns, dataWriter));
     }
 
     private void logMetaIfNeeded() throws IOException {

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyGroupedPriorityQueue.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyGroupedPriorityQueue.java
@@ -125,7 +125,13 @@ public class ChangelogKeyGroupedPriorityQueue<T>
     @Nonnull
     public CloseableIterator<T> iterator() {
         return StateChangeLoggingIterator.create(
-                delegatedPriorityQueue.iterator(), logger, serializer::serialize, null);
+                delegatedPriorityQueue.iterator(),
+                logger,
+                serializer::serialize,
+                null,
+                lastReturned ->
+                        logger.valueElementRemoved(
+                                out -> serializer.serialize(lastReturned, out), null));
     }
 
     @Override

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
@@ -439,7 +439,8 @@ public class ChangelogKeyedStateBackend<K>
                             stateChangelogWriter,
                             new RegisteredPriorityQueueStateBackendMetaInfo<>(
                                     stateName, byteOrderedElementSerializer),
-                            ++lastCreatedStateId);
+                            ++lastCreatedStateId,
+                            keyedStateBackend.getNumberOfKeyGroups());
             closer.register(priorityQueueStateChangeLogger);
             queue =
                     new ChangelogKeyGroupedPriorityQueue<>(

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
@@ -152,7 +152,7 @@ public class ChangelogKeyedStateBackend<K>
      */
     private final Map<String, ChangelogState> changelogStates;
 
-    private final Map<String, ChangelogKeyGroupedPriorityQueue<?>> priorityQueueStatesByName;
+    private final Map<String, ChangelogKeyGroupedPriorityQueue<?, ?>> priorityQueueStatesByName;
 
     private final ExecutionConfig executionConfig;
 
@@ -429,10 +429,10 @@ public class ChangelogKeyedStateBackend<K>
             KeyGroupedInternalPriorityQueue<T> create(
                     @Nonnull String stateName,
                     @Nonnull TypeSerializer<T> byteOrderedElementSerializer) {
-        ChangelogKeyGroupedPriorityQueue<T> queue =
-                (ChangelogKeyGroupedPriorityQueue<T>) priorityQueueStatesByName.get(stateName);
+        ChangelogKeyGroupedPriorityQueue<K, T> queue =
+                (ChangelogKeyGroupedPriorityQueue<K, T>) priorityQueueStatesByName.get(stateName);
         if (queue == null) {
-            PriorityQueueStateChangeLoggerImpl<K, T> priorityQueueStateChangeLogger =
+            PriorityQueueStateChangeLogger<K, T, Void> priorityQueueStateChangeLogger =
                     new PriorityQueueStateChangeLoggerImpl<>(
                             byteOrderedElementSerializer,
                             keyedStateBackend.getKeyContext(),
@@ -657,7 +657,7 @@ public class ChangelogKeyedStateBackend<K>
                 changelogState.resetWritingMetaFlag();
             }
 
-            for (ChangelogKeyGroupedPriorityQueue<?> priorityQueueState :
+            for (ChangelogKeyGroupedPriorityQueue<?, ?> priorityQueueState :
                     priorityQueueStatesByName.values()) {
                 priorityQueueState.resetWritingMetaFlag();
             }

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogMapState.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogMapState.java
@@ -143,7 +143,10 @@ class ChangelogMapState<K, N, UK, UV>
                         }),
                 changeLogger,
                 (entry, out) -> serializeKey(entry.getKey(), out),
-                currentNamespace);
+                currentNamespace,
+                entry ->
+                        changeLogger.valueElementRemoved(
+                                out -> serializeKey(entry.getKey(), out), currentNamespace));
     }
 
     @Override
@@ -154,7 +157,11 @@ class ChangelogMapState<K, N, UK, UV>
                         CloseableIterator.adapterForIterator(iterable.iterator()),
                         changeLogger,
                         this::serializeKey,
-                        getCurrentNamespace());
+                        getCurrentNamespace(),
+                        lastReturned ->
+                                changeLogger.valueElementRemoved(
+                                        out -> serializeKey(lastReturned, out),
+                                        getCurrentNamespace()));
     }
 
     @Override

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/PriorityQueueStateChangeLogger.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/PriorityQueueStateChangeLogger.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.changelog;
+
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.util.function.ThrowingConsumer;
+
+import java.io.IOException;
+
+interface PriorityQueueStateChangeLogger<K, T, Namespace> extends StateChangeLogger<T, Namespace> {
+    void valueElementRemoved(
+            K key,
+            ThrowingConsumer<DataOutputViewStreamWrapper, IOException> dataSerializer,
+            Void unused)
+            throws IOException;
+}

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/PriorityQueueStateChangeLoggerImpl.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/PriorityQueueStateChangeLoggerImpl.java
@@ -22,12 +22,14 @@ import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.runtime.state.RegisteredPriorityQueueStateBackendMetaInfo;
 import org.apache.flink.runtime.state.changelog.StateChangelogWriter;
 import org.apache.flink.runtime.state.heap.InternalKeyContext;
+import org.apache.flink.util.function.ThrowingConsumer;
 
 import java.io.IOException;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
-class PriorityQueueStateChangeLoggerImpl<K, T> extends AbstractStateChangeLogger<K, T, Void> {
+class PriorityQueueStateChangeLoggerImpl<K, T> extends AbstractStateChangeLogger<K, T, Void>
+        implements PriorityQueueStateChangeLogger<K, T, Void> {
     private final TypeSerializer<T> serializer;
 
     PriorityQueueStateChangeLoggerImpl(
@@ -48,4 +50,13 @@ class PriorityQueueStateChangeLoggerImpl<K, T> extends AbstractStateChangeLogger
     @Override
     protected void serializeScope(Void unused, DataOutputViewStreamWrapper out)
             throws IOException {}
+
+    @Override
+    public void valueElementRemoved(
+            K key,
+            ThrowingConsumer<DataOutputViewStreamWrapper, IOException> dataSerializer,
+            Void unused)
+            throws IOException {
+        super.valueElementRemoved(dataSerializer, unused);
+    }
 }

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/PriorityQueueStateChangeLoggerImplTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/PriorityQueueStateChangeLoggerImplTest.java
@@ -31,7 +31,7 @@ public class PriorityQueueStateChangeLoggerImplTest extends StateChangeLoggerTes
         RegisteredPriorityQueueStateBackendMetaInfo<String> metaInfo =
                 new RegisteredPriorityQueueStateBackendMetaInfo<>("test", valueSerializer);
         return new PriorityQueueStateChangeLoggerImpl<>(
-                valueSerializer, keyContext, writer, metaInfo, Short.MIN_VALUE);
+                valueSerializer, keyContext, writer, metaInfo, Short.MIN_VALUE, Integer.MAX_VALUE);
     }
 
     @Override

--- a/flink-tests/src/test/java/org/apache/flink/test/state/ChangelogRescalingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/ChangelogRescalingITCase.java
@@ -1,0 +1,354 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.state;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.connector.source.ReaderOutput;
+import org.apache.flink.api.connector.source.SourceReader;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.api.connector.source.lib.NumberSequenceSource;
+import org.apache.flink.api.connector.source.lib.util.IteratorSourceReader;
+import org.apache.flink.api.connector.source.lib.util.IteratorSourceSplit;
+import org.apache.flink.changelog.fs.FsStateChangelogStorageFactory;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.core.io.InputStatus;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.streaming.api.CheckpointingMode;
+import org.apache.flink.streaming.api.datastream.DataStreamUtils;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
+import org.apache.flink.streaming.api.windowing.assigners.SlidingProcessingTimeWindows;
+import org.apache.flink.streaming.api.windowing.time.Time;
+import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Serializable;
+import java.time.Duration;
+import java.util.Iterator;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+
+import static org.apache.flink.changelog.fs.FsStateChangelogOptions.PREEMPTIVE_PERSIST_THRESHOLD;
+import static org.apache.flink.configuration.CheckpointingOptions.CHECKPOINTS_DIRECTORY;
+import static org.apache.flink.configuration.CheckpointingOptions.CHECKPOINT_STORAGE;
+import static org.apache.flink.configuration.CheckpointingOptions.FS_SMALL_FILE_THRESHOLD;
+import static org.apache.flink.configuration.CheckpointingOptions.LOCAL_RECOVERY;
+import static org.apache.flink.configuration.CoreOptions.DEFAULT_PARALLELISM;
+import static org.apache.flink.configuration.PipelineOptions.OBJECT_REUSE;
+import static org.apache.flink.configuration.RestartStrategyOptions.RESTART_STRATEGY;
+import static org.apache.flink.configuration.StateBackendOptions.STATE_BACKEND;
+import static org.apache.flink.configuration.StateChangelogOptions.ENABLE_STATE_CHANGE_LOG;
+import static org.apache.flink.configuration.StateChangelogOptions.PERIODIC_MATERIALIZATION_INTERVAL;
+import static org.apache.flink.configuration.TaskManagerOptions.BUFFER_DEBLOAT_ENABLED;
+import static org.apache.flink.runtime.jobgraph.SavepointRestoreSettings.forPath;
+import static org.apache.flink.runtime.testutils.CommonTestUtils.waitForAllTaskRunning;
+import static org.apache.flink.streaming.api.environment.CheckpointConfig.ExternalizedCheckpointCleanup.RETAIN_ON_CANCELLATION;
+import static org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions.ALIGNED_CHECKPOINT_TIMEOUT;
+import static org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions.CHECKPOINTING_INTERVAL;
+import static org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions.CHECKPOINTING_MODE;
+import static org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions.ENABLE_UNALIGNED;
+import static org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions.EXTERNALIZED_CHECKPOINT;
+import static org.apache.flink.test.util.TestUtils.getMostRecentCompletedCheckpoint;
+import static org.apache.flink.test.util.TestUtils.getMostRecentCompletedCheckpointMaybe;
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+/**
+ * Tests rescaling with Changelog enabled and with timers in state. It uses an adaptation of a
+ * ChangelogTestProgram that aims to generate the highest load possible while still allowing
+ * checkpointing. For that, it uses rate-limited FLIP-27 source and Unaligned checkpoints.
+ */
+@RunWith(Parameterized.class)
+public class ChangelogRescalingITCase extends TestLogger {
+    /** The rate at which events will be generated by the source. */
+    private static final int EVENTS_PER_SECOND_PER_READER = 100;
+    /** Payload size of each event generated randomly. */
+    private static final int PAYLOAD_SIZE = 1000;
+    /** Size of (ProcessingTime) windows. */
+    private static final Time WINDOW_SIZE = Time.milliseconds(100);
+    /** Slide size. */
+    private static final Time WINDOW_SLIDE = Time.milliseconds(10);
+    /** Time to Accumulate some timer delete operations. */
+    private static final int ACCUMULATE_TIME_MILLIS = 5_000;
+
+    @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Parameters(name = "Rescale {0} -> {1}")
+    public static Object[] parameters() {
+        return new Object[][] {new Object[] {6, 4}, new Object[] {4, 6}};
+    }
+
+    private final int parallelism1;
+    private final int parallelism2;
+
+    private MiniClusterWithClientResource cluster;
+
+    public ChangelogRescalingITCase(int parallelism1, int parallelism2) {
+        this.parallelism1 = parallelism1;
+        this.parallelism2 = parallelism2;
+    }
+
+    @Before
+    public void before() throws Exception {
+        Configuration configuration = new Configuration();
+        FsStateChangelogStorageFactory.configure(configuration, temporaryFolder.newFolder());
+        cluster =
+                new MiniClusterWithClientResource(
+                        new MiniClusterResourceConfiguration.Builder()
+                                .setConfiguration(configuration)
+                                .setNumberSlotsPerTaskManager(Math.max(parallelism1, parallelism2))
+                                .build());
+        cluster.before();
+    }
+
+    @After
+    public void after() {
+        if (cluster != null) {
+            cluster.after();
+            cluster = null;
+        }
+    }
+
+    @Test
+    public void test() throws Exception {
+        // before rescale
+        File cpDir1 = temporaryFolder.newFolder();
+        JobID jobID1 = submit(configureJob(parallelism1, cpDir1), graph -> {});
+
+        Thread.sleep(ACCUMULATE_TIME_MILLIS);
+        File cpLocation = checkpointAndCancel(jobID1, cpDir1);
+
+        // rescale and checkpoint to verify
+        JobID jobID2 =
+                submit(
+                        configureJob(parallelism2, temporaryFolder.newFolder()),
+                        graph ->
+                                graph.setSavepointRestoreSettings(
+                                        forPath(cpLocation.toURI().toString())));
+        waitForAllTaskRunning(cluster.getMiniCluster(), jobID2, true);
+        cluster.getClusterClient().cancel(jobID2).get();
+    }
+
+    private JobID submit(Configuration conf, Consumer<JobGraph> updateGraph)
+            throws InterruptedException, ExecutionException {
+        JobGraph jobGraph = createJobGraph(conf);
+        updateGraph.accept(jobGraph);
+        return cluster.getClusterClient().submitJob(jobGraph).get();
+    }
+
+    private JobGraph createJobGraph(Configuration conf) {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment(conf);
+        SingleOutputStreamOperator<TestEvent> map =
+                env.fromSource(
+                                new ThrottlingNumberSequenceSource(
+                                        0, Long.MAX_VALUE, EVENTS_PER_SECOND_PER_READER),
+                                WatermarkStrategy.noWatermarks(),
+                                "Sequence Source")
+                        .keyBy(ChangelogRescalingITCase::key)
+                        .map(
+                                el -> {
+                                    // Thread.sleep(100); // don't block barriers
+                                    byte[] bytes = new byte[PAYLOAD_SIZE];
+                                    ThreadLocalRandom.current().nextBytes(bytes);
+                                    return new TestEvent(el, bytes);
+                                });
+        DataStreamUtils.reinterpretAsKeyedStream(map, e -> key(e.id))
+                .window(SlidingProcessingTimeWindows.of(WINDOW_SIZE, WINDOW_SLIDE))
+                .process(
+                        new ProcessWindowFunction<TestEvent, String, Long, TimeWindow>() {
+                            @Override
+                            public void process(
+                                    Long key,
+                                    ProcessWindowFunction<TestEvent, String, Long, TimeWindow>
+                                                    .Context
+                                            context,
+                                    Iterable<TestEvent> elements,
+                                    Collector<String> out) {}
+                        })
+                .addSink(new DiscardingSink<>());
+
+        return env.getStreamGraph().getJobGraph();
+    }
+
+    private static long key(Long num) {
+        return num % 1000;
+    }
+
+    private Configuration configureJob(int parallelism, File cpDir) {
+        Configuration conf = new Configuration();
+
+        conf.set(EXTERNALIZED_CHECKPOINT, RETAIN_ON_CANCELLATION);
+        conf.set(DEFAULT_PARALLELISM, parallelism);
+        conf.set(ENABLE_STATE_CHANGE_LOG, true);
+        conf.set(CHECKPOINTING_MODE, CheckpointingMode.EXACTLY_ONCE);
+        conf.set(CHECKPOINTING_INTERVAL, Duration.ofMillis(10));
+        conf.set(CHECKPOINT_STORAGE, "filesystem");
+        conf.set(CHECKPOINTS_DIRECTORY, cpDir.toURI().toString());
+        conf.set(STATE_BACKEND, "hashmap");
+        conf.set(LOCAL_RECOVERY, false); // not supported by changelog
+        // tune changelog
+        conf.set(PREEMPTIVE_PERSIST_THRESHOLD, MemorySize.ofMebiBytes(10));
+        conf.set(PERIODIC_MATERIALIZATION_INTERVAL, Duration.ofMinutes(3));
+        // tune flink
+        conf.set(FS_SMALL_FILE_THRESHOLD, MemorySize.ofMebiBytes(1));
+        conf.set(OBJECT_REUSE, true);
+
+        conf.set(ENABLE_UNALIGNED, true); // speedup
+        conf.set(ALIGNED_CHECKPOINT_TIMEOUT, Duration.ZERO); // prevent randomization
+        conf.set(BUFFER_DEBLOAT_ENABLED, false); // prevent randomization
+        conf.set(RESTART_STRATEGY, "none"); // not expecting any failures
+
+        return conf;
+    }
+
+    private static final class TestEvent implements Serializable {
+        private final long id;
+
+        @SuppressWarnings({"FieldCanBeLocal", "unused"})
+        private final byte[] payload;
+
+        private TestEvent(long id, byte[] payload) {
+            this.id = id;
+            this.payload = payload;
+        }
+    }
+
+    private static class ThrottlingNumberSequenceSource extends NumberSequenceSource {
+        private final int numbersPerSecond;
+
+        public ThrottlingNumberSequenceSource(long from, long to, int numbersPerSecondPerReader) {
+            super(from, to);
+            this.numbersPerSecond = numbersPerSecondPerReader;
+        }
+
+        @Override
+        public SourceReader<Long, NumberSequenceSplit> createReader(
+                SourceReaderContext readerContext) {
+            return new ThrottlingIteratorSourceReader<>(
+                    readerContext, new SourceRateLimiter(numbersPerSecond));
+        }
+    }
+
+    private static class ThrottlingIteratorSourceReader<
+                    E, IterT extends Iterator<E>, SplitT extends IteratorSourceSplit<E, IterT>>
+            extends IteratorSourceReader<E, IterT, SplitT> {
+        private final SourceRateLimiter rateLimiter;
+
+        public ThrottlingIteratorSourceReader(
+                SourceReaderContext context, SourceRateLimiter rateLimiter) {
+            super(context);
+            this.rateLimiter = rateLimiter;
+        }
+
+        @Override
+        public InputStatus pollNext(ReaderOutput<E> output) {
+            if (rateLimiter.request()) {
+                return super.pollNext(output);
+            } else {
+                return InputStatus.NOTHING_AVAILABLE;
+            }
+        }
+    }
+
+    private static final class SourceRateLimiter {
+        private final AtomicBoolean newTokensAdded = new AtomicBoolean(false);
+        private final int tokensToAdd;
+        private int tokensAvailable;
+
+        public SourceRateLimiter(int tokensPerSecond) {
+            this(
+                    tokensPerSecond < 10 ? 1000 : 100,
+                    tokensPerSecond < 10 ? tokensPerSecond : tokensPerSecond / 10);
+        }
+
+        public SourceRateLimiter(int intervalMs, int tokensToAdd) {
+            checkArgument(intervalMs > 0);
+            checkArgument(tokensToAdd > 0);
+            this.tokensToAdd = tokensToAdd;
+            this.tokensAvailable = tokensToAdd;
+            new Timer("source-limiter", true)
+                    .scheduleAtFixedRate(
+                            new TimerTask() {
+                                @Override
+                                public void run() {
+                                    newTokensAdded.set(true); // "catch up" is ok
+                                }
+                            },
+                            intervalMs,
+                            intervalMs);
+        }
+
+        public boolean request() {
+            if (tokensAvailable == 0 && newTokensAdded.compareAndSet(true, false)) {
+                tokensAvailable = tokensToAdd;
+            }
+            if (tokensAvailable > 0) {
+                tokensAvailable--;
+                return true;
+            } else {
+                return false;
+            }
+        }
+    }
+
+    private File checkpointAndCancel(JobID jobID, File cpDir)
+            throws IOException, InterruptedException, ExecutionException {
+        while (!getMostRecentCompletedCheckpointMaybe(cpDir).isPresent()) {
+            checkStatus(jobID);
+            Thread.sleep(50);
+        }
+        cluster.getClusterClient().cancel(jobID).get();
+        checkStatus(jobID);
+        return getMostRecentCompletedCheckpoint(cpDir);
+    }
+
+    private void checkStatus(JobID jobID) throws InterruptedException, ExecutionException {
+        if (cluster.getClusterClient().getJobStatus(jobID).get().isGloballyTerminalState()) {
+            cluster.getClusterClient()
+                    .requestJobResult(jobID)
+                    .get()
+                    .getSerializedThrowable()
+                    .ifPresent(
+                            serializedThrowable -> {
+                                throw new RuntimeException(serializedThrowable);
+                            });
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Key group is logged so that state changes can be re-distributed or shuffled.
It is currently obtained from keyContext for remove() operations.
However, keyContext is not updated when dequeing or processing time timers.

This causes re-scaling to fail if:
1. there is materialized state
1. there are remove operations
1. wrong key group was recorded for those operations
1. those groups fall into a different backend as a result of re-scaling

## Verifying this change
- `ChangelogRescalingITCase`
- Verified manually on a standalone cluster
- 
This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
