### PR TITLE
[FLINK-26607][python] There are multiple MAX_LONG_VALUE value errors in pyflink code

### DIFF
--- a/flink-python/pyflink/common/constants.py
+++ b/flink-python/pyflink/common/constants.py
@@ -1,0 +1,8 @@
+"""
+A constant holding the maximum value a long can have, 2^63 – 1.
+"""
+MAX_LONG_VALUE = 0x7fffffffffffffff
+"""
+A constant holding the minimum value a long can have, -2^63
+"""
+MIN_LONG_VALUE = - MAX_LONG_VALUE - 1

--- a/flink-python/pyflink/common/constants.py
+++ b/flink-python/pyflink/common/constants.py
@@ -1,3 +1,20 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
 """
 A constant holding the maximum value a long can have, 2^63 – 1.
 """

--- a/flink-python/pyflink/datastream/window.py
+++ b/flink-python/pyflink/datastream/window.py
@@ -22,6 +22,7 @@ from io import BytesIO
 from typing import TypeVar, Generic, Iterable, Collection, Any, cast
 
 from pyflink.common import Time, Types
+from pyflink.common.constants import MAX_LONG_VALUE, MIN_LONG_VALUE
 from pyflink.common.serializer import TypeSerializer
 from pyflink.datastream.functions import RuntimeContext, InternalWindowFunction
 from pyflink.datastream.state import StateDescriptor, ReducingStateDescriptor, \
@@ -51,15 +52,6 @@ __all__ = ['Window',
            'TimeWindowSerializer',
            'CountWindowSerializer',
            'SessionWindowTimeGapExtractor']
-
-"""
-A constant holding the maximum value a long can have, 2^63 – 1.
-"""
-MAX_LONG_VALUE = 0x7fffffffffffffff
-"""
-A constant holding the minimum value a long can have, -2^63
-"""
-MIN_LONG_VALUE = - MAX_LONG_VALUE - 1
 
 
 def long_to_int_with_bit_mixing(x: int) -> int:

--- a/flink-python/pyflink/fn_execution/datastream/window/window_operator.py
+++ b/flink-python/pyflink/fn_execution/datastream/window/window_operator.py
@@ -18,13 +18,13 @@
 import typing
 from typing import TypeVar, Iterable, Collection
 
+from pyflink.common.constants import MAX_LONG_VALUE
 from pyflink.datastream import WindowAssigner, Trigger, MergingWindowAssigner, TriggerResult
 from pyflink.datastream.functions import KeyedStateStore, RuntimeContext, InternalWindowFunction
 from pyflink.datastream.state import StateDescriptor, ListStateDescriptor, \
     ReducingStateDescriptor, AggregatingStateDescriptor, ValueStateDescriptor, MapStateDescriptor, \
     State, AggregatingState, ReducingState, MapState, ListState, ValueState, AppendingState
 from pyflink.fn_execution.datastream.timerservice import InternalTimerService
-from pyflink.datastream.window import MAX_LONG_VALUE
 from pyflink.fn_execution.datastream.window.merging_window_set import MergingWindowSet
 from pyflink.fn_execution.internal_state import InternalMergingState, InternalKvState, \
     InternalAppendingState

--- a/flink-python/pyflink/fn_execution/table/window_aggregate_fast.pyx
+++ b/flink-python/pyflink/fn_execution/table/window_aggregate_fast.pyx
@@ -25,11 +25,11 @@ from pyflink.fn_execution.table.aggregate_fast cimport DistinctViewDescriptor, R
 from pyflink.fn_execution.coder_impl_fast cimport InternalRowKind
 
 import datetime
-import sys
 from typing import List, Dict
 
 import pytz
 
+from pyflink.common.constants import MAX_LONG_VALUE
 from pyflink.fn_execution.datastream.timerservice_impl import LegacyInternalTimerServiceImpl
 from pyflink.fn_execution.coders import PickleCoder
 from pyflink.fn_execution.table.state_data_view import DataViewSpec, ListViewSpec, MapViewSpec, \
@@ -41,8 +41,6 @@ from pyflink.fn_execution.table.window_process_function import GeneralWindowProc
     InternalWindowProcessFunction, PanedWindowProcessFunction, MergingWindowProcessFunction
 from pyflink.fn_execution.table.window_trigger import Trigger
 from pyflink.table.udf import ImperativeAggregateFunction
-
-MAX_LONG_VALUE = sys.maxsize
 
 cdef InternalRow join_row(list left, list right, InternalRowKind row_kind):
     return InternalRow(left.__add__(right), row_kind)

--- a/flink-python/pyflink/fn_execution/table/window_aggregate_slow.py
+++ b/flink-python/pyflink/fn_execution/table/window_aggregate_slow.py
@@ -16,7 +16,6 @@
 # limitations under the License.
 ################################################################################
 import datetime
-import sys
 from abc import ABC, abstractmethod
 from typing import TypeVar, Generic, List, Dict
 
@@ -37,7 +36,10 @@ from pyflink.fn_execution.table.window_process_function import GeneralWindowProc
 from pyflink.fn_execution.table.window_trigger import Trigger
 from pyflink.table.udf import ImperativeAggregateFunction, FunctionContext
 
-MAX_LONG_VALUE = sys.maxsize
+"""
+A constant holding the maximum value a long can have, 2^63 – 1.
+"""
+MAX_LONG_VALUE = 0x7fffffffffffffff
 
 N = TypeVar('N')
 

--- a/flink-python/pyflink/fn_execution/table/window_aggregate_slow.py
+++ b/flink-python/pyflink/fn_execution/table/window_aggregate_slow.py
@@ -22,6 +22,7 @@ from typing import TypeVar, Generic, List, Dict
 import pytz
 
 from pyflink.common import Row, RowKind
+from pyflink.common.constants import MAX_LONG_VALUE
 from pyflink.fn_execution.datastream.timerservice import InternalTimer
 from pyflink.fn_execution.datastream.timerservice_impl import LegacyInternalTimerServiceImpl
 from pyflink.fn_execution.coders import PickleCoder
@@ -32,8 +33,7 @@ from pyflink.fn_execution.table.window_assigner import WindowAssigner, PanedWind
     MergingWindowAssigner
 from pyflink.fn_execution.table.window_context import WindowContext, TriggerContext, K, W
 from pyflink.fn_execution.table.window_process_function import GeneralWindowProcessFunction, \
-    InternalWindowProcessFunction, PanedWindowProcessFunction, MergingWindowProcessFunction, \
-    MAX_LONG_VALUE
+    InternalWindowProcessFunction, PanedWindowProcessFunction, MergingWindowProcessFunction
 from pyflink.fn_execution.table.window_trigger import Trigger
 from pyflink.table.udf import ImperativeAggregateFunction, FunctionContext
 

--- a/flink-python/pyflink/fn_execution/table/window_aggregate_slow.py
+++ b/flink-python/pyflink/fn_execution/table/window_aggregate_slow.py
@@ -32,14 +32,11 @@ from pyflink.fn_execution.table.window_assigner import WindowAssigner, PanedWind
     MergingWindowAssigner
 from pyflink.fn_execution.table.window_context import WindowContext, TriggerContext, K, W
 from pyflink.fn_execution.table.window_process_function import GeneralWindowProcessFunction, \
-    InternalWindowProcessFunction, PanedWindowProcessFunction, MergingWindowProcessFunction
+    InternalWindowProcessFunction, PanedWindowProcessFunction, MergingWindowProcessFunction, \
+    MAX_LONG_VALUE
 from pyflink.fn_execution.table.window_trigger import Trigger
 from pyflink.table.udf import ImperativeAggregateFunction, FunctionContext
 
-"""
-A constant holding the maximum value a long can have, 2^63 – 1.
-"""
-MAX_LONG_VALUE = 0x7fffffffffffffff
 
 N = TypeVar('N')
 

--- a/flink-python/pyflink/fn_execution/table/window_context.py
+++ b/flink-python/pyflink/fn_execution/table/window_context.py
@@ -18,17 +18,13 @@
 from abc import ABC, abstractmethod
 from typing import Generic, TypeVar, List, Iterable
 
+from pyflink.common.constants import MAX_LONG_VALUE
 from pyflink.datastream.state import StateDescriptor, State, ValueStateDescriptor, \
     ListStateDescriptor, MapStateDescriptor
 from pyflink.datastream.window import TimeWindow, CountWindow
 from pyflink.fn_execution.datastream.timerservice_impl import LegacyInternalTimerServiceImpl
 from pyflink.fn_execution.coders import from_type_info, MapCoder, GenericArrayCoder
 from pyflink.fn_execution.internal_state import InternalMergingState
-
-"""
-A constant holding the maximum value a long can have, 2^63 – 1.
-"""
-MAX_LONG_VALUE = 0x7fffffffffffffff
 
 K = TypeVar('K')
 W = TypeVar('W', TimeWindow, CountWindow)

--- a/flink-python/pyflink/fn_execution/table/window_context.py
+++ b/flink-python/pyflink/fn_execution/table/window_context.py
@@ -15,7 +15,6 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
-import sys
 from abc import ABC, abstractmethod
 from typing import Generic, TypeVar, List, Iterable
 
@@ -26,7 +25,10 @@ from pyflink.fn_execution.datastream.timerservice_impl import LegacyInternalTime
 from pyflink.fn_execution.coders import from_type_info, MapCoder, GenericArrayCoder
 from pyflink.fn_execution.internal_state import InternalMergingState
 
-MAX_LONG_VALUE = sys.maxsize
+"""
+A constant holding the maximum value a long can have, 2^63 – 1.
+"""
+MAX_LONG_VALUE = 0x7fffffffffffffff
 
 K = TypeVar('K')
 W = TypeVar('W', TimeWindow, CountWindow)

--- a/flink-python/pyflink/fn_execution/table/window_process_function.py
+++ b/flink-python/pyflink/fn_execution/table/window_process_function.py
@@ -19,15 +19,11 @@ from abc import abstractmethod, ABC
 from typing import Generic, List, Iterable, Dict, Set
 
 from pyflink.common import Row
+from pyflink.common.constants import MAX_LONG_VALUE
 from pyflink.datastream.state import MapState
 from pyflink.fn_execution.table.window_assigner import WindowAssigner, PanedWindowAssigner, \
     MergingWindowAssigner
 from pyflink.fn_execution.table.window_context import Context, K, W
-
-"""
-A constant holding the maximum value a long can have, 2^63 – 1.
-"""
-MAX_LONG_VALUE = 0x7fffffffffffffff
 
 
 def join_row(left: List, right: List):

--- a/flink-python/pyflink/fn_execution/table/window_process_function.py
+++ b/flink-python/pyflink/fn_execution/table/window_process_function.py
@@ -15,7 +15,6 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
-import sys
 from abc import abstractmethod, ABC
 from typing import Generic, List, Iterable, Dict, Set
 
@@ -25,7 +24,10 @@ from pyflink.fn_execution.table.window_assigner import WindowAssigner, PanedWind
     MergingWindowAssigner
 from pyflink.fn_execution.table.window_context import Context, K, W
 
-MAX_LONG_VALUE = sys.maxsize
+"""
+A constant holding the maximum value a long can have, 2^63 – 1.
+"""
+MAX_LONG_VALUE = 0x7fffffffffffffff
 
 
 def join_row(left: List, right: List):

--- a/flink-python/pyflink/table/functions.py
+++ b/flink-python/pyflink/table/functions.py
@@ -19,16 +19,8 @@ import time
 from abc import abstractmethod
 from decimal import Decimal
 
+from pyflink.common.constants import MAX_LONG_VALUE, MIN_LONG_VALUE
 from pyflink.table import AggregateFunction, MapView, ListView
-
-"""
-A constant holding the maximum value a long can have, 2^63 – 1.
-"""
-MAX_LONG_VALUE = 0x7fffffffffffffff
-"""
-A constant holding the minimum value a long can have, -2^63
-"""
-MIN_LONG_VALUE = - MAX_LONG_VALUE - 1
 
 
 class AvgAggFunction(AggregateFunction):

--- a/flink-python/pyflink/table/functions.py
+++ b/flink-python/pyflink/table/functions.py
@@ -15,15 +15,20 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
-import sys
 import time
 from abc import abstractmethod
 from decimal import Decimal
 
 from pyflink.table import AggregateFunction, MapView, ListView
 
-MAX_LONG_VALUE = sys.maxsize
-MIN_LONG_VALUE = -MAX_LONG_VALUE - 1
+"""
+A constant holding the maximum value a long can have, 2^63 – 1.
+"""
+MAX_LONG_VALUE = 0x7fffffffffffffff
+"""
+A constant holding the minimum value a long can have, -2^63
+"""
+MIN_LONG_VALUE = - MAX_LONG_VALUE - 1
 
 
 class AvgAggFunction(AggregateFunction):


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This PR is mainly to repair MAX_LONG_VALUE value
MAX_LONG_VALUE = sys.maxsize

maxsize attribute of the sys module fetches the largest value a variable of data type Py_ssize_t ** can store. It is the Python platform’s pointer that dictates the maximum size of lists and strings in Python. The size value returned by maxsize depends on the platform architecture:

32-bit: the value will be 2^31 – 1, i.e. 2147483647
64-bit: the value will be 2^63 – 1, i.e. 9223372036854775807

## Brief change log

"""
A constant holding the maximum value a long can have, 2^63 – 1.
"""
MAX_LONG_VALUE = 0x7fffffffffffffff


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
