### PR TITLE
[FLINK-26756][table-planner] Fix the deserialization error for match recognize

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RexNodeJsonDeserializer.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RexNodeJsonDeserializer.java
@@ -375,14 +375,11 @@ final class RexNodeJsonDeserializer extends StdDeserializer<RexNode> {
         }
         // Try FUNC
         final String publicName = BuiltInSqlOperator.extractNameFromQualifiedName(internalName);
-        // FunctionIdentifier require the name should not be empty
-        if (!publicName.isEmpty()) {
-            final Optional<SqlOperator> latestOperator =
-                    lookupOptionalSqlOperator(
-                            FunctionIdentifier.of(publicName), syntax, serdeContext, true);
-            if (latestOperator.isPresent()) {
-                return latestOperator.get();
-            }
+        final Optional<SqlOperator> latestOperator =
+                lookupOptionalSqlOperator(
+                        FunctionIdentifier.of(publicName), syntax, serdeContext, true);
+        if (latestOperator.isPresent()) {
+            return latestOperator.get();
         }
 
         throw new TableException(

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RexNodeJsonDeserializer.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RexNodeJsonDeserializer.java
@@ -383,6 +383,7 @@ final class RexNodeJsonDeserializer extends StdDeserializer<RexNode> {
         }
         // Try FUNC
         final String publicName = BuiltInSqlOperator.extractNameFromQualifiedName(internalName);
+        // FunctionIdentifier require the name should not be empty
         if (!publicName.isEmpty()) {
             final Optional<SqlOperator> latestOperator =
                     lookupOptionalSqlOperator(
@@ -540,16 +541,10 @@ final class RexNodeJsonDeserializer extends StdDeserializer<RexNode> {
                         syntax,
                         foundOperators,
                         SqlNameMatchers.liberal());
-        if (foundOperators.size() == 1) {
-            return Optional.of(foundOperators.get(0));
-        }
-        for (SqlOperator operator : foundOperators) {
-            // in case different operator has the same kind, check with both name and kind.
-            if (sqlKind != null && operator.kind == sqlKind) {
-                return Optional.of(operator);
-            }
-        }
-        return Optional.empty();
+        // in case different operator has the same kind, check with both name and kind.
+        return foundOperators.stream()
+                .filter(o -> sqlKind != null && o.getKind() == sqlKind)
+                .findFirst();
     }
 
     private static TableException missingSystemFunction(String systemName) {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RexNodeJsonSerializer.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RexNodeJsonSerializer.java
@@ -116,6 +116,7 @@ final class RexNodeJsonSerializer extends StdSerializer<RexNode> {
     static final String FIELD_NAME_SYSTEM_NAME = "systemName";
     static final String FIELD_NAME_CATALOG_NAME = "catalogName";
     static final String FIELD_NAME_SYNTAX = "syntax";
+    static final String FIELD_NAME_SQL_KIND = "sqlKind";
     static final String FIELD_NAME_CLASS = "class";
 
     RexNodeJsonSerializer() {
@@ -397,6 +398,9 @@ final class RexNodeJsonSerializer extends StdSerializer<RexNode> {
             // stack is exposed to the user and can thus be external.
             gen.writeStringField(
                     FIELD_NAME_INTERNAL_NAME, BuiltInSqlOperator.toQualifiedName(operator));
+            if (operator.getName().isEmpty()) {
+                gen.writeStringField(FIELD_NAME_SQL_KIND, operator.getKind().name());
+            }
         }
     }
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RexNodeJsonSerializer.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RexNodeJsonSerializer.java
@@ -394,12 +394,14 @@ final class RexNodeJsonSerializer extends StdSerializer<RexNode> {
                 || operator instanceof AggSqlFunction) {
             throw legacyException(operator.toString());
         } else {
-            // We assume that all regular SqlOperators are internal. Only the function definitions
-            // stack is exposed to the user and can thus be external.
-            gen.writeStringField(
-                    FIELD_NAME_INTERNAL_NAME, BuiltInSqlOperator.toQualifiedName(operator));
             if (operator.getName().isEmpty()) {
                 gen.writeStringField(FIELD_NAME_SQL_KIND, operator.getKind().name());
+            } else {
+                // We assume that all regular SqlOperators are internal. Only the function
+                // definitions
+                // stack is exposed to the user and can thus be external.
+                gen.writeStringField(
+                        FIELD_NAME_INTERNAL_NAME, BuiltInSqlOperator.toQualifiedName(operator));
             }
         }
     }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/utils/JsonPlanTestBase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/utils/JsonPlanTestBase.java
@@ -73,6 +73,7 @@ public abstract class JsonPlanTestBase extends AbstractTestBase {
     protected TableResult compileSqlAndExecutePlan(String sql) {
         CompiledPlan compiledPlan = tableEnv.compilePlanSql(sql);
         checkTransformationUids(compiledPlan);
+        // try to execute the string json plan to validate to ser/de result
         String jsonPlan = compiledPlan.asJsonString();
         CompiledPlan newCompiledPlan = tableEnv.loadPlan(PlanReference.fromJsonString(jsonPlan));
         return newCompiledPlan.execute();

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/utils/JsonPlanTestBase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/utils/JsonPlanTestBase.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.streaming.api.transformations.UnionTransformation;
 import org.apache.flink.table.api.CompiledPlan;
 import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.PlanReference;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.api.internal.CompiledPlanUtils;
@@ -72,7 +73,9 @@ public abstract class JsonPlanTestBase extends AbstractTestBase {
     protected TableResult compileSqlAndExecutePlan(String sql) {
         CompiledPlan compiledPlan = tableEnv.compilePlanSql(sql);
         checkTransformationUids(compiledPlan);
-        return compiledPlan.execute();
+        String jsonPlan = compiledPlan.asJsonString();
+        CompiledPlan newCompiledPlan = tableEnv.loadPlan(PlanReference.fromJsonString(jsonPlan));
+        return newCompiledPlan.execute();
     }
 
     protected void checkTransformationUids(CompiledPlan compiledPlan) {

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/MatchRecognizeJsonPlanTest_jsonplan/testMatch.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/MatchRecognizeJsonPlanTest_jsonplan/testMatch.out
@@ -131,10 +131,12 @@
         "kind" : "CALL",
         "syntax" : "BINARY",
         "internalName" : "$$1",
+        "sqlKind" : "PATTERN_CONCAT",
         "operands" : [ {
           "kind" : "CALL",
           "syntax" : "BINARY",
           "internalName" : "$$1",
+          "sqlKind" : "PATTERN_CONCAT",
           "operands" : [ {
             "kind" : "LITERAL",
             "value" : "A\"",

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/MatchRecognizeJsonPlanTest_jsonplan/testMatch.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/MatchRecognizeJsonPlanTest_jsonplan/testMatch.out
@@ -130,12 +130,10 @@
       "pattern" : {
         "kind" : "CALL",
         "syntax" : "BINARY",
-        "internalName" : "$$1",
         "sqlKind" : "PATTERN_CONCAT",
         "operands" : [ {
           "kind" : "CALL",
           "syntax" : "BINARY",
-          "internalName" : "$$1",
           "sqlKind" : "PATTERN_CONCAT",
           "operands" : [ {
             "kind" : "LITERAL",


### PR DESCRIPTION

## What is the purpose of the change

*This pr aims to fix the deserialization error for match recognize. The reason is: RexNodeJsonSerializer and RexNodeJsonDeserializer does not consider the SqlOperators with empty names, such as: pattern_concat, the testing logic in JsonPlanTestBase#compileSqlAndExecutePlan is not correct. *


## Brief change log

  - *Fix the ser/de logic for pattern_concat in  RexNodeJsonSerializer and RexNodeJsonDeserializer *
  - *Fix the JsonPlanTestBase#compileSqlAndExecutePlan*


## Verifying this change


This change is already covered by existing tests, such as *MatchRecognizeJsonPlanTest and MatchRecognizeJsonPlanITCase*.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
