### PR TITLE
[FLINK-26809][tests] Assert histogram state after stopping the uploader

### DIFF
--- a/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/ChangelogStorageMetricsTest.java
+++ b/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/ChangelogStorageMetricsTest.java
@@ -204,12 +204,12 @@ public class ChangelogStorageMetricsTest {
                 writer.append(0, new byte[] {0, 1, 2, 3});
                 writer.persist(from).get();
             }
-            HistogramStatistics histogram = metrics.getAttemptsPerUpload().getStatistics();
-            assertThat(histogram.getMin()).isEqualTo(maxAttempts);
-            assertThat(histogram.getMax()).isEqualTo(maxAttempts);
         } finally {
             storage.close();
         }
+        HistogramStatistics histogram = metrics.getAttemptsPerUpload().getStatistics();
+        assertThat(histogram.getMin()).isEqualTo(maxAttempts);
+        assertThat(histogram.getMax()).isEqualTo(maxAttempts);
     }
 
     @Test


### PR DESCRIPTION
There is a race condition in ChangelogStorageMetricsTest.testAttemptsPerUpload:
- the assertion is made as soon as upload (future) is completed
- the histogram is updated after completing the upload (on success)
Moving assertion out of try/close block solves the problem.