### PR TITLE
[FLINK-26532][metrics][test] using the numRecordsSend counter to get the correct metric

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkMetricsITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkMetricsITCase.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.connector.sink.Sink;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.Metric;
 import org.apache.flink.metrics.groups.OperatorMetricGroup;
 import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
@@ -120,6 +121,7 @@ public class SinkMetricsITCase extends TestLogger {
         jobClient.getJobExecutionResult().get();
     }
 
+    @SuppressWarnings("checkstyle:WhitespaceAfter")
     private void assertSinkMetrics(
             JobID jobId, long processedRecordsPerSubtask, int parallelism, int numSplits) {
         List<OperatorMetricGroup> groups =
@@ -130,8 +132,10 @@ public class SinkMetricsITCase extends TestLogger {
         int subtaskWithMetrics = 0;
         for (OperatorMetricGroup group : groups) {
             Map<String, Metric> metrics = reporter.getMetricsByGroup(group);
-            // there are only 2 splits assigned; so two groups will not update metrics
-            if (group.getIOMetricGroup().getNumRecordsOutCounter().getCount() != 0) {
+            // There are only 2 splits assigned; so two groups will not update metrics.
+            // There is no other way to access the counter via OperatorMetricGroup, we have to use
+            // metrics from the reporter.
+            if (((Counter) metrics.get(MetricNames.NUM_RECORDS_SEND)).getCount() == 0) {
                 continue;
             }
             subtaskWithMetrics++;


### PR DESCRIPTION
## What is the purpose of the change

Fix the flaky test in SinkMetricsITCase. The previous check solution could not provide the guaranty of getting the correct metrics.

Since the target metric `numRecordsSend` for this test case is initialized in `SinkWriterMetricGroup` via parent `OperatorMetricGroup` and the SinkMetricsITCase is working on the abstract layer of `OperatorMetricGroup`, there is no direct access to the `SinkWriterMetricGroup` and to the `numRecordsSend` counter.


## Brief change log

*(for example:)*
  - check the metric by getting the numRecordsSend metric from `InMemoryReporter` and cast it to `Counter`

## Verifying this change

This change is to fix a flaky test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
