### PR TITLE
[FLINK-26798][runtime] Hardens test against unexpected heartbeat

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -97,7 +97,6 @@ import org.apache.flink.runtime.scheduler.TestingSchedulerNGFactory;
 import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
 import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
-import org.apache.flink.runtime.taskexecutor.TaskExecutorToJobManagerHeartbeatPayload;
 import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGateway;
 import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
 import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
@@ -154,7 +153,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
-import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -1746,9 +1744,7 @@ public class JobMasterTest extends TestLogger {
                 (localTaskManagerLocation, jobMasterGateway) ->
                         jobMasterGateway.disconnectTaskManager(
                                 localTaskManagerLocation.getResourceID(),
-                                new FlinkException("Test disconnectTaskManager exception.")),
-                (jobMasterGateway, resourceID) ->
-                        (ignoredA, ignoredB) -> FutureUtils.completedVoidFuture());
+                                new FlinkException("Test disconnectTaskManager exception.")));
     }
 
     @Test
@@ -1760,14 +1756,7 @@ public class JobMasterTest extends TestLogger {
                 testingHeartbeatService,
                 (localTaskManagerLocation, jobMasterGateway) ->
                         testingHeartbeatService.triggerHeartbeatTimeout(
-                                jmResourceId, localTaskManagerLocation.getResourceID()),
-                (jobMasterGateway, taskManagerResourceId) ->
-                        (resourceId, ignored) -> {
-                            jobMasterGateway.heartbeatFromTaskManager(
-                                    taskManagerResourceId,
-                                    TaskExecutorToJobManagerHeartbeatPayload.empty());
-                            return FutureUtils.completedVoidFuture();
-                        });
+                                jmResourceId, localTaskManagerLocation.getResourceID()));
     }
 
     /**
@@ -1979,12 +1968,7 @@ public class JobMasterTest extends TestLogger {
 
     private void runJobFailureWhenTaskExecutorTerminatesTest(
             HeartbeatServices heartbeatServices,
-            BiConsumer<LocalUnresolvedTaskManagerLocation, JobMasterGateway> jobReachedRunningState,
-            BiFunction<
-                            JobMasterGateway,
-                            ResourceID,
-                            BiFunction<ResourceID, AllocatedSlotReport, CompletableFuture<Void>>>
-                    heartbeatConsumerFunction)
+            BiConsumer<LocalUnresolvedTaskManagerLocation, JobMasterGateway> jobReachedRunningState)
             throws Exception {
         final JobGraph jobGraph = JobGraphTestUtils.singleNoOpJobGraph();
         final JobMasterBuilder.TestingOnCompletionActions onCompletionActions =
@@ -2016,10 +2000,6 @@ public class JobMasterTest extends TestLogger {
                                                 taskDeploymentDescriptor.getExecutionAttemptId());
                                         return CompletableFuture.completedFuture(Acknowledge.get());
                                     })
-                            .setHeartbeatJobManagerFunction(
-                                    heartbeatConsumerFunction.apply(
-                                            jobMasterGateway,
-                                            taskManagerUnresolvedLocation.getResourceID()))
                             .createTestingTaskExecutorGateway();
 
             final Collection<SlotOffer> slotOffers =


### PR DESCRIPTION
## What is the purpose of the change

`testJobFailureWhenTaskExecutorHeartbeatTimeout` failed due to a heartbeat
being processed during the test. The missing payload of the test
implementation caused an unexpected error. Increasing the heartbeat
interval to a higher value should prevent this test from failing
because of an unexpected heartbeat.

## Brief change log

* Increased the heartbeat interval. This won't prevent the initial heartbeat (which is ok, because no Executions are scheduled, yet) but let's the next heartbeat being scheduled long time in the future. 

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
