### PR TITLE
[BP-1.14][FLINK-26500][runtime][test] Increases the deadline to wait for parallelism

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerClusterITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerClusterITCase.java
@@ -176,6 +176,6 @@ public class AdaptiveSchedulerClusterITCase extends TestLogger {
                     return archivedExecutionGraph.getAllVertices().get(jobVertexId).getParallelism()
                             == targetParallelism;
                 },
-                Deadline.fromNow(Duration.ofSeconds(10)));
+                Deadline.fromNow(Duration.ofMinutes(5)));
     }
 }


### PR DESCRIPTION
1.14 backport for parent PR #19075 . No conflicts observed while cherry-picking `41c24e3959eb6c079bb87c2273e04ada53e5178f`