### PR TITLE
[FLINK-26964][state/heap] Notify CheckpointStrategy about checkpoint completion/abortion

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.state.heap;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.state.CheckpointListener;
 import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.state.MapStateDescriptor;
 import org.apache.flink.api.common.state.State;
@@ -333,13 +334,17 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
     }
 
     @Override
-    public void notifyCheckpointComplete(long checkpointId) {
-        // Nothing to do
+    public void notifyCheckpointComplete(long checkpointId) throws Exception {
+        if (checkpointStrategy instanceof CheckpointListener) {
+            ((CheckpointListener) checkpointStrategy).notifyCheckpointComplete(checkpointId);
+        }
     }
 
     @Override
-    public void notifyCheckpointAborted(long checkpointId) {
-        // nothing to do
+    public void notifyCheckpointAborted(long checkpointId) throws Exception {
+        if (checkpointStrategy instanceof CheckpointListener) {
+            ((CheckpointListener) checkpointStrategy).notifyCheckpointAborted(checkpointId);
+        }
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change

Notifications could be used by incremental snapshot strategy 
to replace state handles with placeholders.

Please see https://github.com/rkhachatryan/flink/tree/flip-151-full
for the context of how this change is used.

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
