### PR TITLE
[FLINK-26708] TimestampsAndWatermarksOperator should not propagate WatermarkStatus

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/TimestampsAndWatermarksOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/TimestampsAndWatermarksOperator.java
@@ -126,6 +126,10 @@ public class TimestampsAndWatermarksOperator<T> extends AbstractStreamOperator<T
         }
     }
 
+    /** Override the base implementation to completely ignore statuses propagated from upstream. */
+    @Override
+    public void processWatermarkStatus(WatermarkStatus watermarkStatus) throws Exception {}
+
     @Override
     public void finish() throws Exception {
         super.finish();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/TimestampsAndWatermarksOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/TimestampsAndWatermarksOperatorTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.common.eventtime.WatermarkOutput;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 
 import org.junit.Test;
@@ -51,6 +52,19 @@ public class TimestampsAndWatermarksOperatorTest {
                                 .withTimestampAssigner((ctx) -> new LongExtractor()));
 
         testHarness.processWatermark(createLegacyWatermark(42L));
+        testHarness.setProcessingTime(AUTO_WATERMARK_INTERVAL);
+
+        assertThat(testHarness.getOutput(), empty());
+    }
+
+    @Test
+    public void inputStatusesAreNotForwarded() throws Exception {
+        OneInputStreamOperatorTestHarness<Long, Long> testHarness =
+                createTestHarness(
+                        WatermarkStrategy.forGenerator((ctx) -> new PeriodicWatermarkGenerator())
+                                .withTimestampAssigner((ctx) -> new LongExtractor()));
+
+        testHarness.processWatermarkStatus(WatermarkStatus.IDLE);
         testHarness.setProcessingTime(AUTO_WATERMARK_INTERVAL);
 
         assertThat(testHarness.getOutput(), empty());

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/OneInputStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/OneInputStreamOperatorTestHarness.java
@@ -30,6 +30,7 @@ import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
 import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus;
 import org.apache.flink.util.Preconditions;
 
 import java.util.ArrayList;
@@ -223,6 +224,16 @@ public class OneInputStreamOperatorTestHarness<IN, OUT>
 
     public void processWatermark(long watermark) throws Exception {
         processWatermark(new Watermark(watermark));
+    }
+
+    public void processWatermarkStatus(WatermarkStatus status) throws Exception {
+        if (inputs.isEmpty()) {
+            getOneInputOperator().processWatermarkStatus(status);
+        } else {
+            checkState(inputs.size() == 1);
+            Input input = inputs.get(0);
+            input.processWatermarkStatus(status);
+        }
     }
 
     public void processWatermark(Watermark mark) throws Exception {


### PR DESCRIPTION
## What is the purpose of the change

The lifecycle/scope of WatermarkStatus is tightly coupled with watermarks. Upstream watermarks are cut off in the TimestampsAndWatermarksOperator and therefore watermark statuses should be cut off as well.

## Verifying this change

Added tests in:
* `TimestampsAndWatermarksOperatorTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
