### PR TITLE
[FLINK-26767][python] Update code to use the changes for TableConfig

### DIFF
--- a/docs/content.zh/docs/dev/python/dependency_management.md
+++ b/docs/content.zh/docs/dev/python/dependency_management.md
@@ -51,15 +51,15 @@ If third-party JARs are used, you can specify the JARs in the Python Table API a
 # Specify a list of jar URLs via "pipeline.jars". The jars are separated by ";"
 # and will be uploaded to the cluster.
 # NOTE: Only local file URLs (start with "file://") are supported.
-table_env.get_config().get_configuration().set_string("pipeline.jars", "file:///my/jar/path/connector.jar;file:///my/jar/path/udf.jar")
+table_env.get_config().set("pipeline.jars", "file:///my/jar/path/connector.jar;file:///my/jar/path/udf.jar")
 
 # It looks like the following on Windows:
-table_env.get_config().get_configuration().set_string("pipeline.jars", "file:///E:/my/jar/path/connector.jar;file:///E:/my/jar/path/udf.jar")
+table_env.get_config().set("pipeline.jars", "file:///E:/my/jar/path/connector.jar;file:///E:/my/jar/path/udf.jar")
 
 # Specify a list of URLs via "pipeline.classpaths". The URLs are separated by ";" 
 # and will be added to the classpath during job execution.
 # NOTE: The paths must specify a protocol (e.g. file://) and users should ensure that the URLs are accessible on both the client and the cluster.
-table_env.get_config().get_configuration().set_string("pipeline.classpaths", "file:///my/jar/path/connector.jar;file:///my/jar/path/udf.jar")
+table_env.get_config().set("pipeline.classpaths", "file:///my/jar/path/connector.jar;file:///my/jar/path/udf.jar")
 ```
 
 or in the Python DataStream API as following:

--- a/docs/content.zh/docs/dev/python/faq.md
+++ b/docs/content.zh/docs/dev/python/faq.md
@@ -64,10 +64,10 @@ PyFlink作业可能依赖jar文件，比如connector，Java UDF等。
 
 ```python
 # 注意：仅支持本地文件URL（以"file:"开头）。
-table_env.get_config().get_configuration().set_string("pipeline.jars", "file:///my/jar/path/connector.jar;file:///my/jar/path/udf.jar")
+table_env.get_config().set("pipeline.jars", "file:///my/jar/path/connector.jar;file:///my/jar/path/udf.jar")
 
 # 注意：路径必须指定协议（例如：文件——"file"），并且用户应确保在客户端和群集上都可以访问这些URL。
-table_env.get_config().get_configuration().set_string("pipeline.classpaths", "file:///my/jar/path/connector.jar;file:///my/jar/path/udf.jar")
+table_env.get_config().set("pipeline.classpaths", "file:///my/jar/path/connector.jar;file:///my/jar/path/udf.jar")
 ```
 
 有关添加Java依赖项的API的详细信息，请参阅[相关文档]({{< ref "docs/dev/python/dependency_management" >}}#java-dependency-in-python-program)。

--- a/docs/content.zh/docs/dev/python/python_execution_mode.md
+++ b/docs/content.zh/docs/dev/python/python_execution_mode.md
@@ -54,10 +54,10 @@ You could specify the Python execution mode using Python Table API as following:
 
 ```python
 # Specify `PROCESS` mode
-table_env.get_config().get_configuration().set_string("python.execution-mode", "process")
+table_env.get_config().set("python.execution-mode", "process")
 
 # Specify `THREAD` mode
-table_env.get_config().get_configuration().set_string("python.execution-mode", "thread")
+table_env.get_config().set("python.execution-mode", "thread")
 ```
 
 {{< hint info >}}

--- a/docs/content.zh/docs/dev/python/table/python_table_api_connectors.md
+++ b/docs/content.zh/docs/dev/python/table/python_table_api_connectors.md
@@ -36,7 +36,7 @@ under the License.
 要在 PyFlink 作业中使用，首先需要将其指定为作业的 [依赖]({{< ref "docs/dev/python/dependency_management" >}})。
 
 ```python
-table_env.get_config().get_configuration().set_string("pipeline.jars", "file:///my/jar/path/connector.jar;file:///my/jar/path/json.jar")
+table_env.get_config().set("pipeline.jars", "file:///my/jar/path/connector.jar;file:///my/jar/path/json.jar")
 ```
 
 ## 如何使用连接器
@@ -86,7 +86,7 @@ def log_processing():
     env_settings = EnvironmentSettings.in_streaming_mode()
     t_env = TableEnvironment.create(env_settings)
     # specify connector and format jars
-    t_env.get_config().get_configuration().set_string("pipeline.jars", "file:///my/jar/path/connector.jar;file:///my/jar/path/json.jar")
+    t_env.get_config().set("pipeline.jars", "file:///my/jar/path/connector.jar;file:///my/jar/path/json.jar")
     
     source_ddl = """
             CREATE TABLE source_table(

--- a/docs/content.zh/docs/dev/python/table/table_environment.md
+++ b/docs/content.zh/docs/dev/python/table/table_environment.md
@@ -565,7 +565,7 @@ TableEnvironment API
         下面的代码示例展示了如何通过这个 API 来设置配置选项：
 ```python
 # set the parallelism to 8
-table_env.get_config().get_configuration().set_string(
+table_env.get_config().set(
     "parallelism.default", "8")
 ```
       </td>
@@ -816,19 +816,19 @@ Statebackend，Checkpoint 以及重启策略
 下面代码示例展示了如何通过 Table API 来配置 statebackend，checkpoint 以及重启策略：
 ```python
 # 设置重启策略为 "fixed-delay"
-table_env.get_config().get_configuration().set_string("restart-strategy", "fixed-delay")
-table_env.get_config().get_configuration().set_string("restart-strategy.fixed-delay.attempts", "3")
-table_env.get_config().get_configuration().set_string("restart-strategy.fixed-delay.delay", "30s")
+table_env.get_config().set("restart-strategy", "fixed-delay")
+table_env.get_config().set("restart-strategy.fixed-delay.attempts", "3")
+table_env.get_config().set("restart-strategy.fixed-delay.delay", "30s")
 
 # 设置 checkpoint 模式为 EXACTLY_ONCE
-table_env.get_config().get_configuration().set_string("execution.checkpointing.mode", "EXACTLY_ONCE")
-table_env.get_config().get_configuration().set_string("execution.checkpointing.interval", "3min")
+table_env.get_config().set("execution.checkpointing.mode", "EXACTLY_ONCE")
+table_env.get_config().set("execution.checkpointing.interval", "3min")
 
 # 设置 statebackend 类型为 "rocksdb"，其他可选项有 "filesystem" 和 "jobmanager"
 # 你也可以将这个属性设置为 StateBackendFactory 的完整类名
 # e.g. org.apache.flink.contrib.streaming.state.RocksDBStateBackendFactory
-table_env.get_config().get_configuration().set_string("state.backend", "rocksdb")
+table_env.get_config().set("state.backend", "rocksdb")
 
 # 设置 RocksDB statebackend 所需要的 checkpoint 目录
-table_env.get_config().get_configuration().set_string("state.checkpoints.dir", "file:///tmp/checkpoints/")
+table_env.get_config().set("state.checkpoints.dir", "file:///tmp/checkpoints/")
 ```

--- a/docs/content.zh/docs/dev/python/table_api_tutorial.md
+++ b/docs/content.zh/docs/dev/python/table_api_tutorial.md
@@ -66,7 +66,7 @@ $ python -m pip install apache-flink
 
 ```python
 t_env = TableEnvironment.create(EnvironmentSettings.in_streaming_mode())
-t_env.get_config().get_configuration().set_string("parallelism.default", "1")
+t_env.get_config().set("parallelism.default", "1")
 ```
 
 接下来，我们将介绍如何创建源表和结果表。
@@ -200,7 +200,7 @@ word_count_data = ["To be, or not to be,--that is the question:--",
 def word_count(input_path, output_path):
     t_env = TableEnvironment.create(EnvironmentSettings.in_streaming_mode())
     # write all the data to one file
-    t_env.get_config().get_configuration().set_string("parallelism.default", "1")
+    t_env.get_config().set("parallelism.default", "1")
 
     # define the source
     if input_path is not None:

--- a/docs/content.zh/docs/dev/table/tuning.md
+++ b/docs/content.zh/docs/dev/table/tuning.md
@@ -88,11 +88,11 @@ configuration.set("table.exec.mini-batch.size", "5000") // the maximum number of
 t_env = ...
 
 # access flink configuration
-configuration = t_env.get_config().get_configuration();
+configuration = t_env.get_config();
 # set low-level key-value options
-configuration.set_string("table.exec.mini-batch.enabled", "true"); # enable mini-batch optimization
-configuration.set_string("table.exec.mini-batch.allow-latency", "5 s"); # use 5 seconds to buffer input records
-configuration.set_string("table.exec.mini-batch.size", "5000"); # the maximum number of records can be buffered by each aggregate operator task
+configuration.set("table.exec.mini-batch.enabled", "true"); # enable mini-batch optimization
+configuration.set("table.exec.mini-batch.allow-latency", "5 s"); # use 5 seconds to buffer input records
+configuration.set("table.exec.mini-batch.size", "5000"); # the maximum number of records can be buffered by each aggregate operator task
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -152,12 +152,12 @@ configuration.set("table.optimizer.agg-phase-strategy", "TWO_PHASE") // enable t
 t_env = ...
 
 # access flink configuration
-configuration = t_env.get_config().get_configuration();
+configuration = t_env.get_config();
 # set low-level key-value options
-configuration.set_string("table.exec.mini-batch.enabled", "true"); # local-global aggregation depends on mini-batch is enabled
-configuration.set_string("table.exec.mini-batch.allow-latency", "5 s");
-configuration.set_string("table.exec.mini-batch.size", "5000");
-configuration.set_string("table.optimizer.agg-phase-strategy", "TWO_PHASE"); # enable two-phase, i.e. local-global aggregation
+configuration.set("table.exec.mini-batch.enabled", "true"); # local-global aggregation depends on mini-batch is enabled
+configuration.set("table.exec.mini-batch.allow-latency", "5 s");
+configuration.set("table.exec.mini-batch.size", "5000");
+configuration.set("table.optimizer.agg-phase-strategy", "TWO_PHASE"); # enable two-phase, i.e. local-global aggregation
 ```
 {{< /tab >}}
 {{< /tabs >}}

--- a/docs/content/docs/dev/python/dependency_management.md
+++ b/docs/content/docs/dev/python/dependency_management.md
@@ -51,7 +51,7 @@ If third-party JARs are used, you can specify the JARs in the Python Table API a
 # Specify a list of jar URLs via "pipeline.jars". The jars are separated by ";"
 # and will be uploaded to the cluster.
 # NOTE: Only local file URLs (start with "file://") are supported.
-table_env.get_config().get_configuration().set_string("pipeline.jars", "file:///my/jar/path/connector.jar;file:///my/jar/path/udf.jar")
+table_env.get_config().set("pipeline.jars", "file:///my/jar/path/connector.jar;file:///my/jar/path/udf.jar")
 
 # It looks like the following on Windows:
 table_env.get_config().get_configuration().set_string("pipeline.jars", "file:///E:/my/jar/path/connector.jar;file:///E:/my/jar/path/udf.jar")
@@ -59,7 +59,7 @@ table_env.get_config().get_configuration().set_string("pipeline.jars", "file:///
 # Specify a list of URLs via "pipeline.classpaths". The URLs are separated by ";" 
 # and will be added to the classpath during job execution.
 # NOTE: The paths must specify a protocol (e.g. file://) and users should ensure that the URLs are accessible on both the client and the cluster.
-table_env.get_config().get_configuration().set_string("pipeline.classpaths", "file:///my/jar/path/connector.jar;file:///my/jar/path/udf.jar")
+table_env.get_config().set("pipeline.classpaths", "file:///my/jar/path/connector.jar;file:///my/jar/path/udf.jar")
 ```
 
 or in the Python DataStream API as following:

--- a/docs/content/docs/dev/python/faq.md
+++ b/docs/content/docs/dev/python/faq.md
@@ -74,10 +74,10 @@ You can specify the dependencies with the following Python Table APIs or through
 
 ```python
 # NOTE: Only local file URLs (start with "file:") are supported.
-table_env.get_config().get_configuration().set_string("pipeline.jars", "file:///my/jar/path/connector.jar;file:///my/jar/path/udf.jar")
+table_env.get_config().set("pipeline.jars", "file:///my/jar/path/connector.jar;file:///my/jar/path/udf.jar")
 
 # NOTE: The Paths must specify a protocol (e.g. "file") and users should ensure that the URLs are accessible on both the client and the cluster.
-table_env.get_config().get_configuration().set_string("pipeline.classpaths", "file:///my/jar/path/connector.jar;file:///my/jar/path/udf.jar")
+table_env.get_config().set("pipeline.classpaths", "file:///my/jar/path/connector.jar;file:///my/jar/path/udf.jar")
 ```
 
 For details about the APIs of adding Java dependency, you can refer to [the relevant documentation]({{< ref "docs/dev/python/dependency_management" >}}#java-dependency-in-python-program)

--- a/docs/content/docs/dev/python/python_execution_mode.md
+++ b/docs/content/docs/dev/python/python_execution_mode.md
@@ -54,7 +54,7 @@ You could specify the Python execution mode using Python Table API as following:
 
 ```python
 # Specify `PROCESS` mode
-table_env.get_config().get_configuration().set_string("python.execution-mode", "process")
+table_env.get_config().set("python.execution-mode", "process")
 
 # Specify `THREAD` mode
 table_env.get_config().get_configuration().set_string("python.execution-mode", "thread")

--- a/docs/content/docs/dev/python/table/python_table_api_connectors.md
+++ b/docs/content/docs/dev/python/table/python_table_api_connectors.md
@@ -38,7 +38,7 @@ Since Flink is a Java/Scala-based project, for both connectors and formats, impl
 are available as jars that need to be specified as job [dependencies]({{< ref "docs/dev/python/dependency_management" >}}).
 
 ```python
-table_env.get_config().get_configuration().set_string("pipeline.jars", "file:///my/jar/path/connector.jar;file:///my/jar/path/json.jar")
+table_env.get_config().set("pipeline.jars", "file:///my/jar/path/connector.jar;file:///my/jar/path/json.jar")
 ```
 
 ## How to use connectors
@@ -89,7 +89,7 @@ def log_processing():
     env_settings = EnvironmentSettings.in_streaming_mode()
     t_env = TableEnvironment.create(env_settings)
     # specify connector and format jars
-    t_env.get_config().get_configuration().set_string("pipeline.jars", "file:///my/jar/path/connector.jar;file:///my/jar/path/json.jar")
+    t_env.get_config().set("pipeline.jars", "file:///my/jar/path/connector.jar;file:///my/jar/path/json.jar")
     
     source_ddl = """
             CREATE TABLE source_table(

--- a/docs/content/docs/dev/python/table/table_environment.md
+++ b/docs/content/docs/dev/python/table/table_environment.md
@@ -570,7 +570,7 @@ Please refer to the [Dependency Management]({{< ref "docs/dev/python/dependency_
         The following code is an example showing how to set the configuration options through this API:
 ```python
 # set the parallelism to 8
-table_env.get_config().get_configuration().set_string(
+table_env.get_config().set(
     "parallelism.default", "8")
 ```
       </td>
@@ -821,19 +821,19 @@ And now you can configure them by setting key-value options in `TableConfig`, se
 The following code is an example showing how to configure the statebackend, checkpoint and restart strategy through the Table API:
 ```python
 # set the restart strategy to "fixed-delay"
-table_env.get_config().get_configuration().set_string("restart-strategy", "fixed-delay")
-table_env.get_config().get_configuration().set_string("restart-strategy.fixed-delay.attempts", "3")
-table_env.get_config().get_configuration().set_string("restart-strategy.fixed-delay.delay", "30s")
+table_env.get_config().set("restart-strategy", "fixed-delay")
+table_env.get_config().set("restart-strategy.fixed-delay.attempts", "3")
+table_env.get_config().set("restart-strategy.fixed-delay.delay", "30s")
 
 # set the checkpoint mode to EXACTLY_ONCE
-table_env.get_config().get_configuration().set_string("execution.checkpointing.mode", "EXACTLY_ONCE")
-table_env.get_config().get_configuration().set_string("execution.checkpointing.interval", "3min")
+table_env.get_config().set("execution.checkpointing.mode", "EXACTLY_ONCE")
+table_env.get_config().set("execution.checkpointing.interval", "3min")
 
 # set the statebackend type to "rocksdb", other available options are "filesystem" and "jobmanager"
 # you can also set the full qualified Java class name of the StateBackendFactory to this option
 # e.g. org.apache.flink.contrib.streaming.state.RocksDBStateBackendFactory
-table_env.get_config().get_configuration().set_string("state.backend", "rocksdb")
+table_env.get_config().set("state.backend", "rocksdb")
 
 # set the checkpoint directory, which is required by the RocksDB statebackend
-table_env.get_config().get_configuration().set_string("state.checkpoints.dir", "file:///tmp/checkpoints/")
+table_env.get_config().set("state.checkpoints.dir", "file:///tmp/checkpoints/")
 ```

--- a/docs/content/docs/dev/python/table_api_tutorial.md
+++ b/docs/content/docs/dev/python/table_api_tutorial.md
@@ -70,7 +70,7 @@ The table config allows setting Table API specific configurations.
 
 ```python
 t_env = TableEnvironment.create(EnvironmentSettings.in_streaming_mode())
-t_env.get_config().get_configuration().set_string("parallelism.default", "1")
+t_env.get_config().set("parallelism.default", "1")
 ```
 
 You can now create the source and sink tables:
@@ -204,7 +204,7 @@ word_count_data = ["To be, or not to be,--that is the question:--",
 def word_count(input_path, output_path):
     t_env = TableEnvironment.create(EnvironmentSettings.in_streaming_mode())
     # write all the data to one file
-    t_env.get_config().get_configuration().set_string("parallelism.default", "1")
+    t_env.get_config().set("parallelism.default", "1")
 
     # define the source
     if input_path is not None:

--- a/flink-end-to-end-tests/flink-python-test/python/python_job.py
+++ b/flink-end-to-end-tests/flink-python-test/python/python_job.py
@@ -38,7 +38,7 @@ def word_count():
     # used to test pipeline.jars and pipeline.classpaths
     config_key = sys.argv[1]
     config_value = sys.argv[2]
-    t_env.get_config().get_configuration().set_string(config_key, config_value)
+    t_env.get_config().set(config_key, config_value)
 
     # register Results table in table environment
     tmp_dir = tempfile.gettempdir()

--- a/flink-python/pyflink/examples/table/pandas/conversion_from_dataframe.py
+++ b/flink-python/pyflink/examples/table/pandas/conversion_from_dataframe.py
@@ -26,7 +26,7 @@ from pyflink.table import (DataTypes, TableEnvironment, EnvironmentSettings)
 
 def conversion_from_dataframe():
     t_env = TableEnvironment.create(EnvironmentSettings.in_streaming_mode())
-    t_env.get_config().get_configuration().set_string("parallelism.default", "1")
+    t_env.get_config().set("parallelism.default", "1")
 
     # define the source with watermark definition
     pdf = pd.DataFrame(np.random.rand(1000, 2))

--- a/flink-python/pyflink/examples/table/word_count.py
+++ b/flink-python/pyflink/examples/table/word_count.py
@@ -65,7 +65,7 @@ word_count_data = ["To be, or not to be,--that is the question:--",
 def word_count(input_path, output_path):
     t_env = TableEnvironment.create(EnvironmentSettings.in_streaming_mode())
     # write all the data to one file
-    t_env.get_config().get_configuration().set_string("parallelism.default", "1")
+    t_env.get_config().set("parallelism.default", "1")
 
     # define the source
     if input_path is not None:

--- a/flink-python/pyflink/table/table.py
+++ b/flink-python/pyflink/table/table.py
@@ -969,8 +969,8 @@ class Table(object):
         """
         self._t_env._before_execute()
         gateway = get_gateway()
-        max_arrow_batch_size = self._j_table.getTableEnvironment().getConfig().getConfiguration()\
-            .getInteger(gateway.jvm.org.apache.flink.python.PythonOptions.MAX_ARROW_BATCH_SIZE)
+        max_arrow_batch_size = self._j_table.getTableEnvironment().getConfig()\
+            .get(gateway.jvm.org.apache.flink.python.PythonOptions.MAX_ARROW_BATCH_SIZE)
         batches_iterator = gateway.jvm.org.apache.flink.table.runtime.arrow.ArrowUtils\
             .collectAsPandasDataFrame(self._j_table, max_arrow_batch_size)
         if batches_iterator.hasNext():

--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -1189,14 +1189,12 @@ class TableEnvironment(object):
         .. versionadded:: 1.10.0
         """
         jvm = get_gateway().jvm
-        python_files = self.get_config().get_configuration().get_string(
-            jvm.PythonOptions.PYTHON_FILES.key(), None)
+        python_files = self.get_config().get(jvm.PythonOptions.PYTHON_FILES.key(), None)
         if python_files is not None:
             python_files = jvm.PythonDependencyUtils.FILE_DELIMITER.join([file_path, python_files])
         else:
             python_files = file_path
-        self.get_config().get_configuration().set_string(
-            jvm.PythonOptions.PYTHON_FILES.key(), python_files)
+        self.get_config().set(jvm.PythonOptions.PYTHON_FILES.key(), python_files)
 
     def set_python_requirements(self,
                                 requirements_file_path: str,
@@ -1239,7 +1237,7 @@ class TableEnvironment(object):
         if requirements_cache_dir is not None:
             python_requirements = jvm.PythonDependencyUtils.PARAM_DELIMITER.join(
                 [python_requirements, requirements_cache_dir])
-        self.get_config().get_configuration().set_string(
+        self.get_config().set(
             jvm.PythonOptions.PYTHON_REQUIREMENTS.key(), python_requirements)
 
     def add_python_archive(self, archive_path: str, target_dir: str = None):
@@ -1297,15 +1295,13 @@ class TableEnvironment(object):
         if target_dir is not None:
             archive_path = jvm.PythonDependencyUtils.PARAM_DELIMITER.join(
                 [archive_path, target_dir])
-        python_archives = self.get_config().get_configuration().get_string(
-            jvm.PythonOptions.PYTHON_ARCHIVES.key(), None)
+        python_archives = self.get_config().get(jvm.PythonOptions.PYTHON_ARCHIVES.key(), None)
         if python_archives is not None:
             python_files = jvm.PythonDependencyUtils.FILE_DELIMITER.join(
                 [python_archives, archive_path])
         else:
             python_files = archive_path
-        self.get_config().get_configuration().set_string(
-            jvm.PythonOptions.PYTHON_ARCHIVES.key(), python_files)
+        self.get_config().set(jvm.PythonOptions.PYTHON_ARCHIVES.key(), python_files)
 
     def from_elements(self, elements: Iterable, schema: Union[DataType, List[str]] = None,
                       verify_schema: bool = True) -> Table:
@@ -1539,10 +1535,14 @@ class TableEnvironment(object):
 
     def _add_jars_to_j_env_config(self, config_key):
         jvm = get_gateway().jvm
-        jar_urls = self.get_config().get_configuration().get_string(config_key, None)
+        jar_urls = self.get_config().get(config_key, None)
         if jar_urls is not None:
             # normalize
-            jar_urls_list = [jvm.java.net.URL(url).toString() for url in jar_urls.split(";")]
+            jar_urls_list = []
+            for url in jar_urls.split(";"):
+                url = url.strip()
+                if url != "":
+                    jar_urls_list.append(jvm.java.net.URL(url).toString())
             j_configuration = get_j_env_configuration(self._get_j_env())
             if j_configuration.containsKey(config_key):
                 for url in j_configuration.getString(config_key, "").split(";"):

--- a/flink-python/pyflink/table/tests/test_dependency.py
+++ b/flink-python/pyflink/table/tests/test_dependency.py
@@ -96,7 +96,7 @@ class DependencyTests(object):
 class EmbeddedThreadDependencyTests(DependencyTests, PyFlinkStreamTableTestCase):
     def setUp(self):
         super(EmbeddedThreadDependencyTests, self).setUp()
-        self.t_env.get_config().get_configuration().set_string("python.execution-mode", "thread")
+        self.t_env.get_config().set("python.execution-mode", "thread")
 
 
 class BatchDependencyTests(DependencyTests, PyFlinkBatchTableTestCase):

--- a/flink-python/pyflink/table/tests/test_pandas_conversion.py
+++ b/flink-python/pyflink/table/tests/test_pandas_conversion.py
@@ -181,7 +181,7 @@ class BatchPandasConversionTests(PandasConversionTests,
 class StreamPandasConversionTests(PandasConversionITTests,
                                   PyFlinkStreamTableTestCase):
     def test_to_pandas_with_event_time(self):
-        self.t_env.get_config().get_configuration().set_string("parallelism.default", "1")
+        self.t_env.get_config().set("parallelism.default", "1")
         # create source file path
         import tempfile
         import os
@@ -199,7 +199,7 @@ class StreamPandasConversionTests(PandasConversionITTests,
             for ele in data:
                 fd.write(ele + '\n')
 
-        self.t_env.get_config().get_configuration().set_string(
+        self.t_env.get_config().set(
             "pipeline.time-characteristic", "EventTime")
 
         source_table = """

--- a/flink-python/pyflink/table/tests/test_pandas_udaf.py
+++ b/flink-python/pyflink/table/tests/test_pandas_udaf.py
@@ -102,7 +102,7 @@ class BatchPandasUDAFITTests(PyFlinkBatchTableTestCase):
             ['a', 'b', 'c', 'd'],
             [DataTypes.TINYINT(), DataTypes.INT(), DataTypes.FLOAT(), DataTypes.INT()])
         self.t_env.register_table_sink("Results", table_sink)
-        self.t_env.get_config().get_configuration().set_string('python.metric.enabled', 'true')
+        self.t_env.get_config().set('python.metric.enabled', 'true')
         self.t_env.register_function("max_add", udaf(MaxAdd(),
                                                      result_type=DataTypes.INT(),
                                                      func_type="pandas"))
@@ -304,7 +304,7 @@ class StreamPandasUDAFITTests(PyFlinkStreamTableTestCase):
                 fd.write(ele + '\n')
 
         from pyflink.table.window import Slide
-        self.t_env.get_config().get_configuration().set_string(
+        self.t_env.get_config().set(
             "pipeline.time-characteristic", "EventTime")
         self.t_env.register_function("mean_udaf", mean_udaf)
 
@@ -356,7 +356,7 @@ class StreamPandasUDAFITTests(PyFlinkStreamTableTestCase):
         os.remove(source_path)
 
     def test_sliding_group_window_over_proctime(self):
-        self.t_env.get_config().get_configuration().set_string("parallelism.default", "1")
+        self.t_env.get_config().set("parallelism.default", "1")
         from pyflink.table.window import Slide
         self.t_env.register_function("mean_udaf", mean_udaf)
 
@@ -389,7 +389,7 @@ class StreamPandasUDAFITTests(PyFlinkStreamTableTestCase):
         self.assertTrue(result[0][1].year > 1970)
 
     def test_sliding_group_window_over_count(self):
-        self.t_env.get_config().get_configuration().set_string("parallelism.default", "1")
+        self.t_env.get_config().set("parallelism.default", "1")
         # create source file path
         import tempfile
         import os
@@ -409,7 +409,7 @@ class StreamPandasUDAFITTests(PyFlinkStreamTableTestCase):
                 fd.write(ele + '\n')
 
         from pyflink.table.window import Slide
-        self.t_env.get_config().get_configuration().set_string(
+        self.t_env.get_config().set(
             "pipeline.time-characteristic", "ProcessingTime")
         self.t_env.register_function("mean_udaf", mean_udaf)
 
@@ -467,7 +467,7 @@ class StreamPandasUDAFITTests(PyFlinkStreamTableTestCase):
                 fd.write(ele + '\n')
 
         from pyflink.table.window import Tumble
-        self.t_env.get_config().get_configuration().set_string(
+        self.t_env.get_config().set(
             "pipeline.time-characteristic", "EventTime")
         self.t_env.register_function("mean_udaf", mean_udaf)
 
@@ -517,7 +517,7 @@ class StreamPandasUDAFITTests(PyFlinkStreamTableTestCase):
         os.remove(source_path)
 
     def test_tumbling_group_window_over_count(self):
-        self.t_env.get_config().get_configuration().set_string("parallelism.default", "1")
+        self.t_env.get_config().set("parallelism.default", "1")
         # create source file path
         import tempfile
         import os
@@ -538,7 +538,7 @@ class StreamPandasUDAFITTests(PyFlinkStreamTableTestCase):
                 fd.write(ele + '\n')
 
         from pyflink.table.window import Tumble
-        self.t_env.get_config().get_configuration().set_string(
+        self.t_env.get_config().set(
             "pipeline.time-characteristic", "ProcessingTime")
         self.t_env.register_function("mean_udaf", mean_udaf)
 
@@ -594,7 +594,7 @@ class StreamPandasUDAFITTests(PyFlinkStreamTableTestCase):
         max_add_min_udaf = udaf(lambda a: a.max() + a.min(),
                                 result_type=DataTypes.SMALLINT(),
                                 func_type='pandas')
-        self.t_env.get_config().get_configuration().set_string(
+        self.t_env.get_config().set(
             "pipeline.time-characteristic", "EventTime")
         self.t_env.register_function("mean_udaf", mean_udaf)
         self.t_env.register_function("max_add_min_udaf", max_add_min_udaf)
@@ -662,7 +662,7 @@ class StreamPandasUDAFITTests(PyFlinkStreamTableTestCase):
         max_add_min_udaf = udaf(lambda a: a.max() + a.min(),
                                 result_type=DataTypes.SMALLINT(),
                                 func_type='pandas')
-        self.t_env.get_config().get_configuration().set_string(
+        self.t_env.get_config().set(
             "pipeline.time-characteristic", "EventTime")
         self.t_env.register_function("mean_udaf", mean_udaf)
         self.t_env.register_function("max_add_min_udaf", max_add_min_udaf)
@@ -730,8 +730,8 @@ class StreamPandasUDAFITTests(PyFlinkStreamTableTestCase):
         max_add_min_udaf = udaf(lambda a: a.max() + a.min(),
                                 result_type=DataTypes.SMALLINT(),
                                 func_type='pandas')
-        self.t_env.get_config().get_configuration().set_string("parallelism.default", "1")
-        self.t_env.get_config().get_configuration().set_string(
+        self.t_env.get_config().set("parallelism.default", "1")
+        self.t_env.get_config().set(
             "pipeline.time-characteristic", "ProcessingTime")
         self.t_env.register_function("mean_udaf", mean_udaf)
         self.t_env.register_function("max_add_min_udaf", max_add_min_udaf)
@@ -824,7 +824,7 @@ class StreamPandasUDAFITTests(PyFlinkStreamTableTestCase):
         max_add_min_udaf = udaf(lambda a: a.max() + a.min(),
                                 result_type=DataTypes.SMALLINT(),
                                 func_type='pandas')
-        self.t_env.get_config().get_configuration().set_string(
+        self.t_env.get_config().set(
             "pipeline.time-characteristic", "EventTime")
         self.t_env.create_temporary_system_function("mean_udaf", mean_udaf)
         self.t_env.create_temporary_system_function("max_add_min_udaf", max_add_min_udaf)

--- a/flink-python/pyflink/table/tests/test_row_based_operation.py
+++ b/flink-python/pyflink/table/tests/test_row_based_operation.py
@@ -280,10 +280,10 @@ class StreamRowBasedOperationITTests(RowBasedOperationTests, PyFlinkStreamTableT
     def test_flat_aggregate_list_view(self):
         import pandas as pd
         my_concat = udtaf(ListViewConcatTableAggregateFunction())
-        self.t_env.get_config().get_configuration().set_string(
+        self.t_env.get_config().set(
             "python.fn-execution.bundle.size", "2")
         # trigger the cache eviction in a bundle.
-        self.t_env.get_config().get_configuration().set_string(
+        self.t_env.get_config().set(
             "python.state.cache-size", "2")
         t = self.t_env.from_elements([(1, 'Hi', 'Hello'),
                                       (3, 'Hi', 'hi'),

--- a/flink-python/pyflink/table/tests/test_table_config.py
+++ b/flink-python/pyflink/table/tests/test_table_config.py
@@ -58,9 +58,9 @@ class TableConfigTests(PyFlinkTestCase):
     def test_get_configuration(self):
         table_config = TableConfig.get_default()
 
-        table_config.get_configuration().set_string("k1", "v1")
+        table_config.set("k1", "v1")
 
-        self.assertEqual(table_config.get_configuration().get_string("k1", ""), "v1")
+        self.assertEqual(table_config.get("k1", ""), "v1")
 
     def test_add_configuration(self):
         table_config = TableConfig.get_default()
@@ -69,7 +69,7 @@ class TableConfigTests(PyFlinkTestCase):
 
         table_config.add_configuration(configuration)
 
-        self.assertEqual(table_config.get_configuration().get_string("k1", ""), "v1")
+        self.assertEqual(table_config.get("k1", ""), "v1")
 
     def test_get_set_sql_dialect(self):
         table_config = TableConfig.get_default()

--- a/flink-python/pyflink/table/tests/test_table_config_completeness.py
+++ b/flink-python/pyflink/table/tests/test_table_config_completeness.py
@@ -38,7 +38,7 @@ class TableConfigCompletenessTests(PythonAPICompletenessTestCase, PyFlinkTestCas
     def excluded_methods(cls):
         # internal interfaces, no need to expose to users.
         return {'getPlannerConfig', 'setPlannerConfig', 'addJobParameter',
-                'setRootConfiguration', 'get', 'getOptional'}
+                'setRootConfiguration', 'getRootConfiguration', 'getOptional'}
 
     @classmethod
     def java_method_name(cls, python_method_name):

--- a/flink-python/pyflink/table/tests/test_table_environment_api.py
+++ b/flink-python/pyflink/table/tests/test_table_environment_api.py
@@ -243,7 +243,7 @@ class DataStreamConversionTestCases(PyFlinkTestCase):
         self.env.set_parallelism(2)
         config = get_j_env_configuration(self.env._j_stream_execution_environment)
         config.setString("akka.ask.timeout", "20 s")
-        self.t_env.get_config().get_configuration().set_string(
+        self.t_env.get_config().set(
             "python.fn-execution.bundle.size", "1")
         self.test_sink = DataStreamTestSinkFunction()
 

--- a/flink-python/pyflink/table/tests/test_udaf.py
+++ b/flink-python/pyflink/table/tests/test_udaf.py
@@ -247,10 +247,10 @@ class StreamTableAggregateTests(PyFlinkStreamTableTestCase):
         self.t_env.create_temporary_function("my_sum", SumAggregateFunction())
         # trigger the finish bundle more frequently to ensure testing the communication
         # between RemoteKeyedStateBackend and the StateGrpcService.
-        self.t_env.get_config().get_configuration().set_string(
+        self.t_env.get_config().set(
             "python.fn-execution.bundle.size", "2")
         # trigger the cache eviction in a bundle.
-        self.t_env.get_config().get_configuration().set_string(
+        self.t_env.get_config().set(
             "python.state.cache-size", "1")
         t = self.t_env.from_elements([(1, 'Hi', 'Hello'),
                                       (3, 'Hi', 'hi'),
@@ -268,7 +268,7 @@ class StreamTableAggregateTests(PyFlinkStreamTableTestCase):
                            pd.DataFrame([[3, 12, 12, 12.0]], columns=['a', 'b', 'c', 'd']))
 
     def test_mixed_with_built_in_functions_with_retract(self):
-        self.t_env.get_config().get_configuration().set_string("parallelism.default", "1")
+        self.t_env.get_config().set("parallelism.default", "1")
         self.t_env.create_temporary_system_function(
             "concat",
             ConcatAggregateFunction())
@@ -316,7 +316,7 @@ class StreamTableAggregateTests(PyFlinkStreamTableTestCase):
         self.assertEqual(result[len(result) - 1], expected)
 
     def test_mixed_with_built_in_functions_without_retract(self):
-        self.t_env.get_config().get_configuration().set_string("parallelism.default", "1")
+        self.t_env.get_config().set("parallelism.default", "1")
         self.t_env.create_temporary_system_function(
             "concat",
             ConcatAggregateFunction())
@@ -362,10 +362,10 @@ class StreamTableAggregateTests(PyFlinkStreamTableTestCase):
 
     def test_list_view(self):
         my_concat = udaf(ListViewConcatAggregateFunction())
-        self.t_env.get_config().get_configuration().set_string(
+        self.t_env.get_config().set(
             "python.fn-execution.bundle.size", "2")
         # trigger the cache eviction in a bundle.
-        self.t_env.get_config().get_configuration().set_string(
+        self.t_env.get_config().set(
             "python.state.cache-size", "2")
         t = self.t_env.from_elements([(1, 'Hi', 'Hello'),
                                       (3, 'Hi', 'hi'),
@@ -385,14 +385,14 @@ class StreamTableAggregateTests(PyFlinkStreamTableTestCase):
     def test_map_view(self):
         my_count = udaf(CountDistinctAggregateFunction())
         self.t_env.get_config().set_idle_state_retention(datetime.timedelta(days=1))
-        self.t_env.get_config().get_configuration().set_string(
+        self.t_env.get_config().set(
             "python.fn-execution.bundle.size", "2")
         # trigger the cache eviction in a bundle.
-        self.t_env.get_config().get_configuration().set_string(
+        self.t_env.get_config().set(
             "python.state.cache-size", "1")
-        self.t_env.get_config().get_configuration().set_string(
+        self.t_env.get_config().set(
             "python.map-state.read-cache-size", "1")
-        self.t_env.get_config().get_configuration().set_string(
+        self.t_env.get_config().set(
             "python.map-state.write-cache-size", "1")
         t = self.t_env.from_elements(
             [(1, 'Hi_', 'hi'),
@@ -419,10 +419,10 @@ class StreamTableAggregateTests(PyFlinkStreamTableTestCase):
     def test_data_view_clear(self):
         my_count = udaf(CountDistinctAggregateFunction())
         self.t_env.get_config().set_idle_state_retention(datetime.timedelta(days=1))
-        self.t_env.get_config().get_configuration().set_string(
+        self.t_env.get_config().set(
             "python.fn-execution.bundle.size", "2")
         # trigger the cache eviction in a bundle.
-        self.t_env.get_config().get_configuration().set_string(
+        self.t_env.get_config().set(
             "python.state.cache-size", "1")
         t = self.t_env.from_elements(
             [(2, 'hello', 'hello'),
@@ -436,16 +436,16 @@ class StreamTableAggregateTests(PyFlinkStreamTableTestCase):
     def test_map_view_iterate(self):
         test_iterate = udaf(TestIterateAggregateFunction())
         self.t_env.get_config().set_idle_state_retention(datetime.timedelta(days=1))
-        self.t_env.get_config().get_configuration().set_string(
+        self.t_env.get_config().set(
             "python.fn-execution.bundle.size", "2")
         # trigger the cache eviction in a bundle.
-        self.t_env.get_config().get_configuration().set_string(
+        self.t_env.get_config().set(
             "python.state.cache-size", "2")
-        self.t_env.get_config().get_configuration().set_string(
+        self.t_env.get_config().set(
             "python.map-state.read-cache-size", "2")
-        self.t_env.get_config().get_configuration().set_string(
+        self.t_env.get_config().set(
             "python.map-state.write-cache-size", "2")
-        self.t_env.get_config().get_configuration().set_string(
+        self.t_env.get_config().set(
             "python.map-state.iterate-response-batch-size", "2")
         t = self.t_env.from_elements(
             [(1, 'Hi_', 'hi'),
@@ -513,12 +513,12 @@ class StreamTableAggregateTests(PyFlinkStreamTableTestCase):
 
     def test_clean_state(self):
         self.t_env.register_function("my_count", CountAggregateFunction())
-        self.t_env.get_config().get_configuration().set_string("parallelism.default", "1")
-        self.t_env.get_config().get_configuration().set_string(
+        self.t_env.get_config().set("parallelism.default", "1")
+        self.t_env.get_config().set(
             "python.fn-execution.bundle.size", "1")
-        self.t_env.get_config().get_configuration().set_string(
+        self.t_env.get_config().set(
             "python.state.cache-size", "0")
-        self.t_env.get_config().get_configuration().set_string(
+        self.t_env.get_config().set(
             "table.exec.state.ttl", "2ms")
 
         self.t_env.execute_sql("""
@@ -596,7 +596,7 @@ class StreamTableAggregateTests(PyFlinkStreamTableTestCase):
                             "+I[1, 2018-03-11 04:00:00.0, 2018-03-11 05:00:00.0, 1, 1]"])
 
     def test_tumbling_group_window_over_count(self):
-        self.t_env.get_config().get_configuration().set_string("parallelism.default", "1")
+        self.t_env.get_config().set("parallelism.default", "1")
         # create source file path
         tmp_dir = self.tempdir
         data = [
@@ -713,7 +713,7 @@ class StreamTableAggregateTests(PyFlinkStreamTableTestCase):
                             "+I[1, 2018-03-11 04:00:00.0, 2018-03-11 05:00:00.0, 8]"])
 
     def test_sliding_group_window_over_count(self):
-        self.t_env.get_config().get_configuration().set_string("parallelism.default", "1")
+        self.t_env.get_config().set("parallelism.default", "1")
         # create source file path
         tmp_dir = self.tempdir
         data = [

--- a/flink-python/pyflink/table/tests/test_udf.py
+++ b/flink-python/pyflink/table/tests/test_udf.py
@@ -35,7 +35,7 @@ class UserDefinedFunctionTests(object):
 
     def test_scalar_function(self):
         # test metric disabled.
-        self.t_env.get_config().get_configuration().set_string('python.metric.enabled', 'false')
+        self.t_env.get_config().set('python.metric.enabled', 'false')
         # test lambda function
         add_one = udf(lambda i: i + 1, result_type=DataTypes.BIGINT())
 
@@ -66,8 +66,7 @@ class UserDefinedFunctionTests(object):
              DataTypes.BIGINT(), DataTypes.BIGINT(), DataTypes.BIGINT()])
         self.t_env.register_table_sink("Results", table_sink)
 
-        execution_mode = self.t_env.get_config().get_configuration().get_string(
-            "python.execution-mode", "process")
+        execution_mode = self.t_env.get_config().get("python.execution-mode", "process")
 
         t = self.t_env.from_elements([(1, 2, 3), (2, 5, 6), (3, 1, 9)], ['a', 'b', 'c'])
         t.where(add_one(t.b) <= 3).select(
@@ -222,9 +221,8 @@ class UserDefinedFunctionTests(object):
         self.assert_equals(actual, ["+I[2]", "+I[6]", "+I[3]"])
 
     def test_open(self):
-        self.t_env.get_config().get_configuration().set_string('python.metric.enabled', 'true')
-        execution_mode = self.t_env.get_config().get_configuration().get_string(
-            "python.execution-mode", None)
+        self.t_env.get_config().set('python.metric.enabled', 'true')
+        execution_mode = self.t_env.get_config().get("python.execution-mode", None)
 
         if execution_mode == "process":
             subtract = udf(SubtractWithMetrics(), result_type=DataTypes.BIGINT())
@@ -801,8 +799,7 @@ class PyFlinkBatchUserDefinedFunctionTests(UserDefinedFunctionTests,
 class PyFlinkEmbeddedThreadTests(UserDefinedFunctionTests, PyFlinkBatchTableTestCase):
     def setUp(self):
         super(PyFlinkEmbeddedThreadTests, self).setUp()
-        self.t_env.get_config().get_configuration().set_string("python.execution-mode", "thread")
-
+        self.t_env.get_config().set("python.execution-mode", "thread")
 
 # test specify the input_types
 @udf(input_types=[DataTypes.BIGINT(), DataTypes.BIGINT()], result_type=DataTypes.BIGINT())

--- a/flink-python/pyflink/testing/test_case_utils.py
+++ b/flink-python/pyflink/testing/test_case_utils.py
@@ -135,8 +135,8 @@ class PyFlinkStreamTableTestCase(PyFlinkTestCase):
     def setUp(self):
         super(PyFlinkStreamTableTestCase, self).setUp()
         self.t_env = TableEnvironment.create(EnvironmentSettings.in_streaming_mode())
-        self.t_env.get_config().get_configuration().set_string("parallelism.default", "2")
-        self.t_env.get_config().get_configuration().set_string(
+        self.t_env.get_config().set("parallelism.default", "2")
+        self.t_env.get_config().set(
             "python.fn-execution.bundle.size", "1")
 
 
@@ -148,8 +148,8 @@ class PyFlinkBatchTableTestCase(PyFlinkTestCase):
     def setUp(self):
         super(PyFlinkBatchTableTestCase, self).setUp()
         self.t_env = TableEnvironment.create(EnvironmentSettings.in_batch_mode())
-        self.t_env.get_config().get_configuration().set_string("parallelism.default", "2")
-        self.t_env.get_config().get_configuration().set_string(
+        self.t_env.get_config().set("parallelism.default", "2")
+        self.t_env.get_config().set(
             "python.fn-execution.bundle.size", "1")
 
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableConfig.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableConfig.java
@@ -206,6 +206,15 @@ public final class TableConfig implements WritableConfig, ReadableConfig {
     }
 
     /**
+     * Gives direct access to the underlying environment-specific key-value map for advanced
+     * configuration.
+     */
+    @Internal
+    public ReadableConfig getRootConfiguration() {
+        return rootConfiguration;
+    }
+
+    /**
      * Adds the given key-value configuration to the underlying application-specific configuration.
      * It overwrites existing keys.
      *


### PR DESCRIPTION
## What is the purpose of the change

Adjust the python code to match the latest changes to the corresponding
`TableConfig` and `EnvironmentSettings`, so that python also uses the
new API methods, and can benefit from the app config + env config view
that `TableConfig` provides.

## Brief changelog:

 - Use directly `set()` on the `TableConfig` instead of `TableConfig.get_configuration.set_string()`
 - Use the new `get()` on the `TableConfg` instead of `TableConfig.get_configuration.get_string()` so that, transparently, `TableConfig#rootConfiguration` is also used to read options set in the environment. 

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
