### PR TITLE
[FLINK-24862][Connectors / Hive][backport]Fix user-defined hive udaf/udtf cannot be used normally in hive dialect for flink1.14

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FunctionCatalog.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FunctionCatalog.java
@@ -631,16 +631,14 @@ public final class FunctionCatalog {
         // In this situation the UDF have not been validated and cleaned, so we need to validate it
         // and clean its closure here.
         // If the input is instance of `ScalarFunctionDefinition`, `TableFunctionDefinition` and so
-        // on,
-        // it means it uses the old type inference. We assume that they have been validated before
-        // being
-        // wrapped.
-        if (function instanceof InlineCatalogFunction
-                && ((InlineCatalogFunction) function).getDefinition()
-                        instanceof UserDefinedFunction) {
-
+        // on, it means it uses the old type inference. We assume that they have been validated
+        // before being wrapped.
+        if (function instanceof InlineCatalogFunction) {
             FunctionDefinition definition = ((InlineCatalogFunction) function).getDefinition();
-            UserDefinedFunctionHelper.prepareInstance(config, (UserDefinedFunction) definition);
+            if (definition instanceof UserDefinedFunction) {
+                UserDefinedFunctionHelper.prepareInstance(config, (UserDefinedFunction) definition);
+            }
+            // Skip validation if it's not a UserDefinedFunction.
         } else if (function.getFunctionLanguage() == FunctionLanguage.JAVA) {
             ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
             UserDefinedFunctionHelper.validateClass(


### PR DESCRIPTION

Backport of https://github.com/apache/flink/pull/17761
## What is the purpose of the change



Fix user-defined hive udaf/udtf cannot be used normally in hive dialect


## Brief change log


FunctionCatalog#validateAndPrepareFunction method skip validate TableFunctionDefinition

## Verifying this change
This change added tests and can be verified as follows:

  - Added unit test HiveDialectITCase#testTemporaryFunctionUDAF for create temporary udaf function


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no )
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)

