### PR TITLE
[hotfix][runtime][tests] Modify spelling error in RestServerSSLAuthITCase.java

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerSSLAuthITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerSSLAuthITCase.java
@@ -69,9 +69,9 @@ public class RestServerSSLAuthITCase extends TestLogger {
     private final Configuration clientConfig;
     private final Configuration serverConfig;
 
-    public RestServerSSLAuthITCase(final Tuple2<Configuration, Configuration> clinetServerConfig) {
-        this.clientConfig = clinetServerConfig.f0;
-        this.serverConfig = clinetServerConfig.f1;
+    public RestServerSSLAuthITCase(final Tuple2<Configuration, Configuration> clientServerConfig) {
+        this.clientConfig = clientServerConfig.f0;
+        this.serverConfig = clientServerConfig.f1;
     }
 
     @Parameterized.Parameters


### PR DESCRIPTION
## What is the purpose of the change

Fix clinet typo in RestServerSSLAuthITCase class in tests section in `flink-runtime` module


## Brief change log

Replace clinet in the constructor of the RestServerSSLAuthITCase class with client

## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing


This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no know)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)

