### PR TITLE
[FLINK-26716][test][connectors/jdbc] Migrate PostgreSQL tests to Testcontainers

### DIFF
--- a/flink-connectors/flink-connector-jdbc/pom.xml
+++ b/flink-connectors/flink-connector-jdbc/pom.xml
@@ -38,7 +38,6 @@ under the License.
 	<properties>
 		<postgres.version>42.2.10</postgres.version>
 		<oracle.version>19.3.0.0</oracle.version>
-		<otj-pg-embedded.version>0.13.4</otj-pg-embedded.version>
 	</properties>
 
 	<dependencies>
@@ -125,12 +124,6 @@ under the License.
 		</dependency>
 
 		<!-- Postgres tests -->
-		<dependency>
-			<groupId>com.opentable.components</groupId>
-			<artifactId>otj-pg-embedded</artifactId>
-			<version>${otj-pg-embedded.version}</version>
-			<scope>test</scope>
-		</dependency>
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>postgresql</artifactId>

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/xa/JdbcExactlyOnceSinkE2eTest.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/xa/JdbcExactlyOnceSinkE2eTest.java
@@ -41,6 +41,7 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.apache.flink.util.DockerImageVersions;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.LogLevelRule;
 import org.apache.flink.util.function.SerializableSupplier;
@@ -754,7 +755,7 @@ public class JdbcExactlyOnceSinkE2eTest extends JdbcTestBase {
 
         /** {@link PostgreSQLContainer} with XA enabled (by setting max_prepared_transactions). */
         private static final class PgXaDb extends PostgreSQLContainer<PgXaDb> {
-            private static final String IMAGE_NAME = "postgres:9.6.12";
+            private static final String IMAGE_NAME = DockerImageVersions.POSTGRES;
             private static final int SUPERUSER_RESERVED_CONNECTIONS = 1;
 
             @Override

--- a/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/util/DockerImageVersions.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/util/DockerImageVersions.java
@@ -49,4 +49,6 @@ public class DockerImageVersions {
     public static final String MINIO = "minio/minio:RELEASE.2022-02-07T08-17-33Z";
 
     public static final String ZOOKEEPER = "zookeeper:3.4.14";
+
+    public static final String POSTGRES = "postgres:9.6.12";
 }


### PR DESCRIPTION
## What is the purpose of the change
PostgreSQL tests were executed based on an embedded database.  This has issues on some systems (Mac) and blocked work on FLINK-25926. This PR migrates these tests to Testcontainers.

## Verifying this change

This PR modifies the existing tests setup.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
