### PR TITLE
[FLINK-25771][connectors][Cassandra][tests][flaky] Remove testRetrialAndDropTables and make drop tables atomic

### DIFF
--- a/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraConnectorITCase.java
+++ b/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraConnectorITCase.java
@@ -62,7 +62,6 @@ import com.datastax.driver.mapping.annotations.Table;
 import net.bytebuddy.ByteBuddy;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
@@ -177,8 +176,6 @@ public class CassandraConnectorITCase
                     + " int, "
                     + TUPLE_BATCHID_FIELD
                     + " int);";
-    private static final String DROP_TABLE_QUERY =
-            "DROP TABLE " + KEYSPACE + "." + TABLE_NAME_VARIABLE + " ;";
     private static final String INSERT_DATA_QUERY =
             "INSERT INTO "
                     + KEYSPACE
@@ -396,13 +393,6 @@ public class CassandraConnectorITCase
     public void createTable() {
         tableID = random.nextInt(Integer.MAX_VALUE);
         session.execute(injectTableName(CREATE_TABLE_QUERY));
-    }
-
-    @After
-    public void dropTable() {
-        // each Before updates the tableID and it is called even in case or retrials. So, we need to
-        // drop only the created table for this test
-        session.execute(injectTableName(DROP_TABLE_QUERY));
     }
 
     @AfterClass

--- a/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraConnectorITCase.java
+++ b/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraConnectorITCase.java
@@ -164,7 +164,6 @@ public class CassandraConnectorITCase
             "CREATE KEYSPACE "
                     + KEYSPACE
                     + " WITH replication= {'class':'SimpleStrategy', 'replication_factor':1};";
-    private static final String DROP_KEYSPACE_QUERY = "DROP KEYSPACE IF EXISTS " + KEYSPACE + " ;";
     private static final String CREATE_TABLE_QUERY =
             "CREATE TABLE "
                     + KEYSPACE
@@ -177,6 +176,8 @@ public class CassandraConnectorITCase
                     + " int, "
                     + TUPLE_BATCHID_FIELD
                     + " int);";
+    private static final String DROP_TABLE_QUERY =
+            "DROP TABLE " + KEYSPACE + "." + TABLE_NAME_VARIABLE + " ;";
     private static final String INSERT_DATA_QUERY =
             "INSERT INTO "
                     + KEYSPACE
@@ -383,7 +384,6 @@ public class CassandraConnectorITCase
                 }
             }
         }
-        session.execute(DROP_KEYSPACE_QUERY);
         session.execute(CREATE_KEYSPACE_QUERY);
         session.execute(
                 CREATE_TABLE_QUERY.replace(TABLE_NAME_VARIABLE, TABLE_NAME_PREFIX + "initial"));
@@ -396,11 +396,10 @@ public class CassandraConnectorITCase
     }
 
     @After
-    public void dropTables() {
-        // need to drop tables in case of retrials. Need to drop all the tables
-        // that are created in test because this method is executed with every test
-        session.execute(DROP_KEYSPACE_QUERY);
-        session.execute(CREATE_KEYSPACE_QUERY);
+    public void dropTable() {
+        // each Before updates the tableID and it is called even in case or retrials. So, we need to
+        // drop only the created table for this test
+        session.execute(injectTableName(DROP_TABLE_QUERY));
     }
 
     @AfterClass

--- a/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraConnectorITCase.java
+++ b/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraConnectorITCase.java
@@ -401,8 +401,10 @@ public class CassandraConnectorITCase
     public void dropTables() {
         // need to drop tables in case of retrials. Need to drop all the tables
         // that are created in test because this method is executed with every test
-        session.execute(DROP_KEYSPACE_QUERY);
-        session.execute(CREATE_KEYSPACE_QUERY);
+        synchronized (this) {
+            session.execute(DROP_KEYSPACE_QUERY);
+            session.execute(CREATE_KEYSPACE_QUERY);
+        }
     }
 
     @AfterClass

--- a/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraConnectorITCase.java
+++ b/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraConnectorITCase.java
@@ -383,10 +383,6 @@ public class CassandraConnectorITCase
             }
         }
         session.execute(CREATE_KEYSPACE_QUERY);
-        /*
-                session.execute(
-                        CREATE_TABLE_QUERY.replace(TABLE_NAME_VARIABLE, TABLE_NAME_PREFIX + "initial"));
-        */
     }
 
     @Before

--- a/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraConnectorITCase.java
+++ b/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraConnectorITCase.java
@@ -86,6 +86,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Random;
 import java.util.UUID;
@@ -713,6 +714,19 @@ public class CassandraConnectorITCase
         }
         Assert.assertTrue(
                 "The input data was not completely written to Cassandra", input.isEmpty());
+    }
+
+    private static int retrialsCount = 0;
+
+    @Test
+    public void testRetrialAndDropTable() {
+        // should not fail with table exists upon retrial
+        // as @After method that drops the table is called upon retrials.
+        annotatePojoWithTable(KEYSPACE, TABLE_NAME_PREFIX + tableID);
+        if (retrialsCount < 2) {
+            retrialsCount++;
+            throw new NoHostAvailableException(new HashMap<>());
+        }
     }
 
     @Test

--- a/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraConnectorITCase.java
+++ b/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraConnectorITCase.java
@@ -165,8 +165,6 @@ public class CassandraConnectorITCase
                     + KEYSPACE
                     + " WITH replication= {'class':'SimpleStrategy', 'replication_factor':1};";
     private static final String DROP_KEYSPACE_QUERY = "DROP KEYSPACE IF EXISTS " + KEYSPACE + " ;";
-    private static final String DROP_TABLE_QUERY =
-            "DROP TABLE IF EXISTS " + KEYSPACE + "." + TABLE_NAME_VARIABLE + " ;";
     private static final String CREATE_TABLE_QUERY =
             "CREATE TABLE "
                     + KEYSPACE
@@ -719,8 +717,6 @@ public class CassandraConnectorITCase
         Assert.assertTrue(
                 "The input data was not completely written to Cassandra", input.isEmpty());
     }
-
-    private static int retrialsCount = 0;
 
     @Test
     public void testCassandraBatchPojoFormat() throws Exception {

--- a/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraConnectorITCase.java
+++ b/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraConnectorITCase.java
@@ -711,9 +711,7 @@ public class CassandraConnectorITCase
     private static int retrialsCount = 0;
 
     @Test
-    public void testRetrialAndDropTable() {
-        // should not fail with table exists upon retrial
-        // as @After method that drops the table is called upon retrials.
+    public void testRetrial() {
         annotatePojoWithTable(KEYSPACE, TABLE_NAME_PREFIX + tableID);
         if (retrialsCount < 2) {
             retrialsCount++;

--- a/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraConnectorITCase.java
+++ b/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraConnectorITCase.java
@@ -86,7 +86,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Random;
 import java.util.UUID;
@@ -720,17 +719,6 @@ public class CassandraConnectorITCase
     }
 
     private static int retrialsCount = 0;
-
-    @Test
-    public void testRetrialAndDropTables() {
-        // should not fail with table exists upon retrial
-        // as @After method that truncate the keyspace is called upon retrials.
-        annotatePojoWithTable(KEYSPACE, TABLE_NAME_PREFIX + tableID);
-        if (retrialsCount < 2) {
-            retrialsCount++;
-            throw new NoHostAvailableException(new HashMap<>());
-        }
-    }
 
     @Test
     public void testCassandraBatchPojoFormat() throws Exception {

--- a/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraConnectorITCase.java
+++ b/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraConnectorITCase.java
@@ -399,10 +399,8 @@ public class CassandraConnectorITCase
     public void dropTables() {
         // need to drop tables in case of retrials. Need to drop all the tables
         // that are created in test because this method is executed with every test
-        synchronized (this) {
-            session.execute(DROP_KEYSPACE_QUERY);
-            session.execute(CREATE_KEYSPACE_QUERY);
-        }
+        session.execute(DROP_KEYSPACE_QUERY);
+        session.execute(CREATE_KEYSPACE_QUERY);
     }
 
     @AfterClass

--- a/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraConnectorITCase.java
+++ b/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraConnectorITCase.java
@@ -386,8 +386,10 @@ public class CassandraConnectorITCase
             }
         }
         session.execute(CREATE_KEYSPACE_QUERY);
-        session.execute(
-                CREATE_TABLE_QUERY.replace(TABLE_NAME_VARIABLE, TABLE_NAME_PREFIX + "initial"));
+        /*
+                session.execute(
+                        CREATE_TABLE_QUERY.replace(TABLE_NAME_VARIABLE, TABLE_NAME_PREFIX + "initial"));
+        */
     }
 
     @Before


### PR DESCRIPTION
I took a look at the history of flaky test and found that:
**testCassandraBatchTupleFormat failure** https://dev.azure.com/apache-flink/apache-flink/_build/results?buildId=32816&view=results
**testCassandraScalaTuplePartialColumnUpdate** failure https://dev.azure.com/apache-flink/apache-flink/_build/results?buildId=32571&view=resultstestCassandraScalaTuplePartialColumnUpdate
**testCassandraTableSink failure** https://dev.azure.com/apache-flink/apache-flink/_build/results?buildId=32272

They fail because the keyspace does not exist while executing create table (in before) whereas the keyspace is created in before class. My guess it that drop tables (in after) is not atomic and drops the keyspace in between. Hence my commit for making it atomic.

The other failures I see are timeouts in only `testRetrialAndDropTables` method. But this test is no more relevant as the table names are now dynamic. Simply remove this test

R: @XComp 