### PR TITLE
[FLINK-24960][yarn]enable log line of YarnClusterDescriptor

### DIFF
--- a/tools/ci/log4j.properties
+++ b/tools/ci/log4j.properties
@@ -84,3 +84,10 @@ logger.yarn2.appenderRef.out.ref = ConsoleAppender
 # watchdog mechanism to kick in in case of a timeout. Disabling this regular log message helps detecting timeouts.
 logger.yarn3.name = org.apache.hadoop.yarn.server.nodemanager.containermanager.localizer.ResourceLocalizationService
 logger.yarn3.level = WARN
+
+# Enable org.apache.flink.yarn.YarnClusterDescriptor to debug
+# future instances of FLINK-24960. (In my experiments enabling
+# the rootLogger did not enable this logger.)
+logger.yarn4.name = org.apache.flink.yarn.YarnClusterDescriptor
+logger.yarn4.level = INFO
+logger.yarn4.appenderRef.out.ref = ConsoleAppender


### PR DESCRIPTION
Enable log line to debug future instances of YARNSessionCapacitySchedulerITCase.testVCoresAreSetCorrectlyAndJobManagerHostnameAreShownInWebInterfaceAndDynamicPropertiesAndYarnApplicationNameAndTaskManagerSlots timing out.

See https://issues.apache.org/jira/browse/FLINK-24960