### PR TITLE
[FLINK-26638][connectors/elasticsearch] Add user-definable ActionFailureHandler to unified Elasticsearch Sink

### DIFF
--- a/docs/content/docs/connectors/table/elasticsearch.md
+++ b/docs/content/docs/connectors/table/elasticsearch.md
@@ -140,6 +140,21 @@ Connector Options
       <td>Password used to connect to Elasticsearch instance. If <code>username</code> is configured, this option must be configured with non-empty string as well.</td>
     </tr>
     <tr>
+      <td><h5>failure-handler</h5></td>
+      <td>optional</td>
+      <td>yes</td>
+      <td style="word-wrap: break-word;">fail</td>
+      <td>String</td>
+      <td>Failure handling strategy in case a request to Elasticsearch fails. Valid strategies are:
+      <ul>
+        <li><code>fail</code>: throws an exception if a request fails and thus causes a job failure.</li>
+        <li><code>ignore</code>: ignores failures and drops the request.</li>
+        <li><code>retry-rejected</code>: re-adds requests that have failed due to queue capacity saturation.</li>
+        <li>custom class name: for failure handling with a ActionRequestFailureHandler subclass.</li>
+      </ul>
+      </td>
+    </tr>
+    <tr>
       <td><h5>sink.delivery-guarantee</h5></td>
       <td>optional</td>
       <td>no</td>

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/sink/ElasticsearchSink.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/sink/ElasticsearchSink.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.connector.sink2.Sink;
 import org.apache.flink.api.connector.sink2.SinkWriter;
 import org.apache.flink.connector.base.DeliveryGuarantee;
+import org.apache.flink.streaming.connectors.elasticsearch.ActionRequestFailureHandler;
 
 import org.apache.http.HttpHost;
 
@@ -59,6 +60,7 @@ public class ElasticsearchSink<IN> implements Sink<IN> {
     private final BulkProcessorBuilderFactory bulkProcessorBuilderFactory;
     private final NetworkClientConfig networkClientConfig;
     private final DeliveryGuarantee deliveryGuarantee;
+    private final ActionRequestFailureHandler failureHandler;
 
     ElasticsearchSink(
             List<HttpHost> hosts,
@@ -66,7 +68,8 @@ public class ElasticsearchSink<IN> implements Sink<IN> {
             DeliveryGuarantee deliveryGuarantee,
             BulkProcessorBuilderFactory bulkProcessorBuilderFactory,
             BulkProcessorConfig buildBulkProcessorConfig,
-            NetworkClientConfig networkClientConfig) {
+            NetworkClientConfig networkClientConfig,
+            ActionRequestFailureHandler failureHandler) {
         this.hosts = checkNotNull(hosts);
         this.bulkProcessorBuilderFactory = checkNotNull(bulkProcessorBuilderFactory);
         checkArgument(!hosts.isEmpty(), "Hosts cannot be empty.");
@@ -74,6 +77,7 @@ public class ElasticsearchSink<IN> implements Sink<IN> {
         this.deliveryGuarantee = checkNotNull(deliveryGuarantee);
         this.buildBulkProcessorConfig = checkNotNull(buildBulkProcessorConfig);
         this.networkClientConfig = checkNotNull(networkClientConfig);
+        this.failureHandler = checkNotNull(failureHandler);
     }
 
     @Override
@@ -86,6 +90,7 @@ public class ElasticsearchSink<IN> implements Sink<IN> {
                 bulkProcessorBuilderFactory,
                 networkClientConfig,
                 context.metricGroup(),
-                context.getMailboxExecutor());
+                context.getMailboxExecutor(),
+                failureHandler);
     }
 }

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/sink/ElasticsearchSinkBuilderBase.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/sink/ElasticsearchSinkBuilderBase.java
@@ -22,6 +22,8 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.java.ClosureCleaner;
 import org.apache.flink.connector.base.DeliveryGuarantee;
+import org.apache.flink.streaming.connectors.elasticsearch.ActionRequestFailureHandler;
+import org.apache.flink.streaming.connectors.elasticsearch.util.NoOpFailureHandler;
 import org.apache.flink.util.InstantiationUtil;
 
 import org.apache.http.HttpHost;
@@ -57,6 +59,7 @@ public abstract class ElasticsearchSinkBuilderBase<
     private Integer connectionTimeout;
     private Integer connectionRequestTimeout;
     private Integer socketTimeout;
+    private ActionRequestFailureHandler failureHandler = new NoOpFailureHandler();
 
     protected ElasticsearchSinkBuilderBase() {}
 
@@ -81,6 +84,11 @@ public abstract class ElasticsearchSinkBuilderBase<
         final ElasticsearchSinkBuilderBase<T, ?> self = self();
         self.emitter = emitter;
         return self;
+    }
+
+    public B setFailureHandler(ActionRequestFailureHandler failureHandler) {
+        this.failureHandler = checkNotNull(failureHandler);
+        return self();
     }
 
     /**
@@ -282,7 +290,8 @@ public abstract class ElasticsearchSinkBuilderBase<
                 deliveryGuarantee,
                 bulkProcessorBuilderFactory,
                 bulkProcessorConfig,
-                networkClientConfig);
+                networkClientConfig,
+                failureHandler);
     }
 
     private NetworkClientConfig buildNetworkClientConfig() {

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/table/ElasticsearchConnectorOptions.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/table/ElasticsearchConnectorOptions.java
@@ -22,11 +22,14 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.configuration.description.Description;
 import org.apache.flink.connector.base.DeliveryGuarantee;
 import org.apache.flink.connector.elasticsearch.sink.FlushBackoffType;
 
 import java.time.Duration;
 import java.util.List;
+
+import static org.apache.flink.configuration.description.TextElement.text;
 
 /**
  * Base options for the Elasticsearch connector. Needs to be public so that the {@link
@@ -68,6 +71,25 @@ public class ElasticsearchConnectorOptions {
                     .defaultValue("_")
                     .withDescription(
                             "Delimiter for composite keys e.g., \"$\" would result in IDs \"KEY1$KEY2$KEY3\".");
+
+    public static final ConfigOption<String> FAILURE_HANDLER_OPTION =
+            ConfigOptions.key("failure-handler")
+                    .stringType()
+                    .defaultValue("fail")
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "Failure handling strategy in case a request to Elasticsearch fails")
+                                    .list(
+                                            text(
+                                                    "\"fail\" (throws an exception if a request fails and thus causes a job failure)"),
+                                            text(
+                                                    "\"ignore\" (ignores failures and drops the request)"),
+                                            text(
+                                                    "\"retry-rejected\" (re-adds requests that have failed due to queue capacity saturation)"),
+                                            text(
+                                                    "\"class name\" for failure handling with a ActionRequestFailureHandler subclass"))
+                                    .build());
 
     public static final ConfigOption<Integer> BULK_FLUSH_MAX_ACTIONS_OPTION =
             ConfigOptions.key("sink.bulk-flush.max-actions")

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/table/ElasticsearchDynamicSink.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/table/ElasticsearchDynamicSink.java
@@ -132,6 +132,7 @@ class ElasticsearchDynamicSink implements DynamicTableSink {
         ElasticsearchSinkBuilderBase<RowData, ? extends ElasticsearchSinkBuilderBase> builder =
                 builderSupplier.get();
         builder.setEmitter(rowElasticsearchEmitter);
+        builder.setFailureHandler(config.getFailureHandler());
         builder.setHosts(config.getHosts().toArray(new HttpHost[0]));
         builder.setDeliveryGuarantee(config.getDeliveryGuarantee());
         builder.setBulkFlushMaxActions(config.getBulkFlushMaxActions());

--- a/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/connector/elasticsearch/sink/ElasticsearchWriterITCase.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/connector/elasticsearch/sink/ElasticsearchWriterITCase.java
@@ -27,6 +27,7 @@ import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
 import org.apache.flink.metrics.testutils.MetricListener;
 import org.apache.flink.runtime.metrics.groups.InternalSinkWriterMetricGroup;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
+import org.apache.flink.streaming.connectors.elasticsearch.util.NoOpFailureHandler;
 import org.apache.flink.util.DockerImageVersions;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.TestLoggerExtension;
@@ -247,7 +248,8 @@ class ElasticsearchWriterITCase {
                 new TestBulkProcessorBuilderFactory(),
                 new NetworkClientConfig(null, null, null, null, null, null),
                 metricGroup,
-                new TestMailbox());
+                new TestMailbox(),
+                new NoOpFailureHandler());
     }
 
     private static class TestBulkProcessorBuilderFactory implements BulkProcessorBuilderFactory {

--- a/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/connector/elasticsearch/sink/FailureHandlerTestEmitter.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/connector/elasticsearch/sink/FailureHandlerTestEmitter.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.elasticsearch.sink;
+
+import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.api.java.tuple.Tuple2;
+
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.update.UpdateRequest;
+import org.elasticsearch.client.Requests;
+
+import java.util.HashMap;
+import java.util.Map;
+
+class FailureHandlerTestEmitter implements ElasticsearchEmitter<Tuple2<Integer, String>> {
+    private final String index;
+    private final String documentType;
+
+    FailureHandlerTestEmitter(String index, String documentType) {
+        this.index = index;
+        this.documentType = documentType;
+    }
+
+    @Override
+    public void emit(
+            Tuple2<Integer, String> element, SinkWriter.Context context, RequestIndexer indexer) {
+        indexer.add(createIndexRequest(element));
+        indexer.add(createUpdateRequest(element));
+    }
+
+    private IndexRequest createIndexRequest(Tuple2<Integer, String> element) {
+        Map<String, Object> json = new HashMap<>();
+        json.put("data", element.f1);
+
+        String idx;
+        if (element.f1.startsWith("message #15")) {
+            idx = ":intentional invalid index:";
+        } else {
+            idx = index;
+        }
+
+        return Requests.indexRequest().index(idx).id(element.f1).type(documentType).source(json);
+    }
+
+    private UpdateRequest createUpdateRequest(Tuple2<Integer, String> element) {
+        Map<String, Object> json = new HashMap<>();
+        json.put("data", element.f1);
+
+        return new UpdateRequest(index, documentType, String.valueOf(element.f0))
+                .doc(json)
+                .upsert(json);
+    }
+}

--- a/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/connector/elasticsearch/sink/TestFailureHandler.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/connector/elasticsearch/sink/TestFailureHandler.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.elasticsearch.sink;
+
+import org.apache.flink.streaming.connectors.elasticsearch.ActionRequestFailureHandler;
+import org.apache.flink.streaming.connectors.elasticsearch.RequestIndexer;
+
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.client.Requests;
+
+import java.util.HashMap;
+import java.util.Map;
+
+class TestFailureHandler implements ActionRequestFailureHandler {
+    private static final long serialVersionUID = 942269087742453482L;
+
+    private final String index;
+    private final String documentType;
+
+    TestFailureHandler(String index, String documentType) {
+        this.index = index;
+        this.documentType = documentType;
+    }
+
+    @Override
+    public void onFailure(
+            ActionRequest action, Throwable failure, int restStatusCode, RequestIndexer indexer)
+            throws Throwable {
+        if (action instanceof IndexRequest) {
+            Map<String, Object> json = new HashMap<>();
+            json.put("data", ((IndexRequest) action).source());
+
+            indexer.add(
+                    Requests.indexRequest()
+                            .index(index)
+                            .type(documentType)
+                            .id(((IndexRequest) action).id())
+                            .source(json));
+        } else {
+            throw new IllegalStateException("unexpected");
+        }
+    }
+}

--- a/flink-connectors/flink-connector-elasticsearch6/src/main/java/org/apache/flink/connector/elasticsearch/table/Elasticsearch6Configuration.java
+++ b/flink-connectors/flink-connector-elasticsearch6/src/main/java/org/apache/flink/connector/elasticsearch/table/Elasticsearch6Configuration.java
@@ -27,8 +27,8 @@ import static org.apache.flink.connector.elasticsearch.table.Elasticsearch6Conne
 @Internal
 final class Elasticsearch6Configuration extends ElasticsearchConfiguration {
 
-    Elasticsearch6Configuration(ReadableConfig config) {
-        super(config);
+    Elasticsearch6Configuration(ReadableConfig config, ClassLoader classLoader) {
+        super(config, classLoader);
     }
 
     public String getDocumentType() {

--- a/flink-connectors/flink-connector-elasticsearch6/src/main/java/org/apache/flink/connector/elasticsearch/table/Elasticsearch6DynamicSinkFactory.java
+++ b/flink-connectors/flink-connector-elasticsearch6/src/main/java/org/apache/flink/connector/elasticsearch/table/Elasticsearch6DynamicSinkFactory.java
@@ -43,8 +43,9 @@ public class Elasticsearch6DynamicSinkFactory extends ElasticsearchDynamicSinkFa
     }
 
     @Override
-    ElasticsearchConfiguration getConfiguration(FactoryUtil.TableFactoryHelper helper) {
-        return new Elasticsearch6Configuration(helper.getOptions());
+    ElasticsearchConfiguration getConfiguration(
+            FactoryUtil.TableFactoryHelper helper, ClassLoader classLoader) {
+        return new Elasticsearch6Configuration(helper.getOptions(), classLoader);
     }
 
     @Nullable


### PR DESCRIPTION
## What is the purpose of the change

In 1.15 we ported the Elasticsearch sink to the new unified Sink interface. We initially did not port over the `ActionFailureHandler` as we wanted to deprecate it. When release-testing the Sink we found out that users depend on having the customizable FailureHandler so we want to re-introduce it to the sink.


## Brief change log

  - Added ActionFailureHandler back, adding the failed requests in the ElasticsearchWriter
  - Wrote a unit test that simulates the logic from the `Elasticsearch7Example` E2E Test.
  - Updated the docs


## Verifying this change

This change can be tested with the newly introduced unit test, as well as the old E2E test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
