### PR TITLE
[FLINK-26819][table-runtime] Fix wrong results when AppendOnlyFirstNFunction with offset and without rank number

### DIFF
--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/rank/AppendOnlyFirstNFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/rank/AppendOnlyFirstNFunction.java
@@ -89,7 +89,7 @@ public class AppendOnlyFirstNFunction extends AbstractTopNFunction {
         currentRank += 1;
         state.update(currentRank);
 
-        if (outputRankNumber) {
+        if (outputRankNumber || hasOffset()) {
             collectInsert(out, input, currentRank);
         } else {
             collectInsert(out, input);

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/rank/AppendOnlyFirstNFunctionTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/rank/AppendOnlyFirstNFunctionTest.java
@@ -135,9 +135,7 @@ public class AppendOnlyFirstNFunctionTest extends TopNFunctionTestBase {
         testHarness.close();
 
         List<Object> expectedOutput = new ArrayList<>();
-        expectedOutput.add(insertRecord("book", 2L, 12));
         expectedOutput.add(insertRecord("book", 2L, 19));
-        expectedOutput.add(insertRecord("fruit", 1L, 33));
         expectedOutput.add(insertRecord("fruit", 1L, 44));
         assertorWithRowNumber.assertOutputEquals(
                 "output wrong.", expectedOutput, testHarness.getOutput());


### PR DESCRIPTION
## What is the purpose of the change
fix the wrong result when AppendOnlyFirstNFunction with offset and without rank number.

## Brief change log
update the process logic in AppendOnlyFirstNFunction

## Verifying this change
AppendOnlyFirstNFunctionTest.testConstantRankRangeWithOffset

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation
  - Does this pull request introduce a new feature? (no)