### PR TITLE
[FLINK-26779][rest] OperationKey implements Serializable

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/async/OperationKey.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/async/OperationKey.java
@@ -21,13 +21,16 @@ package org.apache.flink.runtime.rest.handler.async;
 import org.apache.flink.runtime.rest.messages.TriggerId;
 import org.apache.flink.util.Preconditions;
 
+import java.io.Serializable;
 import java.util.Objects;
 
 /**
  * Any operation key for the {@link AbstractAsynchronousOperationHandlers} must extend this class.
  * It is used to store the trigger id.
  */
-public class OperationKey {
+public class OperationKey implements Serializable {
+
+    private static final long serialVersionUID = 6138473450686379255L;
 
     private final TriggerId triggerId;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/AsynchronousJobOperationKey.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/AsynchronousJobOperationKey.java
@@ -37,6 +37,8 @@ import static java.util.Objects.requireNonNull;
 @Immutable
 public class AsynchronousJobOperationKey extends OperationKey {
 
+    private static final long serialVersionUID = -4907777251835275859L;
+
     private final JobID jobId;
 
     private AsynchronousJobOperationKey(final TriggerId triggerId, final JobID jobId) {


### PR DESCRIPTION
These are used in some RPC calls for triggering savepoints and must be serializable in case the request was sent from a standby JM.