### PR TITLE
[FLINK-25931] Add projection pushdown support for CsvFormatFactory

### DIFF
--- a/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvFormatFactoryTest.java
+++ b/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvFormatFactoryTest.java
@@ -21,6 +21,8 @@ package org.apache.flink.formats.csv;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.connector.Projection;
+import org.apache.flink.table.connector.format.ProjectableDecodingFormat;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.data.GenericRowData;
@@ -35,7 +37,10 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
@@ -199,10 +204,8 @@ public class CsvFormatFactoryTest extends TestLogger {
         final Map<String, String> options =
                 getModifiedOptions(opts -> opts.put("csv.field-delimiter", "\t"));
 
-        final DynamicTableSource actualSource = createTableSource(SCHEMA, options);
-        assertThat(actualSource).isInstanceOf(TestDynamicTableFactory.DynamicTableSourceMock.class);
         TestDynamicTableFactory.DynamicTableSourceMock sourceMock =
-                (TestDynamicTableFactory.DynamicTableSourceMock) actualSource;
+                createDynamicTableSourceMock(options);
 
         DeserializationSchema<RowData> deserializationSchema =
                 sourceMock.valueFormat.createRuntimeDecoder(
@@ -225,6 +228,57 @@ public class CsvFormatFactoryTest extends TestLogger {
                 getModifiedOptions(opts -> opts.put("csv.ignore-parse-errors", "abc"));
 
         createTableSink(SCHEMA, options);
+    }
+
+    @Test
+    public void testProjectionPushdown() throws IOException {
+        final Map<String, String> options = getAllOptions();
+
+        final Projection projection =
+                Projection.fromFieldNames(PHYSICAL_DATA_TYPE, Collections.singletonList("c"));
+
+        final int[][] projectionMatrix = projection.toNestedIndexes();
+        DeserializationSchema<RowData> actualDeser =
+                createDeserializationSchema(options, projectionMatrix);
+
+        String data = "a1;2;false";
+        RowData deserialized = actualDeser.deserialize(data.getBytes());
+        GenericRowData expected = GenericRowData.of(false);
+
+        assertThat(deserialized).isEqualTo(expected);
+    }
+
+    @Test
+    public void testProjectionPushdownNoOpProjection() throws IOException {
+        final Map<String, String> options = getAllOptions();
+
+        List<String> fields = Arrays.asList("a", "b", "c");
+        final Projection projection = Projection.fromFieldNames(PHYSICAL_DATA_TYPE, fields);
+
+        final int[][] projectionMatrix = projection.toNestedIndexes();
+        DeserializationSchema<RowData> actualDeser =
+                createDeserializationSchema(options, projectionMatrix);
+
+        String data = "a1;2;false";
+        RowData deserialized = actualDeser.deserialize(data.getBytes());
+        GenericRowData expected = GenericRowData.of(fromString("a1"), 2, false);
+
+        assertThat(deserialized).isEqualTo(expected);
+    }
+
+    @Test
+    public void testProjectionPushdownEmptyProjection() throws IOException {
+        final Map<String, String> options = getAllOptions();
+
+        final int[][] projectionMatrix = new int[][] {};
+        DeserializationSchema<RowData> actualDeser =
+                createDeserializationSchema(options, projectionMatrix);
+
+        String data = "a1;2;false";
+        RowData deserialized = actualDeser.deserialize(data.getBytes());
+        GenericRowData expected = GenericRowData.of();
+
+        assertThat(deserialized).isEqualTo(expected);
     }
 
     // ------------------------------------------------------------------------
@@ -262,13 +316,30 @@ public class CsvFormatFactoryTest extends TestLogger {
 
     private static DeserializationSchema<RowData> createDeserializationSchema(
             Map<String, String> options) {
-        final DynamicTableSource actualSource = createTableSource(SCHEMA, options);
-        assertThat(actualSource).isInstanceOf(TestDynamicTableFactory.DynamicTableSourceMock.class);
         TestDynamicTableFactory.DynamicTableSourceMock sourceMock =
-                (TestDynamicTableFactory.DynamicTableSourceMock) actualSource;
+                createDynamicTableSourceMock(options);
 
         return sourceMock.valueFormat.createRuntimeDecoder(
                 ScanRuntimeProviderContext.INSTANCE, PHYSICAL_DATA_TYPE);
+    }
+
+    private static DeserializationSchema<RowData> createDeserializationSchema(
+            Map<String, String> options, int[][] projections) {
+        TestDynamicTableFactory.DynamicTableSourceMock sourceMock =
+                createDynamicTableSourceMock(options);
+
+        ProjectableDecodingFormat<DeserializationSchema<RowData>> valueFormat =
+                (ProjectableDecodingFormat<DeserializationSchema<RowData>>) sourceMock.valueFormat;
+
+        return valueFormat.createRuntimeDecoder(
+                ScanRuntimeProviderContext.INSTANCE, PHYSICAL_DATA_TYPE, projections);
+    }
+
+    private static TestDynamicTableFactory.DynamicTableSourceMock createDynamicTableSourceMock(
+            Map<String, String> options) {
+        final DynamicTableSource actualSource = createTableSource(SCHEMA, options);
+        assertThat(actualSource).isInstanceOf(TestDynamicTableFactory.DynamicTableSourceMock.class);
+        return (TestDynamicTableFactory.DynamicTableSourceMock) actualSource;
     }
 
     private static SerializationSchema<RowData> createSerializationSchema(


### PR DESCRIPTION
## What is the purpose of the change
FLINK-24703 added support for projection pushdown in CsvFileFormatFactory. This PR adds the same functionality for non-file-based connectors that use CsvFormatFactory and on Ser/DeSerialization schemas.

## Brief change log

 - Switches CsvFormatFactory to using ProjectableDecodingFormat instead of simple DecodingFormat
 - A distinction is made between the physical(read from file) RowType and the returned projected RowData type
 - CsvRowDataDeserializationSchema is initialized with both physical and projected RowTypes and filters out unused fields from the returned results

## Verifying this change

This change added tests and can be verified as follows:
  - Adds and a unit test that verifies that the fields not required by the TableAPI are filtered out

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (**yes** / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (**not applicable - internal optimization** / docs / JavaDocs / not documented)
