### PR TITLE
[FLINK-25227][BP-1.15][table-planner] Fix LEAST/GREATEST to return primitives

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
@@ -1381,10 +1381,11 @@ object ScalarOperatorGens {
       elements: Seq[GeneratedExpression],
       greatest: Boolean = true)
   : GeneratedExpression = {
-    val Seq(result, cur, nullTerm) = newNames("result", "cur", "nullTerm")
+    val Seq(result, tmpResult, cur, nullTerm) = newNames("result", "tmpResult", "cur", "nullTerm")
     val widerType = toScala(findCommonType(elements.map(element => element.resultType)))
       .orElse(throw new CodeGenException(s"Unable to find common type for $elements."))
-    val resultTypeTerm = boxedTypeTermForType(widerType.get)
+    val boxedResultTypeTerm = boxedTypeTermForType(widerType.get)
+    val primitiveResultTypeTerm = primitiveTypeTermForType(widerType.get)
 
     def castIfNumeric(t: GeneratedExpression): String = {
       if (isNumeric(widerType.get)) {
@@ -1398,13 +1399,13 @@ object ScalarOperatorGens {
       s"""
          | ${element.code}
          | if (!$nullTerm) {
-         |   $resultTypeTerm $cur = ${castIfNumeric(element)};
+         |   $boxedResultTypeTerm $cur = ${castIfNumeric(element)};
          |   if (${element.nullTerm}) {
          |     $nullTerm = true;
          |   } else {
-         |     int compareResult = $result.compareTo($cur);
+         |     int compareResult = $tmpResult.compareTo($cur);
          |     if (($greatest && compareResult < 0) || (compareResult > 0 && !$greatest)) {
-         |       $result = $cur;
+         |       $tmpResult = $cur;
          |     }
          |   }
          | }
@@ -1413,11 +1414,12 @@ object ScalarOperatorGens {
 
     val code =
       s"""
-         | $resultTypeTerm $result = ${castIfNumeric(elements.head)};
+         | $boxedResultTypeTerm $tmpResult = ${castIfNumeric(elements.head)};
+         | $primitiveResultTypeTerm $result = ${primitiveDefaultValue(widerType.get)};
          | boolean $nullTerm = false;
          | $elementsCode
-         | if ($nullTerm) {
-         |   $result = null;
+         | if (!$nullTerm) {
+         |   $result = $tmpResult;
          | }
        """.stripMargin
     GeneratedExpression(result, nullTerm, code, resultType)

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/GreatestLeastFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/GreatestLeastFunctionsITCase.java
@@ -81,20 +81,63 @@ public class GreatestLeastFunctionsITCase extends BuiltInFunctionTestBase {
                                         call("GREATEST", $("f6"), $("f7")),
                                         "GREATEST(f6, f7)",
                                         LocalDateTime.parse("1970-01-01T00:00:03.001"),
-                                        DataTypes.TIMESTAMP(3).notNull()))
+                                        DataTypes.TIMESTAMP(3).notNull()),
+                                resultSpec(
+                                        call("GREATEST", $("f0"), $("f1"), $("f2")),
+                                        "GREATEST(f0, f1, f2)",
+                                        null,
+                                        DataTypes.INT()),
+                                resultSpec(
+                                        call("GREATEST", $("f4"), $("f5")),
+                                        "GREATEST(f4, f5)",
+                                        "world",
+                                        DataTypes.STRING().notNull()),
+                                resultSpec(
+                                        call("GREATEST", $("f6"), $("f7")),
+                                        "GREATEST(f6, f7)",
+                                        LocalDateTime.parse("1970-01-01T00:00:03.001"),
+                                        DataTypes.TIMESTAMP(3).notNull()),
+                                // assert that primitive types are returned and used in the equality
+                                // operator applied on top of the GREATEST functions
+                                resultSpec(
+                                        call(
+                                                "EQUALS",
+                                                call("GREATEST", $("f1"), $("f2")),
+                                                call("GREATEST", $("f1"), $("f2"))),
+                                        "GREATEST(f1, f2) = GREATEST(f1, f2)",
+                                        true,
+                                        DataTypes.BOOLEAN().notNull()),
+                                resultSpec(
+                                        call(
+                                                "EQUALS",
+                                                call("GREATEST", $("f0"), $("f1")),
+                                                call("GREATEST", $("f0"), $("f1"))),
+                                        "GREATEST(f0, f1) = GREATEST(f0, f1)",
+                                        null,
+                                        DataTypes.BOOLEAN()))
                         .testSqlValidationError(
                                 "GREATEST(f5, f6)",
                                 "SQL validation failed. Invalid function call:\n"
                                         + "GREATEST(STRING NOT NULL, TIMESTAMP(3) NOT NULL)"),
                 TestSpec.forFunction(BuiltInFunctionDefinitions.LEAST)
-                        .onFieldsWithData(null, 1, 2, 3.14, "hello", "world")
+                        .onFieldsWithData(
+                                null,
+                                1,
+                                2,
+                                3.14,
+                                "hello",
+                                "world",
+                                LocalDateTime.parse("1970-01-01T00:00:03.001"),
+                                LocalDateTime.parse("1970-01-01T00:00:02.001"))
                         .andDataTypes(
                                 DataTypes.INT().nullable(),
                                 DataTypes.INT().notNull(),
                                 DataTypes.INT().notNull(),
                                 DataTypes.DECIMAL(3, 2).notNull(),
                                 DataTypes.STRING().notNull(),
-                                DataTypes.STRING().notNull())
+                                DataTypes.STRING().notNull(),
+                                DataTypes.TIMESTAMP(3).notNull(),
+                                DataTypes.TIMESTAMP(3).notNull())
                         .testSqlValidationError(
                                 "LEAST(f1, f4)",
                                 "SQL validation failed. Invalid function call:\n"
@@ -115,6 +158,38 @@ public class GreatestLeastFunctionsITCase extends BuiltInFunctionTestBase {
                                         call("LEAST", $("f4"), $("f5")),
                                         "LEAST(f4, f5)",
                                         "hello",
-                                        DataTypes.STRING().notNull())));
+                                        DataTypes.STRING().notNull()),
+                                resultSpec(
+                                        call("LEAST", $("f0"), $("f1")),
+                                        "LEAST(f0, f1)",
+                                        null,
+                                        DataTypes.INT()),
+                                resultSpec(
+                                        call("LEAST", $("f4"), $("f5")),
+                                        "LEAST(f4, f5)",
+                                        "hello",
+                                        DataTypes.STRING().notNull()),
+                                // assert that primitive types are returned and used in the equality
+                                // operator applied on top of the GREATEST functions
+                                resultSpec(
+                                        call(
+                                                "EQUALS",
+                                                call("LEAST", $("f1"), $("f2")),
+                                                call("LEAST", $("f1"), $("f2"))),
+                                        "LEAST(f1, f2) = LEAST(f1, f2)",
+                                        true,
+                                        DataTypes.BOOLEAN().notNull()),
+                                resultSpec(
+                                        call(
+                                                "EQUALS",
+                                                call("LEAST", $("f0"), $("f1")),
+                                                call("LEAST", $("f0"), $("f1"))),
+                                        "LEAST(f0, f1) = LEAST(f0, f1)",
+                                        null,
+                                        DataTypes.BOOLEAN()))
+                        .testSqlValidationError(
+                                "LEAST(f5, f6)",
+                                "SQL validation failed. Invalid function call:\n"
+                                        + "LEAST(STRING NOT NULL, TIMESTAMP(3) NOT NULL)"));
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Previously, `LEAST` and `GREATEST` functions would return primitive
types in the generated code implementing their logic, producing issues
for operators applied on top of them, and most importantly comparison
operators, i.e.:
```
f0 INT, f1 INT
SELECT GREATEST(f0, f1) = GREATEST(f0, f1)
```
would return `FALSE`, since the generated code would return `Integer`
instead of `int`, as the result of `GREATEST`, and the `=` operator
on `Integer` objects would return false, even if the actual integer
value of them was the same.


## Brief change log

  - Change code generation for `LEAST`/`GREATEST` to return primitive types instead of boxed, (null is already handled correctly with the use of `nullTerm`s.


## Verifying this change

This change added tests and can be verified as follows:

  - Added more tests in `GreatestLeastFunctionsITCase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive):**no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
