### PR TITLE
[FLINK-26733][table-api-java][python] Deprecate TableConfig ctor and options

### DIFF
--- a/flink-python/pyflink/table/environment_settings.py
+++ b/flink-python/pyflink/table/environment_settings.py
@@ -15,6 +15,8 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
+import warnings
+
 from pyflink.java_gateway import get_gateway
 
 from pyflink.common import Configuration

--- a/flink-python/pyflink/table/table_config.py
+++ b/flink-python/pyflink/table/table_config.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 ################################################################################
 import datetime
+import warnings
 
 from py4j.compat import long
 from typing import Tuple
@@ -285,7 +286,7 @@ class TableConfig(object):
         .. note:: Deprecated in 1.15 and will be removed in next release.
         """
         warnings.warn("Deprecated in 1.15.", DeprecationWarning)
-        
+
         if rounding_mode not in (
                 "UP",
                 "DOWN",


### PR DESCRIPTION
## What is the purpose of the change

Update python with the latest changes to `EnviromentSettings` and `TableConfig`.

Follows: 1e3344854b3bfd7b6f5498a0297ba49d55127003
Follows: 57742b85095147711070c566069244c40ed8e77c

## Brief change log

  - Deprecate `new TableConfig()` in favour of `TableConfig.getDefault()`
  - Update example based on EnviromentSettings, to use the new `with_configuration` method
  - Deprecate `get/set_null_check` and `get/set_decimal_context` which are also deprecated in `TableConfig` java class


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**