### PR TITLE
[FLINK-26698][runtime] Uses the actual basePath instance instead of only the path of Path instance

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/FileSystemJobResultStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/FileSystemJobResultStore.java
@@ -114,7 +114,7 @@ public class FileSystemJobResultStore extends AbstractThreadsafeJobResultStore {
      * @return A path for a dirty entry for the given the Job ID.
      */
     private Path constructDirtyPath(JobID jobId) {
-        return new Path(this.basePath.getPath(), jobId.toString() + DIRTY_FILE_EXTENSION);
+        return constructEntryPath(jobId.toString() + DIRTY_FILE_EXTENSION);
     }
 
     /**
@@ -125,7 +125,12 @@ public class FileSystemJobResultStore extends AbstractThreadsafeJobResultStore {
      * @return A path for a clean entry for the given the Job ID.
      */
     private Path constructCleanPath(JobID jobId) {
-        return new Path(this.basePath.getPath(), jobId.toString() + ".json");
+        return constructEntryPath(jobId.toString() + ".json");
+    }
+
+    @VisibleForTesting
+    Path constructEntryPath(String fileName) {
+        return new Path(this.basePath, fileName);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/FileSystemJobResultStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/FileSystemJobResultStore.java
@@ -125,7 +125,7 @@ public class FileSystemJobResultStore extends AbstractThreadsafeJobResultStore {
      * @return A path for a clean entry for the given the Job ID.
      */
     private Path constructCleanPath(JobID jobId) {
-        return constructEntryPath(jobId.toString() + ".json");
+        return constructEntryPath(jobId.toString() + FILE_EXTENSION);
     }
 
     @VisibleForTesting

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/FileSystemJobResultStoreTestInternal.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/FileSystemJobResultStoreTestInternal.java
@@ -51,10 +51,31 @@ public class FileSystemJobResultStoreTestInternal {
 
     @TempDir File temporaryFolder;
 
+    private Path basePath;
+
     @BeforeEach
     public void setupTest() throws IOException {
-        Path path = new Path(temporaryFolder.toURI());
-        fileSystemJobResultStore = new FileSystemJobResultStore(path.getFileSystem(), path, false);
+        basePath = new Path(temporaryFolder.toURI());
+        fileSystemJobResultStore =
+                new FileSystemJobResultStore(basePath.getFileSystem(), basePath, false);
+    }
+
+    @Test
+    public void testValidEntryPathCreation() {
+        final Path entryParent =
+                fileSystemJobResultStore.constructEntryPath("random-name").getParent();
+        assertThat(entryParent)
+                .extracting(FileSystemJobResultStoreTestInternal::stripSucceedingSlash)
+                .isEqualTo(stripSucceedingSlash(basePath));
+    }
+
+    private static String stripSucceedingSlash(Path path) {
+        final String uriStr = path.toUri().toString();
+        if (uriStr.charAt(uriStr.length() - 1) == '/') {
+            return uriStr.substring(0, uriStr.length() - 1);
+        }
+
+        return uriStr;
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

The issue before the fix was, that using getPath would strip
off the scheme information which causes problems in situations
where the FileSystem is not the default FileSystem.

## Brief change log

* removes `getPath` from path construction methods

## Verifying this change

* Added unit tests for verifying that the constructed paths' parent matches the basePath

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
