### PR TITLE
[FLINK-27150][runtime-web] Improve error message rendering

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/app.interceptor.ts
+++ b/flink-runtime-web/web-dashboard/src/app/app.interceptor.ts
@@ -35,7 +35,7 @@ export class AppInterceptor implements HttpInterceptor {
     const ignoreErrorMessage = ['File not found.'];
     const option: NzNotificationDataOptions = {
       nzDuration: 0,
-      nzStyle: { width: '1000px', 'white-space': 'pre-wrap' }
+      nzStyle: { width: 'auto', 'white-space': 'pre-wrap' }
     };
 
     return next.handle(req).pipe(

--- a/flink-runtime-web/web-dashboard/src/app/app.interceptor.ts
+++ b/flink-runtime-web/web-dashboard/src/app/app.interceptor.ts
@@ -21,7 +21,7 @@ import { Injectable, Injector } from '@angular/core';
 import { Observable, throwError } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
-import { NzNotificationService } from 'ng-zorro-antd/notification';
+import { NzNotificationService, NzNotificationDataOptions } from 'ng-zorro-antd/notification';
 
 import { StatusService } from 'services';
 
@@ -33,6 +33,10 @@ export class AppInterceptor implements HttpInterceptor {
     // Error response from below url should be ignored
     const ignoreErrorUrlEndsList = ['checkpoints/config', 'checkpoints'];
     const ignoreErrorMessage = ['File not found.'];
+    const option: NzNotificationDataOptions = {
+      nzDuration: 0,
+      nzStyle: { width: '1000px', 'white-space': 'pre-wrap' }
+    };
 
     return next.handle(req).pipe(
       catchError(res => {
@@ -45,7 +49,7 @@ export class AppInterceptor implements HttpInterceptor {
           this.injector.get<StatusService>(StatusService).listOfErrorMessage.push(errorMessage);
           this.injector
             .get<NzNotificationService>(NzNotificationService)
-            .info('Server Response Message:', errorMessage);
+            .info('Server Response Message:', errorMessage.replaceAll(' at ', '\n at '), option);
         }
         return throwError(res);
       })


### PR DESCRIPTION
```
- don't hide after a timeout (was: 4.5s)
- expand the message box
```

This allows for example to clearly see what the arguments the program is missing on submission.

![Screenshot_2022-03-30_23-20-57](https://user-images.githubusercontent.com/3939322/160935304-e0322fad-62b7-44a2-9c39-1bc365bfaee4.png)
