### PR TITLE
[FLINK-26998] Remove log-related configuration from predefined options in RocksDB state backend

### DIFF
--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/PredefinedOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/PredefinedOptions.java
@@ -53,11 +53,7 @@ public enum PredefinedOptions {
      * <p>Note: Because Flink does not rely on RocksDB data on disk for recovery, there is no need
      * to sync data to stable storage.
      *
-     * <p>The following options are set:
-     *
-     * <ul>
-     *   <li>setInfoLogLevel(InfoLogLevel.HEADER_LEVEL)
-     * </ul>
+     * <p>There are no specified options here.
      */
     DEFAULT(Collections.emptyMap()),
 
@@ -75,7 +71,6 @@ public enum PredefinedOptions {
      *   <li>setMaxBackgroundJobs(4)
      *   <li>setDisableDataSync(true)
      *   <li>setMaxOpenFiles(-1)
-     *   <li>setInfoLogLevel(InfoLogLevel.HEADER_LEVEL)
      * </ul>
      *
      * <p>Note: Because Flink does not rely on RocksDB data on disk for recovery, there is no need
@@ -112,7 +107,6 @@ public enum PredefinedOptions {
      *   <li>setMinWriteBufferNumberToMerge(3)
      *   <li>setMaxWriteBufferNumber(4)
      *   <li>setMaxOpenFiles(-1)
-     *   <li>setInfoLogLevel(InfoLogLevel.HEADER_LEVEL)
      *   <li>BlockBasedTableConfig.setBlockCacheSize(256 MBytes)
      *   <li>BlockBasedTableConfig.setBlockSize(128 KBytes)
      * </ul>
@@ -154,7 +148,6 @@ public enum PredefinedOptions {
      *   <li>setMaxBackgroundJobs(4)
      *   <li>setDisableDataSync(true)
      *   <li>setMaxOpenFiles(-1)
-     *   <li>setInfoLogLevel(InfoLogLevel.HEADER_LEVEL)
      * </ul>
      *
      * <p>Note: Because Flink does not rely on RocksDB data on disk for recovery, there is no need

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/PredefinedOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/PredefinedOptions.java
@@ -22,7 +22,6 @@ import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.MemorySize;
 
 import org.rocksdb.CompactionStyle;
-import org.rocksdb.InfoLogLevel;
 
 import javax.annotation.Nullable;
 
@@ -60,9 +59,7 @@ public enum PredefinedOptions {
      *   <li>setInfoLogLevel(InfoLogLevel.HEADER_LEVEL)
      * </ul>
      */
-    DEFAULT(
-            Collections.singletonMap(
-                    RocksDBConfigurableOptions.LOG_LEVEL, InfoLogLevel.HEADER_LEVEL)),
+    DEFAULT(Collections.emptyMap()),
 
     /**
      * Pre-defined options for regular spinning hard disks.
@@ -91,7 +88,6 @@ public enum PredefinedOptions {
                 {
                     put(RocksDBConfigurableOptions.MAX_BACKGROUND_THREADS, 4);
                     put(RocksDBConfigurableOptions.MAX_OPEN_FILES, -1);
-                    put(RocksDBConfigurableOptions.LOG_LEVEL, InfoLogLevel.HEADER_LEVEL);
                     put(RocksDBConfigurableOptions.COMPACTION_STYLE, CompactionStyle.LEVEL);
                     put(RocksDBConfigurableOptions.USE_DYNAMIC_LEVEL_SIZE, true);
                 }
@@ -131,7 +127,6 @@ public enum PredefinedOptions {
                 {
                     put(RocksDBConfigurableOptions.MAX_BACKGROUND_THREADS, 4);
                     put(RocksDBConfigurableOptions.MAX_OPEN_FILES, -1);
-                    put(RocksDBConfigurableOptions.LOG_LEVEL, InfoLogLevel.HEADER_LEVEL);
                     put(RocksDBConfigurableOptions.COMPACTION_STYLE, CompactionStyle.LEVEL);
                     put(RocksDBConfigurableOptions.USE_DYNAMIC_LEVEL_SIZE, true);
                     put(
@@ -172,7 +167,6 @@ public enum PredefinedOptions {
                 {
                     put(RocksDBConfigurableOptions.MAX_BACKGROUND_THREADS, 4);
                     put(RocksDBConfigurableOptions.MAX_OPEN_FILES, -1);
-                    put(RocksDBConfigurableOptions.LOG_LEVEL, InfoLogLevel.HEADER_LEVEL);
                 }
             });
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
@@ -102,6 +102,9 @@ public class RocksDBStateBackendConfigTest {
         // set the environment variable 'log.file' with the Flink log file location
         System.setProperty("log.file", logFile.getPath());
         try (RocksDBResourceContainer container = backend.createOptionsAndResourceContainer()) {
+            assertEquals(
+                    RocksDBConfigurableOptions.LOG_LEVEL.defaultValue(),
+                    container.getDbOptions().infoLogLevel());
             assertEquals(logFile.getParent(), container.getDbOptions().dbLogDir());
         } finally {
             logFile.delete();


### PR DESCRIPTION
## What is the purpose of the change

After FLINK-23791, the RocksDB log should be enabled by default. However, the log-related configuration remains in ```PredefinedOptions```, which will override the default value provided in ```RocksDBConfigurableOptions```.
We could remove the related values in ```PredefinedOptions``` and let ```RocksDBConfigurableOptions``` take control of the default value.

## Brief change log

  -  Remove the log related values in ```org/apache/flink/contrib/streaming/state/PredefinedOptions.java```

## Verifying this change

This change modified test RocksDBStateBackendConfigTest.testDefaultDbLogDir

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no
 
## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
