### PR TITLE
[FLINK-26865][python] Fix the potential failure of loading library inThread Mode

### DIFF
--- a/flink-python/dev/dev-requirements.txt
+++ b/flink-python/dev/dev-requirements.txt
@@ -27,4 +27,4 @@ numpy>=1.14.3,<1.20
 fastavro>=0.21.4,<0.24
 grpcio>=1.29.0,<2
 grpcio-tools>=1.3.5,<=1.14.2
-pemja==0.1.2; python_version >= '3.7'
+pemja==0.1.3; python_version >= '3.7'

--- a/flink-python/pom.xml
+++ b/flink-python/pom.xml
@@ -107,7 +107,7 @@ under the License.
 		<dependency>
 			<groupId>com.alibaba</groupId>
 			<artifactId>pemja</artifactId>
-			<version>0.1.2</version>
+			<version>0.1.3</version>
 		</dependency>
 
 		<!-- Protobuf dependencies -->

--- a/flink-python/setup.py
+++ b/flink-python/setup.py
@@ -313,7 +313,7 @@ try:
                           'pandas>=1.0,<1.2.0', 'pyarrow>=0.15.1,<3.0.0',
                           'pytz>=2018.3', 'numpy>=1.14.3,<1.20', 'fastavro>=0.21.4,<0.24',
                           'requests>=2.26.0', 'protobuf<3.18',
-                          'pemja==0.1.2;python_full_version >= "3.7"',
+                          'pemja==0.1.3;python_full_version >= "3.7"',
                           apache_flink_libraries_dependency],
         cmdclass={'build_ext': build_ext},
         tests_require=['pytest==4.4.1'],

--- a/flink-python/src/main/resources/META-INF/NOTICE
+++ b/flink-python/src/main/resources/META-INF/NOTICE
@@ -27,7 +27,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.beam:beam-vendor-sdks-java-extensions-protobuf:2.27.0
 - org.apache.beam:beam-vendor-guava-26_0-jre:0.1
 - org.apache.beam:beam-vendor-grpc-1_26_0:0.3
-- com.alibaba:pemja:0.1.2
+- com.alibaba:pemja:0.1.3
 
 This project bundles the following dependencies under the BSD license.
 See bundled license files for details


### PR DESCRIPTION
## What is the purpose of the change

*This pull request fix the potential failure of loading library inThread Mode*


## Brief change log

  - *Update the dependent pemja version to 0.1.3 to fix this problem.*


## Verifying this change

This change added tests and can be verified as follows:

  - *Original tests*
  - *This failure occurs in session mode and test it mannually*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
