### PR TITLE
[hotfix][test-utils-junit] Improve assertion errors

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactoryTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactoryTest.java
@@ -93,7 +93,7 @@ import java.util.Set;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
 
-import static org.apache.flink.core.testutils.FlinkAssertions.containsCause;
+import static org.apache.flink.core.testutils.FlinkAssertions.anyCauseMatches;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptionsUtil.AVRO_CONFLUENT;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptionsUtil.DEBEZIUM_AVRO_CONFLUENT;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptionsUtil.PROPERTIES_PREFIX;
@@ -744,9 +744,9 @@ public class KafkaDynamicTableFactoryTest {
                         })
                 .isInstanceOf(ValidationException.class)
                 .satisfies(
-                        containsCause(
-                                new ValidationException(
-                                        "Option 'topic' and 'topic-pattern' shouldn't be set together.")));
+                        anyCauseMatches(
+                                ValidationException.class,
+                                "Option 'topic' and 'topic-pattern' shouldn't be set together."));
     }
 
     @Test
@@ -763,10 +763,10 @@ public class KafkaDynamicTableFactoryTest {
                         })
                 .isInstanceOf(ValidationException.class)
                 .satisfies(
-                        containsCause(
-                                new ValidationException(
-                                        "'scan.startup.timestamp-millis' "
-                                                + "is required in 'timestamp' startup mode but missing.")));
+                        anyCauseMatches(
+                                ValidationException.class,
+                                "'scan.startup.timestamp-millis' "
+                                        + "is required in 'timestamp' startup mode but missing."));
     }
 
     @Test
@@ -784,10 +784,10 @@ public class KafkaDynamicTableFactoryTest {
                         })
                 .isInstanceOf(ValidationException.class)
                 .satisfies(
-                        containsCause(
-                                new ValidationException(
-                                        "'scan.startup.specific-offsets' "
-                                                + "is required in 'specific-offsets' startup mode but missing.")));
+                        anyCauseMatches(
+                                ValidationException.class,
+                                "'scan.startup.specific-offsets' "
+                                        + "is required in 'specific-offsets' startup mode but missing."));
     }
 
     @Test
@@ -803,10 +803,9 @@ public class KafkaDynamicTableFactoryTest {
                         })
                 .isInstanceOf(ValidationException.class)
                 .satisfies(
-                        containsCause(
-                                new ValidationException(
-                                        "Could not find and instantiate partitioner "
-                                                + "class 'abc'")));
+                        anyCauseMatches(
+                                ValidationException.class,
+                                "Could not find and instantiate partitioner " + "class 'abc'"));
     }
 
     @Test
@@ -823,10 +822,10 @@ public class KafkaDynamicTableFactoryTest {
                         })
                 .isInstanceOf(ValidationException.class)
                 .satisfies(
-                        containsCause(
-                                new ValidationException(
-                                        "Currently 'round-robin' partitioner only works "
-                                                + "when option 'key.fields' is not specified.")));
+                        anyCauseMatches(
+                                ValidationException.class,
+                                "Currently 'round-robin' partitioner only works "
+                                        + "when option 'key.fields' is not specified."));
     }
 
     @Test
@@ -850,9 +849,9 @@ public class KafkaDynamicTableFactoryTest {
                         })
                 .isInstanceOf(ValidationException.class)
                 .satisfies(
-                        containsCause(
-                                new ValidationException(
-                                        "sink.transactional-id-prefix must be specified when using DeliveryGuarantee.EXACTLY_ONCE.")));
+                        anyCauseMatches(
+                                ValidationException.class,
+                                "sink.transactional-id-prefix must be specified when using DeliveryGuarantee.EXACTLY_ONCE."));
     }
 
     @Test

--- a/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActorTest.java
+++ b/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActorTest.java
@@ -430,7 +430,9 @@ class AkkaRpcActorTest {
         onStartEndpoint.awaitUntilOnStartCalled();
 
         assertThatThrownBy(() -> onStartEndpoint.getTerminationFuture().get())
-                .satisfies(FlinkAssertions.anyCauseMatches(testException));
+                .satisfies(
+                        FlinkAssertions.anyCauseMatches(
+                                testException.getClass(), testException.getMessage()));
     }
 
     /**

--- a/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActorTest.java
+++ b/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActorTest.java
@@ -430,7 +430,7 @@ class AkkaRpcActorTest {
         onStartEndpoint.awaitUntilOnStartCalled();
 
         assertThatThrownBy(() -> onStartEndpoint.getTerminationFuture().get())
-                .satisfies(FlinkAssertions.containsCause(testException));
+                .satisfies(FlinkAssertions.anyCauseMatches(testException));
     }
 
     /**

--- a/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/core/testutils/FlinkAssertions.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/core/testutils/FlinkAssertions.java
@@ -60,30 +60,11 @@ public final class FlinkAssertions {
                         .anySatisfy(
                                 cause ->
                                         assertThat(cause)
+                                                .as(
+                                                        "Any cause is instance of class '%s' and contains message '%s'",
+                                                        clazz, containsMessage)
                                                 .isInstanceOf(clazz)
                                                 .hasMessageContaining(containsMessage));
-    }
-
-    /**
-     * Shorthand to assert the chain of causes includes a specific {@link Throwable}. Same as:
-     *
-     * <pre>{@code
-     * assertThatChainOfCauses(t)
-     *     .anySatisfy(
-     *          cause ->
-     *              assertThat(cause)
-     *                  .isInstanceOf(throwable.getClass())
-     *                  .hasMessage(throwable.getMessage()));
-     * }</pre>
-     */
-    public static ThrowingConsumer<? super Throwable> containsCause(Throwable throwable) {
-        return t ->
-                assertThatChainOfCauses(t)
-                        .anySatisfy(
-                                cause ->
-                                        assertThat(cause)
-                                                .isInstanceOf(throwable.getClass())
-                                                .hasMessage(throwable.getMessage()));
     }
 
     /**
@@ -102,6 +83,7 @@ public final class FlinkAssertions {
             Class<? extends Throwable> clazz) {
         return t ->
                 assertThatChainOfCauses(t)
+                        .as("Any cause is instance of class '%s'", clazz)
                         .anySatisfy(cause -> assertThat(cause).isInstanceOf(clazz));
     }
 
@@ -120,6 +102,7 @@ public final class FlinkAssertions {
     public static ThrowingConsumer<? super Throwable> anyCauseMatches(String containsMessage) {
         return t ->
                 assertThatChainOfCauses(t)
+                        .as("Any cause contains message '%s'", containsMessage)
                         .anySatisfy(t1 -> assertThat(t1).hasMessageContaining(containsMessage));
     }
 

--- a/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/core/testutils/FlinkAssertions.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/core/testutils/FlinkAssertions.java
@@ -57,12 +57,12 @@ public final class FlinkAssertions {
             Class<? extends Throwable> clazz, String containsMessage) {
         return t ->
                 assertThatChainOfCauses(t)
+                        .as(
+                                "Any cause is instance of class '%s' and contains message '%s'",
+                                clazz, containsMessage)
                         .anySatisfy(
                                 cause ->
                                         assertThat(cause)
-                                                .as(
-                                                        "Any cause is instance of class '%s' and contains message '%s'",
-                                                        clazz, containsMessage)
                                                 .isInstanceOf(clazz)
                                                 .hasMessageContaining(containsMessage));
     }


### PR DESCRIPTION
This PR improves a bit the assertion error when using `anyCauseMatches`.

It also removes the `containsCause` method, which is a misleading (as `contains` is used in assertj lingo to refer to search in a list through equality) and was agreed to not be introduced here https://github.com/apache/flink/pull/17932#pullrequestreview-819921970