### PR TITLE
[FLINK-26965][state] Allow reuse of PeriodicMaterializationManager

### DIFF
--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
@@ -111,7 +111,7 @@ public class ChangelogKeyedStateBackend<K>
                 CheckpointListener,
                 TestableKeyedStateBackend<K>,
                 InternalCheckpointListener,
-                MaterializationTarget {
+                MaterializationTarget<SequenceNumber> {
     private static final Logger LOG = LoggerFactory.getLogger(ChangelogKeyedStateBackend.class);
 
     /**
@@ -757,7 +757,8 @@ public class ChangelogKeyedStateBackend<K>
      *     SequenceNumber} identifying the latest change in the changelog
      */
     @Override
-    public Optional<MaterializationRunnable> initMaterialization() throws Exception {
+    public Optional<MaterializationRunnable<SequenceNumber>> initMaterialization()
+            throws Exception {
         SequenceNumber upTo = stateChangelogWriter.nextSequenceNumber();
         SequenceNumber lastMaterializedTo = changelogSnapshotState.lastMaterializedTo();
 
@@ -774,8 +775,8 @@ public class ChangelogKeyedStateBackend<K>
             // checkpoint ID. A faked materialized Id is provided here.
             long materializationID = materializedId++;
 
-            MaterializationRunnable materializationRunnable =
-                    new MaterializationRunnable(
+            MaterializationRunnable<SequenceNumber> materializationRunnable =
+                    new MaterializationRunnable<>(
                             keyedStateBackend.snapshot(
                                     materializationID,
                                     System.currentTimeMillis(),

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
@@ -65,6 +65,7 @@ import org.apache.flink.runtime.state.ttl.TtlStateFactory;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 import org.apache.flink.state.changelog.restore.ChangelogRestoreTarget;
 import org.apache.flink.state.changelog.restore.FunctionDelegationHelper;
+import org.apache.flink.state.common.PeriodicMaterializationManager.MaterializationTarget;
 
 import org.apache.flink.shaded.guava30.com.google.common.io.Closer;
 
@@ -95,7 +96,7 @@ import java.util.stream.Stream;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.apache.flink.runtime.state.StateSnapshotTransformer.StateSnapshotTransformFactory.noTransform;
-import static org.apache.flink.state.changelog.PeriodicMaterializationManager.MaterializationRunnable;
+import static org.apache.flink.state.common.PeriodicMaterializationManager.MaterializationRunnable;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -109,7 +110,8 @@ public class ChangelogKeyedStateBackend<K>
         implements CheckpointableKeyedStateBackend<K>,
                 CheckpointListener,
                 TestableKeyedStateBackend<K>,
-                InternalCheckpointListener {
+                InternalCheckpointListener,
+                MaterializationTarget {
     private static final Logger LOG = LoggerFactory.getLogger(ChangelogKeyedStateBackend.class);
 
     /**
@@ -754,6 +756,7 @@ public class ChangelogKeyedStateBackend<K>
      * @return a tuple of - future snapshot result from the underlying state backend - a {@link
      *     SequenceNumber} identifying the latest change in the changelog
      */
+    @Override
     public Optional<MaterializationRunnable> initMaterialization() throws Exception {
         SequenceNumber upTo = stateChangelogWriter.nextSequenceNumber();
         SequenceNumber lastMaterializedTo = changelogSnapshotState.lastMaterializedTo();
@@ -800,7 +803,8 @@ public class ChangelogKeyedStateBackend<K>
      * This method is not thread safe. It should be called either under a lock or through task
      * mailbox executor.
      */
-    public void updateChangelogSnapshotState(
+    @Override
+    public void handleMaterializationResult(
             SnapshotResult<KeyedStateHandle> materializedSnapshot,
             long materializationID,
             SequenceNumber upTo) {

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogStateBackend.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogStateBackend.java
@@ -34,6 +34,8 @@ import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 import org.apache.flink.runtime.taskmanager.AsynchronousException;
 import org.apache.flink.state.changelog.restore.ChangelogBackendRestoreOperation;
 import org.apache.flink.state.changelog.restore.ChangelogBackendRestoreOperation.BaseBackendBuilder;
+import org.apache.flink.state.common.ChangelogMaterializationMetricGroup;
+import org.apache.flink.state.common.PeriodicMaterializationManager;
 import org.apache.flink.util.Preconditions;
 
 import java.util.Collection;

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackendTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackendTest.java
@@ -72,7 +72,7 @@ public class ChangelogKeyedStateBackendTest {
         MockKeyedStateBackend<Integer> mock = createMock();
         ChangelogKeyedStateBackend<Integer> changelog = createChangelog(mock);
         try {
-            changelog.updateChangelogSnapshotState(
+            changelog.handleMaterializationResult(
                     SnapshotResult.empty(), materializationId, SequenceNumber.of(Long.MAX_VALUE));
             checkpoint(changelog, checkpointId).get().discardState();
 

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogMetricGroupTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogMetricGroupTest.java
@@ -37,6 +37,8 @@ import org.apache.flink.runtime.state.hashmap.HashMapStateBackend;
 import org.apache.flink.runtime.state.memory.MemCheckpointStreamFactory;
 import org.apache.flink.runtime.state.storage.JobManagerCheckpointStorage;
 import org.apache.flink.runtime.testutils.ExceptionallyDoneFuture;
+import org.apache.flink.state.common.ChangelogMaterializationMetricGroup;
+import org.apache.flink.state.common.PeriodicMaterializationManager;
 import org.apache.flink.util.Preconditions;
 
 import org.junit.Test;
@@ -48,13 +50,13 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.RunnableFuture;
 
 import static org.apache.flink.runtime.state.StateBackendTestUtils.wrapStateBackendWithSnapshotFunction;
-import static org.apache.flink.state.changelog.ChangelogMaterializationMetricGroup.COMPLETED_MATERIALIZATION;
-import static org.apache.flink.state.changelog.ChangelogMaterializationMetricGroup.FAILED_MATERIALIZATION;
-import static org.apache.flink.state.changelog.ChangelogMaterializationMetricGroup.STARTED_MATERIALIZATION;
 import static org.apache.flink.state.changelog.ChangelogStateBackendMetricGroup.LATEST_FULL_SIZE_OF_MATERIALIZATION;
 import static org.apache.flink.state.changelog.ChangelogStateBackendMetricGroup.LATEST_FULL_SIZE_OF_NON_MATERIALIZATION;
 import static org.apache.flink.state.changelog.ChangelogStateBackendMetricGroup.LATEST_INC_SIZE_OF_MATERIALIZATION;
 import static org.apache.flink.state.changelog.ChangelogStateBackendMetricGroup.LATEST_INC_SIZE_OF_NON_MATERIALIZATION;
+import static org.apache.flink.state.common.ChangelogMaterializationMetricGroup.COMPLETED_MATERIALIZATION;
+import static org.apache.flink.state.common.ChangelogMaterializationMetricGroup.FAILED_MATERIALIZATION;
+import static org.apache.flink.state.common.ChangelogMaterializationMetricGroup.STARTED_MATERIALIZATION;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogStateBackendTestUtils.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogStateBackendTestUtils.java
@@ -58,6 +58,8 @@ import org.apache.flink.runtime.state.VoidNamespace;
 import org.apache.flink.runtime.state.VoidNamespaceSerializer;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 import org.apache.flink.runtime.testutils.statemigration.TestType;
+import org.apache.flink.state.common.ChangelogMaterializationMetricGroup;
+import org.apache.flink.state.common.PeriodicMaterializationManager;
 import org.apache.flink.util.CloseableIterator;
 import org.apache.flink.util.IOUtils;
 import org.apache.flink.util.concurrent.Executors;

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogStateDiscardTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogStateDiscardTest.java
@@ -450,7 +450,7 @@ public class ChangelogStateDiscardTest {
 
     private static void materialize(
             ChangelogKeyedStateBackend<String> backend, StateChangelogWriter<?> writer) {
-        backend.updateChangelogSnapshotState(empty(), 0L, writer.nextSequenceNumber());
+        backend.handleMaterializationResult(empty(), 0L, writer.nextSequenceNumber());
     }
 
     private static void truncate(

--- a/flink-state-backends/flink-statebackend-common/pom.xml
+++ b/flink-state-backends/flink-statebackend-common/pom.xml
@@ -28,10 +28,11 @@ under the License.
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-state-backends</artifactId>
 		<version>1.16-SNAPSHOT</version>
+		<relativePath>..</relativePath>
 	</parent>
 
-	<artifactId>flink-statebackend-changelog</artifactId>
-	<name>Flink : State backends : Changelog</name>
+	<artifactId>flink-statebackend-common</artifactId>
+	<name>Flink : State backends : Common</name>
 
 	<packaging>jar</packaging>
 
@@ -56,52 +57,18 @@ under the License.
             <artifactId>flink-shaded-guava</artifactId>
         </dependency>
 
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-statebackend-common</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-
-		<!-- test dependencies -->
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-test-utils-junit</artifactId>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-dstl-dfs</artifactId>
-			<version>${project.version}</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime</artifactId>
-			<version>${project.version}</version>
-			<scope>test</scope>
-			<type>test-jar</type>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-statebackend-rocksdb</artifactId>
-			<version>${project.version}</version>
-			<scope>test</scope>
-			<type>test-jar</type>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-statebackend-rocksdb</artifactId>
-			<version>${project.version}</version>
-			<scope>test</scope>
-		</dependency>
+        <!-- test dependencies -->
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-streaming-java</artifactId>
+            <artifactId>flink-runtime</artifactId>
             <version>${project.version}</version>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-test-utils-junit</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/flink-state-backends/flink-statebackend-common/src/main/java/org/apache/flink/state/common/ChangelogMaterializationMetricGroup.java
+++ b/flink-state-backends/flink-statebackend-common/src/main/java/org/apache/flink/state/common/ChangelogMaterializationMetricGroup.java
@@ -15,8 +15,9 @@
  * limitations under the License.
  */
 
-package org.apache.flink.state.changelog;
+package org.apache.flink.state.common;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.MetricGroup;
@@ -24,24 +25,25 @@ import org.apache.flink.metrics.ThreadSafeSimpleCounter;
 import org.apache.flink.runtime.metrics.groups.ProxyMetricGroup;
 
 /** Metrics related to the materialization part of Changelog. */
-class ChangelogMaterializationMetricGroup extends ProxyMetricGroup<MetricGroup> {
+@Internal
+public class ChangelogMaterializationMetricGroup extends ProxyMetricGroup<MetricGroup> {
 
     private static final String PREFIX = "ChangelogMaterialization";
 
     @VisibleForTesting
-    static final String STARTED_MATERIALIZATION = PREFIX + ".startedMaterialization";
+    public static final String STARTED_MATERIALIZATION = PREFIX + ".startedMaterialization";
 
     @VisibleForTesting
-    static final String COMPLETED_MATERIALIZATION = PREFIX + ".completedMaterialization";
+    public static final String COMPLETED_MATERIALIZATION = PREFIX + ".completedMaterialization";
 
     @VisibleForTesting
-    static final String FAILED_MATERIALIZATION = PREFIX + ".failedMaterialization";
+    public static final String FAILED_MATERIALIZATION = PREFIX + ".failedMaterialization";
 
     private final Counter startedMaterializationCounter;
     private final Counter completedMaterializationCounter;
     private final Counter failedMaterializationCounter;
 
-    ChangelogMaterializationMetricGroup(MetricGroup parentMetricGroup) {
+    public ChangelogMaterializationMetricGroup(MetricGroup parentMetricGroup) {
         super(parentMetricGroup);
         this.startedMaterializationCounter =
                 counter(STARTED_MATERIALIZATION, new ThreadSafeSimpleCounter());

--- a/flink-state-backends/pom.xml
+++ b/flink-state-backends/pom.xml
@@ -39,5 +39,6 @@ under the License.
 		<module>flink-statebackend-rocksdb</module>
 		<module>flink-statebackend-heap-spillable</module>
 		<module>flink-statebackend-changelog</module>
+		<module>flink-statebackend-common</module>
 	</modules>
 </project>


### PR DESCRIPTION
## What is the purpose of the change

The same approach that is used with Changelog can be 
used with other state backends too, 
in particular IncrementalHeapStateBackend (FLIP-151).

Please see https://github.com/rkhachatryan/flink/tree/flip-151-full
for the context of how this change is used.
## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
