### PR TITLE
[FLINK-26943][table] Add DATE_ADD supported in SQL & Table API

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -50,116 +50,7 @@ import static org.apache.flink.table.expressions.ApiExpressionUtils.toMonthInter
 import static org.apache.flink.table.expressions.ApiExpressionUtils.typeLiteral;
 import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedCall;
 import static org.apache.flink.table.expressions.ApiExpressionUtils.valueLiteral;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ABS;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ACOS;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.AND;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_ELEMENT;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ASIN;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.AT;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ATAN;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.AVG;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.BETWEEN;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.BIN;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.CARDINALITY;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.CAST;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.CEIL;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.CHAR_LENGTH;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.COLLECT;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.COS;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.COSH;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.COT;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.COUNT;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.DEGREES;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.DISTINCT;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.DIVIDE;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.EQUALS;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.EXP;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.EXTRACT;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.FLATTEN;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.FLOOR;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.FROM_BASE64;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.GET;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.GREATER_THAN;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.GREATER_THAN_OR_EQUAL;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.HEX;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.IF;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.IF_NULL;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.IN;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.INIT_CAP;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.IS_FALSE;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.IS_JSON;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.IS_NOT_FALSE;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.IS_NOT_NULL;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.IS_NOT_TRUE;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.IS_NULL;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.IS_TRUE;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.JSON_EXISTS;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.JSON_QUERY;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.JSON_VALUE;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.LESS_THAN;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.LESS_THAN_OR_EQUAL;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.LIKE;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.LN;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.LOG;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.LOG10;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.LOG2;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.LOWER;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.LPAD;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.LTRIM;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.MAX;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.MD5;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.MIN;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.MINUS;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.MOD;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.NOT;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.NOT_BETWEEN;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.NOT_EQUALS;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.OR;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ORDER_ASC;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ORDER_DESC;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.OVER;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.OVERLAY;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.PLUS;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.POSITION;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.POWER;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.PROCTIME;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.RADIANS;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.REGEXP_EXTRACT;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.REGEXP_REPLACE;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.REPEAT;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.REPLACE;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ROUND;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ROWTIME;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.RPAD;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.RTRIM;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.SHA1;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.SHA2;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.SHA224;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.SHA256;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.SHA384;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.SHA512;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.SIGN;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.SIMILAR;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.SIN;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.SINH;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.SQRT;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.STDDEV_POP;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.STDDEV_SAMP;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.SUBSTRING;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.SUM;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.SUM0;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.TAN;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.TANH;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.TIMES;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.TO_BASE64;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.TRIM;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.TRUNCATE;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.TRY_CAST;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.UPPER;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.VAR_POP;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.VAR_SAMP;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.WINDOW_END;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.WINDOW_START;
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.*;
 import static org.apache.flink.table.types.utils.TypeConversions.fromLegacyInfoToDataType;
 
 /**
@@ -1245,6 +1136,13 @@ public abstract class BaseExpressions<InType, OutType> {
     /** Creates an interval of the given number of milliseconds. */
     public OutType millis() {
         return milli();
+    }
+
+    /** Parses a timestamp string in the form "yyyy-MM-dd HH:mm:ss[.SSS]" to a SQL Timestamp. */
+    public OutType dateAdd(InType numberOfDays) {
+        return toApiSpecificExpression(
+                unresolvedCall(
+                        DATE_ADD, objectToExpression(toExpr()), objectToExpression(numberOfDays)));
     }
 
     // Hash functions

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -1287,11 +1287,20 @@ public final class BuiltInFunctionDefinitions {
                     .kind(SCALAR)
                     .outputTypeStrategy(TypeStrategies.MISSING)
                     .build();
+
     public static final BuiltInFunctionDefinition TO_TIMESTAMP_LTZ =
             BuiltInFunctionDefinition.newBuilder()
                     .name("toTimestampLtz")
                     .kind(SCALAR)
                     .outputTypeStrategy(TypeStrategies.MISSING)
+                    .build();
+
+    public static final BuiltInFunctionDefinition DATE_ADD =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("DATE_ADD")
+                    .runtimeClass("org.apache.flink.table.runtime.functions.scalar.DateAddFunction")
+                    .kind(SCALAR)
+                    .outputTypeStrategy(explicit(DataTypes.STRING().nullable()))
                     .build();
 
     // --------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
@@ -21,7 +21,6 @@ package org.apache.flink.table.planner.expressions
 import org.apache.flink.table.api._
 import org.apache.flink.table.expressions.{Expression, TimeIntervalUnit, TimePointUnit}
 import org.apache.flink.table.planner.expressions.utils.ScalarTypesTestBase
-
 import org.junit.Test
 
 class ScalarFunctionsTest extends ScalarTypesTestBase {
@@ -2497,6 +2496,41 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
   @Test
   def testToDate(): Unit = {
     testSqlApi("to_date('2017-09-15 00:00:00')", "2017-09-15")
+  }
+
+  @Test
+  def testDateAdd(): Unit = {
+    testSqlApi("DATE_ADD('2022-04-01 00:00:00', 1)", "2022-04-02")
+
+    testAllApis(
+      "2022-04-01".dateAdd(1),
+      s"DATE_ADD('2022-04-01', 1)",
+      "2022-04-02")
+
+    testAllApis(
+      "2022-03-31".dateAdd(1),
+      s"DATE_ADD('2022-03-31', 1)",
+      "2022-04-01")
+
+    testAllApis(
+      "2022-03-31".dateAdd(0),
+      s"DATE_ADD('2022-03-31', 0)",
+      "2022-03-31")
+
+    testAllApis(
+      "2022-04-01".dateAdd(-1),
+      s"DATE_ADD('2022-04-01', -1)",
+      "2022-03-31")
+
+    testAllApis(
+      "2022-04-01 23:59:59".dateAdd( 1),
+      s"DATE_ADD('2022-04-01 23:59:59', 1)",
+      "2022-04-02")
+
+    testAllApis(
+      "2022-04-01 23:59:59".dateAdd(-1),
+      s"DATE_ADD('2022-04-01 23:59:59', -1)",
+      "2022-03-31")
   }
 
   // ----------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/DateAddFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/DateAddFunction.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.table.runtime.functions.scalar;
 
 import org.apache.flink.table.data.StringData;
@@ -11,6 +29,7 @@ import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 
+/** Implementation of {@link BuiltInFunctionDefinitions#DATE_ADD}. */
 public class DateAddFunction extends BuiltInScalarFunction {
 
     /** The SimpleDateFormat string for ISO dates, "yyyy-MM-dd". */

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/DateAddFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/DateAddFunction.java
@@ -46,8 +46,7 @@ public class DateAddFunction extends BuiltInScalarFunction {
         super(BuiltInFunctionDefinitions.DATE_ADD, context);
     }
 
-    public @Nullable
-    StringData eval(StringData startDate, int numberOfDays) {
+    public @Nullable StringData eval(StringData startDate, int numberOfDays) {
         final String dateStr = startDate.toString();
         long startMillSecond;
         try {

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/DateAddFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/DateAddFunction.java
@@ -70,5 +70,4 @@ public class DateAddFunction extends BuiltInScalarFunction {
                 .format(new Date(calendar.getTimeInMillis())));
     }
 
-
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/DateAddFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/DateAddFunction.java
@@ -1,0 +1,56 @@
+package org.apache.flink.table.runtime.functions.scalar;
+
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.SpecializedFunction;
+
+import javax.annotation.Nullable;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+
+public class DateAddFunction extends BuiltInScalarFunction {
+
+    /** The SimpleDateFormat string for ISO dates, "yyyy-MM-dd". */
+    private static final String DATE_FORMAT_STRING = "yyyy-MM-dd";
+
+    /** The SimpleDateFormat string for ISO times, "HH:mm:ss". */
+    private static final String TIME_FORMAT_STRING = "HH:mm:ss";
+
+    /** The SimpleDateFormat string for ISO timestamps, "yyyy-MM-dd HH:mm:ss". */
+    private static final String TIMESTAMP_FORMAT_STRING =
+            DATE_FORMAT_STRING + " " + TIME_FORMAT_STRING;
+
+    public DateAddFunction(SpecializedFunction.SpecializedContext context) {
+        super(BuiltInFunctionDefinitions.DATE_ADD, context);
+    }
+
+    public @Nullable
+    StringData eval(StringData startDate, int numberOfDays) {
+        final String dateStr = startDate.toString();
+        long startMillSecond;
+        try {
+            startMillSecond = new SimpleDateFormat(DATE_FORMAT_STRING).parse(dateStr).getTime();
+        } catch (ParseException e) {
+            try {
+                startMillSecond =
+                        new SimpleDateFormat(TIMESTAMP_FORMAT_STRING).parse(dateStr).getTime();
+            } catch (ParseException parseException) {
+                throw new IllegalArgumentException(
+                        String.format(
+                                "Unsupported datetime format '%s', "
+                                        + "please use '%s' or '%s' instead.",
+                                dateStr, DATE_FORMAT_STRING, TIMESTAMP_FORMAT_STRING));
+            }
+        }
+        final Calendar calendar = Calendar.getInstance();
+        calendar.setTimeInMillis(startMillSecond);
+        calendar.add(Calendar.DAY_OF_MONTH, numberOfDays);
+        return StringData.fromString(new SimpleDateFormat(DATE_FORMAT_STRING)
+                .format(new Date(calendar.getTimeInMillis())));
+    }
+
+
+}


### PR DESCRIPTION
## What is the purpose of the change

Make SQL function `DATE_ADD` supported in SQL & Table API.

## Brief change log

Make SQL function `DATE_ADD` supported in SQL & Table API.

## Verifying this change

This change added tests and can be verified in `TemporalTypesTest#testValidDateAdd`.
**_(More tests and docs descriprions will be added soon ...)_**

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
