### PR TITLE
[FLINK-26957][BP-1.15][runtime] Removes flush in FileSystemJobResultStore.createDirtyResultInternal 

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalDataOutputStream.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalDataOutputStream.java
@@ -51,6 +51,11 @@ public class LocalDataOutputStream extends FSDataOutputStream {
     }
 
     @Override
+    public void write(@Nonnull final byte[] b) throws IOException {
+        fos.write(b);
+    }
+
+    @Override
     public void write(final byte[] b, final int off, final int len) throws IOException {
         fos.write(b, off, len);
     }

--- a/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalDataOutputStream.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalDataOutputStream.java
@@ -21,9 +21,12 @@ package org.apache.flink.core.fs.local;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.core.fs.FSDataOutputStream;
 
+import javax.annotation.Nonnull;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.channels.ClosedChannelException;
 
 /**
  * The <code>LocalDataOutputStream</code> class is a wrapper class for a data output stream to the
@@ -34,6 +37,8 @@ public class LocalDataOutputStream extends FSDataOutputStream {
 
     /** The file output stream used to write data. */
     private final FileOutputStream fos;
+
+    private boolean closed = false;
 
     /**
      * Constructs a new <code>LocalDataOutputStream</code> object from a given {@link File} object.
@@ -47,36 +52,49 @@ public class LocalDataOutputStream extends FSDataOutputStream {
 
     @Override
     public void write(final int b) throws IOException {
+        checkOpen();
         fos.write(b);
     }
 
     @Override
     public void write(@Nonnull final byte[] b) throws IOException {
+        checkOpen();
         fos.write(b);
     }
 
     @Override
     public void write(final byte[] b, final int off, final int len) throws IOException {
+        checkOpen();
         fos.write(b, off, len);
     }
 
     @Override
     public void close() throws IOException {
+        closed = true;
         fos.close();
     }
 
     @Override
     public void flush() throws IOException {
+        checkOpen();
         fos.flush();
     }
 
     @Override
     public void sync() throws IOException {
+        checkOpen();
         fos.getFD().sync();
     }
 
     @Override
     public long getPos() throws IOException {
+        checkOpen();
         return fos.getChannel().position();
+    }
+
+    private void checkOpen() throws IOException {
+        if (closed) {
+            throw new ClosedChannelException();
+        }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/SnappyStreamCompressionDecorator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/SnappyStreamCompressionDecorator.java
@@ -20,7 +20,7 @@ package org.apache.flink.runtime.state;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.runtime.util.NonClosingInputStreamDecorator;
-import org.apache.flink.runtime.util.NonClosingOutpusStreamDecorator;
+import org.apache.flink.runtime.util.NonClosingOutputStreamDecorator;
 
 import org.xerial.snappy.SnappyFramedInputStream;
 import org.xerial.snappy.SnappyFramedOutputStream;
@@ -42,7 +42,7 @@ public class SnappyStreamCompressionDecorator extends StreamCompressionDecorator
     private static final double MIN_COMPRESSION_RATIO = 0.85d;
 
     @Override
-    protected OutputStream decorateWithCompression(NonClosingOutpusStreamDecorator stream)
+    protected OutputStream decorateWithCompression(NonClosingOutputStreamDecorator stream)
             throws IOException {
         return new SnappyFramedOutputStream(stream, COMPRESSION_BLOCK_SIZE, MIN_COMPRESSION_RATIO);
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StreamCompressionDecorator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StreamCompressionDecorator.java
@@ -20,7 +20,7 @@ package org.apache.flink.runtime.state;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.runtime.util.NonClosingInputStreamDecorator;
-import org.apache.flink.runtime.util.NonClosingOutpusStreamDecorator;
+import org.apache.flink.runtime.util.NonClosingOutputStreamDecorator;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -46,7 +46,7 @@ public abstract class StreamCompressionDecorator implements Serializable {
      * @return an output stream that is decorated by the compression scheme.
      */
     public final OutputStream decorateWithCompression(OutputStream stream) throws IOException {
-        return decorateWithCompression(new NonClosingOutpusStreamDecorator(stream));
+        return decorateWithCompression(new NonClosingOutputStreamDecorator(stream));
     }
 
     /**
@@ -64,7 +64,7 @@ public abstract class StreamCompressionDecorator implements Serializable {
      * @param stream the stream to decorate
      * @return an output stream that is decorated by the compression scheme.
      */
-    protected abstract OutputStream decorateWithCompression(NonClosingOutpusStreamDecorator stream)
+    protected abstract OutputStream decorateWithCompression(NonClosingOutputStreamDecorator stream)
             throws IOException;
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/UncompressedStreamCompressionDecorator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/UncompressedStreamCompressionDecorator.java
@@ -20,7 +20,7 @@ package org.apache.flink.runtime.state;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.runtime.util.NonClosingInputStreamDecorator;
-import org.apache.flink.runtime.util.NonClosingOutpusStreamDecorator;
+import org.apache.flink.runtime.util.NonClosingOutputStreamDecorator;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -36,7 +36,7 @@ public class UncompressedStreamCompressionDecorator extends StreamCompressionDec
     private static final long serialVersionUID = 1L;
 
     @Override
-    protected OutputStream decorateWithCompression(NonClosingOutpusStreamDecorator stream)
+    protected OutputStream decorateWithCompression(NonClosingOutputStreamDecorator stream)
             throws IOException {
         return stream;
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/NonClosingOutputStreamDecorator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/NonClosingOutputStreamDecorator.java
@@ -25,9 +25,9 @@ import java.io.OutputStream;
 
 /** Decorator for input streams that ignores calls to {@link OutputStream#close()}. */
 @Internal
-public class NonClosingOutpusStreamDecorator extends ForwardingOutputStream {
+public class NonClosingOutputStreamDecorator extends ForwardingOutputStream {
 
-    public NonClosingOutpusStreamDecorator(OutputStream delegate) {
+    public NonClosingOutputStreamDecorator(OutputStream delegate) {
         super(delegate);
     }
 


### PR DESCRIPTION
1.15 backport (excluding some minor hotfix commits) for parent PR #19304 