### PR TITLE
[FLINK-26560][StateBackends] Make the threshold of the overlap fraction of incremental restoring configurable

### DIFF
--- a/docs/layouts/shortcodes/generated/rocksdb_configurable_configuration.html
+++ b/docs/layouts/shortcodes/generated/rocksdb_configurable_configuration.html
@@ -93,6 +93,12 @@
             <td>The maximum size of RocksDB's file used for information logging. If the log files becomes larger than this, a new file will be created. If 0, all logs will be written to one log file. The default maximum file size is '25MB'. </td>
         </tr>
         <tr>
+            <td><h5>state.backend.rocksdb.restore-overlap-fraction-threshold</h5></td>
+            <td style="word-wrap: break-word;">0.75</td>
+            <td>Double</td>
+            <td>The threshold of the overlap fraction between the handle's key-group range and target key-group range. When restore base DB, only the handle which overlap fraction greater than or equal to *threshold* has a chance to be an initial handle.</td>
+        </tr>
+        <tr>
             <td><h5>state.backend.rocksdb.thread.num</h5></td>
             <td style="word-wrap: break-word;">2</td>
             <td>Integer</td>

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBConfigurableOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBConfigurableOptions.java
@@ -255,6 +255,15 @@ public class RocksDBConfigurableOptions implements Serializable {
                             "If true, RocksDB will use block-based filter instead of full filter, this only take effect when bloom filter is used. "
                                     + "The default value is 'false'.");
 
+    public static final ConfigOption<Double> RESTORE_OVERLAP_FRACTION_THRESHOLD =
+            key("state.backend.rocksdb.restore-overlap-fraction-threshold")
+                    .doubleType()
+                    .defaultValue(0.75)
+                    .withDescription(
+                            "The threshold of the overlap fraction between the handle's key-group range and target key-group range. "
+                                    + "When restore base DB, only the handle which overlap fraction greater than or equal to *threshold* "
+                                    + "has a chance to be an initial handle.");
+
     static final ConfigOption<?>[] CANDIDATE_CONFIGS =
             new ConfigOption<?>[] {
                 // configurable DBOptions
@@ -278,7 +287,8 @@ public class RocksDBConfigurableOptions implements Serializable {
                 BLOCK_CACHE_SIZE,
                 USE_BLOOM_FILTER,
                 BLOOM_FILTER_BITS_PER_KEY,
-                BLOOM_FILTER_BLOCK_BASED_MODE
+                BLOOM_FILTER_BLOCK_BASED_MODE,
+                RESTORE_OVERLAP_FRACTION_THRESHOLD
             };
 
     private static final Set<ConfigOption<?>> POSITIVE_INT_CONFIG_SET =

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBIncrementalRestoreOperation.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBIncrementalRestoreOperation.java
@@ -99,6 +99,7 @@ public class RocksDBIncrementalRestoreOperation<K> implements RocksDBRestoreOper
     private long lastCompletedCheckpointId;
     private UUID backendUID;
     private final long writeBatchSize;
+    private final double overlapFractionThreshold;
 
     private boolean isKeySerializerCompatibilityChecked;
 
@@ -120,7 +121,8 @@ public class RocksDBIncrementalRestoreOperation<K> implements RocksDBRestoreOper
             @Nonnull Collection<KeyedStateHandle> restoreStateHandles,
             @Nonnull RocksDbTtlCompactFiltersManager ttlCompactFiltersManager,
             @Nonnegative long writeBatchSize,
-            Long writeBufferManagerCapacity) {
+            Long writeBufferManagerCapacity,
+            double overlapFractionThreshold) {
         this.rocksHandle =
                 new RocksDBHandle(
                         kvStateInformation,
@@ -136,6 +138,7 @@ public class RocksDBIncrementalRestoreOperation<K> implements RocksDBRestoreOper
         this.lastCompletedCheckpointId = -1L;
         this.backendUID = UUID.randomUUID();
         this.writeBatchSize = writeBatchSize;
+        this.overlapFractionThreshold = overlapFractionThreshold;
         this.restoreStateHandles = restoreStateHandles;
         this.cancelStreamRegistry = cancelStreamRegistry;
         this.keyGroupRange = keyGroupRange;
@@ -284,7 +287,7 @@ public class RocksDBIncrementalRestoreOperation<K> implements RocksDBRestoreOper
         // Prepare for restore with rescaling
         KeyedStateHandle initialHandle =
                 RocksDBIncrementalCheckpointUtils.chooseTheBestStateHandleForInitial(
-                        restoreStateHandles, keyGroupRange);
+                        restoreStateHandles, keyGroupRange, overlapFractionThreshold);
 
         // Init base DB instance
         if (initialHandle != null) {

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBIncrementalCheckpointUtilsTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBIncrementalCheckpointUtilsTest.java
@@ -38,6 +38,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import static org.apache.flink.contrib.streaming.state.RocksDBConfigurableOptions.RESTORE_OVERLAP_FRACTION_THRESHOLD;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -95,31 +96,38 @@ public class RocksDBIncrementalCheckpointUtilsTest extends TestLogger {
         when(keyedStateHandle3.getKeyGroupRange()).thenReturn(new KeyGroupRange(8, 12));
         keyedStateHandles.add(keyedStateHandle3);
 
-        // this should choose no one handle.
         Assert.assertNull(
                 RocksDBIncrementalCheckpointUtils.chooseTheBestStateHandleForInitial(
-                        keyedStateHandles, new KeyGroupRange(3, 5)));
+                        keyedStateHandles,
+                        new KeyGroupRange(3, 5),
+                        RESTORE_OVERLAP_FRACTION_THRESHOLD.defaultValue()));
 
         // this should choose keyedStateHandle2, because keyedStateHandle2's key-group range
         // satisfies the overlap fraction demand.
         Assert.assertEquals(
                 keyedStateHandle2,
                 RocksDBIncrementalCheckpointUtils.chooseTheBestStateHandleForInitial(
-                        keyedStateHandles, new KeyGroupRange(3, 6)));
+                        keyedStateHandles,
+                        new KeyGroupRange(3, 6),
+                        RESTORE_OVERLAP_FRACTION_THRESHOLD.defaultValue()));
 
         // both keyedStateHandle2 & keyedStateHandle3's key-group range satisfies the overlap
         // fraction, but keyedStateHandle3's key group range is better.
         Assert.assertEquals(
                 keyedStateHandle3,
                 RocksDBIncrementalCheckpointUtils.chooseTheBestStateHandleForInitial(
-                        keyedStateHandles, new KeyGroupRange(5, 12)));
+                        keyedStateHandles,
+                        new KeyGroupRange(5, 12),
+                        RESTORE_OVERLAP_FRACTION_THRESHOLD.defaultValue()));
 
         // The intersect key group number of keyedStateHandle2 & keyedStateHandle3's with [4, 11]
         // are 4. But the over fraction of keyedStateHandle2 is better.
         Assert.assertEquals(
                 keyedStateHandle2,
                 RocksDBIncrementalCheckpointUtils.chooseTheBestStateHandleForInitial(
-                        keyedStateHandles, new KeyGroupRange(4, 11)));
+                        keyedStateHandles,
+                        new KeyGroupRange(4, 11),
+                        RESTORE_OVERLAP_FRACTION_THRESHOLD.defaultValue()));
 
         // both keyedStateHandle2 & keyedStateHandle3's key-group range are covered by [3, 12],
         // but this should choose the keyedStateHandle3, because keyedStateHandle3's key-group is
@@ -127,7 +135,9 @@ public class RocksDBIncrementalCheckpointUtilsTest extends TestLogger {
         Assert.assertEquals(
                 keyedStateHandle3,
                 RocksDBIncrementalCheckpointUtils.chooseTheBestStateHandleForInitial(
-                        keyedStateHandles, new KeyGroupRange(3, 12)));
+                        keyedStateHandles,
+                        new KeyGroupRange(3, 12),
+                        RESTORE_OVERLAP_FRACTION_THRESHOLD.defaultValue()));
     }
 
     private void testClipDBWithKeyGroupRangeHelper(

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
@@ -499,6 +499,8 @@ public class RocksDBStateBackendConfigTest {
             verifyIllegalArgument(RocksDBConfigurableOptions.COMPACTION_STYLE, "LEV");
             verifyIllegalArgument(RocksDBConfigurableOptions.USE_BLOOM_FILTER, "NO");
             verifyIllegalArgument(RocksDBConfigurableOptions.BLOOM_FILTER_BLOCK_BASED_MODE, "YES");
+            verifyIllegalArgument(
+                    RocksDBConfigurableOptions.RESTORE_OVERLAP_FRACTION_THRESHOLD, "2");
         }
 
         // verify legal configuration
@@ -521,6 +523,8 @@ public class RocksDBStateBackendConfigTest {
             configuration.setString(RocksDBConfigurableOptions.METADATA_BLOCK_SIZE.key(), "8 kb");
             configuration.setString(RocksDBConfigurableOptions.BLOCK_CACHE_SIZE.key(), "512 mb");
             configuration.setString(RocksDBConfigurableOptions.USE_BLOOM_FILTER.key(), "TRUE");
+            configuration.setString(
+                    RocksDBConfigurableOptions.RESTORE_OVERLAP_FRACTION_THRESHOLD.key(), "0.5");
 
             try (RocksDBResourceContainer optionsContainer =
                     new RocksDBResourceContainer(


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Currently, the threshold of the overlap fraction of incremental restoring `OVERLAP_FRACTION_THRESHOLD` is a hard-coded, fixed value.
`OVERLAP_FRACTION_THRESHOLD` is used to control how to restore a state handle, different thresholds can affect the performance of restoring. The behavior of deletion in restoring has been changed after [FLINK-21321](https://issues.apache.org/jira/browse/FLINK-21321), the old threshold no longer fits the current situation.

To make it easier to modify the threshold according to different situations, changing `OVERLAP_FRACTION_THRESHOLD` to be configurable is suggested.

## Brief change log

  - Add `RESTORE_OVERLAP_FRACTION_THRESHOLD` into RocksDBConfigurableOptions.

  

## Verifying this change

This change added tests and can be verified as follows:

- Add UT cases in RocksDBStateBackendConfigTest#testConfigurableOptionsFromConfig().

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
