### PR TITLE
[FLINK-26726][connector][hive]Hive enumerators do not assign splits to unregistered (failed) readers.

### DIFF
--- a/flink-connectors/flink-connector-hive/pom.xml
+++ b/flink-connectors/flink-connector-hive/pom.xml
@@ -872,6 +872,13 @@ under the License.
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-test-utils</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
 		<!-- The derby we use suffers some security vulnerabilities. Explicitly set it to test scope here. -->
 		<dependency>
 			<groupId>org.apache.derby</groupId>

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/ContinuousHiveSplitEnumerator.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/ContinuousHiveSplitEnumerator.java
@@ -166,6 +166,14 @@ public class ContinuousHiveSplitEnumerator<T extends Comparable<T>>
                 readersAwaitingSplit.entrySet().iterator();
         while (awaitingReader.hasNext()) {
             final Map.Entry<Integer, String> nextAwaiting = awaitingReader.next();
+
+            // if the reader that requested another split has failed in the meantime, remove
+            // it from the list of waiting readers
+            if (!enumeratorContext.registeredReaders().containsKey(nextAwaiting.getKey())) {
+                awaitingReader.remove();
+                continue;
+            }
+
             final String hostname = nextAwaiting.getValue();
             final int awaitingSubtask = nextAwaiting.getKey();
             final Optional<FileSourceSplit> nextSplit = splitAssigner.getNext(hostname);

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/ContinuousHiveSplitEnumeratorTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/ContinuousHiveSplitEnumeratorTest.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connectors.hive;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.file.src.assigners.SimpleSplitAssigner;
+import org.apache.flink.connector.file.table.ContinuousPartitionFetcher;
+import org.apache.flink.connector.file.table.PartitionFetcher;
+import org.apache.flink.connector.testutils.source.reader.TestingSplitEnumeratorContext;
+import org.apache.flink.connectors.hive.read.HiveSourceSplit;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.table.catalog.ObjectPath;
+
+import org.apache.hadoop.hive.metastore.api.Partition;
+import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.thrift.TException;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/** Unit tests for the {@link ContinuousHiveSplitEnumerator}. */
+public class ContinuousHiveSplitEnumeratorTest {
+
+    @Test
+    public void testDiscoverSplitWhenNoReaderRegistered() throws Exception {
+        final TestingSplitEnumeratorContext<HiveSourceSplit> context =
+                new TestingSplitEnumeratorContext<>(4);
+
+        final ContinuousHiveSplitEnumerator enumerator =
+                new ContinuousHiveSplitEnumerator(
+                        context,
+                        0L,
+                        Collections.emptySet(),
+                        new SimpleSplitAssigner(Collections.emptyList()),
+                        1000L,
+                        1,
+                        new JobConf(),
+                        new ObjectPath("testDb", "testTable"),
+                        mockPartitionFetcher(),
+                        new MockHiveContinuousPartitionFetcherContext(
+                                new ObjectPath("testDb", "testTable")));
+        enumerator.start();
+
+        HiveSourceSplit split = createSplit();
+        enumerator.addSplitsBack(Collections.singletonList(split), 0);
+        context.triggerAllActions();
+        assertEquals(1, enumerator.snapshotState(1L).getSplits().size());
+        assertTrue(enumerator.snapshotState(1L).getSplits().contains(split));
+    }
+
+    @Test
+    public void testDiscoverWhenReaderRegistered() throws Exception {
+        final TestingSplitEnumeratorContext<HiveSourceSplit> context =
+                new TestingSplitEnumeratorContext<>(4);
+
+        final ContinuousHiveSplitEnumerator enumerator =
+                new ContinuousHiveSplitEnumerator(
+                        context,
+                        0L,
+                        Collections.emptySet(),
+                        new SimpleSplitAssigner(Collections.emptyList()),
+                        1000L,
+                        1,
+                        new JobConf(),
+                        new ObjectPath("testDb", "testTable"),
+                        mockPartitionFetcher(),
+                        new MockHiveContinuousPartitionFetcherContext(
+                                new ObjectPath("testDb", "testTable")));
+        enumerator.start();
+        // register one reader, and let it request a split
+        context.registerReader(2, "localhost");
+        enumerator.addReader(2);
+        enumerator.handleSplitRequest(2, "localhost");
+        HiveSourceSplit split = createSplit();
+        enumerator.addSplitsBack(Collections.singletonList(split), 0);
+        context.triggerAllActions();
+        assertEquals(0, enumerator.snapshotState(1L).getSplits().size());
+        assertTrue(context.getSplitAssignments().get(2).getAssignedSplits().contains(split));
+    }
+
+    @Test
+    public void testRequestingReaderUnavailableWhenSplitDiscovered() throws Exception {
+        final TestingSplitEnumeratorContext<HiveSourceSplit> context =
+                new TestingSplitEnumeratorContext<>(4);
+
+        final ContinuousHiveSplitEnumerator enumerator =
+                new ContinuousHiveSplitEnumerator(
+                        context,
+                        0L,
+                        Collections.emptySet(),
+                        new SimpleSplitAssigner(Collections.emptyList()),
+                        1000L,
+                        1,
+                        new JobConf(),
+                        new ObjectPath("testDb", "testTable"),
+                        mockPartitionFetcher(),
+                        new MockHiveContinuousPartitionFetcherContext(
+                                new ObjectPath("testDb", "testTable")));
+        enumerator.start();
+        // register one reader, and let it request a split
+        context.registerReader(2, "localhost");
+        enumerator.addReader(2);
+        enumerator.handleSplitRequest(2, "localhost");
+
+        // remove the reader (like in a failure)
+        context.registeredReaders().remove(2);
+        HiveSourceSplit split = createSplit();
+        enumerator.addSplitsBack(Collections.singletonList(split), 0);
+        context.triggerAllActions();
+        assertFalse(context.getSplitAssignments().containsKey(2));
+        assertTrue(enumerator.snapshotState(1L).getSplits().contains(split));
+    }
+
+    private HiveSourceSplit createSplit() {
+        StorageDescriptor sd = new StorageDescriptor();
+        sd.setLocation("/tmp");
+        return new HiveSourceSplit(
+                "1",
+                new Path("/tmp"),
+                0,
+                0,
+                0,
+                0,
+                new String[] {"host1"},
+                null,
+                new HiveTablePartition(sd, new HashMap<>(), new Properties()));
+    }
+
+    private ContinuousPartitionFetcher mockPartitionFetcher() {
+        return new ContinuousPartitionFetcher<Partition, Long>() {
+
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public List<Tuple2<Partition, Long>> fetchPartitions(
+                    Context<Partition, Long> context, Long previousOffset) throws Exception {
+                return Collections.emptyList();
+            }
+
+            @Override
+            public List<Partition> fetch(PartitionFetcher.Context<Partition> context)
+                    throws Exception {
+                return Collections.emptyList();
+            }
+        };
+    }
+
+    private class MockHiveContinuousPartitionFetcherContext
+            extends HiveTableSource.HiveContinuousPartitionFetcherContext {
+
+        public MockHiveContinuousPartitionFetcherContext(ObjectPath tablePath) {
+            super(tablePath, null, null, null, null, null, new Configuration(), "default");
+        }
+
+        @Override
+        public void close() throws Exception {}
+
+        @Override
+        public void open() throws Exception {}
+
+        @Override
+        public Optional<Partition> getPartition(List partValues) throws TException {
+            return Optional.empty();
+        }
+
+        @Override
+        public HiveTablePartition toHiveTablePartition(Partition partition) {
+            return new HiveTablePartition(partition.getSd(), new HashMap<>(), new Properties());
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

  Let hive-enumerators do not assign splits to unregistered (failed) readers.


## Brief change log

  - add filter logic in ContinuousHiveSplitEnumerator#assignSplits
  - add test for ContinuousHiveSplitEnumerator


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
