### PR TITLE
[FLINK-27014][hive] Fix exception when select null literal in subquery for Hive dialect

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveParserRexNodeConverter.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveParserRexNodeConverter.java
@@ -449,7 +449,8 @@ public class HiveParserRexNodeConverter {
             case VOID:
                 calciteLiteral =
                         cluster.getRexBuilder()
-                                .makeLiteral(null, dtFactory.createSqlType(SqlTypeName.NULL), true);
+                                .makeLiteral(
+                                        null, dtFactory.createSqlType(SqlTypeName.VARCHAR), true);
                 break;
             case BINARY:
             case UNKNOWN:

--- a/flink-connectors/flink-connector-hive/src/test/resources/query-test/misc.q
+++ b/flink-connectors/flink-connector-hive/src/test/resources/query-test/misc.q
@@ -39,3 +39,7 @@ select coalesce('abc',1);
 select default.hiveudf(y) from foo;
 
 [+I[1], +I[2], +I[3], +I[4], +I[5]]
+
+select count(key) from (select null as key from src)src;
+
+[+I[0]]


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
To fix  the exception when select null literal in subquery for Hive dialect


## Brief change log
- Consider Hive's void type as a null varchar type instead of null type in [HiveParserRexNodeConverter#convertConstant](https://github.com/apache/flink/pull/19336/files#diff-740d38be323cfeb26b80ef310d448328db55634f1dd9ecb68d7d74f35307df4aR420) just like what has been done in [HiveInspectors#getObjectInspectorForPrimitiveConstant](https://github.com/apache/flink/blob/2e5cac1f31aa571276df20e24889994672692a89/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/conversion/HiveInspectors.java#L553) for Flink dosen't support null type.

## Verifying this change
Add test query in [flink-connectors/flink-connector-hive/src/test/resources/query-test/misc.q](https://github.com/apache/flink/pull/19336/files#diff-0a3c613f393e32172699bed289f295a841a3e0a54e017f5964fa2a29642572a0)


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers:  no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector:  no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented?  NA
