### PR TITLE
[hotfix][table-planner] RawToBinaryCastRule can fail

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/RawToBinaryCastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/RawToBinaryCastRule.java
@@ -43,6 +43,11 @@ class RawToBinaryCastRule extends AbstractNullAwareCodeGeneratorCastRule<Object,
                         .build());
     }
 
+    @Override
+    public boolean canFail(LogicalType inputLogicalType, LogicalType targetLogicalType) {
+        return true;
+    }
+
     /* Example generated code for BINARY(3):
 
     // legacy behavior


### PR DESCRIPTION
Reintroducing the change removed by https://github.com/apache/flink/commit/d212b83fddb53f2ec0363b6c08cd3cabb3c02990