### PR TITLE
[FLINK-26741][runtime] The CheckpointIDCounter.shutdown method should work idempotently

### DIFF
--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesHighAvailabilityTestBase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesHighAvailabilityTestBase.java
@@ -118,6 +118,10 @@ public class KubernetesHighAvailabilityTestBase extends TestLogger {
             return kubernetesTestFixture.createFlinkKubeClientBuilder();
         }
 
+        String getClusterId() {
+            return CLUSTER_ID;
+        }
+
         KubernetesConfigMap getLeaderConfigMap() {
             return kubernetesTestFixture.getLeaderConfigMap();
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointIDCounter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointIDCounter.java
@@ -20,6 +20,8 @@ package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.api.common.JobStatus;
 
+import java.util.concurrent.CompletableFuture;
+
 /** A checkpoint ID counter. */
 public interface CheckpointIDCounter {
     int INITIAL_CHECKPOINT_ID = 1;
@@ -34,8 +36,9 @@ public interface CheckpointIDCounter {
      * or kept.
      *
      * @param jobStatus Job state on shut down
+     * @return The {@code CompletableFuture} holding the result of the shutdown operation.
      */
-    void shutdown(JobStatus jobStatus) throws Exception;
+    CompletableFuture<Void> shutdown(JobStatus jobStatus);
 
     /**
      * Atomically increments the current checkpoint ID.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DeactivatedCheckpointIDCounter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DeactivatedCheckpointIDCounter.java
@@ -19,6 +19,9 @@
 package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.util.concurrent.FutureUtils;
+
+import java.util.concurrent.CompletableFuture;
 
 /**
  * This class represents a {@link CheckpointIDCounter} if checkpointing is deactivated.
@@ -32,7 +35,9 @@ public enum DeactivatedCheckpointIDCounter implements CheckpointIDCounter {
     public void start() throws Exception {}
 
     @Override
-    public void shutdown(JobStatus jobStatus) throws Exception {}
+    public CompletableFuture<Void> shutdown(JobStatus jobStatus) {
+        return FutureUtils.completedVoidFuture();
+    }
 
     @Override
     public long getAndIncrement() throws Exception {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StandaloneCheckpointIDCounter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StandaloneCheckpointIDCounter.java
@@ -20,7 +20,9 @@ package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
+import org.apache.flink.util.concurrent.FutureUtils;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -37,7 +39,9 @@ public class StandaloneCheckpointIDCounter implements CheckpointIDCounter {
     public void start() throws Exception {}
 
     @Override
-    public void shutdown(JobStatus jobStatus) throws Exception {}
+    public CompletableFuture<Void> shutdown(JobStatus jobStatus) {
+        return FutureUtils.completedVoidFuture();
+    }
 
     @Override
     public long getAndIncrement() throws Exception {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/ZooKeeperCheckpointIDCounter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/ZooKeeperCheckpointIDCounter.java
@@ -22,18 +22,27 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
 import org.apache.flink.runtime.util.ZooKeeperUtils;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.concurrent.FutureUtils;
 
+import org.apache.flink.shaded.curator5.com.google.common.collect.Sets;
 import org.apache.flink.shaded.curator5.org.apache.curator.framework.CuratorFramework;
+import org.apache.flink.shaded.curator5.org.apache.curator.framework.api.CuratorEvent;
+import org.apache.flink.shaded.curator5.org.apache.curator.framework.api.CuratorEventType;
 import org.apache.flink.shaded.curator5.org.apache.curator.framework.recipes.shared.SharedCount;
 import org.apache.flink.shaded.curator5.org.apache.curator.framework.recipes.shared.VersionedValue;
 import org.apache.flink.shaded.curator5.org.apache.curator.framework.state.ConnectionState;
+import org.apache.flink.shaded.zookeeper3.org.apache.zookeeper.KeeperException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.concurrent.GuardedBy;
 
+import java.io.IOException;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -101,21 +110,64 @@ public class ZooKeeperCheckpointIDCounter implements CheckpointIDCounter {
     }
 
     @Override
-    public void shutdown(JobStatus jobStatus) throws Exception {
+    public CompletableFuture<Void> shutdown(JobStatus jobStatus) {
         synchronized (startStopLock) {
             if (isStarted) {
                 LOG.info("Shutting down.");
-                sharedCount.close();
+                try {
+                    sharedCount.close();
+                } catch (IOException e) {
+                    return FutureUtils.completedExceptionally(e);
+                }
 
                 client.getConnectionStateListenable().removeListener(connectionStateListener);
 
                 if (jobStatus.isGloballyTerminalState()) {
                     LOG.info("Removing {} from ZooKeeper", counterPath);
-                    client.delete().deletingChildrenIfNeeded().inBackground().forPath(counterPath);
+                    try {
+                        final CompletableFuture<Void> deletionFuture = new CompletableFuture<>();
+                        client.delete()
+                                .inBackground(
+                                        (curatorFramework, curatorEvent) ->
+                                                handleDeletionOfCounterPath(
+                                                        curatorEvent, deletionFuture))
+                                .forPath(counterPath);
+                        return deletionFuture;
+                    } catch (Exception e) {
+                        return FutureUtils.completedExceptionally(e);
+                    }
                 }
 
                 isStarted = false;
             }
+        }
+
+        return FutureUtils.completedVoidFuture();
+    }
+
+    private void handleDeletionOfCounterPath(
+            CuratorEvent curatorEvent, CompletableFuture<Void> deletionFuture) {
+        Preconditions.checkArgument(
+                curatorEvent.getType() == CuratorEventType.DELETE,
+                "An unexpected CuratorEvent was monitored: " + curatorEvent.getType());
+        Preconditions.checkArgument(
+                counterPath.endsWith(curatorEvent.getPath()),
+                "An unexpected path was selected for deletion: " + curatorEvent.getPath());
+
+        final KeeperException.Code eventCode =
+                KeeperException.Code.get(curatorEvent.getResultCode());
+        if (Sets.immutableEnumSet(KeeperException.Code.OK, KeeperException.Code.NONODE)
+                .contains(eventCode)) {
+            deletionFuture.complete(null);
+        } else {
+            final String namespacedCounterPath =
+                    ZooKeeperUtils.generateZookeeperPath(client.getNamespace(), counterPath);
+            deletionFuture.completeExceptionally(
+                    new FlinkException(
+                            String.format(
+                                    "An error occurred while shutting down the CheckpointIDCounter in path '%s'.",
+                                    namespacedCounterPath),
+                            KeeperException.create(eventCode, namespacedCounterPath)));
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/CheckpointResourcesCleanupRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/CheckpointResourcesCleanupRunner.java
@@ -129,7 +129,7 @@ public class CheckpointResourcesCleanupRunner implements JobManagerRunner {
         }
 
         try {
-            checkpointIDCounter.shutdown(getJobStatus());
+            checkpointIDCounter.shutdown(getJobStatus()).get();
         } catch (Exception e) {
             exception = ExceptionUtils.firstOrSuppressed(e, exception);
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -245,7 +245,7 @@ public abstract class SchedulerBase implements SchedulerNG, CheckpointScheduling
         }
 
         try {
-            checkpointIdCounter.shutdown(jobStatus);
+            checkpointIdCounter.shutdown(jobStatus).get();
         } catch (Exception e) {
             exception = ExceptionUtils.firstOrSuppressed(e, exception);
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
@@ -463,7 +463,7 @@ public class AdaptiveScheduler
         }
 
         try {
-            checkpointIdCounter.shutdown(terminalState);
+            checkpointIdCounter.shutdown(terminalState).get();
         } catch (Exception e) {
             exception = ExceptionUtils.firstOrSuppressed(e, exception);
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTriggeringTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTriggeringTest.java
@@ -35,6 +35,7 @@ import org.apache.flink.runtime.messages.checkpoint.AcknowledgeCheckpoint;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.ExecutorUtils;
 import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.concurrent.FutureUtils;
 import org.apache.flink.util.concurrent.ManuallyTriggeredScheduledExecutor;
 import org.apache.flink.util.concurrent.ScheduledExecutorServiceAdapter;
 
@@ -835,7 +836,9 @@ public class CheckpointCoordinatorTriggeringTest extends TestLogger {
         public void start() {}
 
         @Override
-        public void shutdown(JobStatus jobStatus) throws Exception {}
+        public CompletableFuture<Void> shutdown(JobStatus jobStatus) {
+            return FutureUtils.completedVoidFuture();
+        }
 
         @Override
         public long getAndIncrement() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointIDCounterTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointIDCounterTestBase.java
@@ -58,7 +58,7 @@ abstract class CheckpointIDCounterTestBase {
             counter.start();
             assertThat(counter.get()).isGreaterThanOrEqualTo(0L);
         } finally {
-            counter.shutdown(JobStatus.FINISHED);
+            counter.shutdown(JobStatus.FINISHED).join();
         }
     }
 
@@ -78,7 +78,7 @@ abstract class CheckpointIDCounterTestBase {
             assertThat(counter.get()).isEqualTo(4);
             assertThat(counter.getAndIncrement()).isEqualTo(4);
         } finally {
-            counter.shutdown(JobStatus.FINISHED);
+            counter.shutdown(JobStatus.FINISHED).join();
         }
     }
 
@@ -136,7 +136,7 @@ abstract class CheckpointIDCounterTestBase {
                 executor.shutdown();
             }
 
-            counter.shutdown(JobStatus.FINISHED);
+            counter.shutdown(JobStatus.FINISHED).join();
         }
     }
 
@@ -161,7 +161,7 @@ abstract class CheckpointIDCounterTestBase {
         assertThat(counter.get()).isEqualTo(1338);
         assertThat(counter.getAndIncrement()).isEqualTo(1338);
 
-        counter.shutdown(JobStatus.FINISHED);
+        counter.shutdown(JobStatus.FINISHED).join();
     }
 
     /** Task repeatedly incrementing the {@link CheckpointIDCounter}. */

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCheckpointIDCounterITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCheckpointIDCounterITCase.java
@@ -19,16 +19,21 @@
 package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.core.testutils.FlinkAssertions;
+import org.apache.flink.runtime.util.ZooKeeperUtils;
 import org.apache.flink.runtime.zookeeper.ZooKeeperTestEnvironment;
 
 import org.apache.flink.shaded.curator5.org.apache.curator.framework.CuratorFramework;
+import org.apache.flink.shaded.zookeeper3.org.apache.zookeeper.KeeperException;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.concurrent.ExecutionException;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Unit tests for the {@link ZooKeeperCheckpointIDCounter}. The tests are inherited from the test
@@ -38,19 +43,21 @@ class ZooKeeperCheckpointIDCounterITCase extends CheckpointIDCounterTestBase {
 
     private static ZooKeeperTestEnvironment zookeeper;
 
-    @BeforeAll
-    public static void setUp() throws Exception {
+    @BeforeEach
+    void setup() {
         zookeeper = new ZooKeeperTestEnvironment(1);
     }
 
-    @AfterAll
-    private static void tearDown() throws Exception {
-        zookeeper.shutdown();
+    @AfterEach
+    void tearDown() throws Exception {
+        cleanAndStopZooKeeperIfRunning();
     }
 
-    @BeforeEach
-    private void cleanUp() throws Exception {
-        zookeeper.deleteAll();
+    private void cleanAndStopZooKeeperIfRunning() throws Exception {
+        if (zookeeper.getClient().isStarted()) {
+            zookeeper.deleteAll();
+            zookeeper.shutdown();
+        }
     }
 
     /** Tests that counter node is removed from ZooKeeper after shutdown. */
@@ -62,8 +69,71 @@ class ZooKeeperCheckpointIDCounterITCase extends CheckpointIDCounterTestBase {
         CuratorFramework client = zookeeper.getClient();
         assertThat(client.checkExists().forPath(counter.getPath())).isNotNull();
 
-        counter.shutdown(JobStatus.FINISHED);
+        counter.shutdown(JobStatus.FINISHED).join();
         assertThat(client.checkExists().forPath(counter.getPath())).isNull();
+    }
+
+    @Test
+    public void testIdempotentShutdown() throws Exception {
+        ZooKeeperCheckpointIDCounter counter = createCheckpointIdCounter();
+        counter.start();
+
+        CuratorFramework client = zookeeper.getClient();
+        counter.shutdown(JobStatus.FINISHED).join();
+
+        // shutdown shouldn't fail due to missing path
+        counter.shutdown(JobStatus.FINISHED).join();
+        assertThat(client.checkExists().forPath(counter.getPath())).isNull();
+    }
+
+    @Test
+    public void testShutdownWithFailureDueToMissingConnection() throws Exception {
+        ZooKeeperCheckpointIDCounter counter = createCheckpointIdCounter();
+        counter.start();
+
+        cleanAndStopZooKeeperIfRunning();
+
+        assertThatThrownBy(() -> counter.shutdown(JobStatus.FINISHED).get())
+                .as("The shutdown should fail because of the client connection being dropped.")
+                .isInstanceOf(ExecutionException.class)
+                .hasCauseExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void testShutdownWithFailureDueToExistingChildNodes() throws Exception {
+        final ZooKeeperCheckpointIDCounter counter = createCheckpointIdCounter();
+        counter.start();
+
+        final CuratorFramework client =
+                ZooKeeperUtils.useNamespaceAndEnsurePath(zookeeper.getClient(), "/");
+        final String counterNodePath = ZooKeeperUtils.generateZookeeperPath(counter.getPath());
+        final String childNodePath =
+                ZooKeeperUtils.generateZookeeperPath(
+                        counterNodePath, "unexpected-child-node-causing-a-failure");
+        client.create().forPath(childNodePath);
+
+        final String namespacedCounterNodePath =
+                ZooKeeperUtils.generateZookeeperPath(client.getNamespace(), counterNodePath);
+        final Throwable expectedRootCause =
+                KeeperException.create(KeeperException.Code.NOTEMPTY, namespacedCounterNodePath);
+        assertThatThrownBy(() -> counter.shutdown(JobStatus.FINISHED).get())
+                .as(
+                        "The shutdown should fail because of a child node being present and the shutdown not performing an explicit recursive deletion.")
+                .isInstanceOf(ExecutionException.class)
+                .extracting(FlinkAssertions::chainOfCauses, FlinkAssertions.STREAM_THROWABLE)
+                .anySatisfy(
+                        cause ->
+                                assertThat(cause)
+                                        .isInstanceOf(expectedRootCause.getClass())
+                                        .hasMessage(expectedRootCause.getMessage()));
+
+        client.delete().forPath(childNodePath);
+        counter.shutdown(JobStatus.FINISHED).join();
+
+        assertThat(client.checkExists().forPath(counterNodePath))
+                .as(
+                        "A retry of the shutdown should have worked now after the root cause was resolved.")
+                .isNull();
     }
 
     /** Tests that counter node is NOT removed from ZooKeeper after suspend. */
@@ -75,13 +145,14 @@ class ZooKeeperCheckpointIDCounterITCase extends CheckpointIDCounterTestBase {
         CuratorFramework client = zookeeper.getClient();
         assertThat(client.checkExists().forPath(counter.getPath())).isNotNull();
 
-        counter.shutdown(JobStatus.SUSPENDED);
+        counter.shutdown(JobStatus.SUSPENDED).join();
         assertThat(client.checkExists().forPath(counter.getPath())).isNotNull();
     }
 
     @Override
     protected ZooKeeperCheckpointIDCounter createCheckpointIdCounter() throws Exception {
         return new ZooKeeperCheckpointIDCounter(
-                zookeeper.getClient(), new DefaultLastStateConnectionStateListener());
+                ZooKeeperUtils.useNamespaceAndEnsurePath(zookeeper.getClient(), "/"),
+                new DefaultLastStateConnectionStateListener());
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerTest.java
@@ -1462,7 +1462,8 @@ public class AdaptiveSchedulerTest extends TestLogger {
                             throw new RuntimeException(e);
                         }
                     },
-                    executorService);
+                    executorService,
+                    log);
         } finally {
             executorService.shutdownNow();
         }


### PR DESCRIPTION
## What is the purpose of the change

We should make sure that the shutdown mechanism works idempotently. Additionally, errors should be propagated. Returning a CompletableFuture as the result object of the shutdown matches the general pattern we're using for cleanup tasks that are then handled downstream.

## Brief change log

* Modified `CheckpointIDCounter.shutdown` method signature
* Refactored `ZooKeeperIDCounter` to make cleanup being handled asynchronously properly

## Verifying this change

* Tests were added to `ZooKeeperIDCounterITCase` and 
`KubernetesCheckpointIDCounterTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
