### PR TITLE
[BP-1.14][FLINK-26381][docs] Wrong document order of Chinese version

### DIFF
--- a/docs/content.zh/docs/learn-flink/datastream_api.md
+++ b/docs/content.zh/docs/learn-flink/datastream_api.md
@@ -1,6 +1,6 @@
 ---
 title: DataStream API 简介
-weight: 2
+weight: 3
 type: docs
 ---
 <!--

--- a/docs/content.zh/docs/learn-flink/event_driven.md
+++ b/docs/content.zh/docs/learn-flink/event_driven.md
@@ -1,6 +1,6 @@
 ---
 title: 事件驱动应用
-weight: 5
+weight: 6
 type: docs
 ---
 <!--

--- a/docs/content.zh/docs/learn-flink/fault_tolerance.md
+++ b/docs/content.zh/docs/learn-flink/fault_tolerance.md
@@ -1,6 +1,6 @@
 ---
 title: 容错处理
-weight: 6
+weight: 7
 type: docs
 ---
 <!--

--- a/docs/content.zh/docs/learn-flink/streaming_analytics.md
+++ b/docs/content.zh/docs/learn-flink/streaming_analytics.md
@@ -1,6 +1,6 @@
 ---
 title: 流式分析
-weight: 3
+weight: 5
 type: docs
 ---
 <!--


### PR DESCRIPTION
Unchanged backport of https://github.com/apache/flink/pull/19010 on release-1.14