### PR TITLE
[FLINK-26613][streaming] Allow setting operator uid hashes for predefined sink operators

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/CustomSinkOperatorUidHashes.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/CustomSinkOperatorUidHashes.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.datastream;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.PublicEvolving;
+
+import javax.annotation.Nullable;
+
+/**
+ * This class is responsible to hold operator Uid hashes from the common operators of the sink. With
+ * this, users can recover a sink snapshot that did not bind uids to the operator before changing
+ * the topology.
+ */
+@PublicEvolving
+public class CustomSinkOperatorUidHashes {
+
+    /** Default instance providing no custom sink operator hashes. */
+    public static final CustomSinkOperatorUidHashes DEFAULT =
+            CustomSinkOperatorUidHashes.builder().build();
+
+    @Nullable private final String writerUidHash;
+    @Nullable private final String committerUidHash;
+    @Nullable private final String globalCommitterUidHash;
+
+    private CustomSinkOperatorUidHashes(
+            @Nullable String writerUidHash,
+            @Nullable String committerUidHash,
+            @Nullable String globalCommitterUidHash) {
+        this.writerUidHash = writerUidHash;
+        this.committerUidHash = committerUidHash;
+        this.globalCommitterUidHash = globalCommitterUidHash;
+    }
+
+    /**
+     * Creates a builder to construct {@link CustomSinkOperatorUidHashes}.
+     *
+     * @return {@link SinkOperatorUidHashesBuilder}
+     */
+    public static SinkOperatorUidHashesBuilder builder() {
+        return new SinkOperatorUidHashesBuilder();
+    }
+
+    @Internal
+    @Nullable
+    public String getWriterUidHash() {
+        return writerUidHash;
+    }
+
+    @Internal
+    @Nullable
+    public String getCommitterUidHash() {
+        return committerUidHash;
+    }
+
+    @Internal
+    @Nullable
+    public String getGlobalCommitterUidHash() {
+        return globalCommitterUidHash;
+    }
+
+    /** Builder to construct {@link CustomSinkOperatorUidHashes}. */
+    @PublicEvolving
+    public static class SinkOperatorUidHashesBuilder {
+
+        @Nullable String writerUidHash = null;
+        @Nullable String committerUidHash = null;
+        @Nullable String globalCommitterUidHash = null;
+
+        /**
+         * Sets the uid hash of the writer operator used to recover state.
+         *
+         * @param writerUidHash uid hash denoting writer operator
+         * @return {@link SinkOperatorUidHashesBuilder}
+         */
+        public SinkOperatorUidHashesBuilder setWriterUidHash(String writerUidHash) {
+            this.writerUidHash = writerUidHash;
+            return this;
+        }
+
+        /**
+         * Sets the uid hash of the committer operator used to recover state.
+         *
+         * @param committerUidHash uid hash denoting the committer operator
+         * @return {@link SinkOperatorUidHashesBuilder}
+         */
+        public SinkOperatorUidHashesBuilder setCommitterUidHash(String committerUidHash) {
+            this.committerUidHash = committerUidHash;
+            return this;
+        }
+
+        /**
+         * Sets the uid hash of the global committer operator used to recover state.
+         *
+         * @param globalCommitterUidHash uid hash denoting the global committer operator
+         * @return {@link SinkOperatorUidHashesBuilder}
+         */
+        public SinkOperatorUidHashesBuilder setGlobalCommitterUidHash(
+                String globalCommitterUidHash) {
+            this.globalCommitterUidHash = globalCommitterUidHash;
+            return this;
+        }
+
+        /**
+         * Constructs the {@link CustomSinkOperatorUidHashes} with the given uid hashes.
+         *
+         * @return {@link CustomSinkOperatorUidHashes}
+         */
+        public CustomSinkOperatorUidHashes build() {
+            return new CustomSinkOperatorUidHashes(
+                    writerUidHash, committerUidHash, globalCommitterUidHash);
+        }
+    }
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
@@ -1250,10 +1250,27 @@ public class DataStream<T> {
      */
     @PublicEvolving
     public DataStreamSink<T> sinkTo(org.apache.flink.api.connector.sink.Sink<T, ?, ?, ?> sink) {
+        return this.sinkTo(sink, CustomSinkOperatorUidHashes.DEFAULT);
+    }
+
+    /**
+     * Adds the given {@link Sink} to this DataStream. Only streams with sinks added will be
+     * executed once the {@link StreamExecutionEnvironment#execute()} method is called.
+     *
+     * <p>This method is intended to be used only to recover a snapshot where no uids have been set
+     * before taking the snapshot.
+     *
+     * @param sink The user defined sink.
+     * @return The closed DataStream.
+     */
+    @PublicEvolving
+    public DataStreamSink<T> sinkTo(
+            org.apache.flink.api.connector.sink.Sink<T, ?, ?, ?> sink,
+            CustomSinkOperatorUidHashes customSinkOperatorUidHashes) {
         // read the output type of the input Transform to coax out errors about MissingTypeInfo
         transformation.getOutputType();
 
-        return DataStreamSink.forSinkV1(this, sink);
+        return DataStreamSink.forSinkV1(this, sink, customSinkOperatorUidHashes);
     }
 
     /**
@@ -1265,10 +1282,27 @@ public class DataStream<T> {
      */
     @PublicEvolving
     public DataStreamSink<T> sinkTo(Sink<T> sink) {
+        return this.sinkTo(sink, CustomSinkOperatorUidHashes.DEFAULT);
+    }
+
+    /**
+     * Adds the given {@link Sink} to this DataStream. Only streams with sinks added will be
+     * executed once the {@link StreamExecutionEnvironment#execute()} method is called.
+     *
+     * <p>This method is intended to be used only to recover a snapshot where no uids have been set
+     * before taking the snapshot.
+     *
+     * @param customSinkOperatorUidHashes operator hashes to support state binding
+     * @param sink The user defined sink.
+     * @return The closed DataStream.
+     */
+    @PublicEvolving
+    public DataStreamSink<T> sinkTo(
+            Sink<T> sink, CustomSinkOperatorUidHashes customSinkOperatorUidHashes) {
         // read the output type of the input Transform to coax out errors about MissingTypeInfo
         transformation.getOutputType();
 
-        return DataStreamSink.forSink(this, sink);
+        return DataStreamSink.forSink(this, sink, customSinkOperatorUidHashes);
     }
 
     /**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSink.java
@@ -65,7 +65,10 @@ public class DataStreamSink<T> {
     }
 
     @Internal
-    public static <T> DataStreamSink<T> forSink(DataStream<T> inputStream, Sink<T> sink) {
+    public static <T> DataStreamSink<T> forSink(
+            DataStream<T> inputStream,
+            Sink<T> sink,
+            CustomSinkOperatorUidHashes customSinkOperatorUidHashes) {
         final StreamExecutionEnvironment executionEnvironment =
                 inputStream.getExecutionEnvironment();
         SinkTransformation<T, T> transformation =
@@ -74,15 +77,18 @@ public class DataStreamSink<T> {
                         sink,
                         inputStream.getType(),
                         "Sink",
-                        executionEnvironment.getParallelism());
+                        executionEnvironment.getParallelism(),
+                        customSinkOperatorUidHashes);
         executionEnvironment.addOperator(transformation);
         return new DataStreamSink<>(transformation);
     }
 
     @Internal
     public static <T> DataStreamSink<T> forSinkV1(
-            DataStream<T> inputStream, org.apache.flink.api.connector.sink.Sink<T, ?, ?, ?> sink) {
-        return forSink(inputStream, SinkV1Adapter.wrap(sink));
+            DataStream<T> inputStream,
+            org.apache.flink.api.connector.sink.Sink<T, ?, ?, ?> sink,
+            CustomSinkOperatorUidHashes customSinkOperatorUidHashes) {
+        return forSink(inputStream, SinkV1Adapter.wrap(sink), customSinkOperatorUidHashes);
     }
 
     /** Returns the transformation that contains the actual sink operator of this sink. */

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/SinkTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/SinkTransformation.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.connector.sink2.Sink;
 import org.apache.flink.api.connector.sink2.SinkWriter;
 import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.streaming.api.datastream.CustomSinkOperatorUidHashes;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
 
@@ -47,6 +48,7 @@ public class SinkTransformation<InputT, OutputT> extends PhysicalTransformation<
     private final DataStream<InputT> inputStream;
     private final Sink<InputT> sink;
     private final Transformation<InputT> input;
+    private final CustomSinkOperatorUidHashes customSinkOperatorUidHashes;
 
     private ChainingStrategy chainingStrategy;
 
@@ -55,11 +57,13 @@ public class SinkTransformation<InputT, OutputT> extends PhysicalTransformation<
             Sink<InputT> sink,
             TypeInformation<OutputT> outputType,
             String name,
-            int parallelism) {
+            int parallelism,
+            CustomSinkOperatorUidHashes customSinkOperatorUidHashes) {
         super(name, outputType, parallelism);
         this.inputStream = checkNotNull(inputStream);
         this.sink = checkNotNull(sink);
         this.input = inputStream.getTransformation();
+        this.customSinkOperatorUidHashes = checkNotNull(customSinkOperatorUidHashes);
     }
 
     @Override
@@ -91,5 +95,9 @@ public class SinkTransformation<InputT, OutputT> extends PhysicalTransformation<
 
     public Sink<InputT> getSink() {
         return sink;
+    }
+
+    public CustomSinkOperatorUidHashes getSinkOperatorsUidHashes() {
+        return customSinkOperatorUidHashes;
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/SinkTransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/SinkTransformationTranslator.java
@@ -355,9 +355,10 @@ public class SinkTransformationTranslator<Input, Output>
                 BiConsumer<Transformation<?>, String> setter,
                 @Nullable String transformationName) {
             if (transformationName != null && getter.apply(transformation) != null) {
-                // Use the same uid pattern than for Sink V1
+                // Use the same uid pattern than for Sink V1. We deliberately decided to use the uid
+                // pattern of Flink 1.13 because 1.14 did not have a dedicated committer operator.
                 if (transformationName.equals(COMMITTER_NAME)) {
-                    final String committerFormat = "Sink %s Committer";
+                    final String committerFormat = "Sink Committer: %s";
                     setter.accept(
                             subTransformation,
                             String.format(committerFormat, getter.apply(transformation)));
@@ -369,7 +370,7 @@ public class SinkTransformationTranslator<Input, Output>
                     return;
                 }
 
-                // Use the same uid pattern than for Sink V1
+                // Use the same uid pattern than for Sink V1 in Flink 1.14.
                 if (transformationName.equals(
                         StandardSinkTopologies.GLOBAL_COMMITTER_TRANSFORMATION_NAME)) {
                     final String committerFormat = "Sink %s Global Committer";

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/SinkTransformationTranslatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/SinkTransformationTranslatorTest.java
@@ -293,6 +293,29 @@ public class SinkTransformationTranslatorTest extends TestLogger {
         assertEquals(findGlobalCommitter(streamGraph).getUserHash(), globalCommitterHash);
     }
 
+    /**
+     * When ever you need to change something in this test case please think about possible state
+     * upgrade problems introduced by your changes.
+     */
+    @Test
+    public void testSettingOperatorUids() {
+        final String sinkUid = "f6b178ce445dc3ffaa06bad27a51fead";
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        final DataStreamSource<Integer> src = env.fromElements(1, 2);
+        src.sinkTo(TestSink.newBuilder().setDefaultCommitter().setDefaultGlobalCommitter().build())
+                .name(NAME)
+                .uid(sinkUid);
+
+        final StreamGraph streamGraph = env.getStreamGraph();
+        assertEquals(findWriter(streamGraph).getTransformationUID(), sinkUid);
+        assertEquals(
+                findCommitter(streamGraph).getTransformationUID(),
+                String.format("Sink Committer: %s", sinkUid));
+        assertEquals(
+                findGlobalCommitter(streamGraph).getTransformationUID(),
+                String.format("Sink %s Global Committer", sinkUid));
+    }
+
     private void validateTopology(
             StreamNode src,
             Class<?> srcOutTypeInfo,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/SinkTransformationTranslatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/SinkTransformationTranslatorTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.core.io.SimpleVersionedSerializerTypeSerializerProxy;
+import org.apache.flink.streaming.api.datastream.CustomSinkOperatorUidHashes;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
 import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -47,6 +48,7 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 
 /** Tests for {@link org.apache.flink.streaming.api.transformations.SinkTransformation}. */
 @RunWith(Parameterized.class)
@@ -261,6 +263,34 @@ public class SinkTransformationTranslatorTest extends TestLogger {
         assertThat(
                 globalCommitter.getOperatorFactory().getChainingStrategy(),
                 is(ChainingStrategy.NEVER));
+    }
+
+    @Test
+    public void testSettingOperatorUidHash() {
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        final DataStreamSource<Integer> src = env.fromElements(1, 2);
+        final String writerHash = "f6b178ce445dc3ffaa06bad27a51fead";
+        final String committerHash = "68ac8ae79eae4e3135a54f9689c4aa10";
+        final String globalCommitterHash = "77e6aa6eeb1643b3765e1e4a7a672f37";
+        final CustomSinkOperatorUidHashes operatorsUidHashes =
+                CustomSinkOperatorUidHashes.builder()
+                        .setWriterUidHash(writerHash)
+                        .setCommitterUidHash(committerHash)
+                        .setGlobalCommitterUidHash(globalCommitterHash)
+                        .build();
+        src.sinkTo(
+                        TestSink.newBuilder()
+                                .setDefaultCommitter()
+                                .setDefaultGlobalCommitter()
+                                .build(),
+                        operatorsUidHashes)
+                .name(NAME);
+
+        final StreamGraph streamGraph = env.getStreamGraph();
+
+        assertEquals(findWriter(streamGraph).getUserHash(), writerHash);
+        assertEquals(findCommitter(streamGraph).getUserHash(), committerHash);
+        assertEquals(findGlobalCommitter(streamGraph).getUserHash(), globalCommitterHash);
     }
 
     private void validateTopology(

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecSink.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecSink.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.api.java.typeutils.InputTypeConfigurable;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
+import org.apache.flink.streaming.api.datastream.CustomSinkOperatorUidHashes;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -491,7 +492,9 @@ public abstract class CommonExecSink extends ExecNodeBase<Object>
             final DataStream<RowData> dataStream = new DataStream<>(env, sinkTransformation);
             final Transformation<?> transformation =
                     DataStreamSink.forSinkV1(
-                                    dataStream, ((SinkProvider) runtimeProvider).createSink())
+                                    dataStream,
+                                    ((SinkProvider) runtimeProvider).createSink(),
+                                    CustomSinkOperatorUidHashes.DEFAULT)
                             .getTransformation();
             transformation.setParallelism(sinkParallelism);
             sinkMeta.fill(transformation);
@@ -503,7 +506,9 @@ public abstract class CommonExecSink extends ExecNodeBase<Object>
             final DataStream<RowData> dataStream = new DataStream<>(env, sinkTransformation);
             final Transformation<?> transformation =
                     DataStreamSink.forSink(
-                                    dataStream, ((SinkV2Provider) runtimeProvider).createSink())
+                                    dataStream,
+                                    ((SinkV2Provider) runtimeProvider).createSink(),
+                                    CustomSinkOperatorUidHashes.DEFAULT)
                             .getTransformation();
             transformation.setParallelism(sinkParallelism);
             sinkMeta.fill(transformation);


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Since the topology has changes between Flink 1.14 and 1.15 it might
happen that stateful upgrades are not possible if no pior operator uids
were set. With this commit, users can set operator uid hashes for the
respective operators.


## Brief change log

- Add a parameter to `DataStream#sinkTo` to pass operator uid hashes`
- Set the operator uid hashes for `Writer`, `Committer`, `GlobalCommitter` during `SinkTransformation` translation


## Verifying this change

Added a test to verify the respective sink operators have the uid hash set.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
