### PR TITLE
[FLINK-24491][runtime] Make the job termination wait until the archiving of ExecutionGraphInfo finishes

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/application/ApplicationDispatcherBootstrap.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/application/ApplicationDispatcherBootstrap.java
@@ -317,8 +317,12 @@ public class ApplicationDispatcherBootstrap implements DispatcherBootstrap {
                 final JobID failedJobId =
                         JobID.fromHexString(
                                 configuration.get(PipelineOptionsInternal.PIPELINE_FIXED_JOB_ID));
-                dispatcherGateway.submitFailedJob(failedJobId, FAILED_JOB_NAME, t);
-                jobIdsFuture.complete(Collections.singletonList(failedJobId));
+                dispatcherGateway
+                        .submitFailedJob(failedJobId, FAILED_JOB_NAME, t)
+                        .thenAccept(
+                                ignored ->
+                                        jobIdsFuture.complete(
+                                                Collections.singletonList(failedJobId)));
             } else {
                 jobIdsFuture.completeExceptionally(
                         new ApplicationExecutionException("Could not execute application.", t));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherResourceCleanupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherResourceCleanupTest.java
@@ -79,13 +79,15 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.apache.flink.core.testutils.FlinkMatchers.containsCause;
 import static org.apache.flink.core.testutils.FlinkMatchers.containsMessage;
 import static org.apache.flink.runtime.dispatcher.AbstractDispatcherTest.awaitStatus;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 
 /** Tests the resource cleanup by the {@link Dispatcher}. */
@@ -651,6 +653,58 @@ public class DispatcherResourceCleanupTest extends TestLogger {
 
         // Ensure job is running
         awaitStatus(dispatcherGateway, jobId, JobStatus.RUNNING);
+    }
+
+    @Test
+    public void testArchivingFinishedJobToHistoryServer() throws Exception {
+
+        final CompletableFuture<Acknowledge> archiveFuture = new CompletableFuture<>();
+
+        final TestingDispatcher.Builder testingDispatcherBuilder =
+                createTestingDispatcherBuilder()
+                        .setHistoryServerArchivist(executionGraphInfo -> archiveFuture);
+
+        final TestingJobManagerRunnerFactory jobManagerRunnerFactory =
+                startDispatcherAndSubmitJob(testingDispatcherBuilder, 0);
+
+        finishJob(jobManagerRunnerFactory.takeCreatedJobManagerRunner());
+
+        // Before the archiving is finished, the cleanup is not finished and the job is not
+        // terminated
+        assertThatNoCleanupWasTriggered();
+        final CompletableFuture<Void> jobTerminationFuture =
+                dispatcher.getJobTerminationFuture(jobId, Time.hours(1));
+        assertFalse(jobTerminationFuture.isDone());
+
+        archiveFuture.complete(Acknowledge.get());
+
+        // Once the archive is finished, the cleanup is finished and the job is terminated.
+        assertGlobalCleanupTriggered(jobId);
+        jobTerminationFuture.join();
+    }
+
+    @Test
+    public void testNotArchivingSuspendedJobToHistoryServer() throws Exception {
+
+        final AtomicBoolean isArchived = new AtomicBoolean(false);
+
+        final TestingDispatcher.Builder testingDispatcherBuilder =
+                createTestingDispatcherBuilder()
+                        .setHistoryServerArchivist(
+                                executionGraphInfo -> {
+                                    isArchived.set(true);
+                                    return CompletableFuture.completedFuture(Acknowledge.get());
+                                });
+
+        final TestingJobManagerRunnerFactory jobManagerRunnerFactory =
+                startDispatcherAndSubmitJob(testingDispatcherBuilder, 0);
+
+        suspendJob(jobManagerRunnerFactory.takeCreatedJobManagerRunner());
+
+        assertLocalCleanupTriggered(jobId);
+        dispatcher.getJobTerminationFuture(jobId, Time.hours(1)).join();
+
+        assertFalse(isArchived.get());
     }
 
     private static final class BlockingJobManagerRunnerFactory


### PR DESCRIPTION
## Brief change log

With this change, the job won't be terminated until the archiving of its ExecutionGraphInfo finishes.

## Verifying this change

This change added tests and can be verified as follows:

  - *Added unit tests that validates that the waiting works well.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
