### PR TITLE
[FLINK-26642][connector/pulsar] Fix support for non-partitioned topic

### DIFF
--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/topic/TopicMetadataListener.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/topic/TopicMetadataListener.java
@@ -43,7 +43,9 @@ import static java.util.Collections.emptyList;
 import static org.apache.flink.connector.pulsar.common.config.PulsarClientFactory.createAdmin;
 import static org.apache.flink.connector.pulsar.common.utils.PulsarExceptionUtils.sneakyAdmin;
 import static org.apache.flink.connector.pulsar.source.enumerator.topic.TopicNameUtils.isPartitioned;
+import static org.apache.flink.connector.pulsar.source.enumerator.topic.TopicNameUtils.topicNameWithNonPartition;
 import static org.apache.flink.connector.pulsar.source.enumerator.topic.TopicNameUtils.topicNameWithPartition;
+import static org.apache.pulsar.common.partition.PartitionedTopicMetadata.NON_PARTITIONED;
 
 /**
  * We need the latest topic metadata for making sure the newly created topic partitions would be
@@ -115,8 +117,14 @@ public class TopicMetadataListener implements Serializable, Closeable {
                 && (!partitionedTopics.isEmpty() || !topicMetadata.isEmpty())) {
             List<String> results = new ArrayList<>();
             for (Map.Entry<String, Integer> entry : topicMetadata.entrySet()) {
-                for (int i = 0; i < entry.getValue(); i++) {
-                    results.add(topicNameWithPartition(entry.getKey(), i));
+                int partitionNums = entry.getValue();
+                // Get all topics from partitioned and non-partitioned topic names
+                if (partitionNums == NON_PARTITIONED) {
+                    results.add(topicNameWithNonPartition(entry.getKey()));
+                } else {
+                    for (int i = 0; i < partitionNums; i++) {
+                        results.add(topicNameWithPartition(entry.getKey(), i));
+                    }
                 }
             }
 

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/topic/TopicNameUtils.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/topic/TopicNameUtils.java
@@ -52,6 +52,11 @@ public final class TopicNameUtils {
         return TopicName.get(topic).getPartition(partitionId).toString();
     }
 
+    /** Get a non-partitioned topic name that does not belong to any partitioned topic. */
+    public static String topicNameWithNonPartition(String topic) {
+        return TopicName.get(topic).toString();
+    }
+
     public static boolean isPartitioned(String topic) {
         return TopicName.get(topic).isPartitioned();
     }

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/sink/writer/topic/TopicMetadataListenerTest.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/sink/writer/topic/TopicMetadataListenerTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.IntStream;
 
@@ -33,6 +34,7 @@ import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
 import static org.apache.flink.connector.pulsar.sink.PulsarSinkOptions.PULSAR_TOPIC_METADATA_REFRESH_INTERVAL;
+import static org.apache.flink.connector.pulsar.source.enumerator.topic.TopicNameUtils.topicNameWithNonPartition;
 import static org.apache.flink.connector.pulsar.source.enumerator.topic.TopicNameUtils.topicNameWithPartition;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -122,6 +124,23 @@ class TopicMetadataListenerTest extends PulsarTestSuiteBase {
         topics = listener.availableTopics();
         desiredTopics = topicPartitions(topic, 16);
         assertThat(topics).isEqualTo(desiredTopics);
+    }
+
+    @Test
+    void fetchNonPartitionTopic() {
+        String topic = randomAlphabetic(10);
+        operator().createTopic(topic, 0);
+        List<String> nonPartitionTopic =
+                Collections.singletonList(topicNameWithNonPartition(topic));
+
+        TopicMetadataListener listener = new TopicMetadataListener(nonPartitionTopic);
+        long interval = Duration.ofMinutes(15).toMillis();
+        SinkConfiguration configuration = sinkConfiguration(interval);
+        TestProcessingTimeService timeService = new TestProcessingTimeService();
+
+        listener.open(configuration, timeService);
+        List<String> topics = listener.availableTopics();
+        assertEquals(topics, nonPartitionTopic);
     }
 
     private List<String> topicPartitions(String topic, int partitionSize) {


### PR DESCRIPTION
This PR tries to fix the[FLINK-26642](https://issues.apache.org/jira/browse/FLINK-26642)
Pulsar Sink should support partitioned and non-partitioned topics. 