### PR TITLE
[FLINK-26388][docs] Adds information about missed out artifacts in repeatable cleanup with a reference to the FLINK issue

### DIFF
--- a/docs/content.zh/docs/deployment/overview.md
+++ b/docs/content.zh/docs/deployment/overview.md
@@ -159,6 +159,11 @@ external component resources associated with the job are then cleaned up. In the
 failure when cleaning up a resource, Flink will attempt to retry the cleanup. You can
 [configure]({{< ref "docs/deployment/config#retryable-cleanup" >}}) the retry strategy used.
 
+There is currently an issue with the cleanup of CompletedCheckpoints that failed to be deleted
+while subsuming them as part of the usual CompletedCheckpoint management. These artifacts are
+not covered by the repeatable cleanup, i.e. they have to be deleted manually, still. This is
+covered by [FLINK-26606](https://issues.apache.org/jira/browse/FLINK-26606).
+
 ## Deployment Modes
 
 Flink can execute applications in one of three ways:

--- a/docs/content/docs/deployment/overview.md
+++ b/docs/content/docs/deployment/overview.md
@@ -160,6 +160,11 @@ external component resources associated with the job are then cleaned up. In the
 failure when cleaning up a resource, Flink will attempt to retry the cleanup. You can
 [configure]({{< ref "docs/deployment/config#retryable-cleanup" >}}) the retry strategy used.
 
+There is currently an issue with the cleanup of CompletedCheckpoints that failed to be deleted 
+while subsuming them as part of the usual CompletedCheckpoint management. These artifacts are 
+not covered by the repeatable cleanup, i.e. they have to be deleted manually, still. This is 
+covered by [FLINK-26606](https://issues.apache.org/jira/browse/FLINK-26606).
+
 ## Deployment Modes
 
 Flink can execute applications in one of three ways:


### PR DESCRIPTION
## What is the purpose of the change

* Adds reference to FLINK-26606 to inform the user on some on-going bug in the cleanup of CompletedCheckpoints that failed to be discarded

## Brief change log

* Update of repeatable cleanup documentation

## Verifying this change

* Build docs locally and verified the change in the Chinese and English version

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
