### PR TITLE
[FLINK-26695][runtime] Evaluation of deleteConfigMap's return value added

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClient.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClient.java
@@ -349,6 +349,8 @@ public class Fabric8FlinkKubeClient implements FlinkKubeClient {
 
     @Override
     public CompletableFuture<Void> deleteConfigMapsByLabels(Map<String, String> labels) {
+        // the only time, the delete method returns false is due to a 404 HTTP status which is
+        // returned if the underlying resource doesn't exist
         return CompletableFuture.runAsync(
                 () -> this.internalClient.configMaps().withLabels(labels).delete(),
                 kubeClientExecutorService);
@@ -356,6 +358,8 @@ public class Fabric8FlinkKubeClient implements FlinkKubeClient {
 
     @Override
     public CompletableFuture<Void> deleteConfigMap(String configMapName) {
+        // the only time, the delete method returns false is due to a 404 HTTP status which is
+        // returned if the underlying resource doesn't exist
         return CompletableFuture.runAsync(
                 () -> this.internalClient.configMaps().withName(configMapName).delete(),
                 kubeClientExecutorService);

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/FlinkKubeClient.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/FlinkKubeClient.java
@@ -171,7 +171,8 @@ public interface FlinkKubeClient extends AutoCloseable {
      * org.apache.flink.kubernetes.highavailability.KubernetesHaServices} to clean up all data.
      *
      * @param labels labels to filter the resources. e.g. type: high-availability
-     * @return Return the delete future.
+     * @return Return the delete future that only completes successfully, if the resources that are
+     *     subject to deletion are actually gone.
      */
     CompletableFuture<Void> deleteConfigMapsByLabels(Map<String, String> labels);
 

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClientTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClientTest.java
@@ -464,10 +464,28 @@ public class Fabric8FlinkKubeClientTest extends KubernetesClientTestBase {
     }
 
     @Test
+    public void testDeleteNotExistingConfigMapByLabels() throws Exception {
+        assertThat(
+                this.flinkKubeClient.getConfigMap(TESTING_CONFIG_MAP_NAME).isPresent(), is(false));
+        this.flinkKubeClient.deleteConfigMapsByLabels(TESTING_LABELS).get();
+        assertThat(
+                this.flinkKubeClient.getConfigMap(TESTING_CONFIG_MAP_NAME).isPresent(), is(false));
+    }
+
+    @Test
     public void testDeleteConfigMapByName() throws Exception {
         this.flinkKubeClient.createConfigMap(buildTestingConfigMap()).get();
         assertThat(
                 this.flinkKubeClient.getConfigMap(TESTING_CONFIG_MAP_NAME).isPresent(), is(true));
+        this.flinkKubeClient.deleteConfigMap(TESTING_CONFIG_MAP_NAME).get();
+        assertThat(
+                this.flinkKubeClient.getConfigMap(TESTING_CONFIG_MAP_NAME).isPresent(), is(false));
+    }
+
+    @Test
+    public void testDeleteNotExistingConfigMapByName() throws Exception {
+        assertThat(
+                this.flinkKubeClient.getConfigMap(TESTING_CONFIG_MAP_NAME).isPresent(), is(false));
         this.flinkKubeClient.deleteConfigMap(TESTING_CONFIG_MAP_NAME).get();
         assertThat(
                 this.flinkKubeClient.getConfigMap(TESTING_CONFIG_MAP_NAME).isPresent(), is(false));


### PR DESCRIPTION
## What is the purpose of the change

The only issue where we can run into this right now is where the k8s API returns 404 which is quite unlikely to happen. But still it's good to have the implementation harden for such cases.

The `deleteConfigMapByLabels` implementation couldn't be tested like that due to a bug in the fabric8 code: See issue [fabric8io/kubernetes-client issue #3982](https://github.com/fabric8io/kubernetes-client/issues/3982)

## Brief change log

Added evaluation around the delete return value.

## Verifying this change

* Added tests for non-existing ConfigMap deletion (not related to the change)
* Added test for error case where the HTTP request responding with 404 which is the only case where the delete returns `false`
* Disabled the test that's not working because of issue mentioned above

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
