### PR TITLE
[FLINK-26500][runtime][test] Increases the deadline to wait for parallelism

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerClusterITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerClusterITCase.java
@@ -282,6 +282,6 @@ public class AdaptiveSchedulerClusterITCase extends TestLogger {
 
                     return executionJobVertex.getParallelism() == targetParallelism;
                 },
-                Deadline.fromNow(Duration.ofSeconds(10)));
+                Deadline.fromNow(Duration.ofMinutes(5)));
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

* Makes test more flexible to run on slower machines by increasing the wait period

## Brief change log

* Increased the deadline for the wait period

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
