### PR TITLE
[FLINK-26797][runtime] Hardens ZKCheckpointIDCounterMultiServersTest

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZKCheckpointIDCounterMultiServersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZKCheckpointIDCounterMultiServersTest.java
@@ -33,9 +33,7 @@ import org.apache.flink.shaded.curator5.org.apache.curator.framework.state.Conne
 import org.junit.Rule;
 import org.junit.Test;
 
-import java.util.concurrent.atomic.AtomicLong;
-
-import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.number.OrderingComparison.greaterThan;
 import static org.junit.Assert.assertThat;
 
 /** Tests for {@link ZooKeeperCheckpointIDCounter} in a ZooKeeper ensemble. */
@@ -71,22 +69,14 @@ public final class ZKCheckpointIDCounterMultiServersTest extends TestLogger {
                             curatorFrameworkWrapper.asCuratorFramework(), listener);
             idCounter.start();
 
-            AtomicLong localCounter = new AtomicLong(1L);
-
-            assertThat(
-                    "ZooKeeperCheckpointIDCounter doesn't properly work.",
-                    idCounter.getAndIncrement(),
-                    is(localCounter.getAndIncrement()));
+            final long initialID = idCounter.getAndIncrement();
 
             zooKeeperResource.restart();
 
             connectionLossLatch.await();
             reconnectedLatch.await();
 
-            assertThat(
-                    "ZooKeeperCheckpointIDCounter doesn't properly work after reconnected.",
-                    idCounter.getAndIncrement(),
-                    is(localCounter.getAndIncrement()));
+            assertThat(idCounter.getAndIncrement(), greaterThan(initialID));
         } finally {
             curatorFrameworkWrapper.close();
         }

--- a/tools/ci/log4j.properties
+++ b/tools/ci/log4j.properties
@@ -61,6 +61,11 @@ logger.zookeeper.name = org.apache.zookeeper
 logger.zookeeper.level = INFO
 logger.zookeeper.additivity = false
 logger.zookeeper.appenderRef.zk.ref = ZooKeeperServerAppender
+# FinalRequestProcessor in DEBUG mode enables us to see requests being processed by the ZK server
+logger.zookeeper_FinalRequestProcessor.name = org.apache.zookeeper.server.FinalRequestProcessor
+logger.zookeeper_FinalRequestProcessor.level = DEBUG
+logger.zookeeper_FinalRequestProcessor.additivity = false
+logger.zookeeper_FinalRequestProcessor.appenderRef.zk.ref = ZooKeeperServerAppender
 logger.shaded_zookeeper.name = org.apache.flink.shaded.zookeeper3
 logger.shaded_zookeeper.level = INFO
 logger.shaded_zookeeper.additivity = false


### PR DESCRIPTION
## What is the purpose of the change

There was a connection issue again with ZK that supposedly caused the IDCounter to be incremented once too often.

## Brief change log

* I fixed the issue in the same way it was done in FLINK-26120.
* Additionally, I extended the ci log4j properties to log also request handling on the ZK server side

## Verifying this change

A CI run with a forced ZK test failure was added temporarily to verify the log4j configuration changes.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
