### PR TITLE
[FLINK-26650][checkpoint] Avoid to print stack trace for checkpoint trigger failure if not all tasks are started

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManager.java
@@ -104,12 +104,20 @@ public class CheckpointFailureManager {
                         : pendingCheckpoint.getCheckpointID();
         updateStatsAfterCheckpointFailed(pendingCheckpointStats, statsTracker, exception);
 
-        LOG.warn(
-                "Failed to trigger or complete checkpoint {} for job {}. ({} consecutive failed attempts so far)",
-                checkpointId == UNKNOWN_CHECKPOINT_ID ? "UNKNOWN_CHECKPOINT_ID" : checkpointId,
-                job,
-                continuousFailureCounter.get(),
-                exception);
+        if (CheckpointFailureReason.NOT_ALL_REQUIRED_TASKS_RUNNING.equals(
+                exception.getCheckpointFailureReason())) {
+            LOG.info(
+                    "Failed to trigger checkpoint for job {} since {}.",
+                    job,
+                    exception.getMessage());
+        } else {
+            LOG.warn(
+                    "Failed to trigger or complete checkpoint {} for job {}. ({} consecutive failed attempts so far)",
+                    checkpointId == UNKNOWN_CHECKPOINT_ID ? "UNKNOWN_CHECKPOINT_ID" : checkpointId,
+                    job,
+                    continuousFailureCounter.get(),
+                    exception);
+        }
         if (isJobManagerFailure(exception, executionAttemptID)) {
             handleJobLevelCheckpointException(checkpointProperties, exception, checkpointId);
         } else {


### PR DESCRIPTION
## What is the purpose of the change

Avoid to print stack trace for checkpoint trigger failure if not all tasks are started. This is somehow like FLINK-22117.

## Brief change log

Consider to avoid to print stack trace for checkpoint trigger failure if not all tasks are started.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no
## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable