### PR TITLE
[hotfix][doc] fix typo in sql doc.

### DIFF
--- a/docs/content.zh/docs/dev/table/sql/queries/deduplication.md
+++ b/docs/content.zh/docs/dev/table/sql/queries/deduplication.md
@@ -56,7 +56,7 @@ The following examples show how to specify SQL queries with Deduplication on str
 
 ```sql
 CREATE TABLE Orders (
-  order_time  STRING,
+  order_id  STRING,
   user        STRING,
   product     STRING,
   num         BIGINT,

--- a/docs/content/docs/dev/table/sql/queries/deduplication.md
+++ b/docs/content/docs/dev/table/sql/queries/deduplication.md
@@ -56,7 +56,7 @@ The following examples show how to specify SQL queries with Deduplication on str
 
 ```sql
 CREATE TABLE Orders (
-  order_time  STRING,
+  order_id  STRING,
   user        STRING,
   product     STRING,
   num         BIGINT,


### PR DESCRIPTION
order_time should be order_id in the table creation statement.