### PR TITLE
[FLINK-26121][BP-1.14][runtime] Adds clearUnhandledEvents() method

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderretrieval/ZooKeeperLeaderRetrievalConnectionHandlingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderretrieval/ZooKeeperLeaderRetrievalConnectionHandlingTest.java
@@ -127,6 +127,7 @@ public class ZooKeeperLeaderRetrievalConnectionHandlingTest extends TestLogger {
                     secondAddress.get(),
                     is(nullValue()));
         } finally {
+            queueLeaderElectionListener.clearUnhandledEvents();
             if (leaderRetrievalDriver != null) {
                 leaderRetrievalDriver.close();
             }
@@ -172,6 +173,7 @@ public class ZooKeeperLeaderRetrievalConnectionHandlingTest extends TestLogger {
                     secondAddress.get(),
                     is(nullValue()));
         } finally {
+            queueLeaderElectionListener.clearUnhandledEvents();
             if (leaderRetrievalDriver != null) {
                 leaderRetrievalDriver.close();
             }
@@ -214,6 +216,7 @@ public class ZooKeeperLeaderRetrievalConnectionHandlingTest extends TestLogger {
             // make sure that no new leader information is published
             assertThat(queueLeaderElectionListener.next(Duration.ofMillis(100L)), is(nullValue()));
         } finally {
+            queueLeaderElectionListener.clearUnhandledEvents();
             if (leaderRetrievalDriver != null) {
                 leaderRetrievalDriver.close();
             }
@@ -259,6 +262,7 @@ public class ZooKeeperLeaderRetrievalConnectionHandlingTest extends TestLogger {
                     queueLeaderElectionListener.next();
             assertThat(connectionReconnect.get(), is(leaderAddress));
         } finally {
+            queueLeaderElectionListener.clearUnhandledEvents();
             if (leaderRetrievalDriver != null) {
                 leaderRetrievalDriver.close();
             }
@@ -340,6 +344,7 @@ public class ZooKeeperLeaderRetrievalConnectionHandlingTest extends TestLogger {
                     },
                     Deadline.fromNow(Duration.ofSeconds(30L)));
         } finally {
+            queueLeaderElectionListener.clearUnhandledEvents();
             if (leaderRetrievalDriver != null) {
                 leaderRetrievalDriver.close();
             }
@@ -390,6 +395,17 @@ public class ZooKeeperLeaderRetrievalConnectionHandlingTest extends TestLogger {
                 }
             } catch (InterruptedException e) {
                 throw new IllegalStateException(e);
+            }
+        }
+
+        /**
+         * Clears any unhandled events. This is useful in cases where there was an unplanned
+         * reconnect after the test passed to prepare the shutdown. Outstanding events might cause
+         * an {@link InterruptedException} during shutdown, otherwise.
+         */
+        public void clearUnhandledEvents() {
+            while (!queue.isEmpty()) {
+                queue.poll();
             }
         }
     }


### PR DESCRIPTION
This is a missed-out 1.14 backport of PR #18844 only including the actually test fix.

## What is the purpose of the change

We experienced some ZK connection issue which resulted in a
SUSPEND and a RECONNECT event which were not handled and,
therefore, stayed in the queue blocking a thread for the
second event (because the capacity of the internally used
ArrayBlockingQueue is set to 1). Shutting down the driver
initiates a shutdown of the ExecutorService which is used
for the listeners internally (see
ZooKeeperLeaderRetrievalDriver.close()). The blocking thread
will cause a fatal error through an InterruptedException.
The test will fail due to the fatal error in the end.

Cleaning unhandled events at the end of the test run fix the
issue. Additionally, the tests were aligned by moving generic
code into a helper method.

## Brief change log

* Adds queue cleanup method to each test

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
