### PR TITLE
[FLINK-26692][e2e] migrate TpcdsTestProgram.java to new source

### DIFF
--- a/flink-end-to-end-tests/flink-tpcds-test/pom.xml
+++ b/flink-end-to-end-tests/flink-tpcds-test/pom.xml
@@ -54,6 +54,12 @@ under the License.
 			<version>${project.version}</version>
 			<scope>provided</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-csv</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/flink-end-to-end-tests/flink-tpcds-test/src/main/java/org/apache/flink/table/tpcds/TpcdsTestProgram.java
+++ b/flink-end-to-end-tests/flink-tpcds-test/src/main/java/org/apache/flink/table/tpcds/TpcdsTestProgram.java
@@ -19,23 +19,20 @@
 package org.apache.flink.table.tpcds;
 
 import org.apache.flink.api.java.utils.ParameterTool;
-import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.formats.csv.CsvFormatOptions;
 import org.apache.flink.streaming.api.graph.GlobalStreamExchangeMode;
 import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.FormatDescriptor;
+import org.apache.flink.table.api.Schema;
 import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.TableDescriptor;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.flink.table.api.config.OptimizerConfigOptions;
-import org.apache.flink.table.api.internal.TableEnvironmentInternal;
-import org.apache.flink.table.catalog.ConnectorCatalogTable;
-import org.apache.flink.table.catalog.ObjectPath;
-import org.apache.flink.table.sinks.CsvTableSink;
-import org.apache.flink.table.sources.CsvTableSource;
 import org.apache.flink.table.tpcds.schema.TpcdsSchema;
 import org.apache.flink.table.tpcds.schema.TpcdsSchemaProvider;
 import org.apache.flink.table.tpcds.stats.TpcdsStatsProvider;
-import org.apache.flink.table.types.utils.TypeConversions;
 
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -43,6 +40,8 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
+
+import static org.apache.flink.table.factories.FactoryUtil.SINK_PARALLELISM;
 
 /** End-to-end test for TPC-DS. */
 public class TpcdsTestProgram {
@@ -90,6 +89,11 @@ public class TpcdsTestProgram {
     private static final String RESULT_SUFFIX = ".ans";
     private static final String COL_DELIMITER = "|";
     private static final String FILE_SEPARATOR = "/";
+    private static final String FILE_PATH = "path";
+    private static final String CSV_FORMAT = "csv";
+    private static final String FILE_CONNECTOR_NAME = "filesystem";
+    private static final String NULL_LITERAL = "";
+    private static final Integer CSV_SINK_PARALLELISM = 1;
 
     public static void main(String[] args) throws Exception {
         ParameterTool params = ParameterTool.fromArgs(args);
@@ -109,17 +113,22 @@ public class TpcdsTestProgram {
 
             // register sink table
             String sinkTableName = QUERY_PREFIX + queryId + "_sinkTable";
-            ((TableEnvironmentInternal) tableEnvironment)
-                    .registerTableSinkInternal(
-                            sinkTableName,
-                            new CsvTableSink(
-                                    sinkTablePath + FILE_SEPARATOR + queryId + RESULT_SUFFIX,
-                                    COL_DELIMITER,
-                                    1,
-                                    FileSystem.WriteMode.OVERWRITE,
-                                    resultTable.getSchema().getFieldNames(),
-                                    resultTable.getSchema().getFieldDataTypes()));
-            TableResult tableResult = resultTable.executeInsert(sinkTableName);
+            tableEnvironment.createTable(
+                    sinkTableName,
+                    TableDescriptor.forConnector(FILE_CONNECTOR_NAME)
+                            .schema(resultTable.getSchema().toSchema())
+                            .format(
+                                    FormatDescriptor.forFormat(CSV_FORMAT)
+                                            .option(CsvFormatOptions.FIELD_DELIMITER, COL_DELIMITER)
+                                            .option(CsvFormatOptions.DISABLE_QUOTE_CHARACTER, true)
+                                            .build())
+                            .option(
+                                    FILE_PATH,
+                                    sinkTablePath + FILE_SEPARATOR + queryId + RESULT_SUFFIX)
+                            .option(SINK_PARALLELISM, CSV_SINK_PARALLELISM)
+                            .build());
+
+            TableResult tableResult = resultTable.executeInsert(sinkTableName, true);
             // wait job finish
             tableResult.getJobClient().get().getJobExecutionResult().get();
             System.out.println("[INFO]Run TPC-DS query " + queryId + " success.");
@@ -157,34 +166,30 @@ public class TpcdsTestProgram {
         TPCDS_TABLES.forEach(
                 table -> {
                     TpcdsSchema schema = TpcdsSchemaProvider.getTableSchema(table);
-                    CsvTableSource.Builder builder = CsvTableSource.builder();
-                    builder.path(sourceTablePath + FILE_SEPARATOR + table + DATA_SUFFIX);
-                    for (int i = 0; i < schema.getFieldNames().size(); i++) {
-                        builder.field(
-                                schema.getFieldNames().get(i),
-                                TypeConversions.fromDataTypeToLegacyInfo(
-                                        schema.getFieldTypes().get(i)));
-                    }
-                    builder.fieldDelimiter(COL_DELIMITER);
-                    builder.emptyColumnAsNull();
-                    builder.lineDelimiter("\n");
-                    CsvTableSource tableSource = builder.build();
-                    ConnectorCatalogTable catalogTable =
-                            ConnectorCatalogTable.source(tableSource, true);
-                    tEnv.getCatalog(tEnv.getCurrentCatalog())
-                            .ifPresent(
-                                    catalog -> {
-                                        try {
-                                            catalog.createTable(
-                                                    new ObjectPath(
-                                                            tEnv.getCurrentDatabase(), table),
-                                                    catalogTable,
-                                                    false);
-                                        } catch (Exception e) {
-                                            throw new RuntimeException(e);
-                                        }
-                                    });
+                    String filePath = sourceTablePath + FILE_SEPARATOR + table + DATA_SUFFIX;
+
+                    tEnv.createTable(
+                            table,
+                            TableDescriptor.forConnector(FILE_CONNECTOR_NAME)
+                                    .schema(
+                                            Schema.newBuilder()
+                                                    .fromFields(
+                                                            schema.getFieldNames(),
+                                                            schema.getFieldTypes())
+                                                    .build())
+                                    .format(
+                                            FormatDescriptor.forFormat(CSV_FORMAT)
+                                                    .option(
+                                                            CsvFormatOptions.FIELD_DELIMITER,
+                                                            COL_DELIMITER)
+                                                    .option(
+                                                            CsvFormatOptions.NULL_LITERAL,
+                                                            NULL_LITERAL)
+                                                    .build())
+                                    .option(FILE_PATH, filePath)
+                                    .build());
                 });
+
         // register statistics info
         if (useTableStats) {
             TpcdsStatsProvider.registerTpcdsStats(tEnv);

--- a/flink-end-to-end-tests/flink-tpcds-test/src/main/java/org/apache/flink/table/tpcds/utils/TpcdsResultComparator.java
+++ b/flink-end-to-end-tests/flink-tpcds-test/src/main/java/org/apache/flink/table/tpcds/utils/TpcdsResultComparator.java
@@ -26,6 +26,7 @@ import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Result comparator for TPC-DS test according to the TPC-DS standard specification v2.11.0. Query
@@ -61,7 +62,8 @@ public class TpcdsResultComparator {
 
         for (String queryId : VALIDATE_QUERIES) {
             File expectedFile = new File(expectedDir, queryId + RESULT_SUFFIX);
-            File actualFile = new File(actualDir, queryId + RESULT_SUFFIX);
+            File actualFileDirectory = new File(actualDir, queryId + RESULT_SUFFIX);
+            File actualFile = Objects.requireNonNull(actualFileDirectory.listFiles())[0];
 
             if (compareResult(queryId, expectedFile, actualFile)) {
                 passCnt++;

--- a/flink-end-to-end-tests/flink-tpcds-test/tpcds-tool/data_generator.sh
+++ b/flink-end-to-end-tests/flink-tpcds-test/tpcds-tool/data_generator.sh
@@ -130,6 +130,13 @@ elif  [[ "$OS_TYPE" == "linux" ]]; then
         chmod +x  $generator_dir/dsdgen_linux
         cd  $generator_dir
         ./dsdgen_linux -SCALE $scale_factor -FORCE Y -DIR $data_dir
+
+        # TODO: The following code can be removed when FLINK-26760 is fixed
+        # the data generator may generate files encoded in latin1, which the new csv source cannot read
+        echo "[INFO] `date +%H:%M:%S` Convert file encoding of customer.dat to UTF-8 start."
+        iconv -f latin1 -t UTF-8 $data_dir/customer.dat -o $data_dir/customer.dat.tmp
+        echo "[INFO] `date +%H:%M:%S` Convert file encoding of customer.dat to UTF-8 success."
+        mv $data_dir/customer.dat.tmp $data_dir/customer.dat
     else
         echo "[ERROR] Download and validate data generator files fail, please check the network."
         exit 127

--- a/flink-end-to-end-tests/test-scripts/test_tpcds.sh
+++ b/flink-end-to-end-tests/test-scripts/test_tpcds.sh
@@ -44,6 +44,14 @@ cd "$TPCDS_TOOL_DIR"
 TPCDS_GENERATOR_RELATIVE_DIR="../target/generator"
 TPCDS_DATA_RELATIVE_DIR="../table"
 
+ANSWER_OF_QUERY_30="$ORGIN_ANSWER_DIR/30.ans"
+ANSWER_OF_QUERY_30_FILE_ENCODING=`file $ANSWER_OF_QUERY_30`
+if [[ $ANSWER_OF_QUERY_30_FILE_ENCODING =~ "ISO-8859" ]]; then
+  echo "[INFO] `date +%H:%M:%S` Convert file encoding of 30.ans to UTF-8 start."
+  iconv -f latin1 -t UTF-8 $ANSWER_OF_QUERY_30 -o $ANSWER_OF_QUERY_30
+  echo "[INFO] `date +%H:%M:%S` Convert file encoding of 30.ans to UTF-8 success."
+fi
+
 ${TPCDS_TOOL_DIR}/data_generator.sh "$TPCDS_GENERATOR_RELATIVE_DIR" "$SCALE" "$TPCDS_DATA_RELATIVE_DIR" "$END_TO_END_DIR/test-scripts"
 
 cd "$END_TO_END_DIR"


### PR DESCRIPTION
## What is the purpose of the change

As described in [FLINK-26692](https://issues.apache.org/jira/browse/FLINK-26692), we should migrate TpcdsTestProgram.java to new source.

## Verifying this change

- e2e test

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**no**)
  - The serializers: (**no**)
  - The runtime per-record code paths (performance sensitive): (**no**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**no**)
  - The S3 file system connector: (**no**)

## Documentation

  - Does this pull request introduce a new feature? (**no**)
  - If yes, how is the feature documented? (**not applicable**)