### PR TITLE
[FLINK-27035][python][tests] Reduce memory usage of ByteArrayWrapperSerializerTest

### DIFF
--- a/flink-python/src/test/java/org/apache/flink/streaming/api/utils/ByteArrayWrapperSerializerTest.java
+++ b/flink-python/src/test/java/org/apache/flink/streaming/api/utils/ByteArrayWrapperSerializerTest.java
@@ -52,7 +52,6 @@ public class ByteArrayWrapperSerializerTest extends SerializerTestBase<ByteArray
             randomByteArray(1),
             randomByteArray(2),
             randomByteArray(1024 * 1024),
-            randomByteArray(32 * 1024 * 1024),
         };
     }
 


### PR DESCRIPTION
The removed case was overly expensive, able to consume 1gb of heap space on it's own.