### PR TITLE
[FLINK-26701] Revert FLINK-25927 apart from adding connector-base to flink-dist

### DIFF
--- a/flink-connectors/flink-connector-aws-kinesis-firehose/pom.xml
+++ b/flink-connectors/flink-connector-aws-kinesis-firehose/pom.xml
@@ -48,6 +48,12 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-base</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-connector-aws-base</artifactId>
 			<version>${project.version}</version>
 		</dependency>
@@ -155,34 +161,6 @@ under the License.
 						<goals>
 							<goal>test-jar</goal>
 						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-shade-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>shade-flink</id>
-						<phase>package</phase>
-						<goals>
-							<goal>shade</goal>
-						</goals>
-						<configuration>
-							<promoteTransitiveDependencies>true</promoteTransitiveDependencies>
-							<artifactSet>
-								<includes>
-									<include>org.apache.flink:flink-connector-base</include>
-									<include>org.apache.flink:flink-connector-aws-base</include>
-								</includes>
-							</artifactSet>
-							<relocations>
-								<relocation>
-									<pattern>org.apache.flink.connector.base</pattern>
-									<shadedPattern>org.apache.flink.connector.firehose.shaded.org.apache.flink.connector.base</shadedPattern>
-								</relocation>
-							</relocations>
-						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/flink-connectors/flink-connector-aws-kinesis-streams/pom.xml
+++ b/flink-connectors/flink-connector-aws-kinesis-streams/pom.xml
@@ -48,6 +48,12 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-base</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-connector-aws-base</artifactId>
 			<version>${project.version}</version>
 		</dependency>
@@ -136,34 +142,6 @@ under the License.
 						<goals>
 							<goal>test-jar</goal>
 						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-shade-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>shade-flink</id>
-						<phase>package</phase>
-						<goals>
-							<goal>shade</goal>
-						</goals>
-						<configuration>
-							<promoteTransitiveDependencies>true</promoteTransitiveDependencies>
-							<artifactSet>
-								<includes>
-									<include>org.apache.flink:flink-connector-base</include>
-									<include>org.apache.flink:flink-connector-aws-base</include>
-								</includes>
-							</artifactSet>
-							<relocations>
-								<relocation>
-									<pattern>org.apache.flink.connector.base</pattern>
-									<shadedPattern>org.apache.flink.connector.kinesis.shaded.org.apache.flink.connector.base</shadedPattern>
-								</relocation>
-							</relocations>
-						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/flink-connectors/flink-connector-elasticsearch6/pom.xml
+++ b/flink-connectors/flink-connector-elasticsearch6/pom.xml
@@ -199,33 +199,6 @@ under the License.
 					<forkCount>1</forkCount>
 				</configuration>
 			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-shade-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>shade-flink</id>
-						<phase>package</phase>
-						<goals>
-							<goal>shade</goal>
-						</goals>
-						<configuration>
-							<artifactSet>
-								<includes>
-									<include>org.apache.flink:flink-connector-base</include>
-									<include>org.apache.flink:flink-connector-elasticsearch-base</include>
-								</includes>
-							</artifactSet>
-							<relocations>
-								<relocation>
-									<pattern>org.apache.flink.connector.base</pattern>
-									<shadedPattern>org.apache.flink.connector.elasticsearch6.shaded.org.apache.flink.connector.base</shadedPattern>
-								</relocation>
-							</relocations>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/flink-connectors/flink-connector-elasticsearch7/pom.xml
+++ b/flink-connectors/flink-connector-elasticsearch7/pom.xml
@@ -196,33 +196,6 @@ under the License.
 					<forkCount>1</forkCount>
 				</configuration>
 			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-shade-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>shade-flink</id>
-						<phase>package</phase>
-						<goals>
-							<goal>shade</goal>
-						</goals>
-						<configuration>
-							<artifactSet>
-								<includes>
-									<include>org.apache.flink:flink-connector-base</include>
-									<include>org.apache.flink:flink-connector-elasticsearch-base</include>
-								</includes>
-							</artifactSet>
-							<relocations>
-								<relocation>
-									<pattern>org.apache.flink.connector.base</pattern>
-									<shadedPattern>org.apache.flink.connector.elasticsearch7.shaded.org.apache.flink.connector.base</shadedPattern>
-								</relocation>
-							</relocations>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/flink-connectors/flink-connector-files/pom.xml
+++ b/flink-connectors/flink-connector-files/pom.xml
@@ -152,12 +152,6 @@ under the License.
 									<include>org.apache.flink:flink-connector-base</include>
 								</includes>
 							</artifactSet>
-							<relocations>
-								<relocation>
-									<pattern>org.apache.flink.connector.base</pattern>
-									<shadedPattern>org.apache.flink.connector.files.shaded.org.apache.flink.connector.base</shadedPattern>
-								</relocation>
-							</relocations>
 						</configuration>
 					</execution>
 				</executions>

--- a/flink-connectors/flink-connector-hive/pom.xml
+++ b/flink-connectors/flink-connector-hive/pom.xml
@@ -549,13 +549,6 @@ under the License.
 			<scope>test</scope>
 		</dependency>
 
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-connector-base</artifactId>
-			<version>${project.version}</version>
-			<scope>test</scope>
-		</dependency>
-
 		<!--flink-java and flink-clients test dependencies used for HiveInputFormatTest-->
 		<dependency>
 			<groupId>org.apache.flink</groupId>

--- a/flink-connectors/flink-connector-kafka/pom.xml
+++ b/flink-connectors/flink-connector-kafka/pom.xml
@@ -288,33 +288,6 @@ under the License.
 					<argLine>-Xms256m -Xmx2048m -Dmvn.forkNumber=${surefire.forkNumber} -XX:-UseGCOverheadLimit -Duser.country=US -Duser.language=en</argLine>
 				</configuration>
 			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-shade-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>shade-flink</id>
-						<phase>package</phase>
-						<goals>
-							<goal>shade</goal>
-						</goals>
-						<configuration>
-							<artifactSet>
-								<includes>
-									<include>org.apache.flink:flink-connector-base</include>
-								</includes>
-							</artifactSet>
-							<shadeTestJar>true</shadeTestJar>
-							<relocations>
-								<relocation>
-									<pattern>org.apache.flink.connector.base</pattern>
-									<shadedPattern>org.apache.flink.connector.kafka.shaded.org.apache.flink.connector.base</shadedPattern>
-								</relocation>
-							</relocations>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
 		</plugins>
 	</build>
 

--- a/flink-connectors/flink-connector-pulsar/pom.xml
+++ b/flink-connectors/flink-connector-pulsar/pom.xml
@@ -355,32 +355,6 @@ under the License.
 					</execution>
 				</executions>
 			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-shade-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>shade-flink</id>
-						<phase>package</phase>
-						<goals>
-							<goal>shade</goal>
-						</goals>
-						<configuration>
-							<artifactSet>
-								<includes>
-									<include>org.apache.flink:flink-connector-base</include>
-								</includes>
-							</artifactSet>
-							<relocations>
-								<relocation>
-									<pattern>org.apache.flink.connector.base</pattern>
-									<shadedPattern>org.apache.flink.connector.pulsar.shaded.org.apache.flink.connector.base</shadedPattern>
-								</relocation>
-							</relocations>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/flink-connectors/flink-sql-connector-aws-kinesis-firehose/pom.xml
+++ b/flink-connectors/flink-sql-connector-aws-kinesis-firehose/pom.xml
@@ -54,6 +54,7 @@
 						<configuration>
 							<artifactSet>
 								<includes>
+									<include>org.apache.flink:flink-connector-base</include>
 									<include>org.apache.flink:flink-connector-aws-base</include>
 									<include>org.apache.flink:flink-connector-aws-kinesis-firehose</include>
 									<include>software.amazon.awssdk:*</include>

--- a/flink-connectors/flink-sql-connector-aws-kinesis-streams/pom.xml
+++ b/flink-connectors/flink-sql-connector-aws-kinesis-streams/pom.xml
@@ -55,6 +55,7 @@
 						<configuration>
 							<artifactSet>
 								<includes>
+									<include>org.apache.flink:flink-connector-base</include>
 									<include>org.apache.flink:flink-connector-aws-base</include>
 									<include>org.apache.flink:flink-connector-aws-kinesis-streams</include>
 									<include>software.amazon.awssdk:*</include>

--- a/flink-connectors/flink-sql-connector-hbase-1.4/pom.xml
+++ b/flink-connectors/flink-sql-connector-hbase-1.4/pom.xml
@@ -113,10 +113,6 @@ under the License.
 								</filter>
 							</filters>
 							<relocations>
-								<relocation>
-									<pattern>org.apache.flink.connector.base</pattern>
-									<shadedPattern>org.apache.flink.connector.sql.hbase14.shaded.org.apache.flink.connector.base</shadedPattern>
-								</relocation>
 								<!-- Force relocation of all HBase dependencies. -->
 								<relocation>
 									<pattern>org.apache.zookeeper</pattern>

--- a/flink-connectors/flink-sql-connector-hbase-2.2/pom.xml
+++ b/flink-connectors/flink-sql-connector-hbase-2.2/pom.xml
@@ -117,10 +117,6 @@ under the License.
 								</filter>
 							</filters>
 							<relocations>
-								<relocation>
-									<pattern>org.apache.flink.connector.base</pattern>
-									<shadedPattern>org.apache.flink.connector.sql.hbase22.shaded.org.apache.flink.connector.base</shadedPattern>
-								</relocation>
 								<!-- Force relocation of all HBase dependencies. -->
 								<relocation>
 									<pattern>org.apache.zookeeper</pattern>

--- a/flink-connectors/flink-sql-connector-kafka/pom.xml
+++ b/flink-connectors/flink-sql-connector-kafka/pom.xml
@@ -58,6 +58,7 @@ under the License.
 						<configuration>
 							<artifactSet>
 								<includes>
+									<include>org.apache.flink:flink-connector-base</include>
 									<include>org.apache.flink:flink-connector-kafka</include>
 									<include>org.apache.kafka:*</include>
 								</includes>

--- a/flink-connectors/flink-sql-connector-kinesis/pom.xml
+++ b/flink-connectors/flink-sql-connector-kinesis/pom.xml
@@ -58,6 +58,7 @@ under the License.
 						<configuration>
 							<artifactSet>
 								<includes>
+									<include>org.apache.flink:flink-connector-base</include>
 									<include>org.apache.flink:flink-connector-kinesis</include>
 									<include>com.fasterxml.jackson.core:jackson-core</include>
 									<include>com.fasterxml.jackson.core:jackson-databind</include>

--- a/flink-end-to-end-tests/flink-end-to-end-tests-aws-kinesis-firehose/pom.xml
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-aws-kinesis-firehose/pom.xml
@@ -51,14 +51,6 @@
 			<scope>test</scope>
 			<type>test-jar</type>
 		</dependency>
-
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-connector-aws-base</artifactId>
-			<version>${project.version}</version>
-			<scope>test</scope>
-		</dependency>
-
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-table-planner_${scala.binary.version}</artifactId>

--- a/flink-end-to-end-tests/flink-end-to-end-tests-aws-kinesis-streams/pom.xml
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-aws-kinesis-streams/pom.xml
@@ -65,13 +65,6 @@
 			<artifactId>jackson-databind</artifactId>
 			<scope>test</scope>
 		</dependency>
-
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-connector-aws-base</artifactId>
-			<version>${project.version}</version>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 
 	<build>

--- a/flink-end-to-end-tests/flink-streaming-kinesis-test/pom.xml
+++ b/flink-end-to-end-tests/flink-streaming-kinesis-test/pom.xml
@@ -89,13 +89,6 @@ under the License.
 		</dependency>
 
 		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-connector-aws-base</artifactId>
-			<version>${project.version}</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter</artifactId>
 			<scope>compile</scope>

--- a/flink-formats/flink-orc/pom.xml
+++ b/flink-formats/flink-orc/pom.xml
@@ -45,12 +45,6 @@ under the License.
 			<scope>provided</scope>
 		</dependency>
 
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-connector-base</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-
 		<!-- Table ecosystem and filesystem connector -->
 
 		<dependency>
@@ -207,33 +201,6 @@ under the License.
 						<goals>
 							<goal>test-jar</goal>
 						</goals>
-					</execution>
-				</executions>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-shade-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>shade-flink</id>
-						<phase>package</phase>
-						<goals>
-							<goal>shade</goal>
-						</goals>
-						<configuration>
-							<artifactSet>
-								<includes>
-									<include>org.apache.flink:flink-connector-base</include>
-								</includes>
-							</artifactSet>
-							<relocations>
-								<relocation>
-									<pattern>org.apache.flink.connector.base</pattern>
-									<shadedPattern>org.apache.flink.format.orc.shaded.org.apache.flink.connector.base</shadedPattern>
-								</relocation>
-							</relocations>
-						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/flink-formats/flink-parquet/pom.xml
+++ b/flink-formats/flink-parquet/pom.xml
@@ -45,12 +45,6 @@ under the License.
 			<scope>provided</scope>
 		</dependency>
 
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-connector-base</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-
 		<!-- Table ecosystem and filesystem connector -->
 
 		<dependency>
@@ -310,33 +304,6 @@ under the License.
 						</goals>
 						<configuration>
 							<skip>true</skip>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-shade-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>shade-flink</id>
-						<phase>package</phase>
-						<goals>
-							<goal>shade</goal>
-						</goals>
-						<configuration>
-							<artifactSet>
-								<includes>
-									<include>org.apache.flink:flink-connector-base</include>
-								</includes>
-							</artifactSet>
-							<relocations>
-								<relocation>
-									<pattern>org.apache.flink.connector.base</pattern>
-									<shadedPattern>org.apache.flink.format.parquet.shaded.org.apache.flink.connector.base</shadedPattern>
-								</relocation>
-							</relocations>
 						</configuration>
 					</execution>
 				</executions>

--- a/tools/ci/compile.sh
+++ b/tools/ci/compile.sh
@@ -108,10 +108,6 @@ check_shaded_artifacts_connector_elasticsearch 6
 EXIT_CODE=$(($EXIT_CODE+$?))
 check_shaded_artifacts_connector_elasticsearch 7
 EXIT_CODE=$(($EXIT_CODE+$?))
-check_one_per_package_file_connector_base
-EXIT_CODE=$(($EXIT_CODE+$?))
-check_relocated_file_connector_base
-EXIT_CODE=$(($EXIT_CODE+$?))
 
 echo "============ Run license check ============"
 

--- a/tools/ci/shade.sh
+++ b/tools/ci/shade.sh
@@ -153,7 +153,7 @@ check_shaded_artifacts_connector_elasticsearch() {
 	VARIANT=$1
 	find flink-connectors/flink-connector-elasticsearch${VARIANT}/target/flink-connector-elasticsearch${VARIANT}*.jar ! -name "*-tests.jar" -exec jar tf {} \; > allClasses
 
-	UNSHADED_CLASSES=`cat allClasses | grep -v -e '^META-INF' -e '^assets' -e "^org/apache/flink/connector/elasticsearch/" -e "^org/apache/flink/streaming/connectors/elasticsearch/" -e "^org/apache/flink/streaming/connectors/elasticsearch${VARIANT}/" -e "^org/apache/flink/connector/elasticsearch${VARIANT}/shaded/" -e "^org/apache/flink/table/descriptors/" -e "^org/elasticsearch/" | grep '\.class$'`
+	UNSHADED_CLASSES=`cat allClasses | grep -v -e '^META-INF' -e '^assets' -e "^org/apache/flink/connector/elasticsearch/" -e "^org/apache/flink/streaming/connectors/elasticsearch/" -e "^org/apache/flink/streaming/connectors/elasticsearch${VARIANT}/" -e "^org/apache/flink/table/descriptors/" -e "^org/elasticsearch/" | grep '\.class$'`
 	if [ "$?" = "0" ]; then
 		echo "=============================================================================="
 		echo "Detected unshaded dependencies in flink-connector-elasticsearch${VARIANT}'s fat jar:"
@@ -173,62 +173,3 @@ check_shaded_artifacts_connector_elasticsearch() {
 
 	return 0
 }
-
-check_one_per_package() {
-    read foo
-	if [ $foo -gt 1 ]
-	then
-		echo "ERROR - CHECK FAILED: $1 is shaded multiple times!"
-		exit 1
-	else
-		echo "OK"
-	fi
-}
-
-check_relocated() {
-    read foo
-	if [ $foo -ne 0 ]
-	then
-		echo "ERROR - CHECK FAILED: found $1 classes that where not relocated!"
-		exit 1
-	else
-		echo "OK"
-	fi
-}
-
-check_one_per_package_file_connector_base() {
-  echo "Checking that flink-connector-base is included only once:"
-  echo "__________________________________________________________________________"
-
-  CONNECTOR_JARS=$(find flink-connectors -type f -name '*.jar' | grep -vE "original|connector-hive" | grep -v '\-test');
-  EXIT_CODE=0
-
-  for i in $CONNECTOR_JARS;
-    do
-      echo -n "- $i: ";
-      jar tf $i | grep 'org/apache/flink/connector/base/source/reader/RecordEmitter' | wc -l | check_one_per_package "flink-connector-base";
-      EXIT_CODE=$((EXIT_CODE+$?))
-    done;
-    return $EXIT_CODE;
-}
-
-check_relocated_file_connector_base() {
-  echo -e "\n\n"
-  echo "Checking that flink-connector-base is relocated:"
-  echo "__________________________________________________________________________"
-
-  CONNECTOR_JARS=$(find flink-connectors -type f -name '*.jar' | \
-    grep -v original | grep -v '\-test' | grep -v 'flink-connectors/flink-connector-base');
-
-  EXIT_CODE=0
-  for i in $CONNECTOR_JARS;
-    do
-      echo -n "- $i: ";
-      jar tf $i | grep '^org/apache/flink/connector/base/source/reader/RecordEmitter' | wc -l | check_relocated "flink-connector-base";
-      EXIT_CODE=$((EXIT_CODE+$?))
-    done;
-  return $EXIT_CODE;
-}
-
-
-


### PR DESCRIPTION
With the introduction of [FLINK-25927](https://issues.apache.org/jira/browse/FLINK-25927), every connector now relocates connector-base to better support connectors compatibility with different Flink versions. Unfortunately, not all classes in connector-base are only used by connector but some are supposed to be used inside the user jar directly i.e. DeliveryGuarantee, HybridSource...

Because of the relocation, the existing imports for those classes are broken.