### PR TITLE
[FLINK-26690][BP-1.15][runtime] Makes globalCleanupAsync call the removal even if the JobGraph is not put into the JobGraphStore, yet

### DIFF
--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesStateHandleStoreTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesStateHandleStoreTest.java
@@ -804,6 +804,33 @@ public class KubernetesStateHandleStoreTest extends KubernetesHighAvailabilityTe
     }
 
     @Test
+    public void testRemoveOfNonExistingState() throws Exception {
+        new Context() {
+            {
+                runTest(
+                        () -> {
+                            leaderCallbackGrantLeadership();
+
+                            final KubernetesStateHandleStore<
+                                            TestingLongStateHandleHelper.LongStateHandle>
+                                    store =
+                                            new KubernetesStateHandleStore<>(
+                                                    flinkKubeClient,
+                                                    LEADER_CONFIGMAP_NAME,
+                                                    longStateStorage,
+                                                    filter,
+                                                    LOCK_IDENTITY);
+                            assertThat(store.getAllAndLock().size(), is(0));
+                            assertThat(store.releaseAndTryRemove(key), is(true));
+                            assertThat(store.getAllAndLock().size(), is(0));
+
+                            assertThat(TestingLongStateHandleHelper.getGlobalDiscardCount(), is(0));
+                        });
+            }
+        };
+    }
+
+    @Test
     public void testRemoveFailedShouldNotDiscardState() throws Exception {
         new Context() {
             {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/DefaultJobGraphStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/DefaultJobGraphStore.java
@@ -249,12 +249,10 @@ public class DefaultJobGraphStore<R extends ResourceVersion<R>>
                 () -> {
                     LOG.debug("Removing job graph {} from {}.", jobId, jobGraphStateHandleStore);
 
-                    if (addedJobGraphs.contains(jobId)) {
-                        final String name = jobGraphStoreUtil.jobIDToName(jobId);
-                        releaseAndRemoveOrThrowCompletionException(jobId, name);
+                    final String name = jobGraphStoreUtil.jobIDToName(jobId);
+                    releaseAndRemoveOrThrowCompletionException(jobId, name);
 
-                        addedJobGraphs.remove(jobId);
-                    }
+                    addedJobGraphs.remove(jobId);
 
                     LOG.info("Removed job graph {} from {}.", jobId, jobGraphStateHandleStore);
                 },

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/persistence/StateHandleStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/persistence/StateHandleStore.java
@@ -121,7 +121,8 @@ public interface StateHandleStore<T extends Serializable, R extends ResourceVers
      * node if any. Also the state on the external storage will be discarded.
      *
      * @param name Key name in ConfigMap or child path name in ZooKeeper
-     * @return True if the state handle could be removed.
+     * @return {@code true} if the state handle is removed (also if it didn't exist in the first
+     *     place); otherwise {@code false}.
      * @throws Exception if releasing, removing the handles or discarding the state failed
      */
     boolean releaseAndTryRemove(String name) throws Exception;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/persistence/StateHandleStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/persistence/StateHandleStore.java
@@ -117,8 +117,7 @@ public interface StateHandleStore<T extends Serializable, R extends ResourceVers
 
     /**
      * Releases the lock for the given state handle and tries to remove the state handle if it is no
-     * longer locked. It returns the {@link RetrievableStateHandle} stored under the given state
-     * node if any. Also the state on the external storage will be discarded.
+     * longer locked. Also the state on the external storage will be discarded.
      *
      * @param name Key name in ConfigMap or child path name in ZooKeeper
      * @return {@code true} if the state handle is removed (also if it didn't exist in the first

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/zookeeper/ZooKeeperStateHandleStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/zookeeper/ZooKeeperStateHandleStoreTest.java
@@ -224,6 +224,18 @@ public class ZooKeeperStateHandleStoreTest extends TestLogger {
     }
 
     @Test
+    public void testCleanupOfNonExistingState() throws Exception {
+        final ZooKeeperStateHandleStore<TestingLongStateHandleHelper.LongStateHandle> testInstance =
+                new ZooKeeperStateHandleStore<>(
+                        ZOOKEEPER.getClient(), new TestingLongStateHandleHelper());
+
+        final String pathInZooKeeper = "/testCleanupOfNonExistingState";
+
+        assertTrue(testInstance.releaseAndTryRemove(pathInZooKeeper));
+        assertFalse(testInstance.exists(pathInZooKeeper).isExisting());
+    }
+
+    @Test
     public void testRepeatableCleanupWithLockOnNode() throws Exception {
         final CuratorFramework client =
                 ZooKeeperUtils.useNamespaceAndEnsurePath(


### PR DESCRIPTION
This is a 1.15 backport of parent PR #19121 which was approved. Cherry-picking the commits didn't produce any conflicts