### PR TITLE
[FLINK-21783][state/heap] Allow snapshotting customization

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/SnapshotResult.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/SnapshotResult.java
@@ -129,4 +129,16 @@ public class SnapshotResult<T extends StateObject> implements StateObject {
             @Nonnull T jobManagerState, @Nonnull T localState) {
         return new SnapshotResult<>(jobManagerState, localState);
     }
+
+    public boolean isEmpty() {
+        return jobManagerOwnedSnapshot == null && taskLocalSnapshot == null;
+    }
+
+    @Override
+    public String toString() {
+        return "jobManagerOwnedSnapshot="
+                + jobManagerOwnedSnapshot
+                + ", taskLocalSnapshot="
+                + taskLocalSnapshot;
+    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackendBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackendBuilder.java
@@ -183,6 +183,7 @@ public class HeapKeyedStateBackendBuilder<K> extends AbstractKeyedStateBackendBu
                 localRecoveryConfig,
                 keyGroupRange,
                 keySerializerProvider,
-                numberOfKeyGroups);
+                numberOfKeyGroups,
+                StateSnapshotWriter.DEFAULT);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapSnapshotResources.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapSnapshotResources.java
@@ -41,13 +41,10 @@ import java.util.Map;
  * HeapKeyedStateBackend}.
  */
 @Internal
-final class HeapSnapshotResources<K> implements FullSnapshotResources<K> {
-    private final List<StateMetaInfoSnapshot> metaInfoSnapshots;
-    private final Map<StateUID, StateSnapshot> cowStateStableSnapshots;
+final class HeapSnapshotResources<K> extends HeapSnapshotResourcesBase<K>
+        implements FullSnapshotResources<K> {
     private final StreamCompressionDecorator streamCompressionDecorator;
-    private final Map<StateUID, Integer> stateNamesToId;
     private final KeyGroupRange keyGroupRange;
-    private final TypeSerializer<K> keySerializer;
     private final int totalKeyGroups;
 
     private HeapSnapshotResources(
@@ -58,12 +55,9 @@ final class HeapSnapshotResources<K> implements FullSnapshotResources<K> {
             KeyGroupRange keyGroupRange,
             TypeSerializer<K> keySerializer,
             int totalKeyGroups) {
-        this.metaInfoSnapshots = metaInfoSnapshots;
-        this.cowStateStableSnapshots = cowStateStableSnapshots;
+        super(metaInfoSnapshots, cowStateStableSnapshots, stateNamesToId, keySerializer);
         this.streamCompressionDecorator = streamCompressionDecorator;
-        this.stateNamesToId = stateNamesToId;
         this.keyGroupRange = keyGroupRange;
-        this.keySerializer = keySerializer;
         this.totalKeyGroups = totalKeyGroups;
     }
 
@@ -145,17 +139,6 @@ final class HeapSnapshotResources<K> implements FullSnapshotResources<K> {
     }
 
     @Override
-    public void release() {
-        for (StateSnapshot stateSnapshot : cowStateStableSnapshots.values()) {
-            stateSnapshot.release();
-        }
-    }
-
-    public List<StateMetaInfoSnapshot> getMetaInfoSnapshots() {
-        return metaInfoSnapshots;
-    }
-
-    @Override
     public KeyValueStateIterator createKVStateIterator() throws IOException {
         return new HeapKeyValueStateIterator(
                 keyGroupRange,
@@ -171,20 +154,7 @@ final class HeapSnapshotResources<K> implements FullSnapshotResources<K> {
     }
 
     @Override
-    public TypeSerializer<K> getKeySerializer() {
-        return keySerializer;
-    }
-
-    @Override
     public StreamCompressionDecorator getStreamCompressionDecorator() {
         return streamCompressionDecorator;
-    }
-
-    public Map<StateUID, StateSnapshot> getCowStateStableSnapshots() {
-        return cowStateStableSnapshots;
-    }
-
-    public Map<StateUID, Integer> getStateNamesToId() {
-        return stateNamesToId;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapSnapshotResourcesBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapSnapshotResourcesBase.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.heap;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.state.SnapshotResources;
+import org.apache.flink.runtime.state.StateSnapshot;
+import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Base class for heap {@link SnapshotResources}.
+ *
+ * @param <K> type of key
+ */
+@Internal
+public class HeapSnapshotResourcesBase<K> implements SnapshotResources {
+    protected final List<StateMetaInfoSnapshot> metaInfoSnapshots;
+    protected final Map<StateUID, StateSnapshot> cowStateStableSnapshots;
+    protected final Map<StateUID, Integer> stateNamesToId;
+    protected final TypeSerializer<K> keySerializer;
+
+    protected HeapSnapshotResourcesBase(
+            List<StateMetaInfoSnapshot> metaInfoSnapshots,
+            Map<StateUID, StateSnapshot> cowStateStableSnapshots,
+            Map<StateUID, Integer> stateNamesToId,
+            TypeSerializer<K> keySerializer) {
+        this.metaInfoSnapshots = metaInfoSnapshots;
+        this.cowStateStableSnapshots = cowStateStableSnapshots;
+        this.stateNamesToId = stateNamesToId;
+        this.keySerializer = keySerializer;
+    }
+
+    @Override
+    public void release() {
+        for (StateSnapshot stateSnapshot : cowStateStableSnapshots.values()) {
+            stateSnapshot.release();
+        }
+    }
+
+    public List<StateMetaInfoSnapshot> getMetaInfoSnapshots() {
+        return metaInfoSnapshots;
+    }
+
+    public Map<StateUID, StateSnapshot> getCowStateStableSnapshots() {
+        return cowStateStableSnapshots;
+    }
+
+    public Map<StateUID, Integer> getStateNamesToId() {
+        return stateNamesToId;
+    }
+
+    public TypeSerializer<K> getKeySerializer() {
+        return keySerializer;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/StateSnapshotWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/StateSnapshotWriter.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.heap;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.runtime.state.StateSnapshot;
+
+import java.io.IOException;
+
+/** Writer for the given state snapshot and key group. */
+@Internal
+public interface StateSnapshotWriter {
+    void write(StateSnapshot snapshot, DataOutputViewStreamWrapper out, int keyGroupId)
+            throws IOException;
+
+    StateSnapshotWriter DEFAULT =
+            (snapshot, out, keyGroup) ->
+                    snapshot.getKeyGroupWriter().writeStateInKeyGroup(out, keyGroup);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/StateUID.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/StateUID.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.state.heap;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot;
 
 import javax.annotation.Nonnull;
@@ -25,7 +26,8 @@ import javax.annotation.Nonnull;
 import java.util.Objects;
 
 /** Unique identifier for registered state in this backend. */
-final class StateUID {
+@Internal
+public final class StateUID {
 
     @Nonnull private final String stateName;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/metainfo/StateMetaInfoSnapshotReadersWriters.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/metainfo/StateMetaInfoSnapshotReadersWriters.java
@@ -206,9 +206,9 @@ public class StateMetaInfoSnapshotReadersWriters {
      * Implementation of {@link StateMetaInfoReader} for the current version and generic for all
      * state types.
      */
-    static class CurrentReaderImpl implements StateMetaInfoReader {
+    public static class CurrentReaderImpl implements StateMetaInfoReader {
 
-        private static final CurrentReaderImpl INSTANCE = new CurrentReaderImpl();
+        public static final CurrentReaderImpl INSTANCE = new CurrentReaderImpl();
 
         @Nonnull
         @Override


### PR DESCRIPTION
## What is the purpose of the change

Allow customization of snapshotting of HeapKeyedStateBackend
so that it can be snapshotted incrementally.

Please see https://github.com/rkhachatryan/flink/tree/flip-151-full
for the context of how this change is used.

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
