### PR TITLE
[FLINK-26688] Completely remove unused options from TableConfig

### DIFF
--- a/flink-python/pyflink/table/environment_settings.py
+++ b/flink-python/pyflink/table/environment_settings.py
@@ -15,6 +15,8 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
+import warnings
+
 from pyflink.java_gateway import get_gateway
 
 from pyflink.common import Configuration
@@ -168,6 +170,7 @@ class EnvironmentSettings(object):
         .. note:: Deprecated in 1.15. Please use
                 :func:`EnvironmentSettings.get_configuration` instead.
         """
+        warnings.warn("Deprecated in 1.15.", DeprecationWarning)
         return Configuration(j_configuration=self._j_environment_settings.toConfiguration())
 
     def get_configuration(self) -> Configuration:
@@ -197,6 +200,7 @@ class EnvironmentSettings(object):
         .. note:: Deprecated in 1.15. Please use
                 :func:`EnvironmentSettings.Builder.with_configuration` instead.
         """
+        warnings.warn("Deprecated in 1.15.", DeprecationWarning)
         return EnvironmentSettings(
             get_gateway().jvm.EnvironmentSettings.fromConfiguration(config._j_configuration))
 

--- a/flink-python/pyflink/table/table_config.py
+++ b/flink-python/pyflink/table/table_config.py
@@ -47,7 +47,7 @@ class TableConfig(object):
     def __init__(self, j_table_config=None):
         gateway = get_gateway()
         if j_table_config is None:
-            self._j_table_config = gateway.jvm.TableConfig()
+            self._j_table_config = gateway.jvm.TableConfig.getDefault()
         else:
             self._j_table_config = j_table_config
 

--- a/flink-python/pyflink/table/table_config.py
+++ b/flink-python/pyflink/table/table_config.py
@@ -18,7 +18,6 @@
 import datetime
 
 from py4j.compat import long
-from typing import Tuple
 
 from pyflink.common.configuration import Configuration
 from pyflink.java_gateway import get_gateway

--- a/flink-python/pyflink/table/table_config.py
+++ b/flink-python/pyflink/table/table_config.py
@@ -82,21 +82,6 @@ class TableConfig(object):
         else:
             raise Exception("TableConfig.timezone should be a string!")
 
-    def get_null_check(self) -> bool:
-        """
-        A boolean value, "True" enables NULL check and "False" disables NULL check.
-        """
-        return self._j_table_config.getNullCheck()
-
-    def set_null_check(self, null_check: bool):
-        """
-        Sets the NULL check. If enabled, all fields need to be checked for NULL first.
-        """
-        if null_check is not None and isinstance(null_check, bool):
-            self._j_table_config.setNullCheck(null_check)
-        else:
-            raise Exception("TableConfig.null_check should be a bool value!")
-
     def get_max_generated_code_length(self) -> int:
         """
         The current threshold where generated code will be split into sub-function calls. Java has
@@ -229,79 +214,6 @@ class TableConfig(object):
         """
         return datetime.timedelta(
             milliseconds=self._j_table_config.getIdleStateRetention().toMillis())
-
-    def set_decimal_context(self, precision: int, rounding_mode: str):
-        """
-        Sets the default context for decimal division calculation.
-        (precision=34, rounding_mode=HALF_EVEN) by default.
-
-        The precision is the number of digits to be used for an operation. A value of 0 indicates
-        that unlimited precision (as many digits as are required) will be used. Note that leading
-        zeros (in the coefficient of a number) are never significant.
-
-        The rounding mode is the rounding algorithm to be used for an operation. It could be:
-
-        **UP**, **DOWN**, **CEILING**, **FLOOR**, **HALF_UP**, **HALF_DOWN**, **HALF_EVEN**,
-        **UNNECESSARY**
-
-        The table below shows the results of rounding input to one digit with the given rounding
-        mode:
-
-        +-------+----+------+---------+-------+---------+-----------+-----------+-------------+
-        | Input | UP | DOWN | CEILING | FLOOR | HALF_UP | HALF_DOWN | HALF_EVEN | UNNECESSARY |
-        +=======+====+======+=========+=======+=========+===========+===========+=============+
-        | 5.5   |  6 |   5  |    6    |   5   |    6    |     5     |     6     |  Exception  |
-        +-------+----+------+---------+-------+---------+-----------+-----------+-------------+
-        | 2.5   |  3 |   2  |    3    |   2   |    3    |     2     |     2     |  Exception  |
-        +-------+----+------+---------+-------+---------+-----------+-----------+-------------+
-        | 1.6   |  2 |   1  |    2    |   1   |    2    |     2     |     2     |  Exception  |
-        +-------+----+------+---------+-------+---------+-----------+-----------+-------------+
-        | 1.1   |  2 |   1  |    2    |   1   |    1    |     1     |     1     |  Exception  |
-        +-------+----+------+---------+-------+---------+-----------+-----------+-------------+
-        | 1.0   |  1 |   1  |    1    |   1   |    1    |     1     |     1     |      1      |
-        +-------+----+------+---------+-------+---------+-----------+-----------+-------------+
-        | -1.0  | -1 |  -1  |   -1    |  -1   |   -1    |    -1     |    -1     |     -1      |
-        +-------+----+------+---------+-------+---------+-----------+-----------+-------------+
-        | -1.1  | -2 |  -1  |   -1    |  -2   |   -1    |    -1     |    -1     |  Exception  |
-        +-------+----+------+---------+-------+---------+-----------+-----------+-------------+
-        | -1.6  | -2 |  -1  |   -1    |  -2   |   -2    |    -2     |    -2     |  Exception  |
-        +-------+----+------+---------+-------+---------+-----------+-----------+-------------+
-        | 2.5   | -3 |  -2  |   -2    |  -3   |   -3    |    -2     |    -2     |  Exception  |
-        +-------+----+------+---------+-------+---------+-----------+-----------+-------------+
-        | 5.5   | -6 |  -5  |   -5    |  -6   |   -6    |    -5     |    -6     |  Exception  |
-        +-------+----+------+---------+-------+---------+-----------+-----------+-------------+
-
-        :param precision: The precision of the decimal context.
-        :param rounding_mode: The rounding mode of the decimal context.
-        """
-        if rounding_mode not in (
-                "UP",
-                "DOWN",
-                "CEILING",
-                "FLOOR",
-                "HALF_UP",
-                "HALF_DOWN",
-                "HALF_EVEN",
-                "UNNECESSARY"):
-            raise ValueError("Unsupported rounding_mode: %s" % rounding_mode)
-        gateway = get_gateway()
-        j_rounding_mode = getattr(gateway.jvm.java.math.RoundingMode, rounding_mode)
-        j_math_context = gateway.jvm.java.math.MathContext(precision, j_rounding_mode)
-        self._j_table_config.setDecimalContext(j_math_context)
-
-    def get_decimal_context(self) -> Tuple[int, str]:
-        """
-        Returns current context for decimal division calculation,
-        (precision=34, rounding_mode=HALF_EVEN) by default.
-
-        .. seealso:: :func:`set_decimal_context`
-
-        :return: the current context for decimal division calculation.
-        """
-        j_math_context = self._j_table_config.getDecimalContext()
-        precision = j_math_context.getPrecision()
-        rounding_mode = j_math_context.getRoundingMode().name()
-        return precision, rounding_mode
 
     def get_configuration(self) -> Configuration:
         """

--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -1666,7 +1666,6 @@ class StreamTableEnvironment(TableEnvironment):
             >>> table_env = StreamTableEnvironment.create(env)
             # create with StreamExecutionEnvironment and TableConfig.
             >>> table_config = TableConfig()
-            >>> table_config.set_null_check(False)
             >>> table_env = StreamTableEnvironment.create(env, table_config)
             # create with StreamExecutionEnvironment and EnvironmentSettings.
             >>> environment_settings = EnvironmentSettings.in_streaming_mode()

--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -1653,7 +1653,6 @@ class StreamTableEnvironment(TableEnvironment):
 
     @staticmethod
     def create(stream_execution_environment: StreamExecutionEnvironment = None,  # type: ignore
-               table_config: TableConfig = None,
                environment_settings: EnvironmentSettings = None) -> 'StreamTableEnvironment':
         """
         Creates a :class:`~pyflink.table.StreamTableEnvironment`.
@@ -1664,11 +1663,14 @@ class StreamTableEnvironment(TableEnvironment):
             # create with StreamExecutionEnvironment.
             >>> env = StreamExecutionEnvironment.get_execution_environment()
             >>> table_env = StreamTableEnvironment.create(env)
-            # create with StreamExecutionEnvironment and TableConfig.
-            >>> table_config = TableConfig()
-            >>> table_env = StreamTableEnvironment.create(env, table_config)
             # create with StreamExecutionEnvironment and EnvironmentSettings.
-            >>> environment_settings = EnvironmentSettings.in_streaming_mode()
+            >>> configuration = Configuration()
+            >>> configuration.set_string('execution.buffer-timeout', '1 min')
+            >>> environment_settings = EnvironmentSettings
+            >>>     .new_instance()
+            >>>     .in_streaming_mode()
+            >>>     .with_configuration(configuration)
+            >>>     .build()
             >>> table_env = StreamTableEnvironment.create(
             ...     env, environment_settings=environment_settings)
             # create with EnvironmentSettings.
@@ -1678,27 +1680,15 @@ class StreamTableEnvironment(TableEnvironment):
         :param stream_execution_environment: The
                                              :class:`~pyflink.datastream.StreamExecutionEnvironment`
                                              of the TableEnvironment.
-        :param table_config: The configuration of the TableEnvironment, optional.
         :param environment_settings: The environment settings used to instantiate the
                                      TableEnvironment.
         :return: The StreamTableEnvironment created from given StreamExecutionEnvironment and
                  configuration.
         """
         if stream_execution_environment is None and \
-                table_config is None and \
                 environment_settings is None:
             raise ValueError("No argument found, the param 'stream_execution_environment' "
                              "or 'environment_settings' is required.")
-        elif stream_execution_environment is None and \
-                table_config is not None and \
-                environment_settings is None:
-            raise ValueError("Only the param 'table_config' is found, "
-                             "the param 'stream_execution_environment' is also required.")
-        if table_config is not None and \
-                environment_settings is not None:
-            raise ValueError("The param 'table_config' and "
-                             "'environment_settings' cannot be used at the same time")
-
         gateway = get_gateway()
         if environment_settings is not None:
             if stream_execution_environment is None:
@@ -1709,13 +1699,9 @@ class StreamTableEnvironment(TableEnvironment):
                     stream_execution_environment._j_stream_execution_environment,
                     environment_settings._j_environment_settings)
         else:
-            if table_config is not None:
-                j_tenv = gateway.jvm.StreamTableEnvironment.create(
-                    stream_execution_environment._j_stream_execution_environment,
-                    table_config._j_table_config)
-            else:
-                j_tenv = gateway.jvm.StreamTableEnvironment.create(
-                    stream_execution_environment._j_stream_execution_environment)
+            j_tenv = gateway.jvm.StreamTableEnvironment.create(
+                stream_execution_environment._j_stream_execution_environment)
+
         return StreamTableEnvironment(j_tenv)
 
     def from_data_stream(self,

--- a/flink-python/pyflink/table/tests/test_table_config.py
+++ b/flink-python/pyflink/table/tests/test_table_config.py
@@ -39,26 +39,6 @@ class TableConfigTests(PyFlinkTestCase):
 
         self.assertEqual(datetime.timedelta(days=1), table_config.get_idle_state_retention())
 
-    def test_get_set_decimal_context(self):
-        table_config = TableConfig.get_default()
-
-        table_config.set_decimal_context(20, "UNNECESSARY")
-        self.assertEqual((20, "UNNECESSARY"), table_config.get_decimal_context())
-        table_config.set_decimal_context(20, "HALF_EVEN")
-        self.assertEqual((20, "HALF_EVEN"), table_config.get_decimal_context())
-        table_config.set_decimal_context(20, "HALF_DOWN")
-        self.assertEqual((20, "HALF_DOWN"), table_config.get_decimal_context())
-        table_config.set_decimal_context(20, "HALF_UP")
-        self.assertEqual((20, "HALF_UP"), table_config.get_decimal_context())
-        table_config.set_decimal_context(20, "FLOOR")
-        self.assertEqual((20, "FLOOR"), table_config.get_decimal_context())
-        table_config.set_decimal_context(20, "CEILING")
-        self.assertEqual((20, "CEILING"), table_config.get_decimal_context())
-        table_config.set_decimal_context(20, "DOWN")
-        self.assertEqual((20, "DOWN"), table_config.get_decimal_context())
-        table_config.set_decimal_context(20, "UP")
-        self.assertEqual((20, "UP"), table_config.get_decimal_context())
-
     def test_get_set_local_timezone(self):
         table_config = TableConfig.get_default()
 
@@ -74,17 +54,6 @@ class TableConfigTests(PyFlinkTestCase):
         max_generated_code_length = table_config.get_max_generated_code_length()
 
         self.assertEqual(max_generated_code_length, 32000)
-
-    def test_get_set_null_check(self):
-        table_config = TableConfig.get_default()
-
-        null_check = table_config.get_null_check()
-        self.assertTrue(null_check)
-
-        table_config.set_null_check(False)
-        null_check = table_config.get_null_check()
-
-        self.assertFalse(null_check)
 
     def test_get_configuration(self):
         table_config = TableConfig.get_default()

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableConfig.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableConfig.java
@@ -96,6 +96,10 @@ import static java.time.ZoneId.SHORT_IDS;
 @PublicEvolving
 public final class TableConfig implements WritableConfig, ReadableConfig {
 
+    /** Please use {@link TableConfig#getDefault()} instead. */
+    @Deprecated
+    public TableConfig() {}
+
     // Note to implementers:
     // TableConfig is a ReadableConfig which is built once the TableEnvironment is created and
     // contains both the configuration defined in the execution context (flink-conf.yaml + CLI

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableConfig.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableConfig.java
@@ -33,7 +33,6 @@ import org.apache.flink.table.api.config.TableConfigOptions;
 import org.apache.flink.table.delegation.Executor;
 import org.apache.flink.util.Preconditions;
 
-import java.math.MathContext;
 import java.time.Duration;
 import java.time.ZoneId;
 import java.util.HashMap;
@@ -109,17 +108,8 @@ public final class TableConfig implements WritableConfig, ReadableConfig {
     //
     // The set() methods only impact the application-specific configuration.
 
-    /** Defines if all fields need to be checked for NULL first. */
-    private Boolean nullCheck = true;
-
     /** Defines the configuration of Planner for Table API and SQL queries. */
     private PlannerConfig plannerConfig = PlannerConfig.EMPTY_CONFIG;
-
-    /**
-     * Defines the default context for decimal division calculation. We use Scala's default
-     * MathContext.DECIMAL128.
-     */
-    private MathContext decimalContext = MathContext.DECIMAL128;
 
     /**
      * A configuration object to hold all configuration that has been set specifically in the Table
@@ -312,16 +302,6 @@ public final class TableConfig implements WritableConfig, ReadableConfig {
         }
     }
 
-    /** Returns the NULL check. If enabled, all fields need to be checked for NULL first. */
-    public Boolean getNullCheck() {
-        return nullCheck;
-    }
-
-    /** Sets the NULL check. If enabled, all fields need to be checked for NULL first. */
-    public void setNullCheck(Boolean nullCheck) {
-        this.nullCheck = Preconditions.checkNotNull(nullCheck);
-    }
-
     /** Returns the current configuration of Planner for Table API and SQL queries. */
     public PlannerConfig getPlannerConfig() {
         return plannerConfig;
@@ -333,22 +313,6 @@ public final class TableConfig implements WritableConfig, ReadableConfig {
      */
     public void setPlannerConfig(PlannerConfig plannerConfig) {
         this.plannerConfig = Preconditions.checkNotNull(plannerConfig);
-    }
-
-    /**
-     * Returns the default context for decimal division calculation. {@link
-     * java.math.MathContext#DECIMAL128} by default.
-     */
-    public MathContext getDecimalContext() {
-        return decimalContext;
-    }
-
-    /**
-     * Sets the default context for decimal division calculation. {@link
-     * java.math.MathContext#DECIMAL128} by default.
-     */
-    public void setDecimalContext(MathContext decimalContext) {
-        this.decimalContext = Preconditions.checkNotNull(decimalContext);
     }
 
     /**


### PR DESCRIPTION
Follows: 1e3344854b3bfd7b6f5498a0297ba49d55127003
Follows: 2eacc7373aa0fca2f2c59a72b0affb0ebda49ddf

## What is the purpose of the change

Further updates to clean up TableConfig and its usages

## Brief changelog:

 - Completely remove unused options from `TableConfig`
 - Deprecate `new TableConfig()` in favour of `TableConfig.getDefault()`
 - Remove the `TableConfig` from python's `StreamTableEnviroment#create()` and allow configuration only via `EnviromentSettings.with_configuration()`.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
