### PR TITLE
[FLINK-26923] Do not trigger global failover if failed during commiting side-effects during stop-with-savepoint for adaptive scheduler

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/stopwithsavepoint/StopWithSavepointStoppingException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/stopwithsavepoint/StopWithSavepointStoppingException.java
@@ -35,14 +35,22 @@ public class StopWithSavepointStoppingException extends FlinkException {
     private final String savepointPath;
 
     public StopWithSavepointStoppingException(String savepointPath, JobID jobID) {
-        super(
-                String.format(
-                        "A savepoint has been created at: %s, but the corresponding job %s failed "
-                                + "during stopping. The savepoint is consistent, but might have "
-                                + "uncommitted transactions. If you want to commit the transaction "
-                                + "please restart a job from this savepoint.",
-                        savepointPath, jobID));
+        super(formatMessage(savepointPath, jobID));
         this.savepointPath = savepointPath;
+    }
+
+    public StopWithSavepointStoppingException(String savepointPath, JobID jobID, Throwable cause) {
+        super(formatMessage(savepointPath, jobID), cause);
+        this.savepointPath = savepointPath;
+    }
+
+    private static String formatMessage(String savepointPath, JobID jobID) {
+        return String.format(
+                "A savepoint has been created at: %s, but the corresponding job %s failed "
+                        + "during stopping. The savepoint is consistent, but might have "
+                        + "uncommitted transactions. If you want to commit the transaction "
+                        + "please restart a job from this savepoint.",
+                savepointPath, jobID);
     }
 
     public String getSavepointPath() {

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
@@ -145,6 +145,7 @@ import static org.apache.flink.util.ExceptionUtils.assertThrowable;
 import static org.apache.flink.util.ExceptionUtils.assertThrowableWithMessage;
 import static org.apache.flink.util.ExceptionUtils.findThrowable;
 import static org.apache.flink.util.ExceptionUtils.findThrowableWithMessage;
+import static org.hamcrest.CoreMatchers.either;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -296,8 +297,6 @@ public class SavepointITCase extends TestLogger {
         public void initializeState(FunctionInitializationContext context) throws Exception {}
     }
 
-    private static final OneShotLatch stopWithSavepointRestartLatch = new OneShotLatch();
-
     @Test
     public void testStopWithSavepointFailsOverToSavepoint() throws Throwable {
         int sinkParallelism = 5;
@@ -342,7 +341,9 @@ public class SavepointITCase extends TestLogger {
                                     && throwable
                                             .getMessage()
                                             .startsWith("A savepoint has been created at: "));
-            assertThat(client.getJobStatus(jobGraph.getJobID()).get(), is(JobStatus.FAILED));
+            assertThat(
+                    client.getJobStatus(jobGraph.getJobID()).get(),
+                    either(is(JobStatus.FAILED)).or(is(JobStatus.FAILING)));
         } finally {
             cluster.after();
         }


### PR DESCRIPTION
## What is the purpose of the change
This is an equivalent of #19198 for adaptive scheduler

## Verifying this change

Run `org.apache.flink.test.checkpointing.SavepointITCase#testStopWithSavepointFailsOverToSavepoint` with adaptive scheduler enabled.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no /** don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
