### PR TITLE
[FLINK-26596][BP-1.14][runtime][test] Adds leadership loss handling

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderretrieval/ZooKeeperLeaderRetrievalConnectionHandlingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderretrieval/ZooKeeperLeaderRetrievalConnectionHandlingTest.java
@@ -338,9 +338,10 @@ public class ZooKeeperLeaderRetrievalConnectionHandlingTest extends TestLogger {
             // check that we find the new leader information eventually
             CommonTestUtils.waitUntilCondition(
                     () -> {
-                        final CompletableFuture<String> afterConnectionReconnect =
-                                queueLeaderElectionListener.next();
-                        return afterConnectionReconnect.get().equals(newLeaderAddress);
+                        final String afterConnectionReconnect =
+                                queueLeaderElectionListener.next().get();
+                        return afterConnectionReconnect != null
+                                && afterConnectionReconnect.equals(newLeaderAddress);
                     },
                     Deadline.fromNow(Duration.ofSeconds(30L)));
         } finally {


### PR DESCRIPTION
This is a 1.14 backport of PR #19066 

## What is the purpose of the change

If the ZK connection is flaky, we might collect another
ZK connection loss. This is now handled properly.

## Brief change log

* Adds `null` check to condition

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
