### PR TITLE
[FLINK-25256][streaming] Externally induced sources replay barriers received over RPC instead of inventing them out of thin air. [1.14]

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/ExternallyInducedSourceReader.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/ExternallyInducedSourceReader.java
@@ -24,16 +24,16 @@ import org.apache.flink.annotation.PublicEvolving;
 import java.util.Optional;
 
 /**
- * Sources that implement this interface do not trigger checkpoints when receiving a trigger message
- * from the checkpoint coordinator, but when their input data/events indicate that a checkpoint
+ * Sources that implement this interface delay checkpoints when receiving a trigger message from the
+ * checkpoint coordinator to the point when their input data/events indicate that a checkpoint
  * should be triggered.
  *
  * <p>The ExternallyInducedSourceReader tells the Flink runtime that a checkpoint needs to be made
- * by returning a checkpointId when shouldTriggerCheckpoint() is invoked.
+ * by returning a checkpointId when {@link #shouldTriggerCheckpoint()} is invoked.
  *
- * <p>The implementations typically works together with the SplitEnumerator which informs the
- * external system to trigger a checkpoint. The external system also needs to forward the Checkpoint
- * ID to the source, so the source knows which checkpoint to trigger.
+ * <p>The implementations typically works together with the {@link SplitEnumerator} which informs
+ * the external system to trigger a checkpoint. The external system also needs to forward the
+ * Checkpoint ID to the source, so the source knows which checkpoint to trigger.
  *
  * <p><b>Important:</b> It is crucial that all parallel source tasks trigger their checkpoints at
  * roughly the same time. Otherwise this leads to performance issues due to long checkpoint

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/checkpoint/ExternallyInducedSource.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/checkpoint/ExternallyInducedSource.java
@@ -23,8 +23,8 @@ import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.util.FlinkException;
 
 /**
- * Sources that implement this interface do not trigger checkpoints when receiving a trigger message
- * from the checkpoint coordinator, but when their input data/events indicate that a checkpoint
+ * Sources that implement this interface delay checkpoints when receiving a trigger message from the
+ * checkpoint coordinator to the point when their input data/events indicate that a checkpoint
  * should be triggered.
  *
  * <p>Since sources cannot simply create a new checkpoint on their own, this mechanism always goes

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskExternallyInducedSourceInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskExternallyInducedSourceInput.java
@@ -21,12 +21,14 @@ package org.apache.flink.streaming.runtime.io;
 import org.apache.flink.api.connector.source.ExternallyInducedSourceReader;
 import org.apache.flink.streaming.api.operators.SourceOperator;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
 /** A subclass of {@link StreamTaskSourceInput} for {@link ExternallyInducedSourceReader}. */
 public class StreamTaskExternallyInducedSourceInput<T> extends StreamTaskSourceInput<T> {
     private final Consumer<Long> checkpointTriggeringHook;
     private final ExternallyInducedSourceReader<T, ?> sourceReader;
+    private CompletableFuture<?> blockFuture;
 
     @SuppressWarnings("unchecked")
     public StreamTaskExternallyInducedSourceInput(
@@ -39,12 +41,34 @@ public class StreamTaskExternallyInducedSourceInput<T> extends StreamTaskSourceI
         this.sourceReader = (ExternallyInducedSourceReader<T, ?>) operator.getSourceReader();
     }
 
+    public void blockUntil(CompletableFuture<?> blockFuture) {
+        this.blockFuture = blockFuture;
+        // assume that the future is completed in mailbox thread
+        blockFuture.whenComplete((v, e) -> unblock());
+    }
+
+    private void unblock() {
+        this.blockFuture = null;
+    }
+
     @Override
     public DataInputStatus emitNext(DataOutput<T> output) throws Exception {
+        if (blockFuture != null) {
+            return DataInputStatus.NOTHING_AVAILABLE;
+        }
+
         DataInputStatus status = super.emitNext(output);
         if (status == DataInputStatus.NOTHING_AVAILABLE) {
             sourceReader.shouldTriggerCheckpoint().ifPresent(checkpointTriggeringHook);
         }
         return status;
+    }
+
+    @Override
+    public CompletableFuture<?> getAvailableFuture() {
+        if (blockFuture != null) {
+            return blockFuture;
+        }
+        return super.getAvailableFuture();
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTask.java
@@ -24,11 +24,9 @@ import org.apache.flink.api.connector.source.SourceReader;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
-import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.metrics.MetricNames;
 import org.apache.flink.runtime.metrics.groups.InternalSourceReaderMetricGroup;
-import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
 import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.api.operators.SourceOperator;
 import org.apache.flink.streaming.api.watermark.Watermark;
@@ -45,7 +43,12 @@ import org.apache.flink.util.concurrent.FutureUtils;
 
 import javax.annotation.Nullable;
 
+import java.util.SortedMap;
+import java.util.SortedSet;
+import java.util.TreeMap;
+import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -54,7 +57,25 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public class SourceOperatorStreamTask<T> extends StreamTask<T, SourceOperator<T, ?>> {
 
     private AsyncDataOutputToOutput<T> output;
-    private boolean isExternallyInducedSource;
+    /**
+     * Contains information about all checkpoints where RPC from checkpoint coordinator arrives
+     * before the source reader triggers it. (Common case)
+     */
+    private SortedMap<Long, UntriggeredCheckpoint> untriggeredCheckpoints = new TreeMap<>();
+    /**
+     * Contains the checkpoints that are triggered by the source but the RPC from checkpoint
+     * coordinator has yet to arrive. This may happen if the barrier is inserted as an event into
+     * the data plane by the source coordinator and the (distributed) source reader reads that event
+     * before receiving Flink's checkpoint RPC. (Rare case)
+     */
+    private SortedSet<Long> triggeredCheckpoints = new TreeSet<>();
+    /**
+     * Blocks input until the RPC call has been received that corresponds to the triggered
+     * checkpoint. This future must only be accessed and completed in the mailbox thread.
+     */
+    private CompletableFuture<Void> waitForRPC = FutureUtils.completedVoidFuture();
+    /** Only set for externally induced sources. See also {@link #isExternallyInducedSource()}. */
+    private StreamTaskExternallyInducedSourceInput<T> externallyInducedSourceInput;
 
     public SourceOperatorStreamTask(Environment env) throws Exception {
         super(env);
@@ -76,14 +97,14 @@ public class SourceOperatorStreamTask<T> extends StreamTask<T, SourceOperator<T,
         if (operatorChain.isTaskDeployedAsFinished()) {
             input = new StreamTaskFinishedOnRestoreSourceInput<>(sourceOperator, 0, 0);
         } else if (sourceReader instanceof ExternallyInducedSourceReader) {
-            isExternallyInducedSource = true;
-
-            input =
+            externallyInducedSourceInput =
                     new StreamTaskExternallyInducedSourceInput<>(
                             sourceOperator,
                             this::triggerCheckpointForExternallyInducedSource,
                             0,
                             0);
+
+            input = externallyInducedSourceInput;
         } else {
             input = new StreamTaskSourceInput<>(sourceOperator, 0, 0);
         }
@@ -114,15 +135,53 @@ public class SourceOperatorStreamTask<T> extends StreamTask<T, SourceOperator<T,
     @Override
     public CompletableFuture<Boolean> triggerCheckpointAsync(
             CheckpointMetaData checkpointMetaData, CheckpointOptions checkpointOptions) {
-        if (!isExternallyInducedSource) {
-            if (checkpointOptions.getCheckpointType().shouldDrain()) {
-                return triggerStopWithSavepointWithDrainAsync(
-                        checkpointMetaData, checkpointOptions);
-            } else {
-                return super.triggerCheckpointAsync(checkpointMetaData, checkpointOptions);
-            }
+        if (!isExternallyInducedSource()) {
+            return triggerCheckpointNowAsync(checkpointMetaData, checkpointOptions);
+        }
+        CompletableFuture<Boolean> triggerFuture = new CompletableFuture<>();
+        // immediately move RPC to mailbox so we don't need to synchronize fields
+        mainMailboxExecutor.execute(
+                () ->
+                        triggerCheckpointOnExternallyInducedSource(
+                                checkpointMetaData, checkpointOptions, triggerFuture),
+                "SourceOperatorStreamTask#triggerCheckpointAsync(%s, %s)",
+                checkpointMetaData,
+                checkpointOptions);
+        return triggerFuture;
+    }
+
+    private boolean isExternallyInducedSource() {
+        return externallyInducedSourceInput != null;
+    }
+
+    private void triggerCheckpointOnExternallyInducedSource(
+            CheckpointMetaData checkpointMetaData,
+            CheckpointOptions checkpointOptions,
+            CompletableFuture<Boolean> triggerFuture) {
+        assert (mailboxProcessor.isMailboxThread());
+        if (!triggeredCheckpoints.remove(checkpointMetaData.getCheckpointId())) {
+            // common case: RPC is received before source reader triggers checkpoint
+            // store metadata and options for later
+            untriggeredCheckpoints.put(
+                    checkpointMetaData.getCheckpointId(),
+                    new UntriggeredCheckpoint(checkpointMetaData, checkpointOptions));
+            triggerFuture.complete(isRunning());
         } else {
-            return CompletableFuture.completedFuture(isRunning());
+            // trigger already received (rare case)
+            FutureUtils.forward(
+                    triggerCheckpointNowAsync(checkpointMetaData, checkpointOptions),
+                    triggerFuture);
+
+            cleanupOldCheckpoints(checkpointMetaData.getCheckpointId());
+        }
+    }
+
+    private CompletableFuture<Boolean> triggerCheckpointNowAsync(
+            CheckpointMetaData checkpointMetaData, CheckpointOptions checkpointOptions) {
+        if (checkpointOptions.getCheckpointType().shouldDrain()) {
+            return triggerStopWithSavepointWithDrainAsync(checkpointMetaData, checkpointOptions);
+        } else {
+            return super.triggerCheckpointAsync(checkpointMetaData, checkpointOptions);
         }
     }
 
@@ -150,22 +209,69 @@ public class SourceOperatorStreamTask<T> extends StreamTask<T, SourceOperator<T,
         output.emitWatermark(Watermark.MAX_WATERMARK);
     }
 
+    @Override
+    protected void declineCheckpoint(long checkpointId) {
+        cleanupCheckpoint(checkpointId);
+        super.declineCheckpoint(checkpointId);
+    }
+
+    @Override
+    public Future<Void> notifyCheckpointAbortAsync(
+            long checkpointId, long latestCompletedCheckpointId) {
+        mainMailboxExecutor.execute(
+                () -> cleanupCheckpoint(checkpointId), "Cleanup checkpoint %d", checkpointId);
+        return super.notifyCheckpointAbortAsync(checkpointId, latestCompletedCheckpointId);
+    }
+
     // --------------------------
 
     private void triggerCheckpointForExternallyInducedSource(long checkpointId) {
-        final CheckpointOptions checkpointOptions =
-                CheckpointOptions.forConfig(
-                        CheckpointType.CHECKPOINT,
-                        CheckpointStorageLocationReference.getDefault(),
-                        configuration.isExactlyOnceCheckpointMode(),
-                        configuration.isUnalignedCheckpointsEnabled(),
-                        configuration.getAlignedCheckpointTimeout().toMillis());
-        final long timestamp = System.currentTimeMillis();
+        UntriggeredCheckpoint untriggeredCheckpoint = untriggeredCheckpoints.remove(checkpointId);
+        if (untriggeredCheckpoint != null) {
+            // common case: RPC before external sources induces it
+            triggerCheckpointNowAsync(
+                    untriggeredCheckpoint.getMetadata(),
+                    untriggeredCheckpoint.getCheckpointOptions());
+            cleanupOldCheckpoints(checkpointId);
+        } else {
+            // rare case: external source induced first
+            triggeredCheckpoints.add(checkpointId);
+            if (waitForRPC.isDone()) {
+                waitForRPC = new CompletableFuture<>();
+                externallyInducedSourceInput.blockUntil(waitForRPC);
+            }
+        }
+    }
 
-        final CheckpointMetaData checkpointMetaData =
-                new CheckpointMetaData(checkpointId, timestamp, timestamp);
+    /**
+     * Cleanup any orphaned checkpoint before the given currently triggered checkpoint. These
+     * checkpoint may occur when the checkpoint is cancelled but the RPC is lost. Note, to be safe,
+     * checkpoint X is only removed when both RPC and trigger for a checkpoint Y>X is received.
+     */
+    private void cleanupOldCheckpoints(long checkpointId) {
+        assert (mailboxProcessor.isMailboxThread());
+        triggeredCheckpoints.headSet(checkpointId).clear();
+        untriggeredCheckpoints.headMap(checkpointId).clear();
 
-        super.triggerCheckpointAsync(checkpointMetaData, checkpointOptions);
+        maybeResumeProcessing();
+    }
+
+    /** Resumes processing if it was blocked before or else is a no-op. */
+    private void maybeResumeProcessing() {
+        assert (mailboxProcessor.isMailboxThread());
+
+        if (triggeredCheckpoints.isEmpty()) {
+            waitForRPC.complete(null);
+        }
+    }
+
+    /** Remove temporary data about a canceled checkpoint. */
+    private void cleanupCheckpoint(long checkpointId) {
+        assert (mailboxProcessor.isMailboxThread());
+        triggeredCheckpoints.remove(checkpointId);
+        untriggeredCheckpoints.remove(checkpointId);
+
+        maybeResumeProcessing();
     }
 
     // ---------------------------
@@ -214,6 +320,25 @@ public class SourceOperatorStreamTask<T> extends StreamTask<T, SourceOperator<T,
         @Override
         public void emitWatermarkStatus(WatermarkStatus watermarkStatus) throws Exception {
             output.emitWatermarkStatus(watermarkStatus);
+        }
+    }
+
+    private static class UntriggeredCheckpoint {
+        private final CheckpointMetaData metadata;
+        private final CheckpointOptions checkpointOptions;
+
+        private UntriggeredCheckpoint(
+                CheckpointMetaData metadata, CheckpointOptions checkpointOptions) {
+            this.metadata = metadata;
+            this.checkpointOptions = checkpointOptions;
+        }
+
+        public CheckpointMetaData getMetadata() {
+            return metadata;
+        }
+
+        public CheckpointOptions getCheckpointOptions() {
+            return checkpointOptions;
         }
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/ExternallyInducedSourceOperatorStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/ExternallyInducedSourceOperatorStreamTaskTest.java
@@ -1,0 +1,238 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks;
+
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.connector.source.ExternallyInducedSourceReader;
+import org.apache.flink.api.connector.source.ReaderOutput;
+import org.apache.flink.api.connector.source.SourceReader;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.api.connector.source.mocks.MockSource;
+import org.apache.flink.api.connector.source.mocks.MockSourceSplit;
+import org.apache.flink.core.io.InputStatus;
+import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointType;
+import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
+import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
+import org.apache.flink.streaming.api.operators.SourceOperator;
+
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.apache.flink.runtime.checkpoint.CheckpointType.SAVEPOINT;
+import static org.apache.flink.runtime.checkpoint.CheckpointType.SAVEPOINT_SUSPEND;
+import static org.apache.flink.runtime.checkpoint.CheckpointType.SAVEPOINT_TERMINATE;
+import static org.apache.flink.streaming.runtime.tasks.SourceOperatorStreamTaskTest.createTestHarness;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for verifying that the {@link ExternallyInducedSourceReader} can trigger any type of
+ * snapshot.
+ */
+@RunWith(Parameterized.class)
+public class ExternallyInducedSourceOperatorStreamTaskTest extends SourceStreamTaskTestBase {
+    public static final CheckpointStorageLocationReference SAVEPOINT_LOCATION =
+            new CheckpointStorageLocationReference("Savepoint".getBytes());
+    public static final CheckpointStorageLocationReference CHECKPOINT_LOCATION =
+            new CheckpointStorageLocationReference("Checkpoint".getBytes());
+
+    @Parameter(0)
+    public CheckpointOptions checkpointOptions;
+
+    @Parameter(1)
+    public boolean rpcFirst;
+
+    @Parameters(name = "checkpoint = {0}, rpcFirst = {1}")
+    public static List<Object[]> provideExternallyInducedParameters() {
+        return Stream.of(
+                        CheckpointOptions.alignedNoTimeout(SAVEPOINT, SAVEPOINT_LOCATION),
+                        CheckpointOptions.alignedNoTimeout(SAVEPOINT_TERMINATE, SAVEPOINT_LOCATION),
+                        CheckpointOptions.alignedNoTimeout(SAVEPOINT_SUSPEND, SAVEPOINT_LOCATION),
+                        CheckpointOptions.alignedNoTimeout(
+                                CheckpointType.CHECKPOINT, CHECKPOINT_LOCATION),
+                        CheckpointOptions.alignedWithTimeout(CHECKPOINT_LOCATION, 123L),
+                        CheckpointOptions.unaligned(CHECKPOINT_LOCATION),
+                        CheckpointOptions.notExactlyOnce(
+                                CheckpointType.CHECKPOINT, CHECKPOINT_LOCATION))
+                .flatMap(
+                        options ->
+                                Stream.of(
+                                        new Object[] {options, true},
+                                        new Object[] {options, false}))
+                .collect(Collectors.toList());
+    }
+
+    @Test
+    public void testExternallyInducedSource() throws Exception {
+        final int numEventsBeforeCheckpoint = 10;
+        final int totalNumEvents = 20;
+        TestingExternallyInducedSourceReader testingReader =
+                new TestingExternallyInducedSourceReader(numEventsBeforeCheckpoint, totalNumEvents);
+        try (StreamTaskMailboxTestHarness<Integer> testHarness =
+                createTestHarness(new TestingExternallyInducedSource(testingReader), 0, null)) {
+            TestingExternallyInducedSourceReader runtimeTestingReader =
+                    (TestingExternallyInducedSourceReader)
+                            ((SourceOperator) testHarness.getStreamTask().mainOperator)
+                                    .getSourceReader();
+
+            CheckpointMetaData checkpointMetaData =
+                    new CheckpointMetaData(TestingExternallyInducedSourceReader.CHECKPOINT_ID, 2);
+            if (rpcFirst) {
+                testHarness.streamTask.triggerCheckpointAsync(
+                        checkpointMetaData, checkpointOptions);
+                testHarness.processAll();
+            } else {
+                do {
+                    testHarness.processSingleStep();
+                } while (!runtimeTestingReader.shouldTriggerCheckpoint().isPresent());
+                // stream task should block when trigger received but no RPC
+                assertFalse(testHarness.streamTask.inputProcessor.isAvailable());
+                CompletableFuture<Boolean> triggerCheckpointAsync =
+                        testHarness.streamTask.triggerCheckpointAsync(
+                                checkpointMetaData, checkpointOptions);
+                // process mails until checkpoint has been processed
+                while (!triggerCheckpointAsync.isDone()) {
+                    testHarness.processSingleStep();
+                }
+                // stream task should be unblocked now
+                assertTrue(testHarness.streamTask.inputProcessor.isAvailable());
+                testHarness.processAll();
+            }
+
+            int expectedEvents =
+                    checkpointOptions.getCheckpointType().isSavepoint()
+                                    && checkpointOptions.getCheckpointType().isSynchronous()
+                                    && checkpointOptions.getCheckpointType().shouldDrain()
+                            ? numEventsBeforeCheckpoint
+                            : totalNumEvents;
+            assertEquals(expectedEvents, runtimeTestingReader.numEmittedEvents);
+            assertTrue(runtimeTestingReader.checkpointed);
+            assertEquals(
+                    TestingExternallyInducedSourceReader.CHECKPOINT_ID,
+                    runtimeTestingReader.checkpointedId);
+            assertEquals(numEventsBeforeCheckpoint, runtimeTestingReader.checkpointedAt);
+            assertThat(
+                    testHarness.getOutput(),
+                    Matchers.hasItem(
+                            new CheckpointBarrier(
+                                    checkpointMetaData.getCheckpointId(),
+                                    checkpointMetaData.getTimestamp(),
+                                    checkpointOptions)));
+        }
+    }
+
+    private static class TestingExternallyInducedSource extends MockSource {
+        private static final long serialVersionUID = 3078454109555893721L;
+        private final TestingExternallyInducedSourceReader reader;
+
+        private TestingExternallyInducedSource(TestingExternallyInducedSourceReader reader) {
+            super(Boundedness.CONTINUOUS_UNBOUNDED, 1);
+            this.reader = reader;
+        }
+
+        @Override
+        public SourceReader<Integer, MockSourceSplit> createReader(
+                SourceReaderContext readerContext) {
+            return reader;
+        }
+    }
+
+    private static class TestingExternallyInducedSourceReader
+            implements ExternallyInducedSourceReader<Integer, MockSourceSplit>, Serializable {
+        private static final long CHECKPOINT_ID = 1234L;
+        private final int numEventsBeforeCheckpoint;
+        private final int totalNumEvents;
+        private int numEmittedEvents;
+
+        private boolean checkpointed;
+        private int checkpointedAt;
+        private long checkpointedId;
+
+        TestingExternallyInducedSourceReader(int numEventsBeforeCheckpoint, int totalNumEvents) {
+            this.numEventsBeforeCheckpoint = numEventsBeforeCheckpoint;
+            this.totalNumEvents = totalNumEvents;
+            this.numEmittedEvents = 0;
+            this.checkpointed = false;
+            this.checkpointedAt = -1;
+        }
+
+        @Override
+        public Optional<Long> shouldTriggerCheckpoint() {
+            if (numEmittedEvents == numEventsBeforeCheckpoint && !checkpointed) {
+                return Optional.of(CHECKPOINT_ID);
+            } else {
+                return Optional.empty();
+            }
+        }
+
+        @Override
+        public void start() {}
+
+        @Override
+        public InputStatus pollNext(ReaderOutput<Integer> output) throws Exception {
+            if (numEmittedEvents == numEventsBeforeCheckpoint - 1) {
+                numEmittedEvents++;
+                return InputStatus.NOTHING_AVAILABLE;
+            } else if (numEmittedEvents < totalNumEvents) {
+                numEmittedEvents++;
+                return InputStatus.MORE_AVAILABLE;
+            } else {
+                return InputStatus.END_OF_INPUT;
+            }
+        }
+
+        @Override
+        public List<MockSourceSplit> snapshotState(long checkpointId) {
+            checkpointed = true;
+            checkpointedAt = numEmittedEvents;
+            checkpointedId = checkpointId;
+            return Collections.emptyList();
+        }
+
+        @Override
+        public CompletableFuture<Void> isAvailable() {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public void addSplits(List<MockSourceSplit> splits) {}
+
+        @Override
+        public void notifyNoMoreSplits() {}
+
+        @Override
+        public void close() throws Exception {}
+    }
+}


### PR DESCRIPTION
Slightly changed backport of #19138. 

Production code is almost the same and test code is pulled into a parameterized test as no migration to JUnit5 is possible.