### PR TITLE
[FLINK-26616][tests] Remove deadlines from CommonTestUtils

### DIFF
--- a/flink-clients/src/test/java/org/apache/flink/client/deployment/application/ApplicationDispatcherBootstrapITCase.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/deployment/application/ApplicationDispatcherBootstrapITCase.java
@@ -20,7 +20,6 @@ package org.apache.flink.client.deployment.application;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
-import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.client.cli.ClientOptions;
 import org.apache.flink.client.deployment.application.executors.EmbeddedExecutor;
 import org.apache.flink.client.program.PackagedProgram;
@@ -97,7 +96,6 @@ public class ApplicationDispatcherBootstrapITCase {
     @Test
     public void testDispatcherRecoversAfterLosingAndRegainingLeadership() throws Exception {
         final String blockId = UUID.randomUUID().toString();
-        final Deadline deadline = Deadline.fromNow(TIMEOUT);
         final Configuration configuration = new Configuration();
         configuration.set(HighAvailabilityOptions.HA_MODE, HighAvailabilityMode.ZOOKEEPER.name());
         configuration.set(DeploymentOptions.TARGET, EmbeddedExecutor.NAME);
@@ -121,11 +119,7 @@ public class ApplicationDispatcherBootstrapITCase {
             cluster.start();
 
             // wait until job is running
-            awaitJobStatus(
-                    cluster,
-                    ApplicationDispatcherBootstrap.ZERO_JOB_ID,
-                    JobStatus.RUNNING,
-                    deadline);
+            awaitJobStatus(cluster, ApplicationDispatcherBootstrap.ZERO_JOB_ID, JobStatus.RUNNING);
 
             // make sure the operator is actually running
             BlockingJob.awaitRunning(blockId);
@@ -140,11 +134,7 @@ public class ApplicationDispatcherBootstrapITCase {
             haServices.grantDispatcherLeadership();
 
             // job is suspended, wait until it's running
-            awaitJobStatus(
-                    cluster,
-                    ApplicationDispatcherBootstrap.ZERO_JOB_ID,
-                    JobStatus.RUNNING,
-                    deadline);
+            awaitJobStatus(cluster, ApplicationDispatcherBootstrap.ZERO_JOB_ID, JobStatus.RUNNING);
 
             // unblock processing so the job can finish
             BlockingJob.unblock(blockId);
@@ -157,7 +147,7 @@ public class ApplicationDispatcherBootstrapITCase {
                     .isEqualTo(ApplicationStatus.SUCCEEDED);
 
             // the cluster should shut down automatically once the application completes
-            awaitClusterStopped(cluster, deadline);
+            awaitClusterStopped(cluster);
         } finally {
             BlockingJob.cleanUp(blockId);
         }
@@ -165,7 +155,6 @@ public class ApplicationDispatcherBootstrapITCase {
 
     @Test
     public void testDirtyJobResultRecoveryInApplicationMode() throws Exception {
-        final Deadline deadline = Deadline.fromNow(TIMEOUT);
         final Configuration configuration = new Configuration();
         configuration.set(HighAvailabilityOptions.HA_MODE, HighAvailabilityMode.ZOOKEEPER.name());
         configuration.set(DeploymentOptions.TARGET, EmbeddedExecutor.NAME);
@@ -203,7 +192,7 @@ public class ApplicationDispatcherBootstrapITCase {
             cluster.start();
 
             // the cluster should shut down automatically once the application completes
-            awaitClusterStopped(cluster, deadline);
+            awaitClusterStopped(cluster);
         }
 
         FlinkAssertions.assertThatChainOfCauses(ErrorHandlingSubmissionJob.getSubmissionException())
@@ -223,7 +212,6 @@ public class ApplicationDispatcherBootstrapITCase {
 
     @Test
     public void testSubmitFailedJobOnApplicationError() throws Exception {
-        final Deadline deadline = Deadline.fromNow(TIMEOUT);
         final JobID jobId = new JobID();
         final Configuration configuration = new Configuration();
         configuration.set(HighAvailabilityOptions.HA_MODE, HighAvailabilityMode.ZOOKEEPER.name());
@@ -251,7 +239,7 @@ public class ApplicationDispatcherBootstrapITCase {
             cluster.start();
 
             // wait until the failed job has been submitted
-            awaitJobStatus(cluster, jobId, JobStatus.FAILED, deadline);
+            awaitJobStatus(cluster, jobId, JobStatus.FAILED);
 
             final ArchivedExecutionGraph graph = cluster.getArchivedExecutionGraph(jobId).get();
 
@@ -272,13 +260,11 @@ public class ApplicationDispatcherBootstrapITCase {
         }
     }
 
-    private static void awaitClusterStopped(MiniCluster cluster, Deadline deadline)
-            throws Exception {
-        CommonTestUtils.waitUntilCondition(() -> !cluster.isRunning(), deadline);
+    private static void awaitClusterStopped(MiniCluster cluster) throws Exception {
+        CommonTestUtils.waitUntilCondition(() -> !cluster.isRunning());
     }
 
-    private static void awaitJobStatus(
-            MiniCluster cluster, JobID jobId, JobStatus status, Deadline deadline)
+    private static void awaitJobStatus(MiniCluster cluster, JobID jobId, JobStatus status)
             throws Exception {
         CommonTestUtils.waitUntilCondition(
                 () -> {
@@ -292,7 +278,6 @@ public class ApplicationDispatcherBootstrapITCase {
                         }
                         throw e;
                     }
-                },
-                deadline);
+                });
     }
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/deployment/application/ApplicationDispatcherBootstrapITCase.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/deployment/application/ApplicationDispatcherBootstrapITCase.java
@@ -73,8 +73,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ExtendWith(TestLoggerExtension.class)
 public class ApplicationDispatcherBootstrapITCase {
 
-    private static final Duration TIMEOUT = Duration.ofMinutes(10);
-
     private static Supplier<DispatcherResourceManagerComponentFactory>
             createApplicationModeDispatcherResourceManagerComponentFactorySupplier(
                     Configuration configuration, PackagedProgram program) {

--- a/flink-connectors/flink-connector-rabbitmq/src/test/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSourceITCase.java
+++ b/flink-connectors/flink-connector-rabbitmq/src/test/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSourceITCase.java
@@ -23,7 +23,6 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.common.serialization.SimpleStringSchema;
-import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.client.program.rest.RestClusterClient;
 import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.runtime.execution.ExecutionState;
@@ -54,7 +53,6 @@ import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.utility.DockerImageName;
 
 import java.io.IOException;
-import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -132,7 +130,6 @@ public class RMQSourceITCase {
                                                 info ->
                                                         info.getExecutionState()
                                                                 == ExecutionState.RUNNING),
-                Deadline.fromNow(Duration.ofSeconds(10)),
                 5L);
 
         clusterClient
@@ -156,10 +153,7 @@ public class RMQSourceITCase {
         source.addSink(CountingSink.getInstance());
         final JobGraph jobGraph = env.getStreamGraph().getJobGraph();
         JobID jobId = clusterClient.submitJob(jobGraph).get();
-        CommonTestUtils.waitUntilCondition(
-                () -> CountingSink.getCount() == msgs.size(),
-                Deadline.fromNow(Duration.ofSeconds(30)),
-                5L);
+        CommonTestUtils.waitUntilCondition(() -> CountingSink.getCount() == msgs.size(), 5L);
         clusterClient.cancel(jobId);
     }
 
@@ -190,10 +184,7 @@ public class RMQSourceITCase {
         source.addSink(CountingSink.getInstance());
         final JobGraph jobGraph = env.getStreamGraph().getJobGraph();
         JobID jobId = clusterClient.submitJob(jobGraph).get();
-        CommonTestUtils.waitUntilCondition(
-                () -> CountingSink.getCount() == msgs.size(),
-                Deadline.fromNow(Duration.ofSeconds(60)),
-                5L);
+        CommonTestUtils.waitUntilCondition(() -> CountingSink.getCount() == msgs.size(), 5L);
         clusterClient.cancel(jobId);
     }
 

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/FlinkContainerTestEnvironment.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/FlinkContainerTestEnvironment.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.tests.util.flink;
 
-import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.testframe.environment.ClusterControllable;
 import org.apache.flink.connector.testframe.environment.TestEnvironment;
@@ -35,7 +34,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.URL;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -149,8 +147,7 @@ public class FlinkContainerTestEnvironment implements TestEnvironment, ClusterCo
                                     flinkContainers
                                             .getRestClusterClient()
                                             .getJobDetails(jobClient.getJobID())
-                                            .get(),
-                            Deadline.fromNow(Duration.ofMinutes(5)));
+                                            .get());
                     afterFailAction.run();
                 });
     }

--- a/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/HAJobRunOnMinioS3StoreITCase.java
+++ b/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/HAJobRunOnMinioS3StoreITCase.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.fs.s3.common;
 
-import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.testutils.AllCallbackWrapper;
@@ -39,7 +38,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import java.time.Duration;
 import java.util.List;
 
 import static org.apache.flink.shaded.guava30.com.google.common.base.Predicates.not;
@@ -130,9 +128,8 @@ public abstract class HAJobRunOnMinioS3StoreITCase extends AbstractHAJobRunITCas
                                             FileSystemJobResultStore
                                                     ::hasValidDirtyJobResultStoreEntryExtension);
                 },
-                Deadline.fromNow(Duration.ofSeconds(60)),
-                2000L,
-                "Wait for the JobResult being written to the JobResultStore.");
+                2000L
+		);
 
         final S3ObjectSummary objRef = Iterables.getOnlyElement(getObjectsFromJobResultStore());
         assertThat(objRef.getKey())

--- a/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/HAJobRunOnMinioS3StoreITCase.java
+++ b/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/HAJobRunOnMinioS3StoreITCase.java
@@ -128,8 +128,7 @@ public abstract class HAJobRunOnMinioS3StoreITCase extends AbstractHAJobRunITCas
                                             FileSystemJobResultStore
                                                     ::hasValidDirtyJobResultStoreEntryExtension);
                 },
-                2000L
-		);
+                2000L);
 
         final S3ObjectSummary objRef = Iterables.getOnlyElement(getObjectsFromJobResultStore());
         assertThat(objRef.getKey())

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesResourceManagerDriverTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesResourceManagerDriverTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.kubernetes;
 
-import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.configuration.KubernetesResourceManagerDriverConfiguration;
@@ -40,7 +39,6 @@ import org.apache.flink.util.concurrent.FutureUtils;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import org.junit.Test;
 
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -213,7 +211,6 @@ public class KubernetesResourceManagerDriverTest
                             // Verify the old watch is closed and a new one is created
                             CommonTestUtils.waitUntilCondition(
                                     () -> getPodsWatches().size() == 2,
-                                    Deadline.fromNow(Duration.ofSeconds(TIMEOUT_SEC)),
                                     String.format(
                                             "New watch is not created in %s seconds.",
                                             TIMEOUT_SEC));

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesResourceManagerDriverTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesResourceManagerDriverTest.java
@@ -209,11 +209,7 @@ public class KubernetesResourceManagerDriverTest
                                             new KubernetesTooOldResourceVersionException(
                                                     new Exception("too old resource version")));
                             // Verify the old watch is closed and a new one is created
-                            CommonTestUtils.waitUntilCondition(
-                                    () -> getPodsWatches().size() == 2,
-                                    String.format(
-                                            "New watch is not created in %s seconds.",
-                                            TIMEOUT_SEC));
+                            CommonTestUtils.waitUntilCondition(() -> getPodsWatches().size() == 2);
                             assertThat(getPodsWatches().get(0).isClosed(), is(true));
                             assertThat(getPodsWatches().get(1).isClosed(), is(false));
                         });

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesCheckpointIDCounterTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesCheckpointIDCounterTest.java
@@ -203,7 +203,7 @@ public class KubernetesCheckpointIDCounterTest extends KubernetesHighAvailabilit
 
                             // lost leadership
                             getLeaderCallback().notLeader();
-                            electionEventHandler.waitForRevokeLeader(TIMEOUT);
+                            electionEventHandler.waitForRevokeLeader();
                             getLeaderConfigMap()
                                     .getAnnotations()
                                     .remove(KubernetesLeaderElector.LEADER_ANNOTATION_KEY);
@@ -284,7 +284,7 @@ public class KubernetesCheckpointIDCounterTest extends KubernetesHighAvailabilit
 
                             // lost leadership
                             getLeaderCallback().notLeader();
-                            electionEventHandler.waitForRevokeLeader(TIMEOUT);
+                            electionEventHandler.waitForRevokeLeader();
                             getLeaderConfigMap()
                                     .getAnnotations()
                                     .remove(KubernetesLeaderElector.LEADER_ANNOTATION_KEY);

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesHighAvailabilityRecoverFromSavepointITCase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesHighAvailabilityRecoverFromSavepointITCase.java
@@ -25,7 +25,6 @@ import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
-import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.client.program.ClusterClient;
@@ -59,7 +58,6 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.IOException;
-import java.time.Duration;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
@@ -110,7 +108,6 @@ public class KubernetesHighAvailabilityRecoverFromSavepointITCase extends TestLo
         // Wait until all tasks running and getting a successful savepoint
         CommonTestUtils.waitUntilCondition(
                 () -> triggerSavepoint(clusterClient, jobGraph.getJobID(), savepointPath) != null,
-                Deadline.fromNow(TestingUtils.infiniteDuration()),
                 1000);
 
         // Trigger savepoint 2
@@ -121,7 +118,6 @@ public class KubernetesHighAvailabilityRecoverFromSavepointITCase extends TestLo
         clusterClient.cancel(jobGraph.getJobID());
         CommonTestUtils.waitUntilCondition(
                 () -> clusterClient.getJobStatus(jobGraph.getJobID()).get() == JobStatus.CANCELED,
-                Deadline.fromNow(Duration.ofMillis(TIMEOUT)),
                 1000);
 
         // Start a new job with savepoint 2

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesHighAvailabilityTestBase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesHighAvailabilityTestBase.java
@@ -129,7 +129,7 @@ public class KubernetesHighAvailabilityTestBase extends TestLogger {
         // Use the leader callback to manually grant leadership
         void leaderCallbackGrantLeadership() throws Exception {
             kubernetesTestFixture.leaderCallbackGrantLeadership();
-            electionEventHandler.waitForLeader(TIMEOUT);
+            electionEventHandler.waitForLeader();
         }
 
         FlinkKubeClient.WatchCallbackHandler<KubernetesConfigMap>

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionAndRetrievalITCase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionAndRetrievalITCase.java
@@ -56,8 +56,6 @@ public class KubernetesLeaderElectionAndRetrievalITCase extends TestLogger {
             "akka.tcp://flink@172.20.1.21:6123/user/rpc/dispatcher";
     @ClassRule public static KubernetesResource kubernetesResource = new KubernetesResource();
 
-    private static final long TIMEOUT = 120L * 1000L;
-
     @Test
     public void testLeaderElectionAndRetrieval() throws Exception {
         final String configMapName = LEADER_CONFIGMAP_NAME + System.currentTimeMillis();
@@ -101,14 +99,14 @@ public class KubernetesLeaderElectionAndRetrievalITCase extends TestLogger {
                             KubernetesUtils::getLeaderInformationFromConfigMap,
                             retrievalEventHandler::handleError);
 
-            electionEventHandler.waitForLeader(TIMEOUT);
+            electionEventHandler.waitForLeader();
             // Check the new leader is confirmed
             final LeaderInformation confirmedLeaderInformation =
                     electionEventHandler.getConfirmedLeaderInformation();
             assertThat(confirmedLeaderInformation.getLeaderAddress(), is(LEADER_ADDRESS));
 
             // Check the leader retrieval driver should be notified the leader address
-            retrievalEventHandler.waitForNewLeader(TIMEOUT);
+            retrievalEventHandler.waitForNewLeader();
             assertThat(
                     retrievalEventHandler.getLeaderSessionID(),
                     is(confirmedLeaderInformation.getLeaderSessionID()));

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionDriverTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionDriverTest.java
@@ -70,7 +70,7 @@ public class KubernetesLeaderElectionDriverTest extends KubernetesHighAvailabili
                             // Revoke leadership
                             getLeaderCallback().notLeader();
 
-                            electionEventHandler.waitForRevokeLeader(TIMEOUT);
+                            electionEventHandler.waitForRevokeLeader();
                             assertThat(electionEventHandler.isLeader(), is(false));
                             assertThat(
                                     electionEventHandler.getConfirmedLeaderInformation(),
@@ -94,7 +94,7 @@ public class KubernetesLeaderElectionDriverTest extends KubernetesHighAvailabili
                 runTest(
                         () -> {
                             leaderElectionDriver.hasLeadership();
-                            electionEventHandler.waitForError(TIMEOUT);
+                            electionEventHandler.waitForError();
                             final String errorMsg =
                                     "ConfigMap " + LEADER_CONFIGMAP_NAME + " does not exist.";
                             assertThat(electionEventHandler.getError(), is(notNullValue()));
@@ -137,7 +137,7 @@ public class KubernetesLeaderElectionDriverTest extends KubernetesHighAvailabili
                         () -> {
                             leaderElectionDriver.writeLeaderInformation(
                                     LeaderInformation.known(UUID.randomUUID(), LEADER_ADDRESS));
-                            electionEventHandler.waitForError(TIMEOUT);
+                            electionEventHandler.waitForError();
 
                             final String errorMsg =
                                     "Could not write leader information since ConfigMap "
@@ -205,7 +205,7 @@ public class KubernetesLeaderElectionDriverTest extends KubernetesHighAvailabili
                             callbackHandler.onDeleted(
                                     Collections.singletonList(getLeaderConfigMap()));
 
-                            electionEventHandler.waitForError(TIMEOUT);
+                            electionEventHandler.waitForError();
                             final String errorMsg =
                                     "ConfigMap " + LEADER_CONFIGMAP_NAME + " is deleted externally";
                             assertThat(electionEventHandler.getError(), is(notNullValue()));
@@ -230,7 +230,7 @@ public class KubernetesLeaderElectionDriverTest extends KubernetesHighAvailabili
                             callbackHandler.onError(
                                     Collections.singletonList(getLeaderConfigMap()));
 
-                            electionEventHandler.waitForError(TIMEOUT);
+                            electionEventHandler.waitForError();
                             final String errorMsg =
                                     "Error while watching the ConfigMap " + LEADER_CONFIGMAP_NAME;
                             assertThat(electionEventHandler.getError(), is(notNullValue()));

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderRetrievalDriverTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderRetrievalDriverTest.java
@@ -48,7 +48,7 @@ public class KubernetesLeaderRetrievalDriverTest extends KubernetesHighAvailabil
                                     Collections.singletonList(getLeaderConfigMap()));
                             final String errMsg =
                                     "Error while watching the ConfigMap " + LEADER_CONFIGMAP_NAME;
-                            retrievalEventHandler.waitForError(TIMEOUT);
+                            retrievalEventHandler.waitForError();
                             assertThat(
                                     retrievalEventHandler.getError(),
                                     FlinkMatchers.containsMessage(errMsg));
@@ -76,8 +76,7 @@ public class KubernetesLeaderRetrievalDriverTest extends KubernetesHighAvailabil
                             callbackHandler.onModified(
                                     Collections.singletonList(getLeaderConfigMap()));
 
-                            assertThat(
-                                    retrievalEventHandler.waitForNewLeader(TIMEOUT), is(newLeader));
+                            assertThat(retrievalEventHandler.waitForNewLeader(), is(newLeader));
                         });
             }
         };
@@ -98,7 +97,7 @@ public class KubernetesLeaderRetrievalDriverTest extends KubernetesHighAvailabil
                             getLeaderConfigMap().getData().clear();
                             callbackHandler.onModified(
                                     Collections.singletonList(getLeaderConfigMap()));
-                            retrievalEventHandler.waitForEmptyLeaderInformation(TIMEOUT);
+                            retrievalEventHandler.waitForEmptyLeaderInformation();
                             assertThat(retrievalEventHandler.getAddress(), is(nullValue()));
                         });
             }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesMultipleComponentLeaderElectionDriverTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesMultipleComponentLeaderElectionDriverTest.java
@@ -118,7 +118,7 @@ public class KubernetesMultipleComponentLeaderElectionDriverTest {
 
                             notifyLeaderRetrievalWatchOnModifiedConfigMap();
 
-                            leaderRetrievalListener.waitForNewLeader(10_000L);
+                            leaderRetrievalListener.waitForNewLeader();
                             assertThat(leaderRetrievalListener.getLeader())
                                     .isEqualTo(leaderInformation);
                         });

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesStateHandleStoreITCase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesStateHandleStoreITCase.java
@@ -51,8 +51,6 @@ public class KubernetesStateHandleStoreITCase extends TestLogger {
 
     private final FlinkKubeClientFactory kubeClientFactory = new FlinkKubeClientFactory();
 
-    private static final long TIMEOUT = 120L * 1000L;
-
     private static final String KEY = "state-handle-test";
 
     @Test
@@ -94,8 +92,7 @@ public class KubernetesStateHandleStoreITCase extends TestLogger {
             }
 
             // Wait for the leader
-            final String lockIdentity =
-                    TestingLeaderCallbackHandler.waitUntilNewLeaderAppears(TIMEOUT);
+            final String lockIdentity = TestingLeaderCallbackHandler.waitUntilNewLeaderAppears();
             Long expectedState = null;
 
             for (int i = 0; i < leaderNum; i++) {

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesStateHandleStoreTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesStateHandleStoreTest.java
@@ -445,7 +445,7 @@ public class KubernetesStateHandleStoreTest extends KubernetesHighAvailabilityTe
                             store.addAndLock(key, state);
                             // Lost leadership
                             getLeaderCallback().notLeader();
-                            electionEventHandler.waitForRevokeLeader(TIMEOUT);
+                            electionEventHandler.waitForRevokeLeader();
                             getLeaderConfigMap()
                                     .getAnnotations()
                                     .remove(KubernetesLeaderElector.LEADER_ANNOTATION_KEY);
@@ -851,7 +851,7 @@ public class KubernetesStateHandleStoreTest extends KubernetesHighAvailabilityTe
                             store.addAndLock(key, state);
                             // Lost leadership
                             getLeaderCallback().notLeader();
-                            electionEventHandler.waitForRevokeLeader(TIMEOUT);
+                            electionEventHandler.waitForRevokeLeader();
                             getLeaderConfigMap()
                                     .getAnnotations()
                                     .remove(KubernetesLeaderElector.LEADER_ANNOTATION_KEY);

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/resources/KubernetesLeaderElectorITCase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/resources/KubernetesLeaderElectorITCase.java
@@ -42,8 +42,6 @@ public class KubernetesLeaderElectorITCase extends TestLogger {
 
     @ClassRule public static KubernetesResource kubernetesResource = new KubernetesResource();
 
-    private static final long TIMEOUT = 120L * 1000L;
-
     private final FlinkKubeClientFactory kubeClientFactory = new FlinkKubeClientFactory();
 
     private static final String LEADER_CONFIGMAP_NAME_PREFIX = "leader-test-cluster";
@@ -81,17 +79,17 @@ public class KubernetesLeaderElectorITCase extends TestLogger {
 
             // Wait for the first leader
             final String firstLockIdentity =
-                    TestingLeaderCallbackHandler.waitUntilNewLeaderAppears(TIMEOUT);
+                    TestingLeaderCallbackHandler.waitUntilNewLeaderAppears();
 
             for (int i = 0; i < leaderNum; i++) {
                 if (leaderCallbackHandlers[i].getLockIdentity().equals(firstLockIdentity)) {
                     // Check the callback isLeader is called.
-                    leaderCallbackHandlers[i].waitForNewLeader(TIMEOUT);
+                    leaderCallbackHandlers[i].waitForNewLeader();
                     assertThat(leaderCallbackHandlers[i].hasLeadership(), is(true));
                     // Current leader died
                     leaderElectors[i].stop();
                     // Check the callback notLeader is called.
-                    leaderCallbackHandlers[i].waitForRevokeLeader(TIMEOUT);
+                    leaderCallbackHandlers[i].waitForRevokeLeader();
                     assertThat(leaderCallbackHandlers[i].hasLeadership(), is(false));
                 } else {
                     assertThat(leaderCallbackHandlers[i].hasLeadership(), is(false));
@@ -100,7 +98,7 @@ public class KubernetesLeaderElectorITCase extends TestLogger {
 
             // Another leader should be elected successfully and update the lock identity
             final String anotherLockIdentity =
-                    TestingLeaderCallbackHandler.waitUntilNewLeaderAppears(TIMEOUT);
+                    TestingLeaderCallbackHandler.waitUntilNewLeaderAppears();
             assertThat(anotherLockIdentity, is(not(firstLockIdentity)));
         } finally {
             // Cleanup the resources

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/resources/TestingLeaderCallbackHandler.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/resources/TestingLeaderCallbackHandler.java
@@ -18,10 +18,8 @@
 
 package org.apache.flink.kubernetes.kubeclient.resources;
 
-import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
 
-import java.time.Duration;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -70,31 +68,23 @@ public class TestingLeaderCallbackHandler extends KubernetesLeaderElector.Leader
                     final String lockIdentity = sharedQueue.poll(timeout, TimeUnit.MILLISECONDS);
                     leaderRef.set(lockIdentity);
                     return lockIdentity != null;
-                },
-                Deadline.fromNow(Duration.ofMillis(timeout)),
-                "No leader is elected with " + timeout + "ms");
+                });
         return leaderRef.get();
     }
 
     public void waitForNewLeader(long timeout) throws Exception {
-        final String errorMsg =
-                "No leader with " + lockIdentity + " is elected within " + timeout + "ms";
-        poll(leaderQueue, timeout, errorMsg);
+        poll(leaderQueue, timeout);
     }
 
     public void waitForRevokeLeader(long timeout) throws Exception {
-        final String errorMsg =
-                "No leader with " + lockIdentity + " is revoke within " + timeout + "ms";
-        poll(revokeQueue, timeout, errorMsg);
+        poll(revokeQueue, timeout);
     }
 
-    private void poll(BlockingQueue<String> queue, long timeout, String errorMsg) throws Exception {
+    private void poll(BlockingQueue<String> queue, long timeout) throws Exception {
         CommonTestUtils.waitUntilCondition(
                 () -> {
                     final String lockIdentity = queue.poll(timeout, TimeUnit.MILLISECONDS);
                     return this.lockIdentity.equals(lockIdentity);
-                },
-                Deadline.fromNow(Duration.ofMillis(timeout)),
-                errorMsg);
+                });
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerCleanupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerCleanupTest.java
@@ -379,9 +379,7 @@ public class BlobServerCleanupTest extends TestLogger {
 
         try (final BlobServer blobServer =
                 createTestInstance(temporaryFolder.getAbsolutePath(), cleanupInterval)) {
-            CommonTestUtils.waitUntilCondition(
-                    () -> !blob.exists(),
-                    "The transient blob has not been cleaned up automatically.");
+            CommonTestUtils.waitUntilCondition(() -> !blob.exists());
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerCleanupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerCleanupTest.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.blob;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
@@ -382,7 +381,6 @@ public class BlobServerCleanupTest extends TestLogger {
                 createTestInstance(temporaryFolder.getAbsolutePath(), cleanupInterval)) {
             CommonTestUtils.waitUntilCondition(
                     () -> !blob.exists(),
-                    Deadline.fromNow(Duration.ofSeconds(cleanupInterval * 5L)),
                     "The transient blob has not been cleaned up automatically.");
         }
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/PermanentBlobCacheTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/PermanentBlobCacheTest.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.blob;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
@@ -35,7 +34,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -109,7 +107,6 @@ public class PermanentBlobCacheTest {
                         configuration, storageDirectory.toFile(), new VoidBlobStore(), null)) {
             CommonTestUtils.waitUntilCondition(
                     () -> !blobFile.exists(),
-                    Deadline.fromNow(Duration.ofSeconds(cleanupInterval * 5L)),
                     "The permanent blob file was not cleaned up automatically.");
         }
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/PermanentBlobCacheTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/PermanentBlobCacheTest.java
@@ -105,9 +105,7 @@ public class PermanentBlobCacheTest {
         try (final PermanentBlobCache permanentBlobCache =
                 new PermanentBlobCache(
                         configuration, storageDirectory.toFile(), new VoidBlobStore(), null)) {
-            CommonTestUtils.waitUntilCondition(
-                    () -> !blobFile.exists(),
-                    "The permanent blob file was not cleaned up automatically.");
+            CommonTestUtils.waitUntilCondition(() -> !blobFile.exists());
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/TransientBlobCacheTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/TransientBlobCacheTest.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.blob;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
@@ -33,7 +32,6 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -92,9 +90,7 @@ public class TransientBlobCacheTest {
 
         try (final TransientBlobCache transientBlobCache =
                 new TransientBlobCache(configuration, storageDirectory.toFile(), null)) {
-            CommonTestUtils.waitUntilCondition(
-                    () -> !blobFile.exists(),
-                    Deadline.fromNow(Duration.ofSeconds(cleanupInterval * 5L)));
+            CommonTestUtils.waitUntilCondition(() -> !blobFile.exists());
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreITCase.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
-import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.runtime.state.RetrievableStateHandle;
 import org.apache.flink.runtime.state.SharedStateRegistry;
 import org.apache.flink.runtime.state.SharedStateRegistryImpl;
@@ -41,7 +40,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.Serializable;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -383,8 +381,7 @@ public class ZooKeeperCompletedCheckpointStoreITCase extends CompletedCheckpoint
         CommonTestUtils.waitUntilCondition(
                 () ->
                         checkpointsCleaner.getNumberOfCheckpointsToClean()
-                                == nbCheckpointsSubmittedForCleaning,
-                Deadline.fromNow(Duration.ofSeconds(3)));
+                                == nbCheckpointsSubmittedForCleaning);
         assertEquals(
                 nbCheckpointsSubmittedForCleaning,
                 checkpointsCleaner.getNumberOfCheckpointsToClean());
@@ -401,8 +398,7 @@ public class ZooKeeperCompletedCheckpointStoreITCase extends CompletedCheckpoint
         CommonTestUtils.waitUntilCondition(
                 () ->
                         checkpointsCleaner.getNumberOfCheckpointsToClean()
-                                < nbCheckpointsSubmittedForCleaning,
-                Deadline.fromNow(Duration.ofSeconds(3)));
+                                < nbCheckpointsSubmittedForCleaning);
         // some checkpoints were cleaned
         assertTrue(
                 checkpointsCleaner.getNumberOfCheckpointsToClean()

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/AbstractDispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/AbstractDispatcherTest.java
@@ -19,7 +19,6 @@ package org.apache.flink.runtime.dispatcher;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
-import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobServer;
@@ -36,7 +35,6 @@ import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.runtime.util.TestingFatalErrorHandlerResource;
 import org.apache.flink.util.TestLogger;
-import org.apache.flink.util.TimeUtils;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -69,8 +67,7 @@ public class AbstractDispatcherTest extends TestLogger {
     static void awaitStatus(DispatcherGateway dispatcherGateway, JobID jobId, JobStatus status)
             throws Exception {
         CommonTestUtils.waitUntilCondition(
-                () -> status.equals(dispatcherGateway.requestJobStatus(jobId, TIMEOUT).get()),
-                Deadline.fromNow(TimeUtils.toDuration(TIMEOUT)));
+                () -> status.equals(dispatcherGateway.requestJobStatus(jobId, TIMEOUT).get()));
     }
 
     @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherCleanupITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherCleanupITCase.java
@@ -19,7 +19,6 @@ package org.apache.flink.runtime.dispatcher;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
-import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.configuration.CleanupOptions;
 import org.apache.flink.core.testutils.FlinkMatchers;
 import org.apache.flink.core.testutils.OneShotLatch;
@@ -50,7 +49,6 @@ import org.apache.flink.runtime.testtasks.NoOpInvokable;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.runtime.testutils.TestingJobGraphStore;
 import org.apache.flink.runtime.testutils.TestingJobResultStore;
-import org.apache.flink.util.TimeUtils;
 import org.apache.flink.util.concurrent.FutureUtils;
 
 import org.hamcrest.CoreMatchers;
@@ -60,7 +58,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
@@ -192,9 +189,7 @@ public class DispatcherCleanupITCase extends AbstractDispatcherTest {
                 IsEmptyCollection.empty());
 
         CommonTestUtils.waitUntilCondition(
-                () -> haServices.getJobResultStore().hasJobResultEntry(jobId),
-                Deadline.fromNow(Duration.ofMinutes(5)),
-                "The JobResultStore should have this job marked as clean.");
+                () -> haServices.getJobResultStore().hasJobResultEntry(jobId));
     }
 
     @Test
@@ -224,10 +219,7 @@ public class DispatcherCleanupITCase extends AbstractDispatcherTest {
 
         toTerminate.add(dispatcher);
 
-        CommonTestUtils.waitUntilCondition(
-                () -> jobManagerRunnerEntry.get() != null,
-                Deadline.fromNow(Duration.ofSeconds(10)),
-                "JobManagerRunner wasn't loaded in time.");
+        CommonTestUtils.waitUntilCondition(() -> jobManagerRunnerEntry.get() != null);
 
         assertThat(
                 "The JobResultStore should have this job still marked as dirty.",
@@ -246,9 +238,7 @@ public class DispatcherCleanupITCase extends AbstractDispatcherTest {
         jobManagerRunnerCleanupFuture.complete(null);
 
         CommonTestUtils.waitUntilCondition(
-                () -> haServices.getJobResultStore().hasCleanJobResultEntry(jobId),
-                Deadline.fromNow(Duration.ofSeconds(60)),
-                "The JobResultStore should have this job marked as clean now.");
+                () -> haServices.getJobResultStore().hasCleanJobResultEntry(jobId));
     }
 
     @Test
@@ -340,8 +330,7 @@ public class DispatcherCleanupITCase extends AbstractDispatcherTest {
         leaderElectionService.isLeader(UUID.randomUUID());
 
         CommonTestUtils.waitUntilCondition(
-                () -> haServices.getJobResultStore().getDirtyResults().isEmpty(),
-                Deadline.fromNow(TimeUtils.toDuration(TIMEOUT)));
+                () -> haServices.getJobResultStore().getDirtyResults().isEmpty());
 
         assertThat(
                 "The JobGraph is not stored in the JobGraphStore.",

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -21,7 +21,6 @@ package org.apache.flink.runtime.dispatcher;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.common.operators.ResourceSpec;
-import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.execution.SavepointFormatType;
@@ -87,7 +86,6 @@ import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.Preconditions;
-import org.apache.flink.util.TimeUtils;
 import org.apache.flink.util.concurrent.FutureUtils;
 
 import org.assertj.core.api.Assertions;
@@ -854,7 +852,6 @@ public class DispatcherTest extends AbstractDispatcherTest {
                                         .getState();
                         return status == JobStatus.SUSPENDED;
                     },
-                    Deadline.fromNow(TimeUtils.toDuration(TIMEOUT)),
                     5L);
         } finally {
             // Unblock the termination of the second job

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/ZooKeeperDefaultDispatcherRunnerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/ZooKeeperDefaultDispatcherRunnerTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.dispatcher.runner;
 
-import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
@@ -71,7 +70,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
-import java.time.Duration;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ForkJoinPool;
@@ -87,8 +85,6 @@ public class ZooKeeperDefaultDispatcherRunnerTest extends TestLogger {
             LoggerFactory.getLogger(ZooKeeperDefaultDispatcherRunnerTest.class);
 
     private static final Time TESTING_TIMEOUT = Time.seconds(10L);
-
-    private static final Duration VERIFICATION_TIMEOUT = Duration.ofSeconds(10L);
 
     @ClassRule public static ZooKeeperResource zooKeeperResource = new ZooKeeperResource();
 
@@ -225,9 +221,7 @@ public class ZooKeeperDefaultDispatcherRunnerTest extends TestLogger {
                 final JobGraphStore submittedJobGraphStore = createZooKeeperJobGraphStore(client);
 
                 CommonTestUtils.waitUntilCondition(
-                        () -> submittedJobGraphStore.getJobIds().isEmpty(),
-                        Deadline.fromNow(VERIFICATION_TIMEOUT),
-                        20L);
+                        () -> submittedJobGraphStore.getJobIds().isEmpty(), 20L);
             }
         }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/ZooKeeperJobGraphStoreWatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/ZooKeeperJobGraphStoreWatcherTest.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.jobmanager;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.runtime.highavailability.zookeeper.CuratorFrameworkWithUnhandledErrorListener;
@@ -41,8 +40,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import java.time.Duration;
-
 import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertThat;
 
@@ -52,8 +49,6 @@ public class ZooKeeperJobGraphStoreWatcherTest extends TestLogger {
     @Rule public ZooKeeperResource zooKeeperResource = new ZooKeeperResource();
 
     @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
-
-    private static final Duration TIMEOUT = Duration.ofMillis(30 * 1000);
 
     private Configuration configuration;
 
@@ -87,16 +82,14 @@ public class ZooKeeperJobGraphStoreWatcherTest extends TestLogger {
             stateHandleStore.addAndLock("/" + jobID, jobGraph);
 
             CommonTestUtils.waitUntilCondition(
-                    () -> testingJobGraphListener.getAddedJobGraphs().size() > 0,
-                    Deadline.fromNow(TIMEOUT));
+                    () -> testingJobGraphListener.getAddedJobGraphs().size() > 0);
 
             assertThat(testingJobGraphListener.getAddedJobGraphs(), contains(jobID));
 
             stateHandleStore.releaseAndTryRemove("/" + jobID);
 
             CommonTestUtils.waitUntilCondition(
-                    () -> testingJobGraphListener.getRemovedJobGraphs().size() > 0,
-                    Deadline.fromNow(TIMEOUT));
+                    () -> testingJobGraphListener.getRemovedJobGraphs().size() > 0);
             assertThat(testingJobGraphListener.getRemovedJobGraphs(), contains(jobID));
 
             jobGraphStoreWatcher.stop();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -24,7 +24,6 @@ import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.common.functions.AggregateFunction;
 import org.apache.flink.api.common.io.DefaultInputSplitAssigner;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
-import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.ClosureCleaner;
 import org.apache.flink.api.java.tuple.Tuple3;
@@ -116,7 +115,6 @@ import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.TestLogger;
-import org.apache.flink.util.TimeUtils;
 import org.apache.flink.util.concurrent.FutureUtils;
 
 import org.hamcrest.Matchers;
@@ -780,7 +778,6 @@ public class JobMasterTest extends TestLogger {
                         jobMasterGateway.heartbeatFromResourceManager(rmResourceId);
                         return disconnectedJobManagerFuture.isDone();
                     },
-                    Deadline.fromNow(TimeUtils.toDuration(testingTimeout)),
                     50L);
 
             // heartbeat timeout should trigger disconnect JobManager from ResourceManager
@@ -1179,8 +1176,6 @@ public class JobMasterTest extends TestLogger {
 
     private void waitUntilAllExecutionsAreScheduledOrDeployed(
             final JobMasterGateway jobMasterGateway) throws Exception {
-        final Duration duration = Duration.ofMillis(testingTimeout.toMilliseconds());
-        final Deadline deadline = Deadline.fromNow(duration);
 
         CommonTestUtils.waitUntilCondition(
                 () -> {
@@ -1192,8 +1187,7 @@ public class JobMasterTest extends TestLogger {
                                                     execution.getState() == ExecutionState.SCHEDULED
                                                             || execution.getState()
                                                                     == ExecutionState.DEPLOYING);
-                },
-                deadline);
+                });
     }
 
     private static AccessExecution getFirstExecution(
@@ -1957,8 +1951,7 @@ public class JobMasterTest extends TestLogger {
             CommonTestUtils.waitUntilCondition(
                     () ->
                             jobMasterGateway.requestJobStatus(testingTimeout).get()
-                                    == JobStatus.RUNNING,
-                    Deadline.fromNow(TimeUtils.toDuration(testingTimeout)));
+                                    == JobStatus.RUNNING);
 
             jobMasterGateway.disconnectTaskManager(
                     unresolvedTaskManagerLocation.getResourceID(),
@@ -1967,8 +1960,7 @@ public class JobMasterTest extends TestLogger {
             CommonTestUtils.waitUntilCondition(
                     () ->
                             jobMasterGateway.requestJobStatus(testingTimeout).get()
-                                    == JobStatus.RESTARTING,
-                    Deadline.fromNow(TimeUtils.toDuration(testingTimeout)));
+                                    == JobStatus.RESTARTING);
 
             assertThat(
                     registerSlotsAtJobMaster(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolInteractionsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolInteractionsTest.java
@@ -18,13 +18,11 @@
 
 package org.apache.flink.runtime.jobmaster.slotpool;
 
-import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.executiongraph.TestingComponentMainThreadExecutor;
 import org.apache.flink.runtime.jobmaster.SlotRequestId;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
-import org.apache.flink.testutils.TestingUtils;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.TestLogger;
 
@@ -96,9 +94,7 @@ public class SlotPoolInteractionsTest extends TestLogger {
                 assertTrue(ExceptionUtils.stripExecutionException(e) instanceof TimeoutException);
             }
 
-            CommonTestUtils.waitUntilCondition(
-                    () -> pool.getNumPendingRequests() == 0,
-                    Deadline.fromNow(TestingUtils.TESTING_DURATION));
+            CommonTestUtils.waitUntilCondition(() -> pool.getNumPendingRequests() == 0);
         }
     }
 
@@ -123,9 +119,7 @@ public class SlotPoolInteractionsTest extends TestLogger {
                 assertTrue(ExceptionUtils.stripExecutionException(e) instanceof TimeoutException);
             }
 
-            CommonTestUtils.waitUntilCondition(
-                    () -> pool.getNumPendingRequests() == 0,
-                    Deadline.fromNow(TestingUtils.TESTING_DURATION));
+            CommonTestUtils.waitUntilCondition(() -> pool.getNumPendingRequests() == 0);
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionServiceTest.java
@@ -27,13 +27,11 @@ import org.apache.flink.util.function.RunnableWithException;
 import org.junit.Test;
 
 import java.util.UUID;
-import java.util.concurrent.TimeoutException;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
 
 /** Tests for {@link DefaultLeaderElectionService}. */
 public class DefaultLeaderElectionServiceTest extends TestLogger {
@@ -258,15 +256,6 @@ public class DefaultLeaderElectionServiceTest extends TestLogger {
 
                             leaderElectionService.stop();
                             testingLeaderElectionDriver.onFatalError(testException);
-
-                            try {
-                                testingContender.waitForError(timeout);
-                                fail(
-                                        "We expect to have a timeout here because there's no error should be passed to contender.");
-                            } catch (TimeoutException ex) {
-                                // noop
-                            }
-
                             assertThat(testingContender.getError(), is(nullValue()));
                         });
             }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionServiceTest.java
@@ -37,7 +37,6 @@ import static org.junit.Assert.assertThat;
 public class DefaultLeaderElectionServiceTest extends TestLogger {
 
     private static final String TEST_URL = "akka//user/jobmanager";
-    private static final long timeout = 50L;
 
     @Test
     public void testOnGrantAndRevokeLeadership() throws Exception {
@@ -48,7 +47,7 @@ public class DefaultLeaderElectionServiceTest extends TestLogger {
                             // grant leadership
                             testingLeaderElectionDriver.isLeader();
 
-                            testingContender.waitForLeader(timeout);
+                            testingContender.waitForLeader();
                             assertThat(testingContender.getDescription(), is(TEST_URL));
                             assertThat(
                                     testingContender.getLeaderSessionID(),
@@ -63,7 +62,7 @@ public class DefaultLeaderElectionServiceTest extends TestLogger {
 
                             // revoke leadership
                             testingLeaderElectionDriver.notLeader();
-                            testingContender.waitForRevokeLeader(timeout);
+                            testingContender.waitForRevokeLeader();
                             assertThat(testingContender.getLeaderSessionID(), is(nullValue()));
                             assertThat(leaderElectionService.getLeaderSessionID(), is(nullValue()));
                             // External storage should be cleared
@@ -236,7 +235,7 @@ public class DefaultLeaderElectionServiceTest extends TestLogger {
 
                             testingLeaderElectionDriver.onFatalError(testException);
 
-                            testingContender.waitForError(timeout);
+                            testingContender.waitForError();
                             assertThat(testingContender.getError(), is(notNullValue()));
                             assertThat(
                                     testingContender.getError(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderChangeClusterComponentsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderChangeClusterComponentsTest.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.leaderelection;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobSubmissionResult;
-import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.highavailability.nonha.embedded.EmbeddedHaServicesWithLeadershipControl;
@@ -155,8 +154,7 @@ public class LeaderChangeClusterComponentsTest extends TestLogger {
 
     @Test
     public void testTaskExecutorsReconnectToClusterWithLeadershipChange() throws Exception {
-        final Deadline deadline = Deadline.fromNow(TESTING_TIMEOUT);
-        waitUntilTaskExecutorsHaveConnected(NUM_TMS, deadline);
+        waitUntilTaskExecutorsHaveConnected(NUM_TMS);
         highAvailabilityServices.revokeResourceManagerLeadership().get();
         highAvailabilityServices.grantResourceManagerLeadership();
 
@@ -168,16 +166,14 @@ public class LeaderChangeClusterComponentsTest extends TestLogger {
                         .getLeaderSessionId(),
                 is(notNullValue()));
 
-        waitUntilTaskExecutorsHaveConnected(NUM_TMS, deadline);
+        waitUntilTaskExecutorsHaveConnected(NUM_TMS);
     }
 
-    private void waitUntilTaskExecutorsHaveConnected(int numTaskExecutors, Deadline deadline)
-            throws Exception {
+    private void waitUntilTaskExecutorsHaveConnected(int numTaskExecutors) throws Exception {
         CommonTestUtils.waitUntilCondition(
                 () ->
                         miniCluster.requestClusterOverview().get().getNumTaskManagersConnected()
                                 == numTaskExecutors,
-                deadline,
                 10L);
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/StandaloneLeaderElectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/StandaloneLeaderElectionTest.java
@@ -46,13 +46,13 @@ public class StandaloneLeaderElectionTest extends TestLogger {
             leaderElectionService.start(contender);
             leaderRetrievalService.start(testingListener);
 
-            contender.waitForLeader(1000l);
+            contender.waitForLeader();
 
             assertTrue(contender.isLeader());
             assertEquals(
                     HighAvailabilityServices.DEFAULT_LEADER_ID, contender.getLeaderSessionID());
 
-            testingListener.waitForNewLeader(1000l);
+            testingListener.waitForNewLeader();
 
             assertEquals(TEST_URL, testingListener.getAddress());
             assertEquals(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderBase.java
@@ -42,14 +42,12 @@ public class TestingLeaderBase {
     public void waitForLeader(long timeout) throws Exception {
         throwExceptionIfNotNull();
 
-        final String errorMsg = "Contender was not elected as the leader within " + timeout + "ms";
         CommonTestUtils.waitUntilCondition(
                 () -> {
                     final LeaderInformation leader =
                             leaderEventQueue.poll(timeout, TimeUnit.MILLISECONDS);
                     return leader != null && !leader.isEmpty();
-                },
-                errorMsg);
+                });
 
         isLeader = true;
     }
@@ -57,26 +55,22 @@ public class TestingLeaderBase {
     public void waitForRevokeLeader(long timeout) throws Exception {
         throwExceptionIfNotNull();
 
-        final String errorMsg = "Contender was not revoked within " + timeout + "ms";
         CommonTestUtils.waitUntilCondition(
                 () -> {
                     final LeaderInformation leader =
                             leaderEventQueue.poll(timeout, TimeUnit.MILLISECONDS);
                     return leader != null && leader.isEmpty();
-                },
-                errorMsg);
+                });
 
         isLeader = false;
     }
 
     public void waitForError(long timeout) throws Exception {
-        final String errorMsg = "Contender did not see an exception with " + timeout + "ms";
         CommonTestUtils.waitUntilCondition(
                 () -> {
                     error = errorQueue.poll(timeout, TimeUnit.MILLISECONDS);
                     return error != null;
-                },
-                errorMsg);
+                });
     }
 
     public void handleError(Throwable ex) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderBase.java
@@ -84,7 +84,7 @@ public class TestingLeaderBase {
      */
     @Nullable
     public Throwable getError() {
-        return this.error;
+        return error == null ? errorQueue.poll() : error;
     }
 
     public boolean isLeader() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderBase.java
@@ -18,13 +18,11 @@
 
 package org.apache.flink.runtime.leaderelection;
 
-import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.util.ExceptionUtils;
 
 import javax.annotation.Nullable;
 
-import java.time.Duration;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -51,7 +49,6 @@ public class TestingLeaderBase {
                             leaderEventQueue.poll(timeout, TimeUnit.MILLISECONDS);
                     return leader != null && !leader.isEmpty();
                 },
-                Deadline.fromNow(Duration.ofMillis(timeout)),
                 errorMsg);
 
         isLeader = true;
@@ -67,7 +64,6 @@ public class TestingLeaderBase {
                             leaderEventQueue.poll(timeout, TimeUnit.MILLISECONDS);
                     return leader != null && leader.isEmpty();
                 },
-                Deadline.fromNow(Duration.ofMillis(timeout)),
                 errorMsg);
 
         isLeader = false;
@@ -80,7 +76,6 @@ public class TestingLeaderBase {
                     error = errorQueue.poll(timeout, TimeUnit.MILLISECONDS);
                     return error != null;
                 },
-                Deadline.fromNow(Duration.ofMillis(timeout)),
                 errorMsg);
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderBase.java
@@ -44,7 +44,7 @@ public class TestingLeaderBase {
         CommonTestUtils.waitUntilCondition(
                 () -> {
                     final LeaderInformation leader = leaderEventQueue.take();
-                    return leader != null && !leader.isEmpty();
+                    return !leader.isEmpty();
                 });
 
         isLeader = true;
@@ -56,7 +56,7 @@ public class TestingLeaderBase {
         CommonTestUtils.waitUntilCondition(
                 () -> {
                     final LeaderInformation leader = leaderEventQueue.take();
-                    return leader != null && leader.isEmpty();
+                    return leader.isEmpty();
                 });
 
         isLeader = false;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderBase.java
@@ -25,7 +25,6 @@ import javax.annotation.Nullable;
 
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Base class which provides some convenience functions for testing purposes of {@link
@@ -39,38 +38,32 @@ public class TestingLeaderBase {
     private boolean isLeader = false;
     private Throwable error;
 
-    public void waitForLeader(long timeout) throws Exception {
+    public void waitForLeader() throws Exception {
         throwExceptionIfNotNull();
 
         CommonTestUtils.waitUntilCondition(
                 () -> {
-                    final LeaderInformation leader =
-                            leaderEventQueue.poll(timeout, TimeUnit.MILLISECONDS);
+                    final LeaderInformation leader = leaderEventQueue.take();
                     return leader != null && !leader.isEmpty();
                 });
 
         isLeader = true;
     }
 
-    public void waitForRevokeLeader(long timeout) throws Exception {
+    public void waitForRevokeLeader() throws Exception {
         throwExceptionIfNotNull();
 
         CommonTestUtils.waitUntilCondition(
                 () -> {
-                    final LeaderInformation leader =
-                            leaderEventQueue.poll(timeout, TimeUnit.MILLISECONDS);
+                    final LeaderInformation leader = leaderEventQueue.take();
                     return leader != null && leader.isEmpty();
                 });
 
         isLeader = false;
     }
 
-    public void waitForError(long timeout) throws Exception {
-        CommonTestUtils.waitUntilCondition(
-                () -> {
-                    error = errorQueue.poll(timeout, TimeUnit.MILLISECONDS);
-                    return error != null;
-                });
+    public void waitForError() throws Exception {
+        error = errorQueue.take();
     }
 
     public void handleError(Throwable ex) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingRetrievalBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingRetrievalBase.java
@@ -46,16 +46,13 @@ public class TestingRetrievalBase {
     public String waitForNewLeader(long timeout) throws Exception {
         throwExceptionIfNotNull();
 
-        final String errorMsg =
-                "Listener was not notified about a new leader within " + timeout + "ms";
         CommonTestUtils.waitUntilCondition(
                 () -> {
                     leader = leaderEventQueue.poll(timeout, TimeUnit.MILLISECONDS);
                     return leader != null
                             && !leader.isEmpty()
                             && !leader.getLeaderAddress().equals(oldAddress);
-                },
-                errorMsg);
+                });
 
         oldAddress = leader.getLeaderAddress();
 
@@ -65,26 +62,21 @@ public class TestingRetrievalBase {
     public void waitForEmptyLeaderInformation(long timeout) throws Exception {
         throwExceptionIfNotNull();
 
-        final String errorMsg =
-                "Listener was not notified about an empty leader within " + timeout + "ms";
         CommonTestUtils.waitUntilCondition(
                 () -> {
                     leader = leaderEventQueue.poll(timeout, TimeUnit.MILLISECONDS);
                     return leader != null && leader.isEmpty();
-                },
-                errorMsg);
+                });
 
         oldAddress = null;
     }
 
     public void waitForError(long timeout) throws Exception {
-        final String errorMsg = "Listener did not see an exception with " + timeout + "ms";
         CommonTestUtils.waitUntilCondition(
                 () -> {
                     error = errorQueue.poll(timeout, TimeUnit.MILLISECONDS);
                     return error != null;
-                },
-                errorMsg);
+                });
     }
 
     public void handleError(Throwable ex) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingRetrievalBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingRetrievalBase.java
@@ -110,7 +110,7 @@ public class TestingRetrievalBase {
      */
     @Nullable
     public Throwable getError() {
-        return this.error;
+        return error == null ? errorQueue.poll() : error;
     }
 
     private void throwExceptionIfNotNull() throws Exception {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingRetrievalBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingRetrievalBase.java
@@ -48,9 +48,7 @@ public class TestingRetrievalBase {
         CommonTestUtils.waitUntilCondition(
                 () -> {
                     leader = leaderEventQueue.take();
-                    return leader != null
-                            && !leader.isEmpty()
-                            && !leader.getLeaderAddress().equals(oldAddress);
+                    return !leader.isEmpty() && !leader.getLeaderAddress().equals(oldAddress);
                 });
 
         oldAddress = leader.getLeaderAddress();
@@ -64,7 +62,7 @@ public class TestingRetrievalBase {
         CommonTestUtils.waitUntilCondition(
                 () -> {
                     leader = leaderEventQueue.take();
-                    return leader != null && leader.isEmpty();
+                    return leader.isEmpty();
                 });
 
         oldAddress = null;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingRetrievalBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingRetrievalBase.java
@@ -27,7 +27,6 @@ import javax.annotation.Nullable;
 import java.util.UUID;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Base class which provides some convenience functions for testing purposes of {@link
@@ -43,12 +42,12 @@ public class TestingRetrievalBase {
     private String oldAddress;
     private Throwable error;
 
-    public String waitForNewLeader(long timeout) throws Exception {
+    public String waitForNewLeader() throws Exception {
         throwExceptionIfNotNull();
 
         CommonTestUtils.waitUntilCondition(
                 () -> {
-                    leader = leaderEventQueue.poll(timeout, TimeUnit.MILLISECONDS);
+                    leader = leaderEventQueue.take();
                     return leader != null
                             && !leader.isEmpty()
                             && !leader.getLeaderAddress().equals(oldAddress);
@@ -59,24 +58,20 @@ public class TestingRetrievalBase {
         return leader.getLeaderAddress();
     }
 
-    public void waitForEmptyLeaderInformation(long timeout) throws Exception {
+    public void waitForEmptyLeaderInformation() throws Exception {
         throwExceptionIfNotNull();
 
         CommonTestUtils.waitUntilCondition(
                 () -> {
-                    leader = leaderEventQueue.poll(timeout, TimeUnit.MILLISECONDS);
+                    leader = leaderEventQueue.take();
                     return leader != null && leader.isEmpty();
                 });
 
         oldAddress = null;
     }
 
-    public void waitForError(long timeout) throws Exception {
-        CommonTestUtils.waitUntilCondition(
-                () -> {
-                    error = errorQueue.poll(timeout, TimeUnit.MILLISECONDS);
-                    return error != null;
-                });
+    public void waitForError() throws Exception {
+        error = errorQueue.take();
     }
 
     public void handleError(Throwable ex) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingRetrievalBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingRetrievalBase.java
@@ -18,14 +18,12 @@
 
 package org.apache.flink.runtime.leaderelection;
 
-import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalListener;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.util.ExceptionUtils;
 
 import javax.annotation.Nullable;
 
-import java.time.Duration;
 import java.util.UUID;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -57,7 +55,6 @@ public class TestingRetrievalBase {
                             && !leader.isEmpty()
                             && !leader.getLeaderAddress().equals(oldAddress);
                 },
-                Deadline.fromNow(Duration.ofMillis(timeout)),
                 errorMsg);
 
         oldAddress = leader.getLeaderAddress();
@@ -75,7 +72,6 @@ public class TestingRetrievalBase {
                     leader = leaderEventQueue.poll(timeout, TimeUnit.MILLISECONDS);
                     return leader != null && leader.isEmpty();
                 },
-                Deadline.fromNow(Duration.ofMillis(timeout)),
                 errorMsg);
 
         oldAddress = null;
@@ -88,7 +84,6 @@ public class TestingRetrievalBase {
                     error = errorQueue.poll(timeout, TimeUnit.MILLISECONDS);
                     return error != null;
                 },
-                Deadline.fromNow(Duration.ofMillis(timeout)),
                 errorMsg);
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionTest.java
@@ -163,12 +163,12 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
                             .createLeaderRetrievalDriver(
                                     retrievalEventHandler, retrievalEventHandler::handleError);
 
-            electionEventHandler.waitForLeader(timeout);
+            electionEventHandler.waitForLeader();
             final LeaderInformation confirmedLeaderInformation =
                     electionEventHandler.getConfirmedLeaderInformation();
             assertThat(confirmedLeaderInformation.getLeaderAddress(), is(LEADER_ADDRESS));
 
-            retrievalEventHandler.waitForNewLeader(timeout);
+            retrievalEventHandler.waitForNewLeader();
 
             assertThat(
                     retrievalEventHandler.getLeaderSessionID(),
@@ -232,7 +232,7 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
 
             while (deadline.hasTimeLeft() && numberSeenLeaders < num) {
                 LOG.debug("Wait for new leader #{}.", numberSeenLeaders);
-                String address = listener.waitForNewLeader(deadline.timeLeft().toMillis());
+                String address = listener.waitForNewLeader();
 
                 Matcher m = regex.matcher(address);
 
@@ -319,7 +319,7 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
             Pattern regex = Pattern.compile(pattern);
 
             for (int i = 0; i < numTries; i++) {
-                listener.waitForNewLeader(timeout);
+                listener.waitForNewLeader();
 
                 String address = listener.getAddress();
 
@@ -387,7 +387,7 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
                     createAndInitLeaderElectionDriver(
                             curatorFrameworkWrapper.asCuratorFramework(), electionEventHandler);
 
-            electionEventHandler.waitForLeader(timeout);
+            electionEventHandler.waitForLeader();
             final LeaderInformation confirmedLeaderInformation =
                     electionEventHandler.getConfirmedLeaderInformation();
             assertThat(confirmedLeaderInformation.getLeaderAddress(), is(LEADER_ADDRESS));
@@ -435,8 +435,8 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
                             .createLeaderRetrievalDriver(
                                     retrievalEventHandler, retrievalEventHandler::handleError);
 
-            if (retrievalEventHandler.waitForNewLeader(timeout).equals(faultyContenderUrl)) {
-                retrievalEventHandler.waitForNewLeader(timeout);
+            if (retrievalEventHandler.waitForNewLeader().equals(faultyContenderUrl)) {
+                retrievalEventHandler.waitForNewLeader();
             }
 
             assertThat(
@@ -490,7 +490,7 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
 
             leaderElectionDriver = createAndInitLeaderElectionDriver(client, electionEventHandler);
 
-            electionEventHandler.waitForError(timeout);
+            electionEventHandler.waitForError();
 
             assertNotNull(electionEventHandler.getError());
             assertThat(
@@ -555,9 +555,9 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
             cache.getListenable().addListener(existsListener);
             cache.start();
 
-            electionEventHandler.waitForLeader(timeout);
+            electionEventHandler.waitForLeader();
 
-            retrievalEventHandler.waitForNewLeader(timeout);
+            retrievalEventHandler.waitForNewLeader();
 
             Future<Boolean> existsFuture = existsListener.nodeExists();
 
@@ -575,7 +575,7 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
             // make sure that the leader node has been deleted
             deletedFuture.get(timeout, TimeUnit.MILLISECONDS);
 
-            retrievalEventHandler.waitForEmptyLeaderInformation(1000L);
+            retrievalEventHandler.waitForEmptyLeaderInformation();
         } finally {
             electionEventHandler.close();
             if (leaderRetrievalDriver != null) {
@@ -607,14 +607,14 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
                     createAndInitLeaderElectionDriver(
                             curatorFrameworkWrapper.asCuratorFramework(), electionEventHandler);
 
-            electionEventHandler.waitForLeader(timeout);
+            electionEventHandler.waitForLeader();
             final LeaderInformation confirmedLeaderInformation =
                     electionEventHandler.getConfirmedLeaderInformation();
             assertThat(confirmedLeaderInformation.getLeaderAddress(), is(LEADER_ADDRESS));
 
             // Leader is revoked
             leaderElectionDriver.notLeader();
-            electionEventHandler.waitForRevokeLeader(timeout);
+            electionEventHandler.waitForRevokeLeader();
             assertThat(
                     electionEventHandler.getConfirmedLeaderInformation(),
                     is(LeaderInformation.empty()));
@@ -625,7 +625,7 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
                             .createLeaderRetrievalDriver(
                                     retrievalEventHandler, retrievalEventHandler::handleError);
 
-            retrievalEventHandler.waitForNewLeader(timeout);
+            retrievalEventHandler.waitForNewLeader();
 
             assertThat(
                     retrievalEventHandler.getLeaderSessionID(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionTest.java
@@ -69,7 +69,6 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -576,15 +575,7 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
             // make sure that the leader node has been deleted
             deletedFuture.get(timeout, TimeUnit.MILLISECONDS);
 
-            try {
-                retrievalEventHandler.waitForNewLeader(1000L);
-
-                fail(
-                        "TimeoutException was expected because there is no leader registered and "
-                                + "thus there shouldn't be any leader information in ZooKeeper.");
-            } catch (TimeoutException e) {
-                // that was expected
-            }
+            retrievalEventHandler.waitForEmptyLeaderInformation(1000L);
         } finally {
             electionEventHandler.close();
             if (leaderRetrievalDriver != null) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperMultipleComponentLeaderElectionDriverTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperMultipleComponentLeaderElectionDriverTest.java
@@ -112,7 +112,7 @@ class ZooKeeperMultipleComponentLeaderElectionDriverTest {
                             leaderElectionDriver.publishLeaderInformation(
                                     componentId, leaderInformation);
 
-                            leaderRetrievalListener.waitForNewLeader(10_000L);
+                            leaderRetrievalListener.waitForNewLeader();
 
                             assertThat(leaderRetrievalListener.getLeader())
                                     .isEqualTo(leaderInformation);
@@ -146,12 +146,12 @@ class ZooKeeperMultipleComponentLeaderElectionDriverTest {
                                     componentId,
                                     LeaderInformation.known(UUID.randomUUID(), "foobar"));
 
-                            leaderRetrievalListener.waitForNewLeader(10_000L);
+                            leaderRetrievalListener.waitForNewLeader();
 
                             leaderElectionDriver.publishLeaderInformation(
                                     componentId, LeaderInformation.empty());
 
-                            leaderRetrievalListener.waitForEmptyLeaderInformation(10_000L);
+                            leaderRetrievalListener.waitForEmptyLeaderInformation();
 
                             assertThat(leaderRetrievalListener.getLeader())
                                     .isEqualTo(LeaderInformation.empty());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderretrieval/DefaultLeaderRetrievalServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderretrieval/DefaultLeaderRetrievalServiceTest.java
@@ -38,7 +38,6 @@ import static org.junit.Assert.assertThat;
 public class DefaultLeaderRetrievalServiceTest extends TestLogger {
 
     private static final String TEST_URL = "akka//user/jobmanager";
-    private static final long timeout = 50L;
 
     @Test
     public void testNotifyLeaderAddress() throws Exception {
@@ -49,7 +48,7 @@ public class DefaultLeaderRetrievalServiceTest extends TestLogger {
                             final LeaderInformation newLeader =
                                     LeaderInformation.known(UUID.randomUUID(), TEST_URL);
                             testingLeaderRetrievalDriver.onUpdate(newLeader);
-                            testingListener.waitForNewLeader(timeout);
+                            testingListener.waitForNewLeader();
                             assertThat(
                                     testingListener.getLeaderSessionID(),
                                     is(newLeader.getLeaderSessionID()));
@@ -69,10 +68,10 @@ public class DefaultLeaderRetrievalServiceTest extends TestLogger {
                             final LeaderInformation newLeader =
                                     LeaderInformation.known(UUID.randomUUID(), TEST_URL);
                             testingLeaderRetrievalDriver.onUpdate(newLeader);
-                            testingListener.waitForNewLeader(timeout);
+                            testingListener.waitForNewLeader();
 
                             testingLeaderRetrievalDriver.onUpdate(LeaderInformation.empty());
-                            testingListener.waitForEmptyLeaderInformation(timeout);
+                            testingListener.waitForEmptyLeaderInformation();
                             assertThat(testingListener.getLeaderSessionID(), is(nullValue()));
                             assertThat(testingListener.getAddress(), is(nullValue()));
                         });
@@ -90,7 +89,7 @@ public class DefaultLeaderRetrievalServiceTest extends TestLogger {
 
                             testingLeaderRetrievalDriver.onFatalError(testException);
 
-                            testingListener.waitForError(timeout);
+                            testingListener.waitForError();
                             assertThat(
                                     testingListener.getError(),
                                     FlinkMatchers.containsCause(testException));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderretrieval/DefaultLeaderRetrievalServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderretrieval/DefaultLeaderRetrievalServiceTest.java
@@ -28,13 +28,11 @@ import org.apache.flink.util.function.RunnableWithException;
 import org.junit.Test;
 
 import java.util.UUID;
-import java.util.concurrent.TimeoutException;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
 
 /** Tests for {@link DefaultLeaderElectionService}. */
 public class DefaultLeaderRetrievalServiceTest extends TestLogger {
@@ -112,13 +110,6 @@ public class DefaultLeaderRetrievalServiceTest extends TestLogger {
                             leaderRetrievalService.stop();
                             testingLeaderRetrievalDriver.onFatalError(testException);
 
-                            try {
-                                testingListener.waitForError(timeout);
-                                fail(
-                                        "We expect to have a timeout here because there's no error should be passed to listener.");
-                            } catch (TimeoutException ex) {
-                                // noop
-                            }
                             assertThat(testingListener.getError(), is(nullValue()));
                         });
             }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderretrieval/SettableLeaderRetrievalServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderretrieval/SettableLeaderRetrievalServiceTest.java
@@ -25,8 +25,6 @@ import org.apache.flink.util.TestLogger;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.time.Duration;
-
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
@@ -34,7 +32,6 @@ import static org.junit.Assert.assertThat;
 public class SettableLeaderRetrievalServiceTest extends TestLogger {
 
     private SettableLeaderRetrievalService settableLeaderRetrievalService;
-    private static final Duration TIMEOUT = Duration.ofHours(1);
 
     @Before
     public void setUp() {
@@ -50,7 +47,7 @@ public class SettableLeaderRetrievalServiceTest extends TestLogger {
         final TestingListener listener = new TestingListener();
         settableLeaderRetrievalService.start(listener);
 
-        listener.waitForNewLeader(TIMEOUT.toMillis());
+        listener.waitForNewLeader();
         assertThat(listener.getAddress(), equalTo(localhost));
         assertThat(
                 listener.getLeaderSessionID(), equalTo(HighAvailabilityServices.DEFAULT_LEADER_ID));
@@ -65,7 +62,7 @@ public class SettableLeaderRetrievalServiceTest extends TestLogger {
         settableLeaderRetrievalService.notifyListener(
                 localhost, HighAvailabilityServices.DEFAULT_LEADER_ID);
 
-        listener.waitForNewLeader(TIMEOUT.toMillis());
+        listener.waitForNewLeader();
         assertThat(listener.getAddress(), equalTo(localhost));
         assertThat(
                 listener.getLeaderSessionID(), equalTo(HighAvailabilityServices.DEFAULT_LEADER_ID));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderretrieval/ZooKeeperLeaderRetrievalConnectionHandlingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderretrieval/ZooKeeperLeaderRetrievalConnectionHandlingTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.leaderretrieval;
 
-import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.core.testutils.EachCallbackWrapper;
 import org.apache.flink.runtime.leaderelection.LeaderInformation;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
@@ -279,8 +278,7 @@ class ZooKeeperLeaderRetrievalConnectionHandlingTest {
                                         && afterConnectionReconnect
                                                 .getLeaderAddress()
                                                 .equals(newLeaderAddress);
-                            },
-                            Deadline.fromNow(Duration.ofSeconds(30L)));
+                            });
                 });
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerClusterITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerClusterITCase.java
@@ -21,7 +21,6 @@ package org.apache.flink.runtime.scheduler.adaptive;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
-import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.WebOptions;
@@ -188,8 +187,7 @@ public class AdaptiveSchedulerClusterITCase extends TestLogger {
                                                                 .getCounts()
                                                                 .getNumberOfCompletedCheckpoints()
                                                         > 0)
-                                .get(),
-                Deadline.fromNow(Duration.ofHours(1)));
+                                .get());
 
         miniCluster.terminateTaskManager(0);
 
@@ -281,7 +279,6 @@ public class AdaptiveSchedulerClusterITCase extends TestLogger {
                     }
 
                     return executionJobVertex.getParallelism() == targetParallelism;
-                },
-                Deadline.fromNow(Duration.ofMinutes(5)));
+                });
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerSimpleITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerSimpleITCase.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
-import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.runtime.execution.Environment;
@@ -46,7 +45,6 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.time.Duration;
-import java.time.temporal.ChronoUnit;
 
 import static org.junit.Assert.assertTrue;
 
@@ -129,7 +127,6 @@ public class AdaptiveSchedulerSimpleITCase extends TestLogger {
         // wait until we are in RESTARTING state
         CommonTestUtils.waitUntilCondition(
                 () -> miniCluster.getJobStatus(jobGraph.getJobID()).get() == JobStatus.RESTARTING,
-                Deadline.fromNow(Duration.of(timeInRestartingState, ChronoUnit.MILLIS)),
                 5);
 
         // now cancel while in RESTARTING state

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorITCase.java
@@ -21,7 +21,6 @@ package org.apache.flink.runtime.taskexecutor;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
-import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.AccessExecution;
@@ -137,9 +136,7 @@ public class TaskExecutorITCase extends TestLogger {
         assertThat(jobResultFuture.isDone(), is(false));
 
         CommonTestUtils.waitUntilCondition(
-                jobIsRunning(() -> miniCluster.getExecutionGraph(jobGraph.getJobID())),
-                Deadline.fromNow(TESTING_TIMEOUT),
-                50L);
+                jobIsRunning(() -> miniCluster.getExecutionGraph(jobGraph.getJobID())), 50L);
 
         return jobResultFuture;
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorITCase.java
@@ -45,7 +45,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.function.Predicate;
@@ -57,7 +56,6 @@ import static org.junit.Assert.assertThat;
 /** Integration tests for the {@link TaskExecutor}. */
 public class TaskExecutorITCase extends TestLogger {
 
-    private static final Duration TESTING_TIMEOUT = Duration.ofMinutes(2L);
     private static final int NUM_TMS = 2;
     private static final int SLOTS_PER_TM = 2;
     private static final int PARALLELISM = NUM_TMS * SLOTS_PER_TM;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.taskexecutor;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.resources.CPUResource;
-import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.configuration.ConfigConstants;
@@ -489,7 +488,6 @@ public class TaskExecutorTest extends TestLogger {
                                     taskExecutorGateway.heartbeatFromResourceManager(rmResourceId);
                                     return taskExecutorDisconnectFuture.isDone();
                                 },
-                                Deadline.fromNow(TimeUtils.toDuration(timeout)),
                                 50L));
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/CommonTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/CommonTestUtils.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.testutils;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
-import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
@@ -41,8 +40,6 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.management.ManagementFactory;
 import java.lang.management.RuntimeMXBean;
-import java.time.Duration;
-import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -131,40 +128,16 @@ public class CommonTestUtils {
         }
     }
 
-    public static void waitUntilCondition(
-            SupplierWithException<Boolean, Exception> condition, Deadline timeout)
+    public static void waitUntilCondition(SupplierWithException<Boolean, Exception> condition)
             throws Exception {
-        waitUntilCondition(condition, timeout, RETRY_INTERVAL);
+        waitUntilCondition(condition, RETRY_INTERVAL);
     }
 
     public static void waitUntilCondition(
-            SupplierWithException<Boolean, Exception> condition,
-            Deadline timeout,
-            long retryIntervalMillis)
+            SupplierWithException<Boolean, Exception> condition, long retryIntervalMillis)
             throws Exception {
-        waitUntilCondition(
-                condition, timeout, retryIntervalMillis, "Condition was not met in given timeout.");
-    }
-
-    public static void waitUntilCondition(
-            SupplierWithException<Boolean, Exception> condition, Deadline timeout, String errorMsg)
-            throws Exception {
-        waitUntilCondition(condition, timeout, RETRY_INTERVAL, errorMsg);
-    }
-
-    public static void waitUntilCondition(
-            SupplierWithException<Boolean, Exception> condition,
-            Deadline timeout,
-            long retryIntervalMillis,
-            String errorMsg)
-            throws Exception {
-        while (timeout.hasTimeLeft() && !condition.get()) {
-            final long timeLeft = Math.max(0, timeout.timeLeft().toMillis());
-            Thread.sleep(Math.min(retryIntervalMillis, timeLeft));
-        }
-
-        if (!timeout.hasTimeLeft()) {
-            throw new TimeoutException(errorMsg);
+        while (!condition.get()) {
+            Thread.sleep(retryIntervalMillis);
         }
     }
 
@@ -180,17 +153,6 @@ public class CommonTestUtils {
 
     public static void waitForAllTaskRunning(
             SupplierWithException<AccessExecutionGraph, Exception> executionGraphSupplier,
-            boolean allowFinished)
-            throws Exception {
-        waitForAllTaskRunning(
-                executionGraphSupplier,
-                Deadline.fromNow(Duration.of(1, ChronoUnit.MINUTES)),
-                allowFinished);
-    }
-
-    public static void waitForAllTaskRunning(
-            SupplierWithException<AccessExecutionGraph, Exception> executionGraphSupplier,
-            Deadline timeout,
             boolean allowFinished)
             throws Exception {
         Predicate<AccessExecutionVertex> subtaskPredicate =
@@ -225,13 +187,11 @@ public class CommonTestUtils {
                                             jobVertex ->
                                                     Arrays.stream(jobVertex.getTaskVertices())
                                                             .allMatch(subtaskPredicate));
-                },
-                timeout);
+                });
     }
 
     public static void waitForAllTaskRunning(
-            SupplierWithException<JobDetailsInfo, Exception> jobDetailsSupplier, Deadline timeout)
-            throws Exception {
+            SupplierWithException<JobDetailsInfo, Exception> jobDetailsSupplier) throws Exception {
         waitUntilCondition(
                 () -> {
                     final JobDetailsInfo jobDetailsInfo = jobDetailsSupplier.get();
@@ -249,39 +209,27 @@ public class CommonTestUtils {
                         }
                     }
                     return true;
-                },
-                timeout,
-                "Some tasks are not running until timeout");
+                });
     }
 
     public static void waitForNoTaskRunning(
-            SupplierWithException<JobDetailsInfo, Exception> jobDetailsSupplier, Deadline timeout)
-            throws Exception {
+            SupplierWithException<JobDetailsInfo, Exception> jobDetailsSupplier) throws Exception {
         waitUntilCondition(
                 () -> {
                     final Map<ExecutionState, Integer> state =
                             jobDetailsSupplier.get().getJobVerticesPerState();
                     final Integer numRunningTasks = state.get(ExecutionState.RUNNING);
                     return numRunningTasks == null || numRunningTasks.equals(0);
-                },
-                timeout,
-                "Some tasks are still running until timeout");
+                });
     }
 
     public static void waitUntilJobManagerIsInitialized(
             SupplierWithException<JobStatus, Exception> jobStatusSupplier) throws Exception {
-        waitUntilJobManagerIsInitialized(
-                jobStatusSupplier, Deadline.fromNow(Duration.of(1, ChronoUnit.MINUTES)));
+        waitUntilCondition(() -> jobStatusSupplier.get() != JobStatus.INITIALIZING, 20L);
     }
 
-    public static void waitUntilJobManagerIsInitialized(
-            SupplierWithException<JobStatus, Exception> jobStatusSupplier, Deadline timeout)
+    public static void waitForJobStatus(JobClient client, List<JobStatus> expectedStatus)
             throws Exception {
-        waitUntilCondition(() -> jobStatusSupplier.get() != JobStatus.INITIALIZING, timeout, 20L);
-    }
-
-    public static void waitForJobStatus(
-            JobClient client, List<JobStatus> expectedStatus, Deadline deadline) throws Exception {
         waitUntilCondition(
                 () -> {
                     final JobStatus currentStatus = client.getJobStatus().get();
@@ -311,8 +259,7 @@ public class CommonTestUtils {
 
                     // Continue waiting for expected status
                     return false;
-                },
-                deadline);
+                });
     }
 
     public static void terminateJob(JobClient client) throws Exception {
@@ -355,8 +302,7 @@ public class CommonTestUtils {
                     return allSubtasks
                             ? vertexStream.allMatch(subtaskPredicate)
                             : vertexStream.anyMatch(subtaskPredicate);
-                },
-                Deadline.fromNow(Duration.of(1, ChronoUnit.MINUTES)));
+                });
     }
 
     /** Utility class to read the output of a process stream and forward it into a StringWriter. */

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/MiniClusterResource.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/MiniClusterResource.java
@@ -159,8 +159,7 @@ public class MiniClusterResource extends ExternalResource {
                                                                 .isGloballyTerminalState())
                                         .count();
                         return unfinishedJobs == 0;
-                    },
-                    jobCancellationDeadline);
+                    });
 
             if (waitUntilSlotsAreFreed) {
                 CommonTestUtils.waitUntilCondition(
@@ -169,8 +168,7 @@ public class MiniClusterResource extends ExternalResource {
                                     miniCluster.getResourceOverview().get();
                             return resourceOverview.getNumberRegisteredSlots()
                                     == resourceOverview.getNumberFreeSlots();
-                        },
-                        jobCancellationDeadline);
+                        });
             }
         } catch (Exception e) {
             log.warn("Exception while shutting down remaining jobs.", e);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskFinalCheckpointsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskFinalCheckpointsTest.java
@@ -21,7 +21,6 @@ package org.apache.flink.streaming.runtime.tasks;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
-import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.core.execution.SavepointFormatType;
@@ -62,7 +61,6 @@ import org.junit.Test;
 
 import javax.annotation.Nullable;
 
-import java.time.Duration;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
@@ -886,8 +884,7 @@ public class StreamTaskFinalCheckpointsTest {
             CommonTestUtils.waitUntilCondition(
                     () ->
                             checkpointResponder.getAcknowledgeLatch().isTriggered()
-                                    || checkpointResponder.getDeclinedLatch().isTriggered(),
-                    Deadline.fromNow(Duration.ofSeconds(10)));
+                                    || checkpointResponder.getDeclinedLatch().isTriggered());
 
             assertEquals(
                     Collections.singletonList(2L),

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.table.client.cli;
 
-import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.client.cli.DefaultCLI;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ReadableConfig;
@@ -64,7 +63,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -327,8 +325,7 @@ public class CliClientTest extends TestLogger {
 
             client.getTerminal().raise(Terminal.Signal.INT);
             CommonTestUtils.waitUntilCondition(
-                    () -> outputStream.toString().contains("'key' = 'value'"),
-                    Deadline.fromNow(Duration.ofMillis(10000)));
+                    () -> outputStream.toString().contains("'key' = 'value'"));
         }
     }
 

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliTableauResultViewTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliTableauResultViewTest.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.client.cli;
 
 import org.apache.flink.api.common.RuntimeExecutionMode;
-import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.table.api.DataTypes;
@@ -44,7 +43,6 @@ import org.junit.Test;
 import java.io.ByteArrayOutputStream;
 import java.math.BigDecimal;
 import java.sql.Timestamp;
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -242,9 +240,7 @@ public class CliTableauResultViewTest {
 
         // wait until we trying to get batch result
         CommonTestUtils.waitUntilCondition(
-                () -> mockExecutor.getNumRetrieveResultChancesCalls() > 1,
-                Deadline.now().plus(Duration.ofSeconds(5)),
-                50L);
+                () -> mockExecutor.getNumRetrieveResultChancesCalls() > 1, 50L);
 
         // send signal to cancel
         terminal.raise(Terminal.Signal.INT);
@@ -440,9 +436,7 @@ public class CliTableauResultViewTest {
 
         // wait until we processed first result
         CommonTestUtils.waitUntilCondition(
-                () -> mockExecutor.getNumRetrieveResultChancesCalls() > 1,
-                Deadline.now().plus(Duration.ofSeconds(5)),
-                50L);
+                () -> mockExecutor.getNumRetrieveResultChancesCalls() > 1, 50L);
 
         // send signal to cancel
         terminal.raise(Terminal.Signal.INT);

--- a/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/environment/MiniClusterTestEnvironment.java
+++ b/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/environment/MiniClusterTestEnvironment.java
@@ -19,7 +19,6 @@
 package org.apache.flink.connector.testframe.environment;
 
 import org.apache.flink.annotation.Experimental;
-import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.runtime.highavailability.nonha.embedded.HaLeadershipControl;
@@ -38,7 +37,6 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.Duration;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
@@ -132,8 +130,7 @@ public class MiniClusterTestEnvironment implements TestEnvironment, ClusterContr
             throws Exception {
         terminateTaskManager();
         CommonTestUtils.waitForNoTaskRunning(
-                () -> miniCluster.getRestClusterClient().getJobDetails(jobClient.getJobID()).get(),
-                Deadline.fromNow(Duration.ofMinutes(5)));
+                () -> miniCluster.getRestClusterClient().getJobDetails(jobClient.getJobID()).get());
         afterFailAction.run();
         startTaskManager();
     }

--- a/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/testsuites/SinkTestSuiteBase.java
+++ b/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/testsuites/SinkTestSuiteBase.java
@@ -23,7 +23,6 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
-import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.connector.sink2.Sink;
 import org.apache.flink.api.connector.source.Boundedness;
@@ -80,7 +79,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.connector.testframe.utils.ConnectorTestConstants.DEFAULT_COLLECT_DATA_TIMEOUT;
-import static org.apache.flink.connector.testframe.utils.ConnectorTestConstants.DEFAULT_JOB_STATUS_CHANGE_TIMEOUT;
 import static org.apache.flink.connector.testframe.utils.MetricQuerier.getJobDetails;
 import static org.apache.flink.runtime.testutils.CommonTestUtils.terminateJob;
 import static org.apache.flink.runtime.testutils.CommonTestUtils.waitForAllTaskRunning;
@@ -152,10 +150,7 @@ public abstract class SinkTestSuiteBase<T extends Comparable<T>> {
                 .name("sinkInSinkTest");
         final JobClient jobClient = execEnv.executeAsync("DataStream Sink Test");
 
-        waitForJobStatus(
-                jobClient,
-                Collections.singletonList(JobStatus.FINISHED),
-                Deadline.fromNow(DEFAULT_JOB_STATUS_CHANGE_TIMEOUT));
+        waitForJobStatus(jobClient, Collections.singletonList(JobStatus.FINISHED));
 
         // Check test result
         checkResultWithSemantic(
@@ -281,8 +276,7 @@ public abstract class SinkTestSuiteBase<T extends Comparable<T>> {
                             getJobDetails(
                                     new RestClient(new Configuration(), executorService),
                                     testEnv.getRestEndpoint(),
-                                    jobClient.getJobID()),
-                    Deadline.fromNow(DEFAULT_JOB_STATUS_CHANGE_TIMEOUT));
+                                    jobClient.getJobID()));
 
             waitExpectedSizeData(iterator, numBeforeSuccess);
 
@@ -291,10 +285,7 @@ public abstract class SinkTestSuiteBase<T extends Comparable<T>> {
                             .stopWithSavepoint(
                                     true, testEnv.getCheckpointUri(), SavepointFormatType.CANONICAL)
                             .get(30, TimeUnit.SECONDS);
-            waitForJobStatus(
-                    jobClient,
-                    Collections.singletonList(JobStatus.FINISHED),
-                    Deadline.fromNow(DEFAULT_JOB_STATUS_CHANGE_TIMEOUT));
+            waitForJobStatus(jobClient, Collections.singletonList(JobStatus.FINISHED));
         } catch (Exception e) {
             executorService.shutdown();
             killJob(jobClient);
@@ -392,8 +383,7 @@ public abstract class SinkTestSuiteBase<T extends Comparable<T>> {
                             getJobDetails(
                                     new RestClient(new Configuration(), executorService),
                                     testEnv.getRestEndpoint(),
-                                    jobClient.getJobID()),
-                    Deadline.fromNow(DEFAULT_JOB_STATUS_CHANGE_TIMEOUT));
+                                    jobClient.getJobID()));
 
             waitUntilCondition(
                     () -> {
@@ -411,8 +401,7 @@ public abstract class SinkTestSuiteBase<T extends Comparable<T>> {
                             // skip failed assert try
                             return false;
                         }
-                    },
-                    Deadline.fromNow(DEFAULT_COLLECT_DATA_TIMEOUT));
+                    });
         } finally {
             // Clean up
             executorService.shutdown();
@@ -521,8 +510,7 @@ public abstract class SinkTestSuiteBase<T extends Comparable<T>> {
                     } catch (Throwable t) {
                         return false;
                     }
-                },
-                Deadline.fromNow(DEFAULT_COLLECT_DATA_TIMEOUT));
+                });
     }
 
     /** Compare the metrics. */
@@ -562,10 +550,7 @@ public abstract class SinkTestSuiteBase<T extends Comparable<T>> {
 
     private void killJob(JobClient jobClient) throws Exception {
         terminateJob(jobClient);
-        waitForJobStatus(
-                jobClient,
-                Collections.singletonList(JobStatus.CANCELED),
-                Deadline.fromNow(DEFAULT_JOB_STATUS_CHANGE_TIMEOUT));
+        waitForJobStatus(jobClient, Collections.singletonList(JobStatus.CANCELED));
     }
 
     private DataStreamSink<T> tryCreateSink(

--- a/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/utils/ConnectorTestConstants.java
+++ b/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/utils/ConnectorTestConstants.java
@@ -26,6 +26,5 @@ public class ConnectorTestConstants {
     public static final long SLOT_REQUEST_TIMEOUT_MS = 10_000L;
     public static final long HEARTBEAT_TIMEOUT_MS = 5_000L;
     public static final long HEARTBEAT_INTERVAL_MS = 1000L;
-    public static final Duration DEFAULT_JOB_STATUS_CHANGE_TIMEOUT = Duration.ofSeconds(30L);
     public static final Duration DEFAULT_COLLECT_DATA_TIMEOUT = Duration.ofSeconds(120L);
 }

--- a/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterStopWithSavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterStopWithSavepointITCase.java
@@ -279,7 +279,6 @@ public class JobMasterStopWithSavepointITCase extends AbstractTestBase {
     }
 
     private void waitForJob() throws Exception {
-        Deadline deadline = Deadline.fromNow(Duration.ofMinutes(5));
         JobID jobID = jobGraph.getJobID();
         CommonTestUtils.waitForAllTaskRunning(
                 () ->
@@ -287,7 +286,6 @@ public class JobMasterStopWithSavepointITCase extends AbstractTestBase {
                                 .getMiniCluster()
                                 .getExecutionGraph(jobID)
                                 .get(60, TimeUnit.SECONDS),
-                deadline,
                 false);
     }
 

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ManualCheckpointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ManualCheckpointITCase.java
@@ -24,7 +24,6 @@ import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.functions.RichFlatMapFunction;
 import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
-import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.connector.source.mocks.MockSource;
 import org.apache.flink.configuration.Configuration;
@@ -46,7 +45,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.io.IOException;
-import java.time.Duration;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
@@ -91,10 +89,7 @@ public class ManualCheckpointITCase extends AbstractTestBase {
         final JobID jobID = jobClient.getJobID();
         final MiniCluster miniCluster = MINI_CLUSTER_RESOURCE.getMiniCluster();
 
-        CommonTestUtils.waitForJobStatus(
-                jobClient,
-                Collections.singletonList(JobStatus.RUNNING),
-                Deadline.fromNow(Duration.ofSeconds(30)));
+        CommonTestUtils.waitForJobStatus(jobClient, Collections.singletonList(JobStatus.RUNNING));
         CommonTestUtils.waitForAllTaskRunning(miniCluster, jobID, false);
 
         // wait for the checkpoint to be taken
@@ -126,14 +121,10 @@ public class ManualCheckpointITCase extends AbstractTestBase {
         final JobID jobID = jobClient.getJobID();
         final MiniCluster miniCluster = MINI_CLUSTER_RESOURCE.getMiniCluster();
 
-        CommonTestUtils.waitForJobStatus(
-                jobClient,
-                Collections.singletonList(JobStatus.RUNNING),
-                Deadline.fromNow(Duration.ofSeconds(30)));
+        CommonTestUtils.waitForJobStatus(jobClient, Collections.singletonList(JobStatus.RUNNING));
         CommonTestUtils.waitForAllTaskRunning(miniCluster, jobID, false);
         CommonTestUtils.waitUntilCondition(
                 () -> queryCompletedCheckpoints(miniCluster, jobID) > 0L,
-                Deadline.fromNow(Duration.ofSeconds(30)),
                 checkpointingInterval / 2);
 
         final long numberOfPeriodicCheckpoints = queryCompletedCheckpoints(miniCluster, jobID);

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
@@ -1229,8 +1229,7 @@ public class SavepointITCase extends TestLogger {
                                         detailsInfo ->
                                                 allVerticesRunning(
                                                         detailsInfo.getJobVerticesPerState()))
-                                .get(),
-                Deadline.fromNow(Duration.ofSeconds(10)));
+                                .get());
     }
 
     private static boolean allVerticesRunning(Map<ExecutionState, Integer> states) {

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointFailureHandlingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointFailureHandlingITCase.java
@@ -63,7 +63,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static java.util.Collections.singletonList;
 import static org.apache.flink.api.common.JobStatus.RUNNING;
-import static org.apache.flink.api.common.time.Deadline.fromNow;
 import static org.apache.flink.core.fs.Path.fromLocalFile;
 import static org.apache.flink.runtime.testutils.CommonTestUtils.waitForAllTaskRunning;
 import static org.apache.flink.runtime.testutils.CommonTestUtils.waitForJobStatus;
@@ -105,7 +104,7 @@ public class UnalignedCheckpointFailureHandlingITCase {
         JobID jobID = jobClient.getJobID();
         MiniCluster miniCluster = miniClusterResource.getMiniCluster();
 
-        waitForJobStatus(jobClient, singletonList(RUNNING), fromNow(Duration.ofSeconds(30)));
+        waitForJobStatus(jobClient, singletonList(RUNNING));
         waitForAllTaskRunning(miniCluster, jobID, false);
 
         triggerFailingCheckpoint(jobID, TestException.class, miniCluster);

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/ClusterEntrypointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/ClusterEntrypointITCase.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.test.recovery;
 
-import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.configuration.ClusterOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
@@ -38,7 +37,6 @@ import org.junit.rules.TemporaryFolder;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.Duration;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -73,8 +71,7 @@ public class ClusterEntrypointITCase extends TestLogger {
 
         boolean success = false;
         try {
-            CommonTestUtils.waitUntilCondition(
-                    workingDirectory::exists, Deadline.fromNow(Duration.ofMinutes(1L)));
+            CommonTestUtils.waitUntilCondition(workingDirectory::exists);
 
             jobManagerProcess.getProcess().destroy();
 
@@ -112,8 +109,7 @@ public class ClusterEntrypointITCase extends TestLogger {
                         try (Stream<Path> files = Files.list(workingDirBase.toPath())) {
                             return files.findAny().isPresent();
                         }
-                    },
-                    Deadline.fromNow(Duration.ofMinutes(1L)));
+                    });
 
             final File workingDirectory =
                     Iterables.getOnlyElement(

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/JobManagerHAProcessFailureRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/JobManagerHAProcessFailureRecoveryITCase.java
@@ -309,7 +309,7 @@ public class JobManagerHAProcessFailureRecoveryITCase extends TestLogger {
             leaderRetrievalService.start(leaderListener);
 
             // Initial submission
-            leaderListener.waitForNewLeader(deadline.timeLeft().toMillis());
+            leaderListener.waitForNewLeader();
 
             String leaderAddress = leaderListener.getAddress();
             UUID leaderId = leaderListener.getLeaderSessionID();

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/LocalRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/LocalRecoveryITCase.java
@@ -21,7 +21,6 @@ package org.apache.flink.test.recovery;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
-import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.ClusterOptions;
 import org.apache.flink.configuration.Configuration;
@@ -105,10 +104,7 @@ class LocalRecoveryITCase {
 
             final long waitingTimeInSeconds = 45L;
             waitUntilCheckpointCompleted(
-                    configuration,
-                    clusterEntrypoint.getRestPort(),
-                    jobClient.getJobID(),
-                    Deadline.fromNow(Duration.ofSeconds(waitingTimeInSeconds)));
+                    configuration, clusterEntrypoint.getRestPort(), jobClient.getJobID());
 
             restartTaskManagerProcesses(taskManagerProcesses, parallelism - 1);
 
@@ -219,8 +215,7 @@ class LocalRecoveryITCase {
     }
 
     private void waitUntilCheckpointCompleted(
-            Configuration configuration, int restPort, JobID jobId, Deadline deadline)
-            throws Exception {
+            Configuration configuration, int restPort, JobID jobId) throws Exception {
         final RestClient restClient = new RestClient(configuration, Executors.directExecutor());
         final JobMessageParameters messageParameters = new JobMessageParameters();
         messageParameters.jobPathParameter.resolve(jobId);
@@ -237,8 +232,7 @@ class LocalRecoveryITCase {
                                             EmptyRequestBody.getInstance())
                                     .join();
                     return checkpointingStatistics.getCounts().getNumberCompletedCheckpoints() > 0;
-                },
-                deadline);
+                });
     }
 
     private JobClient submitJob(

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/TaskManagerRunnerITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/TaskManagerRunnerITCase.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.test.recovery;
 
-import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.configuration.AkkaOptions;
 import org.apache.flink.configuration.ClusterOptions;
 import org.apache.flink.configuration.Configuration;
@@ -76,8 +75,7 @@ public class TaskManagerRunnerITCase extends TestLogger {
 
         boolean success = false;
         try {
-            CommonTestUtils.waitUntilCondition(
-                    workingDirectory::exists, Deadline.fromNow(Duration.ofMinutes(1L)));
+            CommonTestUtils.waitUntilCondition(workingDirectory::exists);
 
             taskManagerProcess.getProcess().destroy();
 
@@ -115,8 +113,7 @@ public class TaskManagerRunnerITCase extends TestLogger {
                         try (Stream<Path> files = Files.list(workingDirBase.toPath())) {
                             return files.findAny().isPresent();
                         }
-                    },
-                    Deadline.fromNow(Duration.ofMinutes(1L)));
+                    });
 
             final File workingDirectory =
                     Iterables.getOnlyElement(

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/DefaultSchedulerLocalRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/DefaultSchedulerLocalRecoveryITCase.java
@@ -21,7 +21,6 @@ package org.apache.flink.test.runtime;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
-import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.client.program.MiniClusterClient;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
@@ -47,7 +46,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import java.io.IOException;
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -160,9 +158,7 @@ public class DefaultSchedulerLocalRecoveryITCase extends TestLogger {
     private void waitUntilAllVerticesRunning(JobID jobId, MiniCluster miniCluster)
             throws Exception {
         CommonTestUtils.waitForAllTaskRunning(
-                () -> miniCluster.getExecutionGraph(jobId).get(TIMEOUT, TimeUnit.SECONDS),
-                Deadline.fromNow(Duration.ofMillis(TIMEOUT)),
-                false);
+                () -> miniCluster.getExecutionGraph(jobId).get(TIMEOUT, TimeUnit.SECONDS), false);
     }
 
     private JobGraph createJobGraph(int parallelism) throws IOException {

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/leaderelection/ZooKeeperLeaderElectionITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/leaderelection/ZooKeeperLeaderElectionITCase.java
@@ -21,7 +21,6 @@ package org.apache.flink.test.runtime.leaderelection;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
-import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.ClusterOptions;
 import org.apache.flink.configuration.Configuration;
@@ -62,8 +61,6 @@ import static org.junit.Assert.fail;
 
 /** Test the election of a new JobManager leader. */
 public class ZooKeeperLeaderElectionITCase extends TestLogger {
-
-    private static final Duration TEST_TIMEOUT = Duration.ofMinutes(5L);
 
     private static final Time RPC_TIMEOUT = Time.minutes(1L);
 
@@ -111,8 +108,6 @@ public class ZooKeeperLeaderElectionITCase extends TestLogger {
                         .setNumSlotsPerTaskManager(numSlotsPerTM)
                         .build();
 
-        final Deadline timeout = Deadline.fromNow(TEST_TIMEOUT);
-
         try (TestingMiniCluster miniCluster =
                         TestingMiniCluster.newBuilder(miniClusterConfiguration).build();
                 final CuratorFrameworkWithUnhandledErrorListener curatorFramework =
@@ -146,20 +141,19 @@ public class ZooKeeperLeaderElectionITCase extends TestLogger {
 
             for (int i = 0; i < numDispatchers - 1; i++) {
                 final DispatcherGateway leaderDispatcherGateway =
-                        getNextLeadingDispatcherGateway(
-                                miniCluster, previousLeaderAddress, timeout);
+                        getNextLeadingDispatcherGateway(miniCluster, previousLeaderAddress);
                 // Make sure resource manager has also changed leadership.
                 resourceManagerLeaderFutures[i].get();
                 previousLeaderAddress = leaderDispatcherGateway.getAddress();
-                awaitRunningStatus(leaderDispatcherGateway, jobGraph, timeout);
+                awaitRunningStatus(leaderDispatcherGateway, jobGraph);
                 leaderDispatcherGateway.shutDownCluster();
             }
 
             final DispatcherGateway leaderDispatcherGateway =
-                    getNextLeadingDispatcherGateway(miniCluster, previousLeaderAddress, timeout);
+                    getNextLeadingDispatcherGateway(miniCluster, previousLeaderAddress);
             // Make sure resource manager has also changed leadership.
             resourceManagerLeaderFutures[numDispatchers - 1].get();
-            awaitRunningStatus(leaderDispatcherGateway, jobGraph, timeout);
+            awaitRunningStatus(leaderDispatcherGateway, jobGraph);
             CompletableFuture<JobResult> jobResultFuture =
                     leaderDispatcherGateway.requestJobResult(jobGraph.getJobID(), RPC_TIMEOUT);
             BlockingOperator.unblock();
@@ -170,21 +164,17 @@ public class ZooKeeperLeaderElectionITCase extends TestLogger {
         }
     }
 
-    private static void awaitRunningStatus(
-            DispatcherGateway dispatcherGateway, JobGraph jobGraph, Deadline timeout)
+    private static void awaitRunningStatus(DispatcherGateway dispatcherGateway, JobGraph jobGraph)
             throws Exception {
         CommonTestUtils.waitUntilCondition(
                 () ->
                         dispatcherGateway.requestJobStatus(jobGraph.getJobID(), RPC_TIMEOUT).get()
                                 == JobStatus.RUNNING,
-                timeout,
                 50L);
     }
 
     private DispatcherGateway getNextLeadingDispatcherGateway(
-            TestingMiniCluster miniCluster,
-            @Nullable String previousLeaderAddress,
-            Deadline timeout)
+            TestingMiniCluster miniCluster, @Nullable String previousLeaderAddress)
             throws Exception {
         CommonTestUtils.waitUntilCondition(
                 () ->
@@ -193,7 +183,6 @@ public class ZooKeeperLeaderElectionITCase extends TestLogger {
                                 .get()
                                 .getAddress()
                                 .equals(previousLeaderAddress),
-                timeout,
                 20L);
         return miniCluster.getDispatcherGatewayFuture().get();
     }

--- a/flink-tests/src/test/java/org/apache/flink/test/scheduling/AdaptiveSchedulerITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/scheduling/AdaptiveSchedulerITCase.java
@@ -23,7 +23,6 @@ import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.common.state.CheckpointListener;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
-import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.client.program.rest.RestClusterClient;
 import org.apache.flink.configuration.ClusterOptions;
 import org.apache.flink.configuration.Configuration;
@@ -60,8 +59,6 @@ import org.junit.rules.TemporaryFolder;
 import javax.annotation.Nullable;
 
 import java.io.File;
-import java.time.Duration;
-import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
@@ -179,9 +176,7 @@ public class AdaptiveSchedulerITCase extends TestLogger {
             assertThat(e, containsCause(FlinkException.class));
         }
         // expect job to run again (maybe restart)
-        CommonTestUtils.waitUntilCondition(
-                () -> client.getJobStatus().get() == JobStatus.RUNNING,
-                Deadline.fromNow(Duration.of(1, ChronoUnit.MINUTES)));
+        CommonTestUtils.waitUntilCondition(() -> client.getJobStatus().get() == JobStatus.RUNNING);
     }
 
     @Test
@@ -206,9 +201,7 @@ public class AdaptiveSchedulerITCase extends TestLogger {
             assertThat(e, containsCause(FlinkException.class));
         }
         // expect job to run again (maybe restart)
-        CommonTestUtils.waitUntilCondition(
-                () -> client.getJobStatus().get() == JobStatus.RUNNING,
-                Deadline.fromNow(Duration.of(1, ChronoUnit.MINUTES)));
+        CommonTestUtils.waitUntilCondition(() -> client.getJobStatus().get() == JobStatus.RUNNING);
     }
 
     @Test
@@ -243,9 +236,7 @@ public class AdaptiveSchedulerITCase extends TestLogger {
         // ensure failed savepoint files have been removed from the directory.
         // We execute this in a retry loop with a timeout, because the savepoint deletion happens
         // asynchronously and is not bound to the job lifecycle. See FLINK-22493 for more details.
-        CommonTestUtils.waitUntilCondition(
-                () -> isDirectoryEmpty(savepointDirectory),
-                Deadline.fromNow(Duration.ofSeconds(10)));
+        CommonTestUtils.waitUntilCondition(() -> isDirectoryEmpty(savepointDirectory));
 
         // trigger second savepoint
         final String savepoint =
@@ -259,7 +250,6 @@ public class AdaptiveSchedulerITCase extends TestLogger {
 
     @Test
     public void testExceptionHistoryIsRetrievableFromTheRestAPI() throws Exception {
-        final Deadline deadline = Deadline.fromNow(Duration.ofMinutes(1));
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.setParallelism(PARALLELISM);
         env.enableCheckpointing(20L, CheckpointingMode.EXACTLY_ONCE);
@@ -281,11 +271,9 @@ public class AdaptiveSchedulerITCase extends TestLogger {
                             exceptionsFuture.get();
                     return jobExceptionsInfoWithHistory.getExceptionHistory().getEntries().size()
                             > 0;
-                },
-                deadline);
+                });
         jobClient.cancel().get();
-        CommonTestUtils.waitForJobStatus(
-                jobClient, Collections.singletonList(JobStatus.CANCELED), deadline);
+        CommonTestUtils.waitForJobStatus(jobClient, Collections.singletonList(JobStatus.CANCELED));
     }
 
     private boolean isDirectoryEmpty(File directory) {

--- a/flink-tests/src/test/java/org/apache/flink/test/scheduling/ReactiveModeITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/scheduling/ReactiveModeITCase.java
@@ -20,7 +20,6 @@ package org.apache.flink.test.scheduling;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
-import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.client.program.rest.RestClusterClient;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
@@ -40,7 +39,6 @@ import org.apache.flink.util.TestLogger;
 import org.junit.Rule;
 import org.junit.Test;
 
-import java.time.Duration;
 import java.util.concurrent.ExecutionException;
 
 /** Tests for Reactive Mode (FLIP-159). */
@@ -146,9 +144,7 @@ public class ReactiveModeITCase extends TestLogger {
 
     private void startAdditionalTaskManager() throws Exception {
         miniClusterResource.getMiniCluster().startTaskManager();
-        CommonTestUtils.waitUntilCondition(
-                () -> getNumberOfConnectedTaskManagers() == 2,
-                Deadline.fromNow(Duration.ofMillis(10_000L)));
+        CommonTestUtils.waitUntilCondition(() -> getNumberOfConnectedTaskManagers() == 2);
     }
 
     private static class DummySource implements SourceFunction<String> {
@@ -213,7 +209,6 @@ public class ReactiveModeITCase extends TestLogger {
                         }
                     }
                     return false;
-                },
-                Deadline.fromNow(Duration.ofSeconds(10)));
+                });
     }
 }

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNHighAvailabilityITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNHighAvailabilityITCase.java
@@ -20,7 +20,6 @@ package org.apache.flink.yarn;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
-import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.client.deployment.ClusterDeploymentException;
 import org.apache.flink.client.deployment.ClusterSpecification;
 import org.apache.flink.client.program.ClusterClient;
@@ -262,8 +261,7 @@ public class YARNHighAvailabilityITCase extends YarnTestBase {
                             yarnClient.getApplicationReport(applicationId);
                     return applicationReport.getCurrentApplicationAttemptId().getAttemptId()
                             >= attemptId;
-                },
-                Deadline.fromNow(TIMEOUT));
+                });
         log.info("Attempt {} id detected.", attemptId);
     }
 
@@ -319,8 +317,7 @@ public class YARNHighAvailabilityITCase extends YarnTestBase {
                                         EnumSet.of(
                                                 YarnApplicationState.KILLED,
                                                 YarnApplicationState.FINISHED))
-                                .isEmpty(),
-                Deadline.fromNow(TIMEOUT));
+                                .isEmpty());
     }
 
     private void waitForJobTermination(
@@ -389,8 +386,7 @@ public class YARNHighAvailabilityITCase extends YarnTestBase {
                 () -> {
                     final Set<Integer> curPids = getApplicationMasterPids(processName);
                     return origPids.stream().noneMatch(curPids::contains);
-                },
-                Deadline.fromNow(TIMEOUT));
+                });
     }
 
     private Set<Integer> getApplicationMasterPids(final String processName)
@@ -417,8 +413,7 @@ public class YARNHighAvailabilityITCase extends YarnTestBase {
                             && jobDetails.getJobVertexInfos().stream()
                                     .map(toExecutionState())
                                     .allMatch(isRunning());
-                },
-                Deadline.fromNow(TIMEOUT));
+                });
     }
 
     private static Function<JobDetailsInfo.JobVertexDetailsInfo, ExecutionState>
@@ -436,8 +431,7 @@ public class YARNHighAvailabilityITCase extends YarnTestBase {
             final int expectedFullRestarts)
             throws Exception {
         CommonTestUtils.waitUntilCondition(
-                () -> getJobFullRestarts(restClusterClient, jobId) >= expectedFullRestarts,
-                Deadline.fromNow(TIMEOUT));
+                () -> getJobFullRestarts(restClusterClient, jobId) >= expectedFullRestarts);
     }
 
     private static int getJobFullRestarts(

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNHighAvailabilityITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNHighAvailabilityITCase.java
@@ -75,7 +75,6 @@ import javax.annotation.Nonnull;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -106,7 +105,6 @@ public class YARNHighAvailabilityITCase extends YarnTestBase {
     @ClassRule public static final TemporaryFolder FOLDER = new TemporaryFolder();
 
     private static final String LOG_DIR = "flink-yarn-tests-ha";
-    private static final Duration TIMEOUT = Duration.ofSeconds(200L);
 
     private static TestingServer zkServer;
     private static String storageDir;
@@ -326,7 +324,7 @@ public class YARNHighAvailabilityITCase extends YarnTestBase {
         log.info("Sending stop job signal");
         stopJobSignal.signal();
         final CompletableFuture<JobResult> jobResult = restClusterClient.requestJobResult(jobId);
-        jobResult.get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+        jobResult.get(200, TimeUnit.SECONDS);
     }
 
     @Nonnull

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionCapacitySchedulerITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionCapacitySchedulerITCase.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.yarn;
 
-import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.client.cli.CliFrontend;
 import org.apache.flink.configuration.Configuration;
@@ -390,16 +389,14 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
 
     private static void waitForTaskManagerRegistration(
             final String host, final int port, final Duration waitDuration) throws Exception {
-        CommonTestUtils.waitUntilCondition(
-                () -> getNumberOfTaskManagers(host, port) > 0, Deadline.fromNow(waitDuration));
+        CommonTestUtils.waitUntilCondition(() -> getNumberOfTaskManagers(host, port) > 0);
     }
 
     private static void assertNumberOfSlotsPerTask(
             final String host, final int port, final int slotsNumber) throws Exception {
         try {
             CommonTestUtils.waitUntilCondition(
-                    () -> getNumberOfSlotsPerTaskManager(host, port) == slotsNumber,
-                    Deadline.fromNow(Duration.ofSeconds(30)));
+                    () -> getNumberOfSlotsPerTaskManager(host, port) == slotsNumber);
         } catch (final TimeoutException e) {
             final int currentNumberOfSlots = getNumberOfSlotsPerTaskManager(host, port);
             fail(

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionCapacitySchedulerITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionCapacitySchedulerITCase.java
@@ -65,7 +65,6 @@ import java.io.FilenameFilter;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
@@ -332,7 +331,7 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
                         //
                         // Assert the number of TaskManager slots are set
                         //
-                        waitForTaskManagerRegistration(host, port, Duration.ofMillis(30_000));
+                        waitForTaskManagerRegistration(host, port);
                         assertNumberOfSlotsPerTask(host, port, 3);
 
                         final Map<String, String> flinkConfig = getFlinkConfig(host, port);
@@ -387,8 +386,8 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
         jobRunner.join();
     }
 
-    private static void waitForTaskManagerRegistration(
-            final String host, final int port, final Duration waitDuration) throws Exception {
+    private static void waitForTaskManagerRegistration(final String host, final int port)
+            throws Exception {
         CommonTestUtils.waitUntilCondition(() -> getNumberOfTaskManagers(host, port) > 0);
     }
 

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
@@ -44,7 +44,6 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
 
 import java.io.File;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -149,7 +148,6 @@ public class YARNSessionFIFOITCase extends YarnTestBase {
 
         jobRunner.join();
 
-        final Duration timeout = Duration.ofMinutes(1);
         final long testConditionIntervalInMillis = 500;
         // in "new" mode we can only wait after the job is submitted, because TMs
         // are spun up lazily

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.yarn;
 
-import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
@@ -157,12 +156,7 @@ public class YARNSessionFIFOITCase extends YarnTestBase {
         // wait until two containers are running
         LOG.info("Waiting until two containers are running");
         CommonTestUtils.waitUntilCondition(
-                () -> getRunningContainers() >= 2,
-                Deadline.fromNow(timeout),
-                testConditionIntervalInMillis,
-                "We didn't reach the state of two containers running (instead: "
-                        + getRunningContainers()
-                        + ")");
+                () -> getRunningContainers() >= 2, testConditionIntervalInMillis);
 
         LOG.info("Waiting until the job reaches FINISHED state");
         final ApplicationId applicationId = getOnlyApplicationReport().getApplicationId();
@@ -172,11 +166,7 @@ public class YARNSessionFIFOITCase extends YarnTestBase {
                                 new String[] {"switched from state RUNNING to FINISHED"},
                                 applicationId,
                                 "jobmanager.log"),
-                Deadline.fromNow(timeout),
-                testConditionIntervalInMillis,
-                "The deployed job didn't finish on time reaching the timeout of "
-                        + timeout
-                        + " seconds. The application will be cancelled forcefully.");
+                testConditionIntervalInMillis);
 
         // kill application "externally".
         try {
@@ -202,7 +192,6 @@ public class YARNSessionFIFOITCase extends YarnTestBase {
                                                     YarnApplicationState.KILLED,
                                                     YarnApplicationState.FINISHED))
                                     .isEmpty(),
-                    Deadline.fromNow(timeout),
                     testConditionIntervalInMillis);
         } catch (Throwable t) {
             LOG.warn("Killing failed", t);


### PR DESCRIPTION
Since we concluded to not use timeouts in tests we should remove them from test utils. That way we don't do the removal again and again for individual test cases.