### PR TITLE
[FLINK-21585][metrics] Add options for in-/excluding metrics 

### DIFF
--- a/docs/layouts/shortcodes/generated/metric_configuration.html
+++ b/docs/layouts/shortcodes/generated/metric_configuration.html
@@ -69,6 +69,18 @@
             <td>The reporter factory class to use for the reporter named &lt;name&gt;.</td>
         </tr>
         <tr>
+            <td><h5>metrics.reporter.&lt;name&gt;.filter.excludes</h5></td>
+            <td style="word-wrap: break-word;"></td>
+            <td>List&lt;String&gt;</td>
+            <td>The metrics that should be excluded for the reporter named &lt;name&gt;. The format is identical to <code class="highlighter-rouge">filter.includes</code><br /></td>
+        </tr>
+        <tr>
+            <td><h5>metrics.reporter.&lt;name&gt;.filter.includes</h5></td>
+            <td style="word-wrap: break-word;">"*:*:*"</td>
+            <td>List&lt;String&gt;</td>
+            <td>The metrics that should be included for the reporter named &lt;name&gt;. Filters are specified as a list, with each filter following this format:<br /><code class="highlighter-rouge">&lt;scope&gt;[:&lt;name&gt;[,&lt;name&gt;][:&lt;type&gt;[,&lt;type&gt;]]]</code><br />A metric matches a filter if the scope pattern and at least one of the name patterns and at least one of the types match.<br /><ul><li>scope: Filters based on the logical scope.<br />Specified as a pattern where <code class="highlighter-rouge">*</code> matches any sequence of characters and <code class="highlighter-rouge">.</code> separates scope components.<br /><br />For example:<br /> "<code class="highlighter-rouge">jobmanager.job</code>" matches any job-related metrics on the JobManager,<br /> "<code class="highlighter-rouge">*.job</code>" matches all job-related metrics and<br /> "<code class="highlighter-rouge">*.job.*</code>" matches all metrics below the job-level (i.e., task/operator metrics etc.).<br /><br /></li><li>name: Filters based on the metric name.<br />Specified as a comma-separate list of patterns where <code class="highlighter-rouge">*</code> matches any sequence of characters.<br /><br />For example, "<code class="highlighter-rouge">*Records*,*Bytes*</code>" matches any metrics where the name contains <code class="highlighter-rouge">"Records" or "Bytes"</code>.<br /><br /></li><li>type: Filters based on the metric type. Specified as a comma-separated list of metric types: <code class="highlighter-rouge">[counter, meter, gauge, histogram]</code></li></ul>Examples:<ul><li>"<code class="highlighter-rouge">*:numRecords*</code>" Matches metrics like <code class="highlighter-rouge">numRecordsIn</code>.</li><li>"<code class="highlighter-rouge">*.job.task.operator:numRecords*</code>" Matches metrics like <code class="highlighter-rouge">numRecordsIn</code> on the operator level.</li><li>"<code class="highlighter-rouge">*.job.task.operator:numRecords*:meter</code>" Matches meter metrics like <code class="highlighter-rouge">numRecordsInPerSecond</code> on the operator level.</li><li>"<code class="highlighter-rouge">*:numRecords*,numBytes*:counter,meter</code>" Matches all counter/meter metrics like or <code class="highlighter-rouge">numRecordsInPerSecond</code>.</li></ul></td>
+        </tr>
+        <tr>
             <td><h5>metrics.reporter.&lt;name&gt;.interval</h5></td>
             <td style="word-wrap: break-word;">10 s</td>
             <td>Duration</td>

--- a/docs/layouts/shortcodes/generated/metric_reporters_section.html
+++ b/docs/layouts/shortcodes/generated/metric_reporters_section.html
@@ -45,6 +45,18 @@
             <td>The set of variables that should be excluded for the reporter named &lt;name&gt;. Only applicable to tag-based reporters (e.g., PRometheus, InfluxDB).</td>
         </tr>
         <tr>
+            <td><h5>metrics.reporter.&lt;name&gt;.filter.includes</h5></td>
+            <td style="word-wrap: break-word;">"*:*:*"</td>
+            <td>List&lt;String&gt;</td>
+            <td>The metrics that should be included for the reporter named &lt;name&gt;. Filters are specified as a list, with each filter following this format:<br /><code class="highlighter-rouge">&lt;scope&gt;[:&lt;name&gt;[,&lt;name&gt;][:&lt;type&gt;[,&lt;type&gt;]]]</code><br />A metric matches a filter if the scope pattern and at least one of the name patterns and at least one of the types match.<br /><ul><li>scope: Filters based on the logical scope.<br />Specified as a pattern where <code class="highlighter-rouge">*</code> matches any sequence of characters and <code class="highlighter-rouge">.</code> separates scope components.<br /><br />For example:<br /> "<code class="highlighter-rouge">jobmanager.job</code>" matches any job-related metrics on the JobManager,<br /> "<code class="highlighter-rouge">*.job</code>" matches all job-related metrics and<br /> "<code class="highlighter-rouge">*.job.*</code>" matches all metrics below the job-level (i.e., task/operator metrics etc.).<br /><br /></li><li>name: Filters based on the metric name.<br />Specified as a comma-separate list of patterns where <code class="highlighter-rouge">*</code> matches any sequence of characters.<br /><br />For example, "<code class="highlighter-rouge">*Records*,*Bytes*</code>" matches any metrics where the name contains <code class="highlighter-rouge">"Records" or "Bytes"</code>.<br /><br /></li><li>type: Filters based on the metric type. Specified as a comma-separated list of metric types: <code class="highlighter-rouge">[counter, meter, gauge, histogram]</code></li></ul>Examples:<ul><li>"<code class="highlighter-rouge">*:numRecords*</code>" Matches metrics like <code class="highlighter-rouge">numRecordsIn</code>.</li><li>"<code class="highlighter-rouge">*.job.task.operator:numRecords*</code>" Matches metrics like <code class="highlighter-rouge">numRecordsIn</code> on the operator level.</li><li>"<code class="highlighter-rouge">*.job.task.operator:numRecords*:meter</code>" Matches meter metrics like <code class="highlighter-rouge">numRecordsInPerSecond</code> on the operator level.</li><li>"<code class="highlighter-rouge">*:numRecords*,numBytes*:counter,meter</code>" Matches all counter/meter metrics like or <code class="highlighter-rouge">numRecordsInPerSecond</code>.</li></ul></td>
+        </tr>
+        <tr>
+            <td><h5>metrics.reporter.&lt;name&gt;.filter.excludes</h5></td>
+            <td style="word-wrap: break-word;"></td>
+            <td>List&lt;String&gt;</td>
+            <td>The metrics that should be excluded for the reporter named &lt;name&gt;. The format is identical to <code class="highlighter-rouge">filter.includes</code><br /></td>
+        </tr>
+        <tr>
             <td><h5>metrics.reporter.&lt;name&gt;.&lt;parameter&gt;</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigurationUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigurationUtils.java
@@ -371,7 +371,7 @@ public class ConfigurationUtils {
     }
 
     @SuppressWarnings("unchecked")
-    static <E extends Enum<?>> E convertToEnum(Object o, Class<E> clazz) {
+    public static <E extends Enum<?>> E convertToEnum(Object o, Class<E> clazz) {
         if (o.getClass().equals(clazz)) {
             return (E) o;
         }

--- a/flink-core/src/main/java/org/apache/flink/configuration/MetricOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/MetricOptions.java
@@ -30,6 +30,8 @@ import java.util.List;
 import java.util.Map;
 
 import static org.apache.flink.configuration.ConfigOptions.key;
+import static org.apache.flink.configuration.description.LineBreakElement.linebreak;
+import static org.apache.flink.configuration.description.TextElement.code;
 import static org.apache.flink.configuration.description.TextElement.text;
 
 /** Configuration options for metrics and metric reporters. */
@@ -119,6 +121,95 @@ public class MetricOptions {
 
     @Documentation.SuffixOption(NAMED_REPORTER_CONFIG_PREFIX)
     @Documentation.Section(value = Documentation.Sections.METRIC_REPORTERS, position = 4)
+    public static final ConfigOption<List<String>> REPORTER_INCLUDES =
+            key("filter.includes")
+                    .stringType()
+                    .asList()
+                    .defaultValues("*:*:*")
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "The metrics that should be included for the reporter named <name>."
+                                                    + " Filters are specified as a list, with each filter following this format:")
+                                    .linebreak()
+                                    .text("%s", code("<scope>[:<name>[,<name>][:<type>[,<type>]]]"))
+                                    .linebreak()
+                                    .text(
+                                            "A metric matches a filter if the scope pattern and at least one of the name patterns and at least one of the types match.")
+                                    .linebreak()
+                                    .list(
+                                            text(
+                                                    "scope: Filters based on the logical scope.%s"
+                                                            + "Specified as a pattern where %s matches any sequence of characters and %s separates scope components.%s%s"
+                                                            + "For example:%s"
+                                                            + " \"%s\" matches any job-related metrics on the JobManager,%s"
+                                                            + " \"%s\" matches all job-related metrics and%s"
+                                                            + " \"%s\" matches all metrics below the job-level (i.e., task/operator metrics etc.).%s%s",
+                                                    linebreak(),
+                                                    code("*"),
+                                                    code("."),
+                                                    linebreak(),
+                                                    linebreak(),
+                                                    linebreak(),
+                                                    code("jobmanager.job"),
+                                                    linebreak(),
+                                                    code("*.job"),
+                                                    linebreak(),
+                                                    code("*.job.*"),
+                                                    linebreak(),
+                                                    linebreak()),
+                                            text(
+                                                    "name: Filters based on the metric name.%s"
+                                                            + "Specified as a comma-separate list of patterns where %s matches any sequence of characters.%s%s"
+                                                            + "For example, \"%s\" matches any metrics where the name contains %s.%s%s",
+                                                    linebreak(),
+                                                    code("*"),
+                                                    linebreak(),
+                                                    linebreak(),
+                                                    code("*Records*,*Bytes*"),
+                                                    code("\"Records\" or \"Bytes\""),
+                                                    linebreak(),
+                                                    linebreak()),
+                                            text(
+                                                    "type: Filters based on the metric type. Specified as a comma-separated list of metric types: %s",
+                                                    code("[counter, meter, gauge, histogram]")))
+                                    .text("Examples:")
+                                    .list(
+                                            text(
+                                                    "\"%s\" Matches metrics like %s.",
+                                                    code("*:numRecords*"), code("numRecordsIn")),
+                                            text(
+                                                    "\"%s\" Matches metrics like %s on the operator level.",
+                                                    code("*.job.task.operator:numRecords*"),
+                                                    code("numRecordsIn")),
+                                            text(
+                                                    "\"%s\" Matches meter metrics like %s on the operator level.",
+                                                    code("*.job.task.operator:numRecords*:meter"),
+                                                    code("numRecordsInPerSecond")),
+                                            text(
+                                                    "\"%s\" Matches all counter/meter metrics like or %s.",
+                                                    code("*:numRecords*,numBytes*:counter,meter"),
+                                                    code("numRecordsInPerSecond"),
+                                                    code("numBytesOut")))
+                                    .build());
+
+    @Documentation.SuffixOption(NAMED_REPORTER_CONFIG_PREFIX)
+    @Documentation.Section(value = Documentation.Sections.METRIC_REPORTERS, position = 5)
+    public static final ConfigOption<List<String>> REPORTER_EXCLUDES =
+            key("filter.excludes")
+                    .stringType()
+                    .asList()
+                    .defaultValues()
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "The metrics that should be excluded for the reporter named <name>. The format is identical to %s",
+                                            code(REPORTER_INCLUDES.key()))
+                                    .linebreak()
+                                    .build());
+
+    @Documentation.SuffixOption(NAMED_REPORTER_CONFIG_PREFIX)
+    @Documentation.Section(value = Documentation.Sections.METRIC_REPORTERS, position = 6)
     public static final ConfigOption<String> REPORTER_CONFIG_PARAMETER =
             key("<parameter>")
                     .stringType()

--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -628,9 +628,10 @@ function kill_random_taskmanager {
 }
 
 function setup_flink_slf4j_metric_reporter() {
-  INTERVAL="${1:-1 SECONDS}"
+  METRIC_NAME_PATTERN="${1:-"*"}"
   set_config_key "metrics.reporter.slf4j.factory.class" "org.apache.flink.metrics.slf4j.Slf4jReporterFactory"
-  set_config_key "metrics.reporter.slf4j.interval" "${INTERVAL}"
+  set_config_key "metrics.reporter.slf4j.interval" "1 SECONDS"
+  set_config_key "metrics.reporter.slf4j.filter.includes" "*:${METRIC_NAME_PATTERN}"
 }
 
 function get_job_metric {

--- a/flink-end-to-end-tests/test-scripts/test_resume_externalized_checkpoints.sh
+++ b/flink-end-to-end-tests/test-scripts/test_resume_externalized_checkpoints.sh
@@ -40,7 +40,7 @@ function run_resume_externalized_checkpoints() {
 
   set_config_key "taskmanager.numberOfTaskSlots" "${NUM_SLOTS}"
   set_config_key "metrics.fetcher.update-interval" "2000"
-  setup_flink_slf4j_metric_reporter
+  setup_flink_slf4j_metric_reporter "numRecordsIn"
   start_cluster
 
   CHECKPOINT_DIR="$TEST_DATA_DIR/externalized-chckpt-e2e-backend-dir"

--- a/flink-end-to-end-tests/test-scripts/test_resume_savepoint.sh
+++ b/flink-end-to-end-tests/test-scripts/test_resume_savepoint.sh
@@ -65,7 +65,7 @@ run_resume_savepoint_test() {
   fi
   set_config_key "metrics.fetcher.update-interval" "2000"
 
-  setup_flink_slf4j_metric_reporter
+  setup_flink_slf4j_metric_reporter "numRecordsIn"
 
   start_cluster
 

--- a/flink-end-to-end-tests/test-scripts/test_rocksdb_state_memory_control.sh
+++ b/flink-end-to-end-tests/test-scripts/test_rocksdb_state_memory_control.sh
@@ -51,7 +51,7 @@ set_config_key "state.backend.rocksdb.metrics.num-immutable-mem-table" "true"
 set_config_key "state.backend.rocksdb.metrics.block-cache-usage" "true"
 set_config_key "state.backend.rocksdb.metrics.estimate-table-readers-mem" "true"
 set_config_key "metrics.fetcher.update-interval" "1000"
-setup_flink_slf4j_metric_reporter
+setup_flink_slf4j_metric_reporter "numRecordsIn,block-cache-usage"
 start_cluster
 
 echo "Running RocksDB state backend memory control test"

--- a/flink-end-to-end-tests/test-scripts/test_stateful_stream_job_upgrade.sh
+++ b/flink-end-to-end-tests/test-scripts/test_stateful_stream_job_upgrade.sh
@@ -29,7 +29,7 @@ else
 fi
 
 set_config_key "taskmanager.numberOfTaskSlots" "${NUM_SLOTS}"
-setup_flink_slf4j_metric_reporter
+setup_flink_slf4j_metric_reporter "numRecordsIn"
 set_config_key "metrics.fetcher.update-interval" "2000"
 
 start_cluster

--- a/flink-end-to-end-tests/test-scripts/test_stream_state_ttl.sh
+++ b/flink-end-to-end-tests/test-scripts/test_stream_state_ttl.sh
@@ -31,7 +31,7 @@ TEST=flink-stream-state-ttl-test
 TEST_PROGRAM_NAME=DataStreamStateTTLTestProgram
 TEST_PROGRAM_JAR=${END_TO_END_DIR}/$TEST/target/$TEST_PROGRAM_NAME.jar
 
-setup_flink_slf4j_metric_reporter
+setup_flink_slf4j_metric_reporter "numRecordsIn"
 
 set_config_key "metrics.fetcher.update-interval" "2000"
 

--- a/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTest.java
+++ b/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTest.java
@@ -32,6 +32,7 @@ import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.metrics.MetricRegistryImpl;
 import org.apache.flink.runtime.metrics.MetricRegistryTestUtils;
 import org.apache.flink.runtime.metrics.ReporterSetup;
+import org.apache.flink.runtime.metrics.filter.MetricFilter;
 import org.apache.flink.runtime.metrics.groups.FrontMetricGroup;
 import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
 import org.apache.flink.runtime.metrics.groups.JobManagerMetricGroup;
@@ -340,6 +341,7 @@ class PrometheusReporterTest {
     }
 
     private static ReporterScopedSettings createReporterScopedSettings() {
-        return new ReporterScopedSettings(0, ',', Collections.emptySet(), Collections.emptyMap());
+        return new ReporterScopedSettings(
+                0, ',', MetricFilter.NO_OP_FILTER, Collections.emptySet(), Collections.emptyMap());
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/filter/DefaultMetricFilter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/filter/DefaultMetricFilter.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.metrics.filter;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ConfigurationUtils;
+import org.apache.flink.configuration.MetricOptions;
+import org.apache.flink.metrics.Metric;
+import org.apache.flink.metrics.MetricType;
+
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Default {@link MetricFilter} implementation that filters metrics based on {@link
+ * MetricOptions#REPORTER_INCLUDES}/{@link MetricOptions#REPORTER_EXCLUDES}.
+ */
+public class DefaultMetricFilter implements MetricFilter {
+
+    private static final EnumSet<MetricType> ALL_METRIC_TYPES = EnumSet.allOf(MetricType.class);
+    @VisibleForTesting static final String LIST_DELIMITER = ",";
+
+    private final List<FilterSpec> includes;
+    private final List<FilterSpec> excludes;
+
+    private DefaultMetricFilter(List<FilterSpec> includes, List<FilterSpec> excludes) {
+        this.includes = includes;
+        this.excludes = excludes;
+    }
+
+    @Override
+    public boolean filter(Metric metric, String name, String logicalScope) {
+        for (FilterSpec exclude : excludes) {
+            if (exclude.namePattern.matcher(name).matches()
+                    && exclude.scopePattern.matcher(logicalScope).matches()
+                    && exclude.types.contains(metric.getMetricType())) {
+                return false;
+            }
+        }
+        for (FilterSpec include : includes) {
+            if (include.namePattern.matcher(name).matches()
+                    && include.scopePattern.matcher(logicalScope).matches()
+                    && include.types.contains(metric.getMetricType())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static MetricFilter fromConfiguration(Configuration configuration) {
+        final List<String> includes = configuration.get(MetricOptions.REPORTER_INCLUDES);
+        final List<String> excludes = configuration.get(MetricOptions.REPORTER_EXCLUDES);
+
+        final List<FilterSpec> includeFilters =
+                includes.stream().map(i -> parse(i)).collect(Collectors.toList());
+        final List<FilterSpec> excludeFilters =
+                excludes.stream().map(e -> parse(e)).collect(Collectors.toList());
+
+        return new DefaultMetricFilter(includeFilters, excludeFilters);
+    }
+
+    private static FilterSpec parse(String filter) {
+        final String[] split = filter.split(":");
+        final Pattern scope = convertToPattern(split[0]);
+        final Pattern name = split.length > 1 ? convertToPattern(split[1]) : convertToPattern("*");
+        final EnumSet<MetricType> type =
+                split.length > 2 ? parseMetricTypes(split[2]) : ALL_METRIC_TYPES;
+
+        return new FilterSpec(scope, name, type);
+    }
+
+    @VisibleForTesting
+    static Pattern convertToPattern(String scopeOrNameComponent) {
+        final String[] split = scopeOrNameComponent.split(LIST_DELIMITER);
+
+        final String rawPattern =
+                Arrays.stream(split)
+                        .map(s -> s.replaceAll("\\.", "\\."))
+                        .map(s -> s.replaceAll("\\*", ".*"))
+                        .collect(Collectors.joining("|", "(", ")"));
+
+        return Pattern.compile(rawPattern);
+    }
+
+    @VisibleForTesting
+    static EnumSet<MetricType> parseMetricTypes(String typeComponent) {
+        final String[] split = typeComponent.split(LIST_DELIMITER);
+
+        if (split.length == 1 && split[0].equals("*")) {
+            return ALL_METRIC_TYPES;
+        }
+
+        return EnumSet.copyOf(
+                Arrays.stream(split)
+                        .map(s -> ConfigurationUtils.convertToEnum(s, MetricType.class))
+                        .collect(Collectors.toSet()));
+    }
+
+    private static class FilterSpec {
+        private final Pattern scopePattern;
+        private final Pattern namePattern;
+        private final EnumSet<MetricType> types;
+
+        private FilterSpec(Pattern scopePattern, Pattern namePattern, EnumSet<MetricType> types) {
+            this.scopePattern = scopePattern;
+            this.namePattern = namePattern;
+            this.types = types;
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/filter/MetricFilter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/filter/MetricFilter.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.metrics.filter;
+
+import org.apache.flink.metrics.Metric;
+
+/** A filter for metrics. */
+public interface MetricFilter {
+
+    /** Filter that accepts every metric. */
+    MetricFilter NO_OP_FILTER = (metric, name, scope) -> true;
+
+    /**
+     * Filters a given metric.
+     *
+     * @param metric the metric to filter
+     * @param name the name of the metric
+     * @param logicalScope the logical scope of the metric
+     * @return true, if the metric matches, false otherwise
+     */
+    boolean filter(Metric metric, String name, String logicalScope);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/ReporterScopedSettings.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/ReporterScopedSettings.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.runtime.metrics.groups;
 
+import org.apache.flink.runtime.metrics.filter.MetricFilter;
 import org.apache.flink.util.Preconditions;
 
 import java.util.Map;
@@ -31,17 +32,21 @@ public class ReporterScopedSettings {
 
     private final Set<String> excludedVariables;
 
+    private final MetricFilter filter;
+
     private final Map<String, String> additionalVariables;
 
     public ReporterScopedSettings(
             int reporterIndex,
             char delimiter,
+            MetricFilter filter,
             Set<String> excludedVariables,
             Map<String, String> additionalVariables) {
         this.excludedVariables = excludedVariables;
         Preconditions.checkArgument(reporterIndex >= 0);
         this.reporterIndex = reporterIndex;
         this.delimiter = delimiter;
+        this.filter = filter;
         this.additionalVariables = additionalVariables;
     }
 
@@ -51,6 +56,10 @@ public class ReporterScopedSettings {
 
     public char getDelimiter() {
         return delimiter;
+    }
+
+    public MetricFilter getFilter() {
+        return filter;
     }
 
     public Set<String> getExcludedVariables() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/filter/DefaultMetricFilterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/filter/DefaultMetricFilterTest.java
@@ -1,0 +1,215 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.metrics.filter;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.MetricOptions;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.Meter;
+import org.apache.flink.metrics.MetricType;
+import org.apache.flink.metrics.util.TestCounter;
+import org.apache.flink.metrics.util.TestMeter;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Execution(ExecutionMode.CONCURRENT)
+class DefaultMetricFilterTest {
+
+    private static final Counter COUNTER = new TestCounter();
+    private static final Meter METER = new TestMeter();
+    private static final Gauge<Integer> GAUGE = () -> 4;
+
+    @Test
+    void testConvertToPatternWithoutWildcards() {
+        final Pattern pattern = DefaultMetricFilter.convertToPattern("numRecordsIn");
+        assertThat(pattern.toString()).isEqualTo("(numRecordsIn)");
+        assertThat(pattern.matcher("numRecordsIn").matches()).isEqualTo(true);
+        assertThat(pattern.matcher("numBytesOut").matches()).isEqualTo(false);
+    }
+
+    @Test
+    void testConvertToPatternSingle() {
+        final Pattern pattern = DefaultMetricFilter.convertToPattern("numRecords*");
+        assertThat(pattern.toString()).isEqualTo("(numRecords.*)");
+        assertThat(pattern.matcher("numRecordsIn").matches()).isEqualTo(true);
+        assertThat(pattern.matcher("numBytesOut").matches()).isEqualTo(false);
+    }
+
+    @Test
+    void testConvertToPatternMultiple() {
+        final Pattern pattern = DefaultMetricFilter.convertToPattern("numRecords*,numBytes*");
+        assertThat(pattern.toString()).isEqualTo("(numRecords.*|numBytes.*)");
+        assertThat(pattern.matcher("numRecordsIn").matches()).isEqualTo(true);
+        assertThat(pattern.matcher("numBytesOut").matches()).isEqualTo(true);
+        assertThat(pattern.matcher("numBytes").matches()).isEqualTo(true);
+        assertThat(pattern.matcher("hello").matches()).isEqualTo(false);
+    }
+
+    @Test
+    void testParseMetricTypesSingle() {
+        final EnumSet<MetricType> types = DefaultMetricFilter.parseMetricTypes("meter");
+        assertThat(types).containsExactly(MetricType.METER);
+    }
+
+    @Test
+    void testParseMetricTypesMultiple() {
+        final EnumSet<MetricType> types = DefaultMetricFilter.parseMetricTypes("meter,counter");
+        assertThat(types).containsExactlyInAnyOrder(MetricType.METER, MetricType.COUNTER);
+    }
+
+    @Test
+    void testParseMetricTypesCaseIgnored() {
+        final EnumSet<MetricType> types = DefaultMetricFilter.parseMetricTypes("meter,CoUnTeR");
+        assertThat(types).containsExactlyInAnyOrder(MetricType.METER, MetricType.COUNTER);
+    }
+
+    @Test
+    void testFromConfigurationIncludeByScope() {
+        Configuration configuration = new Configuration();
+        configuration.set(
+                MetricOptions.REPORTER_INCLUDES, Arrays.asList("include1:*:*", "include2.*:*:*"));
+        configuration.set(MetricOptions.REPORTER_EXCLUDES, Collections.emptyList());
+
+        final MetricFilter metricFilter = DefaultMetricFilter.fromConfiguration(configuration);
+
+        assertThat(metricFilter.filter(COUNTER, "name", "include1")).isEqualTo(true);
+        assertThat(metricFilter.filter(COUNTER, "name", "include1.bar")).isEqualTo(false);
+        assertThat(metricFilter.filter(COUNTER, "name", "include2")).isEqualTo(false);
+        assertThat(metricFilter.filter(COUNTER, "name", "include2.bar")).isEqualTo(true);
+    }
+
+    @Test
+    void testFromConfigurationIncludeByName() {
+        Configuration configuration = new Configuration();
+        configuration.set(MetricOptions.REPORTER_INCLUDES, Arrays.asList("*:name:*"));
+        configuration.set(MetricOptions.REPORTER_EXCLUDES, Collections.emptyList());
+
+        final MetricFilter metricFilter = DefaultMetricFilter.fromConfiguration(configuration);
+
+        assertThat(metricFilter.filter(COUNTER, "name", "bar")).isEqualTo(true);
+        assertThat(metricFilter.filter(COUNTER, "foo", "bar")).isEqualTo(false);
+    }
+
+    @Test
+    void testFromConfigurationIncludeByType() {
+        Configuration configuration = new Configuration();
+        configuration.set(MetricOptions.REPORTER_INCLUDES, Arrays.asList("*:*:counter"));
+        configuration.set(MetricOptions.REPORTER_EXCLUDES, Collections.emptyList());
+
+        final MetricFilter metricFilter = DefaultMetricFilter.fromConfiguration(configuration);
+
+        assertThat(metricFilter.filter(COUNTER, "foo", "bar")).isEqualTo(true);
+        assertThat(metricFilter.filter(METER, "foo", "bar")).isEqualTo(false);
+    }
+
+    @Test
+    void testFromConfigurationExcludeByScope() {
+        Configuration configuration = new Configuration();
+        configuration.set(MetricOptions.REPORTER_INCLUDES, Arrays.asList("*:*:*"));
+        configuration.set(MetricOptions.REPORTER_EXCLUDES, Arrays.asList("include1", "include2.*"));
+
+        final MetricFilter metricFilter = DefaultMetricFilter.fromConfiguration(configuration);
+
+        assertThat(metricFilter.filter(COUNTER, "name", "include1")).isEqualTo(false);
+        assertThat(metricFilter.filter(COUNTER, "name", "include1.bar")).isEqualTo(true);
+        assertThat(metricFilter.filter(COUNTER, "name", "include2")).isEqualTo(true);
+        assertThat(metricFilter.filter(COUNTER, "name", "include2.bar")).isEqualTo(false);
+    }
+
+    @Test
+    void testFromConfigurationExcludeByName() {
+        Configuration configuration = new Configuration();
+        configuration.set(MetricOptions.REPORTER_INCLUDES, Arrays.asList("*:*:*"));
+        configuration.set(MetricOptions.REPORTER_EXCLUDES, Arrays.asList("*:faa*", "*:foo"));
+
+        final MetricFilter metricFilter = DefaultMetricFilter.fromConfiguration(configuration);
+
+        assertThat(metricFilter.filter(COUNTER, "name", "bar")).isEqualTo(true);
+        assertThat(metricFilter.filter(COUNTER, "foo", "bar")).isEqualTo(false);
+        assertThat(metricFilter.filter(COUNTER, "foob", "bar")).isEqualTo(true);
+        assertThat(metricFilter.filter(COUNTER, "faab", "bar")).isEqualTo(false);
+    }
+
+    @Test
+    void testFromConfigurationExcludeByType() {
+        Configuration configuration = new Configuration();
+        configuration.set(MetricOptions.REPORTER_INCLUDES, Arrays.asList("*:*:*"));
+        configuration.set(MetricOptions.REPORTER_EXCLUDES, Arrays.asList("*:*:meter"));
+
+        final MetricFilter metricFilter = DefaultMetricFilter.fromConfiguration(configuration);
+
+        assertThat(metricFilter.filter(COUNTER, "foo", "bar")).isEqualTo(true);
+        assertThat(metricFilter.filter(METER, "foo", "bar")).isEqualTo(false);
+    }
+
+    @Test
+    void testFromConfigurationIncludeDefault() {
+        Configuration configuration = new Configuration();
+        configuration.set(MetricOptions.REPORTER_EXCLUDES, Arrays.asList("*:*:meter"));
+
+        final MetricFilter metricFilter = DefaultMetricFilter.fromConfiguration(configuration);
+
+        assertThat(metricFilter.filter(COUNTER, "foo", "hello")).isEqualTo(true);
+        assertThat(metricFilter.filter(METER, "foo", "hello")).isEqualTo(false);
+    }
+
+    @Test
+    void testFromConfigurationExcludeDefault() {
+        Configuration configuration = new Configuration();
+        configuration.set(MetricOptions.REPORTER_INCLUDES, Arrays.asList("*:*:*"));
+
+        final MetricFilter metricFilter = DefaultMetricFilter.fromConfiguration(configuration);
+
+        assertThat(metricFilter.filter(COUNTER, "foo", "bar")).isEqualTo(true);
+    }
+
+    @Test
+    void testFromConfigurationAllDefault() {
+        Configuration configuration = new Configuration();
+
+        final MetricFilter metricFilter = DefaultMetricFilter.fromConfiguration(configuration);
+
+        assertThat(metricFilter.filter(COUNTER, "foo", "bar")).isEqualTo(true);
+        assertThat(metricFilter.filter(METER, "foo", "bar")).isEqualTo(true);
+    }
+
+    @Test
+    void testFromConfigurationMultiplePatterns() {
+        Configuration configuration = new Configuration();
+
+        configuration.set(MetricOptions.REPORTER_EXCLUDES, Arrays.asList("*:*:*"));
+        configuration.setString(
+                MetricOptions.REPORTER_EXCLUDES.key(), "*:foo,bar:meter;*:foo,bar:gauge");
+
+        final MetricFilter metricFilter = DefaultMetricFilter.fromConfiguration(configuration);
+
+        assertThat(metricFilter.filter(COUNTER, "foo", "bar")).isEqualTo(true);
+        assertThat(metricFilter.filter(METER, "foo", "bar")).isEqualTo(false);
+        assertThat(metricFilter.filter(GAUGE, "foo", "bar")).isEqualTo(false);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/FrontMetricGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/FrontMetricGroupTest.java
@@ -19,6 +19,7 @@ package org.apache.flink.runtime.metrics.groups;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MetricOptions;
+import org.apache.flink.runtime.metrics.filter.MetricFilter;
 import org.apache.flink.runtime.metrics.scope.ScopeFormat;
 import org.apache.flink.runtime.metrics.scope.ScopeFormats;
 import org.apache.flink.runtime.metrics.util.TestingMetricRegistry;
@@ -48,7 +49,11 @@ public class FrontMetricGroupTest {
         final FrontMetricGroup<?> frontMetricGroup =
                 new FrontMetricGroup<>(
                         new ReporterScopedSettings(
-                                0, delimiter, Collections.emptySet(), Collections.emptyMap()),
+                                0,
+                                delimiter,
+                                MetricFilter.NO_OP_FILTER,
+                                Collections.emptySet(),
+                                Collections.emptyMap()),
                         new ProcessMetricGroup(
                                 TestingMetricRegistry.builder()
                                         .setScopeFormats(ScopeFormats.fromConfig(config))
@@ -79,7 +84,11 @@ public class FrontMetricGroupTest {
         final FrontMetricGroup<?> frontMetricGroup =
                 new FrontMetricGroup<>(
                         new ReporterScopedSettings(
-                                0, delimiter, Collections.emptySet(), Collections.emptyMap()),
+                                0,
+                                delimiter,
+                                MetricFilter.NO_OP_FILTER,
+                                Collections.emptySet(),
+                                Collections.emptyMap()),
                         new ProcessMetricGroup(
                                 TestingMetricRegistry.builder()
                                         .setScopeFormats(ScopeFormats.fromConfig(config))
@@ -107,6 +116,7 @@ public class FrontMetricGroupTest {
                         new ReporterScopedSettings(
                                 0,
                                 '.',
+                                MetricFilter.NO_OP_FILTER,
                                 Collections.emptySet(),
                                 ImmutableMap.of(ScopeFormat.asVariable("foo"), "bar")),
                         new ProcessMetricGroup(TestingMetricRegistry.builder().build(), "host"));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/MetricGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/MetricGroupTest.java
@@ -402,7 +402,7 @@ public class MetricGroupTest extends TestLogger {
 
         @Override
         protected String getGroupName(CharacterFilter filter) {
-            return "";
+            return "foo";
         }
 
         @Override


### PR DESCRIPTION
This PR introduces 2 new configuration options that allow users to define filters for each reporter that control whether a given metric is passed to the reporter or not.
Effectively this allows the user to select the metrics to be reported.