### PR TITLE
[FLINK-12639] Expand glossary

### DIFF
--- a/docs/content/docs/concepts/glossary.md
+++ b/docs/content/docs/concepts/glossary.md
@@ -131,7 +131,12 @@ to implement streaming joins.
 
 #### Dataflow
 
-#### Determinism
+See [logical graph](#logical-graph).
+
+#### DataStream
+
+This is a collection of data in a Flink application. You can think of them as immutable collections 
+of data that can contain duplicates. This data can either be finite or unbounded.
 
 #### Directed Acyclic Graph (DAG)
 
@@ -156,68 +161,56 @@ calculation is performed.
 If you want to use event time, you will also need to supply a Timestamp Extractor and Watermark Generator 
 that Flink will use to track the progress of event time.
 
-#### Evictors
-
-This is part of the window API and allows you to remove elements collected in a [window](#window). 
-
 #### Exactly-Once
 
-A fault-tolerance guarantee
-Nothing is lost or duplicated
-
-does not mean that every event will be processed exactly once. Instead, it means that every event will affect the state being managed by Flink exactly once.
+A fault-tolerance guarantee and data delivery approach where nothing is lost or duplicated. This does 
+not mean that every event will be processed exactly once. Instead, it means that every event will affect 
+the state being managed by Flink exactly once.
 
 #### ExecutionGraph
 
-see [Physical Graph](#physical-graph)
+See [Physical Graph](#physical-graph).
 
 #### Externalized Checkpoint
 
-normally checkpoints are not intended to be manipulated by users. Flink retains only the n-most-recent checkpoints (n being configurable) while a job is running, and deletes them when a job is cancelled. But you can configure them to be retained instead, in which case you can manually resume from them.
+A checkpoint that is configured to be retained instead of being deleted when a job is cancelled. 
+Flink normally retains only the n-most-recent checkpoints (n being configurable) while a job is running 
+and deletes them when a job is cancelled. 
+
+You can manually resume from an externalized checkpoint. 
 
 #### Ingestion Time
 
-a timestamp recorded by Flink at the moment it ingests the event
-
-#### Instance
-
-The term *instance* is used to describe a specific instance of a specific type (usually
-[operator](#operator) or [function](#function)) during runtime. Since Flink is mostly written in
-Java, this corresponds to the definition of *instance* or *object* in Java. In the context of Flink,
-the term *parallel instance* is also frequently used to emphasize that multiple instances of the
-same [operator](#operator) or [function](#function) type are running in parallel.
-
-#### JVM Heap
+A timestamp recorded by Flink at the moment it ingests the event.
 
 #### (Flink) Job
 
-A Flink Job is the runtime representation of a [logical graph](#logical-graph) (also often called dataflow
+This is the runtime representation of a [logical graph](#logical-graph) (also often called dataflow
 graph) that is created and submitted by calling `execute()` in a [Flink Application](#flink-application).
 
 #### Job Cluster
 
-A Flink Job Cluster is a dedicated [Flink Cluster](#flink-cluster) that only executes a single 
-[Flink Job](#flink-job). The lifetime of the [Flink Cluster](#flink-cluster) is bound to the lifetime 
-of the Flink Job. This deployment mode has been deprecated since Flink 1.15.
+This is a dedicated [Flink Cluster](#flink-cluster) that only executes a single [Flink Job](#flink-job). 
+The lifetime of the [Flink Cluster](#flink-cluster) is bound to the lifetime of the Flink Job. This 
+deployment mode has been deprecated since Flink 1.15.
 
 #### JobGraph
 
-see [Logical Graph](#logical-graph)
+See [Logical Graph](#logical-graph).
 
 #### JobManager
 
-The JobManager is the orchestrator of a [Flink Cluster](#flink-cluster). It contains three distinct
-components: Flink Resource Manager, Flink Dispatcher and one [Flink JobMaster](#flink-jobmaster)
-per running [Flink Job](#flink-job).
+The JobManager is the orchestrator of a [Flink Cluster](#(flink)-cluster). It contains three distinct
+components: ResourceManager, Dispatcher, and a [JobMaster](#jobmaster) per running [Flink Job](#(flink)-job).
 
-There is always at least one JobManager. A high-availability setup might have multiple JobManagers, one of which is always the leader
+There is always at least one JobManager. A high-availability setup might have multiple JobManagers, 
+one of which is always the leader.
 
 #### JobMaster
 
-JobMasters are one of the components running in the [JobManager](#flink-jobmanager). A JobMaster is
-responsible for supervising the execution of the [Tasks](#task) of a single job.
-
-is responsible for managing the execution of a single JobGraph. Multiple jobs can run simultaneously in a Flink cluster, each having its own JobMaster.
+This is one of the components that run in the [JobManager](#jobmanager). It is responsible for supervising 
+the execution of the [tasks](#task) of a single [job](#(flink)-job). Multiple jobs can run simultaneously 
+in a [Flink cluster](#(flink)-cluster), each having its own JobMaster.
 
 #### JobResultStore
 
@@ -227,50 +220,64 @@ are then used by Flink to determine whether jobs should be subject to recovery i
 
 #### Key Group
 
-Key Groups are the atomic unit by which Flink can redistribute Keyed State; there are exactly as many Key Groups as the defined maximum parallelism. During execution each parallel instance of a keyed operator works with the keys for one or more Key Groups.
+These are the atomic unit by which Flink can redistribute [Keyed State](#keyed-state). There are 
+exactly as many key groups as the defined maximum parallelism. During execution, each parallel instance 
+of a keyed operator works with the keys for one or more key groups.
 
 #### Keyed State
 
-It is often very useful to be able to partition a stream around one of its attributes, so that all events with the same value of that attribute are grouped together.
+Keyed state is one of the two basic types of state in Apache Flink (the other being operator state).
+In order to have all events with the same value of an attribute grouped together, you can partition 
+a stream around that attribute, and maintain it as an embedded key/value store. This results in a keyed
+state. 
 
-Flink supports several different types of keyed state.
+A keyed state is always bound to keys and is only available to functions and operators that process
+data from a keyed stream.
 
-Simplest one is valuestate
+Flink supports several different types of keyed state, with the simplest one being [ValueState](#valuestate).
 
-maintained in what can be thought of as an embedded key/value store.
+#### Keyed Stream
 
-#### Latency
+A keyed stream is a [DataStream](#DataStream) on which [operator state](#operator-state) is partitioned 
+by a key. Typical operations supported by a DataStream are also possible on a keyed stream, except for 
+partitioning methods such as shuffle, forward, and keyBy.
 
 #### Lateness
 
-Lateness is defined relative to the watermarks. A Watermark(t) asserts that the stream is complete up through time t; any event following this watermark whose timestamp is ≤ t is late.
-
-#### Lazy Evaluation
+Lateness is defined relative to the [watermarks](#watermark). A watermark(t) asserts that the stream 
+is complete up through to time t. Any event is considered late if it comes after the watermark whose 
+timestamp is ≤ t.
 
 #### List State
 
 #### Logical Graph
 
-A logical graph is a directed graph where the nodes are [operators](#operator) and the edges define 
-input/output relationships of the operators and correspond to data streams. A logical graph is created 
-by submitting jobs to a [Flink cluster](#flink-cluster) from a [Flink application](#flink-application).
+This is a directed graph where the nodes are [operators](#operator) and the edges define input/output 
+relationships of the operators and correspond to [DataStreams](#datastreams). A logical graph is created 
+by submitting jobs to a [Flink cluster](#(flink)-cluster) from a [Flink application](#(flink)-application).
 
-Logical graphs are also often referred to as *dataflow graphs*.
+Logical graphs are also often referred to as [dataflow](#dataflow).
 
 #### Managed State
 
 Managed State describes application state which has been registered with the stream processing framework. 
 Apache Flink will take care of the persistence and rescaling of the managed state.  
 
+Managed State is represented in data structures controlled by the Flink runtime, such as internal hash tables, or RocksDB. Examples are “ValueState”, “ListState”, etc. Flink’s runtime encodes the states and writes them into the checkpoints.
+
+Keyed State and Operator State exist in two forms: managed and raw.
+
 #### Map State
 
 #### Non-keyed state
 
-operator state
+This type of state is bound to one parallel operator instance and is also called [operator state](#operator-state). 
 
-It is also possible to work with managed state in non-keyed contexts. This is sometimes called operator state. The interfaces involved are somewhat different, and since it is unusual for user-defined functions to need non-keyed state, it is not covered here. This feature is most often used in the implementation of sources and sinks.
+It is also possible to work with managed state in non-keyed contexts. The interfaces involved are somewhat different, and since it is unusual for user-defined functions to need non-keyed state, it is not covered here. This feature is most often used in the implementation of sources and sinks.
 
 #### Offset
+
+a number identifying how far you're from the beginning of a certain information stream (e.g. when you open a file, the offset determines where you wanna start reading the file, counting from the beginning of the file itself)
 
 #### Operator
 
@@ -285,6 +292,8 @@ repartitioning in between. Operators within the same operator chain forward reco
 directly without going through serialization or Flink's network stack.
 
 For distributed execution, Flink chains operator subtasks together into tasks. Each task is executed by one thread. Chaining operators together into tasks is a useful optimization: it reduces the overhead of thread-to-thread handover and buffering, and increases overall throughput while decreasing latency. The chaining behavior can be configured
+
+#### Operator State
 
 #### Parallelism 
 
@@ -323,6 +332,12 @@ Computing analytics based on processing time causes inconsistencies, and makes i
 #### Queryable state 
 
 allows you to access state from outside of Flink during runtime.
+
+#### Raw State
+
+Keyed State and Operator State exist in two forms: managed and raw.
+
+Raw State is state that operators keep in their own data structures. When checkpointed, they only write a sequence of bytes into the checkpoint. Flink knows nothing about the state’s data structures and sees only the raw bytes.
 
 #### Record
 
@@ -377,8 +392,6 @@ Formerly, a Flink Session Cluster was also known as a Flink Cluster in *session 
 
 punctuated by a gap of inactivity
 
-#### Sharding
-
 #### Shuffling
 
 #### Side Outputs
@@ -412,10 +425,6 @@ For stream processing programs, the State Backend of a [Flink Job](#flink-job) d
 RocksDB).
 
 Two implementations of state backends are available – one based on RocksDB, an embedded key/value store that keeps its working state on disk, and another heap-based state backend that keeps its working state in memory, on the Java heap.
-
-#### Stream
-
-a collection of data in a Flink program. You can think of them as immutable collections of data that can contain duplicates. This data can either be finite or unbounded
 
 #### Stream barriers
 
@@ -469,8 +478,6 @@ Timers are fault tolerant and checkpointed along with the state of the applicati
 
 there are at most one timer per key and second
 
-#### Throughput
-
 #### Transformation
 
 A transformation is applied on one or more data streams and results in one or more output data streams. 
@@ -479,10 +486,6 @@ partitioning or perform an aggregation. While [operators](#operator) and [functi
 the "physical" parts of Flink's API, transformations are only an API concept. Specifically, most 
 transformations are implemented by certain [operators](#operator).
 
-#### Trigger
-
-Part of the window API and determines when to call the window function. 
-
 #### Tumbling Window
 
 A type of window
@@ -490,7 +493,7 @@ no overlap
 
 #### Tuple
 
-This is a composite data type. 
+A composite data type that has a finite ordered list of immutable elements. 
 
 #### Unbounded streams
 

--- a/docs/content/docs/concepts/glossary.md
+++ b/docs/content/docs/concepts/glossary.md
@@ -25,148 +25,216 @@ under the License.
 
 # Glossary
 
-#### Checkpoint Storage
+#### (Flink) Application
 
-The location where the [State Backend](#state-backend) will store its snapshot during a checkpoint (Java Heap of [JobManager](#flink-jobmanager) or Filesystem).
+A Flink application is a Java application that submits one or multiple [Flink Jobs](#flink-job) from
+the `main()` method (or by some other means). Submitting jobs is usually done by calling `execute()`
+on an execution environment.
 
-#### Flink Application Cluster
+The jobs of an application can either be submitted to a long running [Session Cluster](#session-cluster),
+to a dedicated [Application Cluster](#application-cluster), or to a [Job Cluster](#job-cluster).
+
+#### Application Cluster
 
 A Flink Application Cluster is a dedicated [Flink Cluster](#flink-cluster) that
 only executes [Flink Jobs](#flink-job) from one [Flink
 Application](#flink-application). The lifetime of the [Flink
 Cluster](#flink-cluster) is bound to the lifetime of the Flink Application.
 
-#### Flink Job Cluster
+#### At-least-once
 
-A Flink Job Cluster is a dedicated [Flink Cluster](#flink-cluster) that only
-executes a single [Flink Job](#flink-job). The lifetime of the
-[Flink Cluster](#flink-cluster) is bound to the lifetime of the Flink Job. 
-This deployment mode has been deprecated since Flink 1.15.  
+#### At-most-once
 
-#### Flink Cluster
+#### Backpressure
 
-A distributed system consisting of (typically) one [JobManager](#flink-jobmanager) and one or more
-[Flink TaskManager](#flink-taskmanager) processes.
+#### Batch processing
+
+#### Bounded streams
+
+#### Category
+
+#### Checkpoint
+
+#### Checkpoint Storage
+
+The location where the [state backend](#state-backend) will store its snapshot during a checkpoint 
+(Java Heap of [JobManager](#flink-jobmanager) or Filesystem).
+
+#### (Flink) Cluster
+
+A distributed system consisting of (typically) one [JobManager](#jobmanager) and one or more
+[TaskManager](#taskmanager) processes.
+
+#### Connectors
+
+#### Data Parallelism
+
+#### Dataflow
+
+
+#### Determinism
+
+#### Directed Acyclic Graph (DAG)
 
 #### Event
 
-An event is a statement about a change of the state of the domain modelled by the
-application. Events can be input and/or output of a stream or batch processing application.
-Events are special types of [records](#Record).
+An event is a statement about a change of the state of the domain modelled by the application. Events
+can be input and/or output of a stream or batch processing application. Events are special types of
+[records](#Record).
+
+#### Event Time
+
+#### Exactly-Once
 
 #### ExecutionGraph
 
 see [Physical Graph](#physical-graph)
 
-#### Function
-
-Functions are implemented by the user and encapsulate the
-application logic of a Flink program. Most Functions are wrapped by a corresponding
-[Operator](#operator).
-
 #### Instance
 
 The term *instance* is used to describe a specific instance of a specific type (usually
-[Operator](#operator) or [Function](#function)) during runtime. As Apache Flink is mostly written in
-Java, this corresponds to the definition of *Instance* or *Object* in Java. In the context of Apache
-Flink, the term *parallel instance* is also frequently used to emphasize that multiple instances of
-the same [Operator](#operator) or [Function](#function) type are running in parallel.
+[operator](#operator) or [function](#function)) during runtime. Since Flink is mostly written in
+Java, this corresponds to the definition of *instance* or *object* in Java. In the context of Flink,
+the term *parallel instance* is also frequently used to emphasize that multiple instances of the
+same [operator](#operator) or [function](#function) type are running in parallel.
 
-#### Flink Application
+#### JVM Heap
 
-A Flink application is a Java Application that submits one or multiple [Flink
-Jobs](#flink-job) from the `main()` method (or by some other means). Submitting
-jobs is usually done by calling `execute()` on an execution environment.
+#### (Flink) Job
 
-The jobs of an application can either be submitted to a long running [Flink
-Session Cluster](#flink-session-cluster), to a dedicated [Flink Application
-Cluster](#flink-application-cluster), or to a [Flink Job
-Cluster](#flink-job-cluster).
+A Flink Job is the runtime representation of a [logical graph](#logical-graph) (also often called dataflow
+graph) that is created and submitted by calling `execute()` in a [Flink Application](#flink-application).
 
-#### Flink Job
+#### Job Cluster
 
-A Flink Job is the runtime representation of a [logical graph](#logical-graph)
-(also often called dataflow graph) that is created and submitted by calling
-`execute()` in a [Flink Application](#flink-application).
+A Flink Job Cluster is a dedicated [Flink Cluster](#flink-cluster) that only executes a single 
+[Flink Job](#flink-job). The lifetime of the [Flink Cluster](#flink-cluster) is bound to the lifetime 
+of the Flink Job. This deployment mode has been deprecated since Flink 1.15.
 
 #### JobGraph
 
 see [Logical Graph](#logical-graph)
 
-#### Flink JobManager
+#### JobManager
 
 The JobManager is the orchestrator of a [Flink Cluster](#flink-cluster). It contains three distinct
 components: Flink Resource Manager, Flink Dispatcher and one [Flink JobMaster](#flink-jobmaster)
 per running [Flink Job](#flink-job).
 
-#### Flink JobMaster
+#### JobMaster
 
 JobMasters are one of the components running in the [JobManager](#flink-jobmanager). A JobMaster is
 responsible for supervising the execution of the [Tasks](#task) of a single job.
 
 #### JobResultStore
 
-The JobResultStore is a Flink component that persists the results of globally terminated
-(i.e. finished, cancelled or failed) jobs to a filesystem, allowing the results to outlive
-a finished job. These results are then used by Flink to determine whether jobs should
-be subject to recovery in highly-available clusters.
+The JobResultStore is a Flink component that persists the results of globally terminated (i.e. finished, 
+cancelled or failed) jobs to a filesystem, allowing the results to outlive a finished job. These results 
+are then used by Flink to determine whether jobs should be subject to recovery in highly-available clusters.
+
+#### Keyed State
+
+#### Latency
+
+#### Lazy Evaluation
+
+#### List State
 
 #### Logical Graph
 
-A logical graph is a directed graph where the nodes are  [Operators](#operator)
-and the edges define input/output-relationships of the operators and correspond
-to data streams or data sets. A logical graph is created by submitting jobs
-from a [Flink Application](#flink-application).
+A logical graph is a directed graph where the nodes are [operators](#operator) and the edges define 
+input/output relationships of the operators and correspond to data streams. A logical graph is created 
+by submitting jobs to a [Flink cluster](#flink-cluster) from a [Flink application](#flink-application).
 
 Logical graphs are also often referred to as *dataflow graphs*.
 
 #### Managed State
 
-Managed State describes application state which has been registered with the framework. For
-Managed State, Apache Flink will take care about persistence and rescaling among other things.
+Managed State describes application state which has been registered with the stream processing framework. 
+Apache Flink will take care of the persistence and rescaling of the managed state.  
+
+#### Map State
+
+#### Offset
 
 #### Operator
 
-Node of a [Logical Graph](#logical-graph). An Operator performs a certain operation, which is
-usually executed by a [Function](#function). Sources and Sinks are special Operators for data
+An operator is a node of a [logical graph](#logical-graph). An operator performs a certain operation, 
+which is usually executed by a [function](#function). Sources and sinks are special operators for data
 ingestion and data egress.
 
 #### Operator Chain
 
-An Operator Chain consists of two or more consecutive [Operators](#operator) without any
-repartitioning in between. Operators within the same Operator Chain forward records to each other
+An operator chain consists of two or more consecutive [operators](#operator) without any
+repartitioning in between. Operators within the same operator chain forward records to each other
 directly without going through serialization or Flink's network stack.
+
+#### Parallelism 
 
 #### Partition
 
-A partition is an independent subset of the overall data stream or data set. A data stream or
-data set is divided into partitions by assigning each [record](#Record) to one or more partitions.
-Partitions of data streams or data sets are consumed by [Tasks](#task) during runtime. A
-transformation which changes the way a data stream or data set is partitioned is often called
-repartitioning.
+A partition is an independent subset of the overall data stream. A data stream is divided into 
+partitions by assigning each [record](#record) to one or more partitions via keys. Partitions of data 
+streams are consumed by [Tasks](#task) during runtime. A transformation which changes the way a data 
+stream is partitioned is often called repartitioning.
 
 #### Physical Graph
 
-A physical graph is the result of translating a [Logical Graph](#logical-graph) for execution in a
-distributed runtime. The nodes are [Tasks](#task) and the edges indicate input/output-relationships
-or [partitions](#partition) of data streams or data sets.
+A physical graph is the result of translating a [logical graph](#logical-graph) for execution in a
+distributed runtime. The nodes are [Tasks](#task) and the edges indicate input/output relationships
+or [partitions](#partition) of data streams.
+
+#### POJO
+
+This is a composite data type.  It can be serialized
+
+Flink recognizes a data type as a POJO type (and allows “by-name” field referencing) if the following conditions are fulfilled:
+
+    The class is public and standalone (no non-static inner class)
+    The class has a public no-argument constructor
+    All non-static, non-transient fields in the class (and all superclasses) are either public (and non-final) or have public getter- and setter- methods that follow the Java beans naming conventions for getters and setters.
+
+
+#### Processing Time
 
 #### Record
 
-Records are the constituent elements of a data set or data stream. [Operators](#operator) and
-[Functions](#Function) receive records as input and emit records as output.
+Records are the constituent elements of a data stream. [Operators](#operator) and [functions](#function) 
+receive records as input and emit records as output.
+
+#### Rich Functions
 
 #### (Runtime) Execution Mode
 
 DataStream API programs can be executed in one of two execution modes: `BATCH`
-or `STREAMING`. See [Execution Mode]({{< ref "/docs/dev/datastream/execution_mode" >}}) for more details.
+or `STREAMING`. See the [Execution Mode]({{< ref "/docs/dev/datastream/execution_mode" >}}) for more details.
 
-#### Flink Session Cluster
+#### Savepoint
+
+#### Schema
+
+#### Serialization
+
+#### Session Cluster
 
 A long-running [Flink Cluster](#flink-cluster) which accepts multiple [Flink Jobs](#flink-job) for
 execution. The lifetime of this Flink Cluster is not bound to the lifetime of any Flink Job.
 Formerly, a Flink Session Cluster was also known as a Flink Cluster in *session mode*. Compare to
 [Flink Application Cluster](#flink-application-cluster).
+
+#### Sharding
+
+#### Shuffling
+
+#### Side Outputs
+
+#### Sink
+
+#### Snapshot
+
+#### Source
+
+#### Spilling
 
 #### State Backend
 
@@ -174,10 +242,12 @@ For stream processing programs, the State Backend of a [Flink Job](#flink-job) d
 [state](#managed-state) is stored on each TaskManager (Java Heap of TaskManager or (embedded)
 RocksDB).
 
-#### Sub-Task
+#### Stream
 
-A Sub-Task is a [Task](#task) responsible for processing a [partition](#partition) of
-the data stream. The term "Sub-Task" emphasizes that there are multiple parallel Tasks for the same
+#### Subtask
+
+A subtask is a [Task](#task) responsible for processing a [partition](#partition) of
+the data stream. The term "subtask" emphasizes that there are multiple parallel Tasks for the same
 [Operator](#operator) or [Operator Chain](#operator-chain).
 
 #### Table Program
@@ -187,20 +257,47 @@ A generic term for pipelines declared with Flink's relational APIs (Table API or
 #### Task
 
 Node of a [Physical Graph](#physical-graph). A task is the basic unit of work, which is executed by
-Flink's runtime. Tasks encapsulate exactly one parallel instance of an
-[Operator](#operator) or [Operator Chain](#operator-chain).
+Flink's runtime. Tasks encapsulate exactly one parallel instance of an [operator](#operator) or
+[operator Chain](#operator-chain).
 
-#### Flink TaskManager
+#### Task Chaining
+
+#### Task Parallelism
+
+#### TaskManager
 
 TaskManagers are the worker processes of a [Flink Cluster](#flink-cluster). [Tasks](#task) are
 scheduled to TaskManagers for execution. They communicate with each other to exchange data between
 subsequent Tasks.
 
+#### Throughput
+
 #### Transformation
 
-A Transformation is applied on one or more data streams or data sets and results in one or more
-output data streams or data sets. A transformation might change a data stream or data set on a
-per-record basis, but might also only change its partitioning or perform an aggregation. While
-[Operators](#operator) and [Functions](#function) are the "physical" parts of Flink's API,
-Transformations are only an API concept. Specifically, most transformations are
-implemented by certain [Operators](#operator).
+A transformation is applied on one or more data streams and results in one or more output data streams. 
+A transformation might change a data stream on a per-record basis, but might also only change its 
+partitioning or perform an aggregation. While [operators](#operator) and [functions](#function) are 
+the "physical" parts of Flink's API, transformations are only an API concept. Specifically, most 
+transformations are implemented by certain [operators](#operator).
+
+#### Tuple
+
+This is a composite data type. 
+
+#### Unbounded streams
+
+#### (User-Defined) Functions
+
+Functions are implemented by the user and encapsulate the application logic of a Flink program. Most
+functions are wrapped by a corresponding [operator](#operator).
+
+#### User-Defined Aggregate Function (UDAF)
+
+#### User-Defined Scalar Function (UDSF)
+
+#### User-Defined Table-valued Function (UDTF)
+
+#### Value State
+
+#### Watermark
+

--- a/docs/content/docs/concepts/glossary.md
+++ b/docs/content/docs/concepts/glossary.md
@@ -293,17 +293,16 @@ Lateness is defined relative to the [watermarks](#watermark). A `watermark(t)` a
 is complete up through to time `t`. A [record](#record) with timestamp `s` is considered late if it 
 arrives after any watermark whose timestamp is `≤ s`.
 
-#### ListState<T>
+#### List State
 
 This is a type of [keyed state](#keyed-state) that keeps a list of elements per key. You can append 
-elements and retrieve an Iterable over all currently stored elements. Elements are added using add(T) 
-or addAll(List<T>). The Iterable can be retrieved using Iterable<T> get().
+elements and retrieve an Iterable over all currently stored elements.
 
 #### Logical Graph
 
 This is a directed graph where the nodes are [operators](#operator) and the edges define input/output 
-relationships of the operators and correspond to [DataStreams](#datastreams). A logical graph is created 
-by submitting jobs to a [Flink cluster](#(flink)-cluster) from a [Flink application](#flink-application).
+relationships of the operators and correspond to [DataStreams](#datastreams) or SQL queries. A logical 
+graph is created by submitting jobs to a [Flink cluster](#(flink)-cluster) from a [Flink application](#flink-application).
 
 Logical graphs are also often referred to as [dataflow](#dataflow).
 
@@ -317,20 +316,19 @@ hash tables, or RocksDB. Flink’s runtime encodes the states and writes them in
 
 [Keyed state](#keyed-state) and [operator state](#operator-state) exist in two forms: managed and [raw](#raw-state).
 
-#### MapState<UK, UV>
+#### Map State
 
 This is a type of [keyed state](#keyed-state) that keeps a list of mappings. You can put key-value 
-pairs into the state and retrieve an Iterable over all currently stored mappings. Mappings are added 
-using put(UK, UV) or putAll(Map<UK, UV>). The value associated with a key can be retrieved using get(UK).
+pairs into the state and retrieve an Iterable over all currently stored mappings.
 
-#### Non-keyed State
+#### Non-Keyed State
 
 This type of state is bound to one parallel operator instance and is also called [operator state](#operator-state). 
 
 It is possible to work with [managed state](#managed-state) in non-keyed contexts but it is unusual 
 for user-defined functions to need non-keyed state and the interfaces involved would be different. 
 
-This feature is most often used in the implementation of [sources](#source) and [sinks](#sink).
+This feature is often used in the implementation of [sources](#source) and [sinks](#sink).
 
 #### Offset
 

--- a/docs/content/docs/concepts/glossary.md
+++ b/docs/content/docs/concepts/glossary.md
@@ -76,13 +76,16 @@ input streams up to (but not past) both barriers.
 
 #### Batch Processing
 
-When the processing and analysis happens on a set of data that have already been stored over a period 
-of time. The results are usually not available in real-time. Flink executes batch programs as a special 
-case of streaming programs.
+This is the processing and analysis on a set of data that have already been stored over a period 
+of time (i.e. in groups or batches). The results are usually not available in real-time. Flink 
+executes batch programs as a special case of streaming programs.
 
 #### Bounded Streams
 
-#### Category
+Bounded [DataStreams](#datastream) have a defined start and end. They can be processed by ingesting 
+all data before performing any computations. Ordered ingestion is not required to process bounded streams 
+because a bounded data set can always be sorted. Processing of bounded streams is also known as 
+[batch processing](#batch-processing).
 
 #### Checkpoint
 
@@ -126,7 +129,8 @@ to implement streaming joins.
 
 #### Connectors
 
-#### Data Parallelism
+Connectors allow [Flink applications](#(flink)-applications) to read from and write to various external 
+systems. They support multiple formats in order to encode and decode data to match Flink’s data structures.
 
 #### Dataflow
 
@@ -138,6 +142,9 @@ This is a collection of data in a Flink application. You can think of them as im
 of data that can contain duplicates. This data can either be finite or unbounded.
 
 #### Directed Acyclic Graph (DAG)
+
+This is a graph that is directed and without cycles connecting the other edges. It can be used to 
+conceptually represent a [dataflow](#dataflow) where you never look back to previous events.
 
 #### Dispatcher
 
@@ -177,6 +184,11 @@ Flink normally retains only the n-most-recent checkpoints (n being configurable)
 and deletes them when a job is cancelled. 
 
 You can manually resume from an externalized checkpoint. 
+
+#### Format
+
+A table format is a storage format that defines how to map binary data onto table columns.
+Flink comes with a variety of built-in output formats that can be used with table [connectors](#connector).
 
 #### Ingestion Time
 
@@ -305,7 +317,11 @@ and increases overall throughput while decreasing latency. The chaining behavior
 
 #### Operator State
 
+See [non-keyed state](#non-keyed-state).
+
 #### Parallelism 
+
+This is a technique for making programs run faster by performing several computations simultaneously.
 
 #### Partition
 
@@ -330,6 +346,8 @@ type as a POJO type (and allows “by-name” field referencing) if the followin
 - all non-static, non-transient fields in the class (and all superclasses) are either public (and 
   non-final) or have public getter- and setter- methods that follow the Java naming conventions for 
   getters and setters
+  
+Flink analyzes the structure of POJO types and can process POJOs more efficiently than general types.
 
 #### Process Functions
 
@@ -386,9 +404,21 @@ A [snapshot](#snapshot) triggered manually by a user (or an API call) for some o
 such as a stateful redeploy/upgrade/rescaling. Savepoints are always complete and aligned and are 
 optimized for operational flexibility.
 
+#### Scalar
+
+A scalar refers to a single value. This is in contrast to a set of values. 
+
 #### Schema
 
+This refers to the organization or structure of data as a blueprint. 
+
 #### Serialization
+
+This is the process of turning a data element in memory into a stream of bytes so that you can more 
+efficiently store it on disk or send it over the network.
+
+Flink handles data types and serialization in a unique way, containing its own type descriptors, 
+generic type extraction, and type serialization framework.
 
 #### Session Cluster
 
@@ -405,12 +435,21 @@ certain period of time (i.e. when a gap of inactivity occurred).
 
 #### Shuffling
 
+This is a process of redistributing data across [partitions](#partition) (aka repartitioning) that 
+may or may not cause moving data across JVM processes or over the network.
+
 #### Side Outputs
 
 This is an extra output stream from a Flink operator. Beyond error reporting, side outputs are also 
 a good way to implement an n-way split of a stream.
 
 #### Sink
+
+A sink is a component that consumes incoming processed [DataStreams](#datastream) from Flink and 
+forwards them to files, sockets, external systems, or print them. 
+
+A few predefined data sinks are built into Flink, such as support for writing to files, to stdout/stderr, 
+and to sockets.
 
 #### Sliding Window
 
@@ -433,7 +472,15 @@ Flink uses a variant of the Chandy-Lamport algorithm known as asynchronous barri
 
 #### Source
 
+This is the source of the data that gets piped into a [Flink application](#(flink)-application) to be 
+processed. As long as data keeps flowing in, Flink can keep performing calculations. 
+
+A few basic data sources are built into Flink and are always available, such as reading from files, 
+directories, sockets, and ingesting data from collections and iterators. 
+
 #### Spilling
+
+This is a technique where state data is spilled to disk before JVM heap memory is exhausted.
 
 #### State Backend
 
@@ -469,7 +516,14 @@ by Flink's runtime. Tasks encapsulate exactly one parallel instance of an [opera
 
 #### Task Chaining
 
+This is an optimization where Flink puts two subsequent [transformations](#transformation) in the same thread, if possible. 
+
 #### Task Parallelism
+
+This is the number of parallel instances of a task. A [Flink application](#(flink)-application) consists 
+of multiple [tasks](#task) ([transformations](#transformation), [operators](#operator), [sources](#source), 
+[sinks](#sink)). A task is split into several parallel instances for execution and each parallel instance 
+processes a subset of the task's input data. 
 
 #### Task Slot
 
@@ -516,6 +570,9 @@ A composite data type that has a finite ordered list of immutable elements.
 
 #### Unbounded streams
 
+Unbounded [DataStreams](#datastream) have a start but no defined end. They do not terminate, provide 
+data as it is generated, and must be continuously processed. 
+
 #### (User-Defined) Functions
 
 Functions are implemented by the user and encapsulate the application logic of a [Flink application](#(flink)-application). 
@@ -523,9 +580,17 @@ Most functions are wrapped by a corresponding [operator](#operator).
 
 #### User-Defined Aggregate Function (UDAF)
 
+This type of user-defined function aggregates multiple values into a single value.
+
 #### User-Defined Scalar Function (UDSF)
 
+This type of user-defined function maps zero, one, or more [scalar](#scalar) values to a new scalar value.
+
 #### User-Defined Table-valued Function (UDTF)
+
+This type of user-defined function uses zero, one, or multiple [scalar](#scalar) values as input parameters 
+(including variable-length parameters). A UDTF returns any number of rows, rather than a single value. 
+The returned rows can consist of one or more columns.
 
 #### ValueState<T>
 
@@ -548,17 +613,17 @@ DatasStream.
 
 #### Windows
 
-Flink features very expressive window semantics.
+These are vital to processing unbounded streams. Windows split the [DataStream](#datastream) into 
+“buckets” of finite size, over which computations can be applied. 
 
-used to compute aggregates on unbounded streams,
-
-Windows can be time driven (example: every 30 seconds) or data driven (example: every 100 elements).
+Flink features very expressive window semantics. Windows can be time-driven (i.e. every 30 seconds) 
+or data-driven (i.e. every 100 elements).
 
 #### Window Assigner
 
-An abstraction that assigns events to windows and creates new window objects as necessary. Flink has 
-several built-in types of window assigners. 
+This is an abstraction that assigns [events](#event) to [windows](#window) and creates new window 
+objects as necessary. Flink has several built-in types of window assigners. 
 
 #### Window Function 
 
-An abstraction that is applied to the events that are assigned to a window.
+This is an abstraction that is applied to the [events](#event) that are assigned to a [window](#window).

--- a/docs/content/docs/concepts/glossary.md
+++ b/docs/content/docs/concepts/glossary.md
@@ -336,8 +336,13 @@ A number identifying how far you are from the beginning of a certain [stream](#s
 
 #### Operator
 
-An operator is a node of a [logical graph](#logical-graph). An operator performs a certain operation, 
-which is usually executed by a [function](#function). Sources and sinks are special operators for data
+An operator is a node of a [logical graph](#logical-graph) executing a specific stream processing logic. 
+In general, Flink's [stream](#stream) operators can have `N` input streams, `N` output streams, and 
+an arbitrary amount of [keyed state](#keyed-state)/global state assigned to it. Operator behavior can 
+usually be customized by user-provided [functions](#function). 
+
+An example is the map operator, which is a 1-input/1-output stream that transforms the input records 
+with a user-provided function. [Sources](#source) and [sinks](#sink) are special operators for data 
 ingestion and data egress.
 
 #### Operator Chain
@@ -440,8 +445,10 @@ savepoint is controlled by the user.
 This is the process of turning a data element in memory into a stream of bytes so that you can store 
 it on disk or send it over the network.
 
-Flink handles data types and serialization in a unique way, containing its own type descriptors, 
-generic type extraction, and type serialization framework.
+Flink automatically generates serializers for most data types and handles [data types and 
+serialization]({{< ref "/docs/dev/datastream/fault-tolerance/serialization/types_serialization" >}}) 
+in a unique way, containing its own type descriptors, generic type extraction, and type serialization 
+framework.
 
 #### Session Cluster
 
@@ -610,17 +617,20 @@ Most functions are wrapped by a corresponding [operator](#operator).
 
 #### User-Defined Aggregate Function (UDAF)
 
-This type of user-defined function aggregates multiple values into a single value.
+In Table API/SQL, this type of [user-defined function]({{< ref "/docs/dev/table/functions/udfs" >}}) 
+aggregates multiple values into a single value.
 
 #### User-Defined Scalar Function (UDSF)
 
-This type of user-defined function maps zero, one, or more [scalar](#scalar) values to a new scalar value.
+In Table API/SQL, this type of [user-defined function]({{< ref "/docs/dev/table/functions/udfs" >}}) 
+maps zero, one, or more [scalar](#scalar) values to a new scalar value.
 
 #### User-Defined Table-valued Function (UDTF)
 
-This type of user-defined function uses zero, one, or multiple [scalar](#scalar) values as input parameters 
-(including variable-length parameters). A UDTF returns any number of rows, rather than a single value. 
-The returned rows can consist of one or more columns.
+In Table API/SQL, this type of [user-defined function]({{< ref "/docs/dev/table/functions/udfs" >}}) 
+uses zero, one, or multiple [scalar](#scalar) values as input parameters (including variable-length 
+parameters). A UDTF returns any number of rows, rather than a single value. The returned rows can 
+consist of one or more columns.
 
 #### ValueState<T>
 

--- a/docs/content/docs/concepts/glossary.md
+++ b/docs/content/docs/concepts/glossary.md
@@ -42,10 +42,9 @@ to a dedicated [Application Cluster](#application-cluster), or to a [Job Cluster
 
 #### Application Cluster
 
-A Flink Application Cluster is a dedicated [Flink Cluster](#flink-cluster) that
-only executes [Flink Jobs](#flink-job) from one [Flink
-Application](#flink-application). The lifetime of the [Flink
-Cluster](#flink-cluster) is bound to the lifetime of the Flink Application.
+A Flink application cluster is a dedicated [Flink cluster](#(flink)-cluster) that only executes 
+[Flink jobs](#flink-job) from one [Flink application](#(flink)-application). The lifetime of the Flink
+cluster is bound to the lifetime of the Flink application.
 
 #### Asynchronous Snapshotting
 
@@ -69,19 +68,19 @@ events may be lost.
 A situation where a system is receiving data at a higher rate than it can process during a temporary 
 load spike.
 
-#### Barrier alignment
+#### Barrier Alignment
 
 For providing exactly-once guarantees, Flink aligns the streams at operators that receive multiple 
 input streams, so that the snapshot will reflect the state resulting from consuming events from both 
 input streams up to (but not past) both barriers. 
 
-#### Batch processing
+#### Batch Processing
 
 When the processing and analysis happens on a set of data that have already been stored over a period 
 of time. The results are usually not available in real-time. Flink executes batch programs as a special 
 case of streaming programs.
 
-#### Bounded streams
+#### Bounded Streams
 
 #### Category
 
@@ -120,7 +119,7 @@ in the command line process via `./bin/flink run`.
 A distributed system consisting of (typically) one [JobManager](#jobmanager) and one or more
 [TaskManager](#taskmanager) processes.
 
-#### Connected streams
+#### Connected Streams
 
 A pattern in Flink where a single operator has two input streams. Connected streams can also be used 
 to implement streaming joins.
@@ -161,7 +160,7 @@ calculation is performed.
 If you want to use event time, you will also need to supply a Timestamp Extractor and Watermark Generator 
 that Flink will use to track the progress of event time.
 
-#### Exactly-Once
+#### Exactly-once
 
 A fault-tolerance guarantee and data delivery approach where nothing is lost or duplicated. This does 
 not mean that every event will be processed exactly once. Instead, it means that every event will affect 
@@ -186,13 +185,13 @@ A timestamp recorded by Flink at the moment it ingests the event.
 #### (Flink) Job
 
 This is the runtime representation of a [logical graph](#logical-graph) (also often called dataflow
-graph) that is created and submitted by calling `execute()` in a [Flink Application](#flink-application).
+graph) that is created and submitted by calling `execute()` in a [Flink application](#flink-application).
 
 #### Job Cluster
 
-This is a dedicated [Flink Cluster](#flink-cluster) that only executes a single [Flink Job](#flink-job). 
-The lifetime of the [Flink Cluster](#flink-cluster) is bound to the lifetime of the Flink Job. This 
-deployment mode has been deprecated since Flink 1.15.
+This is a dedicated [Flink cluster](#(flink)-cluster) that only executes a single [Flink job](#(flink)-job). 
+The lifetime of the Flink cluster is bound to the lifetime of the Flink job. This deployment mode has 
+been deprecated since Flink 1.15.
 
 #### JobGraph
 
@@ -200,8 +199,8 @@ See [Logical Graph](#logical-graph).
 
 #### JobManager
 
-The JobManager is the orchestrator of a [Flink Cluster](#(flink)-cluster). It contains three distinct
-components: ResourceManager, Dispatcher, and a [JobMaster](#jobmaster) per running [Flink Job](#(flink)-job).
+The JobManager is the orchestrator of a [Flink cluster](#(flink)-cluster). It contains three distinct
+components: ResourceManager, Dispatcher, and a [JobMaster](#jobmaster) per running [Flink job](#(flink)-job).
 
 There is always at least one JobManager. A high-availability setup might have multiple JobManagers, 
 one of which is always the leader.
@@ -220,7 +219,7 @@ are then used by Flink to determine whether jobs should be subject to recovery i
 
 #### Key Group
 
-These are the atomic unit by which Flink can redistribute [Keyed State](#keyed-state). There are 
+These are the atomic unit by which Flink can redistribute [keyed state](#keyed-state). There are 
 exactly as many key groups as the defined maximum parallelism. During execution, each parallel instance 
 of a keyed operator works with the keys for one or more key groups.
 
@@ -248,7 +247,11 @@ Lateness is defined relative to the [watermarks](#watermark). A watermark(t) ass
 is complete up through to time t. Any event is considered late if it comes after the watermark whose 
 timestamp is ≤ t.
 
-#### List State
+#### ListState<T>
+
+This is a type of [keyed state](#keyed-state) that keeps a list of elements. You can append elements 
+and retrieve an Iterable over all currently stored elements. Elements are added using add(T) or 
+addAll(List<T>). The Iterable can be retrieved using Iterable<T> get().
 
 #### Logical Graph
 
@@ -260,24 +263,32 @@ Logical graphs are also often referred to as [dataflow](#dataflow).
 
 #### Managed State
 
-Managed State describes application state which has been registered with the stream processing framework. 
-Apache Flink will take care of the persistence and rescaling of the managed state.  
+Managed state is application state which has been registered with the stream processing framework, 
+which will take care of the persistence and rescaling of this state.  
 
-Managed State is represented in data structures controlled by the Flink runtime, such as internal hash tables, or RocksDB. Examples are “ValueState”, “ListState”, etc. Flink’s runtime encodes the states and writes them into the checkpoints.
+This type of state is represented in data structures controlled by the Flink runtime, such as internal 
+hash tables, or RocksDB. Flink’s runtime encodes the states and writes them into the checkpoints.
 
-Keyed State and Operator State exist in two forms: managed and raw.
+[Keyed state](#keyed-state) and [operator state](#operator-state) exist in two forms: managed and [raw](#raw-state).
 
-#### Map State
+#### MapState<UK, UV>
 
-#### Non-keyed state
+This is a type of [keyed state](#keyed-state) that keeps a list of mappings. You can put key-value 
+pairs into the state and retrieve an Iterable over all currently stored mappings. Mappings are added 
+using put(UK, UV) or putAll(Map<UK, UV>). The value associated with a key can be retrieved using get(UK).
+
+#### Non-keyed State
 
 This type of state is bound to one parallel operator instance and is also called [operator state](#operator-state). 
 
-It is also possible to work with managed state in non-keyed contexts. The interfaces involved are somewhat different, and since it is unusual for user-defined functions to need non-keyed state, it is not covered here. This feature is most often used in the implementation of sources and sinks.
+It is possible to work with [managed state](#managed-state) in non-keyed contexts but it is unusual 
+for user-defined functions to need non-keyed state and the interfaces involved would be different. 
+
+This feature is most often used in the implementation of [sources](#source) and [sinks](#sink).
 
 #### Offset
 
-a number identifying how far you're from the beginning of a certain information stream (e.g. when you open a file, the offset determines where you wanna start reading the file, counting from the beginning of the file itself)
+A number identifying how far you are from the beginning of a certain [DataStream](#datastream). 
 
 #### Operator
 
@@ -289,9 +300,8 @@ ingestion and data egress.
 
 An operator chain consists of two or more consecutive [operators](#operator) without any
 repartitioning in between. Operators within the same operator chain forward records to each other
-directly without going through serialization or Flink's network stack.
-
-For distributed execution, Flink chains operator subtasks together into tasks. Each task is executed by one thread. Chaining operators together into tasks is a useful optimization: it reduces the overhead of thread-to-thread handover and buffering, and increases overall throughput while decreasing latency. The chaining behavior can be configured
+directly without going through serialization or Flink's network stack. This is a useful optimization
+and increases overall throughput while decreasing latency. The chaining behavior can be configured.
 
 #### Operator State
 
@@ -299,83 +309,82 @@ For distributed execution, Flink chains operator subtasks together into tasks. E
 
 #### Partition
 
-A partition is an independent subset of the overall data stream. A data stream is divided into 
-partitions by assigning each [record](#record) to one or more partitions via keys. Partitions of data 
-streams are consumed by [Tasks](#task) during runtime. A transformation which changes the way a data 
-stream is partitioned is often called repartitioning.
+A partition is an independent subset of the overall [DataStream](#datastream). A DataStream is divided 
+into partitions by assigning each [record](#record) to one or more partitions via keys. Partitions of 
+DataStreams are consumed by [tasks](#task) during runtime. A transformation that changes the way a 
+DataStream is partitioned is often called repartitioning.
 
 #### Physical Graph
 
 A physical graph is the result of translating a [logical graph](#logical-graph) for execution in a
-distributed runtime. The nodes are [Tasks](#task) and the edges indicate input/output relationships
-or [partitions](#partition) of data streams.
+distributed runtime. The nodes are [tasks](#task) and the edges indicate input/output relationships
+or [partitions](#partition) of DataStreams.
 
 #### POJO
 
-This is a composite data type.  It can be serialized
+This is a composite data type and can be serialized with Flink's serializer. Flink recognizes a data 
+type as a POJO type (and allows “by-name” field referencing) if the following conditions are met:
 
-Flink recognizes a data type as a POJO type (and allows “by-name” field referencing) if the following conditions are fulfilled:
-
-    The class is public and standalone (no non-static inner class)
-    The class has a public no-argument constructor
-    All non-static, non-transient fields in the class (and all superclasses) are either public (and non-final) or have public getter- and setter- methods that follow the Java beans naming conventions for getters and setters.
+- the class is public and standalone (no non-static inner class)
+- the class has a public no-argument constructor
+- all non-static, non-transient fields in the class (and all superclasses) are either public (and 
+  non-final) or have public getter- and setter- methods that follow the Java naming conventions for 
+  getters and setters
 
 #### Process Functions
 
-A ProcessFunction combines event processing with timers and state, making it a powerful building block for stream processing applications. This is the basis for creating event-driven applications with Flink.
+This type of function combines event processing with timers and state and is the basis for creating 
+event-driven applications with Flink.
 
 #### Processing Time
 
-the time when a specific operator in your pipeline is processing the event
-Computing analytics based on processing time causes inconsistencies, and makes it difficult to re-analyze historic data or test new implementations.
+The time when a specific operator in your pipeline is processing the event. Computing analytics based 
+on processing time can cause inconsistencies and make it difficult to re-analyze historic data or test 
+new implementations.
 
-#### Queryable state 
+#### Queryable State 
 
-allows you to access state from outside of Flink during runtime.
+This is managed keyed (partitioned) state that can be accessed from outside of Flink during runtime.
 
 #### Raw State
 
-Keyed State and Operator State exist in two forms: managed and raw.
+This is state that operators keep in their own data structures. When checkpointed, only a sequence of 
+bytes is written into the checkpoint and Flink knows nothing about the state’s data structures and will 
+see only the raw bytes.
 
-Raw State is state that operators keep in their own data structures. When checkpointed, they only write a sequence of bytes into the checkpoint. Flink knows nothing about the state’s data structures and sees only the raw bytes.
+[Keyed state](#keyed-state) and [operator state](#operator-state) exist in two forms: [managed](#managed-state) and raw.
 
 #### Record
 
-Records are the constituent elements of a data stream. [Operators](#operator) and [functions](#function) 
+Records are the elements that make up a [DataStream](#datastream). [Operators](#operator) and [functions](#function) 
 receive records as input and emit records as output.
 
 #### ResourceManager
 
-part of JobManager
-
-responsible for resource de-/allocation and provisioning in a Flink cluster
+This is part of the [JobManager](#JobManager) and is responsible for resource de-/allocation and 
+provisioning in a Flink cluster.
 
 #### Rich Functions
 
-At this point you have already seen several of Flink’s function interfaces, including FilterFunction, MapFunction, and FlatMapFunction. These are all examples of the Single Abstract Method pattern.
+A RichFunction is a "rich" variant of Flink's function interfaces for data transformation. These functions 
+have some additional methods needed for working with managed keyed state such as `open(Configuration c)`, 
+`close()`, `getRuntimeContext()`.
 
-For each of these interfaces, Flink also provides a so-called “rich” variant, e.g., RichFlatMapFunction, which has some additional methods, including:
+#### Rolling Total
 
-    open(Configuration c)
-    close()
-    getRuntimeContext()
-
-has access to the open and getRuntimeContext methods needed for working with managed keyed state.
-
-#### Rolling total
-
-running sum
+The sum of a sequence of numbers which is updated each time a new number is added to the sequence, 
+by adding the value of the new number to the previous rolling total.
 
 #### (Runtime) Execution Mode
 
-DataStream API programs can be executed in one of two execution modes: `BATCH`
-or `STREAMING`. See the [Execution Mode]({{< ref "/docs/dev/datastream/execution_mode" >}}) for more details.
+DataStream API programs can be executed in one of two execution modes: `BATCH` or `STREAMING`. 
+See [Execution Mode]({{< ref "/docs/dev/datastream/execution_mode" >}}) for more details.
 
 #### Savepoint
 
-a snapshot triggered manually by a user (or an API call) for some operational purpose, such as a stateful redeploy/upgrade/rescaling operation. Savepoints are always complete, and are optimized for operational flexibility.
-
-ARe always aligned
+A [snapshot](#snapshot) triggered manually by a user (or an API call) for some operational purpose, 
+such as a stateful redeploy/upgrade/rescaling. Savepoints are always complete and aligned and are 
+optimized for operational flexibility.
 
 #### Schema
 
@@ -383,34 +392,42 @@ ARe always aligned
 
 #### Session Cluster
 
-A long-running [Flink Cluster](#flink-cluster) which accepts multiple [Flink Jobs](#flink-job) for
-execution. The lifetime of this Flink Cluster is not bound to the lifetime of any Flink Job.
-Formerly, a Flink Session Cluster was also known as a Flink Cluster in *session mode*. Compare to
-[Flink Application Cluster](#flink-application-cluster).
+A long-running [Flink cluster](#(flink)-cluster) which accepts multiple [Flink jobs](#(flink)-job) for
+execution. The lifetime of this cluster is not bound to the lifetime of any Flink job. Formerly, a 
+Session Cluster was also known as a Flink Cluster in *session mode*. 
 
 #### Session Windows
 
-punctuated by a gap of inactivity
+This is a [window](#window) that groups elements by sessions of activity. Session windows do not overlap 
+and do not have a fixed start and end time, in contrast to [tumbling windows](#tumbling-window) and 
+[sliding windows](#sliding-window). A session window closes when it does not receive elements for a 
+certain period of time (i.e. when a gap of inactivity occurred).
 
 #### Shuffling
 
 #### Side Outputs
 
-more than one output stream from a Flink operator, Beyond error reporting, side outputs are also a good way to implement an n-way split of a stream.
+This is an extra output stream from a Flink operator. Beyond error reporting, side outputs are also 
+a good way to implement an n-way split of a stream.
 
 #### Sink
 
 #### Sliding Window
 
-with overlap
+This is a [window](#window) that groups elements to windows of fixed length. Similar to [tumbling windows](#tumbling-window), 
+the size of sliding windows are configured by the window size parameter. An additional window slide 
+parameter controls how frequently a sliding window is started. Hence, sliding windows can be overlapping 
+if the slide is smaller than the window size. In this case, elements are assigned to multiple windows.
 
 #### Snapshot
 
-a generic term referring to a global, consistent image of the state of a Flink job. A snapshot includes a pointer into each of the data sources (e.g., an offset into a file or Kafka partition), as well as a copy of the state from each of the job’s stateful operators that resulted from having processed all of the events up to those positions in the sources.
+A generic term referring to a global, consistent image of the state of a [Flink job](#(flink)-job). 
+A snapshot can be full or incremental and includes a pointer into each of the data sources as well as 
+a copy of the state from each of the job’s stateful operators that resulted from having processed all 
+the events up to those positions in the sources.
 
-Flink periodically takes persistent snapshots of all the state in every operator and copies these snapshots somewhere more durable, such as a distributed file system.
-
-full or incremental
+Flink periodically takes persistent snapshots of all the state in every operator and copies these 
+snapshots somewhere more durable, such as a distributed file system.
 
 Flink uses a variant of the Chandy-Lamport algorithm known as asynchronous barrier snapshotting.
 
@@ -420,21 +437,25 @@ Flink uses a variant of the Chandy-Lamport algorithm known as asynchronous barri
 
 #### State Backend
 
-For stream processing programs, the State Backend of a [Flink Job](#flink-job) determines how its
-[state](#managed-state) is stored on each TaskManager (Java Heap of TaskManager or (embedded)
-RocksDB).
+For stream processing programs, the state backend of a [Flink job](#(flink)-job) determines how its
+[state](#managed-state) is stored on each [TaskManager](#taskmanager).
 
-Two implementations of state backends are available – one based on RocksDB, an embedded key/value store that keeps its working state on disk, and another heap-based state backend that keeps its working state in memory, on the Java heap.
+Two implementations of state backends are available. One is based on RocksDB, an embedded key/value 
+store that keeps its working state on disk, and the other is heap-based that keeps its working state 
+in memory, on the Java heap.
 
-#### Stream barriers
+#### Stream Barriers
 
-A core element of Flink's distributed snapshotting. are injected into the data stream and flow with the records as part of the data stream. Barriers never overtake records, they flow strictly in line. A barrier separates the records in the data stream into the set of records that goes into the current snapshot, and the records that go into the next snapshot.
+A core element of Flink's distributed snapshotting. Stream barriers are injected into the [DataStream](#datastream) 
+and flow with the [records](#record) as part of the DataStream. Barriers never overtake records and 
+flow strictly in line. A barrier separates the records in the DataStream into the set of records that 
+goes into the current snapshot, and the records that go into the next snapshot.
 
 #### Subtask
 
-A subtask is a [Task](#task) responsible for processing a [partition](#partition) of
-the data stream. The term "subtask" emphasizes that there are multiple parallel Tasks for the same
-[Operator](#operator) or [Operator Chain](#operator-chain).
+A subtask is a [task](#task) responsible for processing a [partition](#partition) of the [DataStream](#datastream). 
+The term "subtask" emphasizes that there are multiple parallel tasks for the same [operator](#operator) 
+or [operator chain](#operator-chain).
 
 #### Table Program
 
@@ -442,9 +463,9 @@ A generic term for pipelines declared with Flink's relational APIs (Table API or
 
 #### Task
 
-Node of a [Physical Graph](#physical-graph). A task is the basic unit of work, which is executed by
-Flink's runtime. Tasks encapsulate exactly one parallel instance of an [operator](#operator) or
-[operator Chain](#operator-chain).
+This is a node in a [physical graph](#physical-graph). A task is the basic unit of work which is executed 
+by Flink's runtime. Tasks encapsulate exactly one parallel instance of an [operator](#operator) or
+[operator chain](#operator-chain).
 
 #### Task Chaining
 
@@ -452,44 +473,42 @@ Flink's runtime. Tasks encapsulate exactly one parallel instance of an [operator
 
 #### Task Slot
 
-unit of resource scheduling in a Flink cluster
-
-Each task slot represents a fixed subset of resources of the TaskManager.
+This is one unit of resource scheduling in a [Flink cluster](#(flink)-cluster). Each task slot 
+represents a fixed subset of resources of the [TaskManager](#taskmanager). The number of task slots 
+in a TaskManager indicates the number of concurrent processing tasks.
 
 #### TaskManager
 
-TaskManagers are the worker processes of a [Flink Cluster](#flink-cluster). [Tasks](#task) are
-scheduled to TaskManagers for execution. They communicate with each other to exchange data between
-subsequent Tasks.
+TaskManagers are the worker processes of a [Flink cluster](#flink-cluster), execute the tasks of a 
+dataflow, and buffer and exchange the [DataStreams](#datastreams). They connect to [JobManagers](#jobmanagers), 
+announce themselves as available, and are assigned work. [Tasks](#task) are scheduled to TaskManagers 
+for execution. They communicate with each other to exchange data between subsequent tasks. Each TaskManager 
+is a JVM process and may execute one or more subtasks in separate threads.
 
-TaskManagers connect to JobManagers, announcing themselves as available, and are assigned work.
-
-execute the tasks of a dataflow, and buffer and exchange the data streams.
-
-There must always be at least one TaskManager. The smallest unit of resource scheduling in a TaskManager is a task slot. The number of task slots in a TaskManager indicates the number of concurrent processing tasks.
-
-Each worker (TaskManager) is a JVM process, and may execute one or more subtasks in separate threads.
+There must always be at least one TaskManager. The smallest unit of resource scheduling in a TaskManager 
+is a [task slot](#task-slot). 
 
 #### Timer
 
-The timers allow applications to react to changes in processing time and in event time. Every call to the function processElement(...) gets a Context object which gives access to the element’s event time timestamp, and to the TimerService. The TimerService can be used to register callbacks for future event-/processing-time instants.
+Timers allow applications to react to changes in [processing time](#processing-time) and in [event time](#event-time).
+There are at most one timer per key and per second.
 
-Timers are fault tolerant and checkpointed along with the state of the application. In case of a failure recovery or when starting an application from a savepoint, the timers are restored.
-
-there are at most one timer per key and second
+Timers are fault-tolerant and checkpointed along with the state of the application. In case of a failure 
+recovery or when starting an application from a [savepoint](#savepoint), timers are restored.
 
 #### Transformation
 
-A transformation is applied on one or more data streams and results in one or more output data streams. 
-A transformation might change a data stream on a per-record basis, but might also only change its 
-partitioning or perform an aggregation. While [operators](#operator) and [functions](#function) are 
-the "physical" parts of Flink's API, transformations are only an API concept. Specifically, most 
-transformations are implemented by certain [operators](#operator).
+A transformation is applied to one or more [DataStreams](#datastreams) and results in one or more 
+output DataStreams. A transformation might change a DataStream on a [per-record](#record) basis, but 
+might also only change its [partitioning](#partition) or perform an [aggregation](#aggregation). While 
+[operators](#operator) and [functions](#function) are the "physical" parts of Flink's API, transformations 
+are an API concept. Specifically, most transformations are implemented by certain [operators](#operator).
 
 #### Tumbling Window
 
-A type of window
-no overlap
+This is a [window](#window) that groups elements by a specified window size. Tumbling windows have a 
+fixed size and do not overlap. For example, if you specify a tumbling window with a size of 5 minutes, 
+the current window will be evaluated and a new window will be started every five minutes.
 
 #### Tuple
 
@@ -499,8 +518,8 @@ A composite data type that has a finite ordered list of immutable elements.
 
 #### (User-Defined) Functions
 
-Functions are implemented by the user and encapsulate the application logic of a Flink program. Most
-functions are wrapped by a corresponding [operator](#operator).
+Functions are implemented by the user and encapsulate the application logic of a [Flink application](#(flink)-application). 
+Most functions are wrapped by a corresponding [operator](#operator).
 
 #### User-Defined Aggregate Function (UDAF)
 
@@ -508,20 +527,24 @@ functions are wrapped by a corresponding [operator](#operator).
 
 #### User-Defined Table-valued Function (UDTF)
 
-#### ValueState
+#### ValueState<T>
 
-This means that for each key, Flink will store a single object – in this case, an object of type Boolean.
+This is a type of [keyed state](#keyed-state) where Flink will store a single object for each key.
+ValueState keeps a value that can be updated and retrieved (scoped to key of the input element so there 
+will possibly be one value for each key that the operation sees). The value can be set using update(T) 
+and retrieved using T value().
 
 #### Watermark
 
-The mechanism in Flink to measure progress in event time is watermarks. Watermarks flow as part of the data stream and carry a timestamp t.
+This is the mechanism in Flink to measure progress in event time. Watermarks are special timestamped 
+elements that get inserted by watermark generators into a [DataStream](#datastream). They flow as part 
+of the DataStream and carry a timestamp t. A watermark for time t is an assertion that the stream is 
+(probably) now complete up through time t. 
 
-they define when to stop waiting for earlier events.
-Event time processing in Flink depends on watermark generators that insert special timestamped elements into the stream, called watermarks. A watermark for time t is an assertion that the stream is (probably) now complete up through time t.
-
-Another way to think about watermarks is that they give you, the developer of a streaming application, control over the tradeoff between latency and completeness. Unlike in batch processing, where one has the luxury of being able to have complete knowledge of the input before producing any results, with streaming you must eventually stop waiting to see more of the input, and produce some sort of result.
-
-You can either configure your watermarking aggressively, with a short bounded delay, and thereby take the risk of producing results with rather incomplete knowledge of the input – i.e., a possibly wrong result, produced quickly. Or you can wait longer, and produce results that take advantage of having more complete knowledge of the input stream(s).
+Watermarks give you control over the tradeoff between latency and completeness. You can either configure
+your watermark with a short-bounded delay and risk producing results with incomplete knowledge of the input
+or you can wait longer and produce results that take advantage of a more complete knowledge of the input
+DatasStream.
 
 #### Windows
 

--- a/docs/content/docs/concepts/glossary.md
+++ b/docs/content/docs/concepts/glossary.md
@@ -142,17 +142,15 @@ external system. For example, the Kafka connector is the sink/source implementat
 
 See [logical graph](#logical-graph).
 
-#### (Flink) DataStream
+#### DataStream
 
-This is a collection of data in a Flink application. You can think of them as immutable collections 
-of data that can contain duplicates. This data can either be finite or unbounded.
+DataStream refers to a class in Flink that provides a specific API used to represent and work with  
+[streams](#stream) in a [Flink application](#flink-application). You can think of a DataStream as immutable 
+collections of data that can contain duplicates. This data can either be [bounded](#bounded-streams) 
+or [unbounded](#unbounded-streams). You can create an initial DataStream by adding a [source](#source).
 
-DataStream is a proper noun referring to a specific class in Flink that provides a specific API for working with streams of that type. Table is another class in Flink that provides an API for operating on streams (but at a higher level of abstraction, one based on interpreting streams as dynamic tables).
-
-I would say that with the DataStream API, you are operating at the level of bounded and unbounded streams of data records (or events), and conceptually you are operating on one event at a time.
-With DataStreams you are thinking about being part of the event loop, and reacting to each event.
-
-While with Tables you are dealing with either append-only or updating tables, and relations between tables.
+Table is another class in Flink that provides a (relational) API for operating on [streams](#stream), 
+but at a higher level of abstraction, one based on interpreting streams as [dynamic tables](#dynamic-table).
 
 #### Delivery Guarantee
 
@@ -173,6 +171,8 @@ conceptually represent a [logical graph](#logical-graph) where you never look ba
 This is a component of the [JobManager](#jobmanager) and provides a REST interface to submit Flink 
 applications for execution and starts a new [JobMaster](#jobmaster) for each submitted job. It also 
 runs the Flink web UI to provide information about job executions.
+
+#### Dynamic Table
 
 #### Event
 
@@ -340,10 +340,9 @@ This is a technique for making programs run faster by performing several computa
 
 #### Partition
 
-A partition is an independent subset of the overall [DataStream](#datastream). A DataStream is divided 
-into partitions by assigning each [record](#record) to one or more partitions via keys. Partitions of 
-DataStreams are consumed by [tasks](#task) during runtime. A transformation that changes the way a 
-DataStream is partitioned is often called repartitioning.
+A partition is an independent subset of the overall [stream](#stream). Partitions of streams are 
+consumed by [tasks](#task) during runtime. A transformation that changes the way a stream is partitioned 
+is often called repartitioning.
 
 #### Physical Graph
 


### PR DESCRIPTION
## What is the purpose of the change

https://issues.apache.org/jira/browse/FLINK-13002

## Brief change log

Expand, clean up, and update Flink glossary


## Verifying this change

This is a documentation change without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
