### PR TITLE
[FLINK-26757][state] Change the default value of state.backend.rocksdb.restore-overlap-fraction-threshold to 0

### DIFF
--- a/docs/layouts/shortcodes/generated/rocksdb_configurable_configuration.html
+++ b/docs/layouts/shortcodes/generated/rocksdb_configurable_configuration.html
@@ -94,9 +94,9 @@
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.restore-overlap-fraction-threshold</h5></td>
-            <td style="word-wrap: break-word;">0.75</td>
+            <td style="word-wrap: break-word;">0.0</td>
             <td>Double</td>
-            <td>The threshold of the overlap fraction between the handle's key-group range and target key-group range. When restore base DB, only the handle which overlap fraction greater than or equal to *threshold* has a chance to be an initial handle.</td>
+            <td>The threshold of overlap fraction between the handle's key-group range and target key-group range. When restore base DB, only the handle which overlap fraction greater than or equal to threshold has a chance to be an initial handle. The default value is 0.0, there is always a handle will be selected for initialization. </td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.thread.num</h5></td>

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/EmbeddedRocksDBStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/EmbeddedRocksDBStateBackend.java
@@ -498,7 +498,7 @@ public class EmbeddedRocksDBStateBackend extends AbstractManagedMemoryStateBacke
                         .setNativeMetricOptions(
                                 resourceContainer.getMemoryWatcherOptions(defaultMetricOptions))
                         .setWriteBatchSize(getWriteBatchSize())
-                        .setOverlapFractionThreshold(overlapFractionThreshold);
+                        .setOverlapFractionThreshold(getOverlapFractionThreshold());
         return builder.build();
     }
 
@@ -831,6 +831,12 @@ public class EmbeddedRocksDBStateBackend extends AbstractManagedMemoryStateBacke
     public void setWriteBatchSize(long writeBatchSize) {
         checkArgument(writeBatchSize >= 0, "Write batch size have to be no negative.");
         this.writeBatchSize = writeBatchSize;
+    }
+
+    double getOverlapFractionThreshold() {
+        return overlapFractionThreshold == UNDEFINED_OVERLAP_FRACTION_THRESHOLD
+                ? RESTORE_OVERLAP_FRACTION_THRESHOLD.defaultValue()
+                : overlapFractionThreshold;
     }
 
     // ------------------------------------------------------------------------

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBConfigurableOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBConfigurableOptions.java
@@ -258,11 +258,12 @@ public class RocksDBConfigurableOptions implements Serializable {
     public static final ConfigOption<Double> RESTORE_OVERLAP_FRACTION_THRESHOLD =
             key("state.backend.rocksdb.restore-overlap-fraction-threshold")
                     .doubleType()
-                    .defaultValue(0.75)
+                    .defaultValue(0.0)
                     .withDescription(
-                            "The threshold of the overlap fraction between the handle's key-group range and target key-group range. "
-                                    + "When restore base DB, only the handle which overlap fraction greater than or equal to *threshold* "
-                                    + "has a chance to be an initial handle.");
+                            "The threshold of overlap fraction between the handle's key-group range and target key-group range. "
+                                    + "When restore base DB, only the handle which overlap fraction greater than or equal to threshold "
+                                    + "has a chance to be an initial handle. "
+                                    + "The default value is 0.0, there is always a handle will be selected for initialization. ");
 
     static final ConfigOption<?>[] CANDIDATE_CONFIGS =
             new ConfigOption<?>[] {

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBIncrementalCheckpointUtilsTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBIncrementalCheckpointUtilsTest.java
@@ -96,12 +96,6 @@ public class RocksDBIncrementalCheckpointUtilsTest extends TestLogger {
         when(keyedStateHandle3.getKeyGroupRange()).thenReturn(new KeyGroupRange(8, 12));
         keyedStateHandles.add(keyedStateHandle3);
 
-        Assert.assertNull(
-                RocksDBIncrementalCheckpointUtils.chooseTheBestStateHandleForInitial(
-                        keyedStateHandles,
-                        new KeyGroupRange(3, 5),
-                        RESTORE_OVERLAP_FRACTION_THRESHOLD.defaultValue()));
-
         // this should choose keyedStateHandle2, because keyedStateHandle2's key-group range
         // satisfies the overlap fraction demand.
         Assert.assertEquals(

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
@@ -771,6 +771,24 @@ public class RocksDBStateBackendConfigTest {
         }
     }
 
+    @Test
+    public void testDefaultRestoreOverlapThreshold() {
+        EmbeddedRocksDBStateBackend rocksDBStateBackend = new EmbeddedRocksDBStateBackend(true);
+        assertTrue(
+                RocksDBConfigurableOptions.RESTORE_OVERLAP_FRACTION_THRESHOLD.defaultValue()
+                        == rocksDBStateBackend.getOverlapFractionThreshold());
+    }
+
+    @Test
+    public void testConfigureRestoreOverlapThreshold() {
+        EmbeddedRocksDBStateBackend rocksDBStateBackend = new EmbeddedRocksDBStateBackend(true);
+        Configuration configuration = new Configuration();
+        configuration.setDouble(RocksDBConfigurableOptions.RESTORE_OVERLAP_FRACTION_THRESHOLD, 0.3);
+        rocksDBStateBackend =
+                rocksDBStateBackend.configure(configuration, getClass().getClassLoader());
+        assertTrue(0.3 == rocksDBStateBackend.getOverlapFractionThreshold());
+    }
+
     private void verifySetParameter(Runnable setter) {
         try {
             setter.run();


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*`state.backend.rocksdb.restore-overlap-fraction-threshold` is used to control how to restore a state handle, different thresholds can affect the performance of restoring. Currently, the default value is 0.75,  this PR wants to change the default value to 0.*

Here is a comparison between `0` and `0.75` based on [rescaling benchmark](https://github.com/apache/flink-benchmarks/pull/23).  Since `deleteRange()` takes less time than creating a new RocksDB instance and then scan-and-put the records,  we can see that threshold `0` is much better than `0.75`.

  | rescale type | number of keys | key len | value len | state size | delete type | overlap threshold | time(ms/op)
-- | -- | -- | -- | -- | -- | -- | -- | --
1 | 1->2 | 10M | 96 | 128 | ~=2.2GB | native deleteRange | 0 | 1811.478 ± 82.262
2 | 1->2 | 10M | 96 | 128 | ~=2.2GB | native deleteRange | 0.75 | 17640.542 ± 1784.368




## Brief change log

  - *Change the default value of `state.backend.rocksdb.restore-overlap-fraction-threshold` to 0.*
 

## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

This change is already covered by existing tests, such as `RocksDBIncrementalCheckpointUtilsTest#testChooseTheBestStateHandleForInitial()` and `RocksDBStateBackendConfigTest#testConfigureRestoreOverlapThreshold()`


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes /**no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no** )
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
