### PR TITLE
[FLINK-25256][streaming] Externally induced sources replay barriers received over RPC instead of inventing them out of thin air. [1.15]

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/ExternallyInducedSourceReader.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/ExternallyInducedSourceReader.java
@@ -24,16 +24,16 @@ import org.apache.flink.annotation.PublicEvolving;
 import java.util.Optional;
 
 /**
- * Sources that implement this interface do not trigger checkpoints when receiving a trigger message
- * from the checkpoint coordinator, but when their input data/events indicate that a checkpoint
+ * Sources that implement this interface delay checkpoints when receiving a trigger message from the
+ * checkpoint coordinator to the point when their input data/events indicate that a checkpoint
  * should be triggered.
  *
  * <p>The ExternallyInducedSourceReader tells the Flink runtime that a checkpoint needs to be made
- * by returning a checkpointId when shouldTriggerCheckpoint() is invoked.
+ * by returning a checkpointId when {@link #shouldTriggerCheckpoint()} is invoked.
  *
- * <p>The implementations typically works together with the SplitEnumerator which informs the
- * external system to trigger a checkpoint. The external system also needs to forward the Checkpoint
- * ID to the source, so the source knows which checkpoint to trigger.
+ * <p>The implementations typically works together with the {@link SplitEnumerator} which informs
+ * the external system to trigger a checkpoint. The external system also needs to forward the
+ * Checkpoint ID to the source, so the source knows which checkpoint to trigger.
  *
  * <p><b>Important:</b> It is crucial that all parallel source tasks trigger their checkpoints at
  * roughly the same time. Otherwise this leads to performance issues due to long checkpoint

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/checkpoint/ExternallyInducedSource.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/checkpoint/ExternallyInducedSource.java
@@ -23,8 +23,8 @@ import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.util.FlinkException;
 
 /**
- * Sources that implement this interface do not trigger checkpoints when receiving a trigger message
- * from the checkpoint coordinator, but when their input data/events indicate that a checkpoint
+ * Sources that implement this interface delay checkpoints when receiving a trigger message from the
+ * checkpoint coordinator to the point when their input data/events indicate that a checkpoint
  * should be triggered.
  *
  * <p>Since sources cannot simply create a new checkpoint on their own, this mechanism always goes

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskExternallyInducedSourceInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskExternallyInducedSourceInput.java
@@ -21,12 +21,14 @@ package org.apache.flink.streaming.runtime.io;
 import org.apache.flink.api.connector.source.ExternallyInducedSourceReader;
 import org.apache.flink.streaming.api.operators.SourceOperator;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
 /** A subclass of {@link StreamTaskSourceInput} for {@link ExternallyInducedSourceReader}. */
 public class StreamTaskExternallyInducedSourceInput<T> extends StreamTaskSourceInput<T> {
     private final Consumer<Long> checkpointTriggeringHook;
     private final ExternallyInducedSourceReader<T, ?> sourceReader;
+    private CompletableFuture<?> blockFuture;
 
     @SuppressWarnings("unchecked")
     public StreamTaskExternallyInducedSourceInput(
@@ -39,12 +41,34 @@ public class StreamTaskExternallyInducedSourceInput<T> extends StreamTaskSourceI
         this.sourceReader = (ExternallyInducedSourceReader<T, ?>) operator.getSourceReader();
     }
 
+    public void blockUntil(CompletableFuture<?> blockFuture) {
+        this.blockFuture = blockFuture;
+        // assume that the future is completed in mailbox thread
+        blockFuture.whenComplete((v, e) -> unblock());
+    }
+
+    private void unblock() {
+        this.blockFuture = null;
+    }
+
     @Override
     public DataInputStatus emitNext(DataOutput<T> output) throws Exception {
+        if (blockFuture != null) {
+            return DataInputStatus.NOTHING_AVAILABLE;
+        }
+
         DataInputStatus status = super.emitNext(output);
         if (status == DataInputStatus.NOTHING_AVAILABLE) {
             sourceReader.shouldTriggerCheckpoint().ifPresent(checkpointTriggeringHook);
         }
         return status;
+    }
+
+    @Override
+    public CompletableFuture<?> getAvailableFuture() {
+        if (blockFuture != null) {
+            return blockFuture;
+        }
+        return super.getAvailableFuture();
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTaskTest.java
@@ -70,8 +70,7 @@ import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.function.CheckedSupplier;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -94,23 +93,18 @@ import static org.apache.flink.api.common.typeinfo.BasicTypeInfo.INT_TYPE_INFO;
 import static org.apache.flink.api.common.typeinfo.BasicTypeInfo.STRING_TYPE_INFO;
 import static org.apache.flink.streaming.runtime.tasks.StreamTaskFinalCheckpointsTest.triggerCheckpoint;
 import static org.apache.flink.util.Preconditions.checkState;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 /**
  * These tests verify that the RichFunction methods are called (in correct order). And that
  * checkpointing/element emission don't occur concurrently.
  */
-public class SourceStreamTaskTest extends SourceStreamTaskTestBase {
+class SourceStreamTaskTest extends SourceStreamTaskTestBase {
 
     /** This test verifies that open() and close() are correctly called by the StreamTask. */
     @Test
-    public void testOpenClose() throws Exception {
+    void testOpenClose() throws Exception {
         final StreamTaskTestHarness<String> testHarness =
                 new StreamTaskTestHarness<>(SourceStreamTask::new, STRING_TYPE_INFO);
 
@@ -124,15 +118,17 @@ public class SourceStreamTaskTest extends SourceStreamTaskTestBase {
         testHarness.invoke();
         testHarness.waitForTaskCompletion();
 
-        assertTrue("RichFunction methods where not called.", OpenCloseTestSource.closeCalled);
+        assertThat(OpenCloseTestSource.closeCalled)
+                .as("RichFunction methods where not called.")
+                .isTrue();
 
         List<String> resultElements =
                 TestHarnessUtil.getRawElementsFromOutput(testHarness.getOutput());
-        Assert.assertEquals(10, resultElements.size());
+        assertThat(resultElements.size()).isEqualTo(10);
     }
 
     @Test
-    public void testMetrics() throws Exception {
+    void testMetrics() throws Exception {
         testMetrics(
                 SourceStreamTask::new,
                 SimpleOperatorFactory.of(
@@ -140,7 +136,7 @@ public class SourceStreamTaskTest extends SourceStreamTaskTestBase {
                                 new CancelTestSource(
                                         INT_TYPE_INFO.createSerializer(new ExecutionConfig()),
                                         42))),
-                is(Double.NaN));
+                busyTime -> busyTime.isNaN());
     }
 
     /**
@@ -157,7 +153,7 @@ public class SourceStreamTaskTest extends SourceStreamTaskTestBase {
      */
     @Test
     @SuppressWarnings("unchecked")
-    public void testCheckpointing() throws Exception {
+    void testCheckpointing() throws Exception {
         final int numElements = 100;
         final int numCheckpoints = 100;
         final int numCheckpointers = 1;
@@ -214,14 +210,14 @@ public class SourceStreamTaskTest extends SourceStreamTaskTestBase {
 
             List<Tuple2<Long, Integer>> resultElements =
                     TestHarnessUtil.getRawElementsFromOutput(testHarness.getOutput());
-            Assert.assertEquals(numElements, resultElements.size());
+            assertThat(resultElements.size()).isEqualTo(numElements);
         } finally {
             executor.shutdown();
         }
     }
 
     @Test
-    public void testClosingAllOperatorsOnChainProperly() throws Exception {
+    void testClosingAllOperatorsOnChainProperly() throws Exception {
         final StreamTaskTestHarness<String> testHarness =
                 new StreamTaskTestHarness<>(SourceStreamTask::new, STRING_TYPE_INFO);
 
@@ -254,11 +250,11 @@ public class SourceStreamTaskTest extends SourceStreamTaskTestBase {
                 new StreamRecord<>("[Operator1]: Finish"));
 
         final Object[] output = testHarness.getOutput().toArray();
-        assertArrayEquals("Output was not correct.", expected.toArray(), output);
+        assertThat(output).as("Output was not correct.").isEqualTo(expected.toArray());
     }
 
     @Test
-    public void testNotMarkingEndOfInputWhenTaskCancelled() throws Exception {
+    void testNotMarkingEndOfInputWhenTaskCancelled() throws Exception {
         final StreamTaskTestHarness<String> testHarness =
                 new StreamTaskTestHarness<>(SourceStreamTask::new, STRING_TYPE_INFO);
 
@@ -299,22 +295,22 @@ public class SourceStreamTaskTest extends SourceStreamTaskTestBase {
     }
 
     @Test
-    public void testCancellationWithSourceBlockedOnLock() throws Exception {
+    void testCancellationWithSourceBlockedOnLock() throws Exception {
         testCancellationWithSourceBlockedOnLock(false, false);
     }
 
     @Test
-    public void testCancellationWithSourceBlockedOnLockWithPendingMail() throws Exception {
+    void testCancellationWithSourceBlockedOnLockWithPendingMail() throws Exception {
         testCancellationWithSourceBlockedOnLock(true, false);
     }
 
     @Test
-    public void testCancellationWithSourceBlockedOnLockAndThrowingOnError() throws Exception {
+    void testCancellationWithSourceBlockedOnLockAndThrowingOnError() throws Exception {
         testCancellationWithSourceBlockedOnLock(false, true);
     }
 
     @Test
-    public void testCancellationWithSourceBlockedOnLockWithPendingMailAndThrowingOnError()
+    void testCancellationWithSourceBlockedOnLockWithPendingMailAndThrowingOnError()
             throws Exception {
         testCancellationWithSourceBlockedOnLock(true, true);
     }
@@ -324,8 +320,8 @@ public class SourceStreamTaskTest extends SourceStreamTaskTestBase {
      * StreamTask} which, as of the time this test is being written, is not tested anywhere else
      * (like {@link StreamTaskTest} or {@link OneInputStreamTaskTest}).
      */
-    public void testCancellationWithSourceBlockedOnLock(
-            boolean withPendingMail, boolean throwInCancel) throws Exception {
+    void testCancellationWithSourceBlockedOnLock(boolean withPendingMail, boolean throwInCancel)
+            throws Exception {
         final StreamTaskTestHarness<String> testHarness =
                 new StreamTaskTestHarness<>(SourceStreamTask::new, STRING_TYPE_INFO);
 
@@ -354,9 +350,9 @@ public class SourceStreamTaskTest extends SourceStreamTaskTestBase {
                     .createExecutor(0)
                     .execute(
                             () ->
-                                    assertFalse(
-                                            "This should never execute before task cancelation",
-                                            testHarness.getTask().isRunning()),
+                                    assertThat(testHarness.getTask().isRunning())
+                                            .as("This should never execute before task cancelation")
+                                            .isFalse(),
                             "Test");
         }
 
@@ -427,12 +423,12 @@ public class SourceStreamTaskTest extends SourceStreamTaskTestBase {
     }
 
     @Test
-    public void testInterruptionExceptionNotSwallowed() throws Exception {
+    void testInterruptionExceptionNotSwallowed() throws Exception {
         testInterruptionExceptionNotSwallowed(InterruptedException::new);
     }
 
     @Test
-    public void testWrappedInterruptionExceptionNotSwallowed() throws Exception {
+    void testWrappedInterruptionExceptionNotSwallowed() throws Exception {
         testInterruptionExceptionNotSwallowed(
                 () -> new RuntimeException(new FlinkRuntimeException(new InterruptedException())));
     }
@@ -491,7 +487,7 @@ public class SourceStreamTaskTest extends SourceStreamTaskTestBase {
     }
 
     @Test
-    public void testWaitsForSourceThreadOnCancel() throws Exception {
+    void testWaitsForSourceThreadOnCancel() throws Exception {
         StreamTaskTestHarness<String> harness =
                 new StreamTaskTestHarness<>(SourceStreamTask::new, STRING_TYPE_INFO);
 
@@ -504,13 +500,13 @@ public class SourceStreamTaskTest extends SourceStreamTaskTestBase {
         // SourceStreamTask should be still waiting for NonStoppingSource after cancellation
         harness.getTask().cancel();
         harness.waitForTaskCompletion(50, true); // allow task to exit prematurely
-        assertTrue(harness.taskThread.isAlive());
+        assertThat(harness.taskThread.isAlive()).isTrue();
 
         // SourceStreamTask should be still waiting for NonStoppingSource after interruptions
         for (int i = 0; i < 10; i++) {
             harness.getTask().maybeInterruptOnCancel(harness.getTaskThread(), null, null);
             harness.waitForTaskCompletion(50, true); // allow task to exit prematurely
-            assertTrue(harness.taskThread.isAlive());
+            assertThat(harness.taskThread.isAlive()).isTrue();
         }
 
         // It should only exit once NonStoppingSource allows for it
@@ -519,7 +515,7 @@ public class SourceStreamTaskTest extends SourceStreamTaskTestBase {
     }
 
     @Test
-    public void testTriggeringCheckpointAfterSourceThreadFinished() throws Exception {
+    void testTriggeringCheckpointAfterSourceThreadFinished() throws Exception {
         ResultPartition[] partitionWriters = new ResultPartition[2];
         try (NettyShuffleEnvironment env =
                 new NettyShuffleEnvironmentBuilder()
@@ -585,12 +581,12 @@ public class SourceStreamTaskTest extends SourceStreamTaskTestBase {
                         (id, error) ->
                                 testHarness.getStreamTask().notifyCheckpointCompleteAsync(2));
                 testHarness.finishProcessing();
-                assertTrue(checkpointFuture.isDone());
+                assertThat(checkpointFuture.isDone()).isTrue();
 
                 // Each result partition should have emitted 1 barrier, 1 max watermark and 1
                 // EndOfUserRecordEvent.
                 for (ResultPartition resultPartition : partitionWriters) {
-                    assertEquals(3, resultPartition.getNumberOfQueuedBuffers());
+                    assertThat(resultPartition.getNumberOfQueuedBuffers()).isEqualTo(3);
                 }
             }
         } finally {
@@ -603,7 +599,7 @@ public class SourceStreamTaskTest extends SourceStreamTaskTestBase {
     }
 
     @Test
-    public void testClosedOnRestoreSourceSkipExecution() throws Exception {
+    void testClosedOnRestoreSourceSkipExecution() throws Exception {
         LifeCycleMonitorSource testSource = new LifeCycleMonitorSource();
         List<Object> output = new ArrayList<>();
         try (StreamTaskMailboxTestHarness<String> harness =
@@ -626,7 +622,8 @@ public class SourceStreamTaskTest extends SourceStreamTaskTestBase {
             harness.processAll();
             harness.streamTask.getCompletionFuture().get();
 
-            assertThat(output, contains(Watermark.MAX_WATERMARK, new EndOfData(StopMode.DRAIN)));
+            assertThat(output)
+                    .containsExactly(Watermark.MAX_WATERMARK, new EndOfData(StopMode.DRAIN));
 
             LifeCycleMonitorSource source =
                     (LifeCycleMonitorSource)
@@ -642,7 +639,7 @@ public class SourceStreamTaskTest extends SourceStreamTaskTestBase {
     }
 
     @Test
-    public void testTriggeringStopWithSavepointWithDrain() throws Exception {
+    void testTriggeringStopWithSavepointWithDrain() throws Exception {
         SourceFunction<String> testSource = new EmptySource();
 
         CompletableFuture<Boolean> checkpointCompleted = new CompletableFuture<>();
@@ -684,9 +681,9 @@ public class SourceStreamTaskTest extends SourceStreamTaskTestBase {
             harness.streamTask.runMailboxLoop();
             harness.finishProcessing();
 
-            assertTrue(triggerResult.isDone());
-            assertTrue(triggerResult.get());
-            assertTrue(checkpointCompleted.isDone());
+            assertThat(triggerResult.isDone()).isTrue();
+            assertThat(triggerResult.get()).isTrue();
+            assertThat(checkpointCompleted.isDone()).isTrue();
         }
     }
 
@@ -767,7 +764,7 @@ public class SourceStreamTaskTest extends SourceStreamTaskTestBase {
         public List<Serializable> snapshotState(long checkpointId, long timestamp)
                 throws Exception {
             if (!semaphore.tryAcquire()) {
-                Assert.fail("Concurrent invocation of snapshotState.");
+                fail("Concurrent invocation of snapshotState.");
             }
             int startCount = count;
             lastCheckpointId = checkpointId;
@@ -780,7 +777,7 @@ public class SourceStreamTaskTest extends SourceStreamTaskTestBase {
             if (startCount != count) {
                 semaphore.release();
                 // This means that next() was invoked while the snapshot was ongoing
-                Assert.fail("Count is different at start end end of snapshot.");
+                fail("Count is different at start end end of snapshot.");
             }
             semaphore.release();
             return Collections.singletonList(sum);
@@ -871,7 +868,7 @@ public class SourceStreamTaskTest extends SourceStreamTaskTestBase {
         public void open(Configuration parameters) throws Exception {
             super.open(parameters);
             if (closeCalled) {
-                Assert.fail("Close called before open.");
+                fail("Close called before open.");
             }
             openCalled = true;
         }
@@ -880,7 +877,7 @@ public class SourceStreamTaskTest extends SourceStreamTaskTestBase {
         public void close() throws Exception {
             super.close();
             if (!openCalled) {
-                Assert.fail("Open was not called before close.");
+                fail("Open was not called before close.");
             }
             closeCalled = true;
         }
@@ -888,7 +885,7 @@ public class SourceStreamTaskTest extends SourceStreamTaskTestBase {
         @Override
         public void run(SourceContext<String> ctx) throws Exception {
             if (!openCalled) {
-                Assert.fail("Open was not called before run.");
+                fail("Open was not called before run.");
             }
             for (int i = 0; i < 10; i++) {
                 ctx.collect("Hello" + i);


### PR DESCRIPTION
Unchanged backport of #19138.