### PR TITLE
[FLINK-26725][table] Support the new type inference in Scala Table API aggregate functions

### DIFF
--- a/flink-table/flink-table-api-scala/src/main/scala/org/apache/flink/table/api/ImplicitExpressionConversions.scala
+++ b/flink-table/flink-table-api-scala/src/main/scala/org/apache/flink/table/api/ImplicitExpressionConversions.scala
@@ -168,33 +168,13 @@ trait ImplicitExpressionConversions {
     }
   }
 
-  implicit class ImperativeAggregateFunctionCall[T: TypeInformation, ACC: TypeInformation]
-      (val a: ImperativeAggregateFunction[T, ACC]) {
-
-    private def createFunctionDefinition(): FunctionDefinition = {
-      val resultTypeInfo: TypeInformation[T] = UserDefinedFunctionHelper
-        .getReturnTypeOfAggregateFunction(a, implicitly[TypeInformation[T]])
-
-      val accTypeInfo: TypeInformation[ACC] = UserDefinedFunctionHelper.
-        getAccumulatorTypeOfAggregateFunction(a, implicitly[TypeInformation[ACC]])
-
-      a match {
-        case af: AggregateFunction[_, _] =>
-          new AggregateFunctionDefinition(
-            af.getClass.getName, af, resultTypeInfo, accTypeInfo)
-        case taf: TableAggregateFunction[_, _] =>
-          new TableAggregateFunctionDefinition(
-            taf.getClass.getName, taf, resultTypeInfo, accTypeInfo)
-      }
-    }
+  implicit class ImperativeAggregateFunctionCall(val a: ImperativeAggregateFunction[_, _]) {
 
     /**
       * Calls an aggregate function for the given parameters.
       */
     def apply(params: Expression*): Expression = {
-      unresolvedCall(
-        createFunctionDefinition(),
-        params.map(ApiExpressionUtils.objectToExpression): _*)
+      unresolvedCall(a, params.map(ApiExpressionUtils.objectToExpression): _*)
     }
 
     /**

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/utils/JavaUserDefinedAggFunctions.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/utils/JavaUserDefinedAggFunctions.java
@@ -309,7 +309,7 @@ public class JavaUserDefinedAggFunctions {
         }
 
         // Overloaded accumulate method
-        public void accumulate(CountDistinctAccum accumulator, long id) {
+        public void accumulate(CountDistinctAccum accumulator, Long id) {
             try {
                 Integer cnt = accumulator.map.get(String.valueOf(id));
                 if (cnt != null) {
@@ -372,7 +372,7 @@ public class JavaUserDefinedAggFunctions {
     public static class CountDistinctWithRetractAndReset extends CountDistinct {
 
         // Overloaded retract method
-        public void retract(CountDistinctAccum accumulator, long id) {
+        public void retract(CountDistinctAccum accumulator, Long id) {
             try {
                 Integer cnt = accumulator.map.get(String.valueOf(id));
                 if (cnt != null) {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/utils/JavaUserDefinedAggFunctions.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/utils/JavaUserDefinedAggFunctions.java
@@ -90,19 +90,23 @@ public class JavaUserDefinedAggFunctions {
         // overloaded accumulate method
         // dummy to test constants
         public void accumulate(
-                WeightedAvgAccum accumulator, long iValue, int iWeight, int x, String string) {
+                WeightedAvgAccum accumulator,
+                Long iValue,
+                Integer iWeight,
+                Integer x,
+                String string) {
             accumulator.sum += (iValue + Integer.parseInt(string)) * iWeight;
             accumulator.count += iWeight;
         }
 
         // overloaded accumulate method
-        public void accumulate(WeightedAvgAccum accumulator, long iValue, int iWeight) {
+        public void accumulate(WeightedAvgAccum accumulator, Long iValue, Integer iWeight) {
             accumulator.sum += iValue * iWeight;
             accumulator.count += iWeight;
         }
 
         // Overloaded accumulate method
-        public void accumulate(WeightedAvgAccum accumulator, int iValue, int iWeight) {
+        public void accumulate(WeightedAvgAccum accumulator, Integer iValue, Integer iWeight) {
             accumulator.sum += iValue * iWeight;
             accumulator.count += iWeight;
         }
@@ -220,7 +224,7 @@ public class JavaUserDefinedAggFunctions {
         }
 
         // Overloaded accumulate method
-        public void accumulate(CountDistinctAccum accumulator, long id) {
+        public void accumulate(CountDistinctAccum accumulator, Long id) {
             try {
                 Integer cnt = accumulator.map.get(String.valueOf(id));
                 if (cnt != null) {

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/table/PythonAggregateTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/table/PythonAggregateTest.xml
@@ -20,13 +20,13 @@ limitations under the License.
     <Resource name="ast">
       <![CDATA[
 LogicalProject(b=[$0], EXPR$0=[$1])
-+- LogicalAggregate(group=[{1}], EXPR$0=[PandasAggregateFunction($0, $2)])
++- LogicalAggregate(group=[{1}], EXPR$0=[*org.apache.flink.table.planner.runtime.utils.JavaUserDefinedAggFunctions$PandasAggregateFunction*($0, $2)])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-PythonGroupAggregate(groupBy=[b], select=[b, PandasAggregateFunction(a, c) AS EXPR$0])
+PythonGroupAggregate(groupBy=[b], select=[b, *org.apache.flink.table.planner.runtime.utils.JavaUserDefinedAggFunctions$PandasAggregateFunction*(a, c) AS EXPR$0])
 +- Sort(orderBy=[b ASC])
    +- Exchange(distribution=[hash[b]])
       +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
@@ -37,13 +37,13 @@ PythonGroupAggregate(groupBy=[b], select=[b, PandasAggregateFunction(a, c) AS EX
     <Resource name="ast">
       <![CDATA[
 LogicalProject(EXPR$0=[$0])
-+- LogicalAggregate(group=[{}], EXPR$0=[PandasAggregateFunction($0, $2)])
++- LogicalAggregate(group=[{}], EXPR$0=[*org.apache.flink.table.planner.runtime.utils.JavaUserDefinedAggFunctions$PandasAggregateFunction*($0, $2)])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-PythonGroupAggregate(select=[PandasAggregateFunction(a, c) AS EXPR$0])
+PythonGroupAggregate(select=[*org.apache.flink.table.planner.runtime.utils.JavaUserDefinedAggFunctions$PandasAggregateFunction*(a, c) AS EXPR$0])
 +- Exchange(distribution=[single])
    +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/table/PythonGroupWindowAggregateTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/table/PythonGroupWindowAggregateTest.xml
@@ -20,14 +20,14 @@ limitations under the License.
     <Resource name="ast">
       <![CDATA[
 LogicalProject(b=[$0], EXPR$0=[$2], EXPR$1=[$3], EXPR$2=[$1])
-+- LogicalWindowAggregate(group=[{1}], EXPR$2=[PandasAggregateFunction($0, $2)], window=[TumblingGroupWindow('w, rowtime, 5)], properties=[EXPR$0, EXPR$1])
++- LogicalWindowAggregate(group=[{1}], EXPR$2=[*org.apache.flink.table.planner.runtime.utils.JavaUserDefinedAggFunctions$PandasAggregateFunction*($0, $2)], window=[TumblingGroupWindow('w, rowtime, 5)], properties=[EXPR$0, EXPR$1])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, rowtime)]]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[b, EXPR$0, EXPR$1, EXPR$2])
-+- PythonGroupWindowAggregate(groupBy=[b], window=[TumblingGroupWindow('w, rowtime, 5)], properties=[EXPR$0, EXPR$1], select=[b, PandasAggregateFunction(a, c) AS EXPR$2])
++- PythonGroupWindowAggregate(groupBy=[b], window=[TumblingGroupWindow('w, rowtime, 5)], properties=[EXPR$0, EXPR$1], select=[b, *org.apache.flink.table.planner.runtime.utils.JavaUserDefinedAggFunctions$PandasAggregateFunction*(a, c) AS EXPR$2])
    +- Sort(orderBy=[b ASC, rowtime ASC])
       +- Exchange(distribution=[hash[b]])
          +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, rowtime)]]], fields=[a, b, c, rowtime])
@@ -38,14 +38,14 @@ Calc(select=[b, EXPR$0, EXPR$1, EXPR$2])
     <Resource name="ast">
       <![CDATA[
 LogicalProject(b=[$0], EXPR$0=[$2], EXPR$1=[$3], EXPR$2=[$1])
-+- LogicalWindowAggregate(group=[{1}], EXPR$2=[PandasAggregateFunction($0, $2)], window=[SlidingGroupWindow('w, rowtime, 5, 2)], properties=[EXPR$0, EXPR$1])
++- LogicalWindowAggregate(group=[{1}], EXPR$2=[*org.apache.flink.table.planner.runtime.utils.JavaUserDefinedAggFunctions$PandasAggregateFunction*($0, $2)], window=[SlidingGroupWindow('w, rowtime, 5, 2)], properties=[EXPR$0, EXPR$1])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, rowtime)]]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[b, EXPR$0, EXPR$1, EXPR$2])
-+- PythonGroupWindowAggregate(groupBy=[b], window=[SlidingGroupWindow('w, rowtime, 5, 2)], properties=[EXPR$0, EXPR$1], select=[b, PandasAggregateFunction(a, c) AS EXPR$2])
++- PythonGroupWindowAggregate(groupBy=[b], window=[SlidingGroupWindow('w, rowtime, 5, 2)], properties=[EXPR$0, EXPR$1], select=[b, *org.apache.flink.table.planner.runtime.utils.JavaUserDefinedAggFunctions$PandasAggregateFunction*(a, c) AS EXPR$2])
    +- Sort(orderBy=[b ASC, rowtime ASC])
       +- Exchange(distribution=[hash[b]])
          +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, rowtime)]]], fields=[a, b, c, rowtime])
@@ -56,14 +56,14 @@ Calc(select=[b, EXPR$0, EXPR$1, EXPR$2])
     <Resource name="ast">
       <![CDATA[
 LogicalProject(EXPR$0=[$1], EXPR$1=[$2], EXPR$2=[$0])
-+- LogicalWindowAggregate(group=[{}], EXPR$2=[PandasAggregateFunction($0, $2)], window=[SlidingGroupWindow('w, rowtime, 5, 2)], properties=[EXPR$0, EXPR$1])
++- LogicalWindowAggregate(group=[{}], EXPR$2=[*org.apache.flink.table.planner.runtime.utils.JavaUserDefinedAggFunctions$PandasAggregateFunction*($0, $2)], window=[SlidingGroupWindow('w, rowtime, 5, 2)], properties=[EXPR$0, EXPR$1])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, rowtime)]]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[EXPR$0, EXPR$1, EXPR$2])
-+- PythonGroupWindowAggregate(window=[SlidingGroupWindow('w, rowtime, 5, 2)], properties=[EXPR$0, EXPR$1], select=[PandasAggregateFunction(a, c) AS EXPR$2])
++- PythonGroupWindowAggregate(window=[SlidingGroupWindow('w, rowtime, 5, 2)], properties=[EXPR$0, EXPR$1], select=[*org.apache.flink.table.planner.runtime.utils.JavaUserDefinedAggFunctions$PandasAggregateFunction*(a, c) AS EXPR$2])
    +- Sort(orderBy=[rowtime ASC])
       +- Exchange(distribution=[single])
          +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, rowtime)]]], fields=[a, b, c, rowtime])

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/table/PythonOverWindowAggregateTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/table/PythonOverWindowAggregateTest.xml
@@ -26,7 +26,7 @@ LogicalProject(b=[$1], _c1=[AS(*org.apache.flink.table.planner.runtime.utils.Jav
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[b, w0$o0 AS _c1])
-+- PythonOverAggregate(partitionBy=[b], orderBy=[rowtime ASC], window#0=[PandasAggregateFunction(a, c) AS w0$o0 RANG BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW], select=[a, b, c, rowtime, w0$o0])
++- PythonOverAggregate(partitionBy=[b], orderBy=[rowtime ASC], window#0=[*org.apache.flink.table.planner.runtime.utils.JavaUserDefinedAggFunctions$PandasAggregateFunction*(a, c) AS w0$o0 RANG BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW], select=[a, b, c, rowtime, w0$o0])
    +- Sort(orderBy=[b ASC, rowtime ASC])
       +- Exchange(distribution=[hash[b]])
          +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, rowtime)]]], fields=[a, b, c, rowtime])
@@ -43,7 +43,7 @@ LogicalProject(b=[$1], _c1=[AS(*org.apache.flink.table.planner.runtime.utils.Jav
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[b, w0$o0 AS _c1])
-+- PythonOverAggregate(partitionBy=[b], orderBy=[rowtime ASC], window#0=[PandasAggregateFunction(a, c) AS w0$o0 ROWS BETWEEN 10 PRECEDING AND CURRENT ROW], select=[a, b, c, rowtime, w0$o0])
++- PythonOverAggregate(partitionBy=[b], orderBy=[rowtime ASC], window#0=[*org.apache.flink.table.planner.runtime.utils.JavaUserDefinedAggFunctions$PandasAggregateFunction*(a, c) AS w0$o0 ROWS BETWEEN 10 PRECEDING AND CURRENT ROW], select=[a, b, c, rowtime, w0$o0])
    +- Sort(orderBy=[b ASC, rowtime ASC])
       +- Exchange(distribution=[hash[b]])
          +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, rowtime)]]], fields=[a, b, c, rowtime])

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/table/AggregateTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/table/AggregateTest.xml
@@ -20,20 +20,36 @@ limitations under the License.
     <Resource name="ast">
       <![CDATA[
 LogicalProject(b=[AS($0, _UTF-16LE'b')], x=[AS($1.f0, _UTF-16LE'x')], y=[AS($1.f1, _UTF-16LE'y')])
-+- LogicalAggregate(group=[{1}], TMP_0=[CountMinMax($0)])
++- LogicalAggregate(group=[{1}], TMP_0=[*org.apache.flink.table.planner.utils.CountMinMax*($0)])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[b, TMP_0.f0 AS x, TMP_0.f1 AS y])
-+- GroupAggregate(groupBy=[b], select=[b, CountMinMax(a) AS TMP_0])
++- GroupAggregate(groupBy=[b], select=[b, *org.apache.flink.table.planner.utils.CountMinMax*(a) AS TMP_0])
    +- Exchange(distribution=[hash[b]])
       +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>
   <TestCase name="testAggregateWithScalarResult">
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(b=[$0], TMP_0=[$1])
++- LogicalAggregate(group=[{1}], TMP_0=[*org.apache.flink.table.planner.utils.NonMergableCount*($0)])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+GroupAggregate(groupBy=[b], select=[b, *org.apache.flink.table.planner.utils.NonMergableCount*(a) AS TMP_0])
++- Exchange(distribution=[hash[b]])
+   +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAggregateWithScalarResultBuiltIn">
     <Resource name="ast">
       <![CDATA[
 LogicalProject(b=[$0], TMP_0=[$1])
@@ -158,14 +174,14 @@ Calc(select=[4 AS four, EXPR$0])
     <Resource name="ast">
       <![CDATA[
 LogicalProject(b=[AS($0, _UTF-16LE'b')], f0=[AS($1.f0, _UTF-16LE'f0')], f1=[AS($1.f1, _UTF-16LE'f1')])
-+- LogicalAggregate(group=[{1}], TMP_0=[CountMinMax($0)])
++- LogicalAggregate(group=[{1}], TMP_0=[*org.apache.flink.table.planner.utils.CountMinMax*($0)])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[b, TMP_0.f0 AS f0, TMP_0.f1 AS f1])
-+- GroupAggregate(groupBy=[b], select=[b, CountMinMax(a) AS TMP_0])
++- GroupAggregate(groupBy=[b], select=[b, *org.apache.flink.table.planner.utils.CountMinMax*(a) AS TMP_0])
    +- Exchange(distribution=[hash[b]])
       +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
@@ -265,14 +281,14 @@ GroupWindowAggregate(window=[SlidingGroupWindow('w, rowtime, 3600000, 900000)], 
     <Resource name="ast">
       <![CDATA[
 LogicalProject(b=[AS($0, _UTF-16LE'b')], f0=[AS($1.f0, _UTF-16LE'f0')], f1=[AS($1.f1, _UTF-16LE'f1')], f2=[AS($1.f2, _UTF-16LE'f2')])
-+- LogicalAggregate(group=[{1}], TMP_0=[CountMinMax($0)])
++- LogicalAggregate(group=[{1}], TMP_0=[*org.apache.flink.table.planner.utils.CountMinMax*($0)])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[b, TMP_0.f0 AS f0, TMP_0.f1 AS f1, TMP_0.f2 AS f2])
-+- GroupAggregate(groupBy=[b], select=[b, CountMinMax(a) AS TMP_0])
++- GroupAggregate(groupBy=[b], select=[b, *org.apache.flink.table.planner.utils.CountMinMax*(a) AS TMP_0])
    +- Exchange(distribution=[hash[b]])
       +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/table/GroupWindowTableAggregateTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/table/GroupWindowTableAggregateTest.xml
@@ -20,19 +20,19 @@ limitations under the License.
     <Resource name="ast">
       <![CDATA[
 LogicalProject(EXPR$0=[$2], f1=[$1])
-+- LogicalWindowTableAggregate(group=[{}], tableAggregate=[[EmptyTableAggFunc($2)]], window=[SlidingGroupWindow('w2, proctime, 20, 10)], properties=[EXPR$0])
++- LogicalWindowTableAggregate(group=[{}], tableAggregate=[[*org.apache.flink.table.planner.utils.EmptyTableAggFunc*($2)]], window=[SlidingGroupWindow('w2, proctime, 20, 10)], properties=[EXPR$0])
    +- LogicalProject(proctime=[AS($3, _UTF-16LE'proctime')], c=[$0], f0=[$1], f1=[AS(+($2, 1), _UTF-16LE'f1')])
-      +- LogicalWindowTableAggregate(group=[{2}], tableAggregate=[[EmptyTableAggFunc($0, $1)]], window=[TumblingGroupWindow('w1, e, 50)], properties=[EXPR$0])
+      +- LogicalWindowTableAggregate(group=[{2}], tableAggregate=[[*org.apache.flink.table.planner.utils.EmptyTableAggFunc*($0, $1)]], window=[TumblingGroupWindow('w1, e, 50)], properties=[EXPR$0])
          +- LogicalTableScan(table=[[default_catalog, default_database, Table1, source: [TestTableSource(a, b, c, d, e)]]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[EXPR$0, f1])
-+- GroupWindowTableAggregate(window=[SlidingGroupWindow('w2, proctime, 20, 10)], properties=[EXPR$0], select=[EmptyTableAggFunc(f0) AS (f0, f1), start('w2) AS EXPR$0])
++- GroupWindowTableAggregate(window=[SlidingGroupWindow('w2, proctime, 20, 10)], properties=[EXPR$0], select=[*org.apache.flink.table.planner.utils.EmptyTableAggFunc*(f0) AS (f0, f1), start('w2) AS EXPR$0])
    +- Exchange(distribution=[single])
       +- Calc(select=[EXPR$0 AS proctime, c, f0, (f1 + 1) AS f1])
-         +- GroupWindowTableAggregate(groupBy=[c], window=[TumblingGroupWindow('w1, e, 50)], properties=[EXPR$0], select=[c, EmptyTableAggFunc(a, b) AS (f0, f1), proctime('w1) AS EXPR$0])
+         +- GroupWindowTableAggregate(groupBy=[c], window=[TumblingGroupWindow('w1, e, 50)], properties=[EXPR$0], select=[c, *org.apache.flink.table.planner.utils.EmptyTableAggFunc*(a, b) AS (f0, f1), proctime('w1) AS EXPR$0])
             +- Exchange(distribution=[hash[c]])
                +- LegacyTableSourceScan(table=[[default_catalog, default_database, Table1, source: [TestTableSource(a, b, c, d, e)]]], fields=[a, b, c, d, e])
 ]]>
@@ -42,14 +42,14 @@ Calc(select=[EXPR$0, f1])
     <Resource name="ast">
       <![CDATA[
 LogicalProject(f0=[$1], _c1=[AS(+($2, 1), _UTF-16LE'_c1')], EXPR$0=[$3], EXPR$1=[$4])
-+- LogicalWindowTableAggregate(group=[{4}], tableAggregate=[[EmptyTableAggFunc($0, $1)]], window=[TumblingGroupWindow('w, d, 5)], properties=[EXPR$0, EXPR$1])
++- LogicalWindowTableAggregate(group=[{4}], tableAggregate=[[*org.apache.flink.table.planner.utils.EmptyTableAggFunc*($0, $1)]], window=[TumblingGroupWindow('w, d, 5)], properties=[EXPR$0, EXPR$1])
    +- LogicalTableScan(table=[[default_catalog, default_database, Table1, source: [TestTableSource(a, b, c, d, e)]]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[f0, (f1 + 1) AS _c1, EXPR$0, EXPR$1])
-+- GroupWindowTableAggregate(groupBy=[e], window=[TumblingGroupWindow('w, d, 5)], properties=[EXPR$0, EXPR$1], select=[e, EmptyTableAggFunc(a, b) AS (f0, f1), start('w) AS EXPR$0, end('w) AS EXPR$1])
++- GroupWindowTableAggregate(groupBy=[e], window=[TumblingGroupWindow('w, d, 5)], properties=[EXPR$0, EXPR$1], select=[e, *org.apache.flink.table.planner.utils.EmptyTableAggFunc*(a, b) AS (f0, f1), start('w) AS EXPR$0, end('w) AS EXPR$1])
    +- Exchange(distribution=[hash[e]])
       +- Calc(select=[a, b, c, d, PROCTIME_MATERIALIZE(e) AS e])
          +- LegacyTableSourceScan(table=[[default_catalog, default_database, Table1, source: [TestTableSource(a, b, c, d, e)]]], fields=[a, b, c, d, e])
@@ -60,14 +60,14 @@ Calc(select=[f0, (f1 + 1) AS _c1, EXPR$0, EXPR$1])
     <Resource name="ast">
       <![CDATA[
 LogicalProject(f0=[$1], _c1=[AS(+($2, 1), _UTF-16LE'_c1')], EXPR$0=[$3], EXPR$1=[$4])
-+- LogicalWindowTableAggregate(group=[{2}], tableAggregate=[[EmptyTableAggFunc($0, $1)]], window=[TumblingGroupWindow('w, d, 5)], properties=[EXPR$0, EXPR$1])
++- LogicalWindowTableAggregate(group=[{2}], tableAggregate=[[*org.apache.flink.table.planner.utils.EmptyTableAggFunc*($0, $1)]], window=[TumblingGroupWindow('w, d, 5)], properties=[EXPR$0, EXPR$1])
    +- LogicalTableScan(table=[[default_catalog, default_database, Table1, source: [TestTableSource(a, b, c, d, e)]]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[f0, (f1 + 1) AS _c1, EXPR$0, EXPR$1])
-+- GroupWindowTableAggregate(groupBy=[c], window=[TumblingGroupWindow('w, d, 5)], properties=[EXPR$0, EXPR$1], select=[c, EmptyTableAggFunc(a, b) AS (f0, f1), start('w) AS EXPR$0, end('w) AS EXPR$1])
++- GroupWindowTableAggregate(groupBy=[c], window=[TumblingGroupWindow('w, d, 5)], properties=[EXPR$0, EXPR$1], select=[c, *org.apache.flink.table.planner.utils.EmptyTableAggFunc*(a, b) AS (f0, f1), start('w) AS EXPR$0, end('w) AS EXPR$1])
    +- Exchange(distribution=[hash[c]])
       +- LegacyTableSourceScan(table=[[default_catalog, default_database, Table1, source: [TestTableSource(a, b, c, d, e)]]], fields=[a, b, c, d, e])
 ]]>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/table/GroupWindowTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/table/GroupWindowTest.xml
@@ -470,10 +470,10 @@ Calc(select=[string, (EXPR$0 + 1) AS s1, (EXPR$0 + 3) AS s2, EXPR$1 AS x, EXPR$1
       <![CDATA[
 LogicalUnion(all=[true])
 :- LogicalProject(_c0=[AS(1, _UTF-16LE'_c0')])
-:  +- LogicalWindowTableAggregate(group=[{}], tableAggregate=[[EmptyTableAggFunc($1, $2)]], window=[SlidingGroupWindow('w1, ts, 3600000, 3600000)], properties=[])
+:  +- LogicalWindowTableAggregate(group=[{}], tableAggregate=[[*org.apache.flink.table.planner.utils.EmptyTableAggFunc*($1, $2)]], window=[SlidingGroupWindow('w1, ts, 3600000, 3600000)], properties=[])
 :     +- LogicalTableScan(table=[[default_catalog, default_database, Table1, source: [TestTableSource(ts, a, b)]]])
 +- LogicalProject(_c0=[AS(1, _UTF-16LE'_c0')])
-   +- LogicalWindowTableAggregate(group=[{}], tableAggregate=[[EmptyTableAggFunc($1, $2)]], window=[SlidingGroupWindow('w1, ts, 7200000, 3600000)], properties=[])
+   +- LogicalWindowTableAggregate(group=[{}], tableAggregate=[[*org.apache.flink.table.planner.utils.EmptyTableAggFunc*($1, $2)]], window=[SlidingGroupWindow('w1, ts, 7200000, 3600000)], properties=[])
       +- LogicalTableScan(table=[[default_catalog, default_database, Table1, source: [TestTableSource(ts, a, b)]]])
 ]]>
     </Resource>
@@ -481,11 +481,11 @@ LogicalUnion(all=[true])
       <![CDATA[
 Union(all=[true], union=[_c0])
 :- Calc(select=[1 AS _c0])
-:  +- GroupWindowTableAggregate(window=[SlidingGroupWindow('w1, ts, 3600000, 3600000)], select=[EmptyTableAggFunc(a, b) AS (f0, f1)])
+:  +- GroupWindowTableAggregate(window=[SlidingGroupWindow('w1, ts, 3600000, 3600000)], select=[*org.apache.flink.table.planner.utils.EmptyTableAggFunc*(a, b) AS (f0, f1)])
 :     +- Exchange(distribution=[single])(reuse_id=[1])
 :        +- LegacyTableSourceScan(table=[[default_catalog, default_database, Table1, source: [TestTableSource(ts, a, b)]]], fields=[ts, a, b])
 +- Calc(select=[1 AS _c0])
-   +- GroupWindowTableAggregate(window=[SlidingGroupWindow('w1, ts, 7200000, 3600000)], select=[EmptyTableAggFunc(a, b) AS (f0, f1)])
+   +- GroupWindowTableAggregate(window=[SlidingGroupWindow('w1, ts, 7200000, 3600000)], select=[*org.apache.flink.table.planner.utils.EmptyTableAggFunc*(a, b) AS (f0, f1)])
       +- Reused(reference_id=[1])
 ]]>
     </Resource>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/table/PythonAggregateTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/table/PythonAggregateTest.xml
@@ -20,13 +20,13 @@ limitations under the License.
     <Resource name="ast">
       <![CDATA[
 LogicalProject(b=[$0], EXPR$0=[$1], EXPR$1=[$2])
-+- LogicalAggregate(group=[{1}], EXPR$0=[TestPythonAggregateFunction($0, $2)], EXPR$1=[COUNT($0)])
++- LogicalAggregate(group=[{1}], EXPR$0=[*org.apache.flink.table.planner.runtime.utils.JavaUserDefinedAggFunctions$TestPythonAggregateFunction*($0, $2)], EXPR$1=[COUNT($0)])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-PythonGroupAggregate(groupBy=[b], select=[b, TestPythonAggregateFunction(a, c) AS EXPR$0, COUNT(a) AS EXPR$1])
+PythonGroupAggregate(groupBy=[b], select=[b, *org.apache.flink.table.planner.runtime.utils.JavaUserDefinedAggFunctions$TestPythonAggregateFunction*(a, c) AS EXPR$0, COUNT(a) AS EXPR$1])
 +- Exchange(distribution=[hash[b]])
    +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
@@ -36,13 +36,13 @@ PythonGroupAggregate(groupBy=[b], select=[b, TestPythonAggregateFunction(a, c) A
     <Resource name="ast">
       <![CDATA[
 LogicalProject(b=[$0], EXPR$0=[$1])
-+- LogicalAggregate(group=[{1}], EXPR$0=[TestPythonAggregateFunction($0, $2)])
++- LogicalAggregate(group=[{1}], EXPR$0=[*org.apache.flink.table.planner.runtime.utils.JavaUserDefinedAggFunctions$TestPythonAggregateFunction*($0, $2)])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-PythonGroupAggregate(groupBy=[b], select=[b, TestPythonAggregateFunction(a, c) AS EXPR$0])
+PythonGroupAggregate(groupBy=[b], select=[b, *org.apache.flink.table.planner.runtime.utils.JavaUserDefinedAggFunctions$TestPythonAggregateFunction*(a, c) AS EXPR$0])
 +- Exchange(distribution=[hash[b]])
    +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
@@ -52,13 +52,13 @@ PythonGroupAggregate(groupBy=[b], select=[b, TestPythonAggregateFunction(a, c) A
     <Resource name="ast">
       <![CDATA[
 LogicalProject(EXPR$0=[$0])
-+- LogicalAggregate(group=[{}], EXPR$0=[TestPythonAggregateFunction($0, $2)])
++- LogicalAggregate(group=[{}], EXPR$0=[*org.apache.flink.table.planner.runtime.utils.JavaUserDefinedAggFunctions$TestPythonAggregateFunction*($0, $2)])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-PythonGroupAggregate(select=[TestPythonAggregateFunction(a, c) AS EXPR$0])
+PythonGroupAggregate(select=[*org.apache.flink.table.planner.runtime.utils.JavaUserDefinedAggFunctions$TestPythonAggregateFunction*(a, c) AS EXPR$0])
 +- Exchange(distribution=[single])
    +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/table/PythonGroupWindowAggregateTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/table/PythonGroupWindowAggregateTest.xml
@@ -16,17 +16,100 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <Root>
-  <TestCase name="testPandasEventTimeSlidingGroupWindowOverCount">
+  <TestCase name="testGeneralEventTimeSessionGroupWindowOverTime">
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(b=[$0], EXPR$0=[$2], EXPR$1=[$3], EXPR$2=[$1])
++- LogicalWindowAggregate(group=[{1}], EXPR$2=[*org.apache.flink.table.planner.runtime.utils.JavaUserDefinedAggFunctions$TestPythonAggregateFunction*($0, $2)], window=[SessionGroupWindow('w, rowtime, 7)], properties=[EXPR$0, EXPR$1])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, rowtime)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[b, EXPR$0, EXPR$1, EXPR$2])
++- PythonGroupWindowAggregate(groupBy=[b], window=[SessionGroupWindow('w, rowtime, 7)], properties=[EXPR$0, EXPR$1], select=[b, *org.apache.flink.table.planner.runtime.utils.JavaUserDefinedAggFunctions$TestPythonAggregateFunction*(a, c) AS EXPR$2, start('w) AS EXPR$0, end('w) AS EXPR$1])
+   +- Exchange(distribution=[hash[b]])
+      +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, rowtime)]]], fields=[a, b, c, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testGeneralEventTimeSlidingGroupWindowOverCount">
     <Resource name="ast">
       <![CDATA[
 LogicalProject(b=[$0], EXPR$0=[$1])
-+- LogicalWindowAggregate(group=[{1}], EXPR$0=[PandasAggregateFunction($0, $2)], window=[SlidingGroupWindow('w, proctime, 5, 2)], properties=[])
++- LogicalWindowAggregate(group=[{1}], EXPR$0=[*org.apache.flink.table.planner.runtime.utils.JavaUserDefinedAggFunctions$TestPythonAggregateFunction*($0, $2)], window=[SlidingGroupWindow('w, proctime, 5, 2)], properties=[])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, proctime)]]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-PythonGroupWindowAggregate(groupBy=[b], window=[SlidingGroupWindow('w, proctime, 5, 2)], select=[b, PandasAggregateFunction(a, c) AS EXPR$0])
+PythonGroupWindowAggregate(groupBy=[b], window=[SlidingGroupWindow('w, proctime, 5, 2)], select=[b, *org.apache.flink.table.planner.runtime.utils.JavaUserDefinedAggFunctions$TestPythonAggregateFunction*(a, c) AS EXPR$0])
++- Exchange(distribution=[hash[b]])
+   +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, proctime)]]], fields=[a, b, c, proctime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testGeneralEventTimeSlidingGroupWindowOverTime">
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(b=[$0], EXPR$0=[$2], EXPR$1=[$3], EXPR$2=[$1])
++- LogicalWindowAggregate(group=[{1}], EXPR$2=[*org.apache.flink.table.planner.runtime.utils.JavaUserDefinedAggFunctions$TestPythonAggregateFunction*($0, $2)], window=[SlidingGroupWindow('w, rowtime, 5, 2)], properties=[EXPR$0, EXPR$1])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, rowtime)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[b, EXPR$0, EXPR$1, EXPR$2])
++- PythonGroupWindowAggregate(groupBy=[b], window=[SlidingGroupWindow('w, rowtime, 5, 2)], properties=[EXPR$0, EXPR$1], select=[b, *org.apache.flink.table.planner.runtime.utils.JavaUserDefinedAggFunctions$TestPythonAggregateFunction*(a, c) AS EXPR$2, start('w) AS EXPR$0, end('w) AS EXPR$1])
+   +- Exchange(distribution=[hash[b]])
+      +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, rowtime)]]], fields=[a, b, c, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testGeneralEventTimeTumblingGroupWindowOverCount">
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(b=[$0], EXPR$0=[$1])
++- LogicalWindowAggregate(group=[{1}], EXPR$0=[*org.apache.flink.table.planner.runtime.utils.JavaUserDefinedAggFunctions$TestPythonAggregateFunction*($0, $2)], window=[TumblingGroupWindow('w, proctime, 2)], properties=[])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, proctime)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+PythonGroupWindowAggregate(groupBy=[b], window=[TumblingGroupWindow('w, proctime, 2)], select=[b, *org.apache.flink.table.planner.runtime.utils.JavaUserDefinedAggFunctions$TestPythonAggregateFunction*(a, c) AS EXPR$0])
++- Exchange(distribution=[hash[b]])
+   +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, proctime)]]], fields=[a, b, c, proctime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testGeneralEventTimeTumblingGroupWindowOverTime">
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(b=[$0], EXPR$0=[$2], EXPR$1=[$3], EXPR$2=[$1])
++- LogicalWindowAggregate(group=[{1}], EXPR$2=[*org.apache.flink.table.planner.runtime.utils.JavaUserDefinedAggFunctions$TestPythonAggregateFunction*($0, $2)], window=[TumblingGroupWindow('w, rowtime, 5)], properties=[EXPR$0, EXPR$1])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, rowtime)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[b, EXPR$0, EXPR$1, EXPR$2])
++- PythonGroupWindowAggregate(groupBy=[b], window=[TumblingGroupWindow('w, rowtime, 5)], properties=[EXPR$0, EXPR$1], select=[b, *org.apache.flink.table.planner.runtime.utils.JavaUserDefinedAggFunctions$TestPythonAggregateFunction*(a, c) AS EXPR$2, start('w) AS EXPR$0, end('w) AS EXPR$1])
+   +- Exchange(distribution=[hash[b]])
+      +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, rowtime)]]], fields=[a, b, c, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPandasEventTimeSlidingGroupWindowOverCount">
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(b=[$0], EXPR$0=[$1])
++- LogicalWindowAggregate(group=[{1}], EXPR$0=[*org.apache.flink.table.planner.runtime.utils.JavaUserDefinedAggFunctions$PandasAggregateFunction*($0, $2)], window=[SlidingGroupWindow('w, proctime, 5, 2)], properties=[])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, proctime)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+PythonGroupWindowAggregate(groupBy=[b], window=[SlidingGroupWindow('w, proctime, 5, 2)], select=[b, *org.apache.flink.table.planner.runtime.utils.JavaUserDefinedAggFunctions$PandasAggregateFunction*(a, c) AS EXPR$0])
 +- Exchange(distribution=[hash[b]])
    +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, proctime)]]], fields=[a, b, c, proctime])
 ]]>
@@ -36,14 +119,14 @@ PythonGroupWindowAggregate(groupBy=[b], window=[SlidingGroupWindow('w, proctime,
     <Resource name="ast">
       <![CDATA[
 LogicalProject(b=[$0], EXPR$0=[$2], EXPR$1=[$3], EXPR$2=[$1])
-+- LogicalWindowAggregate(group=[{1}], EXPR$2=[PandasAggregateFunction($0, $2)], window=[TumblingGroupWindow('w, rowtime, 5)], properties=[EXPR$0, EXPR$1])
++- LogicalWindowAggregate(group=[{1}], EXPR$2=[*org.apache.flink.table.planner.runtime.utils.JavaUserDefinedAggFunctions$PandasAggregateFunction*($0, $2)], window=[TumblingGroupWindow('w, rowtime, 5)], properties=[EXPR$0, EXPR$1])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, rowtime)]]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[b, EXPR$0, EXPR$1, EXPR$2])
-+- PythonGroupWindowAggregate(groupBy=[b], window=[TumblingGroupWindow('w, rowtime, 5)], properties=[EXPR$0, EXPR$1], select=[b, PandasAggregateFunction(a, c) AS EXPR$2, start('w) AS EXPR$0, end('w) AS EXPR$1])
++- PythonGroupWindowAggregate(groupBy=[b], window=[TumblingGroupWindow('w, rowtime, 5)], properties=[EXPR$0, EXPR$1], select=[b, *org.apache.flink.table.planner.runtime.utils.JavaUserDefinedAggFunctions$PandasAggregateFunction*(a, c) AS EXPR$2, start('w) AS EXPR$0, end('w) AS EXPR$1])
    +- Exchange(distribution=[hash[b]])
       +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, rowtime)]]], fields=[a, b, c, rowtime])
 ]]>
@@ -53,14 +136,14 @@ Calc(select=[b, EXPR$0, EXPR$1, EXPR$2])
     <Resource name="ast">
       <![CDATA[
 LogicalProject(b=[$0], EXPR$0=[$2], EXPR$1=[$3], EXPR$2=[$1])
-+- LogicalWindowAggregate(group=[{1}], EXPR$2=[PandasAggregateFunction($0, $2)], window=[SlidingGroupWindow('w, rowtime, 5, 2)], properties=[EXPR$0, EXPR$1])
++- LogicalWindowAggregate(group=[{1}], EXPR$2=[*org.apache.flink.table.planner.runtime.utils.JavaUserDefinedAggFunctions$PandasAggregateFunction*($0, $2)], window=[SlidingGroupWindow('w, rowtime, 5, 2)], properties=[EXPR$0, EXPR$1])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, rowtime)]]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[b, EXPR$0, EXPR$1, EXPR$2])
-+- PythonGroupWindowAggregate(groupBy=[b], window=[SlidingGroupWindow('w, rowtime, 5, 2)], properties=[EXPR$0, EXPR$1], select=[b, PandasAggregateFunction(a, c) AS EXPR$2, start('w) AS EXPR$0, end('w) AS EXPR$1])
++- PythonGroupWindowAggregate(groupBy=[b], window=[SlidingGroupWindow('w, rowtime, 5, 2)], properties=[EXPR$0, EXPR$1], select=[b, *org.apache.flink.table.planner.runtime.utils.JavaUserDefinedAggFunctions$PandasAggregateFunction*(a, c) AS EXPR$2, start('w) AS EXPR$0, end('w) AS EXPR$1])
    +- Exchange(distribution=[hash[b]])
       +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, rowtime)]]], fields=[a, b, c, rowtime])
 ]]>
@@ -70,99 +153,16 @@ Calc(select=[b, EXPR$0, EXPR$1, EXPR$2])
     <Resource name="ast">
       <![CDATA[
 LogicalProject(b=[$0], EXPR$0=[$1])
-+- LogicalWindowAggregate(group=[{1}], EXPR$0=[PandasAggregateFunction($0, $2)], window=[TumblingGroupWindow('w, proctime, 2)], properties=[])
++- LogicalWindowAggregate(group=[{1}], EXPR$0=[*org.apache.flink.table.planner.runtime.utils.JavaUserDefinedAggFunctions$PandasAggregateFunction*($0, $2)], window=[TumblingGroupWindow('w, proctime, 2)], properties=[])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, proctime)]]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-PythonGroupWindowAggregate(groupBy=[b], window=[TumblingGroupWindow('w, proctime, 2)], select=[b, PandasAggregateFunction(a, c) AS EXPR$0])
+PythonGroupWindowAggregate(groupBy=[b], window=[TumblingGroupWindow('w, proctime, 2)], select=[b, *org.apache.flink.table.planner.runtime.utils.JavaUserDefinedAggFunctions$PandasAggregateFunction*(a, c) AS EXPR$0])
 +- Exchange(distribution=[hash[b]])
    +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, proctime)]]], fields=[a, b, c, proctime])
 ]]>
     </Resource>
-  </TestCase>
-  <TestCase name="testGeneralEventTimeSlidingGroupWindowOverCount">
-	<Resource name="ast">
-  	  <![CDATA[
-LogicalProject(b=[$0], EXPR$0=[$1])
-+- LogicalWindowAggregate(group=[{1}], EXPR$0=[TestPythonAggregateFunction($0, $2)], window=[SlidingGroupWindow('w, proctime, 5, 2)], properties=[])
-   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, proctime)]]])
-]]>
-	</Resource>
-	<Resource name="optimized exec plan">
-	  <![CDATA[
-PythonGroupWindowAggregate(groupBy=[b], window=[SlidingGroupWindow('w, proctime, 5, 2)], select=[b, TestPythonAggregateFunction(a, c) AS EXPR$0])
-+- Exchange(distribution=[hash[b]])
-   +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, proctime)]]], fields=[a, b, c, proctime])
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testGeneralEventTimeTumblingGroupWindowOverTime">
-    <Resource name="ast">
-	  <![CDATA[
-LogicalProject(b=[$0], EXPR$0=[$2], EXPR$1=[$3], EXPR$2=[$1])
-+- LogicalWindowAggregate(group=[{1}], EXPR$2=[TestPythonAggregateFunction($0, $2)], window=[TumblingGroupWindow('w, rowtime, 5)], properties=[EXPR$0, EXPR$1])
-   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, rowtime)]]])
-]]>
-	</Resource>
-	<Resource name="optimized exec plan">
-	  <![CDATA[
-Calc(select=[b, EXPR$0, EXPR$1, EXPR$2])
-+- PythonGroupWindowAggregate(groupBy=[b], window=[TumblingGroupWindow('w, rowtime, 5)], properties=[EXPR$0, EXPR$1], select=[b, TestPythonAggregateFunction(a, c) AS EXPR$2, start('w) AS EXPR$0, end('w) AS EXPR$1])
-   +- Exchange(distribution=[hash[b]])
-      +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, rowtime)]]], fields=[a, b, c, rowtime])
-]]>
-	</Resource>
-  </TestCase>
-  <TestCase name="testGeneralEventTimeSlidingGroupWindowOverTime">
-	<Resource name="ast">
-	  <![CDATA[
-LogicalProject(b=[$0], EXPR$0=[$2], EXPR$1=[$3], EXPR$2=[$1])
-+- LogicalWindowAggregate(group=[{1}], EXPR$2=[TestPythonAggregateFunction($0, $2)], window=[SlidingGroupWindow('w, rowtime, 5, 2)], properties=[EXPR$0, EXPR$1])
-   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, rowtime)]]])
-]]>
-	</Resource>
-    <Resource name="optimized exec plan">
-	  <![CDATA[
-Calc(select=[b, EXPR$0, EXPR$1, EXPR$2])
-+- PythonGroupWindowAggregate(groupBy=[b], window=[SlidingGroupWindow('w, rowtime, 5, 2)], properties=[EXPR$0, EXPR$1], select=[b, TestPythonAggregateFunction(a, c) AS EXPR$2, start('w) AS EXPR$0, end('w) AS EXPR$1])
-   +- Exchange(distribution=[hash[b]])
-      +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, rowtime)]]], fields=[a, b, c, rowtime])
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testGeneralEventTimeTumblingGroupWindowOverCount">
-    <Resource name="ast">
-	  <![CDATA[
-LogicalProject(b=[$0], EXPR$0=[$1])
-+- LogicalWindowAggregate(group=[{1}], EXPR$0=[TestPythonAggregateFunction($0, $2)], window=[TumblingGroupWindow('w, proctime, 2)], properties=[])
-   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, proctime)]]])
-]]>
-	</Resource>
-	<Resource name="optimized exec plan">
-	  <![CDATA[
-PythonGroupWindowAggregate(groupBy=[b], window=[TumblingGroupWindow('w, proctime, 2)], select=[b, TestPythonAggregateFunction(a, c) AS EXPR$0])
-+- Exchange(distribution=[hash[b]])
-   +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, proctime)]]], fields=[a, b, c, proctime])
-]]>
-	</Resource>
-  </TestCase>
-  <TestCase name="testGeneralEventTimeSessionGroupWindowOverTime">
-	<Resource name="ast">
-	  <![CDATA[
-LogicalProject(b=[$0], EXPR$0=[$2], EXPR$1=[$3], EXPR$2=[$1])
-+- LogicalWindowAggregate(group=[{1}], EXPR$2=[TestPythonAggregateFunction($0, $2)], window=[SessionGroupWindow('w, rowtime, 7)], properties=[EXPR$0, EXPR$1])
-   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, rowtime)]]])
-]]>
-	</Resource>
-	<Resource name="optimized exec plan">
-	  <![CDATA[
-Calc(select=[b, EXPR$0, EXPR$1, EXPR$2])
-+- PythonGroupWindowAggregate(groupBy=[b], window=[SessionGroupWindow('w, rowtime, 7)], properties=[EXPR$0, EXPR$1], select=[b, TestPythonAggregateFunction(a, c) AS EXPR$2, start('w) AS EXPR$0, end('w) AS EXPR$1])
-   +- Exchange(distribution=[hash[b]])
-      +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, rowtime)]]], fields=[a, b, c, rowtime])
-]]>
-	</Resource>
   </TestCase>
 </Root>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/table/PythonOverWindowAggregateTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/table/PythonOverWindowAggregateTest.xml
@@ -26,7 +26,7 @@ LogicalProject(b=[$1], _c1=[AS(*org.apache.flink.table.planner.runtime.utils.Jav
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[b, w0$o0 AS _c1])
-+- PythonOverAggregate(partitionBy=[b], orderBy=[proctime ASC], window=[ RANG BETWEEN 10000 PRECEDING AND CURRENT ROW], select=[a, b, c, proctime, PandasAggregateFunction(a, c) AS w0$o0])
++- PythonOverAggregate(partitionBy=[b], orderBy=[proctime ASC], window=[ RANG BETWEEN 10000 PRECEDING AND CURRENT ROW], select=[a, b, c, proctime, *org.apache.flink.table.planner.runtime.utils.JavaUserDefinedAggFunctions$PandasAggregateFunction*(a, c) AS w0$o0])
    +- Exchange(distribution=[hash[b]])
       +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, proctime)]]], fields=[a, b, c, proctime])
 ]]>
@@ -42,7 +42,7 @@ LogicalProject(b=[$1], _c1=[AS(*org.apache.flink.table.planner.runtime.utils.Jav
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[b, w0$o0 AS _c1])
-+- PythonOverAggregate(partitionBy=[b], orderBy=[proctime ASC], window=[ ROWS BETWEEN 10 PRECEDING AND CURRENT ROW], select=[a, b, c, proctime, PandasAggregateFunction(a, c) AS w0$o0])
++- PythonOverAggregate(partitionBy=[b], orderBy=[proctime ASC], window=[ ROWS BETWEEN 10 PRECEDING AND CURRENT ROW], select=[a, b, c, proctime, *org.apache.flink.table.planner.runtime.utils.JavaUserDefinedAggFunctions$PandasAggregateFunction*(a, c) AS w0$o0])
    +- Exchange(distribution=[hash[b]])
       +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, proctime)]]], fields=[a, b, c, proctime])
 ]]>
@@ -58,7 +58,7 @@ LogicalProject(b=[$1], _c1=[AS(*org.apache.flink.table.planner.runtime.utils.Jav
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[b, w0$o0 AS _c1])
-+- PythonOverAggregate(partitionBy=[b], orderBy=[rowtime ASC], window=[ RANG BETWEEN 10000 PRECEDING AND CURRENT ROW], select=[a, b, c, rowtime, PandasAggregateFunction(a, c) AS w0$o0])
++- PythonOverAggregate(partitionBy=[b], orderBy=[rowtime ASC], window=[ RANG BETWEEN 10000 PRECEDING AND CURRENT ROW], select=[a, b, c, rowtime, *org.apache.flink.table.planner.runtime.utils.JavaUserDefinedAggFunctions$PandasAggregateFunction*(a, c) AS w0$o0])
    +- Exchange(distribution=[hash[b]])
       +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, rowtime)]]], fields=[a, b, c, rowtime])
 ]]>
@@ -74,7 +74,7 @@ LogicalProject(b=[$1], _c1=[AS(*org.apache.flink.table.planner.runtime.utils.Jav
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[b, w0$o0 AS _c1])
-+- PythonOverAggregate(partitionBy=[b], orderBy=[rowtime ASC], window=[ ROWS BETWEEN 10 PRECEDING AND CURRENT ROW], select=[a, b, c, rowtime, PandasAggregateFunction(a, c) AS w0$o0])
++- PythonOverAggregate(partitionBy=[b], orderBy=[rowtime ASC], window=[ ROWS BETWEEN 10 PRECEDING AND CURRENT ROW], select=[a, b, c, rowtime, *org.apache.flink.table.planner.runtime.utils.JavaUserDefinedAggFunctions$PandasAggregateFunction*(a, c) AS w0$o0])
    +- Exchange(distribution=[hash[b]])
       +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, rowtime)]]], fields=[a, b, c, rowtime])
 ]]>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/table/PythonTableAggregateTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/table/PythonTableAggregateTest.xml
@@ -20,14 +20,14 @@ limitations under the License.
     <Resource name="ast">
       <![CDATA[
 LogicalProject(d=[AS($1, _UTF-16LE'd')], e=[AS($2, _UTF-16LE'e')])
-+- LogicalTableAggregate(group=[{1}], tableAggregate=[[PythonEmptyTableAggFunc($0, $2)]])
++- LogicalTableAggregate(group=[{1}], tableAggregate=[[*org.apache.flink.table.planner.utils.PythonEmptyTableAggFunc*($0, $2)]])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[f0 AS d, f1 AS e])
-+- PythonGroupTableAggregate(groupBy=[b], select=[b, PythonEmptyTableAggFunc(a, c) AS (f0, f1)])
++- PythonGroupTableAggregate(groupBy=[b], select=[b, *org.apache.flink.table.planner.utils.PythonEmptyTableAggFunc*(a, c) AS (f0, f1)])
    +- Exchange(distribution=[hash[b]])
       +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
@@ -37,14 +37,14 @@ Calc(select=[f0 AS d, f1 AS e])
     <Resource name="ast">
       <![CDATA[
 LogicalProject(d=[AS($0, _UTF-16LE'd')], e=[AS($1, _UTF-16LE'e')])
-+- LogicalTableAggregate(group=[{}], tableAggregate=[[PythonEmptyTableAggFunc($0, $2)]])
++- LogicalTableAggregate(group=[{}], tableAggregate=[[*org.apache.flink.table.planner.utils.PythonEmptyTableAggFunc*($0, $2)]])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[f0 AS d, f1 AS e])
-+- PythonGroupTableAggregate(select=[PythonEmptyTableAggFunc(a, c) AS (f0, f1)])
++- PythonGroupTableAggregate(select=[*org.apache.flink.table.planner.utils.PythonEmptyTableAggFunc*(a, c) AS (f0, f1)])
    +- Exchange(distribution=[single])
       +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
@@ -54,7 +54,7 @@ Calc(select=[f0 AS d, f1 AS e])
     <Resource name="ast">
       <![CDATA[
 LogicalProject(d=[AS($1, _UTF-16LE'd')], e=[AS($2, _UTF-16LE'e')])
-+- LogicalTableAggregate(group=[{1}], tableAggregate=[[PythonEmptyTableAggFunc($0, $2)]])
++- LogicalTableAggregate(group=[{1}], tableAggregate=[[*org.apache.flink.table.planner.utils.PythonEmptyTableAggFunc*($0, $2)]])
    +- LogicalProject(a=[$0], b=[$1], $f3=[+($2, 1)])
       +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
@@ -62,7 +62,7 @@ LogicalProject(d=[AS($1, _UTF-16LE'd')], e=[AS($2, _UTF-16LE'e')])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[f0 AS d, f1 AS e])
-+- PythonGroupTableAggregate(groupBy=[b], select=[b, PythonEmptyTableAggFunc(a, $f3) AS (f0, f1)])
++- PythonGroupTableAggregate(groupBy=[b], select=[b, *org.apache.flink.table.planner.utils.PythonEmptyTableAggFunc*(a, $f3) AS (f0, f1)])
    +- Exchange(distribution=[hash[b]])
       +- Calc(select=[a, b, (c + 1) AS $f3])
          +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/table/TableAggregateTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/table/TableAggregateTest.xml
@@ -20,13 +20,13 @@ limitations under the License.
     <Resource name="ast">
       <![CDATA[
 LogicalProject(c=[$0], f0=[$1], f1=[$2])
-+- LogicalTableAggregate(group=[{2}], tableAggregate=[[EmptyTableAggFunc($0)]])
++- LogicalTableAggregate(group=[{2}], tableAggregate=[[*org.apache.flink.table.planner.utils.EmptyTableAggFunc*($0)]])
    +- LogicalTableScan(table=[[default_catalog, default_database, Table1, source: [TestTableSource(a, b, c)]]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-GroupTableAggregate(groupBy=[c], select=[c, EmptyTableAggFunc(a) AS (f0, f1)])
+GroupTableAggregate(groupBy=[c], select=[c, *org.apache.flink.table.planner.utils.EmptyTableAggFunc*(a) AS (f0, f1)])
 +- Exchange(distribution=[hash[c]])
    +- LegacyTableSourceScan(table=[[default_catalog, default_database, Table1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
@@ -72,13 +72,13 @@ Calc(select=[bb, (f0 + 1) AS _c1, f1 AS y])
     <Resource name="ast">
       <![CDATA[
 LogicalProject(f0=[$0], f0_0=[$1])
-+- LogicalTableAggregate(group=[{0}], tableAggregate=[[EmptyTableAggFuncWithIntResultType($1)]])
++- LogicalTableAggregate(group=[{0}], tableAggregate=[[*org.apache.flink.table.planner.utils.EmptyTableAggFuncWithIntResultType*($1)]])
    +- LogicalTableScan(table=[[default_catalog, default_database, Table2, source: [TestTableSource(f0, f1, f2, d, e)]]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-GroupTableAggregate(groupBy=[f0], select=[f0, EmptyTableAggFuncWithIntResultType(f1) AS (f0_0)])
+GroupTableAggregate(groupBy=[f0], select=[f0, *org.apache.flink.table.planner.utils.EmptyTableAggFuncWithIntResultType*(f1) AS (f0_0)])
 +- Exchange(distribution=[hash[f0]])
    +- LegacyTableSourceScan(table=[[default_catalog, default_database, Table2, source: [TestTableSource(f0, f1, f2, d, e)]]], fields=[f0, f1, f2, d, e])
 ]]>
@@ -88,14 +88,14 @@ GroupTableAggregate(groupBy=[f0], select=[f0, EmptyTableAggFuncWithIntResultType
     <Resource name="ast">
       <![CDATA[
 LogicalProject(a=[*org.apache.flink.table.planner.expressions.utils.Func0$$6ad060e6c46e5cd996d7b888db472ebc*($0)], b=[$1])
-+- LogicalTableAggregate(group=[{}], tableAggregate=[[EmptyTableAggFunc($0, $1)]])
++- LogicalTableAggregate(group=[{}], tableAggregate=[[*org.apache.flink.table.planner.utils.EmptyTableAggFunc*($0, $1)]])
    +- LogicalTableScan(table=[[default_catalog, default_database, Table1, source: [TestTableSource(a, b, c, d, e)]]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[*org.apache.flink.table.planner.expressions.utils.Func0$$6ad060e6c46e5cd996d7b888db472ebc*(f0) AS a, f1 AS b])
-+- GroupTableAggregate(select=[EmptyTableAggFunc(a, b) AS (f0, f1)])
++- GroupTableAggregate(select=[*org.apache.flink.table.planner.utils.EmptyTableAggFunc*(a, b) AS (f0, f1)])
    +- Exchange(distribution=[single])
       +- LegacyTableSourceScan(table=[[default_catalog, default_database, Table1, source: [TestTableSource(a, b, c, d, e)]]], fields=[a, b, c, d, e])
 ]]>
@@ -105,15 +105,16 @@ Calc(select=[*org.apache.flink.table.planner.expressions.utils.Func0$$6ad060e6c4
     <Resource name="ast">
       <![CDATA[
 LogicalProject(a=[$0], b=[$1])
-+- LogicalTableAggregate(group=[{}], tableAggregate=[[EmptyTableAggFunc($3, $4)]])
-   +- LogicalTableScan(table=[[default_catalog, default_database, Table1, source: [TestTableSource(a, b, c, d, e)]]])
++- LogicalTableAggregate(group=[{}], tableAggregate=[[*org.apache.flink.table.planner.utils.EmptyTableAggFunc*($0, $1)]])
+   +- LogicalProject(d0=[CAST($3):TIMESTAMP(9)], e0=[CAST($4):TIMESTAMP(9)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, Table1, source: [TestTableSource(a, b, c, d, e)]]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-GroupTableAggregate(select=[EmptyTableAggFunc(d, e) AS (f0, f1)])
+GroupTableAggregate(select=[*org.apache.flink.table.planner.utils.EmptyTableAggFunc*(d0, e0) AS (f0, f1)])
 +- Exchange(distribution=[single])
-   +- Calc(select=[a, b, c, CAST(d AS TIMESTAMP(3)) AS d, PROCTIME_MATERIALIZE(e) AS e])
+   +- Calc(select=[CAST(CAST(d AS TIMESTAMP(3)) AS TIMESTAMP(9)) AS d0, CAST(PROCTIME_MATERIALIZE(e) AS TIMESTAMP(9)) AS e0])
       +- LegacyTableSourceScan(table=[[default_catalog, default_database, Table1, source: [TestTableSource(a, b, c, d, e)]]], fields=[a, b, c, d, e])
 ]]>
     </Resource>
@@ -122,13 +123,13 @@ GroupTableAggregate(select=[EmptyTableAggFunc(d, e) AS (f0, f1)])
     <Resource name="ast">
       <![CDATA[
 LogicalProject(f0=[$0], f1=[$1])
-+- LogicalTableAggregate(group=[{}], tableAggregate=[[EmptyTableAggFunc($1)]])
++- LogicalTableAggregate(group=[{}], tableAggregate=[[*org.apache.flink.table.planner.utils.EmptyTableAggFunc*($1)]])
    +- LogicalTableScan(table=[[default_catalog, default_database, Table1, source: [TestTableSource(a, b, c, d, e)]]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-GroupTableAggregate(select=[EmptyTableAggFunc(b) AS (f0, f1)])
+GroupTableAggregate(select=[*org.apache.flink.table.planner.utils.EmptyTableAggFunc*(b) AS (f0, f1)])
 +- Exchange(distribution=[single])
    +- LegacyTableSourceScan(table=[[default_catalog, default_database, Table1, source: [TestTableSource(a, b, c, d, e)]]], fields=[a, b, c, d, e])
 ]]>

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/TableAggregateITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/TableAggregateITCase.scala
@@ -208,7 +208,7 @@ class TableAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTes
     expectedException.expect(classOf[ValidationException])
     expectedException.expectMessage(
       s"Could not find an implementation method 'retract' in class '${classOf[Top3].getName}' " +
-      s"for function 'Top3' that matches the following signature:\n" +
+      s"for function '*${classOf[Top3].getName}*' that matches the following signature:\n" +
       s"void retract(${classOf[Top3Accum].getName}, java.lang.Integer)")
 
     val top3 = new Top3

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/CountAggFunction.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/CountAggFunction.scala
@@ -20,6 +20,7 @@ package org.apache.flink.table.planner.utils
 import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
 import org.apache.flink.api.java.tuple.{Tuple1 => JTuple1}
 import org.apache.flink.api.java.typeutils.TupleTypeInfo
+import org.apache.flink.table.annotation.{DataTypeHint, InputGroup}
 import org.apache.flink.table.api.Types
 import org.apache.flink.table.functions.AggregateFunction
 
@@ -35,7 +36,9 @@ class CountAccumulator extends JTuple1[JLong] {
   */
 class CountAggFunction extends AggregateFunction[JLong, CountAccumulator] {
 
-  def accumulate(acc: CountAccumulator, value: Any): Unit = {
+  def accumulate(
+      acc: CountAccumulator,
+      @DataTypeHint(inputGroup = InputGroup.ANY) value: Any): Unit = {
     if (value != null) {
       acc.f0 += 1L
     }
@@ -45,7 +48,9 @@ class CountAggFunction extends AggregateFunction[JLong, CountAccumulator] {
     acc.f0 += 1L
   }
 
-  def retract(acc: CountAccumulator, value: Any): Unit = {
+  def retract(
+      acc: CountAccumulator,
+      @DataTypeHint(inputGroup = InputGroup.ANY) value: Any): Unit = {
     if (value != null) {
       acc.f0 -= 1L
     }
@@ -69,10 +74,4 @@ class CountAggFunction extends AggregateFunction[JLong, CountAccumulator] {
   override def createAccumulator(): CountAccumulator = {
     new CountAccumulator
   }
-
-  override def getAccumulatorType: TypeInformation[CountAccumulator] = {
-    new TupleTypeInfo(classOf[CountAccumulator], BasicTypeInfo.LONG_TYPE_INFO)
-  }
-
-  override def getResultType: TypeInformation[java.lang.Long] = Types.LONG
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/UserDefinedTableAggFunctions.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/UserDefinedTableAggFunctions.scala
@@ -141,13 +141,13 @@ class Top3WithMapView extends TableAggregateFunction[JTuple2[JInt, JInt], Top3Wi
   @Override
   def createAccumulator(): Top3WithMapViewAccum = {
     val acc = new Top3WithMapViewAccum
-    acc.data = new MapView(Types.INT, Types.INT)
+    acc.data = new MapView()
     acc.size = 0
     acc.smallest = Integer.MAX_VALUE
     acc
   }
 
-  def add(acc: Top3WithMapViewAccum, v: Int): Unit = {
+  def add(acc: Top3WithMapViewAccum, v: JInt): Unit = {
     var cnt = acc.data.get(v)
     acc.size += 1
     if (cnt == null) {
@@ -156,7 +156,7 @@ class Top3WithMapView extends TableAggregateFunction[JTuple2[JInt, JInt], Top3Wi
     acc.data.put(v, cnt + 1)
   }
 
-  def delete(acc: Top3WithMapViewAccum, v: Int): Unit = {
+  def delete(acc: Top3WithMapViewAccum, v: JInt): Unit = {
     if (acc.data.contains(v)) {
       acc.size -= 1
       val cnt = acc.data.get(v) - 1
@@ -179,7 +179,7 @@ class Top3WithMapView extends TableAggregateFunction[JTuple2[JInt, JInt], Top3Wi
     }
   }
 
-  def accumulate(acc: Top3WithMapViewAccum, v: Int) {
+  def accumulate(acc: Top3WithMapViewAccum, v: JInt) {
     if (acc.size == 0) {
       acc.size = 1
       acc.smallest = v


### PR DESCRIPTION
## What is the purpose of the change

This updates the Scala implicit AggregateFunction of the Table API to the new type inference. Similar efforts have been done for ScalarFunctions in the last release.

## Brief change log

- Updates Scala implicits to use new type inference
- Fixes bug in Table API with aggregate functions that return composite types

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
