### PR TITLE
[FLINK-26482][python] Support WindowedStream.reduce in Python DataStream API

### DIFF
--- a/docs/content.zh/docs/dev/datastream/operators/windows.md
+++ b/docs/content.zh/docs/dev/datastream/operators/windows.md
@@ -439,6 +439,17 @@ input
     .reduce { (v1, v2) => (v1._1, v1._2 + v2._2) }
 ```
 {{< /tab >}}
+{{< tab "Python" >}}
+```python
+input = ...  # type: DataStream
+
+input \
+    .key_by(<key selector>) \
+    .window(<window assigner>) \
+    .reduce(lambda v1, v2: (v1[0], v1[1] + v2[1]),
+            output_type=Types.TUPLE([Types.STRING(), Types.LONG()]))
+```
+{{< /tab >}}
 {{< /tabs >}}
 
 上面的例子是对窗口内元组的第二个属性求和。

--- a/docs/content/docs/dev/datastream/operators/windows.md
+++ b/docs/content/docs/dev/datastream/operators/windows.md
@@ -464,11 +464,11 @@ input
 {{< /tab >}}
 {{< tab "Python" >}}
 ```python
-input: DataStream = ...
+input = ...  # type: DataStream
 
-input
-    .key_by(<key selector>)
-    .window(<window assigner>)
+input \
+    .key_by(<key selector>) \
+    .window(<window assigner>) \
     .reduce(lambda v1, v2: (v1[0], v1[1] + v2[1]),
             output_type=Types.TUPLE([Types.STRING(), Types.LONG()]))
 ```

--- a/docs/content/docs/dev/datastream/operators/windows.md
+++ b/docs/content/docs/dev/datastream/operators/windows.md
@@ -462,6 +462,17 @@ input
     .reduce { (v1, v2) => (v1._1, v1._2 + v2._2) }
 ```
 {{< /tab >}}
+{{< tab "Python" >}}
+```python
+input: DataStream = ...
+
+input
+    .key_by(<key selector>)
+    .window(<window assigner>)
+    .reduce(lambda v1, v2: (v1[0], v1[1] + v2[1]),
+            output_type=Types.TUPLE([Types.STRING(), Types.LONG()]))
+```
+{{< /tab >}}
 {{< /tabs >}}
 
 The above example sums up the second fields of the tuples for all elements in a window.

--- a/flink-python/pyflink/datastream/data_stream.py
+++ b/flink-python/pyflink/datastream/data_stream.py
@@ -20,10 +20,6 @@ import uuid
 from typing import Callable, Union, List, cast
 
 from pyflink.common import typeinfo, ExecutionConfig, Row
-from pyflink.datastream.slot_sharing_group import SlotSharingGroup
-from pyflink.datastream.window import (TimeWindowSerializer, CountWindowSerializer, WindowAssigner,
-                                       Trigger, WindowOperationDescriptor,
-                                       CountTumblingWindowAssigner, CountSlidingWindowAssigner)
 from pyflink.common.typeinfo import RowTypeInfo, Types, TypeInformation, _from_java_type
 from pyflink.common.watermark_strategy import WatermarkStrategy, TimestampAssigner
 from pyflink.datastream.connectors import Sink
@@ -43,8 +39,9 @@ from pyflink.datastream.slot_sharing_group import SlotSharingGroup
 from pyflink.datastream.state import ValueStateDescriptor, ValueState, ListStateDescriptor, \
     StateDescriptor, ReducingStateDescriptor
 from pyflink.datastream.utils import convert_to_python_obj
-from pyflink.datastream.window import (TimeWindowSerializer, CountWindowSerializer, WindowAssigner,
-                                       Trigger, WindowOperationDescriptor)
+from pyflink.datastream.window import (CountTumblingWindowAssigner, CountSlidingWindowAssigner,
+                                       CountWindowSerializer, TimeWindowSerializer, Trigger,
+                                       WindowAssigner, WindowOperationDescriptor)
 from pyflink.java_gateway import get_gateway
 
 __all__ = ['CloseableIterator', 'DataStream', 'KeyedStream', 'ConnectedStreams', 'WindowedStream',
@@ -1388,7 +1385,7 @@ class WindowedStream(object):
         """
         if window_function is None:
             internal_window_function = InternalSingleValueWindowFunction(
-                PassThroughWindowFunction())
+                PassThroughWindowFunction())  # type: InternalWindowFunction
             if output_type is None:
                 output_type = self.get_input_type()
         elif isinstance(window_function, WindowFunction):

--- a/flink-python/pyflink/datastream/data_stream.py
+++ b/flink-python/pyflink/datastream/data_stream.py
@@ -35,13 +35,22 @@ from pyflink.datastream.functions import (_get_python_env, FlatMapFunction, MapF
                                           KeyedCoProcessFunction, WindowFunction,
                                           ProcessWindowFunction, InternalWindowFunction,
                                           InternalIterableWindowFunction,
-                                          InternalIterableProcessWindowFunction, CoProcessFunction)
-from pyflink.datastream.state import ValueStateDescriptor, ValueState, ListStateDescriptor
+                                          InternalIterableProcessWindowFunction, CoProcessFunction,
+                                          InternalSingleValueWindowFunction,
+                                          InternalSingleValueProcessWindowFunction,
+                                          PassThroughWindowFunction)
+from pyflink.datastream.slot_sharing_group import SlotSharingGroup
+from pyflink.datastream.state import ValueStateDescriptor, ValueState, ListStateDescriptor, \
+    StateDescriptor, ReducingStateDescriptor
 from pyflink.datastream.utils import convert_to_python_obj
+from pyflink.datastream.window import (TimeWindowSerializer, CountWindowSerializer, WindowAssigner,
+                                       Trigger, WindowOperationDescriptor)
 from pyflink.java_gateway import get_gateway
 
 __all__ = ['CloseableIterator', 'DataStream', 'KeyedStream', 'ConnectedStreams', 'WindowedStream',
            'DataStreamSink', 'CloseableIterator']
+
+WINDOW_STATE_NAME = 'window-contents'
 
 
 class DataStream(object):
@@ -1347,6 +1356,55 @@ class WindowedStream(object):
         self._allowed_lateness = time_ms
         return self
 
+    def reduce(self,
+               reduce_function: Union[Callable, ReduceFunction],
+               window_function: Union[WindowFunction, ProcessWindowFunction] = None,
+               result_type: TypeInformation = None) -> DataStream:
+        """
+        Applies a reduce function to the window. The window function is called for each evaluation of
+        the window for each key individually. The output of the reduce function is interpreted as a
+        regular non-windowed stream.
+
+        This window will try and incrementally aggregate data as much as the window policies
+        permit. For example, tumbling time windows can aggregate the data, meaning that only one
+        element per key is stored. Sliding time windows will aggregate on the granularity of the
+        slide interval, so a few elements are stored per key (one per slide interval). Custom windows
+        may not be able to incrementally aggregate, or may need to store extra values in an
+        aggregation tree.
+
+        Example:
+        ::
+
+            >>> ds.key_by(lambda x: x[1]) \
+                    .window(TumblingEventTimeWindow.of(Time.seconds(5))) \
+                    .reduce(lambda a, b: a[0] + b[0], b[1])
+
+        :param reduce_function: The reduce function.
+        :param window_function: The window function.
+        :param result_type: Type information for the result type of the window function.
+        :return: The data stream that is the result of applying the reduce function to the window.
+
+        .. versionadded:: 1.16
+        """
+        if window_function is None:
+            internal_window_function = InternalSingleValueWindowFunction(PassThroughWindowFunction())
+            if result_type is None:
+                result_type = self.get_input_type()
+        elif isinstance(window_function, WindowFunction):
+            internal_window_function = InternalSingleValueWindowFunction(window_function)
+        elif isinstance(window_function, ProcessWindowFunction):
+            internal_window_function = InternalSingleValueProcessWindowFunction(window_function)
+        else:
+            raise TypeError("window_function should be a WindowFunction or ProcessWindowFunction")
+
+        reducing_state_descriptor = ReducingStateDescriptor(WINDOW_STATE_NAME,
+                                                            reduce_function,
+                                                            self.get_input_type())
+
+        return self._get_result_data_stream(internal_window_function,
+                                            reducing_state_descriptor,
+                                            result_type)
+
     def apply(self,
               window_function: WindowFunction, result_type: TypeInformation = None) -> DataStream:
         """
@@ -1363,7 +1421,10 @@ class WindowedStream(object):
         """
         internal_window_function = InternalIterableWindowFunction(
             window_function)  # type: InternalWindowFunction
-        return self._get_result_data_stream(internal_window_function, result_type)
+        list_state_descriptor = ListStateDescriptor(WINDOW_STATE_NAME, self.get_input_type())
+        return self._get_result_data_stream(internal_window_function,
+                                            list_state_descriptor,
+                                            result_type)
 
     def process(self,
                 process_window_function: ProcessWindowFunction,
@@ -1382,16 +1443,19 @@ class WindowedStream(object):
         """
         internal_window_function = InternalIterableProcessWindowFunction(
             process_window_function)  # type: InternalWindowFunction
-        return self._get_result_data_stream(internal_window_function, result_type)
+        list_state_descriptor = ListStateDescriptor(WINDOW_STATE_NAME, self.get_input_type())
+        return self._get_result_data_stream(internal_window_function,
+                                            list_state_descriptor,
+                                            result_type)
 
-    def _get_result_data_stream(
-            self, internal_window_function: InternalWindowFunction, result_type):
+    def _get_result_data_stream(self,
+                                internal_window_function: InternalWindowFunction,
+                                window_state_descriptor: StateDescriptor,
+                                result_type: TypeInformation):
         if self._window_trigger is None:
             self._window_trigger = self._window_assigner.get_default_trigger(
                 self.get_execution_environment())
         window_serializer = self._window_assigner.get_window_serializer()
-        window_state_descriptor = ListStateDescriptor(
-            "window-contents", self.get_input_type())
         window_operation_descriptor = WindowOperationDescriptor(
             self._window_assigner,
             self._window_trigger,

--- a/flink-python/pyflink/datastream/data_stream.py
+++ b/flink-python/pyflink/datastream/data_stream.py
@@ -1372,16 +1372,16 @@ class WindowedStream(object):
         Example:
         ::
 
-            >>> ds.key_by(lambda x: x[1]) \
-                    .window(TumblingEventTimeWindow.of(Time.seconds(5))) \
-                    .reduce(lambda a, b: a[0] + b[0], b[1])
+            >>> ds.key_by(lambda x: x[1]) \\
+            ...     .window(TumblingEventTimeWindows.of(Time.seconds(5))) \\
+            ...     .reduce(lambda a, b: a[0] + b[0], b[1])
 
         :param reduce_function: The reduce function.
         :param window_function: The window function.
         :param output_type: Type information for the result type of the window function.
         :return: The data stream that is the result of applying the reduce function to the window.
 
-        .. versionadded:: 1.16
+        .. versionadded:: 1.16.0
         """
         if window_function is None:
             internal_window_function = InternalSingleValueWindowFunction(
@@ -1426,7 +1426,7 @@ class WindowedStream(object):
 
     def process(self,
                 process_window_function: ProcessWindowFunction,
-                output_type: TypeInformation = None):
+                output_type: TypeInformation = None) -> DataStream:
         """
         Applies the given window function to each window. The window function is called for each
         evaluation of the window for each key individually. The output of the window function is

--- a/flink-python/pyflink/datastream/functions.py
+++ b/flink-python/pyflink/datastream/functions.py
@@ -956,13 +956,13 @@ class ProcessWindowFunction(Function, Generic[IN, OUT, KEY, W]):
     @abstractmethod
     def process(self,
                 key: KEY,
-                content: 'ProcessWindowFunction.Context',
+                context: 'ProcessWindowFunction.Context',
                 elements: Iterable[IN]) -> Iterable[OUT]:
         """
         Evaluates the window and outputs none or several elements.
 
         :param key: The key for which this window is evaluated.
-        :param content: The context in which the window is being evaluated.
+        :param context: The context in which the window is being evaluated.
         :param elements: The elements in the window being evaluated.
         :return: The iterable object which produces the elements to emit.
         """
@@ -979,7 +979,13 @@ class ProcessWindowFunction(Function, Generic[IN, OUT, KEY, W]):
         pass
 
 
-class InternalWindowFunction(Function, Generic[IN, KEY, W]):
+class PassThroughWindowFunction(WindowFunction):
+
+    def apply(self, key: KEY, window: W, inputs: Iterable[IN]) -> Iterable[OUT]:
+        yield from inputs
+
+
+class InternalWindowFunction(Function, Generic[IN, OUT, KEY, W]):
 
     class InternalWindowContext(ABC):
 
@@ -1004,7 +1010,7 @@ class InternalWindowFunction(Function, Generic[IN, KEY, W]):
                 key: KEY,
                 window: W,
                 context: InternalWindowContext,
-                input_data: Iterable[IN]) -> Iterable[OUT]:
+                input_data: IN) -> Iterable[OUT]:
         pass
 
     @abstractmethod
@@ -1012,7 +1018,29 @@ class InternalWindowFunction(Function, Generic[IN, KEY, W]):
         pass
 
 
-class InternalIterableWindowFunction(InternalWindowFunction[IN, KEY, W]):
+class InternalSingleValueWindowFunction(InternalWindowFunction[IN, OUT, KEY, W]):
+
+    def __init__(self, wrapped_function: WindowFunction):
+        self._wrapped_function = wrapped_function
+
+    def open(self, runtime_context: RuntimeContext):
+        self._wrapped_function.open(runtime_context)
+
+    def close(self):
+        self._wrapped_function.close()
+
+    def process(self,
+                key: KEY,
+                window: W,
+                context: InternalWindowFunction.InternalWindowContext,
+                input_data: IN) -> Iterable[OUT]:
+        return self._wrapped_function.apply(key, window, [input_data])
+
+    def clear(self, window: W, context: InternalWindowFunction.InternalWindowContext):
+        pass
+
+
+class InternalIterableWindowFunction(InternalWindowFunction[Iterable[IN], OUT, KEY, W]):
 
     def __init__(self, wrapped_function: WindowFunction):
         self._wrapped_function = wrapped_function
@@ -1058,7 +1086,35 @@ class InternalProcessWindowContext(ProcessWindowFunction.Context[W]):
         return self._underlying.global_state()
 
 
-class InternalIterableProcessWindowFunction(InternalWindowFunction[IN, KEY, W]):
+class InternalSingleValueProcessWindowFunction(InternalWindowFunction[IN, OUT, KEY, W]):
+
+    def __init__(self, wrapped_function: ProcessWindowFunction):
+        self._wrapped_function = wrapped_function
+        self._internal_context = \
+            InternalProcessWindowContext()  # type: InternalProcessWindowContext
+
+    def open(self, runtime_context: RuntimeContext):
+        self._wrapped_function.open(runtime_context)
+
+    def close(self):
+        self._wrapped_function.close()
+
+    def process(self,
+                key: KEY,
+                window: W,
+                context: InternalWindowFunction.InternalWindowContext,
+                input_data: IN) -> Iterable[OUT]:
+        self._internal_context._window = window
+        self._internal_context._underlying = context
+        return self._wrapped_function.process(key, self._internal_context, [input_data])
+
+    def clear(self, window: W, context: InternalWindowFunction.InternalWindowContext):
+        self._internal_context._window = window
+        self._internal_context._underlying = context
+        self._wrapped_function.clear(self._internal_context)
+
+
+class InternalIterableProcessWindowFunction(InternalWindowFunction[Iterable[IN], OUT, KEY, W]):
 
     def __init__(self, wrapped_function: ProcessWindowFunction):
         self._wrapped_function = wrapped_function

--- a/flink-python/pyflink/datastream/functions.py
+++ b/flink-python/pyflink/datastream/functions.py
@@ -979,9 +979,9 @@ class ProcessWindowFunction(Function, Generic[IN, OUT, KEY, W]):
         pass
 
 
-class PassThroughWindowFunction(WindowFunction):
+class PassThroughWindowFunction(WindowFunction[IN, IN, KEY, W]):
 
-    def apply(self, key: KEY, window: W, inputs: Iterable[IN]) -> Iterable[OUT]:
+    def apply(self, key: KEY, window: W, inputs: Iterable[IN]) -> Iterable[IN]:
         yield from inputs
 
 

--- a/flink-python/pyflink/datastream/tests/test_data_stream.py
+++ b/flink-python/pyflink/datastream/tests/test_data_stream.py
@@ -794,7 +794,6 @@ class DataStreamTests(object):
         self.assert_equals_sorted(expected, results)
 
     def test_time_window_reduce_passthrough(self):
-        self.env.set_parallelism(1)
         data_stream = self.env.from_collection([
             ('a', 1), ('a', 2), ('b', 3), ('a', 6), ('b', 8), ('b', 9), ('a', 15)],
             type_info=Types.TUPLE([Types.STRING(), Types.INT()]))  # type: DataStream
@@ -804,7 +803,7 @@ class DataStreamTests(object):
             .key_by(lambda x: x[0], key_type=Types.STRING()) \
             .window(SimpleMergeTimeWindowAssigner()) \
             .reduce(lambda a, b: (b[0], a[1] + b[1]),
-                    result_type=Types.TUPLE([Types.STRING(), Types.INT()])) \
+                    output_type=Types.TUPLE([Types.STRING(), Types.INT()])) \
             .add_sink(self.test_sink)
 
         self.env.execute('test_time_window_reduce_passthrough')
@@ -813,7 +812,6 @@ class DataStreamTests(object):
         self.assert_equals_sorted(expected, results)
 
     def test_time_window_reduce_process(self):
-        self.env.set_parallelism(1)
         data_stream = self.env.from_collection([
             ('a', 1), ('a', 2), ('b', 3), ('a', 6), ('b', 8), ('b', 9), ('a', 15)],
             type_info=Types.TUPLE([Types.STRING(), Types.INT()]))  # type: DataStream
@@ -837,7 +835,7 @@ class DataStreamTests(object):
             .window(SimpleMergeTimeWindowAssigner()) \
             .reduce(lambda a, b: (b[0], a[1] + b[1]),
                     window_function=MyProcessFunction(),
-                    result_type=Types.STRING()) \
+                    output_type=Types.STRING()) \
             .add_sink(self.test_sink)
 
         self.env.execute('test_time_window_reduce_process')

--- a/flink-python/pyflink/datastream/tests/test_data_stream.py
+++ b/flink-python/pyflink/datastream/tests/test_data_stream.py
@@ -21,7 +21,6 @@ import os
 import uuid
 
 from pyflink.common import Row, Configuration
-from pyflink.common.serializer import TypeSerializer
 from pyflink.common.time import Time
 from pyflink.common.typeinfo import Types
 from pyflink.common.watermark_strategy import WatermarkStrategy, TimestampAssigner
@@ -30,15 +29,11 @@ from pyflink.datastream.data_stream import DataStream
 from pyflink.datastream.functions import (AggregateFunction, CoMapFunction, CoFlatMapFunction,
                                           MapFunction, FilterFunction, FlatMapFunction,
                                           KeyedCoProcessFunction, KeyedProcessFunction, KeySelector,
-                                          ProcessFunction, ProcessWindowFunction, ReduceFunction,
-                                          WindowFunction, KEY, IN)
                                           ProcessFunction, ReduceFunction)
 from pyflink.datastream.state import (ValueStateDescriptor, ListStateDescriptor, MapStateDescriptor,
                                       ReducingStateDescriptor, ReducingState, AggregatingState,
                                       AggregatingStateDescriptor, StateTtlConfig)
 from pyflink.datastream.tests.test_util import DataStreamTestSinkFunction
-from pyflink.datastream.window import (CountWindowSerializer, MergingWindowAssigner, TimeWindow,
-                                       TimeWindowSerializer)
 from pyflink.java_gateway import get_gateway
 from pyflink.testing.test_case_utils import PyFlinkBatchTestCase, PyFlinkStreamingTestCase
 from pyflink.util.java_utils import get_j_env_configuration
@@ -760,93 +755,6 @@ class DataStreamTests(object):
         expected = ['(1,hi)', '(2,hello)', '(4,hi)', '(6,hello)', '(9,hi)', '(12,hello)']
         self.assert_equals_sorted(expected, results)
 
-    def test_count_window(self):
-        self.env.set_parallelism(2)
-        data_stream = self.env.from_collection([
-            (1, 'hi'), (2, 'hello'), (3, 'hi'), (4, 'hello'), (5, 'hi'), (6, 'hello')],
-            type_info=Types.TUPLE([Types.INT(), Types.STRING()]))  # type: DataStream
-        data_stream.key_by(lambda x: x[1], key_type=Types.STRING()) \
-            .window(SimpleCountWindowAssigner()) \
-            .apply(SumWindowFunction(), Types.TUPLE([Types.STRING(), Types.INT()])) \
-            .add_sink(self.test_sink)
-
-        self.env.execute('test_count_window')
-        results = self.test_sink.get_results()
-        expected = ['(hello,12)', '(hi,9)']
-        self.assert_equals_sorted(expected, results)
-
-    def test_time_window(self):
-        self.env.set_parallelism(1)
-        data_stream = self.env.from_collection([
-            ('hi', 1), ('hi', 2), ('hi', 3), ('hi', 6), ('hi', 8), ('hi', 9), ('hi', 15)],
-            type_info=Types.TUPLE([Types.STRING(), Types.INT()]))  # type: DataStream
-        watermark_strategy = WatermarkStrategy.for_monotonous_timestamps() \
-            .with_timestamp_assigner(SecondColumnTimestampAssigner())
-        data_stream.assign_timestamps_and_watermarks(watermark_strategy) \
-            .key_by(lambda x: x[0], key_type=Types.STRING()) \
-            .window(SimpleMergeTimeWindowAssigner()) \
-            .process(CountWindowProcessFunction(), Types.TUPLE([Types.STRING(), Types.INT()])) \
-            .add_sink(self.test_sink)
-
-        self.env.execute('test_time_window')
-        results = self.test_sink.get_results()
-        expected = ['(hi,1)', '(hi,1)', '(hi,2)', '(hi,3)']
-        self.assert_equals_sorted(expected, results)
-
-    def test_time_window_reduce_passthrough(self):
-        data_stream = self.env.from_collection([
-            ('a', 1), ('a', 2), ('b', 3), ('a', 6), ('b', 8), ('b', 9), ('a', 15)],
-            type_info=Types.TUPLE([Types.STRING(), Types.INT()]))  # type: DataStream
-        watermark_strategy = WatermarkStrategy.for_monotonous_timestamps() \
-            .with_timestamp_assigner(SecondColumnTimestampAssigner())
-        data_stream.assign_timestamps_and_watermarks(watermark_strategy) \
-            .key_by(lambda x: x[0], key_type=Types.STRING()) \
-            .window(SimpleMergeTimeWindowAssigner()) \
-            .reduce(lambda a, b: (b[0], a[1] + b[1]),
-                    output_type=Types.TUPLE([Types.STRING(), Types.INT()])) \
-            .add_sink(self.test_sink)
-
-        self.env.execute('test_time_window_reduce_passthrough')
-        results = self.test_sink.get_results()
-        expected = ['(a,3)', '(a,6)', '(a,15)', '(b,3)', '(b,17)']
-        self.assert_equals_sorted(expected, results)
-
-    def test_time_window_reduce_process(self):
-        data_stream = self.env.from_collection([
-            ('a', 1), ('a', 2), ('b', 3), ('a', 6), ('b', 8), ('b', 9), ('a', 15)],
-            type_info=Types.TUPLE([Types.STRING(), Types.INT()]))  # type: DataStream
-        watermark_strategy = WatermarkStrategy.for_monotonous_timestamps() \
-            .with_timestamp_assigner(SecondColumnTimestampAssigner())
-
-        class MyProcessFunction(ProcessWindowFunction):
-
-            def clear(self, context: 'ProcessWindowFunction.Context') -> None:
-                pass
-
-            def process(self, key: KEY, context: 'ProcessWindowFunction.Context',
-                        elements: Iterable[IN]) -> Iterable[str]:
-                yield "current window start at {}, reduce result {}".format(
-                    context.window().start,
-                    next(iter(elements)),
-                )
-
-        data_stream.assign_timestamps_and_watermarks(watermark_strategy) \
-            .key_by(lambda x: x[0], key_type=Types.STRING()) \
-            .window(SimpleMergeTimeWindowAssigner()) \
-            .reduce(lambda a, b: (b[0], a[1] + b[1]),
-                    window_function=MyProcessFunction(),
-                    output_type=Types.STRING()) \
-            .add_sink(self.test_sink)
-
-        self.env.execute('test_time_window_reduce_process')
-        results = self.test_sink.get_results()
-        expected = ["current window start at 1, reduce result ('a', 3)",
-                    "current window start at 15, reduce result ('a', 15)",
-                    "current window start at 3, reduce result ('b', 3)",
-                    "current window start at 6, reduce result ('a', 6)",
-                    "current window start at 8, reduce result ('b', 17)"]
-        self.assert_equals_sorted(expected, results)
-
 
 class StreamingModeDataStreamTests(DataStreamTests, PyFlinkStreamingTestCase):
     def test_data_stream_name(self):
@@ -1358,156 +1266,3 @@ class SecondColumnTimestampAssigner(TimestampAssigner):
 
     def extract_timestamp(self, value, record_timestamp) -> int:
         return int(value[1])
-
-
-class SimpleCountWindowTrigger(Trigger[tuple, CountWindow]):
-
-    def __init__(self):
-        self._window_size = 3
-        self._count_state_descriptor = ReducingStateDescriptor(
-            "trigger_counter", lambda a, b: a + b, Types.BIG_INT())
-
-    def on_element(self,
-                   element: tuple,
-                   timestamp: int,
-                   window: CountWindow,
-                   ctx: Trigger.TriggerContext) -> TriggerResult:
-        state = ctx.get_partitioned_state(self._count_state_descriptor)  # type: ReducingState
-        state.add(1)
-        if state.get() >= self._window_size:
-            return TriggerResult.FIRE_AND_PURGE
-        else:
-            return TriggerResult.CONTINUE
-
-    def on_processing_time(self,
-                           time: int,
-                           window: CountWindow,
-                           ctx: Trigger.TriggerContext) -> TriggerResult:
-        return TriggerResult.CONTINUE
-
-    def on_event_time(self,
-                      time: int,
-                      window: CountWindow,
-                      ctx: Trigger.TriggerContext) -> TriggerResult:
-        return TriggerResult.CONTINUE
-
-    def on_merge(self, window: CountWindow, ctx: Trigger.OnMergeContext) -> None:
-        pass
-
-    def clear(self, window: CountWindow, ctx: Trigger.TriggerContext) -> None:
-        state = ctx.get_partitioned_state(self._count_state_descriptor)
-        state.clear()
-
-
-class SimpleCountWindowAssigner(WindowAssigner[tuple, CountWindow]):
-
-    def __init__(self):
-        self._window_id = 0
-        self._window_size = 3
-        self._counter_state_descriptor = ReducingStateDescriptor(
-            "assigner_counter", lambda a, b: a + b, Types.BIG_INT())
-
-    def assign_windows(self,
-                       element: tuple,
-                       timestamp: int,
-                       context: WindowAssigner.WindowAssignerContext) -> Collection[CountWindow]:
-        counter = context.get_runtime_context().get_reducing_state(
-            self._counter_state_descriptor)
-        if counter.get() is None:
-            counter.add(0)
-        result = [CountWindow(counter.get() // self._window_size)]
-        counter.add(1)
-        return result
-
-    def get_default_trigger(self, env) -> Trigger[tuple, CountWindow]:
-        return SimpleCountWindowTrigger()
-
-    def get_window_serializer(self) -> TypeSerializer[CountWindow]:
-        return CountWindowSerializer()
-
-    def is_event_time(self) -> bool:
-        return False
-
-
-class SumWindowFunction(WindowFunction[tuple, tuple, str, CountWindow]):
-
-    def apply(self, key: str, window: CountWindow, inputs: Iterable[tuple]):
-        result = 0
-        for i in inputs:
-            result += i[0]
-        return [(key, result)]
-
-
-class SimpleTimeWindowTrigger(Trigger[tuple, TimeWindow]):
-
-    def on_element(self,
-                   element: tuple,
-                   timestamp: int,
-                   window: TimeWindow,
-                   ctx: 'Trigger.TriggerContext') -> TriggerResult:
-        return TriggerResult.CONTINUE
-
-    def on_processing_time(self,
-                           time: int,
-                           window: TimeWindow,
-                           ctx: 'Trigger.TriggerContext') -> TriggerResult:
-        return TriggerResult.CONTINUE
-
-    def on_event_time(self,
-                      time: int,
-                      window: TimeWindow,
-                      ctx: 'Trigger.TriggerContext') -> TriggerResult:
-        if time >= window.max_timestamp():
-            return TriggerResult.FIRE_AND_PURGE
-        else:
-            return TriggerResult.CONTINUE
-
-    def on_merge(self,
-                 window: TimeWindow,
-                 ctx: 'Trigger.OnMergeContext') -> None:
-        pass
-
-    def clear(self,
-              window: TimeWindow,
-              ctx: 'Trigger.TriggerContext') -> None:
-        pass
-
-
-class SimpleMergeTimeWindowAssigner(MergingWindowAssigner[tuple, TimeWindow]):
-
-    def merge_windows(self,
-                      windows: Iterable[TimeWindow],
-                      callback: 'MergingWindowAssigner.MergeCallback[TimeWindow]') -> None:
-        window_list = [w for w in windows]
-        window_list.sort()
-        for i in range(1, len(window_list)):
-            if window_list[i - 1].end > window_list[i].start:
-                callback.merge([window_list[i - 1], window_list[i]],
-                               TimeWindow(window_list[i - 1].start, window_list[i].end))
-
-    def assign_windows(self,
-                       element: tuple,
-                       timestamp: int,
-                       context: 'WindowAssigner.WindowAssignerContext') -> Collection[TimeWindow]:
-        return [TimeWindow(timestamp, timestamp + 2)]
-
-    def get_default_trigger(self, env) -> Trigger[tuple, TimeWindow]:
-        return SimpleTimeWindowTrigger()
-
-    def get_window_serializer(self) -> TypeSerializer[TimeWindow]:
-        return TimeWindowSerializer()
-
-    def is_event_time(self) -> bool:
-        return True
-
-
-class CountWindowProcessFunction(ProcessWindowFunction[tuple, tuple, str, CountWindow]):
-
-    def process(self,
-                key: str,
-                content: ProcessWindowFunction.Context,
-                elements: Iterable[tuple]) -> Iterable[tuple]:
-        return [(key, len([e for e in elements]))]
-
-    def clear(self, context: ProcessWindowFunction.Context) -> None:
-        pass

--- a/flink-python/pyflink/datastream/tests/test_data_stream.py
+++ b/flink-python/pyflink/datastream/tests/test_data_stream.py
@@ -21,6 +21,7 @@ import os
 import uuid
 
 from pyflink.common import Row, Configuration
+from pyflink.common.serializer import TypeSerializer
 from pyflink.common.time import Time
 from pyflink.common.typeinfo import Types
 from pyflink.common.watermark_strategy import WatermarkStrategy, TimestampAssigner
@@ -29,12 +30,16 @@ from pyflink.datastream.data_stream import DataStream
 from pyflink.datastream.functions import (AggregateFunction, CoMapFunction, CoFlatMapFunction,
                                           MapFunction, FilterFunction, FlatMapFunction,
                                           KeyedCoProcessFunction, KeyedProcessFunction, KeySelector,
+                                          ProcessFunction, ProcessWindowFunction, ReduceFunction,
+                                          WindowFunction, KEY, IN)
                                           ProcessFunction, ReduceFunction)
 from pyflink.datastream.state import (ValueStateDescriptor, ListStateDescriptor, MapStateDescriptor,
                                       ReducingStateDescriptor, ReducingState, AggregatingState,
                                       AggregatingStateDescriptor, StateTtlConfig)
-from pyflink.java_gateway import get_gateway
 from pyflink.datastream.tests.test_util import DataStreamTestSinkFunction
+from pyflink.datastream.window import (CountWindowSerializer, MergingWindowAssigner, TimeWindow,
+                                       TimeWindowSerializer)
+from pyflink.java_gateway import get_gateway
 from pyflink.testing.test_case_utils import PyFlinkBatchTestCase, PyFlinkStreamingTestCase
 from pyflink.util.java_utils import get_j_env_configuration
 
@@ -755,6 +760,95 @@ class DataStreamTests(object):
         expected = ['(1,hi)', '(2,hello)', '(4,hi)', '(6,hello)', '(9,hi)', '(12,hello)']
         self.assert_equals_sorted(expected, results)
 
+    def test_count_window(self):
+        self.env.set_parallelism(2)
+        data_stream = self.env.from_collection([
+            (1, 'hi'), (2, 'hello'), (3, 'hi'), (4, 'hello'), (5, 'hi'), (6, 'hello')],
+            type_info=Types.TUPLE([Types.INT(), Types.STRING()]))  # type: DataStream
+        data_stream.key_by(lambda x: x[1], key_type=Types.STRING()) \
+            .window(SimpleCountWindowAssigner()) \
+            .apply(SumWindowFunction(), Types.TUPLE([Types.STRING(), Types.INT()])) \
+            .add_sink(self.test_sink)
+
+        self.env.execute('test_count_window')
+        results = self.test_sink.get_results()
+        expected = ['(hello,12)', '(hi,9)']
+        self.assert_equals_sorted(expected, results)
+
+    def test_time_window(self):
+        self.env.set_parallelism(1)
+        data_stream = self.env.from_collection([
+            ('hi', 1), ('hi', 2), ('hi', 3), ('hi', 6), ('hi', 8), ('hi', 9), ('hi', 15)],
+            type_info=Types.TUPLE([Types.STRING(), Types.INT()]))  # type: DataStream
+        watermark_strategy = WatermarkStrategy.for_monotonous_timestamps() \
+            .with_timestamp_assigner(SecondColumnTimestampAssigner())
+        data_stream.assign_timestamps_and_watermarks(watermark_strategy) \
+            .key_by(lambda x: x[0], key_type=Types.STRING()) \
+            .window(SimpleMergeTimeWindowAssigner()) \
+            .process(CountWindowProcessFunction(), Types.TUPLE([Types.STRING(), Types.INT()])) \
+            .add_sink(self.test_sink)
+
+        self.env.execute('test_time_window')
+        results = self.test_sink.get_results()
+        expected = ['(hi,1)', '(hi,1)', '(hi,2)', '(hi,3)']
+        self.assert_equals_sorted(expected, results)
+
+    def test_time_window_reduce_passthrough(self):
+        self.env.set_parallelism(1)
+        data_stream = self.env.from_collection([
+            ('a', 1), ('a', 2), ('b', 3), ('a', 6), ('b', 8), ('b', 9), ('a', 15)],
+            type_info=Types.TUPLE([Types.STRING(), Types.INT()]))  # type: DataStream
+        watermark_strategy = WatermarkStrategy.for_monotonous_timestamps() \
+            .with_timestamp_assigner(SecondColumnTimestampAssigner())
+        data_stream.assign_timestamps_and_watermarks(watermark_strategy) \
+            .key_by(lambda x: x[0], key_type=Types.STRING()) \
+            .window(SimpleMergeTimeWindowAssigner()) \
+            .reduce(lambda a, b: (b[0], a[1] + b[1]),
+                    result_type=Types.TUPLE([Types.STRING(), Types.INT()])) \
+            .add_sink(self.test_sink)
+
+        self.env.execute('test_time_window_reduce_passthrough')
+        results = self.test_sink.get_results()
+        expected = ['(a,3)', '(a,6)', '(a,15)', '(b,3)', '(b,17)']
+        self.assert_equals_sorted(expected, results)
+
+    def test_time_window_reduce_process(self):
+        self.env.set_parallelism(1)
+        data_stream = self.env.from_collection([
+            ('a', 1), ('a', 2), ('b', 3), ('a', 6), ('b', 8), ('b', 9), ('a', 15)],
+            type_info=Types.TUPLE([Types.STRING(), Types.INT()]))  # type: DataStream
+        watermark_strategy = WatermarkStrategy.for_monotonous_timestamps() \
+            .with_timestamp_assigner(SecondColumnTimestampAssigner())
+
+        class MyProcessFunction(ProcessWindowFunction):
+
+            def clear(self, context: 'ProcessWindowFunction.Context') -> None:
+                pass
+
+            def process(self, key: KEY, context: 'ProcessWindowFunction.Context',
+                        elements: Iterable[IN]) -> Iterable[str]:
+                yield "current window start at {}, reduce result {}".format(
+                    context.window().start,
+                    next(iter(elements)),
+                )
+
+        data_stream.assign_timestamps_and_watermarks(watermark_strategy) \
+            .key_by(lambda x: x[0], key_type=Types.STRING()) \
+            .window(SimpleMergeTimeWindowAssigner()) \
+            .reduce(lambda a, b: (b[0], a[1] + b[1]),
+                    window_function=MyProcessFunction(),
+                    result_type=Types.STRING()) \
+            .add_sink(self.test_sink)
+
+        self.env.execute('test_time_window_reduce_process')
+        results = self.test_sink.get_results()
+        expected = ["current window start at 1, reduce result ('a', 3)",
+                    "current window start at 15, reduce result ('a', 15)",
+                    "current window start at 3, reduce result ('b', 3)",
+                    "current window start at 6, reduce result ('a', 6)",
+                    "current window start at 8, reduce result ('b', 17)"]
+        self.assert_equals_sorted(expected, results)
+
 
 class StreamingModeDataStreamTests(DataStreamTests, PyFlinkStreamingTestCase):
     def test_data_stream_name(self):
@@ -1266,3 +1360,156 @@ class SecondColumnTimestampAssigner(TimestampAssigner):
 
     def extract_timestamp(self, value, record_timestamp) -> int:
         return int(value[1])
+
+
+class SimpleCountWindowTrigger(Trigger[tuple, CountWindow]):
+
+    def __init__(self):
+        self._window_size = 3
+        self._count_state_descriptor = ReducingStateDescriptor(
+            "trigger_counter", lambda a, b: a + b, Types.BIG_INT())
+
+    def on_element(self,
+                   element: tuple,
+                   timestamp: int,
+                   window: CountWindow,
+                   ctx: Trigger.TriggerContext) -> TriggerResult:
+        state = ctx.get_partitioned_state(self._count_state_descriptor)  # type: ReducingState
+        state.add(1)
+        if state.get() >= self._window_size:
+            return TriggerResult.FIRE_AND_PURGE
+        else:
+            return TriggerResult.CONTINUE
+
+    def on_processing_time(self,
+                           time: int,
+                           window: CountWindow,
+                           ctx: Trigger.TriggerContext) -> TriggerResult:
+        return TriggerResult.CONTINUE
+
+    def on_event_time(self,
+                      time: int,
+                      window: CountWindow,
+                      ctx: Trigger.TriggerContext) -> TriggerResult:
+        return TriggerResult.CONTINUE
+
+    def on_merge(self, window: CountWindow, ctx: Trigger.OnMergeContext) -> None:
+        pass
+
+    def clear(self, window: CountWindow, ctx: Trigger.TriggerContext) -> None:
+        state = ctx.get_partitioned_state(self._count_state_descriptor)
+        state.clear()
+
+
+class SimpleCountWindowAssigner(WindowAssigner[tuple, CountWindow]):
+
+    def __init__(self):
+        self._window_id = 0
+        self._window_size = 3
+        self._counter_state_descriptor = ReducingStateDescriptor(
+            "assigner_counter", lambda a, b: a + b, Types.BIG_INT())
+
+    def assign_windows(self,
+                       element: tuple,
+                       timestamp: int,
+                       context: WindowAssigner.WindowAssignerContext) -> Collection[CountWindow]:
+        counter = context.get_runtime_context().get_reducing_state(
+            self._counter_state_descriptor)
+        if counter.get() is None:
+            counter.add(0)
+        result = [CountWindow(counter.get() // self._window_size)]
+        counter.add(1)
+        return result
+
+    def get_default_trigger(self, env) -> Trigger[tuple, CountWindow]:
+        return SimpleCountWindowTrigger()
+
+    def get_window_serializer(self) -> TypeSerializer[CountWindow]:
+        return CountWindowSerializer()
+
+    def is_event_time(self) -> bool:
+        return False
+
+
+class SumWindowFunction(WindowFunction[tuple, tuple, str, CountWindow]):
+
+    def apply(self, key: str, window: CountWindow, inputs: Iterable[tuple]):
+        result = 0
+        for i in inputs:
+            result += i[0]
+        return [(key, result)]
+
+
+class SimpleTimeWindowTrigger(Trigger[tuple, TimeWindow]):
+
+    def on_element(self,
+                   element: tuple,
+                   timestamp: int,
+                   window: TimeWindow,
+                   ctx: 'Trigger.TriggerContext') -> TriggerResult:
+        return TriggerResult.CONTINUE
+
+    def on_processing_time(self,
+                           time: int,
+                           window: TimeWindow,
+                           ctx: 'Trigger.TriggerContext') -> TriggerResult:
+        return TriggerResult.CONTINUE
+
+    def on_event_time(self,
+                      time: int,
+                      window: TimeWindow,
+                      ctx: 'Trigger.TriggerContext') -> TriggerResult:
+        if time >= window.max_timestamp():
+            return TriggerResult.FIRE_AND_PURGE
+        else:
+            return TriggerResult.CONTINUE
+
+    def on_merge(self,
+                 window: TimeWindow,
+                 ctx: 'Trigger.OnMergeContext') -> None:
+        pass
+
+    def clear(self,
+              window: TimeWindow,
+              ctx: 'Trigger.TriggerContext') -> None:
+        pass
+
+
+class SimpleMergeTimeWindowAssigner(MergingWindowAssigner[tuple, TimeWindow]):
+
+    def merge_windows(self,
+                      windows: Iterable[TimeWindow],
+                      callback: 'MergingWindowAssigner.MergeCallback[TimeWindow]') -> None:
+        window_list = [w for w in windows]
+        window_list.sort()
+        for i in range(1, len(window_list)):
+            if window_list[i - 1].end > window_list[i].start:
+                callback.merge([window_list[i - 1], window_list[i]],
+                               TimeWindow(window_list[i - 1].start, window_list[i].end))
+
+    def assign_windows(self,
+                       element: tuple,
+                       timestamp: int,
+                       context: 'WindowAssigner.WindowAssignerContext') -> Collection[TimeWindow]:
+        return [TimeWindow(timestamp, timestamp + 2)]
+
+    def get_default_trigger(self, env) -> Trigger[tuple, TimeWindow]:
+        return SimpleTimeWindowTrigger()
+
+    def get_window_serializer(self) -> TypeSerializer[TimeWindow]:
+        return TimeWindowSerializer()
+
+    def is_event_time(self) -> bool:
+        return True
+
+
+class CountWindowProcessFunction(ProcessWindowFunction[tuple, tuple, str, CountWindow]):
+
+    def process(self,
+                key: str,
+                content: ProcessWindowFunction.Context,
+                elements: Iterable[tuple]) -> Iterable[tuple]:
+        return [(key, len([e for e in elements]))]
+
+    def clear(self, context: ProcessWindowFunction.Context) -> None:
+        pass


### PR DESCRIPTION
## What is the purpose of the change

This pull request implements `WindowedStream.reduce` in Python DataStream API.

## Verifying this change

This change added tests and can be verified as follows:
  - Added integration tests in test_data_stream.py

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (Sphinx doc)
