### PR TITLE
[FLINK-21649][state/heap] Allow extension of CopyOnWriteState classes

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateMap.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateMap.java
@@ -203,7 +203,7 @@ public class CopyOnWriteStateMap<K, N, S> extends StateMap<K, N, S> {
      *
      * @param stateSerializer the serializer of the key.
      */
-    CopyOnWriteStateMap(TypeSerializer<S> stateSerializer) {
+    protected CopyOnWriteStateMap(TypeSerializer<S> stateSerializer) {
         this(DEFAULT_CAPACITY, stateSerializer);
     }
 
@@ -382,7 +382,7 @@ public class CopyOnWriteStateMap<K, N, S> extends StateMap<K, N, S> {
     // ---------------------------------------------------------------
 
     /** Helper method that is the basis for operations that add mappings. */
-    private StateMapEntry<K, N, S> putEntry(K key, N namespace) {
+    protected StateMapEntry<K, N, S> putEntry(K key, N namespace) {
 
         final int hash = computeHashForOperationAndDoIncrementalRehash(key, namespace);
         final StateMapEntry<K, N, S>[] tab = selectActiveTable(hash);
@@ -409,7 +409,7 @@ public class CopyOnWriteStateMap<K, N, S> extends StateMap<K, N, S> {
     }
 
     /** Helper method that is the basis for operations that remove mappings. */
-    private StateMapEntry<K, N, S> removeEntry(K key, N namespace) {
+    protected StateMapEntry<K, N, S> removeEntry(K key, N namespace) {
 
         final int hash = computeHashForOperationAndDoIncrementalRehash(key, namespace);
         final StateMapEntry<K, N, S>[] tab = selectActiveTable(hash);
@@ -491,6 +491,7 @@ public class CopyOnWriteStateMap<K, N, S> extends StateMap<K, N, S> {
             highestRequiredSnapshotVersion = stateMapVersion;
             snapshotVersions.add(highestRequiredSnapshotVersion);
         }
+        onVersionUpdate(stateMapVersion);
 
         StateMapEntry<K, N, S>[] table = primaryTable;
 
@@ -533,7 +534,7 @@ public class CopyOnWriteStateMap<K, N, S> extends StateMap<K, N, S> {
         return copy;
     }
 
-    int getStateMapVersion() {
+    public int getStateMapVersion() {
         return stateMapVersion;
     }
 
@@ -808,7 +809,7 @@ public class CopyOnWriteStateMap<K, N, S> extends StateMap<K, N, S> {
      * @param <S> type of state.
      */
     @VisibleForTesting
-    protected static class StateMapEntry<K, N, S> implements StateEntry<K, N, S> {
+    public static class StateMapEntry<K, N, S> implements StateEntry<K, N, S> {
 
         /** The key. Assumed to be immumap and not null. */
         @Nonnull final K key;
@@ -843,7 +844,7 @@ public class CopyOnWriteStateMap<K, N, S> extends StateMap<K, N, S> {
         /** The computed secondary hash for the composite of key and namespace. */
         final int hash;
 
-        StateMapEntry(StateMapEntry<K, N, S> other, int entryVersion) {
+        public StateMapEntry(StateMapEntry<K, N, S> other, int entryVersion) {
             this(
                     other.key,
                     other.namespace,
@@ -918,6 +919,18 @@ public class CopyOnWriteStateMap<K, N, S> extends StateMap<K, N, S> {
         @Override
         public final String toString() {
             return "(" + key + "|" + namespace + ")=" + state;
+        }
+
+        public int getStateVersion() {
+            return stateVersion;
+        }
+
+        public int getEntryVersion() {
+            return entryVersion;
+        }
+
+        public StateMapEntry<K, N, S> next() {
+            return next;
         }
     }
 
@@ -1086,4 +1099,6 @@ public class CopyOnWriteStateMap<K, N, S> extends StateMap<K, N, S> {
             CopyOnWriteStateMap.this.put(stateEntry.getKey(), stateEntry.getNamespace(), newValue);
         }
     }
+
+    protected void onVersionUpdate(int stateMapVersion) {}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateMapSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateMapSnapshot.java
@@ -58,7 +58,7 @@ public class CopyOnWriteStateMapSnapshot<K, N, S>
      * Version of the {@link CopyOnWriteStateMap} when this snapshot was created. This can be used
      * to release the snapshot.
      */
-    private final int snapshotVersion;
+    protected final int snapshotVersion;
 
     /**
      * The state map entries, as by the time this snapshot was created. Objects in this array may or
@@ -66,7 +66,7 @@ public class CopyOnWriteStateMapSnapshot<K, N, S>
      * this snapshot. This depends for each entry on whether or not it was subject to copy-on-write
      * operations by the {@link CopyOnWriteStateMap}.
      */
-    @Nonnull private final CopyOnWriteStateMap.StateMapEntry<K, N, S>[] snapshotData;
+    @Nonnull protected final CopyOnWriteStateMap.StateMapEntry<K, N, S>[] snapshotData;
 
     /** The number of (non-null) entries in snapshotData. */
     @Nonnegative private final int numberOfEntriesInSnapshotData;
@@ -80,7 +80,7 @@ public class CopyOnWriteStateMapSnapshot<K, N, S>
      * @param owningStateMap the {@link CopyOnWriteStateMap} for which this object represents a
      *     snapshot.
      */
-    CopyOnWriteStateMapSnapshot(CopyOnWriteStateMap<K, N, S> owningStateMap) {
+    protected CopyOnWriteStateMapSnapshot(CopyOnWriteStateMap<K, N, S> owningStateMap) {
         super(owningStateMap);
 
         this.snapshotData = owningStateMap.snapshotMapArrays();
@@ -111,7 +111,7 @@ public class CopyOnWriteStateMapSnapshot<K, N, S>
     }
 
     @Override
-    public SnapshotIterator<K, N, S> getIterator(
+    public Iterator<StateEntry<K, N, S>> getIterator(
             @Nonnull TypeSerializer<K> keySerializer,
             @Nonnull TypeSerializer<N> namespaceSerializer,
             @Nonnull TypeSerializer<S> stateSerializer,
@@ -131,14 +131,14 @@ public class CopyOnWriteStateMapSnapshot<K, N, S>
             @Nonnull DataOutputView dov,
             @Nullable StateSnapshotTransformer<S> stateSnapshotTransformer)
             throws IOException {
-        SnapshotIterator<K, N, S> snapshotIterator =
+        Iterator<StateEntry<K, N, S>> snapshotIterator =
                 getIterator(
                         keySerializer,
                         namespaceSerializer,
                         stateSerializer,
                         stateSnapshotTransformer);
 
-        int size = snapshotIterator.size();
+        int size = ((SnapshotIterator<K, N, S>) snapshotIterator).size();
         dov.writeInt(size);
         while (snapshotIterator.hasNext()) {
             StateEntry<K, N, S> stateEntry = snapshotIterator.next();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateTable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateTable.java
@@ -43,7 +43,7 @@ public class CopyOnWriteStateTable<K, N, S> extends StateTable<K, N, S> {
      * @param metaInfo the meta information, including the type serializer for state copy-on-write.
      * @param keySerializer the serializer of the key.
      */
-    CopyOnWriteStateTable(
+    protected CopyOnWriteStateTable(
             InternalKeyContext<K> keyContext,
             RegisteredKeyValueStateBackendMetaInfo<N, S> metaInfo,
             TypeSerializer<K> keySerializer) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateTableSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateTableSnapshot.java
@@ -42,7 +42,7 @@ public class CopyOnWriteStateTableSnapshot<K, N, S> extends AbstractStateTableSn
     private final int keyGroupOffset;
 
     /** Snapshots of state partitioned by key-group. */
-    @Nonnull private final List<CopyOnWriteStateMapSnapshot<K, N, S>> stateMapSnapshots;
+    @Nonnull protected final List<CopyOnWriteStateMapSnapshot<K, N, S>> stateMapSnapshots;
 
     /**
      * Creates a new {@link CopyOnWriteStateTableSnapshot}.
@@ -50,7 +50,7 @@ public class CopyOnWriteStateTableSnapshot<K, N, S> extends AbstractStateTableSn
      * @param owningStateTable the {@link CopyOnWriteStateTable} for which this object represents a
      *     snapshot.
      */
-    CopyOnWriteStateTableSnapshot(
+    protected CopyOnWriteStateTableSnapshot(
             CopyOnWriteStateTable<K, N, S> owningStateTable,
             TypeSerializer<K> localKeySerializer,
             TypeSerializer<N> localNamespaceSerializer,


### PR DESCRIPTION
## What is the purpose of the change

Allow extension of CopyOnWriteState classes
so that incremental versions can be added.

Please see https://github.com/rkhachatryan/flink/tree/flip-151-full
for the context of how this change is used.

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
