### PR TITLE
[FLINK-26847][python] Ensure command line option '-py' works in YARN application mode

### DIFF
--- a/flink-python/src/main/java/org/apache/flink/client/python/PythonDriver.java
+++ b/flink-python/src/main/java/org/apache/flink/client/python/PythonDriver.java
@@ -154,10 +154,14 @@ public final class PythonDriver {
      */
     static List<String> constructPythonCommands(final PythonDriverOptions pythonDriverOptions) {
         final List<String> commands = new ArrayList<>();
+        commands.add("-m");
         if (pythonDriverOptions.getEntryPointScript().isPresent()) {
-            commands.add(pythonDriverOptions.getEntryPointScript().get());
+            String pythonFileName = pythonDriverOptions.getEntryPointScript().get();
+            commands.add(
+                    pythonFileName.substring(
+                            pythonFileName.lastIndexOf(File.separator) + 1,
+                            pythonFileName.lastIndexOf(".py")));
         } else {
-            commands.add("-m");
             commands.add(pythonDriverOptions.getEntryPointModule());
         }
         commands.addAll(pythonDriverOptions.getProgramArgs());

--- a/flink-python/src/main/java/org/apache/flink/client/python/PythonDriverOptionsParserFactory.java
+++ b/flink-python/src/main/java/org/apache/flink/client/python/PythonDriverOptionsParserFactory.java
@@ -54,6 +54,12 @@ final class PythonDriverOptionsParserFactory implements ParserResultFactory<Pyth
             throw new FlinkParseException("Cannot use options -py and -pym simultaneously.");
         } else if (commandLine.hasOption(PY_OPTION.getOpt())) {
             entryPointScript = commandLine.getOptionValue(PY_OPTION.getOpt());
+            if (!entryPointScript.endsWith(".py")) {
+                throw new FlinkParseException(
+                        String.format(
+                                "It only accepts Python file which ends with '.py' for option '-py', got '%s'.",
+                                entryPointScript));
+            }
         } else if (commandLine.hasOption(PYMODULE_OPTION.getOpt())) {
             entryPointModule = commandLine.getOptionValue(PYMODULE_OPTION.getOpt());
         } else {

--- a/flink-python/src/test/java/org/apache/flink/client/python/PythonDriverTest.java
+++ b/flink-python/src/test/java/org/apache/flink/client/python/PythonDriverTest.java
@@ -65,11 +65,12 @@ public class PythonDriverTest {
         args.add("--input");
         args.add("in.txt");
 
-        PythonDriverOptions pythonDriverOptions = new PythonDriverOptions(null, "xxx", args);
+        PythonDriverOptions pythonDriverOptions = new PythonDriverOptions(null, "xxx.py", args);
         List<String> commands = PythonDriver.constructPythonCommands(pythonDriverOptions);
-        Assert.assertEquals(3, commands.size());
-        Assert.assertEquals(commands.get(0), "xxx");
-        Assert.assertEquals(commands.get(1), "--input");
-        Assert.assertEquals(commands.get(2), "in.txt");
+        Assert.assertEquals(4, commands.size());
+        Assert.assertEquals(commands.get(0), "-m");
+        Assert.assertEquals(commands.get(1), "xxx");
+        Assert.assertEquals(commands.get(2), "--input");
+        Assert.assertEquals(commands.get(3), "in.txt");
     }
 }


### PR DESCRIPTION

## What is the purpose of the change

*Currently, the command line option '-py' doesn't work in YARN application mode. The root cause is that the passed Python script is accessed in a separate working directory from the working directory managed by YARN. This makes the Python script could not be accessed.*

## Verifying this change

Verified manually and will add an end to end test case in a separate ticket to cover this.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
