### PR TITLE
[FLINK-26967][state/heap] Fix race condition in CopyOnWriteStateMap

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateMap.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateMap.java
@@ -718,7 +718,11 @@ public class CopyOnWriteStateMap<K, N, S> extends StateMap<K, N, S> {
         }
 
         // we iterate the chain up to 'until entry'
-        while (current != untilEntry) {
+        // the entry was already found in this chain, so it's guaranteed to be not null
+        // however, because the entry under `current' can be updated in concurrently
+        // we check for equality and not for identity
+        while (!current.key.equals(untilEntry.key)
+                || !current.namespace.equals(untilEntry.namespace)) {
 
             // advance current
             current = current.next;


### PR DESCRIPTION
## What is the purpose of the change

```
Currently, handling chained entry on copy-on-write uses object
identity to find the wanted entry in the chain. However, if
the same method is running concurrently, the object in the chain
can be replaced by its copy; the condition will never be met and
the chain end will be reached, causing an NPE.

With some tiny changes in timings (i.e. overriding methods of
CopyOnWriteStateMap), StateBackendTestBase.testValueStateRace
fails when running repeatedly (~4 out of 100 runs).

This change replaces object identity with key+namespace equality
in the condition.

The overhead should not be significant because the same check is
already performed to find the element before copying.
```

## Verifying this change

` IncrementalHeapStateBackendTest.testValueStateRace` in https://github.com/rkhachatryan/flink/tree/flip-151-full

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
