### PR TITLE
[FLINK-26766][Runtime/StateBackends] Fix ChangelogStateHandleStreamImpl#getIntersection

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/ChangelogStateHandleStreamImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/ChangelogStateHandleStreamImpl.java
@@ -100,7 +100,7 @@ public final class ChangelogStateHandleStreamImpl implements ChangelogStateHandl
     @Nullable
     @Override
     public KeyedStateHandle getIntersection(KeyGroupRange keyGroupRange) {
-        KeyGroupRange offsets = keyGroupRange.getIntersection(keyGroupRange);
+        KeyGroupRange offsets = this.keyGroupRange.getIntersection(keyGroupRange);
         if (offsets.getNumberOfKeyGroups() == 0) {
             return null;
         }


### PR DESCRIPTION

## What is the purpose of the change

This pull request fix mistake in ChangelogStateHandleStreamImpl#getIntersection. (described in FLINK-26766)

## Brief change log
correct getIntersection method from compute intersection between parameter keyGroupRange and itself to compute intersection between parameter keyGroupRange and ChangelogStateHandleStreamImpl inner one.

## Verifying this change


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)