### PR TITLE
[FLINK-26610] FileSink can not upgrade from 1.13 if the uid of the origin sink is not set

### DIFF
--- a/docs/content.zh/docs/connectors/datastream/filesystem.md
+++ b/docs/content.zh/docs/connectors/datastream/filesystem.md
@@ -1025,7 +1025,9 @@ val fileSink: FileSink[Integer] =
   这种类型的 `CompactingFileWriter` 会逐条读出输入文件的记录用户，然后和`FileWriter`一样写入输出文件中。`CompactingFileWriter` 的一个例子是 {{< javadoc file="org/apache/flink/connector/file/sink/compactor/RecordWiseFileCompactor.html" name="RecordWiseFileCompactor">}} ，它从给定的文件中读出记录并写出到 `CompactingFileWriter` 中。用户需要指定如何从原始文件中读出记录。
 
 {{< hint info >}}
-**重要** 如果启用了文件合并功能，文件可见的时间会被延长。
+**注意事项1** 一旦启用了文件合并功能，此后若需要再关闭，必须在构建`FileSink`时显式调用`disableCompact`方法。
+
+**注意事项2** 如果启用了文件合并功能，文件可见的时间会被延长。
 {{< /hint >}}
 
 <a name="important-considerations"></a>

--- a/docs/content/docs/connectors/datastream/filesystem.md
+++ b/docs/content/docs/connectors/datastream/filesystem.md
@@ -1026,7 +1026,9 @@ the give list of `Path` and write the result file. It could be classified into t
   An example is the {{< javadoc file="org/apache/flink/connector/file/sink/compactor/RecordWiseFileCompactor.html" name="RecordWiseFileCompactor">}} that reads records from the source files and then writes them with the `CompactingFileWriter`. Users need to specify how to read records from the source files.
 
 {{< hint info >}}
-**Important** Once the compaction is enabled, the written files need to wait for longer time before they get visible.
+**Important Note 1** Once the compaction is enabled, you must explicitly call `disableCompact` when building the `FileSink` if you want to disable compaction.
+
+**Important Note 2** When the compaction is enabled, the written files need to wait for longer time before they get visible.
 {{< /hint >}}
 
 ### Important Considerations

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/FileSink.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/FileSink.java
@@ -117,6 +117,11 @@ import static org.apache.flink.util.Preconditions.checkState;
  * finished} state while any {@code in-progress} files are rolled back, so that they do not contain
  * data that arrived after the checkpoint from which we restore.
  *
+ * <p>FileSink also support compacting small files to accelerate the access speed of the resulted
+ * files. Compaction could be enabled via {@code enableCompact}. Once enabled, the compaction could
+ * only be disabled via calling {@code disableCompact} explicitly, otherwise there might be data
+ * loss.
+ *
  * @param <IN> Type of the elements in the input of the sink that are also the elements to be
  *     written to its output
  */

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/BatchCompactingFileSinkITCase.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/BatchCompactingFileSinkITCase.java
@@ -28,6 +28,7 @@ import org.apache.flink.connector.file.sink.utils.PartSizeAndCheckpointRollingPo
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.minicluster.RpcServiceSharing;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.streaming.api.datastream.DataStreamSink;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
 
 import org.junit.Rule;
@@ -58,6 +59,11 @@ public class BatchCompactingFileSinkITCase extends BatchExecutionFileSinkITCase 
                 .withRollingPolicy(new PartSizeAndCheckpointRollingPolicy<>(1024, false))
                 .enableCompact(createFileCompactStrategy(), createFileCompactor())
                 .build();
+    }
+
+    @Override
+    protected void configureSink(DataStreamSink<Integer> sink) {
+        sink.uid("sink");
     }
 
     private static FileCompactor createFileCompactor() {

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/BatchExecutionFileSinkITCase.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/BatchExecutionFileSinkITCase.java
@@ -74,7 +74,8 @@ public class BatchExecutionFileSinkITCase extends FileSinkITBase {
                 .map(new BatchExecutionOnceFailingMap(NUM_RECORDS, triggerFailover))
                 .setParallelism(NUM_SINKS)
                 .sinkTo(createFileSink(path))
-                .setParallelism(NUM_SINKS);
+                .setParallelism(NUM_SINKS)
+                .uid("sink");
 
         StreamGraph streamGraph = env.getStreamGraph();
         return streamGraph.getJobGraph();

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/BatchExecutionFileSinkITCase.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/BatchExecutionFileSinkITCase.java
@@ -27,6 +27,7 @@ import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.streaming.api.datastream.DataStreamSink;
 import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
@@ -69,17 +70,20 @@ public class BatchExecutionFileSinkITCase extends FileSinkITBase {
                         "Source",
                         Boundedness.BOUNDED);
 
-        source.setParallelism(NUM_SOURCES)
-                .rebalance()
-                .map(new BatchExecutionOnceFailingMap(NUM_RECORDS, triggerFailover))
-                .setParallelism(NUM_SINKS)
-                .sinkTo(createFileSink(path))
-                .setParallelism(NUM_SINKS)
-                .uid("sink");
+        DataStreamSink<Integer> sink =
+                source.setParallelism(NUM_SOURCES)
+                        .rebalance()
+                        .map(new BatchExecutionOnceFailingMap(NUM_RECORDS, triggerFailover))
+                        .setParallelism(NUM_SINKS)
+                        .sinkTo(createFileSink(path))
+                        .setParallelism(NUM_SINKS);
+        configureSink(sink);
 
         StreamGraph streamGraph = env.getStreamGraph();
         return streamGraph.getJobGraph();
     }
+
+    protected void configureSink(DataStreamSink<Integer> sink) {}
 
     // ------------------------ Blocking mode user functions ----------------------------------
 

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/StreamingCompactingFileSinkITCase.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/StreamingCompactingFileSinkITCase.java
@@ -28,6 +28,7 @@ import org.apache.flink.connector.file.sink.utils.PartSizeAndCheckpointRollingPo
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.minicluster.RpcServiceSharing;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.streaming.api.datastream.DataStreamSink;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
 
 import org.junit.Rule;
@@ -58,6 +59,11 @@ public class StreamingCompactingFileSinkITCase extends StreamingExecutionFileSin
                 .withRollingPolicy(new PartSizeAndCheckpointRollingPolicy<>(1024, false))
                 .enableCompact(createFileCompactStrategy(), createFileCompactor())
                 .build();
+    }
+
+    @Override
+    protected void configureSink(DataStreamSink<Integer> sink) {
+        sink.uid("sink");
     }
 
     private static FileCompactor createFileCompactor() {

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/StreamingExecutionFileSinkITCase.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/StreamingExecutionFileSinkITCase.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
 import org.apache.flink.streaming.api.CheckpointingMode;
 import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
+import org.apache.flink.streaming.api.datastream.DataStreamSink;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
 import org.apache.flink.streaming.api.graph.StreamGraph;
@@ -89,15 +90,20 @@ public class StreamingExecutionFileSinkITCase extends FileSinkITBase {
             env.setRestartStrategy(RestartStrategies.noRestart());
         }
 
-        env.addSource(new StreamingExecutionTestSource(latchId, NUM_RECORDS, triggerFailover))
-                .setParallelism(NUM_SOURCES)
-                .sinkTo(createFileSink(path))
-                .setParallelism(NUM_SINKS)
-                .uid("sink");
+        DataStreamSink<Integer> sink =
+                env.addSource(
+                                new StreamingExecutionTestSource(
+                                        latchId, NUM_RECORDS, triggerFailover))
+                        .setParallelism(NUM_SOURCES)
+                        .sinkTo(createFileSink(path))
+                        .setParallelism(NUM_SINKS);
+        configureSink(sink);
 
         StreamGraph streamGraph = env.getStreamGraph();
         return streamGraph.getJobGraph();
     }
+
+    protected void configureSink(DataStreamSink<Integer> sink) {}
 
     // ------------------------ Streaming mode user functions ----------------------------------
 

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/StreamingExecutionFileSinkITCase.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/StreamingExecutionFileSinkITCase.java
@@ -92,7 +92,8 @@ public class StreamingExecutionFileSinkITCase extends FileSinkITBase {
         env.addSource(new StreamingExecutionTestSource(latchId, NUM_RECORDS, triggerFailover))
                 .setParallelism(NUM_SOURCES)
                 .sinkTo(createFileSink(path))
-                .setParallelism(NUM_SINKS);
+                .setParallelism(NUM_SINKS)
+                .uid("sink");
 
         StreamGraph streamGraph = env.getStreamGraph();
         return streamGraph.getJobGraph();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/SinkTransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/SinkTransformationTranslator.java
@@ -262,7 +262,10 @@ public class SinkTransformationTranslator<Input, Output>
                 if (isExpandedTopology && subUid != null && !subUid.isEmpty()) {
                     checkState(
                             transformation.getUid() != null && !transformation.getUid().isEmpty(),
-                            "Sink:" + transformation.getName() + " requires to set a uid");
+                            "Sink "
+                                    + transformation.getName()
+                                    + " requires to set a uid since its customized topology"
+                                    + " has set uid for some operators.");
                 }
 
                 concatUid(


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

There are problems if users using FileSink want to upgrade their Flink from 1.13 to the latest 1.15. This pull request fixes some of them relating to the compaction.


## Brief change log

  - Check if the uid is set if the compaction is enabled, to ensure the state can be managed properly.
  - Allow a job of 1.13 with a FileSink whose uid is not set to be upgraded to 1.15, by not changing the topology.
  - Since compactor place holder can be omitted, disabling compaction must be explicit .

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? relating docs are modified.
