### PR TITLE
[FLINK-26987][runtime] Fixes getAllAndLock livelock

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/zookeeper/ZooKeeperStateHandleStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/zookeeper/ZooKeeperStateHandleStore.java
@@ -391,7 +391,6 @@ public class ZooKeeperStateHandleStore<T extends Serializable>
         final String rootPath = "/";
         boolean success = false;
 
-        retry:
         while (!success) {
             stateHandles.clear();
 
@@ -411,8 +410,13 @@ public class ZooKeeperStateHandleStore<T extends Serializable>
                         final RetrievableStateHandle<T> stateHandle = getAndLock(path);
                         stateHandles.add(new Tuple2<>(stateHandle, path));
                     } catch (NotExistException ignored) {
-                        // Concurrent deletion, retry
-                        continue retry;
+                        // The node is subject for deletion which can mean two things:
+                        // 1. The state is marked for deletion: The cVersion of the node does not
+                        // necessarily change. We're not interested in the state anymore, anyway.
+                        // Therefore, this error can be ignored.
+                        // 2. An actual concurrent deletion is going on. The child node is gone.
+                        // That would affect the cVersion of the parent node and, as a consequence,
+                        // would trigger a restart the logic through the while loop.
                     } catch (IOException ioException) {
                         LOG.warn(
                                 "Could not get all ZooKeeper children. Node {} contained "


### PR DESCRIPTION
## What is the purpose of the change

This livelock can happen in situations where an entry was marked
for deletion but is not deleted, yet. There's actually no reason to retry 
in case of a concurrent deletion. See FLINK-26987's description for 
further analysis

## Brief change log

* Removes the goto statement

## Verifying this change

* Adds a test to cover that case (this test would run into an infinite loop with the old implementation)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
