### PR TITLE
 [FLINK-26629][runtime] fix bug in code comment of SubtaskStateMapper.RANGE

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/SubtaskStateMapper.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/SubtaskStateMapper.java
@@ -89,7 +89,7 @@ public enum SubtaskStateMapper {
      * <p>Example:<br>
      * old assignment: 0 -> [0;43); 1 -> [43;87); 2 -> [87;128)<br>
      * new assignment: 0 -> [0;64]; 1 -> [64;128)<br>
-     * subtask 0 recovers data from old subtask 0 + 1 and subtask 1 recovers data from old subtask 0
+     * subtask 0 recovers data from old subtask 0 + 1 and subtask 1 recovers data from old subtask 1
      * + 2
      *
      * <p>For all downscale from n to [n-1 .. n/2], each new subtasks get exactly two old subtasks


### PR DESCRIPTION
## What is the purpose of the change

fix bug in code comment of SubtaskStateMapper.RANGE

## Brief change log

The code comments for SubtaskStateMapper.RANGE are as follows:

```
* <p>Example:<br>
 * old assignment: 0 -> [0;43); 1 -> [43;87); 2 -> [87;128)<br>
 * new assignment: 0 -> [0;64]; 1 -> [64;128)<br>
 * subtask 0 recovers data from old subtask 0 + 1 and subtask 1 recovers data from old subtask 0
 * + 2
```

The correct code comment should be：

```
 * <p>Example:<br>
 * old assignment: 0 -> [0;43); 1 -> [43;87); 2 -> [87;128)<br>
 * new assignment: 0 -> [0;64]; 1 -> [64;128)<br>
 * subtask 0 recovers data from old subtask 0 + 1 and subtask 1 recovers data from old subtask 1
 * + 2
```

**subtask 1 should recovers data from old subtask 1 + 2，not from old subtask 0 + 2**

## Verifying this change



## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
