### PR TITLE
[hotfix] Fix CsvRowDataDeserializationSchema constructor

### DIFF
--- a/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvRowDataDeserializationSchema.java
+++ b/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvRowDataDeserializationSchema.java
@@ -72,7 +72,7 @@ public final class CsvRowDataDeserializationSchema implements DeserializationSch
         this.resultTypeInfo = resultTypeInfo;
         this.runtimeConverter =
                 new CsvToRowDataConverters(ignoreParseErrors).createRowConverter(rowType, true);
-        this.csvSchema = CsvRowSchemaConverter.convert(rowType);
+        this.csvSchema = csvSchema;
         this.objectReader = new CsvMapper().readerFor(JsonNode.class).with(csvSchema);
         this.ignoreParseErrors = ignoreParseErrors;
     }


### PR DESCRIPTION
The `csvSchema` field was wrongly initialized.
