### PR TITLE
[hotfix][table][tests] Improve code - use assertJ

### DIFF
--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/SqlClientTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/SqlClientTest.java
@@ -27,7 +27,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 import org.junit.rules.Timeout;
 
@@ -50,11 +49,10 @@ import java.util.concurrent.TimeUnit;
 
 import static org.apache.flink.configuration.ConfigConstants.ENV_FLINK_CONF_DIR;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link SqlClient}. */
 public class SqlClientTest {
-
-    @Rule public ExpectedException thrown = ExpectedException.none();
 
     @Rule public TemporaryFolder tempFolder = new TemporaryFolder();
 
@@ -119,9 +117,9 @@ public class SqlClientTest {
     @Test
     public void testUnsupportedGatewayMode() {
         String[] args = new String[] {"gateway"};
-        thrown.expect(SqlClientException.class);
-        thrown.expectMessage("Gateway mode is not supported yet.");
-        SqlClient.main(args);
+        assertThatThrownBy(() -> SqlClient.main(args))
+                .isInstanceOf(SqlClientException.class)
+                .hasMessage("Gateway mode is not supported yet.");
     }
 
     @Test
@@ -203,11 +201,11 @@ public class SqlClientTest {
     }
 
     @Test
-    public void testExecuteSqlWithHDFSFile() throws Exception {
+    public void testExecuteSqlWithHDFSFile() {
         String[] args = new String[] {"-f", "hdfs://path/to/file/test.sql"};
-        thrown.expect(SqlClientException.class);
-        thrown.expectMessage("SQL Client only supports to load files in local.");
-        runSqlClient(args);
+        assertThatThrownBy(() -> runSqlClient(args))
+                .isInstanceOf(SqlClientException.class)
+                .hasMessage("SQL Client only supports to load files in local.");
     }
 
     private String runSqlClient(String[] args) throws Exception {

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
@@ -50,9 +50,7 @@ import org.apache.flink.util.TestLogger;
 
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
@@ -119,8 +117,6 @@ public class LocalExecutorITCase extends TestLogger {
         config.setBoolean(WebOptions.SUBMIT_ENABLE, false);
         return config;
     }
-
-    @Rule public ExpectedException exception = ExpectedException.none();
 
     @Test
     public void testCompleteStatement() {

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
@@ -140,7 +140,7 @@ public class LocalExecutorITCase extends TestLogger {
         assertThat(executor.completeStatement(sessionId, "SELECT * FROM TableNumber1 WH", 29))
                 .isEqualTo(expectedClause);
 
-        final List<String> expectedField = Arrays.asList("IntegerField1");
+        final List<String> expectedField = Collections.singletonList("IntegerField1");
         assertThat(
                         executor.completeStatement(
                                 sessionId, "SELECT * FROM TableNumber1 WHERE Inte", 37))

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/CreateTableLikeTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/CreateTableLikeTest.java
@@ -113,7 +113,7 @@ class CreateTableLikeTest {
 
         assertThatThrownBy(extendedSqlNode::validate)
                 .isInstanceOf(SqlValidateException.class)
-                .hasMessageContaining("Each like option feature can be declared only once.");
+                .hasMessage("Each like option feature can be declared only once.");
     }
 
     @Test
@@ -131,8 +131,7 @@ class CreateTableLikeTest {
 
         assertThatThrownBy(extendedSqlNode::validate)
                 .isInstanceOf(SqlValidateException.class)
-                .hasMessageContaining(
-                        "Illegal merging strategy 'OVERWRITING' for 'PARTITIONS' option.");
+                .hasMessage("Illegal merging strategy 'OVERWRITING' for 'PARTITIONS' option.");
     }
 
     @Test
@@ -150,7 +149,7 @@ class CreateTableLikeTest {
 
         assertThatThrownBy(extendedSqlNode::validate)
                 .isInstanceOf(SqlValidateException.class)
-                .hasMessageContaining("Illegal merging strategy 'OVERWRITING' for 'ALL' option.");
+                .hasMessage("Illegal merging strategy 'OVERWRITING' for 'ALL' option.");
     }
 
     @Test
@@ -174,16 +173,11 @@ class CreateTableLikeTest {
 
     @Test
     void testInvalidNoOptions() {
-        assertThatThrownBy(
-                        () ->
-                                createFlinkParser(
-                                                "CREATE TABLE t (\n"
-                                                        + "   a STRING\n"
-                                                        + ")\n"
-                                                        + "LIKE b ()")
-                                        .parseStmt())
+        SqlParser parser =
+                createFlinkParser("CREATE TABLE t (\n" + "   a STRING\n" + ")\n" + "LIKE b ()");
+        assertThatThrownBy(parser::parseStmt)
                 .isInstanceOf(SqlParseException.class)
-                .hasMessageContaining(
+                .hasMessageStartingWith(
                         "Encountered \")\" at line 4, column 9.\n"
                                 + "Was expecting one of:\n"
                                 + "    \"EXCLUDING\" ...\n"
@@ -193,18 +187,18 @@ class CreateTableLikeTest {
 
     @Test
     void testInvalidNoSourceTable() {
-        assertThatThrownBy(
-                        () ->
-                                createFlinkParser(
-                                                "CREATE TABLE t (\n"
-                                                        + "   a STRING\n"
-                                                        + ")\n"
-                                                        + "LIKE ("
-                                                        + "   INCLUDING ALL"
-                                                        + ")")
-                                        .parseStmt())
+        SqlParser parser =
+                createFlinkParser(
+                        "CREATE TABLE t (\n"
+                                + "   a STRING\n"
+                                + ")\n"
+                                + "LIKE ("
+                                + "   INCLUDING ALL"
+                                + ")");
+
+        assertThatThrownBy(parser::parseStmt)
                 .isInstanceOf(SqlParseException.class)
-                .hasMessageContaining(
+                .hasMessageStartingWith(
                         "Encountered \"(\" at line 4, column 6.\n"
                                 + "Was expecting one of:\n"
                                 + "    <BRACKET_QUOTED_IDENTIFIER> ...\n"

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/api/TableConfigTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/api/TableConfigTest.java
@@ -20,103 +20,106 @@ package org.apache.flink.table.api;
 
 import org.apache.flink.configuration.Configuration;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
+import java.time.DateTimeException;
 import java.time.Duration;
 import java.time.ZoneId;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link TableConfig}. */
 public class TableConfigTest {
 
-    @Rule public ExpectedException expectedException = ExpectedException.none();
-
-    private static TableConfig configByMethod = TableConfig.getDefault();
-    private static TableConfig configByConfiguration = TableConfig.getDefault();
-    private static Configuration configuration = new Configuration();
+    private static final TableConfig CONFIG_BY_METHOD = TableConfig.getDefault();
+    private static final TableConfig CONFIG_BY_CONFIGURATION = TableConfig.getDefault();
+    private static final Configuration configuration = new Configuration();
 
     @Test
     public void testSetAndGetSqlDialect() {
         configuration.setString("table.sql-dialect", "HIVE");
-        configByConfiguration.addConfiguration(configuration);
-        configByMethod.setSqlDialect(SqlDialect.HIVE);
+        CONFIG_BY_CONFIGURATION.addConfiguration(configuration);
+        CONFIG_BY_METHOD.setSqlDialect(SqlDialect.HIVE);
 
-        assertThat(configByMethod.getSqlDialect()).isEqualTo(SqlDialect.HIVE);
-        assertThat(configByConfiguration.getSqlDialect()).isEqualTo(SqlDialect.HIVE);
+        assertThat(CONFIG_BY_METHOD.getSqlDialect()).isEqualTo(SqlDialect.HIVE);
+        assertThat(CONFIG_BY_CONFIGURATION.getSqlDialect()).isEqualTo(SqlDialect.HIVE);
     }
 
     @Test
     public void testSetAndGetMaxGeneratedCodeLength() {
         configuration.setString("table.generated-code.max-length", "5000");
-        configByConfiguration.addConfiguration(configuration);
-        configByMethod.setMaxGeneratedCodeLength(5000);
+        CONFIG_BY_CONFIGURATION.addConfiguration(configuration);
+        CONFIG_BY_METHOD.setMaxGeneratedCodeLength(5000);
 
-        assertThat(configByMethod.getMaxGeneratedCodeLength()).isEqualTo(Integer.valueOf(5000));
-        assertThat(configByConfiguration.getMaxGeneratedCodeLength())
+        assertThat(CONFIG_BY_METHOD.getMaxGeneratedCodeLength()).isEqualTo(Integer.valueOf(5000));
+        assertThat(CONFIG_BY_CONFIGURATION.getMaxGeneratedCodeLength())
                 .isEqualTo(Integer.valueOf(5000));
     }
 
     @Test
     public void testSetAndGetLocalTimeZone() {
         configuration.setString("table.local-time-zone", "Asia/Shanghai");
-        configByConfiguration.addConfiguration(configuration);
-        configByMethod.setLocalTimeZone(ZoneId.of("Asia/Shanghai"));
+        CONFIG_BY_CONFIGURATION.addConfiguration(configuration);
+        CONFIG_BY_METHOD.setLocalTimeZone(ZoneId.of("Asia/Shanghai"));
 
-        assertThat(configByMethod.getLocalTimeZone()).isEqualTo(ZoneId.of("Asia/Shanghai"));
-        assertThat(configByConfiguration.getLocalTimeZone()).isEqualTo(ZoneId.of("Asia/Shanghai"));
+        assertThat(CONFIG_BY_METHOD.getLocalTimeZone()).isEqualTo(ZoneId.of("Asia/Shanghai"));
+        assertThat(CONFIG_BY_CONFIGURATION.getLocalTimeZone())
+                .isEqualTo(ZoneId.of("Asia/Shanghai"));
 
         configuration.setString("table.local-time-zone", "GMT-08:00");
-        configByConfiguration.addConfiguration(configuration);
-        configByMethod.setLocalTimeZone(ZoneId.of("GMT-08:00"));
+        CONFIG_BY_CONFIGURATION.addConfiguration(configuration);
+        CONFIG_BY_METHOD.setLocalTimeZone(ZoneId.of("GMT-08:00"));
 
-        assertThat(configByMethod.getLocalTimeZone()).isEqualTo(ZoneId.of("GMT-08:00"));
-        assertThat(configByConfiguration.getLocalTimeZone()).isEqualTo(ZoneId.of("GMT-08:00"));
+        assertThat(CONFIG_BY_METHOD.getLocalTimeZone()).isEqualTo(ZoneId.of("GMT-08:00"));
+        assertThat(CONFIG_BY_CONFIGURATION.getLocalTimeZone()).isEqualTo(ZoneId.of("GMT-08:00"));
     }
 
     @Test
     public void testSetInvalidLocalTimeZone() {
-        expectedException.expectMessage(
-                "The supported Zone ID is either a full name such as 'America/Los_Angeles',"
-                        + " or a custom timezone id such as 'GMT-08:00', but configured Zone ID is 'UTC-10:00'.");
-        configByMethod.setLocalTimeZone(ZoneId.of("UTC-10:00"));
+        assertThatThrownBy(() -> CONFIG_BY_METHOD.setLocalTimeZone(ZoneId.of("UTC-10:00")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(
+                        "The supported Zone ID is either a full name such as 'America/Los_Angeles',"
+                                + " or a custom timezone id such as 'GMT-08:00', but configured Zone ID is 'UTC-10:00'.");
     }
 
     @Test
     public void testInvalidGmtLocalTimeZone() {
-        expectedException.expectMessage("Invalid ID for offset-based ZoneId: GMT-8:00");
-        configByMethod.setLocalTimeZone(ZoneId.of("GMT-8:00"));
+        assertThatThrownBy(() -> CONFIG_BY_METHOD.setLocalTimeZone(ZoneId.of("GMT-8:00")))
+                .isInstanceOf(DateTimeException.class)
+                .hasMessage("Invalid ID for offset-based ZoneId: GMT-8:00");
     }
 
     @Test
     public void testGetInvalidLocalTimeZone() {
         configuration.setString("table.local-time-zone", "UTC+8");
-        configByConfiguration.addConfiguration(configuration);
-        expectedException.expectMessage(
-                "The supported Zone ID is either a full name such as 'America/Los_Angeles',"
-                        + " or a custom timezone id such as 'GMT-08:00', but configured Zone ID is 'UTC+8'.");
-        configByConfiguration.getLocalTimeZone();
+        CONFIG_BY_CONFIGURATION.addConfiguration(configuration);
+        assertThatThrownBy(CONFIG_BY_CONFIGURATION::getLocalTimeZone)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(
+                        "The supported Zone ID is either a full name such as 'America/Los_Angeles',"
+                                + " or a custom timezone id such as 'GMT-08:00', but configured Zone ID is 'UTC+8'.");
     }
 
     @Test
     public void testGetInvalidAbbreviationLocalTimeZone() {
         configuration.setString("table.local-time-zone", "PST");
-        configByConfiguration.addConfiguration(configuration);
-        expectedException.expectMessage(
-                "The supported Zone ID is either a full name such as 'America/Los_Angeles',"
-                        + " or a custom timezone id such as 'GMT-08:00', but configured Zone ID is 'PST'.");
-        configByConfiguration.getLocalTimeZone();
+        CONFIG_BY_CONFIGURATION.addConfiguration(configuration);
+        assertThatThrownBy(CONFIG_BY_CONFIGURATION::getLocalTimeZone)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(
+                        "The supported Zone ID is either a full name such as 'America/Los_Angeles',"
+                                + " or a custom timezone id such as 'GMT-08:00', but configured Zone ID is 'PST'.");
     }
 
     @Test
     public void testSetAndGetIdleStateRetention() {
         configuration.setString("table.exec.state.ttl", "1 h");
-        configByConfiguration.addConfiguration(configuration);
-        configByMethod.setIdleStateRetention(Duration.ofHours(1));
+        CONFIG_BY_CONFIGURATION.addConfiguration(configuration);
+        CONFIG_BY_METHOD.setIdleStateRetention(Duration.ofHours(1));
 
-        assertThat(configByMethod.getIdleStateRetention()).isEqualTo(Duration.ofHours(1));
-        assertThat(configByConfiguration.getIdleStateRetention()).isEqualTo(Duration.ofHours(1));
+        assertThat(CONFIG_BY_METHOD.getIdleStateRetention()).isEqualTo(Duration.ofHours(1));
+        assertThat(CONFIG_BY_CONFIGURATION.getIdleStateRetention()).isEqualTo(Duration.ofHours(1));
     }
 }

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/expressions/ObjectToExpressionTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/expressions/ObjectToExpressionTest.java
@@ -23,9 +23,7 @@ import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.types.Row;
 import org.apache.flink.types.RowKind;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.util.HashMap;
 import java.util.List;
@@ -41,14 +39,13 @@ import static org.apache.flink.table.api.Expressions.row;
 import static org.apache.flink.table.expressions.ApiExpressionUtils.objectToExpression;
 import static org.apache.flink.table.expressions.ApiExpressionUtils.unwrapFromApi;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Tests for converting an object to a {@link Expression} via {@link
  * ApiExpressionUtils#objectToExpression(Object)}.
  */
 public class ObjectToExpressionTest {
-
-    @Rule public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void testListConversion() {
@@ -96,29 +93,32 @@ public class ObjectToExpressionTest {
 
     @Test
     public void testRowWithDeleteKindConversion() {
-        thrown.expect(ValidationException.class);
-        thrown.expectMessage(
-                "Unsupported kind 'DELETE' of a row [-D[1]]. "
-                        + "Only rows with 'INSERT' kind are supported when converting to an expression.");
-        objectToExpression(Row.ofKind(RowKind.DELETE, 1));
+        assertThatThrownBy(() -> objectToExpression(Row.ofKind(RowKind.DELETE, 1)))
+                .isInstanceOf(ValidationException.class)
+                .hasMessage(
+                        "Unsupported kind 'DELETE' of a row [-D[1]]. "
+                                + "Only rows with 'INSERT' kind are supported when converting "
+                                + "to an expression.");
     }
 
     @Test
     public void testRowWithUpdateBeforeKindConversion() {
-        thrown.expect(ValidationException.class);
-        thrown.expectMessage(
-                "Unsupported kind 'UPDATE_BEFORE' of a row [-U[1]]. "
-                        + "Only rows with 'INSERT' kind are supported when converting to an expression.");
-        objectToExpression(Row.ofKind(RowKind.UPDATE_BEFORE, 1));
+        assertThatThrownBy(() -> objectToExpression(Row.ofKind(RowKind.UPDATE_BEFORE, 1)))
+                .isInstanceOf(ValidationException.class)
+                .hasMessage(
+                        "Unsupported kind 'UPDATE_BEFORE' of a row [-U[1]]. "
+                                + "Only rows with 'INSERT' kind are supported when converting "
+                                + "to an expression.");
     }
 
     @Test
     public void testRowWithUpdateAfterKindConversion() {
-        thrown.expect(ValidationException.class);
-        thrown.expectMessage(
-                "Unsupported kind 'UPDATE_AFTER' of a row [+U[1]]. "
-                        + "Only rows with 'INSERT' kind are supported when converting to an expression.");
-        objectToExpression(Row.ofKind(RowKind.UPDATE_AFTER, 1));
+        assertThatThrownBy(() -> objectToExpression(Row.ofKind(RowKind.UPDATE_AFTER, 1)))
+                .isInstanceOf(ValidationException.class)
+                .hasMessage(
+                        "Unsupported kind 'UPDATE_AFTER' of a row [+U[1]]. "
+                                + "Only rows with 'INSERT' kind are supported when converting "
+                                + "to an expression.");
     }
 
     private static void assertThatEquals(Expression actual, Expression expected) {

--- a/flink-table/flink-table-api-scala/src/test/scala/org/apache/flink/table/types/extraction/TypeInferenceExtractorScalaTest.scala
+++ b/flink-table/flink-table-api-scala/src/test/scala/org/apache/flink/table/types/extraction/TypeInferenceExtractorScalaTest.scala
@@ -23,9 +23,8 @@ import org.apache.flink.table.functions.ScalarFunction
 import org.apache.flink.table.types.extraction.TypeInferenceExtractorTest.TestSpec
 import org.apache.flink.table.types.inference.{ArgumentTypeStrategy, InputTypeStrategies, TypeStrategies}
 
-import org.hamcrest.CoreMatchers.equalTo
+import org.assertj.core.api.AssertionsForClassTypes.assertThat
 import org.junit.{Rule, Test}
-import org.junit.Assert.assertThat
 import org.junit.rules.ExpectedException
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
@@ -46,27 +45,24 @@ class TypeInferenceExtractorScalaTest(testSpec: TestSpec) {
   @Test
   def testArgumentNames(): Unit = {
     if (testSpec.expectedArgumentNames != null) {
-      assertThat(
-        testSpec.typeInferenceExtraction.get.getNamedArguments,
-        equalTo(Optional.of(testSpec.expectedArgumentNames)))
+      assertThat(testSpec.typeInferenceExtraction.get.getNamedArguments)
+        .isEqualTo(Optional.of(testSpec.expectedArgumentNames))
     }
   }
 
   @Test
   def testArgumentTypes(): Unit = {
     if (testSpec.expectedArgumentTypes != null) {
-      assertThat(
-        testSpec.typeInferenceExtraction.get.getTypedArguments,
-        equalTo(Optional.of(testSpec.expectedArgumentTypes)))
+      assertThat(testSpec.typeInferenceExtraction.get.getTypedArguments)
+        .isEqualTo(Optional.of(testSpec.expectedArgumentTypes))
     }
   }
 
   @Test
   def testOutputTypeStrategy(): Unit = {
     if (!testSpec.expectedOutputStrategies.isEmpty) {
-      assertThat(
-        testSpec.typeInferenceExtraction.get.getOutputTypeStrategy,
-        equalTo(TypeStrategies.mapping(testSpec.expectedOutputStrategies)))
+      assertThat(testSpec.typeInferenceExtraction.get.getOutputTypeStrategy)
+        .isEqualTo(TypeStrategies.mapping(testSpec.expectedOutputStrategies))
     }
   }
 }

--- a/flink-table/flink-table-api-scala/src/test/scala/org/apache/flink/table/types/extraction/TypeInferenceExtractorScalaTest.scala
+++ b/flink-table/flink-table-api-scala/src/test/scala/org/apache/flink/table/types/extraction/TypeInferenceExtractorScalaTest.scala
@@ -32,15 +32,11 @@ import org.junit.runners.Parameterized.Parameters
 
 import java.util.Optional
 
-import scala.annotation.meta.getter
 import scala.annotation.varargs
 
 /** Scala tests for [[TypeInferenceExtractor]]. */
 @RunWith(classOf[Parameterized])
 class TypeInferenceExtractorScalaTest(testSpec: TestSpec) {
-
-  @(Rule @getter)
-  var thrown: ExpectedException = ExpectedException.none
 
   @Test
   def testArgumentNames(): Unit = {

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/api/constraints/UniqueConstraintTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/api/constraints/UniqueConstraintTest.java
@@ -18,9 +18,7 @@
 
 package org.apache.flink.table.api.constraints;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.util.Collections;
 import java.util.List;
@@ -29,8 +27,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link UniqueConstraint}. */
 public class UniqueConstraintTest {
-
-    @Rule public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void testCreatingPrimaryKey() {

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTest.java
@@ -37,9 +37,7 @@ import org.apache.flink.table.catalog.stats.CatalogTableStatistics;
 
 import org.junit.After;
 import org.junit.AfterClass;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -50,6 +48,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Class for unit tests to run on catalogs. */
 public abstract class CatalogTest {
@@ -73,8 +72,6 @@ public abstract class CatalogTest {
     protected static final String TEST_COMMENT = "test comment";
 
     protected static Catalog catalog;
-
-    @Rule public ExpectedException exception = ExpectedException.none();
 
     @After
     public void cleanup() throws Exception {
@@ -125,9 +122,9 @@ public abstract class CatalogTest {
     public void testCreateDb_DatabaseAlreadyExistException() throws Exception {
         catalog.createDatabase(db1, createDb(), false);
 
-        exception.expect(DatabaseAlreadyExistException.class);
-        exception.expectMessage("Database db1 already exists in Catalog");
-        catalog.createDatabase(db1, createDb(), false);
+        assertThatThrownBy(() -> catalog.createDatabase(db1, createDb(), false))
+                .isInstanceOf(DatabaseAlreadyExistException.class)
+                .hasMessage("Database db1 already exists in Catalog " + TEST_CATALOG_NAME + ".");
     }
 
     @Test
@@ -148,10 +145,13 @@ public abstract class CatalogTest {
     }
 
     @Test
-    public void testGetDb_DatabaseNotExistException() throws Exception {
-        exception.expect(DatabaseNotExistException.class);
-        exception.expectMessage("Database nonexistent does not exist in Catalog");
-        catalog.getDatabase("nonexistent");
+    public void testGetDb_DatabaseNotExistException() {
+        assertThatThrownBy(() -> catalog.getDatabase("nonexistent"))
+                .isInstanceOf(DatabaseNotExistException.class)
+                .hasMessage(
+                        "Database nonexistent does not exist in Catalog "
+                                + TEST_CATALOG_NAME
+                                + ".");
     }
 
     @Test
@@ -166,10 +166,10 @@ public abstract class CatalogTest {
     }
 
     @Test
-    public void testDropDb_DatabaseNotExistException() throws Exception {
-        exception.expect(DatabaseNotExistException.class);
-        exception.expectMessage("Database db1 does not exist in Catalog");
-        catalog.dropDatabase(db1, false, false);
+    public void testDropDb_DatabaseNotExistException() {
+        assertThatThrownBy(() -> catalog.dropDatabase(db1, false, false))
+                .isInstanceOf(DatabaseNotExistException.class)
+                .hasMessage("Database db1 does not exist in Catalog " + TEST_CATALOG_NAME + ".");
     }
 
     @Test
@@ -182,9 +182,9 @@ public abstract class CatalogTest {
         catalog.createDatabase(db1, createDb(), false);
         catalog.createTable(path1, createTable(), false);
 
-        exception.expect(DatabaseNotEmptyException.class);
-        exception.expectMessage("Database db1 in catalog test-catalog is not empty");
-        catalog.dropDatabase(db1, true, false);
+        assertThatThrownBy(() -> catalog.dropDatabase(db1, true, false))
+                .isInstanceOf(DatabaseNotEmptyException.class)
+                .hasMessage("Database db1 in catalog test-catalog is not empty.");
     }
 
     @Test
@@ -205,10 +205,13 @@ public abstract class CatalogTest {
     }
 
     @Test
-    public void testAlterDb_DatabaseNotExistException() throws Exception {
-        exception.expect(DatabaseNotExistException.class);
-        exception.expectMessage("Database nonexistent does not exist in Catalog");
-        catalog.alterDatabase("nonexistent", createDb(), false);
+    public void testAlterDb_DatabaseNotExistException() {
+        assertThatThrownBy(() -> catalog.alterDatabase("nonexistent", createDb(), false))
+                .isInstanceOf(DatabaseNotExistException.class)
+                .hasMessage(
+                        "Database nonexistent does not exist in Catalog "
+                                + TEST_CATALOG_NAME
+                                + ".");
     }
 
     @Test
@@ -249,6 +252,7 @@ public abstract class CatalogTest {
         CatalogBaseTable tableCreated = catalog.getTable(path1);
 
         CatalogTestUtil.checkEquals(table, (CatalogTable) tableCreated);
+        assertThat(tableCreated.getDescription().isPresent()).isTrue();
         assertThat(tableCreated.getDescription().get()).isEqualTo(TEST_COMMENT);
 
         List<String> tables = catalog.listTables(db1);
@@ -276,12 +280,12 @@ public abstract class CatalogTest {
     }
 
     @Test
-    public void testCreateTable_DatabaseNotExistException() throws Exception {
+    public void testCreateTable_DatabaseNotExistException() {
         assertThat(catalog.databaseExists(db1)).isFalse();
 
-        exception.expect(DatabaseNotExistException.class);
-        exception.expectMessage("Database db1 does not exist in Catalog");
-        catalog.createTable(nonExistObjectPath, createTable(), false);
+        assertThatThrownBy(() -> catalog.createTable(nonExistObjectPath, createTable(), false))
+                .isInstanceOf(DatabaseNotExistException.class)
+                .hasMessage("Database db1 does not exist in Catalog " + TEST_CATALOG_NAME + ".");
     }
 
     @Test
@@ -289,9 +293,12 @@ public abstract class CatalogTest {
         catalog.createDatabase(db1, createDb(), false);
         catalog.createTable(path1, createTable(), false);
 
-        exception.expect(TableAlreadyExistException.class);
-        exception.expectMessage("Table (or view) db1.t1 already exists in Catalog");
-        catalog.createTable(path1, createTable(), false);
+        assertThatThrownBy(() -> catalog.createTable(path1, createTable(), false))
+                .isInstanceOf(TableAlreadyExistException.class)
+                .hasMessage(
+                        "Table (or view) db1.t1 already exists in Catalog "
+                                + TEST_CATALOG_NAME
+                                + ".");
     }
 
     @Test
@@ -312,16 +319,22 @@ public abstract class CatalogTest {
     public void testGetTable_TableNotExistException() throws Exception {
         catalog.createDatabase(db1, createDb(), false);
 
-        exception.expect(TableNotExistException.class);
-        exception.expectMessage("Table (or view) db1.nonexist does not exist in Catalog");
-        catalog.getTable(nonExistObjectPath);
+        assertThatThrownBy(() -> catalog.getTable(nonExistObjectPath))
+                .isInstanceOf(TableNotExistException.class)
+                .hasMessage(
+                        "Table (or view) db1.nonexist does not exist in Catalog "
+                                + TEST_CATALOG_NAME
+                                + ".");
     }
 
     @Test
-    public void testGetTable_TableNotExistException_NoDb() throws Exception {
-        exception.expect(TableNotExistException.class);
-        exception.expectMessage("Table (or view) db1.nonexist does not exist in Catalog");
-        catalog.getTable(nonExistObjectPath);
+    public void testGetTable_TableNotExistException_NoDb() {
+        assertThatThrownBy(() -> catalog.getTable(nonExistObjectPath))
+                .isInstanceOf(TableNotExistException.class)
+                .hasMessage(
+                        "Table (or view) db1.nonexist does not exist in Catalog "
+                                + TEST_CATALOG_NAME
+                                + ".");
     }
 
     @Test
@@ -337,10 +350,13 @@ public abstract class CatalogTest {
     }
 
     @Test
-    public void testDropTable_TableNotExistException() throws Exception {
-        exception.expect(TableNotExistException.class);
-        exception.expectMessage("Table (or view) non.exist does not exist in Catalog");
-        catalog.dropTable(nonExistDbPath, false);
+    public void testDropTable_TableNotExistException() {
+        assertThatThrownBy(() -> catalog.dropTable(nonExistDbPath, false))
+                .isInstanceOf(TableNotExistException.class)
+                .hasMessage(
+                        "Table (or view) non.exist does not exist in Catalog "
+                                + TEST_CATALOG_NAME
+                                + ".");
     }
 
     @Test
@@ -403,17 +419,20 @@ public abstract class CatalogTest {
         CatalogTable table = createTable();
         catalog.createTable(path1, table, false);
 
-        exception.expect(CatalogException.class);
-        exception.expectMessage(
-                "Table types don't match. Existing table is 'TABLE' and new table is 'VIEW'.");
-        catalog.alterTable(path1, new TestTable(), false);
+        assertThatThrownBy(() -> catalog.alterTable(path1, new TestTable(), false))
+                .isInstanceOf(CatalogException.class)
+                .hasMessage(
+                        "Table types don't match. Existing table is 'TABLE' and new table is 'VIEW'.");
     }
 
     @Test
-    public void testAlterTable_TableNotExistException() throws Exception {
-        exception.expect(TableNotExistException.class);
-        exception.expectMessage("Table (or view) non.exist does not exist in Catalog");
-        catalog.alterTable(nonExistDbPath, createTable(), false);
+    public void testAlterTable_TableNotExistException() {
+        assertThatThrownBy(() -> catalog.alterTable(nonExistDbPath, createTable(), false))
+                .isInstanceOf(TableNotExistException.class)
+                .hasMessage(
+                        "Table (or view) non.exist does not exist in Catalog "
+                                + TEST_CATALOG_NAME
+                                + ".");
     }
 
     @Test
@@ -442,9 +461,12 @@ public abstract class CatalogTest {
     public void testRenameTable_TableNotExistException() throws Exception {
         catalog.createDatabase(db1, createDb(), false);
 
-        exception.expect(TableNotExistException.class);
-        exception.expectMessage("Table (or view) db1.t1 does not exist in Catalog");
-        catalog.renameTable(path1, t2, false);
+        assertThatThrownBy(() -> catalog.renameTable(path1, t2, false))
+                .isInstanceOf(TableNotExistException.class)
+                .hasMessage(
+                        "Table (or view) db1.t1 does not exist in Catalog "
+                                + TEST_CATALOG_NAME
+                                + ".");
     }
 
     @Test
@@ -460,9 +482,12 @@ public abstract class CatalogTest {
         catalog.createTable(path1, table, false);
         catalog.createTable(path3, createAnotherTable(), false);
 
-        exception.expect(TableAlreadyExistException.class);
-        exception.expectMessage("Table (or view) db1.t2 already exists in Catalog");
-        catalog.renameTable(path1, t2, false);
+        assertThatThrownBy(() -> catalog.renameTable(path1, t2, false))
+                .isInstanceOf(TableAlreadyExistException.class)
+                .hasMessage(
+                        "Table (or view) db1.t2 already exists in Catalog "
+                                + TEST_CATALOG_NAME
+                                + ".");
     }
 
     @Test
@@ -504,12 +529,12 @@ public abstract class CatalogTest {
     }
 
     @Test
-    public void testCreateView_DatabaseNotExistException() throws Exception {
+    public void testCreateView_DatabaseNotExistException() {
         assertThat(catalog.databaseExists(db1)).isFalse();
 
-        exception.expect(DatabaseNotExistException.class);
-        exception.expectMessage("Database db1 does not exist in Catalog");
-        catalog.createTable(nonExistObjectPath, createView(), false);
+        assertThatThrownBy(() -> catalog.createTable(nonExistObjectPath, createView(), false))
+                .isInstanceOf(DatabaseNotExistException.class)
+                .hasMessage("Database db1 does not exist in Catalog " + TEST_CATALOG_NAME + ".");
     }
 
     @Test
@@ -517,9 +542,12 @@ public abstract class CatalogTest {
         catalog.createDatabase(db1, createDb(), false);
         catalog.createTable(path1, createView(), false);
 
-        exception.expect(TableAlreadyExistException.class);
-        exception.expectMessage("Table (or view) db1.t1 already exists in Catalog");
-        catalog.createTable(path1, createView(), false);
+        assertThatThrownBy(() -> catalog.createTable(path1, createView(), false))
+                .isInstanceOf(TableAlreadyExistException.class)
+                .hasMessage(
+                        "Table (or view) db1.t1 already exists in Catalog "
+                                + TEST_CATALOG_NAME
+                                + ".");
     }
 
     @Test
@@ -568,9 +596,12 @@ public abstract class CatalogTest {
 
     @Test
     public void testAlterView_TableNotExistException() throws Exception {
-        exception.expect(TableNotExistException.class);
-        exception.expectMessage("Table (or view) non.exist does not exist in Catalog");
-        catalog.alterTable(nonExistDbPath, createTable(), false);
+        assertThatThrownBy(() -> catalog.alterTable(nonExistDbPath, createTable(), false))
+                .isInstanceOf(TableNotExistException.class)
+                .hasMessage(
+                        "Table (or view) non.exist does not exist in Catalog "
+                                + TEST_CATALOG_NAME
+                                + ".");
     }
 
     @Test
@@ -594,7 +625,8 @@ public abstract class CatalogTest {
         assertThat(new HashSet<>(catalog.listTables(db1)))
                 .isEqualTo(
                         new HashSet<>(Arrays.asList(path1.getObjectName(), path3.getObjectName())));
-        assertThat(catalog.listViews(db1)).isEqualTo(Arrays.asList(path1.getObjectName()));
+        assertThat(catalog.listViews(db1))
+                .isEqualTo(Collections.singletonList(path1.getObjectName()));
     }
 
     @Test
@@ -634,12 +666,12 @@ public abstract class CatalogTest {
     }
 
     @Test
-    public void testCreateFunction_DatabaseNotExistException() throws Exception {
+    public void testCreateFunction_DatabaseNotExistException() {
         assertThat(catalog.databaseExists(db1)).isFalse();
 
-        exception.expect(DatabaseNotExistException.class);
-        exception.expectMessage("Database db1 does not exist in Catalog");
-        catalog.createFunction(path1, createFunction(), false);
+        assertThatThrownBy(() -> catalog.createFunction(path1, createFunction(), false))
+                .isInstanceOf(DatabaseNotExistException.class)
+                .hasMessage("Database db1 does not exist in Catalog " + TEST_CATALOG_NAME + ".");
     }
 
     @Test
@@ -652,9 +684,9 @@ public abstract class CatalogTest {
         // test 'ignoreIfExist' flag
         catalog.createFunction(path1, createAnotherFunction(), true);
 
-        exception.expect(FunctionAlreadyExistException.class);
-        exception.expectMessage("Function db1.t1 already exists in Catalog");
-        catalog.createFunction(path1, createFunction(), false);
+        assertThatThrownBy(() -> catalog.createFunction(path1, createFunction(), false))
+                .isInstanceOf(FunctionAlreadyExistException.class)
+                .hasMessage("Function db1.t1 already exists in Catalog " + TEST_CATALOG_NAME + ".");
     }
 
     @Test
@@ -692,10 +724,13 @@ public abstract class CatalogTest {
     }
 
     @Test
-    public void testAlterFunction_FunctionNotExistException() throws Exception {
-        exception.expect(FunctionNotExistException.class);
-        exception.expectMessage("Function db1.nonexist does not exist in Catalog");
-        catalog.alterFunction(nonExistObjectPath, createFunction(), false);
+    public void testAlterFunction_FunctionNotExistException() {
+        assertThatThrownBy(() -> catalog.alterFunction(nonExistObjectPath, createFunction(), false))
+                .isInstanceOf(FunctionNotExistException.class)
+                .hasMessage(
+                        "Function db1.nonexist does not exist in Catalog "
+                                + TEST_CATALOG_NAME
+                                + ".");
     }
 
     @Test
@@ -717,26 +752,32 @@ public abstract class CatalogTest {
     }
 
     @Test
-    public void testListFunctions_DatabaseNotExistException() throws Exception {
-        exception.expect(DatabaseNotExistException.class);
-        exception.expectMessage("Database db1 does not exist in Catalog");
-        catalog.listFunctions(db1);
+    public void testListFunctions_DatabaseNotExistException() {
+        assertThatThrownBy(() -> catalog.listFunctions(db1))
+                .isInstanceOf(DatabaseNotExistException.class)
+                .hasMessage("Database db1 does not exist in Catalog " + TEST_CATALOG_NAME + ".");
     }
 
     @Test
     public void testGetFunction_FunctionNotExistException() throws Exception {
         catalog.createDatabase(db1, createDb(), false);
 
-        exception.expect(FunctionNotExistException.class);
-        exception.expectMessage("Function db1.nonexist does not exist in Catalog");
-        catalog.getFunction(nonExistObjectPath);
+        assertThatThrownBy(() -> catalog.getFunction(nonExistObjectPath))
+                .isInstanceOf(FunctionNotExistException.class)
+                .hasMessage(
+                        "Function db1.nonexist does not exist in Catalog "
+                                + TEST_CATALOG_NAME
+                                + ".");
     }
 
     @Test
-    public void testGetFunction_FunctionNotExistException_NoDb() throws Exception {
-        exception.expect(FunctionNotExistException.class);
-        exception.expectMessage("Function db1.nonexist does not exist in Catalog");
-        catalog.getFunction(nonExistObjectPath);
+    public void testGetFunction_FunctionNotExistException_NoDb() {
+        assertThatThrownBy(() -> catalog.getFunction(nonExistObjectPath))
+                .isInstanceOf(FunctionNotExistException.class)
+                .hasMessage(
+                        "Function db1.nonexist does not exist in Catalog "
+                                + TEST_CATALOG_NAME
+                                + ".");
     }
 
     @Test
@@ -752,10 +793,11 @@ public abstract class CatalogTest {
     }
 
     @Test
-    public void testDropFunction_FunctionNotExistException() throws Exception {
-        exception.expect(FunctionNotExistException.class);
-        exception.expectMessage("Function non.exist does not exist in Catalog");
-        catalog.dropFunction(nonExistDbPath, false);
+    public void testDropFunction_FunctionNotExistException() {
+        assertThatThrownBy(() -> catalog.dropFunction(nonExistDbPath, false))
+                .isInstanceOf(FunctionNotExistException.class)
+                .hasMessage(
+                        "Function non.exist does not exist in Catalog " + TEST_CATALOG_NAME + ".");
     }
 
     @Test
@@ -796,12 +838,15 @@ public abstract class CatalogTest {
     public void testCreatePartition_TableNotExistException() throws Exception {
         catalog.createDatabase(db1, createDb(), false);
 
-        exception.expect(TableNotExistException.class);
-        exception.expectMessage(
-                String.format(
-                        "Table (or view) %s does not exist in Catalog %s.",
-                        path1.getFullName(), TEST_CATALOG_NAME));
-        catalog.createPartition(path1, createPartitionSpec(), createPartition(), false);
+        assertThatThrownBy(
+                        () ->
+                                catalog.createPartition(
+                                        path1, createPartitionSpec(), createPartition(), false))
+                .isInstanceOf(TableNotExistException.class)
+                .hasMessage(
+                        String.format(
+                                "Table (or view) %s does not exist in Catalog %s.",
+                                path1.getFullName(), TEST_CATALOG_NAME));
     }
 
     @Test
@@ -809,12 +854,15 @@ public abstract class CatalogTest {
         catalog.createDatabase(db1, createDb(), false);
         catalog.createTable(path1, createTable(), false);
 
-        exception.expect(TableNotPartitionedException.class);
-        exception.expectMessage(
-                String.format(
-                        "Table %s in catalog %s is not partitioned.",
-                        path1.getFullName(), TEST_CATALOG_NAME));
-        catalog.createPartition(path1, createPartitionSpec(), createPartition(), false);
+        assertThatThrownBy(
+                        () ->
+                                catalog.createPartition(
+                                        path1, createPartitionSpec(), createPartition(), false))
+                .isInstanceOf(TableNotPartitionedException.class)
+                .hasMessage(
+                        String.format(
+                                "Table %s in catalog %s is not partitioned.",
+                                path1.getFullName(), TEST_CATALOG_NAME));
     }
 
     @Test
@@ -824,15 +872,18 @@ public abstract class CatalogTest {
         catalog.createTable(path1, table, false);
 
         CatalogPartitionSpec partitionSpec = createInvalidPartitionSpecSubset();
-        exception.expect(PartitionSpecInvalidException.class);
-        exception.expectMessage(
-                String.format(
-                        "PartitionSpec %s does not match partition keys %s of table %s in catalog %s.",
-                        partitionSpec,
-                        table.getPartitionKeys(),
-                        path1.getFullName(),
-                        TEST_CATALOG_NAME));
-        catalog.createPartition(path1, partitionSpec, createPartition(), false);
+        assertThatThrownBy(
+                        () ->
+                                catalog.createPartition(
+                                        path1, partitionSpec, createPartition(), false))
+                .isInstanceOf(PartitionSpecInvalidException.class)
+                .hasMessage(
+                        String.format(
+                                "PartitionSpec %s does not match partition keys %s of table %s in catalog %s.",
+                                partitionSpec,
+                                table.getPartitionKeys(),
+                                path1.getFullName(),
+                                TEST_CATALOG_NAME));
     }
 
     @Test
@@ -844,12 +895,15 @@ public abstract class CatalogTest {
 
         CatalogPartitionSpec partitionSpec = createPartitionSpec();
 
-        exception.expect(PartitionAlreadyExistsException.class);
-        exception.expectMessage(
-                String.format(
-                        "Partition %s of table %s in catalog %s already exists.",
-                        partitionSpec, path1.getFullName(), TEST_CATALOG_NAME));
-        catalog.createPartition(path1, partitionSpec, createPartition(), false);
+        assertThatThrownBy(
+                        () ->
+                                catalog.createPartition(
+                                        path1, partitionSpec, createPartition(), false))
+                .isInstanceOf(PartitionAlreadyExistsException.class)
+                .hasMessage(
+                        String.format(
+                                "Partition %s of table %s in catalog %s already exists.",
+                                partitionSpec, path1.getFullName(), TEST_CATALOG_NAME));
     }
 
     @Test
@@ -880,12 +934,12 @@ public abstract class CatalogTest {
         catalog.createDatabase(db1, createDb(), false);
 
         CatalogPartitionSpec partitionSpec = createPartitionSpec();
-        exception.expect(PartitionNotExistException.class);
-        exception.expectMessage(
-                String.format(
-                        "Partition %s of table %s in catalog %s does not exist.",
-                        partitionSpec, path1.getFullName(), TEST_CATALOG_NAME));
-        catalog.dropPartition(path1, partitionSpec, false);
+        assertThatThrownBy(() -> catalog.dropPartition(path1, partitionSpec, false))
+                .isInstanceOf(PartitionNotExistException.class)
+                .hasMessage(
+                        String.format(
+                                "Partition %s of table %s in catalog %s does not exist.",
+                                partitionSpec, path1.getFullName(), TEST_CATALOG_NAME));
     }
 
     @Test
@@ -894,12 +948,12 @@ public abstract class CatalogTest {
         catalog.createTable(path1, createTable(), false);
 
         CatalogPartitionSpec partitionSpec = createPartitionSpec();
-        exception.expect(PartitionNotExistException.class);
-        exception.expectMessage(
-                String.format(
-                        "Partition %s of table %s in catalog %s does not exist.",
-                        partitionSpec, path1.getFullName(), TEST_CATALOG_NAME));
-        catalog.dropPartition(path1, partitionSpec, false);
+        assertThatThrownBy(() -> catalog.dropPartition(path1, partitionSpec, false))
+                .isInstanceOf(PartitionNotExistException.class)
+                .hasMessage(
+                        String.format(
+                                "Partition %s of table %s in catalog %s does not exist.",
+                                partitionSpec, path1.getFullName(), TEST_CATALOG_NAME));
     }
 
     @Test
@@ -909,12 +963,12 @@ public abstract class CatalogTest {
         catalog.createTable(path1, table, false);
 
         CatalogPartitionSpec partitionSpec = createInvalidPartitionSpecSubset();
-        exception.expect(PartitionNotExistException.class);
-        exception.expectMessage(
-                String.format(
-                        "Partition %s of table %s in catalog %s does not exist.",
-                        partitionSpec, path1.getFullName(), TEST_CATALOG_NAME));
-        catalog.dropPartition(path1, partitionSpec, false);
+        assertThatThrownBy(() -> catalog.dropPartition(path1, partitionSpec, false))
+                .isInstanceOf(PartitionNotExistException.class)
+                .hasMessage(
+                        String.format(
+                                "Partition %s of table %s in catalog %s does not exist.",
+                                partitionSpec, path1.getFullName(), TEST_CATALOG_NAME));
     }
 
     @Test
@@ -923,12 +977,12 @@ public abstract class CatalogTest {
         catalog.createTable(path1, createPartitionedTable(), false);
 
         CatalogPartitionSpec partitionSpec = createPartitionSpec();
-        exception.expect(PartitionNotExistException.class);
-        exception.expectMessage(
-                String.format(
-                        "Partition %s of table %s in catalog %s does not exist.",
-                        partitionSpec, path1.getFullName(), TEST_CATALOG_NAME));
-        catalog.dropPartition(path1, partitionSpec, false);
+        assertThatThrownBy(() -> catalog.dropPartition(path1, partitionSpec, false))
+                .isInstanceOf(PartitionNotExistException.class)
+                .hasMessage(
+                        String.format(
+                                "Partition %s of table %s in catalog %s does not exist.",
+                                partitionSpec, path1.getFullName(), TEST_CATALOG_NAME));
     }
 
     @Test
@@ -967,12 +1021,15 @@ public abstract class CatalogTest {
         catalog.createDatabase(db1, createDb(), false);
 
         CatalogPartitionSpec partitionSpec = createPartitionSpec();
-        exception.expect(PartitionNotExistException.class);
-        exception.expectMessage(
-                String.format(
-                        "Partition %s of table %s in catalog %s does not exist.",
-                        partitionSpec, path1.getFullName(), TEST_CATALOG_NAME));
-        catalog.alterPartition(path1, partitionSpec, createPartition(), false);
+        assertThatThrownBy(
+                        () ->
+                                catalog.alterPartition(
+                                        path1, partitionSpec, createPartition(), false))
+                .isInstanceOf(PartitionNotExistException.class)
+                .hasMessage(
+                        String.format(
+                                "Partition %s of table %s in catalog %s does not exist.",
+                                partitionSpec, path1.getFullName(), TEST_CATALOG_NAME));
     }
 
     @Test
@@ -981,12 +1038,15 @@ public abstract class CatalogTest {
         catalog.createTable(path1, createTable(), false);
 
         CatalogPartitionSpec partitionSpec = createPartitionSpec();
-        exception.expect(PartitionNotExistException.class);
-        exception.expectMessage(
-                String.format(
-                        "Partition %s of table %s in catalog %s does not exist.",
-                        partitionSpec, path1.getFullName(), TEST_CATALOG_NAME));
-        catalog.alterPartition(path1, partitionSpec, createPartition(), false);
+        assertThatThrownBy(
+                        () ->
+                                catalog.alterPartition(
+                                        path1, partitionSpec, createPartition(), false))
+                .isInstanceOf(PartitionNotExistException.class)
+                .hasMessage(
+                        String.format(
+                                "Partition %s of table %s in catalog %s does not exist.",
+                                partitionSpec, path1.getFullName(), TEST_CATALOG_NAME));
     }
 
     @Test
@@ -996,12 +1056,15 @@ public abstract class CatalogTest {
         catalog.createTable(path1, table, false);
 
         CatalogPartitionSpec partitionSpec = createInvalidPartitionSpecSubset();
-        exception.expect(PartitionNotExistException.class);
-        exception.expectMessage(
-                String.format(
-                        "Partition %s of table %s in catalog %s does not exist.",
-                        partitionSpec, path1.getFullName(), TEST_CATALOG_NAME));
-        catalog.alterPartition(path1, partitionSpec, createPartition(), false);
+        assertThatThrownBy(
+                        () ->
+                                catalog.alterPartition(
+                                        path1, partitionSpec, createPartition(), false))
+                .isInstanceOf(PartitionNotExistException.class)
+                .hasMessage(
+                        String.format(
+                                "Partition %s of table %s in catalog %s does not exist.",
+                                partitionSpec, path1.getFullName(), TEST_CATALOG_NAME));
     }
 
     @Test
@@ -1010,12 +1073,15 @@ public abstract class CatalogTest {
         catalog.createTable(path1, createPartitionedTable(), false);
 
         CatalogPartitionSpec partitionSpec = createPartitionSpec();
-        exception.expect(PartitionNotExistException.class);
-        exception.expectMessage(
-                String.format(
-                        "Partition %s of table %s in catalog %s does not exist.",
-                        partitionSpec, path1.getFullName(), TEST_CATALOG_NAME));
-        catalog.alterPartition(path1, partitionSpec, createPartition(), false);
+        assertThatThrownBy(
+                        () ->
+                                catalog.alterPartition(
+                                        path1, partitionSpec, createPartition(), false))
+                .isInstanceOf(PartitionNotExistException.class)
+                .hasMessage(
+                        String.format(
+                                "Partition %s of table %s in catalog %s does not exist.",
+                                partitionSpec, path1.getFullName(), TEST_CATALOG_NAME));
     }
 
     @Test
@@ -1028,12 +1094,12 @@ public abstract class CatalogTest {
     @Test
     public void testGetPartition_TableNotExist() throws Exception {
         CatalogPartitionSpec partitionSpec = createPartitionSpec();
-        exception.expect(PartitionNotExistException.class);
-        exception.expectMessage(
-                String.format(
-                        "Partition %s of table %s in catalog %s does not exist.",
-                        partitionSpec, path1.getFullName(), TEST_CATALOG_NAME));
-        catalog.getPartition(path1, partitionSpec);
+        assertThatThrownBy(() -> catalog.getPartition(path1, partitionSpec))
+                .isInstanceOf(PartitionNotExistException.class)
+                .hasMessage(
+                        String.format(
+                                "Partition %s of table %s in catalog %s does not exist.",
+                                partitionSpec, path1.getFullName(), TEST_CATALOG_NAME));
     }
 
     @Test
@@ -1042,12 +1108,12 @@ public abstract class CatalogTest {
         catalog.createTable(path1, createTable(), false);
 
         CatalogPartitionSpec partitionSpec = createPartitionSpec();
-        exception.expect(PartitionNotExistException.class);
-        exception.expectMessage(
-                String.format(
-                        "Partition %s of table %s in catalog %s does not exist.",
-                        partitionSpec, path1.getFullName(), TEST_CATALOG_NAME));
-        catalog.getPartition(path1, partitionSpec);
+        assertThatThrownBy(() -> catalog.getPartition(path1, partitionSpec))
+                .isInstanceOf(PartitionNotExistException.class)
+                .hasMessage(
+                        String.format(
+                                "Partition %s of table %s in catalog %s does not exist.",
+                                partitionSpec, path1.getFullName(), TEST_CATALOG_NAME));
     }
 
     @Test
@@ -1057,12 +1123,12 @@ public abstract class CatalogTest {
         catalog.createTable(path1, table, false);
 
         CatalogPartitionSpec partitionSpec = createInvalidPartitionSpecSubset();
-        exception.expect(PartitionNotExistException.class);
-        exception.expectMessage(
-                String.format(
-                        "Partition %s of table %s in catalog %s does not exist.",
-                        partitionSpec, path1.getFullName(), TEST_CATALOG_NAME));
-        catalog.getPartition(path1, partitionSpec);
+        assertThatThrownBy(() -> catalog.getPartition(path1, partitionSpec))
+                .isInstanceOf(PartitionNotExistException.class)
+                .hasMessage(
+                        String.format(
+                                "Partition %s of table %s in catalog %s does not exist.",
+                                partitionSpec, path1.getFullName(), TEST_CATALOG_NAME));
     }
 
     @Test
@@ -1078,12 +1144,12 @@ public abstract class CatalogTest {
                                 put("second", "bob");
                             }
                         });
-        exception.expect(PartitionNotExistException.class);
-        exception.expectMessage(
-                String.format(
-                        "Partition %s of table %s in catalog %s does not exist.",
-                        partitionSpec, path1.getFullName(), TEST_CATALOG_NAME));
-        catalog.getPartition(path1, partitionSpec);
+        assertThatThrownBy(() -> catalog.getPartition(path1, partitionSpec))
+                .isInstanceOf(PartitionNotExistException.class)
+                .hasMessage(
+                        String.format(
+                                "Partition %s of table %s in catalog %s does not exist.",
+                                partitionSpec, path1.getFullName(), TEST_CATALOG_NAME));
     }
 
     @Test
@@ -1092,12 +1158,12 @@ public abstract class CatalogTest {
         catalog.createTable(path1, createPartitionedTable(), false);
 
         CatalogPartitionSpec partitionSpec = createPartitionSpec();
-        exception.expect(PartitionNotExistException.class);
-        exception.expectMessage(
-                String.format(
-                        "Partition %s of table %s in catalog %s does not exist.",
-                        partitionSpec, path1.getFullName(), TEST_CATALOG_NAME));
-        catalog.getPartition(path1, partitionSpec);
+        assertThatThrownBy(() -> catalog.getPartition(path1, partitionSpec))
+                .isInstanceOf(PartitionNotExistException.class)
+                .hasMessage(
+                        String.format(
+                                "Partition %s of table %s in catalog %s does not exist.",
+                                partitionSpec, path1.getFullName(), TEST_CATALOG_NAME));
     }
 
     @Test
@@ -1130,8 +1196,13 @@ public abstract class CatalogTest {
     @Test
     public void testGetTableStats_TableNotExistException() throws Exception {
         catalog.createDatabase(db1, createDb(), false);
-        exception.expect(org.apache.flink.table.catalog.exceptions.TableNotExistException.class);
-        catalog.getTableStatistics(path1);
+        assertThatThrownBy(() -> catalog.getTableStatistics(path1))
+                .isInstanceOf(
+                        org.apache.flink.table.catalog.exceptions.TableNotExistException.class)
+                .hasMessage(
+                        "Table (or view) db1.t1 does not exist in Catalog "
+                                + TEST_CATALOG_NAME
+                                + ".");
     }
 
     @Test
@@ -1193,12 +1264,18 @@ public abstract class CatalogTest {
     }
 
     @Test
-    public void testAlterTableStats_TableNotExistException() throws Exception {
-        exception.expect(TableNotExistException.class);
-        catalog.alterTableStatistics(
-                new ObjectPath(catalog.getDefaultDatabase(), "nonexist"),
-                CatalogTableStatistics.UNKNOWN,
-                false);
+    public void testAlterTableStats_TableNotExistException() {
+        assertThatThrownBy(
+                        () ->
+                                catalog.alterTableStatistics(
+                                        new ObjectPath(catalog.getDefaultDatabase(), "nonexist"),
+                                        CatalogTableStatistics.UNKNOWN,
+                                        false))
+                .isInstanceOf(TableNotExistException.class)
+                .hasMessage(
+                        "Table (or view) default.nonexist does not exist in Catalog "
+                                + TEST_CATALOG_NAME
+                                + ".");
     }
 
     @Test

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/expressions/ExpressionTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/expressions/ExpressionTest.java
@@ -23,9 +23,7 @@ import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.functions.ScalarFunction;
 import org.apache.flink.table.functions.ScalarFunctionDefinition;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
@@ -50,6 +48,7 @@ import static java.util.Collections.singletonList;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.AND;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.EQUALS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link org.apache.flink.table.expressions.Expression} and its sub-classes. */
 public class ExpressionTest {
@@ -65,8 +64,6 @@ public class ExpressionTest {
     private static final Expression TREE_WITH_SAME_VALUE = createExpressionTree(12);
 
     private static final String TREE_WITH_NULL_STRING = "and(true, equals(field, dummy(null)))";
-
-    @Rule public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void testExpressionString() {
@@ -134,18 +131,17 @@ public class ExpressionTest {
 
     @Test
     public void testInvalidValueLiteral() {
-        thrown.expect(ValidationException.class);
-        thrown.expectMessage("does not support a value literal of class 'java.lang.Integer'");
-
-        new ValueLiteralExpression(12, DataTypes.TINYINT().notNull());
+        assertThatThrownBy(() -> new ValueLiteralExpression(12, DataTypes.TINYINT().notNull()))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining(
+                        "does not support a value literal of class 'java.lang.Integer'");
     }
 
     @Test
     public void testInvalidValueLiteralExtraction() {
-        thrown.expect(ValidationException.class);
-        thrown.expectMessage("Cannot derive a data type");
-
-        new ValueLiteralExpression(this);
+        assertThatThrownBy(() -> new ValueLiteralExpression(this))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("Cannot derive a data type");
     }
 
     @Test

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/TableSinkFactoryServiceTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/TableSinkFactoryServiceTest.java
@@ -18,9 +18,7 @@
 
 package org.apache.flink.table.factories;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -33,14 +31,13 @@ import static org.apache.flink.table.factories.TestTableSinkFactory.FORMAT_TYPE_
 import static org.apache.flink.table.factories.TestTableSinkFactory.REQUIRED_TEST;
 import static org.apache.flink.table.factories.TestTableSinkFactory.REQUIRED_TEST_VALUE;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Tests for testing table sink discovery using {@link TableFactoryService}. The tests assume the
  * table sink factory {@link TestTableSinkFactory} is registered.
  */
 public class TableSinkFactoryServiceTest {
-
-    @Rule public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void testValidProperties() {
@@ -51,10 +48,11 @@ public class TableSinkFactoryServiceTest {
 
     @Test
     public void testInvalidContext() {
-        thrown.expect(NoMatchingTableFactoryException.class);
         Map<String, String> props = properties();
         props.put(CONNECTOR_TYPE, "unknown-connector-type");
-        TableFactoryService.find(TableSinkFactory.class, props);
+        assertThatThrownBy(() -> TableFactoryService.find(TableSinkFactory.class, props))
+                .isInstanceOf(NoMatchingTableFactoryException.class)
+                .hasMessageContaining("Could not find a suitable table factory");
     }
 
     @Test
@@ -68,57 +66,57 @@ public class TableSinkFactoryServiceTest {
 
     @Test
     public void testUnsupportedProperty() {
-        thrown.expect(NoMatchingTableFactoryException.class);
-        thrown.expectMessage(
-                "The matching candidates:\n"
-                        + "org.apache.flink.table.factories.TestTableSinkFactory\n"
-                        + "Unsupported property keys:\n"
-                        + "format.path_new");
         Map<String, String> props = properties();
         props.put("format.path_new", "/new/path");
-        TableFactoryService.find(TableSinkFactory.class, props);
+        assertThatThrownBy(() -> TableFactoryService.find(TableSinkFactory.class, props))
+                .isInstanceOf(NoMatchingTableFactoryException.class)
+                .hasMessageContaining(
+                        "The matching candidates:\n"
+                                + "org.apache.flink.table.factories.TestTableSinkFactory\n"
+                                + "Unsupported property keys:\n"
+                                + "format.path_new");
     }
 
     @Test
     public void testMissingProperty() {
-        thrown.expect(NoMatchingTableFactoryException.class);
-        thrown.expectMessage(
-                "The matching candidates:\n"
-                        + "org.apache.flink.table.factories.TestTableSinkFactory\n"
-                        + "Missing properties:\n"
-                        + "format.type=test");
         Map<String, String> props = properties();
         props.remove(TableFactoryService.FORMAT_TYPE);
-        TableFactoryService.find(TableSinkFactory.class, props);
+        assertThatThrownBy(() -> TableFactoryService.find(TableSinkFactory.class, props))
+                .isInstanceOf(NoMatchingTableFactoryException.class)
+                .hasMessageContaining(
+                        "The matching candidates:\n"
+                                + "org.apache.flink.table.factories.TestTableSinkFactory\n"
+                                + "Missing properties:\n"
+                                + "format.type=test");
     }
 
     @Test
     public void testMismatchedProperty() {
-        thrown.expect(NoMatchingTableFactoryException.class);
-        thrown.expectMessage(
-                "The matching candidates:\n"
-                        + "org.apache.flink.table.factories.TestTableSinkFactory\n"
-                        + "Mismatched properties:\n"
-                        + "'format.type' expects 'test', but is 'test_new'");
         Map<String, String> props = properties();
         props.put(TableFactoryService.FORMAT_TYPE, FORMAT_TYPE_VALUE_TEST + "_new");
-        TableFactoryService.find(TableSinkFactory.class, props);
+        assertThatThrownBy(() -> TableFactoryService.find(TableSinkFactory.class, props))
+                .isInstanceOf(NoMatchingTableFactoryException.class)
+                .hasMessageContaining(
+                        "The matching candidates:\n"
+                                + "org.apache.flink.table.factories.TestTableSinkFactory\n"
+                                + "Mismatched properties:\n"
+                                + "'format.type' expects 'test', but is 'test_new'");
     }
 
     @Test
     public void testMissingAndMismatchedProperty() {
-        thrown.expect(NoMatchingTableFactoryException.class);
-        thrown.expectMessage(
-                "The matching candidates:\n"
-                        + "org.apache.flink.table.factories.TestTableSinkFactory\n"
-                        + "Missing properties:\n"
-                        + "required.test=required-0\n"
-                        + "Mismatched properties:\n"
-                        + "'format.type' expects 'test', but is 'test_new'");
         Map<String, String> props = properties();
         props.put(TableFactoryService.FORMAT_TYPE, FORMAT_TYPE_VALUE_TEST + "_new");
         props.remove(REQUIRED_TEST);
-        TableFactoryService.find(TableSinkFactory.class, props);
+        assertThatThrownBy(() -> TableFactoryService.find(TableSinkFactory.class, props))
+                .isInstanceOf(NoMatchingTableFactoryException.class)
+                .hasMessageContaining(
+                        "The matching candidates:\n"
+                                + "org.apache.flink.table.factories.TestTableSinkFactory\n"
+                                + "Missing properties:\n"
+                                + "required.test=required-0\n"
+                                + "Mismatched properties:\n"
+                                + "'format.type' expects 'test', but is 'test_new'");
     }
 
     private Map<String, String> properties() {

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeParserTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeParserTest.java
@@ -59,9 +59,7 @@ import org.apache.flink.table.types.logical.ZonedTimestampType;
 import org.apache.flink.table.types.logical.utils.LogicalTypeParser;
 import org.apache.flink.table.types.utils.TypeConversions;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
@@ -75,6 +73,7 @@ import java.util.List;
 
 import static org.apache.flink.table.types.logical.LogicalTypeRoot.UNRESOLVED;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link LogicalTypeParser}. */
 @RunWith(Parameterized.class)
@@ -263,8 +262,6 @@ public class LogicalTypeParserTest {
 
     @Parameter public TestSpec testSpec;
 
-    @Rule public ExpectedException thrown = ExpectedException.none();
-
     @Test
     public void testParsing() {
         if (testSpec.expectedType != null) {
@@ -288,10 +285,9 @@ public class LogicalTypeParserTest {
     @Test
     public void testErrorMessage() {
         if (testSpec.expectedErrorMessage != null) {
-            thrown.expect(ValidationException.class);
-            thrown.expectMessage(testSpec.expectedErrorMessage);
-
-            LogicalTypeParser.parse(testSpec.typeString);
+            assertThatThrownBy(() -> LogicalTypeParser.parse(testSpec.typeString))
+                    .isInstanceOf(ValidationException.class)
+                    .hasMessageContaining(testSpec.expectedErrorMessage);
         }
     }
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/extraction/DataTypeExtractorTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/extraction/DataTypeExtractorTest.java
@@ -45,9 +45,7 @@ import org.apache.flink.table.types.utils.DataTypeFactoryMock;
 import org.apache.flink.types.Row;
 
 import org.hamcrest.Matcher;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
@@ -66,9 +64,11 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 
+import static org.apache.flink.core.testutils.FlinkAssertions.anyCauseMatches;
 import static org.apache.flink.core.testutils.FlinkMatchers.containsCause;
 import static org.apache.flink.table.test.TableAssertions.assertThat;
 import static org.apache.flink.table.types.utils.DataTypeFactoryMock.dummyRaw;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link DataTypeExtractor}. */
 @RunWith(Parameterized.class)
@@ -476,15 +476,17 @@ public class DataTypeExtractorTest {
 
     @Parameter public TestSpec testSpec;
 
-    @Rule public ExpectedException thrown = ExpectedException.none();
-
     @Test
     public void testExtraction() {
         if (testSpec.expectedErrorMessage != null) {
-            thrown.expect(ValidationException.class);
-            thrown.expectCause(errorMatcher(testSpec));
+            assertThatThrownBy(() -> runExtraction(testSpec))
+                    .isInstanceOf(ValidationException.class)
+                    .satisfies(
+                            anyCauseMatches(
+                                    ValidationException.class, testSpec.expectedErrorMessage));
+        } else {
+            runExtraction(testSpec);
         }
-        runExtraction(testSpec);
     }
 
     // --------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/utils/TableSchemaUtilsTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/utils/TableSchemaUtilsTest.java
@@ -22,15 +22,13 @@ import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for TableSchemaUtils. */
 public class TableSchemaUtilsTest {
-    @Rule public ExpectedException exceptionRule = ExpectedException.none();
 
     @Test
     public void testBuilderWithGivenSchema() {
@@ -70,8 +68,8 @@ public class TableSchemaUtilsTest {
         assertThat(newSchema).isEqualTo(expectedSchema);
 
         // Drop non-exist constraint.
-        exceptionRule.expect(ValidationException.class);
-        exceptionRule.expectMessage("Constraint ct2 to drop does not exist");
-        TableSchemaUtils.dropConstraint(originalSchema, "ct2");
+        assertThatThrownBy(() -> TableSchemaUtils.dropConstraint(originalSchema, "ct2"))
+                .isInstanceOf(ValidationException.class)
+                .hasMessage("Constraint ct2 to drop does not exist");
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/formats/testcsv/TestCsvDeserializationSchema.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/formats/testcsv/TestCsvDeserializationSchema.java
@@ -83,7 +83,6 @@ class TestCsvDeserializationSchema implements DeserializationSchema<RowData> {
         initFieldParsers();
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public RowData deserialize(byte[] message) throws IOException {
         GenericRowData row = new GenericRowData(physicalFieldCount);

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
@@ -20,7 +20,6 @@ package org.apache.flink.table.planner.functions;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.api.TableException;
-import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.flink.table.api.config.TableConfigOptions;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 import org.apache.flink.table.types.AbstractDataType;
@@ -76,7 +75,6 @@ import static org.apache.flink.table.api.DataTypes.VARBINARY;
 import static org.apache.flink.table.api.DataTypes.VARCHAR;
 import static org.apache.flink.table.api.DataTypes.YEAR;
 import static org.apache.flink.table.api.Expressions.$;
-import static org.apache.flink.table.api.config.ExecutionConfigOptions.LegacyCastBehaviour;
 import static org.apache.flink.util.CollectionUtil.entry;
 import static org.apache.flink.util.CollectionUtil.map;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -117,11 +115,7 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
 
     @Override
     Configuration getConfiguration() {
-        return new Configuration()
-                .set(TableConfigOptions.LOCAL_TIME_ZONE, TEST_TZ.getId())
-                .set(
-                        ExecutionConfigOptions.TABLE_EXEC_LEGACY_CAST_BEHAVIOUR,
-                        LegacyCastBehaviour.DISABLED);
+        return super.getConfiguration().set(TableConfigOptions.LOCAL_TIME_ZONE, TEST_TZ.getId());
     }
 
     @Override

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
@@ -1220,7 +1220,6 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
         private final List<Object> columnData = new ArrayList<>();
         private final List<DataType> columnTypes = new ArrayList<>();
         private final List<Object> expectedValues = new ArrayList<>();
-        private final List<Class<? extends Throwable>> expectedFailureClasses = new ArrayList<>();
         private final List<TestType> testTypes = new ArrayList<>();
 
         private enum TestType {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionMiscITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionMiscITCase.java
@@ -19,10 +19,8 @@
 package org.apache.flink.table.planner.functions;
 
 import org.apache.flink.api.common.typeutils.base.LocalDateTimeSerializer;
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.annotation.DataTypeHint;
 import org.apache.flink.table.api.DataTypes;
-import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 import org.apache.flink.table.functions.ScalarFunction;
 import org.apache.flink.types.Row;
@@ -53,14 +51,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link BuiltInFunctionDefinitions#CAST} regarding {@link DataTypes#ROW}. */
 class CastFunctionMiscITCase extends BuiltInFunctionTestBase {
-
-    @Override
-    Configuration getConfiguration() {
-        return new Configuration()
-                .set(
-                        ExecutionConfigOptions.TABLE_EXEC_LEGACY_CAST_BEHAVIOUR,
-                        ExecutionConfigOptions.LegacyCastBehaviour.DISABLED);
-    }
 
     @Override
     Stream<TestSetSpec> getTestSetSpecs() {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/MergeTableLikeUtilTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/MergeTableLikeUtilTest.java
@@ -49,9 +49,7 @@ import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.SqlTypeUtil;
 import org.apache.calcite.sql.validate.SqlValidator;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -61,11 +59,10 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link MergeTableLikeUtil}. */
 public class MergeTableLikeUtilTest {
-
-    @Rule public ExpectedException thrown = ExpectedException.none();
 
     private final FlinkTypeFactory typeFactory = new FlinkTypeFactory(FlinkTypeSystem.INSTANCE);
     private final SqlValidator sqlValidator =
@@ -114,14 +111,16 @@ public class MergeTableLikeUtilTest {
                         regularColumn("one", DataTypes.INT()),
                         regularColumn("four", DataTypes.STRING()));
 
-        thrown.expect(ValidationException.class);
-        thrown.expectMessage("A column named 'one' already exists in the base table.");
-        util.mergeTables(
-                getDefaultMergingStrategies(),
-                sourceSchema,
-                derivedColumns,
-                Collections.emptyList(),
-                null);
+        assertThatThrownBy(
+                        () ->
+                                util.mergeTables(
+                                        getDefaultMergingStrategies(),
+                                        sourceSchema,
+                                        derivedColumns,
+                                        Collections.emptyList(),
+                                        null))
+                .isInstanceOf(ValidationException.class)
+                .hasMessage("A column named 'one' already exists in the base table.");
     }
 
     @Test
@@ -135,14 +134,16 @@ public class MergeTableLikeUtilTest {
                         regularColumn("two", DataTypes.INT()),
                         regularColumn("four", DataTypes.STRING()));
 
-        thrown.expect(ValidationException.class);
-        thrown.expectMessage("A regular Column named 'two' already exists in the table.");
-        util.mergeTables(
-                getDefaultMergingStrategies(),
-                sourceSchema,
-                derivedColumns,
-                Collections.emptyList(),
-                null);
+        assertThatThrownBy(
+                        () ->
+                                util.mergeTables(
+                                        getDefaultMergingStrategies(),
+                                        sourceSchema,
+                                        derivedColumns,
+                                        Collections.emptyList(),
+                                        null))
+                .isInstanceOf(ValidationException.class)
+                .hasMessage("A regular Column named 'two' already exists in the table.");
     }
 
     @Test
@@ -157,16 +158,18 @@ public class MergeTableLikeUtilTest {
                         regularColumn("three", DataTypes.INT()),
                         regularColumn("four", DataTypes.STRING()));
 
-        thrown.expect(ValidationException.class);
-        thrown.expectMessage(
-                "A column named 'three' already exists in the table. "
-                        + "Duplicate columns exist in the compute column and regular column. ");
-        util.mergeTables(
-                getDefaultMergingStrategies(),
-                sourceSchema,
-                derivedColumns,
-                Collections.emptyList(),
-                null);
+        assertThatThrownBy(
+                        () ->
+                                util.mergeTables(
+                                        getDefaultMergingStrategies(),
+                                        sourceSchema,
+                                        derivedColumns,
+                                        Collections.emptyList(),
+                                        null))
+                .isInstanceOf(ValidationException.class)
+                .hasMessage(
+                        "A column named 'three' already exists in the table. Duplicate columns "
+                                + "exist in the compute column and regular column. ");
     }
 
     @Test
@@ -181,16 +184,18 @@ public class MergeTableLikeUtilTest {
                         regularColumn("two", DataTypes.INT()),
                         regularColumn("four", DataTypes.STRING()));
 
-        thrown.expect(ValidationException.class);
-        thrown.expectMessage(
-                "A column named 'two' already exists in the table. "
-                        + "Duplicate columns exist in the metadata column and regular column. ");
-        util.mergeTables(
-                getDefaultMergingStrategies(),
-                sourceSchema,
-                derivedColumns,
-                Collections.emptyList(),
-                null);
+        assertThatThrownBy(
+                        () ->
+                                util.mergeTables(
+                                        getDefaultMergingStrategies(),
+                                        sourceSchema,
+                                        derivedColumns,
+                                        Collections.emptyList(),
+                                        null))
+                .isInstanceOf(ValidationException.class)
+                .hasMessage(
+                        "A column named 'two' already exists in the table. Duplicate columns "
+                                + "exist in the metadata column and regular column. ");
     }
 
     @Test
@@ -270,16 +275,19 @@ public class MergeTableLikeUtilTest {
         List<SqlNode> derivedColumns =
                 Collections.singletonList(computedColumn("two", plus("one", "3")));
 
-        thrown.expect(ValidationException.class);
-        thrown.expectMessage(
-                "A generated column named 'two' already exists in the base table. You "
-                        + "might want to specify EXCLUDING GENERATED or OVERWRITING GENERATED");
-        util.mergeTables(
-                getDefaultMergingStrategies(),
-                sourceSchema,
-                derivedColumns,
-                Collections.emptyList(),
-                null);
+        assertThatThrownBy(
+                        () ->
+                                util.mergeTables(
+                                        getDefaultMergingStrategies(),
+                                        sourceSchema,
+                                        derivedColumns,
+                                        Collections.emptyList(),
+                                        null))
+                .isInstanceOf(ValidationException.class)
+                .hasMessage(
+                        "A generated column named 'two' already exists in the base table. You "
+                                + "might want to specify EXCLUDING GENERATED or "
+                                + "OVERWRITING GENERATED.");
     }
 
     @Test
@@ -293,16 +301,19 @@ public class MergeTableLikeUtilTest {
         List<SqlNode> derivedColumns =
                 Collections.singletonList(metadataColumn("two", DataTypes.INT(), false));
 
-        thrown.expect(ValidationException.class);
-        thrown.expectMessage(
-                "A metadata column named 'two' already exists in the base table. You "
-                        + "might want to specify EXCLUDING METADATA or OVERWRITING METADATA");
-        util.mergeTables(
-                getDefaultMergingStrategies(),
-                sourceSchema,
-                derivedColumns,
-                Collections.emptyList(),
-                null);
+        assertThatThrownBy(
+                        () ->
+                                util.mergeTables(
+                                        getDefaultMergingStrategies(),
+                                        sourceSchema,
+                                        derivedColumns,
+                                        Collections.emptyList(),
+                                        null))
+                .isInstanceOf(ValidationException.class)
+                .hasMessage(
+                        "A metadata column named 'two' already exists in the base table. You "
+                                + "might want to specify EXCLUDING METADATA or "
+                                + "OVERWRITING METADATA.");
     }
 
     @Test
@@ -443,12 +454,19 @@ public class MergeTableLikeUtilTest {
         Map<FeatureOption, MergingStrategy> mergingStrategies = getDefaultMergingStrategies();
         mergingStrategies.put(FeatureOption.GENERATED, MergingStrategy.OVERWRITING);
 
-        thrown.expect(ValidationException.class);
-        thrown.expectMessage(
-                "A column named 'two' already exists in the table. "
-                        + "Duplicate columns exist in the compute column and regular column. ");
-        util.mergeTables(
-                mergingStrategies, sourceSchema, derivedColumns, Collections.emptyList(), null);
+        assertThatThrownBy(
+                        () ->
+                                util.mergeTables(
+                                        mergingStrategies,
+                                        sourceSchema,
+                                        derivedColumns,
+                                        Collections.emptyList(),
+                                        null))
+                .isInstanceOf(ValidationException.class)
+                .hasMessage(
+                        "A column named 'two' already exists in the table. "
+                                + "Duplicate columns exist in the compute column "
+                                + "and regular column. ");
     }
 
     @Test
@@ -465,12 +483,18 @@ public class MergeTableLikeUtilTest {
         Map<FeatureOption, MergingStrategy> mergingStrategies = getDefaultMergingStrategies();
         mergingStrategies.put(FeatureOption.METADATA, MergingStrategy.OVERWRITING);
 
-        thrown.expect(ValidationException.class);
-        thrown.expectMessage(
-                "A column named 'two' already exists in the base table."
-                        + " Metadata columns can only overwrite other metadata columns.");
-        util.mergeTables(
-                mergingStrategies, sourceSchema, derivedColumns, Collections.emptyList(), null);
+        assertThatThrownBy(
+                        () ->
+                                util.mergeTables(
+                                        mergingStrategies,
+                                        sourceSchema,
+                                        derivedColumns,
+                                        Collections.emptyList(),
+                                        null))
+                .isInstanceOf(ValidationException.class)
+                .hasMessage(
+                        "A column named 'two' already exists in the base table."
+                                + " Metadata columns can only overwrite other metadata columns.");
     }
 
     @Test
@@ -534,16 +558,19 @@ public class MergeTableLikeUtilTest {
                                 identifier("timestamp"),
                                 boundedStrategy("timestamp", "10")));
 
-        thrown.expect(ValidationException.class);
-        thrown.expectMessage(
-                "There already exists a watermark spec for column 'timestamp' in the "
-                        + "base table. You might want to specify EXCLUDING WATERMARKS or OVERWRITING WATERMARKS.");
-        util.mergeTables(
-                getDefaultMergingStrategies(),
-                sourceSchema,
-                Collections.emptyList(),
-                derivedWatermarkSpecs,
-                null);
+        assertThatThrownBy(
+                        () ->
+                                util.mergeTables(
+                                        getDefaultMergingStrategies(),
+                                        sourceSchema,
+                                        Collections.emptyList(),
+                                        derivedWatermarkSpecs,
+                                        null))
+                .isInstanceOf(ValidationException.class)
+                .hasMessage(
+                        "There already exists a watermark spec for column 'timestamp' in the "
+                                + "base table. You might want to specify EXCLUDING WATERMARKS "
+                                + "or OVERWRITING WATERMARKS.");
     }
 
     @Test
@@ -699,16 +726,18 @@ public class MergeTableLikeUtilTest {
                         .primaryKey("constraint-42", new String[] {"one", "two"})
                         .build();
 
-        thrown.expect(ValidationException.class);
-        thrown.expectMessage(
-                "The base table already has a primary key. You might want to specify "
-                        + "EXCLUDING CONSTRAINTS.");
-        util.mergeTables(
-                getDefaultMergingStrategies(),
-                sourceSchema,
-                Collections.emptyList(),
-                Collections.emptyList(),
-                primaryKey("one", "two"));
+        assertThatThrownBy(
+                        () ->
+                                util.mergeTables(
+                                        getDefaultMergingStrategies(),
+                                        sourceSchema,
+                                        Collections.emptyList(),
+                                        Collections.emptyList(),
+                                        primaryKey("one", "two")))
+                .isInstanceOf(ValidationException.class)
+                .hasMessage(
+                        "The base table already has a primary key. You might want to specify "
+                                + "EXCLUDING CONSTRAINTS.");
     }
 
     @Test
@@ -772,10 +801,16 @@ public class MergeTableLikeUtilTest {
         List<String> sourcePartitions = Arrays.asList("col3", "col4");
         List<String> derivedPartitions = Arrays.asList("col1", "col2");
 
-        thrown.expect(ValidationException.class);
-        thrown.expectMessage(
-                "The base table already has partitions defined. You might want to specify EXCLUDING PARTITIONS");
-        util.mergePartitions(MergingStrategy.INCLUDING, sourcePartitions, derivedPartitions);
+        assertThatThrownBy(
+                        () ->
+                                util.mergePartitions(
+                                        MergingStrategy.INCLUDING,
+                                        sourcePartitions,
+                                        derivedPartitions))
+                .isInstanceOf(ValidationException.class)
+                .hasMessage(
+                        "The base table already has partitions defined. You might want "
+                                + "to specify EXCLUDING PARTITIONS.");
     }
 
     @Test
@@ -821,11 +856,15 @@ public class MergeTableLikeUtilTest {
         Map<String, String> derivedOptions = new HashMap<>();
         derivedOptions.put("offset", "2");
 
-        thrown.expect(ValidationException.class);
-        thrown.expectMessage(
-                "There already exists an option ['offset' -> '1']  in the base table. You might want"
-                        + " to specify EXCLUDING OPTIONS or OVERWRITING OPTIONS.");
-        util.mergeOptions(MergingStrategy.INCLUDING, sourceOptions, derivedOptions);
+        assertThatThrownBy(
+                        () ->
+                                util.mergeOptions(
+                                        MergingStrategy.INCLUDING, sourceOptions, derivedOptions))
+                .isInstanceOf(ValidationException.class)
+                .hasMessage(
+                        "There already exists an option ['offset' -> '1']  in the base table. "
+                                + "You might want to specify EXCLUDING OPTIONS or "
+                                + "OVERWRITING OPTIONS.");
     }
 
     @Test

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/TableSinkJsonPlanTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/TableSinkJsonPlanTest.java
@@ -24,13 +24,10 @@ import org.apache.flink.table.planner.utils.StreamTableTestUtil;
 import org.apache.flink.table.planner.utils.TableTestBase;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 /** Test json serialization/deserialization for table sink. */
 public class TableSinkJsonPlanTest extends TableTestBase {
-    @Rule public ExpectedException exception = ExpectedException.none();
 
     private StreamTableTestUtil util;
     private TableEnvironment tEnv;

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/TableSourceJsonPlanTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/TableSourceJsonPlanTest.java
@@ -24,14 +24,10 @@ import org.apache.flink.table.planner.utils.StreamTableTestUtil;
 import org.apache.flink.table.planner.utils.TableTestBase;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 /** Test json serialization/deserialization for table source. */
 public class TableSourceJsonPlanTest extends TableTestBase {
-
-    @Rule public ExpectedException exception = ExpectedException.none();
 
     private StreamTableTestUtil util;
     private TableEnvironment tEnv;

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/utils/DiffRepository.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/utils/DiffRepository.java
@@ -185,7 +185,7 @@ public class DiffRepository {
      * share the same diff-repository: if the repository gets loaded once per test case, then only
      * one diff is recorded.
      */
-    private static final Map<Class, DiffRepository> MAP_CLASS_TO_REPOSITORY = new HashMap<>();
+    private static final Map<Class<?>, DiffRepository> MAP_CLASS_TO_REPOSITORY = new HashMap<>();
 
     // ~ Instance fields --------------------------------------------------------
 
@@ -599,9 +599,6 @@ public class DiffRepository {
                     Node child = childNodes.item(i);
                     writeNode(child, out);
                 }
-
-                //            writeNode(((Document) node).getDocumentElement(),
-                // out);
                 break;
 
             case Node.ELEMENT_NODE:
@@ -678,7 +675,7 @@ public class DiffRepository {
      * @param clazz Test case class
      * @return The diff repository shared between test cases in this class.
      */
-    public static DiffRepository lookup(Class clazz) {
+    public static DiffRepository lookup(Class<?> clazz) {
         return lookup(clazz, null);
     }
 
@@ -689,7 +686,7 @@ public class DiffRepository {
      * @param baseRepository Base class of test class
      * @return The diff repository shared between test cases in this class.
      */
-    public static DiffRepository lookup(Class clazz, DiffRepository baseRepository) {
+    public static DiffRepository lookup(Class<?> clazz, DiffRepository baseRepository) {
         return lookup(clazz, baseRepository, null);
     }
 
@@ -716,7 +713,7 @@ public class DiffRepository {
      * @return The diff repository shared between test cases in this class.
      */
     public static synchronized DiffRepository lookup(
-            Class clazz, DiffRepository baseRepository, Filter filter) {
+            Class<?> clazz, DiffRepository baseRepository, Filter filter) {
         DiffRepository diffRepository = MAP_CLASS_TO_REPOSITORY.get(clazz);
         if (diffRepository == null) {
             final URL refFile = findFile(clazz, ".xml");

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/utils/JsonPlanTestBase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/utils/JsonPlanTestBase.java
@@ -33,8 +33,6 @@ import org.apache.flink.util.StringUtils;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
-import org.junit.rules.ExpectedException;
 
 import javax.annotation.Nullable;
 
@@ -55,8 +53,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /** The base class for json plan testing. */
 public abstract class JsonPlanTestBase extends AbstractTestBase {
-
-    @Rule public ExpectedException exception = ExpectedException.none();
 
     protected TableEnvironment tableEnv;
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/utils/JsonTestUtils.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/utils/JsonTestUtils.java
@@ -41,8 +41,4 @@ public final class JsonTestUtils {
         return ((ObjectNode) target)
                 .set("flinkVersion", OBJECT_MAPPER_INSTANCE.valueToTree(flinkVersion.toString()));
     }
-
-    public static JsonNode clearFlinkVersion(JsonNode target) {
-        return ((ObjectNode) target).remove("flinkVersion");
-    }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/utils/OperationMatchers.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/utils/OperationMatchers.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.planner.utils;
 
 import org.apache.flink.table.api.Schema;
-import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.ddl.CreateTableOperation;
 
@@ -68,7 +67,7 @@ public class OperationMatchers {
      *
      * @param nestedMatchers additional matchers that must match
      * @see #withOptions(MapEntry[])
-     * @see #withSchema(TableSchema)
+     * @see #withSchema(Schema)
      * @see #partitionedBy(String...)
      */
     @SafeVarargs

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableITCase.scala
@@ -25,7 +25,7 @@ import org.apache.flink.table.catalog.{Column, ResolvedSchema}
 import org.apache.flink.table.planner.utils.TestTableSourceSinks
 import org.apache.flink.test.util.AbstractTestBase
 import org.apache.flink.types.{Row, RowKind}
-import org.apache.flink.util.{CollectionUtil, TestLogger}
+import org.apache.flink.util.CollectionUtil
 
 import _root_.java.lang.{Long => JLong}
 import _root_.java.util
@@ -33,7 +33,7 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.containsInAnyOrder
 import org.junit.{Before, Rule, Test}
 import org.junit.Assert.{assertEquals, assertNotEquals, assertTrue}
-import org.junit.rules.{ExpectedException, TemporaryFolder}
+import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
@@ -41,12 +41,6 @@ import java.time.Instant
 
 @RunWith(classOf[Parameterized])
 class TableITCase(tableEnvName: String, isStreaming: Boolean) extends AbstractTestBase {
-
-  // used for accurate exception information checking.
-  val expectedException: ExpectedException = ExpectedException.none()
-
-  @Rule
-  def thrown: ExpectedException = expectedException
 
   private val _tempFolder = new TemporaryFolder()
 

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/data/DataStructureConvertersTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/data/DataStructureConvertersTest.java
@@ -30,9 +30,7 @@ import org.apache.flink.types.Row;
 import org.apache.flink.types.RowKind;
 import org.apache.flink.util.InstantiationUtil;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
@@ -88,7 +86,7 @@ import static org.apache.flink.table.api.DataTypes.VARBINARY;
 import static org.apache.flink.table.api.DataTypes.VARCHAR;
 import static org.apache.flink.table.api.DataTypes.YEAR;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.CoreMatchers.equalTo;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link DataStructureConverters}. */
 @RunWith(Parameterized.class)
@@ -367,36 +365,40 @@ public class DataStructureConvertersTest {
 
     @Parameter public TestSpec testSpec;
 
-    @Rule public ExpectedException thrown = ExpectedException.none();
-
     @Test
     public void testConversions() {
-        if (testSpec.expectedErrorMessage != null) {
-            thrown.expect(TableException.class);
-            thrown.expectMessage(equalTo(testSpec.expectedErrorMessage));
-        }
         for (Map.Entry<Class<?>, Object> from : testSpec.conversions.entrySet()) {
             final DataType fromDataType = testSpec.dataType.bridgedTo(from.getKey());
 
-            final DataStructureConverter<Object, Object> fromConverter =
-                    simulateSerialization(DataStructureConverters.getConverter(fromDataType));
-            fromConverter.open(DataStructureConvertersTest.class.getClassLoader());
+            if (testSpec.expectedErrorMessage != null) {
+                assertThatThrownBy(
+                                () ->
+                                        simulateSerialization(
+                                                DataStructureConverters.getConverter(fromDataType)))
+                        .isInstanceOf(TableException.class)
+                        .hasMessage(testSpec.expectedErrorMessage);
+            } else {
+                final DataStructureConverter<Object, Object> fromConverter =
+                        simulateSerialization(DataStructureConverters.getConverter(fromDataType));
+                fromConverter.open(DataStructureConvertersTest.class.getClassLoader());
 
-            final Object internalValue = fromConverter.toInternalOrNull(from.getValue());
+                final Object internalValue = fromConverter.toInternalOrNull(from.getValue());
 
-            final Object anotherValue = testSpec.conversionsWithAnotherValue.get(from.getKey());
-            if (anotherValue != null) {
-                fromConverter.toInternalOrNull(anotherValue);
-            }
+                final Object anotherValue = testSpec.conversionsWithAnotherValue.get(from.getKey());
+                if (anotherValue != null) {
+                    fromConverter.toInternalOrNull(anotherValue);
+                }
 
-            for (Map.Entry<Class<?>, Object> to : testSpec.conversions.entrySet()) {
-                final DataType toDataType = testSpec.dataType.bridgedTo(to.getKey());
+                for (Map.Entry<Class<?>, Object> to : testSpec.conversions.entrySet()) {
+                    final DataType toDataType = testSpec.dataType.bridgedTo(to.getKey());
 
-                final DataStructureConverter<Object, Object> toConverter =
-                        simulateSerialization(DataStructureConverters.getConverter(toDataType));
-                toConverter.open(DataStructureConvertersTest.class.getClassLoader());
+                    final DataStructureConverter<Object, Object> toConverter =
+                            simulateSerialization(DataStructureConverters.getConverter(toDataType));
+                    toConverter.open(DataStructureConvertersTest.class.getClassLoader());
 
-                assertThat(toConverter.toExternalOrNull(internalValue)).isEqualTo(to.getValue());
+                    assertThat(toConverter.toExternalOrNull(internalValue))
+                            .isEqualTo(to.getValue());
+                }
             }
         }
     }

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/generated/CompileUtilsTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/generated/CompileUtilsTest.java
@@ -22,20 +22,17 @@ import org.apache.flink.util.FlinkRuntimeException;
 
 import org.codehaus.janino.ExpressionEvaluator;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link CompileUtils}. */
 public class CompileUtilsTest {
-
-    @Rule public ExpectedException thrown = ExpectedException.none();
 
     @Before
     public void before() {
@@ -84,9 +81,11 @@ public class CompileUtilsTest {
     @Test
     public void testWrongCode() {
         String code = "public class111 Main {\n" + "  int i;\n" + "  int j;\n" + "}";
-
-        thrown.expect(FlinkRuntimeException.class);
-        CompileUtils.compile(this.getClass().getClassLoader(), "Main", code);
+        assertThatThrownBy(
+                        () -> CompileUtils.compile(this.getClass().getClassLoader(), "Main", code))
+                .isInstanceOf(FlinkRuntimeException.class)
+                .hasMessageContaining(
+                        "Table program cannot be compiled. This is a bug. Please file an issue.");
     }
 
     private static class TestClassLoader extends URLClassLoader {

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/window/WindowOperatorContractTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/window/WindowOperatorContractTest.java
@@ -38,9 +38,7 @@ import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.table.utils.HandwrittenSelectorUtil;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.mockito.Matchers;
 import org.mockito.Mockito;
 
@@ -68,7 +66,6 @@ import static org.powermock.api.mockito.PowerMockito.when;
 public class WindowOperatorContractTest {
 
     private static final ZoneId UTC_ZONE_ID = ZoneId.of("UTC");
-    @Rule public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void testAssignerIsInvokedOncePerElement() throws Exception {

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/window/assigners/CumulativeWindowAssignerTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/window/assigners/CumulativeWindowAssignerTest.java
@@ -24,13 +24,12 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.runtime.operators.window.TimeWindow;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.HamcrestCondition.matching;
 import static org.hamcrest.Matchers.contains;
 
@@ -38,8 +37,6 @@ import static org.hamcrest.Matchers.contains;
 public class CumulativeWindowAssignerTest {
 
     private static final RowData ELEMENT = GenericRowData.of(StringData.fromString("String"));
-
-    @Rule public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void testWindowAssignment() {
@@ -144,23 +141,32 @@ public class CumulativeWindowAssignerTest {
 
     @Test
     public void testInvalidParameters1() {
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("step > 0 and size > 0");
-        CumulativeWindowAssigner.of(Duration.ofSeconds(-2), Duration.ofSeconds(1));
+        assertThatThrownBy(
+                        () ->
+                                CumulativeWindowAssigner.of(
+                                        Duration.ofSeconds(-2), Duration.ofSeconds(1)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("step > 0 and size > 0");
     }
 
     @Test
     public void testInvalidParameters2() {
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("step > 0 and size > 0");
-        CumulativeWindowAssigner.of(Duration.ofSeconds(2), Duration.ofSeconds(-1));
+        assertThatThrownBy(
+                        () ->
+                                CumulativeWindowAssigner.of(
+                                        Duration.ofSeconds(2), Duration.ofSeconds(-1)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("step > 0 and size > 0");
     }
 
     @Test
     public void testInvalidParameters3() {
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("size must be an integral multiple of step.");
-        CumulativeWindowAssigner.of(Duration.ofSeconds(5000), Duration.ofSeconds(2000));
+        assertThatThrownBy(
+                        () ->
+                                CumulativeWindowAssigner.of(
+                                        Duration.ofSeconds(5000), Duration.ofSeconds(2000)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("size must be an integral multiple of step.");
     }
 
     @Test

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/window/assigners/SlidingWindowAssignerTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/window/assigners/SlidingWindowAssignerTest.java
@@ -23,20 +23,17 @@ import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.operators.window.TimeWindow;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link SlidingWindowAssigner}. */
 public class SlidingWindowAssignerTest {
 
     private static final RowData ELEMENT = GenericRowData.of("String");
-
-    @Rule public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void testWindowAssignment() {
@@ -149,16 +146,20 @@ public class SlidingWindowAssignerTest {
 
     @Test
     public void testInvalidParameters() {
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("slide > 0 and size > 0");
-        SlidingWindowAssigner.of(Duration.ofSeconds(-2), Duration.ofSeconds(1));
+        assertThatThrownBy(
+                        () ->
+                                SlidingWindowAssigner.of(
+                                        Duration.ofSeconds(-2), Duration.ofSeconds(1)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("slide > 0 and size > 0");
 
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("slide > 0 and size > 0");
-        SlidingWindowAssigner.of(Duration.ofSeconds(2), Duration.ofSeconds(-1));
+        assertThatThrownBy(
+                        () ->
+                                SlidingWindowAssigner.of(
+                                        Duration.ofSeconds(2), Duration.ofSeconds(-1)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("slide > 0 and size > 0");
 
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("slide > 0 and size > 0");
         SlidingWindowAssigner.of(Duration.ofSeconds(20), Duration.ofSeconds(10))
                 .withOffset(Duration.ofSeconds(-1));
     }

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/window/assigners/TumblingWindowAssignerTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/window/assigners/TumblingWindowAssignerTest.java
@@ -23,19 +23,17 @@ import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.operators.window.TimeWindow;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link TumblingWindowAssigner}. */
 public class TumblingWindowAssignerTest {
 
     private static final RowData ELEMENT = GenericRowData.of("String");
-    @Rule public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void testWindowAssignment() {
@@ -59,16 +57,11 @@ public class TumblingWindowAssignerTest {
 
     @Test
     public void testInvalidParameters() {
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("size > 0");
-        TumblingWindowAssigner.of(Duration.ofSeconds(-1));
+        assertThatThrownBy(() -> TumblingWindowAssigner.of(Duration.ofSeconds(-1)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("TumblingWindowAssigner parameters must satisfy size > 0");
 
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("size > 0");
         TumblingWindowAssigner.of(Duration.ofSeconds(10)).withOffset(Duration.ofSeconds(20));
-
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("size > 0");
         TumblingWindowAssigner.of(Duration.ofSeconds(10)).withOffset(Duration.ofSeconds(-1));
     }
 

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/types/DataTypePrecisionFixerTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/types/DataTypePrecisionFixerTest.java
@@ -33,9 +33,7 @@ import org.apache.flink.table.types.logical.TimeType;
 import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.VarCharType;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -117,8 +115,6 @@ public class DataTypePrecisionFixerTest {
     }
 
     @Parameterized.Parameter public TestSpec testSpec;
-
-    @Rule public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void testPrecisionFixing() {

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/typeutils/RowDataSerializerTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/typeutils/RowDataSerializerTest.java
@@ -202,6 +202,7 @@ public class RowDataSerializerTest extends SerializerTestInstance<RowData> {
         return new Object[] {serializer, data};
     }
 
+    @SuppressWarnings({"unchecked", "rawtypes"})
     private static Object[] testRowDataSerializerWithKryo() {
         RawValueDataSerializer<WrappedString> rawValueSerializer =
                 new RawValueDataSerializer<>(
@@ -212,7 +213,7 @@ public class RowDataSerializerTest extends SerializerTestInstance<RowData> {
                         new TypeSerializer[] {rawValueSerializer});
 
         GenericRowData row = new GenericRowData(1);
-        row.setField(0, RawValueData.fromObject(new WrappedString("a")));
+        row.setField(0, RawValueData.fromObject(new WrappedString()));
 
         return new Object[] {serializer, new GenericRowData[] {row}};
     }
@@ -361,12 +362,5 @@ public class RowDataSerializerTest extends SerializerTestInstance<RowData> {
     }
 
     /** Class used for concurrent testing with KryoSerializer. */
-    private static class WrappedString {
-
-        private final String content;
-
-        WrappedString(String content) {
-            this.content = content;
-        }
-    }
+    private static class WrappedString {}
 }

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/typeutils/RowDataSerializerTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/typeutils/RowDataSerializerTest.java
@@ -41,9 +41,7 @@ import org.apache.flink.table.types.logical.RawType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.testutils.DeeplyEqualsChecker;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -53,12 +51,11 @@ import java.util.Objects;
 
 import static org.apache.flink.table.data.StringData.fromString;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test for {@link RowDataSerializer}. */
 @RunWith(Parameterized.class)
 public class RowDataSerializerTest extends SerializerTestInstance<RowData> {
-
-    @Rule public ExpectedException thrown = ExpectedException.none();
 
     private final RowDataSerializer serializer;
     private final RowData[] testData;
@@ -348,16 +345,21 @@ public class RowDataSerializerTest extends SerializerTestInstance<RowData> {
 
     @Test
     public void testWrongCopy() {
-        thrown.expect(IllegalArgumentException.class);
-        serializer.copy(new GenericRowData(serializer.getArity() + 1));
+        assertThatThrownBy(() -> serializer.copy(new GenericRowData(serializer.getArity() + 1)))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     public void testWrongCopyReuse() {
-        thrown.expect(IllegalArgumentException.class);
         for (RowData row : testData) {
-            checkDeepEquals(
-                    row, serializer.copy(row, new GenericRowData(row.getArity() + 1)), false);
+            assertThatThrownBy(
+                            () ->
+                                    checkDeepEquals(
+                                            row,
+                                            serializer.copy(
+                                                    row, new GenericRowData(row.getArity() + 1)),
+                                            false))
+                    .isInstanceOf(IllegalArgumentException.class);
         }
     }
 


### PR DESCRIPTION

## What is the purpose of the change

Small code improvements around test in `flink-table` module

## Brief change log

  - Since `table.exec.legacy-cast-behaviour` is disabled by default, there is no need to explicitely set it in the configuration of the Cast related IT tests.
  - Call `super.getConfiguration()` to inherit the configuration set in the superclass and add/override with more config options in the subclass.
  - Fix warnings
  - Use assertJ
  - Remove unused code
  - Replace deprecated ExpectedException with assertJ's `assertThatThrownBy` and improve certain assertions by asserting the Exception class or the Exception message where missing.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
