### PR TITLE
[FLINK-26882][tests] Fix unstable RescaleCheckpointManuallyITCase

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RescaleCheckpointManuallyITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RescaleCheckpointManuallyITCase.java
@@ -191,7 +191,10 @@ public class RescaleCheckpointManuallyITCase extends TestLogger {
 
             assertEquals(expectedResult, actualResult);
 
-            TestUtils.waitUntilExternalizedCheckpointCreated(checkpointDir);
+            // ensure contents of state within SubtaskIndexFlatMapper are all included
+            // in the last checkpoint (refer to FLINK-26882 for more details).
+            cluster.getMiniCluster().triggerCheckpoint(jobGraph.getJobID()).get();
+
             client.cancel(jobGraph.getJobID()).get();
             TestUtils.waitUntilJobCanceled(jobGraph.getJobID(), client);
             return TestUtils.getMostRecentCompletedCheckpoint(checkpointDir).getAbsolutePath();


### PR DESCRIPTION
## What is the purpose of the change

Fix unstable `RescaleCheckpointManuallyITCase` via ensuring contents of state within SubtaskIndexFlatMapper are all included in the last checkpoint.

## Brief change log

Fix unstable `RescaleCheckpointManuallyITCase`.


## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
