### PR TITLE
[FLINK-27046][tests][JUnit5 migration] flink-X-glue-schema-registry

### DIFF
--- a/flink-formats/flink-avro-glue-schema-registry/src/test/java/org/apache/flink/formats/avro/glue/schema/registry/GlueSchemaRegistryAvroDeserializationSchemaTest.java
+++ b/flink-formats/flink-avro-glue-schema-registry/src/test/java/org/apache/flink/formats/avro/glue/schema/registry/GlueSchemaRegistryAvroDeserializationSchemaTest.java
@@ -18,12 +18,10 @@
 
 package org.apache.flink.formats.avro.glue.schema.registry;
 
-import org.apache.flink.util.TestLogger;
-
 import com.amazonaws.services.schemaregistry.utils.AWSSchemaRegistryConstants;
 import org.apache.avro.Schema;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -33,13 +31,13 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link GlueSchemaRegistryAvroDeserializationSchema}. */
-public class GlueSchemaRegistryAvroDeserializationSchemaTest extends TestLogger {
+class GlueSchemaRegistryAvroDeserializationSchemaTest {
     private static final String AVRO_USER_SCHEMA_FILE = "src/test/java/resources/avro/user.avsc";
     private static Schema userSchema;
     private static Map<String, Object> configs = new HashMap<>();
 
-    @BeforeClass
-    public static void setup() throws IOException {
+    @BeforeAll
+    static void setup() throws IOException {
         configs.put(AWSSchemaRegistryConstants.AWS_REGION, "us-west-2");
         configs.put(AWSSchemaRegistryConstants.AWS_ENDPOINT, "https://test");
         configs.put(AWSSchemaRegistryConstants.SCHEMA_AUTO_REGISTRATION_SETTING, true);
@@ -50,19 +48,17 @@ public class GlueSchemaRegistryAvroDeserializationSchemaTest extends TestLogger 
 
     /** Test whether forGeneric method works. */
     @Test
-    public void testForGeneric_withValidParams_succeeds() {
+    void testForGeneric_withValidParams_succeeds() {
         assertThat(GlueSchemaRegistryAvroDeserializationSchema.forGeneric(userSchema, configs))
-                .isNotNull();
-        assertThat(GlueSchemaRegistryAvroDeserializationSchema.forGeneric(userSchema, configs))
+                .isNotNull()
                 .isInstanceOf(GlueSchemaRegistryAvroDeserializationSchema.class);
     }
 
     /** Test whether forSpecific method works. */
     @Test
-    public void testForSpecific_withValidParams_succeeds() {
+    void testForSpecific_withValidParams_succeeds() {
         assertThat(GlueSchemaRegistryAvroDeserializationSchema.forSpecific(User.class, configs))
-                .isNotNull();
-        assertThat(GlueSchemaRegistryAvroDeserializationSchema.forSpecific(User.class, configs))
+                .isNotNull()
                 .isInstanceOf(GlueSchemaRegistryAvroDeserializationSchema.class);
     }
 }

--- a/flink-formats/flink-avro-glue-schema-registry/src/test/java/org/apache/flink/formats/avro/glue/schema/registry/GlueSchemaRegistryAvroSchemaCoderTest.java
+++ b/flink-formats/flink-avro-glue-schema-registry/src/test/java/org/apache/flink/formats/avro/glue/schema/registry/GlueSchemaRegistryAvroSchemaCoderTest.java
@@ -18,8 +18,6 @@
 
 package org.apache.flink.formats.avro.glue.schema.registry;
 
-import org.apache.flink.util.TestLogger;
-
 import com.amazonaws.services.schemaregistry.common.AWSSchemaRegistryClient;
 import com.amazonaws.services.schemaregistry.common.configs.GlueSchemaRegistryConfiguration;
 import com.amazonaws.services.schemaregistry.deserializers.GlueSchemaRegistryDeserializationFacade;
@@ -28,10 +26,8 @@ import com.amazonaws.services.schemaregistry.serializers.GlueSchemaRegistrySeria
 import com.amazonaws.services.schemaregistry.utils.AWSSchemaRegistryConstants;
 import lombok.NonNull;
 import org.apache.avro.Schema;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.services.glue.model.EntityNotFoundException;
@@ -48,9 +44,10 @@ import java.util.Map;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link GlueSchemaRegistryAvroSchemaCoder}. */
-public class GlueSchemaRegistryAvroSchemaCoderTest extends TestLogger {
+class GlueSchemaRegistryAvroSchemaCoderTest {
     private static final String testTopic = "Test-Topic";
     private static final String schemaName = "User-Topic";
     private static final String AVRO_USER_SCHEMA_FILE = "src/test/java/resources/avro/user.avsc";
@@ -70,10 +67,9 @@ public class GlueSchemaRegistryAvroSchemaCoderTest extends TestLogger {
     private static AWSSchemaRegistryClient mockClient;
     private static GlueSchemaRegistryInputStreamDeserializer mockInputStreamDeserializer;
     private static GlueSchemaRegistryOutputStreamSerializer mockOutputStreamSerializer;
-    @Rule public ExpectedException thrown = ExpectedException.none();
 
-    @BeforeClass
-    public static void setup() throws IOException {
+    @BeforeAll
+    static void setup() throws IOException {
         metadata.put("test-key", "test-value");
         metadata.put(AWSSchemaRegistryConstants.TRANSPORT_METADATA_KEY, testTopic);
 
@@ -98,13 +94,13 @@ public class GlueSchemaRegistryAvroSchemaCoderTest extends TestLogger {
 
     /** Test whether constructor works. */
     @Test
-    public void testConstructor_withConfigs_succeeds() {
+    void testConstructor_withConfigs_succeeds() {
         assertThat(new GlueSchemaRegistryAvroSchemaCoder(testTopic, configs)).isNotNull();
     }
 
     /** Test whether readSchema method works. */
     @Test
-    public void testReadSchema_withValidParams_succeeds() throws IOException {
+    void testReadSchema_withValidParams_succeeds() throws IOException {
         GlueSchemaRegistryAvroSchemaCoder glueSchemaRegistryAvroSchemaCoder =
                 new GlueSchemaRegistryAvroSchemaCoder(mockInputStreamDeserializer);
         Schema resultSchema =
@@ -115,7 +111,7 @@ public class GlueSchemaRegistryAvroSchemaCoderTest extends TestLogger {
 
     /** Test whether writeSchema method works. */
     @Test
-    public void testWriteSchema_withValidParams_succeeds() throws IOException {
+    void testWriteSchema_withValidParams_succeeds() throws IOException {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         outputStream.write(actualBytes);
         GlueSchemaRegistryAvroSchemaCoder glueSchemaRegistryAvroSchemaCoder =
@@ -127,7 +123,7 @@ public class GlueSchemaRegistryAvroSchemaCoderTest extends TestLogger {
 
     /** Test whether writeSchema method throws exception if auto registration un-enabled. */
     @Test
-    public void testWriteSchema_withoutAutoRegistration_throwsException() throws IOException {
+    void testWriteSchema_withoutAutoRegistration_throwsException() {
         configs.put(AWSSchemaRegistryConstants.SCHEMA_AUTO_REGISTRATION_SETTING, false);
         mockClient = new MockAWSSchemaRegistryClient();
 
@@ -145,9 +141,12 @@ public class GlueSchemaRegistryAvroSchemaCoderTest extends TestLogger {
         GlueSchemaRegistryAvroSchemaCoder glueSchemaRegistryAvroSchemaCoder =
                 new GlueSchemaRegistryAvroSchemaCoder(glueSchemaRegistryOutputStreamSerializer);
 
-        thrown.expect(AWSSchemaRegistryException.class);
-        thrown.expectMessage(AWSSchemaRegistryConstants.AUTO_REGISTRATION_IS_DISABLED_MSG);
-        glueSchemaRegistryAvroSchemaCoder.writeSchema(userSchema, new ByteArrayOutputStream());
+        assertThatThrownBy(
+                        () ->
+                                glueSchemaRegistryAvroSchemaCoder.writeSchema(
+                                        userSchema, new ByteArrayOutputStream()))
+                .isInstanceOf(AWSSchemaRegistryException.class)
+                .hasMessage(AWSSchemaRegistryConstants.AUTO_REGISTRATION_IS_DISABLED_MSG);
     }
 
     private void testForSerializedData(byte[] serializedData) {

--- a/flink-formats/flink-avro-glue-schema-registry/src/test/java/org/apache/flink/formats/avro/glue/schema/registry/GlueSchemaRegistryAvroSerializationSchemaTest.java
+++ b/flink-formats/flink-avro-glue-schema-registry/src/test/java/org/apache/flink/formats/avro/glue/schema/registry/GlueSchemaRegistryAvroSerializationSchemaTest.java
@@ -18,14 +18,12 @@
 
 package org.apache.flink.formats.avro.glue.schema.registry;
 
-import org.apache.flink.util.TestLogger;
-
 import com.amazonaws.services.schemaregistry.common.configs.GlueSchemaRegistryConfiguration;
 import com.amazonaws.services.schemaregistry.serializers.GlueSchemaRegistrySerializationFacade;
 import com.amazonaws.services.schemaregistry.utils.AWSSchemaRegistryConstants;
 import org.apache.avro.Schema;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 
@@ -37,7 +35,7 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link GlueSchemaRegistryAvroSerializationSchema}. */
-public class GlueSchemaRegistryAvroSerializationSchemaTest extends TestLogger {
+class GlueSchemaRegistryAvroSerializationSchemaTest {
     private static final String testTopic = "Test-Topic";
     private static final String schemaName = "User-Topic";
     private static final String AVRO_USER_SCHEMA_FILE = "src/test/java/resources/avro/user.avsc";
@@ -55,8 +53,8 @@ public class GlueSchemaRegistryAvroSerializationSchemaTest extends TestLogger {
             DefaultCredentialsProvider.builder().build();
     private static GlueSchemaRegistrySerializationFacade mockSerializationFacade;
 
-    @BeforeClass
-    public static void setup() throws IOException {
+    @BeforeAll
+    static void setup() throws IOException {
         metadata.put("test-key", "test-value");
         metadata.put(AWSSchemaRegistryConstants.TRANSPORT_METADATA_KEY, testTopic);
 
@@ -81,7 +79,7 @@ public class GlueSchemaRegistryAvroSerializationSchemaTest extends TestLogger {
 
     /** Test whether forGeneric method works. */
     @Test
-    public void testForGeneric_withValidParams_succeeds() {
+    void testForGeneric_withValidParams_succeeds() {
         assertThat(
                         GlueSchemaRegistryAvroSerializationSchema.forGeneric(
                                 userSchema, testTopic, configs))
@@ -94,7 +92,7 @@ public class GlueSchemaRegistryAvroSerializationSchemaTest extends TestLogger {
 
     /** Test whether forSpecific method works. */
     @Test
-    public void testForSpecific_withValidParams_succeeds() {
+    void testForSpecific_withValidParams_succeeds() {
         assertThat(
                         GlueSchemaRegistryAvroSerializationSchema.forSpecific(
                                 User.class, testTopic, configs))
@@ -107,7 +105,7 @@ public class GlueSchemaRegistryAvroSerializationSchemaTest extends TestLogger {
 
     /** Test whether serialize method when compression is not enabled works. */
     @Test
-    public void testSerialize_withValidParams_withoutCompression_succeeds() {
+    void testSerialize_withValidParams_withoutCompression_succeeds() {
         AWSSchemaRegistryConstants.COMPRESSION compressionType =
                 AWSSchemaRegistryConstants.COMPRESSION.NONE;
         configs.put(AWSSchemaRegistryConstants.COMPRESSION_TYPE, compressionType.name());
@@ -128,7 +126,7 @@ public class GlueSchemaRegistryAvroSerializationSchemaTest extends TestLogger {
 
     /** Test whether serialize method when compression is enabled works. */
     @Test
-    public void testSerialize_withValidParams_withCompression_succeeds() {
+    void testSerialize_withValidParams_withCompression_succeeds() {
         AWSSchemaRegistryConstants.COMPRESSION compressionType =
                 AWSSchemaRegistryConstants.COMPRESSION.ZLIB;
         configs.put(AWSSchemaRegistryConstants.COMPRESSION_TYPE, compressionType.name());
@@ -149,7 +147,7 @@ public class GlueSchemaRegistryAvroSerializationSchemaTest extends TestLogger {
 
     /** Test whether serialize method returns null when input object is null. */
     @Test
-    public void testSerialize_withNullObject_returnNull() {
+    void testSerialize_withNullObject_returnNull() {
         GlueSchemaRegistryAvroSerializationSchema<User> glueSchemaRegistryAvroSerializationSchema =
                 GlueSchemaRegistryAvroSerializationSchema.forSpecific(
                         User.class, testTopic, configs);

--- a/flink-formats/flink-avro-glue-schema-registry/src/test/java/org/apache/flink/formats/avro/glue/schema/registry/GlueSchemaRegistryOutputStreamSerializerTest.java
+++ b/flink-formats/flink-avro-glue-schema-registry/src/test/java/org/apache/flink/formats/avro/glue/schema/registry/GlueSchemaRegistryOutputStreamSerializerTest.java
@@ -18,14 +18,12 @@
 
 package org.apache.flink.formats.avro.glue.schema.registry;
 
-import org.apache.flink.util.TestLogger;
-
 import com.amazonaws.services.schemaregistry.common.configs.GlueSchemaRegistryConfiguration;
 import com.amazonaws.services.schemaregistry.serializers.GlueSchemaRegistrySerializationFacade;
 import com.amazonaws.services.schemaregistry.utils.AWSSchemaRegistryConstants;
 import org.apache.avro.Schema;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 
@@ -38,7 +36,7 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link GlueSchemaRegistryOutputStreamSerializer}. */
-public class GlueSchemaRegistryOutputStreamSerializerTest extends TestLogger {
+class GlueSchemaRegistryOutputStreamSerializerTest {
     private static final String testTopic = "Test-Topic";
     private static final String AVRO_USER_SCHEMA_FILE = "src/test/java/resources/avro/user.avsc";
     private static final byte[] actualBytes =
@@ -56,8 +54,8 @@ public class GlueSchemaRegistryOutputStreamSerializerTest extends TestLogger {
             DefaultCredentialsProvider.builder().build();
     private static GlueSchemaRegistrySerializationFacade mockSerializationFacade;
 
-    @BeforeClass
-    public static void setup() throws IOException {
+    @BeforeAll
+    static void setup() throws IOException {
         metadata.put("test-key", "test-value");
         metadata.put(AWSSchemaRegistryConstants.TRANSPORT_METADATA_KEY, testTopic);
 
@@ -82,7 +80,7 @@ public class GlueSchemaRegistryOutputStreamSerializerTest extends TestLogger {
      * map.
      */
     @Test
-    public void testConstructor_withConfigsAndCredential_succeeds() {
+    void testConstructor_withConfigsAndCredential_succeeds() {
         GlueSchemaRegistryOutputStreamSerializer glueSchemaRegistryOutputStreamSerializer =
                 new GlueSchemaRegistryOutputStreamSerializer(testTopic, configs);
         assertThat(glueSchemaRegistryOutputStreamSerializer)
@@ -91,7 +89,7 @@ public class GlueSchemaRegistryOutputStreamSerializerTest extends TestLogger {
 
     /** Test whether constructor works with Glue Schema Registry SerializationFacade. */
     @Test
-    public void testConstructor_withDeserializer_succeeds() {
+    void testConstructor_withDeserializer_succeeds() {
         GlueSchemaRegistryOutputStreamSerializer glueSchemaRegistryOutputStreamSerializer =
                 new GlueSchemaRegistryOutputStreamSerializer(
                         testTopic, configs, mockSerializationFacade);
@@ -101,7 +99,7 @@ public class GlueSchemaRegistryOutputStreamSerializerTest extends TestLogger {
 
     /** Test whether registerSchemaAndSerializeStream method works. */
     @Test
-    public void testRegisterSchemaAndSerializeStream_withValidParams_succeeds() throws IOException {
+    void testRegisterSchemaAndSerializeStream_withValidParams_succeeds() throws IOException {
         GlueSchemaRegistryOutputStreamSerializer glueSchemaRegistryOutputStreamSerializer =
                 new GlueSchemaRegistryOutputStreamSerializer(
                         testTopic, configs, mockSerializationFacade);

--- a/flink-formats/flink-avro-glue-schema-registry/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/flink-formats/flink-avro-glue-schema-registry/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.util.TestLoggerExtension

--- a/flink-formats/flink-json-glue-schema-registry/src/test/java/org/apache/flink/formats/json/glue/schema/registry/GlueSchemaRegistryJsonDeserializationSchemaTest.java
+++ b/flink-formats/flink-json-glue-schema-registry/src/test/java/org/apache/flink/formats/json/glue/schema/registry/GlueSchemaRegistryJsonDeserializationSchemaTest.java
@@ -24,8 +24,8 @@ import com.amazonaws.services.schemaregistry.exception.AWSSchemaRegistryExceptio
 import com.amazonaws.services.schemaregistry.serializers.json.JsonDataWithSchema;
 import com.amazonaws.services.schemaregistry.utils.AWSSchemaRegistryConstants;
 import lombok.NonNull;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 
@@ -40,7 +40,7 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link GlueSchemaRegistryJsonDeserializationSchema}. */
-public class GlueSchemaRegistryJsonDeserializationSchemaTest {
+class GlueSchemaRegistryJsonDeserializationSchemaTest {
     private static final String testTopic = "Test-Topic";
     private static final Map<String, Object> configs = new HashMap<>();
     private static final AwsCredentialsProvider credentialsProvider =
@@ -65,8 +65,8 @@ public class GlueSchemaRegistryJsonDeserializationSchemaTest {
     private static GlueSchemaRegistryDeserializationFacade mockDeserializationFacadeForSpecific;
     private static GlueSchemaRegistryDeserializationFacade mockDeserializationFacadeForGeneric;
 
-    @BeforeClass
-    public static void setup() {
+    @BeforeAll
+    static void setup() {
         configs.put(AWSSchemaRegistryConstants.AWS_REGION, "us-west-2");
         configs.put(AWSSchemaRegistryConstants.AWS_ENDPOINT, "https://test");
         configs.put(AWSSchemaRegistryConstants.SCHEMA_AUTO_REGISTRATION_SETTING, true);
@@ -94,29 +94,23 @@ public class GlueSchemaRegistryJsonDeserializationSchemaTest {
 
     /** Test initialization for generic type JSON Schema works. */
     @Test
-    public void testForGeneric_withValidParams_succeeds() {
+    void testForGeneric_withValidParams_succeeds() {
         assertThat(
                         new GlueSchemaRegistryJsonDeserializationSchema<>(
                                 JsonDataWithSchema.class, testTopic, configs))
                 .isNotNull();
-        assertThat(
-                        new GlueSchemaRegistryJsonDeserializationSchema<>(
-                                JsonDataWithSchema.class, testTopic, configs))
-                .isInstanceOf(GlueSchemaRegistryJsonDeserializationSchema.class);
     }
 
     /** Test initialization for specific type JSON Schema works. */
     @Test
-    public void testForSpecific_withValidParams_succeeds() {
+    void testForSpecific_withValidParams_succeeds() {
         assertThat(new GlueSchemaRegistryJsonDeserializationSchema<>(Car.class, testTopic, configs))
                 .isNotNull();
-        assertThat(new GlueSchemaRegistryJsonDeserializationSchema<>(Car.class, testTopic, configs))
-                .isInstanceOf(GlueSchemaRegistryJsonDeserializationSchema.class);
     }
 
     /** Test whether deserialize method for specific type JSON Schema data works. */
     @Test
-    public void testDeserializePOJO_withValidParams_succeeds() {
+    void testDeserializePOJO_withValidParams_succeeds() {
         GlueSchemaRegistryJsonSchemaCoder glueSchemaRegistryJsonSchemaCoder =
                 new GlueSchemaRegistryJsonSchemaCoder(
                         testTopic, configs, null, mockDeserializationFacadeForSpecific);
@@ -128,13 +122,12 @@ public class GlueSchemaRegistryJsonDeserializationSchemaTest {
 
         Object deserializedObject =
                 glueSchemaRegistryJsonDeserializationSchema.deserialize(serializedBytes);
-        assertThat(deserializedObject).isInstanceOf(Car.class);
-        assertThat(deserializedObject).isEqualTo(userDefinedPojo);
+        assertThat(deserializedObject).isInstanceOf(Car.class).isEqualTo(userDefinedPojo);
     }
 
     /** Test whether deserialize method for generic type JSON Schema data works. */
     @Test
-    public void testDeserializeGenericData_withValidParams_succeeds() {
+    void testDeserializeGenericData_withValidParams_succeeds() {
         GlueSchemaRegistryJsonSchemaCoder glueSchemaRegistryJsonSchemaCoder =
                 new GlueSchemaRegistryJsonSchemaCoder(
                         testTopic, configs, null, mockDeserializationFacadeForGeneric);
@@ -146,13 +139,12 @@ public class GlueSchemaRegistryJsonDeserializationSchemaTest {
 
         Object deserializedObject =
                 glueSchemaRegistryJsonDeserializationSchema.deserialize(serializedBytes);
-        assertThat(deserializedObject).isInstanceOf(JsonDataWithSchema.class);
-        assertThat(deserializedObject).isEqualTo(userSchema);
+        assertThat(deserializedObject).isInstanceOf(JsonDataWithSchema.class).isEqualTo(userSchema);
     }
 
     /** Test whether deserialize method returns null when input byte array is null. */
     @Test
-    public void testDeserialize_withNullObject_returnNull() {
+    void testDeserialize_withNullObject_returnNull() {
         GlueSchemaRegistryJsonDeserializationSchema<Car>
                 glueSchemaRegistryJsonDeserializationSchema =
                         new GlueSchemaRegistryJsonDeserializationSchema<>(

--- a/flink-formats/flink-json-glue-schema-registry/src/test/java/org/apache/flink/formats/json/glue/schema/registry/GlueSchemaRegistryJsonSchemaCoderTest.java
+++ b/flink-formats/flink-json-glue-schema-registry/src/test/java/org/apache/flink/formats/json/glue/schema/registry/GlueSchemaRegistryJsonSchemaCoderTest.java
@@ -20,7 +20,7 @@ package org.apache.flink.formats.json.glue.schema.registry;
 
 import com.amazonaws.services.schemaregistry.deserializers.GlueSchemaRegistryDeserializationFacade;
 import com.amazonaws.services.schemaregistry.utils.AWSSchemaRegistryConstants;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 
@@ -33,10 +33,10 @@ import static org.apache.flink.connector.aws.config.AWSConfigConstants.AWS_SECRE
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link GlueSchemaRegistryJsonSchemaCoder}. */
-public class GlueSchemaRegistryJsonSchemaCoderTest {
+class GlueSchemaRegistryJsonSchemaCoderTest {
 
     @Test
-    public void testDefaultAwsCredentialsProvider() throws Exception {
+    void testDefaultAwsCredentialsProvider() throws Exception {
         GlueSchemaRegistryJsonSchemaCoder coder =
                 new GlueSchemaRegistryJsonSchemaCoder("test", getBaseConfig());
 
@@ -48,7 +48,7 @@ public class GlueSchemaRegistryJsonSchemaCoderTest {
     }
 
     @Test
-    public void testAwsCredentialsProviderFromConfig() throws Exception {
+    void testAwsCredentialsProviderFromConfig() throws Exception {
         Map<String, Object> config = new HashMap<>(getBaseConfig());
         config.put(AWS_ACCESS_KEY_ID, "ak");
         config.put(AWS_SECRET_ACCESS_KEY, "sk");

--- a/flink-formats/flink-json-glue-schema-registry/src/test/java/org/apache/flink/formats/json/glue/schema/registry/GlueSchemaRegistryJsonSerializationSchemaTest.java
+++ b/flink-formats/flink-json-glue-schema-registry/src/test/java/org/apache/flink/formats/json/glue/schema/registry/GlueSchemaRegistryJsonSerializationSchemaTest.java
@@ -24,8 +24,8 @@ import com.amazonaws.services.schemaregistry.serializers.GlueSchemaRegistrySeria
 import com.amazonaws.services.schemaregistry.serializers.json.JsonDataWithSchema;
 import com.amazonaws.services.schemaregistry.utils.AWSSchemaRegistryConstants;
 import lombok.NonNull;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.services.glue.model.DataFormat;
@@ -43,7 +43,7 @@ import static com.amazonaws.services.schemaregistry.utils.AWSSchemaRegistryConst
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link GlueSchemaRegistryJsonSerializationSchema}. */
-public class GlueSchemaRegistryJsonSerializationSchemaTest {
+class GlueSchemaRegistryJsonSerializationSchemaTest {
     private static final String testTopic = "Test-Topic";
     private static final String schemaName = "User-Topic";
     private static final String JSON_SCHEMA =
@@ -71,8 +71,8 @@ public class GlueSchemaRegistryJsonSerializationSchemaTest {
             DefaultCredentialsProvider.builder().build();
     private static GlueSchemaRegistrySerializationFacade mockSerializationFacade;
 
-    @BeforeClass
-    public static void setup() {
+    @BeforeAll
+    static void setup() {
         metadata.put("test-key", "test-value");
         metadata.put(AWSSchemaRegistryConstants.TRANSPORT_METADATA_KEY, testTopic);
 
@@ -103,7 +103,7 @@ public class GlueSchemaRegistryJsonSerializationSchemaTest {
 
     /** Test initialization works. */
     @Test
-    public void testForGeneric_withValidParams_succeeds() {
+    void testForGeneric_withValidParams_succeeds() {
         assertThat(new GlueSchemaRegistryJsonSerializationSchema<>(testTopic, configs)).isNotNull();
         assertThat(new GlueSchemaRegistryJsonSerializationSchema<>(testTopic, configs))
                 .isInstanceOf(GlueSchemaRegistryJsonSerializationSchema.class);
@@ -114,7 +114,7 @@ public class GlueSchemaRegistryJsonSerializationSchemaTest {
      * enabled works.
      */
     @Test
-    public void testSerializePOJO_withValidParams_withoutCompression_succeeds() {
+    void testSerializePOJO_withValidParams_withoutCompression_succeeds() {
         configs.put(AWSSchemaRegistryConstants.COMPRESSION_TYPE, NONE.name());
 
         GlueSchemaRegistryJsonSchemaCoder glueSchemaRegistryJsonSchemaCoder =
@@ -134,7 +134,7 @@ public class GlueSchemaRegistryJsonSerializationSchemaTest {
      * enabled works.
      */
     @Test
-    public void testSerializeGenericData_withValidParams_withoutCompression_succeeds() {
+    void testSerializeGenericData_withValidParams_withoutCompression_succeeds() {
         configs.put(AWSSchemaRegistryConstants.COMPRESSION_TYPE, NONE.name());
 
         GlueSchemaRegistryJsonSchemaCoder glueSchemaRegistryJsonSchemaCoder =
@@ -155,7 +155,7 @@ public class GlueSchemaRegistryJsonSerializationSchemaTest {
      * works.
      */
     @Test
-    public void testSerializePOJO_withValidParams_withCompression_succeeds() {
+    void testSerializePOJO_withValidParams_withCompression_succeeds() {
         AWSSchemaRegistryConstants.COMPRESSION compressionType =
                 AWSSchemaRegistryConstants.COMPRESSION.ZLIB;
         configs.put(AWSSchemaRegistryConstants.COMPRESSION_TYPE, compressionType.name());
@@ -177,7 +177,7 @@ public class GlueSchemaRegistryJsonSerializationSchemaTest {
      * works.
      */
     @Test
-    public void testSerializeGenericData_withValidParams_withCompression_succeeds() {
+    void testSerializeGenericData_withValidParams_withCompression_succeeds() {
         AWSSchemaRegistryConstants.COMPRESSION compressionType =
                 AWSSchemaRegistryConstants.COMPRESSION.ZLIB;
         configs.put(AWSSchemaRegistryConstants.COMPRESSION_TYPE, compressionType.name());
@@ -197,7 +197,7 @@ public class GlueSchemaRegistryJsonSerializationSchemaTest {
 
     /** Test whether serialize method returns null when input object is null. */
     @Test
-    public void testSerialize_withNullObject_returnNull() {
+    void testSerialize_withNullObject_returnNull() {
         GlueSchemaRegistryJsonSerializationSchema<Car> glueSchemaRegistryJsonSerializationSchema =
                 new GlueSchemaRegistryJsonSerializationSchema<>(testTopic, configs);
         assertThat(glueSchemaRegistryJsonSerializationSchema.serialize(null)).isNull();

--- a/flink-formats/flink-json-glue-schema-registry/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/flink-formats/flink-json-glue-schema-registry/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.util.TestLoggerExtension


### PR DESCRIPTION
## What is the purpose of the change

Update the `flink-formats/flink-avro-glue-schema-registry` and `flink-formats/flink-json-glue-schema-registry` module to AssertJ and JUnit 5 following the [JUnit 5 Migration Guide](https://docs.google.com/document/d/1514Wa_aNB9bJUen4xm5uiuXOooOJTtXqS_Jqk9KJitU/edit)

This was an easy change: it was already based on AssertJ

## Brief change log

* Removed dependences on JUnit 4, JUnit 5 Assertions and Hamcrest where possible.

## Verifying this change

This change is a code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive):no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no