### PR TITLE
[FLINK-26968][state/heap] Bump CopyOnWriteStateMap entry version before write

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateMap.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateMap.java
@@ -285,6 +285,11 @@ public class CopyOnWriteStateMap<K, N, S> extends StateMap<K, N, S> {
                     }
                     e.stateVersion = stateMapVersion;
                     e.state = getStateSerializer().copy(e.state);
+                } else if (e.stateVersion < stateMapVersion) {
+                    // the entry state is going to be modified - advance its version so that it
+                    // will be snapshotted by the next incremental checkpoint after this
+                    // modification
+                    e.stateVersion = stateMapVersion;
                 }
 
                 return e.state;


### PR DESCRIPTION
## What is the purpose of the change

```
CopyOnWriteStateMap copies the entry before returning it to the client
for update. This also updates its state and entry versions.

However, if the entry is NOT used by any snapshots, the versions
will stay the same despite that state is going to be updated.

With incremental checkpoints, this causes such updated version to
be ignored in the next snapshot.

This change bumps the state version in this case (entry version
stays the same).
```

## Verifying this change

Multiple IT cases in https://github.com/rkhachatryan/flink/tree/flip-151-full,
e.g. 
 - `ProcessingTimeWindowCheckpointingITCase.testAggregatingTumblingProcessingTimeWindow`
 - `EventTimeWindowCheckpointingITCase.testSlidingTimeWindow`
 - `AggregateITCase.testWindowWithUnboundedAgg`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
