### PR TITLE
[FLINK-26047][yarn] Support remote usrlib in HDFS for YARN deployment

### DIFF
--- a/docs/layouts/shortcodes/generated/yarn_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/yarn_config_configuration.html
@@ -135,6 +135,12 @@
             <td>A semicolon-separated list of provided lib directories. They should be pre-uploaded and world-readable. Flink will use them to exclude the local Flink jars(e.g. flink-dist, lib/, plugins/)uploading to accelerate the job submission process. Also YARN will cache them on the nodes so that they doesn't need to be downloaded every time for each application. An example could be hdfs://$namenode_address/path/of/flink/lib</td>
         </tr>
         <tr>
+            <td><h5>yarn.provided.usrlib.dir</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>The provided usrlib directory in remote. It should be pre-uploaded and world-readable. Flink will use it to exclude the local usrlib directory(i.e. usrlib/ under the parent directory of FLINK_LIB_DIR). Unlike yarn.provided.lib.dirs, YARN will not cache it on the nodes as it is for each application. An example could be hdfs://$namenode_address/path/of/flink/usrlib</td>
+        </tr>
+        <tr>
             <td><h5>yarn.security.kerberos.localized-keytab-path</h5></td>
             <td style="word-wrap: break-word;">"krb5.keytab"</td>
             <td>String</td>

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
@@ -19,12 +19,12 @@
 package org.apache.flink.yarn;
 
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.ConfigUtils;
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
 import org.apache.flink.runtime.clusterframework.ContaineredTaskManagerParameters;
 import org.apache.flink.runtime.security.token.DelegationTokenConverter;
 import org.apache.flink.runtime.util.HadoopUtils;
-import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.StringUtils;
 import org.apache.flink.util.function.FunctionWithException;
 import org.apache.flink.yarn.configuration.YarnConfigOptions;
@@ -67,7 +67,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
+import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.yarn.YarnConfigKeys.ENV_FLINK_CLASSPATH;
 import static org.apache.flink.yarn.YarnConfigKeys.LOCAL_RESOURCE_DESCRIPTOR_SEPARATOR;
@@ -633,12 +635,12 @@ public final class Utils {
         return Resource.newInstance(unitMemMB, unitVcore);
     }
 
-    public static List<Path> getQualifiedRemoteSharedPaths(
+    public static List<Path> getQualifiedRemoteProvidedLibDirs(
             org.apache.flink.configuration.Configuration configuration,
             YarnConfiguration yarnConfiguration)
-            throws IOException, FlinkException {
+            throws IOException {
 
-        return getRemoteSharedPaths(
+        return getRemoteSharedLibPaths(
                 configuration,
                 pathStr -> {
                     final Path path = new Path(pathStr);
@@ -646,10 +648,10 @@ public final class Utils {
                 });
     }
 
-    private static List<Path> getRemoteSharedPaths(
+    private static List<Path> getRemoteSharedLibPaths(
             org.apache.flink.configuration.Configuration configuration,
             FunctionWithException<String, Path, IOException> strToPathMapper)
-            throws IOException, FlinkException {
+            throws IOException {
 
         final List<Path> providedLibDirs =
                 ConfigUtils.decodeListFromConfig(
@@ -657,7 +659,7 @@ public final class Utils {
 
         for (Path path : providedLibDirs) {
             if (!Utils.isRemotePath(path.toString())) {
-                throw new FlinkException(
+                throw new IllegalArgumentException(
                         "The \""
                                 + YarnConfigOptions.PROVIDED_LIB_DIRS.key()
                                 + "\" should only contain"
@@ -667,6 +669,37 @@ public final class Utils {
             }
         }
         return providedLibDirs;
+    }
+
+    public static boolean isUsrLibDirectory(final FileSystem fileSystem, final Path path)
+            throws IOException {
+        final FileStatus fileStatus = fileSystem.getFileStatus(path);
+        // Use the Path obj from fileStatus to get rid of trailing slash
+        return fileStatus.isDirectory()
+                && ConfigConstants.DEFAULT_FLINK_USR_LIB_DIR.equals(fileStatus.getPath().getName());
+    }
+
+    public static Optional<Path> getQualifiedRemoteProvidedUsrLib(
+            org.apache.flink.configuration.Configuration configuration,
+            YarnConfiguration yarnConfiguration)
+            throws IOException, IllegalArgumentException {
+        String usrlib = configuration.getString(YarnConfigOptions.PROVIDED_USRLIB_DIR);
+        if (usrlib == null) {
+            return Optional.empty();
+        }
+        final Path qualifiedUsrLibPath =
+                FileSystem.get(yarnConfiguration).makeQualified(new Path(usrlib));
+        checkArgument(
+                isRemotePath(qualifiedUsrLibPath.toString()),
+                "The \"%s\" must point to a remote dir "
+                        + "which is accessible from all worker nodes.",
+                YarnConfigOptions.PROVIDED_USRLIB_DIR.key());
+        checkArgument(
+                isUsrLibDirectory(FileSystem.get(yarnConfiguration), qualifiedUsrLibPath),
+                "The \"%s\" should be named with \"%s\".",
+                YarnConfigOptions.PROVIDED_USRLIB_DIR.key(),
+                ConfigConstants.DEFAULT_FLINK_USR_LIB_DIR);
+        return Optional.of(qualifiedUsrLibPath);
     }
 
     public static YarnConfiguration getYarnAndHadoopConfiguration(

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnApplicationFileUploader.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnApplicationFileUploader.java
@@ -514,11 +514,7 @@ class YarnApplicationFileUploader implements AutoCloseable {
     private boolean isUsrLibDirIncludedInProvidedLib(final List<Path> providedLibDirs)
             throws IOException {
         for (Path path : providedLibDirs) {
-            final FileStatus fileStatus = fileSystem.getFileStatus(path);
-            // Use the Path obj from fileStatus to get rid of trailing slash
-            if (fileStatus.isDirectory()
-                    && ConfigConstants.DEFAULT_FLINK_USR_LIB_DIR.equals(
-                            fileStatus.getPath().getName())) {
+            if (Utils.isUsrLibDirectory(fileSystem, path)) {
                 return true;
             }
         }

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -811,7 +811,10 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
         ApplicationSubmissionContext appContext = yarnApplication.getApplicationSubmissionContext();
 
         final List<Path> providedLibDirs =
-                Utils.getQualifiedRemoteSharedPaths(configuration, yarnConfiguration);
+                Utils.getQualifiedRemoteProvidedLibDirs(configuration, yarnConfiguration);
+
+        final Optional<Path> providedUsrLibDir =
+                Utils.getQualifiedRemoteProvidedUsrLib(configuration, yarnConfiguration);
 
         Path stagingDirPath = getStagingDir(fs);
         FileSystem stagingDirFs = stagingDirPath.getFileSystem(yarnConfiguration);
@@ -945,8 +948,17 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
                                 : Path.CUR_DIR,
                         LocalResourceType.FILE);
 
-        // usrlib will be automatically shipped if it exists.
-        if (ClusterEntrypointUtils.tryFindUserLibDirectory().isPresent()) {
+        // usrlib in remote will be used first.
+        if (providedUsrLibDir.isPresent()) {
+            final List<String> usrLibClassPaths =
+                    fileUploader.registerMultipleLocalResources(
+                            Collections.singletonList(providedUsrLibDir.get()),
+                            Path.CUR_DIR,
+                            LocalResourceType.FILE);
+            userClassPaths.addAll(usrLibClassPaths);
+        } else if (ClusterEntrypointUtils.tryFindUserLibDirectory().isPresent()) {
+            // local usrlib will be automatically shipped if it exists and there is no remote
+            // usrlib.
             final Set<File> usrLibShipFiles = new HashSet<>();
             addUsrLibFolderToShipFiles(usrLibShipFiles);
             final List<String> usrLibClassPaths =

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
@@ -340,6 +340,21 @@ public class YarnConfigOptions {
                                     + "they doesn't need to be downloaded every time for each application. An example could be "
                                     + "hdfs://$namenode_address/path/of/flink/lib");
 
+    /**
+     * Allows users to directly utilize usrlib directory in HDFS for YARN application mode. The
+     * classloader for loading jars under the usrlib will be controlled by {@link
+     * YarnConfigOptions#CLASSPATH_INCLUDE_USER_JAR}.
+     */
+    public static final ConfigOption<String> PROVIDED_USRLIB_DIR =
+            key("yarn.provided.usrlib.dir")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "The provided usrlib directory in remote. It should be pre-uploaded and "
+                                    + "world-readable. Flink will use it to exclude the local usrlib directory(i.e. usrlib/ under the parent directory of FLINK_LIB_DIR)."
+                                    + " Unlike yarn.provided.lib.dirs, YARN will not cache it on the nodes as it is for each application. An example could be "
+                                    + "hdfs://$namenode_address/path/of/flink/usrlib");
+
     @SuppressWarnings("unused")
     public static final ConfigOption<String> HADOOP_CONFIG_KEY =
             key("flink.hadoop.<key>")


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
Support using `usrlib` in HDFS for jobs submitted in YARN application mode.


## Brief change log

- Introduce new config option `YarnConfigOption.PROVIDED_USRLIB_DIR` to specify `usrlib` in HDFS for application mode.
- Refactor some utils function to reuse codes for parsing and validating remote `usrlib`.
- Add unit/integration tests for using `usrlib` in hdfs.


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

This change added tests and can be verified as follows:

  - Added integration tests for deploying a job in YARN with remote `usrlib`.
  - Added unit tests for validation of specified remote `usrlib` path.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
