### PR TITLE
[FLINK-26986][python] Remove deprecated string expressions in Python Table API

### DIFF
--- a/docs/content.zh/docs/dev/python/table/python_table_api_connectors.md
+++ b/docs/content.zh/docs/dev/python/table/python_table_api_connectors.md
@@ -139,7 +139,7 @@ import numpy as np
 
 # 创建一个 PyFlink 表
 pdf = pd.DataFrame(np.random.rand(1000, 2))
-table = t_env.from_pandas(pdf, ["a", "b"]).filter("a > 0.5")
+table = t_env.from_pandas(pdf, ["a", "b"]).filter(col('a') > 0.5)
 
 # 将 PyFlink 表转换成 Pandas DataFrame
 pdf = table.to_pandas()

--- a/docs/content.zh/docs/dev/python/table/udfs/python_udfs.md
+++ b/docs/content.zh/docs/dev/python/table/udfs/python_udfs.md
@@ -128,7 +128,7 @@ add = udf(functools.partial(partial_add, k=1), result_type=DataTypes.BIGINT())
 # 注册 Python 自定义函数
 table_env.create_temporary_function("add", add)
 # 在 Python Table API 中使用 Python 自定义函数
-my_table.select("add(a, b)")
+my_table.select(call('add', my_table.a, my_table.b))
 
 # 也可以在 Python Table API 中直接使用 Python 自定义函数
 my_table.select(add(my_table.a, my_table.b))
@@ -156,8 +156,8 @@ my_table = ...  # type: Table, table schema: [a: String]
 split = udtf(Split(), result_types=[DataTypes.STRING(), DataTypes.INT()])
 
 # 在 Python Table API 中使用 Python 表值函数
-my_table.join_lateral(split(my_table.a).alias("word, length"))
-my_table.left_outer_join_lateral(split(my_table.a).alias("word, length"))
+my_table.join_lateral(split(my_table.a).alias("word", "length"))
+my_table.left_outer_join_lateral(split(my_table.a).alias("word", "length"))
 
 # 在 SQL API 中使用 Python 表值函数
 table_env.create_temporary_function("split", udtf(Split(), result_types=[DataTypes.STRING(), DataTypes.INT()]))
@@ -194,8 +194,8 @@ my_table = ...  # type: Table, table schema: [a: String]
 table_env.create_java_temporary_function("split", "my.java.function.Split")
 
 # 在 Python Table API 中使用表值函数。 "alias"指定表的字段名称。
-my_table.join_lateral(call('split', my_table.a).alias("word, length")).select(my_table.a, col('word'), col('length'))
-my_table.left_outer_join_lateral(call('split', my_table.a).alias("word, length")).select(my_table.a, col('word'), col('length'))
+my_table.join_lateral(call('split', my_table.a).alias("word", "length")).select(my_table.a, col('word'), col('length'))
+my_table.left_outer_join_lateral(call('split', my_table.a).alias("word", "length")).select(my_table.a, col('word'), col('length'))
 
 # 注册 Python 函数。
 
@@ -337,7 +337,7 @@ tumble_window = Tumble.over(lit(1).hours) \
 
 result = t.window(tumble_window) \
         .group_by(col('w'), col('name')) \
-        .select("w.start, w.end, weighted_avg(value, count)") \
+        .select(col('w').start, col('w').end, weighted_avg(col('value'), col('count'))) \
         .to_pandas()
 print(result)
 

--- a/docs/content.zh/docs/dev/python/table/udfs/vectorized_python_udfs.md
+++ b/docs/content.zh/docs/dev/python/table/udfs/vectorized_python_udfs.md
@@ -101,8 +101,7 @@ tumble_window = Tumble.over(expr.lit(1).hours) \
 
 my_table.window(tumble_window) \
     .group_by("w") \
-    .select("w.start, w.end, mean_udaf(b)")
-
+    .select(col('w').start, col('w').end, mean_udaf(col('b')))
 
 # 在 Over Window Aggregation 中使用向量化聚合函数
 table_env.create_temporary_function("mean_udaf", mean_udaf)

--- a/docs/content.zh/docs/dev/table/catalogs.md
+++ b/docs/content.zh/docs/dev/table/catalogs.md
@@ -241,7 +241,7 @@ schema = Schema.new_builder() \
     
 catalog_table = t_env.create_table("myhive.mydb.mytable", TableDescriptor.for_connector("kafka")
     .schema(schema)
-    // …
+    # …
     .build())
 
 # tables should contain "mytable"

--- a/docs/content.zh/docs/dev/table/tableApi.md
+++ b/docs/content.zh/docs/dev/table/tableApi.md
@@ -417,7 +417,7 @@ val orders: Table = tableEnv.from("Orders").as("x", "y", "z", "t")
 {{< tab "Python" >}}
 ```python
 orders = t_env.from_path("Orders")
-result = orders.alias("x, y, z, t")
+result = orders.alias("x", "y", "z", "t")
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -1054,7 +1054,7 @@ def split(x):
 
 # join
 orders = t_env.from_path("Orders")
-joined_table = orders.join_lateral(split(orders.c).alias("s, t, v"))
+joined_table = orders.join_lateral(split(orders.c).alias("s", "t", "v"))
 result = joined_table.select(joined_table.a, joined_table.b, joined_table.s, joined_table.t, joined_table.v)
 ```
 {{< /tab >}}
@@ -1103,7 +1103,7 @@ def split(x):
 
 # join
 orders = t_env.from_path("Orders")
-joined_table = orders.left_outer_join_lateral(split(orders.c).alias("s, t, v"))
+joined_table = orders.left_outer_join_lateral(split(orders.c).alias("s", "t", "v"))
 result = joined_table.select(joined_table.a, joined_table.b, joined_table.s, joined_table.t, joined_table.v)
 ```
 {{< /tab >}}
@@ -2453,7 +2453,7 @@ agg = udaf(function,
 # 使用 python 通用聚合函数进行聚合
 result = t.group_by(t.a) \
     .aggregate(agg.alias("c", "d")) \
-    .select("a, c, d")
+    .select(col('a'), col('c'), col('d'))
     
 # 使用 python 向量化聚合函数进行聚合
 pandas_udaf = udaf(lambda pd: (pd.b.mean(), pd.b.max()),
@@ -2462,8 +2462,7 @@ pandas_udaf = udaf(lambda pd: (pd.b.mean(), pd.b.max()),
                         DataTypes.FIELD("b", DataTypes.INT())]),
                    func_type="pandas")
 t.aggregate(pandas_udaf.alias("a", "b")) \
-    .select("a, b")
-
+    .select(col('a'), col('b'))
 ```
 
 {{< /tab >}}
@@ -2515,9 +2514,9 @@ tumble_window = Tumble.over(expr.lit(1).hours) \
     .alias("w")
 t.select(t.b, t.rowtime) \
     .window(tumble_window) \
-    .group_by("w") \
+    .group_by(col("w")) \
     .aggregate(pandas_udaf.alias("d", "e")) \
-    .select("w.rowtime, d, e")
+    .select(col('w').rowtime, col('d'), col('e'))
 ```
 {{< /tab >}}
 {{< /tabs >}}

--- a/docs/content/docs/dev/python/table/python_table_api_connectors.md
+++ b/docs/content/docs/dev/python/table/python_table_api_connectors.md
@@ -143,7 +143,7 @@ import numpy as np
 
 # Create a PyFlink Table
 pdf = pd.DataFrame(np.random.rand(1000, 2))
-table = t_env.from_pandas(pdf, ["a", "b"]).filter("a > 0.5")
+table = t_env.from_pandas(pdf, ["a", "b"]).filter(col('a') > 0.5)
 
 # Convert the PyFlink Table to a Pandas DataFrame
 pdf = table.to_pandas()

--- a/docs/content/docs/dev/python/table/udfs/python_udfs.md
+++ b/docs/content/docs/dev/python/table/udfs/python_udfs.md
@@ -129,7 +129,7 @@ add = udf(functools.partial(partial_add, k=1), result_type=DataTypes.BIGINT())
 # register the Python function
 table_env.create_temporary_function("add", add)
 # use the function in Python Table API
-my_table.select("add(a, b)")
+my_table.select(call('add', my_table.a, my_table.b))
 
 # You can also use the Python function in Python Table API directly
 my_table.select(add(my_table.a, my_table.b))
@@ -158,8 +158,8 @@ my_table = ...  # type: Table, table schema: [a: String]
 split = udtf(Split(), result_types=[DataTypes.STRING(), DataTypes.INT()])
 
 # use the Python Table Function in Python Table API
-my_table.join_lateral(split(my_table.a).alias("word, length"))
-my_table.left_outer_join_lateral(split(my_table.a).alias("word, length"))
+my_table.join_lateral(split(my_table.a).alias("word", "length"))
+my_table.left_outer_join_lateral(split(my_table.a).alias("word", "length"))
 
 # use the Python Table function in SQL API
 table_env.create_temporary_function("split", udtf(Split(), result_types=[DataTypes.STRING(), DataTypes.INT()]))
@@ -196,8 +196,8 @@ my_table = ...  # type: Table, table schema: [a: String]
 table_env.create_java_temporary_function("split", "my.java.function.Split")
 
 # Use the table function in the Python Table API. "alias" specifies the field names of the table.
-my_table.join_lateral(call('split', my_table.a).alias("word, length")).select(my_table.a, col('word'), col('length'))
-my_table.left_outer_join_lateral(call('split', my_table.a).alias("word, length")).select(my_table.a, col('word'), col('length'))
+my_table.join_lateral(call('split', my_table.a).alias("word", "length")).select(my_table.a, col('word'), col('length'))
+my_table.left_outer_join_lateral(call('split', my_table.a).alias("word", "length")).select(my_table.a, col('word'), col('length'))
 
 # Register the python function.
 
@@ -338,7 +338,7 @@ tumble_window = Tumble.over(lit(1).hours) \
 
 result = t.window(tumble_window) \
         .group_by(col('w'), col('name')) \
-        .select("w.start, w.end, weighted_avg(value, count)") \
+        .select(col('w').start, col('w').end, weighted_avg(col('value'), col('count'))) \
         .to_pandas()
 print(result)
 

--- a/docs/content/docs/dev/python/table/udfs/vectorized_python_udfs.md
+++ b/docs/content/docs/dev/python/table/udfs/vectorized_python_udfs.md
@@ -100,8 +100,7 @@ tumble_window = Tumble.over(expr.lit(1).hours) \
 
 my_table.window(tumble_window) \
     .group_by("w") \
-    .select("w.start, w.end, mean_udaf(b)")
-
+    .select(col('w').start, col('w').end, mean_udaf(col('b')))
 
 # use the vectorized Python aggregate function in Over Window Aggregation
 table_env.create_temporary_function("mean_udaf", mean_udaf)

--- a/docs/content/docs/dev/table/catalogs.md
+++ b/docs/content/docs/dev/table/catalogs.md
@@ -245,7 +245,7 @@ schema = Schema.new_builder() \
     
 catalog_table = t_env.create_table("myhive.mydb.mytable", TableDescriptor.for_connector("kafka")
     .schema(schema)
-    // …
+    # …
     .build())
 
 # tables should contain "mytable"

--- a/docs/content/docs/dev/table/tableApi.md
+++ b/docs/content/docs/dev/table/tableApi.md
@@ -418,7 +418,7 @@ val orders: Table = tableEnv.from("Orders").as("x", "y", "z", "t")
 {{< tab "Python" >}}
 ```python
 orders = t_env.from_path("Orders")
-result = orders.alias("x, y, z, t")
+result = orders.alias("x", "y", "z", "t")
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -1053,7 +1053,7 @@ def split(x):
 
 # join
 orders = t_env.from_path("Orders")
-joined_table = orders.join_lateral(split(orders.c).alias("s, t, v"))
+joined_table = orders.join_lateral(split(orders.c).alias("s", "t", "v"))
 result = joined_table.select(joined_table.a, joined_table.b, joined_table.s, joined_table.t, joined_table.v)
 ```
 {{< /tab >}}
@@ -1102,7 +1102,7 @@ def split(x):
 
 # join
 orders = t_env.from_path("Orders")
-joined_table = orders.left_outer_join_lateral(split(orders.c).alias("s, t, v"))
+joined_table = orders.left_outer_join_lateral(split(orders.c).alias("s", "t", "v"))
 result = joined_table.select(joined_table.a, joined_table.b, joined_table.s, joined_table.t, joined_table.v)
 ```
 {{< /tab >}}
@@ -2452,7 +2452,7 @@ agg = udaf(function,
 # aggregate with a python general aggregate function
 result = t.group_by(t.a) \
     .aggregate(agg.alias("c", "d")) \
-    .select("a, c, d")
+    select(col('a'), col('c'), col('d'))
     
 # aggregate with a python vectorized aggregate function
 pandas_udaf = udaf(lambda pd: (pd.b.mean(), pd.b.max()),
@@ -2461,8 +2461,7 @@ pandas_udaf = udaf(lambda pd: (pd.b.mean(), pd.b.max()),
                         DataTypes.FIELD("b", DataTypes.INT())]),
                    func_type="pandas")
 t.aggregate(pandas_udaf.alias("a", "b")) \
-    .select("a, b")
-
+    select(col('a'), col('b'))
 ```
 
 {{< /tab >}}
@@ -2515,9 +2514,9 @@ tumble_window = Tumble.over(expr.lit(1).hours) \
     .alias("w")
 t.select(t.b, t.rowtime) \
     .window(tumble_window) \
-    .group_by("w") \
+    .group_by(col("w")) \
     .aggregate(pandas_udaf.alias("d", "e")) \
-    .select("w.rowtime, d, e")
+    .select(col('w').rowtime, col('d'), col('e'))
 ```
 {{< /tab >}}
 {{< /tabs >}}

--- a/flink-python/pyflink/examples/table/pandas/pandas_udaf.py
+++ b/flink-python/pyflink/examples/table/pandas/pandas_udaf.py
@@ -55,7 +55,7 @@ def pandas_udaf():
               .column("f2", DataTypes.FLOAT())
               .watermark("ts", "ts - INTERVAL '3' SECOND")
               .build()
-    ).alias("ts, name, price")
+    ).alias("ts", "name", "price")
 
     # define the sink
     t_env.create_temporary_table(

--- a/flink-python/pyflink/examples/table/windowing/over_window.py
+++ b/flink-python/pyflink/examples/table/windowing/over_window.py
@@ -54,7 +54,7 @@ def tumble_window_demo():
               .column("f2", DataTypes.FLOAT())
               .watermark("ts", "ts - INTERVAL '3' SECOND")
               .build()
-    ).alias("ts, name, price")
+    ).alias("ts", "name", "price")
 
     # define the sink
     t_env.create_temporary_table(
@@ -68,8 +68,8 @@ def tumble_window_demo():
 
     # define the over window operation
     table = table.over_window(
-        Over.partition_by("name")
-            .order_by("ts")
+        Over.partition_by(col("name"))
+            .order_by(col("ts"))
             .preceding(row_interval(2))
             .following(CURRENT_ROW)
             .alias('w')) \

--- a/flink-python/pyflink/examples/table/windowing/session_window.py
+++ b/flink-python/pyflink/examples/table/windowing/session_window.py
@@ -52,7 +52,7 @@ def session_window_demo():
               .column("f2", DataTypes.FLOAT())
               .watermark("ts", "ts - INTERVAL '3' SECOND")
               .build()
-    ).alias("ts, name, price")
+    ).alias("ts", "name", "price")
 
     # define the sink
     t_env.create_temporary_table(

--- a/flink-python/pyflink/examples/table/windowing/sliding_window.py
+++ b/flink-python/pyflink/examples/table/windowing/sliding_window.py
@@ -54,7 +54,7 @@ def sliding_window_demo():
               .column("f2", DataTypes.FLOAT())
               .watermark("ts", "ts - INTERVAL '3' SECOND")
               .build()
-    ).alias("ts, name, price")
+    ).alias("ts", "name", "price")
 
     # define the sink
     t_env.create_temporary_table(

--- a/flink-python/pyflink/examples/table/windowing/tumble_window.py
+++ b/flink-python/pyflink/examples/table/windowing/tumble_window.py
@@ -54,7 +54,7 @@ def tumble_window_demo():
               .column("f2", DataTypes.FLOAT())
               .watermark("ts", "ts - INTERVAL '3' SECOND")
               .build()
-    ).alias("ts, name, price")
+    ).alias("ts", "name", "price")
 
     # define the sink
     t_env.create_temporary_table(

--- a/flink-python/pyflink/table/schema.py
+++ b/flink-python/pyflink/table/schema.py
@@ -122,7 +122,7 @@ class Schema(object):
 
         def column_by_expression(self,
                                  column_name: str,
-                                 expr: Expression) -> 'Schema.Builder':
+                                 expr: Union[str, Expression]) -> 'Schema.Builder':
             """
             Declares a computed column that is appended to this schema.
 
@@ -194,7 +194,7 @@ class Schema(object):
 
         def watermark(self,
                       column_name: str,
-                      watermark_expr: Expression) -> 'Schema.Builder':
+                      watermark_expr: Union[str, Expression]) -> 'Schema.Builder':
             """
             Declares that the given column should serve as an event-time (i.e. rowtime) attribute
             and specifies a corresponding watermark strategy as an expression.

--- a/flink-python/pyflink/table/window.py
+++ b/flink-python/pyflink/table/window.py
@@ -143,9 +143,6 @@ class Session(object):
         >>> Session.with_gap(expr.lit(10).minutes)
         ...        .on(expr.col("rowtime"))
         ...        .alias("w")
-
-        >>> Session.with_gap("10.minutes").on("rowtime").alias("w")
-
     """
 
     @classmethod
@@ -229,8 +226,6 @@ class Slide(object):
         ...      .every(expr.lit(5).minutes)
         ...      .on(expr.col("rowtime"))
         ...      .alias("w")
-
-        >>> Slide.over("10.minutes").every("5.minutes").on("rowtime").alias("w")
     """
 
     @classmethod
@@ -337,8 +332,6 @@ class Over(object):
         ...     .order_by(col("rowtime")) \\
         ...     .preceding(expr.UNBOUNDED_RANGE) \\
         ...     .alias("w")
-
-        >>> Over.partition_by("a").order_by("rowtime").preceding("unbounded_range").alias("w")
     """
 
     @classmethod


### PR DESCRIPTION

## What is the purpose of the change

*In [FLINK-26704](https://issues.apache.org/jira/browse/FLINK-26704), it has removed the string expressions in Table API. However, there are still some APIs still using string expressions in Python Table API, however, they should not work any more as the string expressions have already been removed in the Java Table API.*


## Verifying this change

This change is code cleanup work without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
