### PR TITLE
[FLINK-26033][BP-1.14][flink-connector-kafka]Fix the problem that robin does not take effect due to upgrading kafka client to 2.4.1 since Flink1.11

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/partitioner/FlinkRoundRobinPartitioner.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/partitioner/FlinkRoundRobinPartitioner.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kafka.partitioner;
+
+import org.apache.flink.util.Preconditions;
+
+import org.apache.kafka.common.utils.Utils;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A "Round-Robin" partitioner that can be used when user wants to distribute the writes to all
+ * partitions equally.
+ *
+ * <p>This is the behaviour regardless of record key hash.
+ */
+public class FlinkRoundRobinPartitioner<T> extends FlinkKafkaPartitioner<T> {
+
+    private ConcurrentMap<String, AtomicInteger> topicCounterMap;
+
+    @Override
+    public void open(int parallelInstanceId, int parallelInstances) {
+        Preconditions.checkArgument(
+                parallelInstanceId >= 0, "Id of this subtask cannot be negative.");
+        Preconditions.checkArgument(
+                parallelInstances > 0, "Number of subtasks must be larger than 0.");
+
+        this.topicCounterMap = new ConcurrentHashMap();
+    }
+
+    @Override
+    public int partition(T record, byte[] key, byte[] value, String targetTopic, int[] partitions) {
+        Preconditions.checkArgument(
+                partitions != null && partitions.length > 0,
+                "Partitions of the target topic is empty.");
+
+        int numPartitions = partitions.length;
+        int nextValue = this.nextValue(targetTopic);
+        return Utils.toPositive(nextValue) % numPartitions;
+    }
+
+    private int nextValue(String topic) {
+        AtomicInteger counter =
+                this.topicCounterMap.computeIfAbsent(topic, (k) -> new AtomicInteger(0));
+        return counter.getAndIncrement();
+    }
+}

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaConnectorOptionsUtil.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaConnectorOptionsUtil.java
@@ -28,6 +28,7 @@ import org.apache.flink.streaming.connectors.kafka.config.StartupMode;
 import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartition;
 import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkFixedPartitioner;
 import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaPartitioner;
+import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkRoundRobinPartitioner;
 import org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.ScanStartupMode;
 import org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.ValueFieldsStrategy;
 import org.apache.flink.table.api.TableException;
@@ -310,8 +311,9 @@ class KafkaConnectorOptionsUtil {
                                 case SINK_PARTITIONER_VALUE_FIXED:
                                     return Optional.of(new FlinkFixedPartitioner<>());
                                 case SINK_PARTITIONER_VALUE_DEFAULT:
-                                case SINK_PARTITIONER_VALUE_ROUND_ROBIN:
                                     return Optional.empty();
+                                case SINK_PARTITIONER_VALUE_ROUND_ROBIN:
+                                    return Optional.of(new FlinkRoundRobinPartitioner<>());
                                     // Default fallback to full class name of the partitioner.
                                 default:
                                     return Optional.of(

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkRoundRobinPartitionerTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkRoundRobinPartitionerTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kafka;
+
+import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkRoundRobinPartitioner;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/** Tests for the {@link FlinkRoundRobinPartitioner}. */
+public class FlinkRoundRobinPartitionerTest {
+
+    @Test
+    public void testRoundRobin() {
+        FlinkRoundRobinPartitioner<String> part = new FlinkRoundRobinPartitioner<>();
+
+        int[] partitions = new int[] {0, 1, 2, 3, 4};
+        String topic = "topic1";
+        part.open(0, 2);
+
+        Assert.assertEquals(0, part.partition("abc1", null, null, topic, partitions));
+        Assert.assertEquals(1, part.partition("abc2", null, null, topic, partitions));
+        Assert.assertEquals(2, part.partition("abc3", null, null, topic, partitions));
+        Assert.assertEquals(3, part.partition("abc4", null, null, topic, partitions));
+        Assert.assertEquals(4, part.partition("abc5", null, null, topic, partitions));
+
+        part.open(1, 2);
+        Assert.assertEquals(0, part.partition("abc1", null, null, topic, partitions));
+        Assert.assertEquals(1, part.partition("abc2", null, null, topic, partitions));
+        Assert.assertEquals(2, part.partition("abc3", null, null, topic, partitions));
+        Assert.assertEquals(3, part.partition("abc4", null, null, topic, partitions));
+        Assert.assertEquals(4, part.partition("abc5", null, null, topic, partitions));
+    }
+}

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaTableITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaTableITCase.java
@@ -821,6 +821,70 @@ public class KafkaTableITCase extends KafkaTableTestBase {
         deleteTestTopic(topic);
     }
 
+    @Test
+    public void testKafkaSinkWithRoundRobinPartitioner() throws Exception {
+        final String topic = "round_robin_topic_" + format;
+        createTestTopic(topic, 3, 1);
+
+        // ---------- Produce an event time stream into Kafka -------------------
+        String groupId = getStandardProps().getProperty("group.id");
+        String bootstraps = getBootstrapServers();
+
+        final String createTable =
+                String.format(
+                        "CREATE TABLE kafka (\n"
+                                + "  `name` STRING,\n"
+                                + "  `timestamp` TIMESTAMP(3),\n"
+                                + "  `partition` BIGINT METADATA FROM 'partition' VIRTUAL\n"
+                                + ") WITH (\n"
+                                + "  'connector' = 'kafka',\n"
+                                + "  'topic' = '%s',\n"
+                                + "  'properties.bootstrap.servers' = '%s',\n"
+                                + "  'properties.group.id' = '%s',\n"
+                                + "  'scan.startup.mode' = 'earliest-offset',\n"
+                                + "  'sink.partitioner' = 'round-robin',\n"
+                                + "  'format' = '%s'\n"
+                                + ")",
+                        topic, bootstraps, groupId, format);
+
+        tEnv.executeSql(createTable);
+
+        // make every partition have more than one record
+        String initialValues =
+                "INSERT INTO kafka\n"
+                        + "VALUES\n"
+                        + " ('name-0', TIMESTAMP '2020-03-08 13:12:11.123'),\n"
+                        + " ('name-1', TIMESTAMP '2020-03-09 13:12:11.123'),\n"
+                        + " ('name-2', TIMESTAMP '2020-03-10 13:12:11.123'),\n"
+                        + " ('name-3', TIMESTAMP '2020-03-11 13:12:11.123'),\n"
+                        + " ('name-4', TIMESTAMP '2020-03-12 13:12:11.123'),\n"
+                        + " ('name-5', TIMESTAMP '2020-03-13 13:12:11.123')";
+        tEnv.executeSql(initialValues).await();
+
+        // ---------- Consume stream from Kafka -------------------
+
+        final List<String> result =
+                collectRows(tEnv.sqlQuery("SELECT * FROM kafka"), 6).stream()
+                        .map(row -> row.toString())
+                        .sorted()
+                        .collect(Collectors.toList());
+
+        final List<String> expected =
+                Arrays.asList(
+                        "+I[name-0, 2020-03-08T13:12:11.123, 0]",
+                        "+I[name-1, 2020-03-09T13:12:11.123, 1]",
+                        "+I[name-2, 2020-03-10T13:12:11.123, 2]",
+                        "+I[name-3, 2020-03-11T13:12:11.123, 0]",
+                        "+I[name-4, 2020-03-12T13:12:11.123, 1]",
+                        "+I[name-5, 2020-03-13T13:12:11.123, 2]");
+
+        assertEquals(expected, result);
+
+        // ------------- cleanup -------------------
+
+        deleteTestTopic(topic);
+    }
+
     // --------------------------------------------------------------------------------------------
     // Utilities
     // --------------------------------------------------------------------------------------------


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
The behavior of `DefaultPartitioner` has been changed from round robin to sticky partitioner from Kafka 2.4.0 (See [KIP-480](https://cwiki.apache.org/confluence/display/KAFKA/KIP-480%3A+Sticky+Partitioner)). So it does not take effect since Flink 1.11 that we bumped Kafka client version to 2.4.1.

## Brief change log
- Added two classes `org.apache.flink.streaming.connectors.kafka.partitioner.FlinkRoundRobinPartitioner` and `org.apache.flink.streaming.connectors.kafka.FlinkRoundRobinPartitionerTest` to the flink kafka connector
- Modified the `KafkaConnectorOptionsUtil::getFlinkKafkaPartitioner` method, set `default` and `round-robin` separately


## Verifying this change

This change added tests and can be verified as follows:

  - Assume there are 2 sinks, 5 kafka partitions.
  - The actual situation is that each sink will round-robin on the 5 partitions

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
