### PR TITLE
[FLINK-26846][python] Fix the gauge metric

### DIFF
--- a/flink-python/src/main/java/org/apache/flink/python/metric/FlinkMetricContainer.java
+++ b/flink-python/src/main/java/org/apache/flink/python/metric/FlinkMetricContainer.java
@@ -33,7 +33,6 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMap
 import org.apache.beam.model.pipeline.v1.MetricsApi.MonitoringInfo;
 import org.apache.beam.runners.core.metrics.MetricsContainerImpl;
 import org.apache.beam.runners.core.metrics.MetricsContainerStepMap;
-import org.apache.beam.runners.core.metrics.MonitoringInfoConstants;
 import org.apache.beam.runners.core.metrics.MonitoringInfoMetricName;
 import org.apache.beam.sdk.metrics.DistributionResult;
 import org.apache.beam.sdk.metrics.GaugeResult;
@@ -106,10 +105,7 @@ public final class FlinkMetricContainer {
         MetricName metricName = metricResult.getKey().metricName();
         if (metricName instanceof MonitoringInfoMetricName) {
             String urn = ((MonitoringInfoMetricName) metricName).getUrn();
-            return urn.contains(MonitoringInfoConstants.Urns.USER_SUM_INT64)
-                    || urn.contains(MonitoringInfoConstants.Urns.USER_SUM_DOUBLE)
-                    || urn.contains(MonitoringInfoConstants.Urns.USER_DISTRIBUTION_DOUBLE)
-                    || urn.contains(MonitoringInfoConstants.Urns.USER_DISTRIBUTION_INT64);
+            return urn.startsWith("beam:metric:user");
         }
         return false;
     }


### PR DESCRIPTION

## What is the purpose of the change

*This pull request fixes the gauge metric which is broken when bump Beam*


## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
