### PR TITLE
[FLINK-26848][JDBC]write data when disable flush-interval and max-rows

### DIFF
--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/JdbcOutputFormat.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/JdbcOutputFormat.java
@@ -142,7 +142,9 @@ public class JdbcOutputFormat<In, JdbcIn, JdbcExec extends JdbcBatchStatementExe
             throw new IOException("unable to open JDBC writer", e);
         }
         jdbcStatementExecutor = createAndOpenStatementExecutor(statementExecutorFactory);
-        if (executionOptions.getBatchIntervalMs() != 0 && executionOptions.getBatchSize() != 1) {
+        if (executionOptions.getBatchIntervalMs() != 0
+                && executionOptions.getBatchSize() != 0
+                && executionOptions.getBatchSize() != 1) {
             this.scheduler =
                     Executors.newScheduledThreadPool(
                             1, new ExecutorThreadFactory("jdbc-upsert-output-format"));
@@ -190,7 +192,7 @@ public class JdbcOutputFormat<In, JdbcIn, JdbcExec extends JdbcBatchStatementExe
             In recordCopy = copyIfNecessary(record);
             addToBatch(record, jdbcRecordExtractor.apply(recordCopy));
             batchCount++;
-            if (executionOptions.getBatchSize() > 0
+            if (executionOptions.getBatchSize() >= 0
                     && batchCount >= executionOptions.getBatchSize()) {
                 flush();
             }

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcOutputFormatTest.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcOutputFormatTest.java
@@ -428,7 +428,16 @@ public class JdbcOutputFormatTest extends JdbcDataTestBase {
                                 TEST_DATA[i].qty));
             }
             try (ResultSet resultSet = statement.executeQuery()) {
-                assertFalse(resultSet.next());
+                int recordCount = 0;
+                while (resultSet.next()) {
+                    assertEquals(TEST_DATA[recordCount].id, resultSet.getObject("id"));
+                    assertEquals(TEST_DATA[recordCount].title, resultSet.getObject("title"));
+                    assertEquals(TEST_DATA[recordCount].author, resultSet.getObject("author"));
+                    assertEquals(TEST_DATA[recordCount].price, resultSet.getObject("price"));
+                    assertEquals(TEST_DATA[recordCount].qty, resultSet.getObject("qty"));
+                    recordCount++;
+                }
+                assertEquals(2, recordCount);
             }
         } finally {
             outputFormat.close();


### PR DESCRIPTION
## What is the purpose of the change




sink.buffer-flush.interval | The flush interval mills, over this time, asynchronous threads will flush data. Can be set to '0' to disable it. Note, 'sink.buffer-flush.max-rows' can be set to '0' with the flush interval set allowing for complete async processing of buffered actions.
-- | --
sink.buffer-flush.max-rows | The max size of buffered records before flush. Can be set to zero to disable it.


`Asynchronous thread flush` is disabled&nbsp; when set `sink.buffer-flush.interval` = 0,&nbsp; then disable `sink.buffer-flush.max-rows`, which causes the data is not written out.

The data are not written when disable `flush.interval` and `max-rows`. I think it should write out when the data arrive.


![image](https://user-images.githubusercontent.com/18002496/160043534-ff106f8e-d37a-4020-b598-2bfe639a50c8.png)

