### PR TITLE
[FLINK-26615][tests] Fix timings in BatchingStateChangeUploadSchedulerTest.testUploadTimeout

### DIFF
--- a/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/BatchingStateChangeUploadSchedulerTest.java
+++ b/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/BatchingStateChangeUploadSchedulerTest.java
@@ -220,19 +220,19 @@ public class BatchingStateChangeUploadSchedulerTest {
                 new ManuallyTriggeredScheduledExecutorService();
         BlockingUploader uploader = new BlockingUploader();
         try (BatchingStateChangeUploadScheduler store =
-                scheduler(numAttempts, executorService, uploader, 10)) {
+                scheduler(numAttempts, executorService, uploader, 50)) {
             store.upload(upload);
             Deadline deadline = Deadline.fromNow(Duration.ofMinutes(5));
             while (uploader.getUploadsCount() < numAttempts - 1 && deadline.hasTimeLeft()) {
                 executorService.triggerScheduledTasks();
                 executorService.triggerAll();
-                Thread.sleep(10);
+                Thread.sleep(1); // should be less than timeout to avoid all attempts timing out
             }
             uploader.unblock();
             while (!upload.finished.get() && deadline.hasTimeLeft()) {
                 executorService.triggerScheduledTasks();
                 executorService.triggerAll();
-                Thread.sleep(10);
+                Thread.sleep(1);
             }
         }
 


### PR DESCRIPTION
## What is the purpose of the change

`BatchingStateChangeUploadSchedulerTest.testRetryOnTimeout` might fail if all attempts time out before 
the check is performed and the underlying uploader is unblocked.

This change increases the difference between those timings, so that the check is much faster.  

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
