### PR TITLE
[FLINK-26799][Runtime/StateBackends] fix StateChangeFormat#read and e…

### DIFF
--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/StateChangeFormat.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/StateChangeFormat.java
@@ -91,7 +91,7 @@ public class StateChangeFormat
             throws IOException {
         FSDataInputStream stream = handle.openInputStream();
         DataInputViewStreamWrapper input = wrap(stream);
-        if (stream.getPos() != offset) {
+        if (offset != 0) {
             LOG.debug("seek from {} to {}", stream.getPos(), offset);
             input.skipBytesToRead((int) offset);
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/changelog/inmemory/StateChangelogStorageTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/changelog/inmemory/StateChangelogStorageTest.java
@@ -81,7 +81,7 @@ public class StateChangelogStorageTest<T extends ChangelogStateHandle> {
     @ParameterizedTest(name = "compression = {0}")
     public void testWriteAndRead(boolean compression) throws Exception {
         KeyGroupRange kgRange = KeyGroupRange.of(0, 5);
-        Map<Integer, List<byte[]>> appendsByKeyGroup = generateAppends(kgRange, 10, 20);
+        Map<Integer, List<byte[]>> appendsByKeyGroup = generateAppends(kgRange, 405, 20);
 
         try (StateChangelogStorage<T> client = getFactory(compression, temporaryFolder);
                 StateChangelogWriter<T> writer =
@@ -94,6 +94,7 @@ public class StateChangelogStorageTest<T extends ChangelogStateHandle> {
                 for (byte[] bytes : appends) {
                     writer.append(group, bytes);
                 }
+                writer.nextSequenceNumber();
             }
 
             T handle = writer.persist(prev).get();


### PR DESCRIPTION
…nhance test

## What is the purpose of the change

Fix problem in StateChangeFormat#read  which had been discussed in [FLINK-26799](https://issues.apache.org/jira/browse/FLINK-26799).

## Brief change log

  - correct seek condition in StateChangeFormat#read

## Verifying this change

This change contains modification of StateChangelogStorageTest#testWriteAndRead  to cover this problem.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)