### PR TITLE
[FLINK-27374][hive] Fix using wrong Flink type for Hive's void type 

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/HiveTypeUtil.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/HiveTypeUtil.java
@@ -160,6 +160,9 @@ public class HiveTypeUtil {
             case VARCHAR:
                 return DataTypes.VARCHAR(((VarcharTypeInfo) hiveType).getLength());
             case STRING:
+            case VOID:
+                // There's no corresponding data type to Hive's void in Flink, so convert into to
+                // Flink's string type
                 return DataTypes.STRING();
             case BOOLEAN:
                 return DataTypes.BOOLEAN();

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectQueryITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectQueryITCase.java
@@ -182,7 +182,8 @@ public class HiveDialectQueryITCase {
                                 "select a, one from binary_t lateral view explode(ab) abs as one where a > 0",
                                 "select /*+ mapjoin(dest) */ foo.x from foo join dest on foo.x = dest.x union"
                                         + " all select /*+ mapjoin(dest) */ foo.x from foo join dest on foo.y = dest.y",
-                                "with cte as (select * from src) select * from cte"));
+                                "with cte as (select * from src) select * from cte",
+                                "select nvl(null, null)"));
         if (HiveVersionTestUtil.HIVE_230_OR_LATER) {
             toRun.add(
                     "select weekofyear(current_timestamp()), dayofweek(current_timestamp()) from src limit 1");


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
Convert Hive's void type to Flink's string type to handle the cases that some Hive's udf may return void type which isn't support by Flink. We can mapping it to Flink's string type.


## Brief change log
- Mapping Hive's void type to Flink's string type in [HiveTypeUtil.java](https://github.com/apache/flink/pull/19253/files#diff-52250ee5b9eac198cd2214a6915f8a8fb36b937d40eef19c4c722da0543a1f13)#toFlinkPrimitiveType like what has been done in [HiveInspectors#getObjectInspectorForPrimitiveConstant](https://github.com/apache/flink/blob/2e5cac1f31aa571276df20e24889994672692a89/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/conversion/HiveInspectors.java#L553).


## Verifying this change
Addition query `select nvl(null, null)` in [HiveDialectQueryITCase.java](https://github.com/apache/flink/pull/19253/files#diff-fb5fc4106e27e27f9968e59b643003444fd40af58aa2f147ac301009b53a47ca)#testAdditionalQueries

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? N/A
