### PR TITLE
[FLINK-23890] improve cep operator timer register policy

### DIFF
--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/NFA.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/NFA.java
@@ -120,6 +120,10 @@ public class NFA<T> {
         return Collections.unmodifiableMap(tmp);
     }
 
+    public long getWindowTime() {
+        return windowTime;
+    }
+
     @VisibleForTesting
     public Collection<State<T>> getStates() {
         return states.values();
@@ -332,6 +336,10 @@ public class NFA<T> {
             // if stop state reached in this path
             boolean shouldDiscardPath = false;
             for (final ComputationState newComputationState : newComputationStates) {
+
+                if (isStartState(computationState) && newComputationState.getStartTimestamp() > 0) {
+                    nfaState.setNewStartPartiailMatch();
+                }
 
                 if (isFinalState(newComputationState)) {
                     potentialMatches.add(newComputationState);

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/NFAState.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/NFAState.java
@@ -39,6 +39,9 @@ public class NFAState {
     /** Flag indicating whether the matching status of the state machine has changed. */
     private boolean stateChanged;
 
+    /** Flag indicating whether the current matching status is new partial matched. */
+    private boolean isNewStartPartialMatch;
+
     public static final Comparator<ComputationState> COMPUTATION_STATE_COMPARATOR =
             Comparator.<ComputationState>comparingLong(
                             c ->
@@ -95,6 +98,18 @@ public class NFAState {
 
     public void setNewPartialMatches(PriorityQueue<ComputationState> newPartialMatches) {
         this.partialMatches = newPartialMatches;
+    }
+
+    public boolean isNewStartPartialMatch() {
+        return isNewStartPartialMatch;
+    }
+
+    public void resetNewStartPartialMatch() {
+        this.isNewStartPartialMatch = false;
+    }
+
+    public void setNewStartPartiailMatch() {
+        this.isNewStartPartialMatch = true;
     }
 
     @Override

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/CepOperator.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/CepOperator.java
@@ -238,13 +238,13 @@ public class CepOperator<IN, KEY, OUT>
                 long timestamp = getProcessingTimeService().getCurrentProcessingTime();
                 advanceTime(nfaState, timestamp);
                 processEvent(nfaState, element.getValue(), timestamp);
+                if (nfa.getWindowTime() > 0 && nfaState.isNewStartPartialMatch()) {
+                    registerTimer(timestamp + nfa.getWindowTime());
+                }
                 updateNFA(nfaState);
             } else {
                 long currentTime = timerService.currentProcessingTime();
                 bufferEvent(element.getValue(), currentTime);
-
-                // register a timer for the next millisecond to sort and emit buffered data
-                timerService.registerProcessingTimeTimer(VoidNamespace.INSTANCE, currentTime + 1);
             }
 
         } else {
@@ -262,8 +262,6 @@ public class CepOperator<IN, KEY, OUT>
                 // we have an event with a valid timestamp, so
                 // we buffer it until we receive the proper watermark.
 
-                saveRegisterWatermarkTimer();
-
                 bufferEvent(value, timestamp);
 
             } else if (lateDataOutputTag != null) {
@@ -274,16 +272,12 @@ public class CepOperator<IN, KEY, OUT>
         }
     }
 
-    /**
-     * Registers a timer for {@code current watermark + 1}, this means that we get triggered
-     * whenever the watermark advances, which is what we want for working off the queue of buffered
-     * elements.
-     */
-    private void saveRegisterWatermarkTimer() {
-        long currentWatermark = timerService.currentWatermark();
-        // protect against overflow
-        if (currentWatermark + 1 > currentWatermark) {
-            timerService.registerEventTimeTimer(VoidNamespace.INSTANCE, currentWatermark + 1);
+    private void registerTimer(long timestamp) {
+        if (isProcessingTime) {
+            timerService.registerProcessingTimeTimer(
+                    VoidNamespace.INSTANCE, timestamp);
+        } else {
+            timerService.registerEventTimeTimer(VoidNamespace.INSTANCE, timestamp);
         }
     }
 
@@ -291,6 +285,7 @@ public class CepOperator<IN, KEY, OUT>
         List<IN> elementsForTimestamp = elementQueueState.get(currentTime);
         if (elementsForTimestamp == null) {
             elementsForTimestamp = new ArrayList<>();
+            registerTimer(currentTime);
         }
 
         elementsForTimestamp.add(event);
@@ -335,10 +330,6 @@ public class CepOperator<IN, KEY, OUT>
 
         // STEP 4
         updateNFA(nfaState);
-
-        if (!sortedTimestamps.isEmpty() || !partialMatches.isEmpty()) {
-            saveRegisterWatermarkTimer();
-        }
     }
 
     @Override
@@ -387,6 +378,7 @@ public class CepOperator<IN, KEY, OUT>
     private void updateNFA(NFAState nfaState) throws IOException {
         if (nfaState.isStateChanged()) {
             nfaState.resetStateChanged();
+            nfaState.resetNewStartPartialMatch();
             computationStates.update(nfaState);
         }
     }

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/CepOperator.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/CepOperator.java
@@ -271,7 +271,7 @@ public class CepOperator<IN, KEY, OUT>
 
     private void registerTimer(long timestamp) {
         if (isProcessingTime) {
-            timerService.registerProcessingTimeTimer(VoidNamespace.INSTANCE, timestamp);
+            timerService.registerProcessingTimeTimer(VoidNamespace.INSTANCE, timestamp + 1);
         } else {
             timerService.registerEventTimeTimer(VoidNamespace.INSTANCE, timestamp);
         }
@@ -358,6 +358,9 @@ public class CepOperator<IN, KEY, OUT>
         }
 
         // STEP 3
+        advanceTime(nfa, timerService.currentProcessingTime());
+
+        // STEP 4
         updateNFA(nfa);
     }
 

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/CepOperator.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/CepOperator.java
@@ -238,9 +238,6 @@ public class CepOperator<IN, KEY, OUT>
                 long timestamp = getProcessingTimeService().getCurrentProcessingTime();
                 advanceTime(nfaState, timestamp);
                 processEvent(nfaState, element.getValue(), timestamp);
-                if (nfa.getWindowTime() > 0 && nfaState.isNewStartPartialMatch()) {
-                    registerTimer(timestamp + nfa.getWindowTime());
-                }
                 updateNFA(nfaState);
             } else {
                 long currentTime = timerService.currentProcessingTime();
@@ -274,8 +271,7 @@ public class CepOperator<IN, KEY, OUT>
 
     private void registerTimer(long timestamp) {
         if (isProcessingTime) {
-            timerService.registerProcessingTimeTimer(
-                    VoidNamespace.INSTANCE, timestamp);
+            timerService.registerProcessingTimeTimer(VoidNamespace.INSTANCE, timestamp);
         } else {
             timerService.registerEventTimeTimer(VoidNamespace.INSTANCE, timestamp);
         }
@@ -409,6 +405,9 @@ public class CepOperator<IN, KEY, OUT>
                             timestamp,
                             afterMatchSkipStrategy,
                             cepTimerService);
+            if (nfa.getWindowTime() > 0 && nfaState.isNewStartPartialMatch()) {
+                registerTimer(timestamp + nfa.getWindowTime());
+            }
             processMatchedSequences(patterns, timestamp);
         }
     }

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPOperatorTest.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPOperatorTest.java
@@ -597,7 +597,7 @@ public class CEPOperatorTest extends TestLogger {
             // there must be 2 keys 42, 43 registered for the watermark callback
             // all the seen elements must be in the priority queues but no NFA yet.
 
-            assertEquals(2L, harness.numEventTimeTimers());
+            assertEquals(4L, harness.numEventTimeTimers());
             assertEquals(4L, operator.getPQSize(42));
             assertEquals(1L, operator.getPQSize(43));
             assertTrue(!operator.hasNonEmptySharedBuffer(42));
@@ -612,7 +612,7 @@ public class CEPOperatorTest extends TestLogger {
             // one element in PQ for 42 (the barfoo) as it arrived early
             // for 43 the element entered the NFA and the PQ is empty
 
-            assertEquals(2L, harness.numEventTimeTimers());
+            assertEquals(4L, harness.numEventTimeTimers());
             assertTrue(operator.hasNonEmptySharedBuffer(42));
             assertEquals(1L, operator.getPQSize(42));
             assertTrue(operator.hasNonEmptySharedBuffer(43));
@@ -637,7 +637,7 @@ public class CEPOperatorTest extends TestLogger {
 
             // now we have 1 key because the 43 expired and was removed.
             // 42 is still there due to startEvent2
-            assertEquals(1L, harness.numEventTimeTimers());
+            assertEquals(3L, harness.numEventTimeTimers());
             assertTrue(operator2.hasNonEmptySharedBuffer(42));
             assertTrue(!operator2.hasNonEmptyPQ(42));
             assertTrue(!operator2.hasNonEmptySharedBuffer(43));
@@ -696,7 +696,7 @@ public class CEPOperatorTest extends TestLogger {
             harness.processElement(new StreamRecord<>(middle1Event1, 3));
             harness.processElement(new StreamRecord<>(new Event(41, "d", 6.0), 5));
 
-            assertEquals(1L, harness.numEventTimeTimers());
+            assertEquals(5L, harness.numEventTimeTimers());
             assertEquals(7L, operator.getPQSize(41));
             assertTrue(!operator.hasNonEmptySharedBuffer(41));
 
@@ -705,7 +705,7 @@ public class CEPOperatorTest extends TestLogger {
             verifyWatermark(harness.getOutput().poll(), Long.MIN_VALUE);
             verifyWatermark(harness.getOutput().poll(), 2L);
 
-            assertEquals(1L, harness.numEventTimeTimers());
+            assertEquals(5L, harness.numEventTimeTimers());
             assertEquals(6L, operator.getPQSize(41));
             assertTrue(operator.hasNonEmptySharedBuffer(41)); // processed the first element
 

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPOperatorTest.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPOperatorTest.java
@@ -906,7 +906,7 @@ public class CEPOperatorTest extends TestLogger {
 
             harness.setProcessingTime(21L);
 
-            assertTrue(operator2.hasNonEmptySharedBuffer(42));
+            assertTrue(!operator2.hasNonEmptySharedBuffer(42));
 
             harness.processElement(new StreamRecord<>(startEvent1, 21L));
             assertTrue(operator2.hasNonEmptySharedBuffer(42));


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
