### PR TITLE
[FLINK-26844][tests] fix ConnectionUtilsTest#testReturnLocalHostAddressUsingHeuristics failed

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/net/ConnectionUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/net/ConnectionUtilsTest.java
@@ -42,9 +42,9 @@ import static org.junit.Assert.assertTrue;
 public class ConnectionUtilsTest {
 
     @Test
-    public void testReturnLocalHostAddressUsingHeuristics() throws Exception {
-        // instead of using a unstable localhost:port as "unreachable" to cause Test fails unstably
-        // using a Absolutely unreachable outside ip:port
+    public void testReturnLoopbackAddressUsingHeuristics() throws Exception {
+        // instead of using an unstable localhost:port as "unreachable" to cause Test fails unstably
+        // using an Absolutely unreachable outside ip:port
         InetSocketAddress unreachable = new InetSocketAddress("8.8.8.8", 0xFFFF);
 
         final long start = System.nanoTime();
@@ -58,8 +58,8 @@ public class ConnectionUtilsTest {
         // we should have found a heuristic address
         assertNotNull(add);
 
-        // make sure that we returned the InetAddress.getLocalHost as a heuristic
-        assertEquals(InetAddress.getLocalHost(), add);
+        // make sure that we returned the InetAddress.getLoopbackAddress as a heuristic
+        assertEquals(InetAddress.getLoopbackAddress(), add);
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

Fix the UT failed.
More details see jira: https://issues.apache.org/jira/projects/FLINK/issues/FLINK-26844?filter=reportedbyme

## Brief change log
Change the UT method name and change to expect value to loopBackAddress.


## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no 
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper:  no 
  - The S3 file system connector:  no 

## Documentation

  - Does this pull request introduce a new feature?  no
  - If yes, how is the feature documented? not applicable
