### PR TITLE
[FLINK-26074] Improve FlameGraphs scalability for high parallelism jobs

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/messages/TaskThreadInfoResponse.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/messages/TaskThreadInfoResponse.java
@@ -21,30 +21,30 @@ package org.apache.flink.runtime.messages;
 import org.apache.flink.util.Preconditions;
 
 import java.io.Serializable;
-import java.util.List;
+import java.util.Collection;
 
 /** Response to the request to collect thread details samples. */
 public class TaskThreadInfoResponse implements Serializable {
 
     private static final long serialVersionUID = -4786454630050578031L;
 
-    private final List<ThreadInfoSample> samples;
+    private final Collection<ThreadInfoSample> samples;
 
     /**
      * Creates a response to the request to collect thread details samples.
      *
      * @param samples Thread info samples.
      */
-    public TaskThreadInfoResponse(List<ThreadInfoSample> samples) {
+    public TaskThreadInfoResponse(Collection<ThreadInfoSample> samples) {
         this.samples = Preconditions.checkNotNull(samples);
     }
 
     /**
-     * Returns a list of ThreadInfoSample.
+     * Returns a collection of ThreadInfoSample.
      *
-     * @return List of thread info samples for a particular execution attempt (Task)
+     * @return A collection of thread info samples for a particular execution attempt (Task)
      */
-    public List<ThreadInfoSample> getSamples() {
+    public Collection<ThreadInfoSample> getSamples() {
         return samples;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/messages/ThreadInfoSample.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/messages/ThreadInfoSample.java
@@ -22,7 +22,9 @@ import javax.annotation.Nullable;
 
 import java.io.Serializable;
 import java.lang.management.ThreadInfo;
+import java.util.Collection;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * A serializable wrapper container for transferring parts of the {@link
@@ -54,11 +56,27 @@ public class ThreadInfoSample implements Serializable {
         }
     }
 
+    /**
+     * Constructs a collection of {@link ThreadInfoSample}s from a collection of {@link ThreadInfo}
+     * samples.
+     *
+     * @param threadInfos the collection of {@link ThreadInfo}.
+     * @return the collection of the corresponding {@link ThreadInfoSample}s.
+     */
+    public static Collection<ThreadInfoSample> from(Collection<ThreadInfo> threadInfos) {
+        return threadInfos.stream()
+                .map(
+                        threadInfo ->
+                                new ThreadInfoSample(
+                                        threadInfo.getThreadState(), threadInfo.getStackTrace()))
+                .collect(Collectors.toList());
+    }
+
     public Thread.State getThreadState() {
         return threadState;
     }
 
     public StackTraceElement[] getStackTrace() {
-        return stackTrace.clone();
+        return stackTrace;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -546,23 +546,29 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 
     @Override
     public CompletableFuture<TaskThreadInfoResponse> requestThreadInfoSamples(
-            final ExecutionAttemptID taskExecutionAttemptId,
+            final Collection<ExecutionAttemptID> taskExecutionAttemptIds,
             final ThreadInfoSamplesRequest requestParams,
             final Time timeout) {
 
-        final Task task = taskSlotTable.getTask(taskExecutionAttemptId);
-        if (task == null) {
-            return FutureUtils.completedExceptionally(
-                    new IllegalStateException(
-                            String.format(
-                                    "Cannot sample task %s. "
-                                            + "Task is not known to the task manager.",
-                                    taskExecutionAttemptId)));
+        final Collection<Task> tasks = new ArrayList<>();
+        for (ExecutionAttemptID executionAttemptId : taskExecutionAttemptIds) {
+            final Task task = taskSlotTable.getTask(executionAttemptId);
+            if (task == null) {
+                log.warn(
+                        String.format(
+                                "Cannot sample task %s. "
+                                        + "Task is not known to the task manager.",
+                                executionAttemptId));
+            } else {
+                tasks.add(task);
+            }
         }
 
-        final CompletableFuture<List<ThreadInfoSample>> stackTracesFuture =
-                threadInfoSampleService.requestThreadInfoSamples(
-                        SampleableTaskAdapter.fromTask(task), requestParams);
+        Collection<SampleableTask> sampleableTasks =
+                tasks.stream().map(SampleableTaskAdapter::fromTask).collect(Collectors.toList());
+
+        final CompletableFuture<Collection<ThreadInfoSample>> stackTracesFuture =
+                threadInfoSampleService.requestThreadInfoSamples(sampleableTasks, requestParams);
 
         return stackTracesFuture.thenApply(TaskThreadInfoResponse::new);
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGatewayDecoratorBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGatewayDecoratorBase.java
@@ -231,10 +231,10 @@ public class TaskExecutorGatewayDecoratorBase implements TaskExecutorGateway {
 
     @Override
     public CompletableFuture<TaskThreadInfoResponse> requestThreadInfoSamples(
-            ExecutionAttemptID taskExecutionAttemptId,
+            Collection<ExecutionAttemptID> taskExecutionAttemptIds,
             ThreadInfoSamplesRequest requestParams,
             Time timeout) {
         return originalGateway.requestThreadInfoSamples(
-                taskExecutionAttemptId, requestParams, timeout);
+                taskExecutionAttemptIds, requestParams, timeout);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorThreadInfoGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorThreadInfoGateway.java
@@ -23,20 +23,22 @@ import org.apache.flink.runtime.messages.TaskThreadInfoResponse;
 import org.apache.flink.runtime.rpc.RpcTimeout;
 import org.apache.flink.runtime.webmonitor.threadinfo.ThreadInfoSamplesRequest;
 
+import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 
 /** RPC gateway for requesting {@link org.apache.flink.runtime.messages.ThreadInfoSample}. */
 public interface TaskExecutorThreadInfoGateway {
+
     /**
-     * Request a thread info sample from the given task.
+     * Request a thread info sample from the given tasks.
      *
-     * @param taskExecutionAttemptId identifying the task to sample
+     * @param taskExecutionAttemptIds identifying the task to sample
      * @param requestParams parameters of the request
      * @param timeout of the request
      * @return Future of stack trace sample response
      */
     CompletableFuture<TaskThreadInfoResponse> requestThreadInfoSamples(
-            ExecutionAttemptID taskExecutionAttemptId,
+            Collection<ExecutionAttemptID> taskExecutionAttemptIds,
             ThreadInfoSamplesRequest requestParams,
             @RpcTimeout Time timeout);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/JvmUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/JvmUtils.java
@@ -20,15 +20,23 @@ package org.apache.flink.runtime.util;
 
 import org.apache.flink.runtime.messages.ThreadInfoSample;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 /** Utilities for {@link java.lang.management.ManagementFactory}. */
 public final class JvmUtils {
+
+    private static final Logger LOG = LoggerFactory.getLogger(JvmUtils.class);
 
     /**
      * Creates a thread dump of the current JVM.
@@ -54,6 +62,39 @@ public final class JvmUtils {
         ThreadMXBean threadMxBean = ManagementFactory.getThreadMXBean();
 
         return ThreadInfoSample.from(threadMxBean.getThreadInfo(threadId, maxStackTraceDepth));
+    }
+
+    /**
+     * Creates a {@link ThreadInfoSample} for a specific thread. Contains thread traces if
+     * maxStackTraceDepth > 0.
+     *
+     * @param threadIds The IDs of the threads to create the thread dump for.
+     * @param maxStackTraceDepth The maximum number of entries in the stack trace to be collected.
+     * @return The thread information for the requested thread IDs.
+     */
+    public static Collection<ThreadInfoSample> createThreadInfoSample(
+            Collection<Long> threadIds, int maxStackTraceDepth) {
+        ThreadMXBean threadMxBean = ManagementFactory.getThreadMXBean();
+        long[] threadIdsArray = threadIds.stream().mapToLong(l -> l).toArray();
+
+        ThreadInfo[] threadInfo = threadMxBean.getThreadInfo(threadIdsArray, maxStackTraceDepth);
+
+        List<ThreadInfo> threadInfoNoNulls =
+                IntStream.range(0, threadIdsArray.length)
+                        .filter(
+                                i -> {
+                                    if (threadInfo[i] == null) {
+                                        LOG.debug(
+                                                "FlameGraphs: thread {} is not alive or does not exist.",
+                                                threadIdsArray[i]);
+                                        return false;
+                                    }
+                                    return true;
+                                })
+                        .mapToObj(i -> threadInfo[i])
+                        .collect(Collectors.toList());
+
+        return ThreadInfoSample.from(threadInfoNoNulls);
     }
 
     /** Private default constructor to avoid instantiation. */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/stats/TaskStatsRequestCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/stats/TaskStatsRequestCoordinator.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.webmonitor.stats;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 
+import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableSet;
 import org.apache.flink.shaded.guava30.com.google.common.collect.Maps;
 
 import org.slf4j.Logger;
@@ -39,13 +40,14 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
- * Encapsulates the common functionality for requesting statistics from individual tasks and
- * combining their responses.
+ * Encapsulates the common functionality for requesting statistics from tasks and combining their
+ * responses.
  *
  * @param <T> Type of the statistics to be gathered.
  * @param <V> Type of the combined response.
@@ -60,7 +62,7 @@ public class TaskStatsRequestCoordinator<T, V> {
     /** Executor used to run the futures. */
     protected final Executor executor;
 
-    /** Request time out of a triggered task stats request. */
+    /** Request time out of the triggered tasks stats request. */
     protected final Duration requestTimeout;
 
     /** In progress samples. */
@@ -84,7 +86,7 @@ public class TaskStatsRequestCoordinator<T, V> {
      * Creates a new coordinator for the cluster.
      *
      * @param executor Used to execute the futures.
-     * @param requestTimeout Request time out of a triggered task stats request.
+     * @param requestTimeout Request time out of the triggered tasks stats request.
      */
     public TaskStatsRequestCoordinator(Executor executor, Duration requestTimeout) {
         checkNotNull(requestTimeout, "The request timeout must cannot be null.");
@@ -138,30 +140,36 @@ public class TaskStatsRequestCoordinator<T, V> {
     }
 
     /**
-     * Handles the successfully returned task stats response by collecting the corresponding subtask
-     * samples.
+     * Handles the successfully returned tasks stats response by collecting the corresponding
+     * subtask samples.
      *
      * @param requestId ID of the request.
-     * @param executionId ID of the sampled task.
+     * @param executionIds ID of the sampled task.
      * @param result Result of stats request returned by an individual task.
      * @throws IllegalStateException If unknown request ID and not recently finished or cancelled
      *     sample.
      */
-    public void handleSuccessfulResponse(int requestId, ExecutionAttemptID executionId, T result) {
+    public void handleSuccessfulResponse(
+            int requestId, ImmutableSet<ExecutionAttemptID> executionIds, T result) {
 
         synchronized (lock) {
             if (isShutDown) {
                 return;
             }
 
+            final String ids =
+                    executionIds.stream()
+                            .map(ExecutionAttemptID::toString)
+                            .collect(Collectors.joining(", "));
+
             if (log.isDebugEnabled()) {
-                log.debug("Collecting stats sample {} of task {}", requestId, executionId);
+                log.debug("Collecting stats sample {} of tasks {}", requestId, ids);
             }
 
             PendingStatsRequest<T, V> pending = pendingRequests.get(requestId);
 
             if (pending != null) {
-                pending.collectTaskStats(executionId, result);
+                pending.collectTaskStats(executionIds, result);
 
                 // Publish the sample
                 if (pending.isComplete()) {
@@ -172,7 +180,7 @@ public class TaskStatsRequestCoordinator<T, V> {
                 }
             } else if (recentPendingRequestIds.contains(requestId)) {
                 if (log.isDebugEnabled()) {
-                    log.debug("Received late stats sample {} of task {}", requestId, executionId);
+                    log.debug("Received late stats sample {} of tasks {}", requestId, ids);
                 }
             } else {
                 if (log.isDebugEnabled()) {
@@ -217,12 +225,12 @@ public class TaskStatsRequestCoordinator<T, V> {
         protected final long startTime;
 
         /** All tasks what did not yet return a result. */
-        protected final Set<ExecutionAttemptID> pendingTasks;
+        protected final Set<Set<ExecutionAttemptID>> pendingTasks;
 
         /**
          * Results returned by individual tasks and stored by the tasks' {@link ExecutionAttemptID}.
          */
-        protected final Map<ExecutionAttemptID, T> statsResultByTask;
+        protected final Map<ImmutableSet<ExecutionAttemptID>, T> statsResultByTaskGroup;
 
         /** The future with the final result. */
         protected final CompletableFuture<V> resultFuture;
@@ -236,11 +244,11 @@ public class TaskStatsRequestCoordinator<T, V> {
          * @param tasksToCollect tasks from which the stats responses are expected.
          */
         protected PendingStatsRequest(
-                int requestId, Collection<ExecutionAttemptID> tasksToCollect) {
+                int requestId, Collection<? extends Set<ExecutionAttemptID>> tasksToCollect) {
             this.requestId = requestId;
             this.startTime = System.currentTimeMillis();
             this.pendingTasks = new HashSet<>(tasksToCollect);
-            this.statsResultByTask = Maps.newHashMapWithExpectedSize(tasksToCollect.size());
+            this.statsResultByTaskGroup = Maps.newHashMapWithExpectedSize(tasksToCollect.size());
             this.resultFuture = new CompletableFuture<>();
         }
 
@@ -253,7 +261,7 @@ public class TaskStatsRequestCoordinator<T, V> {
         protected void discard(Throwable cause) {
             if (!isDiscarded) {
                 pendingTasks.clear();
-                statsResultByTask.clear();
+                statsResultByTaskGroup.clear();
 
                 resultFuture.completeExceptionally(new RuntimeException("Discarded", cause));
 
@@ -267,11 +275,12 @@ public class TaskStatsRequestCoordinator<T, V> {
          * @param executionId ID of the Task.
          * @param taskStatsResult Result of the stats sample from the Task.
          */
-        protected void collectTaskStats(ExecutionAttemptID executionId, T taskStatsResult) {
+        protected void collectTaskStats(
+                ImmutableSet<ExecutionAttemptID> executionId, T taskStatsResult) {
             checkDiscarded();
 
             if (pendingTasks.remove(executionId)) {
-                statsResultByTask.put(executionId, taskStatsResult);
+                statsResultByTaskGroup.put(executionId, taskStatsResult);
             } else if (isComplete()) {
                 throw new IllegalStateException("Completed");
             } else {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/threadinfo/JobVertexFlameGraphFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/threadinfo/JobVertexFlameGraphFactory.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.webmonitor.threadinfo;
 import org.apache.flink.runtime.messages.ThreadInfoSample;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -74,7 +75,8 @@ public class JobVertexFlameGraphFactory {
     private static JobVertexFlameGraph createFlameGraphFromSample(
             JobVertexThreadInfoStats sample, Set<Thread.State> threadStates) {
         final NodeBuilder root = new NodeBuilder("root");
-        for (List<ThreadInfoSample> threadInfoSubSamples : sample.getSamplesBySubtask().values()) {
+        for (Collection<ThreadInfoSample> threadInfoSubSamples :
+                sample.getSamplesBySubtask().values()) {
             for (ThreadInfoSample threadInfo : threadInfoSubSamples) {
                 if (threadStates.contains(threadInfo.getThreadState())) {
                     StackTraceElement[] traces = threadInfo.getStackTrace();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/threadinfo/JobVertexThreadInfoStats.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/threadinfo/JobVertexThreadInfoStats.java
@@ -22,8 +22,10 @@ import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.messages.ThreadInfoSample;
 import org.apache.flink.runtime.webmonitor.stats.Statistics;
 
+import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableSet;
+
+import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
@@ -44,7 +46,8 @@ public class JobVertexThreadInfoStats implements Statistics {
     private final long endTime;
 
     /** Map of thread info samples by execution ID. */
-    private final Map<ExecutionAttemptID, List<ThreadInfoSample>> samplesBySubtask;
+    private final Map<ImmutableSet<ExecutionAttemptID>, Collection<ThreadInfoSample>>
+            samplesBySubtask;
 
     /**
      * Creates a thread details sample.
@@ -58,7 +61,7 @@ public class JobVertexThreadInfoStats implements Statistics {
             int requestId,
             long startTime,
             long endTime,
-            Map<ExecutionAttemptID, List<ThreadInfoSample>> samplesBySubtask) {
+            Map<ImmutableSet<ExecutionAttemptID>, Collection<ThreadInfoSample>> samplesBySubtask) {
 
         checkArgument(requestId >= 0, "Negative request ID");
         checkArgument(startTime >= 0, "Negative start time");
@@ -103,7 +106,8 @@ public class JobVertexThreadInfoStats implements Statistics {
      *
      * @return Map of thread info samples by task (execution ID)
      */
-    public Map<ExecutionAttemptID, List<ThreadInfoSample>> getSamplesBySubtask() {
+    public Map<ImmutableSet<ExecutionAttemptID>, Collection<ThreadInfoSample>>
+            getSamplesBySubtask() {
         return samplesBySubtask;
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/threadinfo/JobVertexThreadInfoTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/threadinfo/JobVertexThreadInfoTracker.java
@@ -35,6 +35,7 @@ import org.apache.flink.runtime.webmonitor.stats.JobVertexStatsTracker;
 import org.apache.flink.runtime.webmonitor.stats.Statistics;
 
 import org.apache.flink.shaded.guava30.com.google.common.cache.Cache;
+import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableSet;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,6 +56,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -204,38 +206,73 @@ public class JobVertexThreadInfoTracker<T extends Statistics> implements JobVert
         }
     }
 
-    private Map<ExecutionAttemptID, CompletableFuture<TaskExecutorThreadInfoGateway>>
+    private Map<ImmutableSet<ExecutionAttemptID>, CompletableFuture<TaskExecutorThreadInfoGateway>>
             matchExecutionsWithGateways(
                     AccessExecutionVertex[] executionVertices,
                     ResourceManagerGateway resourceManagerGateway) {
 
-        Map<ExecutionAttemptID, CompletableFuture<TaskExecutorThreadInfoGateway>>
+        // Group executions by their TaskManagerLocation to be able to issue one sampling
+        // request per TaskManager for all relevant tasks at once
+        final Map<TaskManagerLocation, ImmutableSet<ExecutionAttemptID>> executionsByLocation =
+                groupExecutionsByLocation(executionVertices);
+
+        return mapExecutionsToGateways(resourceManagerGateway, executionsByLocation);
+    }
+
+    private Map<ImmutableSet<ExecutionAttemptID>, CompletableFuture<TaskExecutorThreadInfoGateway>>
+            mapExecutionsToGateways(
+                    ResourceManagerGateway resourceManagerGateway,
+                    Map<TaskManagerLocation, ImmutableSet<ExecutionAttemptID>> verticesByLocation) {
+
+        final Map<
+                        ImmutableSet<ExecutionAttemptID>,
+                        CompletableFuture<TaskExecutorThreadInfoGateway>>
                 executionsWithGateways = new HashMap<>();
 
+        for (Map.Entry<TaskManagerLocation, ImmutableSet<ExecutionAttemptID>> entry :
+                verticesByLocation.entrySet()) {
+            TaskManagerLocation tmLocation = entry.getKey();
+            ImmutableSet<ExecutionAttemptID> attemptIds = entry.getValue();
+
+            CompletableFuture<TaskExecutorThreadInfoGateway> taskExecutorGatewayFuture =
+                    resourceManagerGateway.requestTaskExecutorThreadInfoGateway(
+                            tmLocation.getResourceID(), rpcTimeout);
+
+            executionsWithGateways.put(attemptIds, taskExecutorGatewayFuture);
+        }
+        return executionsWithGateways;
+    }
+
+    private Map<TaskManagerLocation, ImmutableSet<ExecutionAttemptID>> groupExecutionsByLocation(
+            AccessExecutionVertex[] executionVertices) {
+
+        final Map<TaskManagerLocation, Set<ExecutionAttemptID>> executionAttemptsByLocation =
+                new HashMap<>();
+
         for (AccessExecutionVertex executionVertex : executionVertices) {
-            TaskManagerLocation tmLocation = executionVertex.getCurrentAssignedResourceLocation();
-
-            if (tmLocation != null) {
-                CompletableFuture<TaskExecutorThreadInfoGateway> taskExecutorGatewayFuture =
-                        resourceManagerGateway.requestTaskExecutorThreadInfoGateway(
-                                tmLocation.getResourceID(), rpcTimeout);
-
-                if (executionVertex.getExecutionState() == ExecutionState.RUNNING) {
-                    executionsWithGateways.put(
-                            executionVertex.getCurrentExecutionAttempt().getAttemptId(),
-                            taskExecutorGatewayFuture);
-                } else {
-                    LOG.trace(
-                            "{} not running, but {}; not sampling",
-                            executionVertex.getTaskNameWithSubtaskIndex(),
-                            executionVertex.getExecutionState());
-                }
-            } else {
-                LOG.trace("ExecutionVertex {} is currently not assigned", executionVertex);
+            if (executionVertex.getExecutionState() != ExecutionState.RUNNING) {
+                LOG.trace(
+                        "{} not running, but {}; not sampling",
+                        executionVertex.getTaskNameWithSubtaskIndex(),
+                        executionVertex.getExecutionState());
+                continue;
             }
+            TaskManagerLocation tmLocation = executionVertex.getCurrentAssignedResourceLocation();
+            if (tmLocation == null) {
+                LOG.trace("ExecutionVertex {} is currently not assigned", executionVertex);
+                continue;
+            }
+            Set<ExecutionAttemptID> groupedAttemptIds =
+                    executionAttemptsByLocation.getOrDefault(tmLocation, new HashSet<>());
+
+            ExecutionAttemptID attemptId =
+                    executionVertex.getCurrentExecutionAttempt().getAttemptId();
+            groupedAttemptIds.add(attemptId);
+            executionAttemptsByLocation.put(tmLocation, ImmutableSet.copyOf(groupedAttemptIds));
         }
 
-        return executionsWithGateways;
+        return executionAttemptsByLocation.entrySet().stream()
+                .collect(Collectors.toMap(e -> e.getKey(), e -> ImmutableSet.copyOf(e.getValue())));
     }
 
     @VisibleForTesting

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/threadinfo/ThreadInfoRequestCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/threadinfo/ThreadInfoRequestCoordinator.java
@@ -26,11 +26,12 @@ import org.apache.flink.runtime.taskexecutor.TaskExecutorThreadInfoGateway;
 import org.apache.flink.runtime.webmonitor.stats.TaskStatsRequestCoordinator;
 import org.apache.flink.util.concurrent.FutureUtils;
 
+import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableSet;
+
 import java.time.Duration;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
@@ -39,7 +40,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** A coordinator for triggering and collecting thread info stats of running job vertex subtasks. */
 public class ThreadInfoRequestCoordinator
-        extends TaskStatsRequestCoordinator<List<ThreadInfoSample>, JobVertexThreadInfoStats> {
+        extends TaskStatsRequestCoordinator<
+                Collection<ThreadInfoSample>, JobVertexThreadInfoStats> {
 
     /**
      * Creates a new coordinator for the job.
@@ -58,7 +60,7 @@ public class ThreadInfoRequestCoordinator
      * from given subtasks. A thread info response of a subtask in turn consists of {@code
      * numSamples}, collected with {@code delayBetweenSamples} milliseconds delay between them.
      *
-     * @param executionWithGateways Execution vertices together with TaskExecutors running them.
+     * @param executionsWithGateways Execution attempts together with TaskExecutors running them.
      * @param numSamples Number of thread info samples to collect from each subtask.
      * @param delayBetweenSamples Delay between consecutive samples (ms).
      * @param maxStackTraceDepth Maximum depth of the stack traces collected within thread info
@@ -66,20 +68,20 @@ public class ThreadInfoRequestCoordinator
      * @return A future of the completed thread info stats.
      */
     public CompletableFuture<JobVertexThreadInfoStats> triggerThreadInfoRequest(
-            Map<ExecutionAttemptID, CompletableFuture<TaskExecutorThreadInfoGateway>>
-                    executionWithGateways,
+            Map<ImmutableSet<ExecutionAttemptID>, CompletableFuture<TaskExecutorThreadInfoGateway>>
+                    executionsWithGateways,
             int numSamples,
             Duration delayBetweenSamples,
             int maxStackTraceDepth) {
 
-        checkNotNull(executionWithGateways, "Tasks to sample");
-        checkArgument(executionWithGateways.size() > 0, "No tasks to sample");
+        checkNotNull(executionsWithGateways, "Tasks to sample");
+        checkArgument(executionsWithGateways.size() > 0, "No tasks to sample");
         checkArgument(numSamples >= 1, "No number of samples");
         checkArgument(maxStackTraceDepth >= 0, "Negative maximum stack trace depth");
 
-        // Execution IDs of running tasks
-        Collection<ExecutionAttemptID> runningSubtasksIds =
-                Collections.unmodifiableSet(executionWithGateways.keySet());
+        // Execution IDs of running tasks grouped by the task manager
+        Collection<ImmutableSet<ExecutionAttemptID>> runningSubtasksIds =
+                executionsWithGateways.keySet();
 
         synchronized (lock) {
             if (isShutDown) {
@@ -108,7 +110,7 @@ public class ThreadInfoRequestCoordinator
                     new ThreadInfoSamplesRequest(
                             requestId, numSamples, delayBetweenSamples, maxStackTraceDepth);
 
-            requestThreadInfo(executionWithGateways, requestParams, timeout);
+            requestThreadInfo(executionsWithGateways, requestParams, timeout);
 
             return pending.getStatsFuture();
         }
@@ -119,13 +121,15 @@ public class ThreadInfoRequestCoordinator
      * return within timeout.
      */
     private void requestThreadInfo(
-            Map<ExecutionAttemptID, CompletableFuture<TaskExecutorThreadInfoGateway>>
+            Map<ImmutableSet<ExecutionAttemptID>, CompletableFuture<TaskExecutorThreadInfoGateway>>
                     executionWithGateways,
             ThreadInfoSamplesRequest requestParams,
             Time timeout) {
 
         // Trigger samples collection from all subtasks
-        for (Map.Entry<ExecutionAttemptID, CompletableFuture<TaskExecutorThreadInfoGateway>>
+        for (Map.Entry<
+                        ImmutableSet<ExecutionAttemptID>,
+                        CompletableFuture<TaskExecutorThreadInfoGateway>>
                 executionWithGateway : executionWithGateways.entrySet()) {
 
             CompletableFuture<TaskExecutorThreadInfoGateway> executorGatewayFuture =
@@ -155,15 +159,17 @@ public class ThreadInfoRequestCoordinator
     // ------------------------------------------------------------------------
 
     private static class PendingThreadInfoRequest
-            extends PendingStatsRequest<List<ThreadInfoSample>, JobVertexThreadInfoStats> {
+            extends PendingStatsRequest<Collection<ThreadInfoSample>, JobVertexThreadInfoStats> {
 
-        PendingThreadInfoRequest(int requestId, Collection<ExecutionAttemptID> tasksToCollect) {
+        PendingThreadInfoRequest(
+                int requestId, Collection<? extends Set<ExecutionAttemptID>> tasksToCollect) {
             super(requestId, tasksToCollect);
         }
 
         @Override
         protected JobVertexThreadInfoStats assembleCompleteStats(long endTime) {
-            return new JobVertexThreadInfoStats(requestId, startTime, endTime, statsResultByTask);
+            return new JobVertexThreadInfoStats(
+                    requestId, startTime, endTime, statsResultByTaskGroup);
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/IdleTestTask.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/IdleTestTask.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskexecutor;
+
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.util.FlinkRuntimeException;
+import org.apache.flink.util.function.RunnableWithException;
+
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+
+import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.createExecutionAttemptId;
+
+/** The test task that creates an idle (sleeping) thread. */
+public class IdleTestTask implements SampleableTask {
+
+    private final ExecutionAttemptID executionAttemptID = createExecutionAttemptId();
+    private final Thread thread;
+    private volatile boolean stopped = false;
+
+    /** Instantiates a new idle test task with default sleep duration (10s). */
+    public IdleTestTask() {
+        this(10000L);
+    }
+
+    /**
+     * Instantiates a new idle test task.
+     *
+     * @param sleepDuration the sleep duration
+     */
+    public IdleTestTask(long sleepDuration) {
+        CountDownLatch startSignal = new CountDownLatch(1);
+        thread =
+                new Thread(
+                        () -> {
+                            while (!stopped) {
+                                try {
+                                    startSignal.countDown();
+                                    Thread.sleep(sleepDuration);
+                                } catch (InterruptedException e) {
+                                    Thread.currentThread().interrupt();
+                                }
+                            }
+                        });
+        thread.setDaemon(true);
+        thread.start();
+        try {
+            startSignal.await(); // This ensures that the new test task always has a stack trace.
+        } catch (InterruptedException e) {
+            throw new FlinkRuntimeException(e);
+        }
+    }
+
+    @Override
+    public Thread getExecutingThread() {
+        return thread;
+    }
+
+    @Override
+    public ExecutionAttemptID getExecutionId() {
+        return executionAttemptID;
+    }
+
+    public void start() {
+        thread.setDaemon(true);
+        thread.start();
+        stopped = false;
+    }
+
+    public void stop() {
+        this.stopped = true;
+    }
+
+    public static void executeWithTerminationGuarantee(
+            RunnableWithException code, Set<IdleTestTask> tasks) throws Exception {
+        try {
+            code.run();
+        } finally {
+            for (IdleTestTask task : tasks) {
+                task.stop();
+            }
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGateway.java
@@ -343,8 +343,8 @@ public class TestingTaskExecutorGateway implements TaskExecutorGateway {
 
     @Override
     public CompletableFuture<TaskThreadInfoResponse> requestThreadInfoSamples(
-            ExecutionAttemptID taskExecutionAttemptId,
-            ThreadInfoSamplesRequest threadInfoSamplesRequest,
+            Collection<ExecutionAttemptID> taskExecutionAttemptIds,
+            ThreadInfoSamplesRequest requestParams,
             Time timeout) {
         return requestThreadInfoSamplesSupplier.get();
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/ThreadInfoSampleServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/ThreadInfoSampleServiceTest.java
@@ -19,32 +19,26 @@
 
 package org.apache.flink.runtime.taskexecutor;
 
-import org.apache.flink.core.testutils.FlinkMatchers;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.messages.ThreadInfoSample;
 import org.apache.flink.runtime.webmonitor.threadinfo.ThreadInfoSamplesRequest;
 import org.apache.flink.util.TestLogger;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
-import java.util.List;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 
-import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.createExecutionAttemptId;
-import static org.hamcrest.Matchers.arrayWithSize;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.lessThanOrEqualTo;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.apache.flink.runtime.taskexecutor.IdleTestTask.executeWithTerminationGuarantee;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link ThreadInfoSampleService}. */
 public class ThreadInfoSampleServiceTest extends TestLogger {
@@ -57,17 +51,15 @@ public class ThreadInfoSampleServiceTest extends TestLogger {
             new ThreadInfoSamplesRequest(
                     1, NUMBER_OF_SAMPLES, DELAY_BETWEEN_SAMPLES, MAX_STACK_TRACK_DEPTH);
 
-    @ClassRule public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
-
     private ThreadInfoSampleService threadInfoSampleService;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         threadInfoSampleService =
                 new ThreadInfoSampleService(Executors.newSingleThreadScheduledExecutor());
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         if (threadInfoSampleService != null) {
             threadInfoSampleService.close();
@@ -75,102 +67,106 @@ public class ThreadInfoSampleServiceTest extends TestLogger {
     }
 
     /** Tests successful thread info samples request. */
-    @Test(timeout = 10000L)
+    @Test
     public void testSampleTaskThreadInfo() throws Exception {
-        final List<ThreadInfoSample> threadInfoSamples =
-                threadInfoSampleService
-                        .requestThreadInfoSamples(new TestTask(), requestParams)
-                        .get();
+        Set<IdleTestTask> tasks = new HashSet<>();
+        executeWithTerminationGuarantee(
+                () -> {
+                    tasks.add(new IdleTestTask());
+                    tasks.add(new IdleTestTask());
+                    Thread.sleep(2000);
+                    final Collection<ThreadInfoSample> threadInfoSamples =
+                            threadInfoSampleService
+                                    .requestThreadInfoSamples(tasks, requestParams)
+                                    .get();
 
-        assertThat(threadInfoSamples, hasSize(NUMBER_OF_SAMPLES));
+                    assertThat(threadInfoSamples).hasSize(NUMBER_OF_SAMPLES * 2);
 
-        for (ThreadInfoSample sample : threadInfoSamples) {
-            StackTraceElement[] traces = sample.getStackTrace();
-            assertTrue(sample.getStackTrace().length <= MAX_STACK_TRACK_DEPTH);
-            assertThat(traces, is(arrayWithSize(lessThanOrEqualTo(MAX_STACK_TRACK_DEPTH))));
-        }
+                    for (ThreadInfoSample sample : threadInfoSamples) {
+                        StackTraceElement[] traces = sample.getStackTrace();
+                        assertThat(traces).hasSizeLessThanOrEqualTo(MAX_STACK_TRACK_DEPTH);
+                    }
+                },
+                tasks);
     }
 
     /** Tests that stack traces are truncated when exceeding the configured depth. */
-    @Test(timeout = 10000L)
+    @Test
     public void testTruncateStackTraceIfLimitIsSpecified() throws Exception {
-        final List<ThreadInfoSample> threadInfoSamples1 =
-                threadInfoSampleService
-                        .requestThreadInfoSamples(new TestTask(), requestParams)
-                        .get();
+        Set<IdleTestTask> tasks = new HashSet<>();
+        executeWithTerminationGuarantee(
+                () -> {
+                    tasks.add(new IdleTestTask());
+                    final Collection<ThreadInfoSample> threadInfoSamples1 =
+                            threadInfoSampleService
+                                    .requestThreadInfoSamples(tasks, requestParams)
+                                    .get();
 
-        final List<ThreadInfoSample> threadInfoSamples2 =
-                threadInfoSampleService
-                        .requestThreadInfoSamples(
-                                new TestTask(),
-                                new ThreadInfoSamplesRequest(
-                                        1,
-                                        NUMBER_OF_SAMPLES,
-                                        DELAY_BETWEEN_SAMPLES,
-                                        MAX_STACK_TRACK_DEPTH - 5))
-                        .get();
+                    final Collection<ThreadInfoSample> threadInfoSamples2 =
+                            threadInfoSampleService
+                                    .requestThreadInfoSamples(
+                                            tasks,
+                                            new ThreadInfoSamplesRequest(
+                                                    1,
+                                                    NUMBER_OF_SAMPLES,
+                                                    DELAY_BETWEEN_SAMPLES,
+                                                    MAX_STACK_TRACK_DEPTH - 6))
+                                    .get();
 
-        for (ThreadInfoSample sample : threadInfoSamples1) {
-            assertThat(
-                    sample.getStackTrace(),
-                    is(arrayWithSize(lessThanOrEqualTo(MAX_STACK_TRACK_DEPTH))));
-            assertTrue(sample.getStackTrace().length <= MAX_STACK_TRACK_DEPTH);
-        }
+                    for (ThreadInfoSample sample : threadInfoSamples1) {
+                        assertThat(sample.getStackTrace())
+                                .hasSizeLessThanOrEqualTo(MAX_STACK_TRACK_DEPTH);
+                    }
 
-        for (ThreadInfoSample sample : threadInfoSamples2) {
-            assertThat(sample.getStackTrace(), is(arrayWithSize(MAX_STACK_TRACK_DEPTH - 5)));
-        }
+                    for (ThreadInfoSample sample : threadInfoSamples2) {
+                        assertThat(sample.getStackTrace()).hasSize(MAX_STACK_TRACK_DEPTH - 6);
+                    }
+                },
+                tasks);
     }
 
     /** Test that negative numSamples parameter is handled. */
     @Test
     public void testThrowExceptionIfNumSamplesIsNegative() {
-        try {
-            threadInfoSampleService.requestThreadInfoSamples(
-                    new TestTask(),
-                    new ThreadInfoSamplesRequest(
-                            1, -1, DELAY_BETWEEN_SAMPLES, MAX_STACK_TRACK_DEPTH));
-            fail("Expected exception not thrown");
-        } catch (final IllegalArgumentException e) {
-            assertThat(e.getMessage(), is(equalTo("numSamples must be positive")));
-        }
+        Set<IdleTestTask> tasks = new HashSet<>();
+        assertThatThrownBy(
+                        () ->
+                                executeWithTerminationGuarantee(
+                                        () -> {
+                                            tasks.add(new IdleTestTask());
+                                            threadInfoSampleService.requestThreadInfoSamples(
+                                                    tasks,
+                                                    new ThreadInfoSamplesRequest(
+                                                            1,
+                                                            -1,
+                                                            DELAY_BETWEEN_SAMPLES,
+                                                            MAX_STACK_TRACK_DEPTH));
+                                        },
+                                        tasks))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("numSamples must be positive");
     }
 
     /** Test that sampling a non-running task throws an exception. */
     @Test
-    public void testShouldThrowExceptionIfTaskIsNotRunningBeforeSampling() {
-        final CompletableFuture<List<ThreadInfoSample>> sampleFuture =
-                threadInfoSampleService.requestThreadInfoSamples(
-                        new NotRunningTask(), requestParams);
-        assertThat(
-                sampleFuture,
-                FlinkMatchers.futureWillCompleteExceptionally(
-                        IllegalStateException.class, Duration.ofSeconds(10)));
+    public void testShouldThrowExceptionIfTaskIsNotRunningBeforeSampling()
+            throws ExecutionException, InterruptedException {
+        Set<SampleableTask> tasks = new HashSet<>();
+        tasks.add(new NotRunningTask());
+        final CompletableFuture<Collection<ThreadInfoSample>> sampleFuture =
+                threadInfoSampleService.requestThreadInfoSamples(tasks, requestParams);
+
+        assertThat(sampleFuture).failsWithin(Duration.ofSeconds(10));
+        assertThat(sampleFuture.handle((ignored, e) -> e).get())
+                .isInstanceOf(IllegalStateException.class);
     }
 
-    private static class TestTask implements SampleableTask {
+    private static class NotRunningTask implements SampleableTask {
 
-        private final ExecutionAttemptID executionAttemptID = createExecutionAttemptId();
-
-        @Override
-        public Thread getExecutingThread() {
-            return Thread.currentThread();
-        }
-
-        @Override
-        public ExecutionAttemptID getExecutionId() {
-            return executionAttemptID;
-        }
-    }
-
-    private static class NotRunningTask extends TestTask {
-
-        @Override
         public Thread getExecutingThread() {
             return new Thread();
         }
 
-        @Override
         public ExecutionAttemptID getExecutionId() {
             return null;
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/threadinfo/ThreadInfoRequestCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/threadinfo/ThreadInfoRequestCoordinatorTest.java
@@ -21,40 +21,40 @@ package org.apache.flink.runtime.webmonitor.threadinfo;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.messages.TaskThreadInfoResponse;
 import org.apache.flink.runtime.messages.ThreadInfoSample;
+import org.apache.flink.runtime.taskexecutor.IdleTestTask;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorThreadInfoGateway;
 import org.apache.flink.runtime.util.JvmUtils;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.TestLogger;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableSet;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.createExecutionAttemptId;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.emptyArray;
-import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.apache.flink.runtime.taskexecutor.IdleTestTask.executeWithTerminationGuarantee;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Fail.fail;
 
 /** Tests for the {@link ThreadInfoRequestCoordinator}. */
 public class ThreadInfoRequestCoordinatorTest extends TestLogger {
@@ -69,30 +69,28 @@ public class ThreadInfoRequestCoordinatorTest extends TestLogger {
     private static ScheduledExecutorService executorService;
     private ThreadInfoRequestCoordinator coordinator;
 
-    @Rule public Timeout caseTimeout = new Timeout(10, TimeUnit.SECONDS);
-
-    @BeforeClass
+    @BeforeAll
     public static void setUp() throws Exception {
         executorService = new ScheduledThreadPoolExecutor(1);
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDown() throws Exception {
         if (executorService != null) {
             executorService.shutdown();
         }
     }
 
-    @Before
+    @BeforeEach
     public void initCoordinator() throws Exception {
         coordinator = new ThreadInfoRequestCoordinator(executorService, REQUEST_TIMEOUT);
     }
 
-    @After
+    @AfterEach
     public void shutdownCoordinator() throws Exception {
         if (coordinator != null) {
             // verify no more pending request
-            assertEquals(0, coordinator.getNumberOfPendingRequests());
+            assertThat(coordinator.getNumberOfPendingRequests()).isEqualTo(0);
             coordinator.shutDown();
         }
     }
@@ -100,7 +98,7 @@ public class ThreadInfoRequestCoordinatorTest extends TestLogger {
     /** Tests successful thread info stats request. */
     @Test
     public void testSuccessfulThreadInfoRequest() throws Exception {
-        Map<ExecutionAttemptID, CompletableFuture<TaskExecutorThreadInfoGateway>>
+        Map<ImmutableSet<ExecutionAttemptID>, CompletableFuture<TaskExecutorThreadInfoGateway>>
                 executionWithGateways =
                         createMockSubtaskWithGateways(
                                 CompletionType.SUCCESSFULLY, CompletionType.SUCCESSFULLY);
@@ -115,20 +113,21 @@ public class ThreadInfoRequestCoordinatorTest extends TestLogger {
         JobVertexThreadInfoStats threadInfoStats = requestFuture.get();
 
         // verify the request result
-        assertEquals(0, threadInfoStats.getRequestId());
+        assertThat(threadInfoStats.getRequestId()).isEqualTo(0);
 
-        Map<ExecutionAttemptID, List<ThreadInfoSample>> samplesBySubtask =
+        Map<ImmutableSet<ExecutionAttemptID>, Collection<ThreadInfoSample>> samplesBySubtask =
                 threadInfoStats.getSamplesBySubtask();
 
-        for (List<ThreadInfoSample> result : samplesBySubtask.values()) {
-            assertThat(result.get(0).getStackTrace(), not(emptyArray()));
+        for (Collection<ThreadInfoSample> result : samplesBySubtask.values()) {
+            StackTraceElement[] stackTrace = result.iterator().next().getStackTrace();
+            assertThat(stackTrace).isNotEmpty();
         }
     }
 
     /** Tests that failed thread info request to one of the tasks fails the future. */
     @Test
     public void testThreadInfoRequestWithException() throws Exception {
-        Map<ExecutionAttemptID, CompletableFuture<TaskExecutorThreadInfoGateway>>
+        Map<ImmutableSet<ExecutionAttemptID>, CompletableFuture<TaskExecutorThreadInfoGateway>>
                 executionWithGateways =
                         createMockSubtaskWithGateways(
                                 CompletionType.SUCCESSFULLY, CompletionType.EXCEPTIONALLY);
@@ -144,14 +143,14 @@ public class ThreadInfoRequestCoordinatorTest extends TestLogger {
             requestFuture.get();
             fail("Exception expected.");
         } catch (ExecutionException e) {
-            assertTrue(e.getCause() instanceof RuntimeException);
+            assertThat(e.getCause()).isInstanceOf(RuntimeException.class);
         }
     }
 
     /** Tests that thread info stats request times out if not finished in time. */
     @Test
     public void testThreadInfoRequestTimeout() throws Exception {
-        Map<ExecutionAttemptID, CompletableFuture<TaskExecutorThreadInfoGateway>>
+        Map<ImmutableSet<ExecutionAttemptID>, CompletableFuture<TaskExecutorThreadInfoGateway>>
                 executionWithGateways =
                         createMockSubtaskWithGateways(
                                 CompletionType.SUCCESSFULLY, CompletionType.TIMEOUT);
@@ -167,9 +166,10 @@ public class ThreadInfoRequestCoordinatorTest extends TestLogger {
             requestFuture.get();
             fail("Exception expected.");
         } catch (ExecutionException e) {
-            assertTrue(
-                    ExceptionUtils.findThrowableWithMessage(e, REQUEST_TIMEOUT_MESSAGE)
-                            .isPresent());
+            assertThat(
+                            ExceptionUtils.findThrowableWithMessage(e, REQUEST_TIMEOUT_MESSAGE)
+                                    .isPresent())
+                    .isTrue();
         } finally {
             coordinator.shutDown();
         }
@@ -178,7 +178,7 @@ public class ThreadInfoRequestCoordinatorTest extends TestLogger {
     /** Tests that shutdown fails all pending requests and future request triggers. */
     @Test
     public void testShutDown() throws Exception {
-        Map<ExecutionAttemptID, CompletableFuture<TaskExecutorThreadInfoGateway>>
+        Map<ImmutableSet<ExecutionAttemptID>, CompletableFuture<TaskExecutorThreadInfoGateway>>
                 executionWithGateways =
                         createMockSubtaskWithGateways(
                                 CompletionType.SUCCESSFULLY, CompletionType.TIMEOUT);
@@ -204,7 +204,7 @@ public class ThreadInfoRequestCoordinatorTest extends TestLogger {
         requestFutures.add(requestFuture2);
 
         for (CompletableFuture<JobVertexThreadInfoStats> future : requestFutures) {
-            assertFalse(future.isDone());
+            assertThat(future).isNotDone();
         }
 
         // shut down
@@ -212,7 +212,7 @@ public class ThreadInfoRequestCoordinatorTest extends TestLogger {
 
         // verify all completed
         for (CompletableFuture<JobVertexThreadInfoStats> future : requestFutures) {
-            assertTrue(future.isCompletedExceptionally());
+            assertThat(future).isCompletedExceptionally();
         }
 
         // verify new trigger returns failed future
@@ -223,19 +223,32 @@ public class ThreadInfoRequestCoordinatorTest extends TestLogger {
                         DEFAULT_DELAY_BETWEEN_SAMPLES,
                         DEFAULT_MAX_STACK_TRACE_DEPTH);
 
-        assertTrue(future.isCompletedExceptionally());
+        assertThat(future).isCompletedExceptionally();
     }
 
     private static CompletableFuture<TaskExecutorThreadInfoGateway> createMockTaskManagerGateway(
-            CompletionType completionType) {
+            CompletionType completionType) throws Exception {
 
         final CompletableFuture<TaskThreadInfoResponse> responseFuture = new CompletableFuture<>();
         switch (completionType) {
             case SUCCESSFULLY:
-                ThreadInfoSample sample =
-                        JvmUtils.createThreadInfoSample(Thread.currentThread().getId(), 100).get();
-                responseFuture.complete(
-                        new TaskThreadInfoResponse(Collections.singletonList(sample)));
+                Set<IdleTestTask> tasks = new HashSet<>();
+                executeWithTerminationGuarantee(
+                        () -> {
+                            tasks.add(new IdleTestTask());
+                            tasks.add(new IdleTestTask());
+                            //                            Thread.sleep(100);
+                            List<Long> threadIds =
+                                    tasks.stream()
+                                            .map(t -> t.getExecutingThread().getId())
+                                            .collect(Collectors.toList());
+                            Collection<ThreadInfoSample> threadInfoSample =
+                                    JvmUtils.createThreadInfoSample(threadIds, 100);
+                            responseFuture.complete(
+                                    new TaskThreadInfoResponse(new ArrayList<>(threadInfoSample)));
+                        },
+                        tasks);
+
                 break;
             case EXCEPTIONALLY:
                 responseFuture.completeExceptionally(new RuntimeException("Request failed."));
@@ -261,12 +274,18 @@ public class ThreadInfoRequestCoordinatorTest extends TestLogger {
         return CompletableFuture.completedFuture(executorGateway);
     }
 
-    private static Map<ExecutionAttemptID, CompletableFuture<TaskExecutorThreadInfoGateway>>
-            createMockSubtaskWithGateways(CompletionType... completionTypes) {
-        final Map<ExecutionAttemptID, CompletableFuture<TaskExecutorThreadInfoGateway>> result =
-                new HashMap<>();
+    private static Map<
+                    ImmutableSet<ExecutionAttemptID>,
+                    CompletableFuture<TaskExecutorThreadInfoGateway>>
+            createMockSubtaskWithGateways(CompletionType... completionTypes) throws Exception {
+        final Map<
+                        ImmutableSet<ExecutionAttemptID>,
+                        CompletableFuture<TaskExecutorThreadInfoGateway>>
+                result = new HashMap<>();
         for (CompletionType completionType : completionTypes) {
-            result.put(createExecutionAttemptId(), createMockTaskManagerGateway(completionType));
+            ImmutableSet<ExecutionAttemptID> ids =
+                    ImmutableSet.of(createExecutionAttemptId(), createExecutionAttemptId());
+            result.put(ids, createMockTaskManagerGateway(completionType));
         }
         return result;
     }


### PR DESCRIPTION
## What is the purpose of the change
The FlameGraph feature added in FLINK-13550 issues 1 RPC call per subtask. This may cause performance problems for jobs with high paralleism and a lot of subtasks. This PR improves sampling by grouping thread sampling request and issuing only one call per TaskManager for all the relevant threads at once.

## Verifying this change
Verified manually and by the existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
