### PR TITLE
[FLINK-26693][Documentation] Modify the grammar mistakes in savepoint

### DIFF
--- a/docs/content/docs/ops/state/savepoints.md
+++ b/docs/content/docs/ops/state/savepoints.md
@@ -270,7 +270,7 @@ Therefore, it is possible Flink leaves an empty savepoints directory if it was r
 
 **LEGACY**
 
-The legacy is mode is how Flink worked until 1.15. In this mode Flink will never delete the initial
+The legacy mode is how Flink worked until 1.15. In this mode Flink will never delete the initial
 checkpoint. At the same time, it is not clear if a user can ever delete it as well. The problem here,
 is that Flink might immediately build an incremental checkpoint on top of the restored one. Therefore,
 subsequent checkpoints depend on the restored checkpoint. Overall, the ownership is not well-defined.


### PR DESCRIPTION
## What is the purpose of the change

*Modify the grammar mistakes in savepoints.md*


## Brief change log

  - *Change the sentence "The legacy is mode is how Flink worked until 1.15." to "The legacy mode is how Flink worked until 1.15."*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
