### PR TITLE
[FLINK-17231][kubernetes]When using LB Service, the optimization of returning RestEndpoint

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
@@ -535,6 +535,16 @@ public class KubernetesConfigOptions {
         public boolean isClusterIP() {
             return this == ClusterIP || this == Headless_ClusterIP;
         }
+
+        /** Check whether it is LoadBalancer type. */
+        public boolean isLoadBalancer() {
+            return this == LoadBalancer;
+        }
+
+        /** Check whether it is NodePort type. */
+        public boolean isNodePort() {
+            return this == NodePort;
+        }
     }
 
     /** The flink rest service exposed type. */

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
@@ -535,16 +535,6 @@ public class KubernetesConfigOptions {
         public boolean isClusterIP() {
             return this == ClusterIP || this == Headless_ClusterIP;
         }
-
-        /** Check whether it is LoadBalancer type. */
-        public boolean isLoadBalancer() {
-            return this == LoadBalancer;
-        }
-
-        /** Check whether it is NodePort type. */
-        public boolean isNodePort() {
-            return this == NodePort;
-        }
     }
 
     /** The flink rest service exposed type. */

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClient.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClient.java
@@ -35,9 +35,11 @@ import org.apache.flink.kubernetes.kubeclient.services.ServiceType;
 import org.apache.flink.kubernetes.utils.Constants;
 import org.apache.flink.kubernetes.utils.KubernetesUtils;
 import org.apache.flink.runtime.persistence.PossibleInconsistentStateException;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.ExecutorUtils;
 import org.apache.flink.util.FlinkRuntimeException;
+import org.apache.flink.util.StringUtils;
 import org.apache.flink.util.concurrent.FutureUtils;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
@@ -186,19 +188,6 @@ public class Fabric8FlinkKubeClient implements FlinkKubeClient {
         }
         final Service service = restService.get().getInternalResource();
         final int restPort = getRestPortFromExternalService(service);
-
-        final KubernetesConfigOptions.ServiceExposedType serviceExposedType =
-                ServiceType.classify(service);
-
-        // Return the external service.namespace directly when using ClusterIP.
-        if (serviceExposedType.isClusterIP()) {
-            return Optional.of(
-                    new Endpoint(
-                            ExternalServiceDecorator.getNamespacedExternalServiceName(
-                                    clusterId, namespace),
-                            restPort));
-        }
-
         return getRestEndPointFromService(service, restPort);
     }
 
@@ -493,61 +482,67 @@ public class Fabric8FlinkKubeClient implements FlinkKubeClient {
     }
 
     private Optional<Endpoint> getRestEndPointFromService(Service service, int restPort) {
-        if (service.getStatus() == null) {
-            return Optional.empty();
-        }
 
-        LoadBalancerStatus loadBalancer = service.getStatus().getLoadBalancer();
-        boolean hasExternalIP =
-                service.getSpec() != null
-                        && service.getSpec().getExternalIPs() != null
-                        && !service.getSpec().getExternalIPs().isEmpty();
+        final KubernetesConfigOptions.ServiceExposedType serviceExposedType =
+                ServiceType.classify(service);
 
-        if (loadBalancer != null) {
-            return getLoadBalancerRestEndpoint(loadBalancer, restPort);
-        } else if (hasExternalIP) {
+        if (serviceExposedType.isClusterIP()) {
+            return getClusterIPRestEndpoint(restPort);
+        } else if (service.getStatus() != null && serviceExposedType.isLoadBalancer()) {
+            return getLoadBalancerRestEndpoint(service.getStatus().getLoadBalancer(), restPort);
+        } else if (service.getSpec() != null
+                && !CollectionUtil.isNullOrEmpty(service.getSpec().getExternalIPs())) {
             final String address = service.getSpec().getExternalIPs().get(0);
             if (address != null && !address.isEmpty()) {
                 return Optional.of(new Endpoint(address, restPort));
             }
+        } else if (serviceExposedType.isNodePort()) {
+            return getNodePortRestEndpoint(restPort);
         }
         return Optional.empty();
     }
 
+    private Optional<Endpoint> getClusterIPRestEndpoint(int restPort) {
+        return Optional.of(
+                new Endpoint(
+                        ExternalServiceDecorator.getNamespacedExternalServiceName(
+                                clusterId, namespace),
+                        restPort));
+    }
+
+    private Optional<Endpoint> getNodePortRestEndpoint(int restPort) {
+
+        final String address =
+                internalClient.nodes().list().getItems().stream()
+                        .flatMap(node -> node.getStatus().getAddresses().stream())
+                        .filter(
+                                nodeAddress ->
+                                        nodePortAddressType.name().equals(nodeAddress.getType()))
+                        .map(NodeAddress::getAddress)
+                        .filter(ip -> !ip.isEmpty())
+                        .findAny()
+                        .orElse(null);
+
+        return StringUtils.isNullOrWhitespaceOnly(address)
+                ? Optional.empty()
+                : Optional.of(new Endpoint(address, restPort));
+    }
+
     private Optional<Endpoint> getLoadBalancerRestEndpoint(
             LoadBalancerStatus loadBalancer, int restPort) {
-        boolean hasIngress =
-                loadBalancer.getIngress() != null && !loadBalancer.getIngress().isEmpty();
-        String address;
-        if (hasIngress) {
-            address = loadBalancer.getIngress().get(0).getIp();
+        if (!CollectionUtil.isNullOrEmpty(loadBalancer.getIngress())) {
+            String address = loadBalancer.getIngress().get(0).getIp();
             // Use hostname when the ip address is null
             if (address == null || address.isEmpty()) {
                 address = loadBalancer.getIngress().get(0).getHostname();
             }
-        } else {
-            // Use node port. Node port is accessible on any node within kubernetes cluster. We'll
-            // only consider IPs with the configured address type.
-            address =
-                    internalClient.nodes().list().getItems().stream()
-                            .flatMap(node -> node.getStatus().getAddresses().stream())
-                            .filter(
-                                    nodeAddress ->
-                                            nodePortAddressType
-                                                    .name()
-                                                    .equals(nodeAddress.getType()))
-                            .map(NodeAddress::getAddress)
-                            .filter(ip -> !ip.isEmpty())
-                            .findAny()
-                            .orElse(null);
-            if (address == null) {
-                LOG.warn(
-                        "Unable to find any node ip with type [{}]. Please see [{}] config option for more details.",
-                        nodePortAddressType,
-                        KubernetesConfigOptions.REST_SERVICE_EXPOSED_NODE_PORT_ADDRESS_TYPE.key());
-            }
+            return StringUtils.isNullOrWhitespaceOnly(address)
+                    ? Optional.empty()
+                    : Optional.of(new Endpoint(address, restPort));
         }
-        boolean noAddress = address == null || address.isEmpty();
-        return noAddress ? Optional.empty() : Optional.of(new Endpoint(address, restPort));
+        LOG.error(
+                "LoadBalancer is temporarily unavailable, which will cause the Flink client to not be able to connect to the JobMaster."
+                        + " Please contact your cloud service provider, or select another service type (parameter configuration is `kubernetes.rest-service.exposed.type`)");
+        throw new FlinkRuntimeException("LoadBalancer is temporarily unavailable");
     }
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

When using LoadBalancer Service, if LoadBalancer is unavailable, it does not fall back to NodePort, but throws an exception

## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change


This change is already covered by existing tests, such as `org.apache.flink.kubernetes.kubeclient.Fabric8FlinkKubeClientTest`.



## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes Kubernetes)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? (no)
