### PR TITLE
[FLINK-14998] [FileSystems] Remove FileUtils#deletePathIfEmpty

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/FileUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/FileUtils.java
@@ -429,45 +429,6 @@ public final class FileUtils {
         }
     }
 
-    // ------------------------------------------------------------------------
-    //  Deleting directories on Flink FileSystem abstraction
-    // ------------------------------------------------------------------------
-
-    /**
-     * Deletes the path if it is empty. A path can only be empty if it is a directory which does not
-     * contain any other directories/files.
-     *
-     * @param fileSystem to use
-     * @param path to be deleted if empty
-     * @return true if the path could be deleted; otherwise false
-     * @throws IOException if the delete operation fails
-     */
-    public static boolean deletePathIfEmpty(FileSystem fileSystem, Path path) throws IOException {
-        final FileStatus[] fileStatuses;
-
-        try {
-            fileStatuses = fileSystem.listStatus(path);
-        } catch (FileNotFoundException e) {
-            // path already deleted
-            return true;
-        } catch (Exception e) {
-            // could not access directory, cannot delete
-            return false;
-        }
-
-        // if there are no more files or if we couldn't list the file status try to delete the path
-        if (fileStatuses == null) {
-            // another indicator of "file not found"
-            return true;
-        } else if (fileStatuses.length == 0) {
-            // attempt to delete the path (will fail and be ignored if the path now contains
-            // some files (possibly added concurrently))
-            return fileSystem.delete(path, false);
-        } else {
-            return false;
-        }
-    }
-
     /**
      * Copies all files from source to target and sets executable flag. Paths might be on different
      * systems.

--- a/flink-core/src/test/java/org/apache/flink/core/fs/local/LocalFileSystemTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/fs/local/LocalFileSystemTest.java
@@ -174,45 +174,6 @@ public class LocalFileSystemTest extends TestLogger {
         assertTrue(!tempdir.exists());
     }
 
-    /**
-     * Test that {@link FileUtils#deletePathIfEmpty(FileSystem, Path)} deletes the path if it is
-     * empty. A path can only be empty if it is a directory which does not contain any
-     * files/directories.
-     */
-    @Test
-    public void testDeletePathIfEmpty() throws IOException {
-        File file = temporaryFolder.newFile();
-        File directory = temporaryFolder.newFolder();
-        File directoryFile = new File(directory, UUID.randomUUID().toString());
-
-        assertTrue(directoryFile.createNewFile());
-
-        Path filePath = new Path(file.toURI());
-        Path directoryPath = new Path(directory.toURI());
-        Path directoryFilePath = new Path(directoryFile.toURI());
-
-        FileSystem fs = FileSystem.getLocalFileSystem();
-
-        // verify that the files have been created
-        assertTrue(fs.exists(filePath));
-        assertTrue(fs.exists(directoryFilePath));
-
-        // delete the single file
-        assertFalse(FileUtils.deletePathIfEmpty(fs, filePath));
-        assertTrue(fs.exists(filePath));
-
-        // try to delete the non-empty directory
-        assertFalse(FileUtils.deletePathIfEmpty(fs, directoryPath));
-        assertTrue(fs.exists(directoryPath));
-
-        // delete the file contained in the directory
-        assertTrue(fs.delete(directoryFilePath, false));
-
-        // now the deletion should work
-        assertTrue(FileUtils.deletePathIfEmpty(fs, directoryPath));
-        assertFalse(fs.exists(directoryPath));
-    }
-
     @Test
     public void testRenamePath() throws IOException {
         final File rootDirectory = temporaryFolder.newFolder();

--- a/flink-core/src/test/java/org/apache/flink/core/fs/local/LocalFileSystemTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/fs/local/LocalFileSystemTest.java
@@ -26,7 +26,6 @@ import org.apache.flink.core.fs.FileSystem.WriteMode;
 import org.apache.flink.core.fs.FileSystemKind;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.util.ExecutorUtils;
-import org.apache.flink.util.FileUtils;
 import org.apache.flink.util.TestLogger;
 
 import org.apache.commons.lang3.RandomStringUtils;

--- a/flink-core/src/test/java/org/apache/flink/util/FileUtilsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/FileUtilsTest.java
@@ -111,28 +111,6 @@ public class FileUtilsTest extends TestLogger {
     }
 
     @Test
-    public void testDeletePathIfEmpty() throws IOException {
-        final FileSystem localFs = FileSystem.getLocalFileSystem();
-
-        final File dir = tmp.newFolder();
-        assertTrue(dir.exists());
-
-        final Path dirPath = new Path(dir.toURI());
-
-        // deleting an empty directory should work
-        assertTrue(FileUtils.deletePathIfEmpty(localFs, dirPath));
-
-        // deleting a non existing directory should work
-        assertTrue(FileUtils.deletePathIfEmpty(localFs, dirPath));
-
-        // create a non-empty dir
-        final File nonEmptyDir = tmp.newFolder();
-        final Path nonEmptyDirPath = new Path(nonEmptyDir.toURI());
-        new FileOutputStream(new File(nonEmptyDir, "filename")).close();
-        assertFalse(FileUtils.deletePathIfEmpty(localFs, nonEmptyDirPath));
-    }
-
-    @Test
     public void testDeleteQuietly() throws Exception {
         // should ignore the call
         FileUtils.deleteDirectoryQuietly(null);

--- a/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/HDFSTest.java
+++ b/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/HDFSTest.java
@@ -203,51 +203,6 @@ public class HDFSTest {
     }
 
     /**
-     * Test that {@link FileUtils#deletePathIfEmpty(FileSystem, Path)} deletes the path if it is
-     * empty. A path can only be empty if it is a directory which does not contain any
-     * files/directories.
-     */
-    @Test
-    public void testDeletePathIfEmpty() throws IOException {
-        final Path basePath = new Path(hdfsURI);
-        final Path directory = new Path(basePath, UUID.randomUUID().toString());
-        final Path directoryFile = new Path(directory, UUID.randomUUID().toString());
-        final Path singleFile = new Path(basePath, UUID.randomUUID().toString());
-
-        FileSystem fs = basePath.getFileSystem();
-
-        fs.mkdirs(directory);
-
-        byte[] data = "HDFSTest#testDeletePathIfEmpty".getBytes(ConfigConstants.DEFAULT_CHARSET);
-
-        for (Path file : Arrays.asList(singleFile, directoryFile)) {
-            org.apache.flink.core.fs.FSDataOutputStream outputStream =
-                    fs.create(file, FileSystem.WriteMode.OVERWRITE);
-            outputStream.write(data);
-            outputStream.close();
-        }
-
-        // verify that the files have been created
-        assertTrue(fs.exists(singleFile));
-        assertTrue(fs.exists(directoryFile));
-
-        // delete the single file
-        assertFalse(FileUtils.deletePathIfEmpty(fs, singleFile));
-        assertTrue(fs.exists(singleFile));
-
-        // try to delete the non-empty directory
-        assertFalse(FileUtils.deletePathIfEmpty(fs, directory));
-        assertTrue(fs.exists(directory));
-
-        // delete the file contained in the directory
-        assertTrue(fs.delete(directoryFile, false));
-
-        // now the deletion should work
-        assertTrue(FileUtils.deletePathIfEmpty(fs, directory));
-        assertFalse(fs.exists(directory));
-    }
-
-    /**
      * Tests that with {@link HighAvailabilityMode#ZOOKEEPER} distributed JARs are recoverable from
      * any participating BlobServer when talking to the {@link
      * org.apache.flink.runtime.blob.BlobServer} directly.

--- a/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/HDFSTest.java
+++ b/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/HDFSTest.java
@@ -38,7 +38,6 @@ import org.apache.flink.runtime.blob.BlobStoreService;
 import org.apache.flink.runtime.blob.BlobUtils;
 import org.apache.flink.runtime.fs.hdfs.HadoopFileSystem;
 import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
-import org.apache.flink.util.FileUtils;
 import org.apache.flink.util.OperatingSystem;
 
 import org.apache.commons.io.IOUtils;

--- a/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/HDFSTest.java
+++ b/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/HDFSTest.java
@@ -58,6 +58,7 @@ import org.junit.rules.TemporaryFolder;
 import java.io.File;
 import java.io.IOException;
 import java.io.StringWriter;
+
 import static org.junit.Assert.assertTrue;
 
 /**

--- a/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/HDFSTest.java
+++ b/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/HDFSTest.java
@@ -58,10 +58,6 @@ import org.junit.rules.TemporaryFolder;
 import java.io.File;
 import java.io.IOException;
 import java.io.StringWriter;
-import java.util.Arrays;
-import java.util.UUID;
-
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /**


### PR DESCRIPTION
## What is the purpose of the change
This pull request is remove useless in Flink production code.


## Brief change log
Remove FileUtils#deletePathIfEmpty and unit test

## Verifying this change

This change is a  code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
