### PR TITLE
[hotfix] [connectors/hbase] Fix equal method of HBaseWriteOptions

### DIFF
--- a/flink-connectors/flink-connector-hbase-base/src/main/java/org/apache/flink/connector/hbase/options/HBaseWriteOptions.java
+++ b/flink-connectors/flink-connector-hbase-base/src/main/java/org/apache/flink/connector/hbase/options/HBaseWriteOptions.java
@@ -86,10 +86,10 @@ public class HBaseWriteOptions implements Serializable {
             return false;
         }
         HBaseWriteOptions that = (HBaseWriteOptions) o;
-        return bufferFlushMaxSizeInBytes == that.bufferFlushMaxSizeInBytes
-                && bufferFlushMaxRows == that.bufferFlushMaxRows
-                && bufferFlushIntervalMillis == that.bufferFlushIntervalMillis
-                && parallelism == that.parallelism;
+        return Objects.equals(bufferFlushMaxSizeInBytes, that.bufferFlushMaxSizeInBytes)
+                && Objects.equals(bufferFlushMaxRows, that.bufferFlushMaxRows)
+                && Objects.equals(bufferFlushIntervalMillis, that.bufferFlushIntervalMillis)
+                && Objects.equals(parallelism, that.parallelism);
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change

The `equals` method of `HBaseWriteOptions` uses `==` to determine whether the `parallelism` of the Integer type is equal, which will cause problems.

The relevant code is as follows.
```java
    private final Integer parallelism;

    public boolean equals(Object o) {
        ....
        return bufferFlushMaxSizeInBytes == that.bufferFlushMaxSizeInBytes
                && bufferFlushMaxRows == that.bufferFlushMaxRows
                && bufferFlushIntervalMillis == that.bufferFlushIntervalMillis
                && parallelism == that.parallelism;
    }
```

In order to avoid similar problems, I refer to `HBaseLookupOptions` and use `Objects.equals()` uniformly to judge whether the internal member variables are equal.

## Brief change log

  - *The `equals` method of `HBaseWriteOptions`*


## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
