### PR TITLE
[FLINK-27045][tests] Remove shared executor

### DIFF
--- a/flink-clients/src/test/java/org/apache/flink/client/deployment/application/ApplicationDispatcherBootstrapITCase.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/deployment/application/ApplicationDispatcherBootstrapITCase.java
@@ -55,16 +55,19 @@ import org.apache.flink.runtime.rest.JobRestEndpointFactory;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.runtime.testutils.TestingJobResultStore;
 import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorExtension;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.TestLoggerExtension;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.time.Duration;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -72,6 +75,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 /** Integration tests related to {@link ApplicationDispatcherBootstrap}. */
 @ExtendWith(TestLoggerExtension.class)
 public class ApplicationDispatcherBootstrapITCase {
+
+    @RegisterExtension
+    static final TestExecutorExtension<ScheduledExecutorService> EXECUTOR_EXTENSION =
+            TestingUtils.defaultExecutorExtension();
 
     private static Supplier<DispatcherResourceManagerComponentFactory>
             createApplicationModeDispatcherResourceManagerComponentFactorySupplier(
@@ -103,7 +110,7 @@ public class ApplicationDispatcherBootstrapITCase {
                         .setConfiguration(configuration)
                         .build();
         final EmbeddedHaServicesWithLeadershipControl haServices =
-                new EmbeddedHaServicesWithLeadershipControl(TestingUtils.defaultExecutor());
+                new EmbeddedHaServicesWithLeadershipControl(EXECUTOR_EXTENSION.getExecutor());
         final TestingMiniCluster.Builder clusterBuilder =
                 TestingMiniCluster.newBuilder(clusterConfiguration)
                         .setHighAvailabilityServicesSupplier(() -> haServices)
@@ -170,7 +177,7 @@ public class ApplicationDispatcherBootstrapITCase {
                         TestingJobResultStore.createSuccessfulJobResult(
                                 ApplicationDispatcherBootstrap.ZERO_JOB_ID)));
         final EmbeddedHaServicesWithLeadershipControl haServices =
-                new EmbeddedHaServicesWithLeadershipControl(TestingUtils.defaultExecutor()) {
+                new EmbeddedHaServicesWithLeadershipControl(EXECUTOR_EXTENSION.getExecutor()) {
 
                     @Override
                     public JobResultStore getJobResultStore() {
@@ -223,7 +230,7 @@ public class ApplicationDispatcherBootstrapITCase {
                         .setConfiguration(configuration)
                         .build();
         final EmbeddedHaServicesWithLeadershipControl haServices =
-                new EmbeddedHaServicesWithLeadershipControl(TestingUtils.defaultExecutor());
+                new EmbeddedHaServicesWithLeadershipControl(EXECUTOR_EXTENSION.getExecutor());
         final TestingMiniCluster.Builder clusterBuilder =
                 TestingMiniCluster.newBuilder(clusterConfiguration)
                         .setHighAvailabilityServicesSupplier(() -> haServices)

--- a/flink-core/src/test/java/org/apache/flink/testutils/TestingUtils.java
+++ b/flink-core/src/test/java/org/apache/flink/testutils/TestingUtils.java
@@ -19,8 +19,8 @@
 package org.apache.flink.testutils;
 
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.util.concurrent.ScheduledExecutor;
-import org.apache.flink.util.concurrent.ScheduledExecutorServiceAdapter;
+import org.apache.flink.testutils.executor.TestExecutorExtension;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 
 import java.time.Duration;
 import java.util.UUID;
@@ -35,8 +35,6 @@ public class TestingUtils {
     public static final Time TIMEOUT = Time.minutes(1L);
     public static final Duration DEFAULT_AKKA_ASK_TIMEOUT = Duration.ofSeconds(200);
 
-    private static ScheduledExecutorService sharedExecutorInstance;
-
     public static Time infiniteTime() {
         return Time.milliseconds(Integer.MAX_VALUE);
     }
@@ -47,16 +45,12 @@ public class TestingUtils {
         return Duration.ofDays(365L);
     }
 
-    public static synchronized ScheduledExecutorService defaultExecutor() {
-        if (sharedExecutorInstance == null || sharedExecutorInstance.isShutdown()) {
-            sharedExecutorInstance = Executors.newSingleThreadScheduledExecutor();
-        }
-
-        return sharedExecutorInstance;
+    public static TestExecutorExtension<ScheduledExecutorService> defaultExecutorExtension() {
+        return new TestExecutorExtension<>(Executors::newSingleThreadScheduledExecutor);
     }
 
-    public static ScheduledExecutor defaultScheduledExecutor() {
-        return new ScheduledExecutorServiceAdapter(defaultExecutor());
+    public static TestExecutorResource<ScheduledExecutorService> defaultExecutorResource() {
+        return new TestExecutorResource<>(Executors::newSingleThreadScheduledExecutor);
     }
 
     public static UUID zeroUUID() {

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesMultipleComponentLeaderElectionDriverTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesMultipleComponentLeaderElectionDriverTest.java
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.leaderelection.TestingLeaderElectionListener;
 import org.apache.flink.runtime.leaderelection.TestingListener;
 import org.apache.flink.runtime.leaderretrieval.DefaultLeaderRetrievalService;
 import org.apache.flink.runtime.util.TestingFatalErrorHandlerExtension;
+import org.apache.flink.testutils.TestingUtils;
 import org.apache.flink.testutils.executor.TestExecutorExtension;
 import org.apache.flink.util.TestLoggerExtension;
 import org.apache.flink.util.function.RunnableWithException;
@@ -40,8 +41,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.Collections;
 import java.util.UUID;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -58,8 +58,8 @@ public class KubernetesMultipleComponentLeaderElectionDriverTest {
             new TestingFatalErrorHandlerExtension();
 
     @RegisterExtension
-    private static final TestExecutorExtension<ExecutorService> testExecutorExtension =
-            new TestExecutorExtension<>(Executors::newSingleThreadScheduledExecutor);
+    private static final TestExecutorExtension<ScheduledExecutorService> testExecutorExtension =
+            TestingUtils.defaultExecutorExtension();
 
     @Test
     public void testElectionDriverGainsLeadership() throws Exception {

--- a/flink-metrics/flink-metrics-jmx/src/test/java/org/apache/flink/runtime/jobmanager/JMXJobManagerMetricTest.java
+++ b/flink-metrics/flink-metrics-jmx/src/test/java/org/apache/flink/runtime/jobmanager/JMXJobManagerMetricTest.java
@@ -39,7 +39,9 @@ import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.test.junit5.InjectClusterClient;
 import org.apache.flink.test.junit5.MiniClusterExtension;
 import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorExtension;
 import org.apache.flink.util.concurrent.FutureUtils;
+import org.apache.flink.util.concurrent.ScheduledExecutorServiceAdapter;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -50,12 +52,17 @@ import javax.management.ObjectName;
 import java.lang.management.ManagementFactory;
 import java.time.Duration;
 import java.util.Set;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests to verify JMX reporter functionality on the JobManager. */
 class JMXJobManagerMetricTest {
+
+    @RegisterExtension
+    static final TestExecutorExtension<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorExtension();
 
     @RegisterExtension
     private static final MiniClusterExtension MINI_CLUSTER_RESOURCE =
@@ -118,7 +125,7 @@ class JMXJobManagerMetricTest {
                             Time.milliseconds(10),
                             deadline,
                             status -> status == JobStatus.RUNNING,
-                            TestingUtils.defaultScheduledExecutor())
+                            new ScheduledExecutorServiceAdapter(EXECUTOR_RESOURCE.getExecutor()))
                     .get(deadline.timeLeft().toMillis(), TimeUnit.MILLISECONDS);
 
             MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();

--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/AbstractQueryableStateTestBase.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/AbstractQueryableStateTestBase.java
@@ -61,7 +61,6 @@ import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.testutils.ClassLoaderUtils;
-import org.apache.flink.testutils.TestingUtils;
 import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.ExceptionUtils;
@@ -1347,7 +1346,7 @@ public abstract class AbstractQueryableStateTestBase extends TestLogger {
                             Time.milliseconds(50),
                             deadline,
                             (jobStatus) -> jobStatus.equals(JobStatus.CANCELED),
-                            TestingUtils.defaultScheduledExecutor());
+                            new ScheduledExecutorServiceAdapter(EXECUTOR_RESOURCE.getExecutor()));
             assertEquals(
                     JobStatus.CANCELED,
                     jobStatusFuture.get(deadline.timeLeft().toMillis(), TimeUnit.MILLISECONDS));

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarHandlerParameterTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarHandlerParameterTest.java
@@ -33,7 +33,6 @@ import org.apache.flink.runtime.util.BlobServerResource;
 import org.apache.flink.runtime.webmonitor.TestingDispatcherGateway;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
 import org.apache.flink.runtime.webmonitor.testutils.ParameterProgram;
-import org.apache.flink.testutils.TestingUtils;
 import org.apache.flink.util.TestLogger;
 
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
@@ -53,7 +52,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
@@ -92,7 +90,6 @@ public abstract class JarHandlerParameterTest<
             CompletableFuture.completedFuture("shazam://localhost:12345");
     static Time timeout = Time.seconds(10);
     static Map<String, String> responseHeaders = Collections.emptyMap();
-    static Executor executor = TestingUtils.defaultExecutor();
 
     private static Path jarWithManifest;
     private static Path jarWithoutManifest;
@@ -129,7 +126,6 @@ public abstract class JarHandlerParameterTest<
         localAddressFuture = CompletableFuture.completedFuture("shazam://localhost:12345");
         timeout = Time.seconds(10);
         responseHeaders = Collections.emptyMap();
-        executor = TestingUtils.defaultExecutor();
     }
 
     @Before

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarHandlerTest.java
@@ -20,6 +20,8 @@ package org.apache.flink.runtime.webmonitor.handlers;
 
 import org.apache.flink.client.program.ProgramInvocationException;
 import org.apache.flink.runtime.webmonitor.TestingDispatcherGateway;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.TestLogger;
 
@@ -32,6 +34,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Optional;
+import java.util.concurrent.ScheduledExecutorService;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -43,6 +46,10 @@ public class JarHandlerTest extends TestLogger {
 
     @ClassRule public static final TemporaryFolder TMP = new TemporaryFolder();
 
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
+
     @Test
     public void testPlanJar() throws Exception {
         runTest("hello out!", "hello err!");
@@ -53,7 +60,9 @@ public class JarHandlerTest extends TestLogger {
         final TestingDispatcherGateway restfulGateway =
                 TestingDispatcherGateway.newBuilder().build();
 
-        final JarHandlers handlers = new JarHandlers(TMP.newFolder().toPath(), restfulGateway);
+        final JarHandlers handlers =
+                new JarHandlers(
+                        TMP.newFolder().toPath(), restfulGateway, EXECUTOR_RESOURCE.getExecutor());
 
         final Path originalJar = Paths.get(System.getProperty("targetDir")).resolve(JAR_NAME);
         final Path jar = Files.copy(originalJar, TMP.newFolder().toPath().resolve(JAR_NAME));

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarHandlers.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarHandlers.java
@@ -28,7 +28,6 @@ import org.apache.flink.runtime.rest.messages.JobPlanInfo;
 import org.apache.flink.runtime.webmonitor.RestfulGateway;
 import org.apache.flink.runtime.webmonitor.TestingDispatcherGateway;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
-import org.apache.flink.testutils.TestingUtils;
 
 import java.nio.file.Path;
 import java.util.Collections;
@@ -45,12 +44,14 @@ public class JarHandlers {
     final JarRunHandler runHandler;
     final JarDeleteHandler deleteHandler;
 
-    JarHandlers(final Path jarDir, final TestingDispatcherGateway restfulGateway) {
+    JarHandlers(
+            final Path jarDir,
+            final TestingDispatcherGateway restfulGateway,
+            final Executor executor) {
         final GatewayRetriever<TestingDispatcherGateway> gatewayRetriever =
                 () -> CompletableFuture.completedFuture(restfulGateway);
         final Time timeout = Time.seconds(10);
         final Map<String, String> responseHeaders = Collections.emptyMap();
-        final Executor executor = TestingUtils.defaultExecutor();
 
         uploadHandler =
                 new JarUploadHandler(

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarPlanHandlerParameterTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarPlanHandlerParameterTest.java
@@ -24,18 +24,26 @@ import org.apache.flink.runtime.jobgraph.jsonplan.JsonPlanGenerator;
 import org.apache.flink.runtime.rest.handler.HandlerRequest;
 import org.apache.flink.runtime.rest.messages.JobPlanInfo;
 import org.apache.flink.runtime.webmonitor.testutils.ParameterProgram;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
 
 /** Tests for the parameter handling of the {@link JarPlanHandler}. */
 public class JarPlanHandlerParameterTest
         extends JarHandlerParameterTest<JarPlanRequestBody, JarPlanMessageParameters> {
     private static JarPlanHandler handler;
+
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     @BeforeClass
     public static void setup() throws Exception {
@@ -48,7 +56,7 @@ public class JarPlanHandlerParameterTest
                         JarPlanGetHeaders.getInstance(),
                         jarDir,
                         new Configuration(),
-                        executor,
+                        EXECUTOR_RESOURCE.getExecutor(),
                         jobGraph -> {
                             LAST_SUBMITTED_JOB_GRAPH_REFERENCE.set(jobGraph);
                             return new JobPlanInfo(JsonPlanGenerator.generatePlan(jobGraph));

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHandlerParameterTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHandlerParameterTest.java
@@ -36,12 +36,14 @@ import org.apache.flink.runtime.webmonitor.TestingDispatcherGateway;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
 import org.apache.flink.runtime.webmonitor.testutils.ParameterProgram;
 import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.ExceptionUtils;
 
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
 
 import org.junit.Assert;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.nio.file.Files;
@@ -54,7 +56,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.containsString;
@@ -71,6 +73,10 @@ public class JarRunHandlerParameterTest
     private static final boolean ALLOW_NON_RESTORED_STATE_QUERY = true;
     private static final String RESTORE_PATH = "/foo/bar";
 
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
+
     private static JarRunHandler handler;
 
     private static Path jarWithEagerSink;
@@ -82,7 +88,6 @@ public class JarRunHandlerParameterTest
                 () -> CompletableFuture.completedFuture(restfulGateway);
         final Time timeout = Time.seconds(10);
         final Map<String, String> responseHeaders = Collections.emptyMap();
-        final Executor executor = TestingUtils.defaultExecutor();
 
         final Path jarLocation = Paths.get(System.getProperty("targetDir"));
         final String parameterProgramWithEagerSink = "parameter-program-with-eager-sink.jar";
@@ -99,7 +104,7 @@ public class JarRunHandlerParameterTest
                         JarRunHeaders.getInstance(),
                         jarDir,
                         new Configuration(),
-                        executor,
+                        EXECUTOR_RESOURCE.getExecutor(),
                         ConfigurationVerifyingDetachedApplicationRunner::new);
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorFailureTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorFailureTest.java
@@ -37,16 +37,20 @@ import org.apache.flink.runtime.state.OperatorStreamStateHandle;
 import org.apache.flink.runtime.state.ResultSubpartitionStateHandle;
 import org.apache.flink.runtime.state.SharedStateRegistry;
 import org.apache.flink.runtime.state.StreamStateHandle;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.concurrent.Executors;
 import org.apache.flink.util.concurrent.ManuallyTriggeredScheduledExecutor;
 
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.util.Collections.emptyList;
@@ -65,6 +69,10 @@ import static org.mockito.Mockito.when;
 /** Tests for failure of checkpoint coordinator. */
 public class CheckpointCoordinatorFailureTest extends TestLogger {
 
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
+
     /**
      * Tests that a failure while storing a completed checkpoint in the completed checkpoint store
      * will properly fail the originating pending checkpoint and clean upt the completed checkpoint.
@@ -79,20 +87,19 @@ public class CheckpointCoordinatorFailureTest extends TestLogger {
         ExecutionGraph testGraph =
                 new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
                         .addJobVertex(jobVertexId)
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
 
         ExecutionVertex vertex = testGraph.getJobVertex(jobVertexId).getTaskVertices()[0];
 
         // set up the coordinator and validate the initial state
         CheckpointCoordinator coord =
                 new CheckpointCoordinatorBuilder()
-                        .setExecutionGraph(testGraph)
                         .setCompletedCheckpointStore(
                                 new FailingCompletedCheckpointStore(
                                         new Exception(
                                                 "The failing completed checkpoint store failed again... :-(")))
                         .setTimer(manuallyTriggeredScheduledExecutor)
-                        .build();
+                        .build(testGraph);
 
         coord.triggerCheckpoint(false);
 
@@ -192,7 +199,7 @@ public class CheckpointCoordinatorFailureTest extends TestLogger {
         final ExecutionGraph graph =
                 new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
                         .addJobVertex(jobVertexID1)
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
 
         final ExecutionVertex vertex = graph.getJobVertex(jobVertexID1).getTaskVertices()[0];
         final ExecutionAttemptID attemptId = vertex.getCurrentExecutionAttempt().getAttemptId();
@@ -211,7 +218,6 @@ public class CheckpointCoordinatorFailureTest extends TestLogger {
         final AtomicInteger cleanupCallCount = new AtomicInteger(0);
         final CheckpointCoordinator checkpointCoordinator =
                 new CheckpointCoordinatorBuilder()
-                        .setExecutionGraph(graph)
                         .setCheckpointIDCounter(checkpointIDCounter)
                         .setCheckpointsCleaner(
                                 new CheckpointsCleaner() {
@@ -231,7 +237,7 @@ public class CheckpointCoordinatorFailureTest extends TestLogger {
                         .setCompletedCheckpointStore(completedCheckpointStore)
                         .setTimer(manuallyTriggeredScheduledExecutor)
                         .setCheckpointStatsTracker(statsTracker)
-                        .build();
+                        .build(graph);
         checkpointCoordinator.triggerCheckpoint(false);
         manuallyTriggeredScheduledExecutor.triggerAll();
         CheckpointMetrics expectedReportedMetrics =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorMasterHooksTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorMasterHooksTest.java
@@ -30,10 +30,13 @@ import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguratio
 import org.apache.flink.runtime.messages.checkpoint.AcknowledgeCheckpoint;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.runtime.state.testutils.TestCompletedCheckpointStorageLocation;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.concurrent.Executors;
 import org.apache.flink.util.concurrent.ManuallyTriggeredScheduledExecutor;
 import org.apache.flink.util.concurrent.ScheduledExecutor;
 
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -47,6 +50,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
 
 import static org.apache.flink.runtime.checkpoint.CheckpointCoordinatorTestingUtils.StringSerializer;
 import static org.junit.Assert.assertArrayEquals;
@@ -67,6 +71,10 @@ import static org.mockito.Mockito.when;
 /** Tests for the user-defined hooks that the checkpoint coordinator can call. */
 public class CheckpointCoordinatorMasterHooksTest {
 
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
+
     // ------------------------------------------------------------------------
     //  hook registration
     // ------------------------------------------------------------------------
@@ -77,7 +85,7 @@ public class CheckpointCoordinatorMasterHooksTest {
         ExecutionGraph graph =
                 new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
                         .addJobVertex(new JobVertexID())
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
         final CheckpointCoordinator cc = instantiateCheckpointCoordinator(graph);
 
         MasterTriggerRestoreHook<?> hook1 = mock(MasterTriggerRestoreHook.class);
@@ -100,7 +108,7 @@ public class CheckpointCoordinatorMasterHooksTest {
         ExecutionGraph graph =
                 new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
                         .addJobVertex(new JobVertexID())
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
         final CheckpointCoordinator cc = instantiateCheckpointCoordinator(graph);
 
         try {
@@ -139,7 +147,7 @@ public class CheckpointCoordinatorMasterHooksTest {
         ExecutionGraph graph =
                 new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
                         .addJobVertex(new JobVertexID())
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
         CheckpointCoordinator cc = instantiateCheckpointCoordinator(graph);
 
         cc.addMasterHook(hook1);
@@ -194,7 +202,7 @@ public class CheckpointCoordinatorMasterHooksTest {
         final ExecutionGraph graph =
                 new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
                         .addJobVertex(jobVertexId)
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
         final ManuallyTriggeredScheduledExecutor manuallyTriggeredScheduledExecutor =
                 new ManuallyTriggeredScheduledExecutor();
         final CheckpointCoordinator cc =
@@ -301,7 +309,7 @@ public class CheckpointCoordinatorMasterHooksTest {
         ExecutionGraph graph =
                 new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
                         .addJobVertex(new JobVertexID())
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
         CheckpointCoordinator cc = instantiateCheckpointCoordinator(graph);
 
         cc.addMasterHook(statefulHook1);
@@ -363,7 +371,7 @@ public class CheckpointCoordinatorMasterHooksTest {
         ExecutionGraph graph =
                 new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
                         .addJobVertex(new JobVertexID())
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
         CheckpointCoordinator cc = instantiateCheckpointCoordinator(graph);
 
         cc.addMasterHook(statefulHook);
@@ -402,7 +410,7 @@ public class CheckpointCoordinatorMasterHooksTest {
         ExecutionGraph graph =
                 new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
                         .addJobVertex(new JobVertexID())
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
         final ManuallyTriggeredScheduledExecutor manuallyTriggeredScheduledExecutor =
                 new ManuallyTriggeredScheduledExecutor();
         CheckpointCoordinator cc =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
@@ -69,6 +69,8 @@ import org.apache.flink.runtime.state.memory.NonPersistentMetadataCheckpointStor
 import org.apache.flink.runtime.state.storage.JobManagerCheckpointStorage;
 import org.apache.flink.runtime.state.testutils.TestCompletedCheckpointStorageLocation;
 import org.apache.flink.runtime.testutils.DirectScheduledExecutorService;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.concurrent.FutureUtils;
@@ -81,6 +83,7 @@ import org.apache.flink.shaded.guava30.com.google.common.collect.Iterables;
 
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -148,6 +151,10 @@ import static org.mockito.Mockito.when;
 /** Tests for the checkpoint coordinator. */
 public class CheckpointCoordinatorTest extends TestLogger {
 
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
+
     @Test
     public void testSharedStateNotDiscaredOnAbort() throws Exception {
         JobVertexID v1 = new JobVertexID(), v2 = new JobVertexID();
@@ -156,13 +163,12 @@ public class CheckpointCoordinatorTest extends TestLogger {
                 new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
                         .addJobVertex(v1)
                         .addJobVertex(v2)
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
 
         CheckpointCoordinator coordinator =
                 new CheckpointCoordinatorBuilder()
-                        .setExecutionGraph(graph)
                         .setTimer(manuallyTriggeredScheduledExecutor)
-                        .build();
+                        .build(graph);
         coordinator.startCheckpointScheduler();
 
         CompletableFuture<CompletedCheckpoint> cpFuture = coordinator.triggerCheckpoint(true);
@@ -234,7 +240,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
                 new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
                         .addJobVertex(decliningVertexID)
                         .addJobVertex(lateReportVertexID)
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
 
         ExecutionVertex decliningVertex =
                 executionGraph.getJobVertex(decliningVertexID).getTaskVertices()[0];
@@ -244,10 +250,9 @@ public class CheckpointCoordinatorTest extends TestLogger {
                 new CheckpointStatsTracker(Integer.MAX_VALUE, new UnregisteredMetricsGroup());
         CheckpointCoordinator coordinator =
                 new CheckpointCoordinatorBuilder()
-                        .setExecutionGraph(executionGraph)
                         .setTimer(manuallyTriggeredScheduledExecutor)
                         .setCheckpointStatsTracker(statsTracker)
-                        .build();
+                        .build(executionGraph);
 
         CompletableFuture<CompletedCheckpoint> result = coordinator.triggerCheckpoint(false);
         manuallyTriggeredScheduledExecutor.triggerAll();
@@ -364,7 +369,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
                                     ComponentMainThreadExecutorServiceAdapter
                                             .forSingleThreadExecutor(
                                                     new DirectScheduledExecutorService()))
-                            .build();
+                            .build(EXECUTOR_RESOURCE.getExecutor());
 
             ExecutionVertex vertex = graph.getJobVertex(jobVertexId).getTaskVertices()[0];
             ExecutionAttemptID attemptId = vertex.getCurrentExecutionAttempt().getAttemptId();
@@ -379,8 +384,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
                                             .setMaxConcurrentCheckpoints(1)
                                             .setMinPauseBetweenCheckpoints(pause)
                                             .build())
-                            .setExecutionGraph(graph)
-                            .build();
+                            .build(graph);
             coordinator.startCheckpointScheduler();
 
             coordinator.triggerCheckpoint(
@@ -422,7 +426,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
                         .addJobVertex(new JobVertexID())
                         .addJobVertex(new JobVertexID(), false)
                         .setTransitToRunning(false)
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
 
         CheckpointCoordinator checkpointCoordinator = getCheckpointCoordinator(graph);
 
@@ -452,7 +456,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
                 new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
                         .addJobVertex(jobVertexID1)
                         .addJobVertex(jobVertexID2, false)
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
 
         CheckpointCoordinator checkpointCoordinator = getCheckpointCoordinator(graph);
         Arrays.stream(graph.getJobVertex(jobVertexID1).getTaskVertices())
@@ -484,7 +488,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
                 new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
                         .addJobVertex(jobVertexID1, 3, 256)
                         .addJobVertex(jobVertexID2, 3, 256)
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
         ExecutionJobVertex jobVertex1 = graph.getJobVertex(jobVertexID1);
         ExecutionJobVertex jobVertex2 = graph.getJobVertex(jobVertexID2);
 
@@ -496,11 +500,10 @@ public class CheckpointCoordinatorTest extends TestLogger {
                 new CheckpointStatsTracker(Integer.MAX_VALUE, new UnregisteredMetricsGroup());
         CheckpointCoordinator checkpointCoordinator =
                 new CheckpointCoordinatorBuilder()
-                        .setExecutionGraph(graph)
                         .setTimer(manuallyTriggeredScheduledExecutor)
                         .setAllowCheckpointsAfterTasksFinished(true)
                         .setCheckpointStatsTracker(statsTracker)
-                        .build();
+                        .build(graph);
 
         // nothing should be happening
         assertEquals(0, checkpointCoordinator.getNumberOfPendingCheckpoints());
@@ -547,7 +550,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
                         .setTransitToRunning(false)
                         .addJobVertex(jobVertexID1, 1, 256)
                         .addJobVertex(jobVertexID2, 1, 256)
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
         ExecutionJobVertex jobVertex1 = graph.getJobVertex(jobVertexID1);
         ExecutionVertex taskVertex = jobVertex1.getTaskVertices()[0];
         ExecutionJobVertex jobVertex2 = graph.getJobVertex(jobVertexID2);
@@ -593,10 +596,9 @@ public class CheckpointCoordinatorTest extends TestLogger {
 
         CheckpointCoordinator checkpointCoordinator =
                 new CheckpointCoordinatorBuilder()
-                        .setExecutionGraph(graph)
                         .setTimer(manuallyTriggeredScheduledExecutor)
                         .setAllowCheckpointsAfterTasksFinished(true)
-                        .build();
+                        .build(graph);
 
         // nothing should be happening
         assertEquals(0, checkpointCoordinator.getNumberOfPendingCheckpoints());
@@ -620,7 +622,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
                 new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
                         .addJobVertex(jobVertexID1)
                         .addJobVertex(jobVertexID2)
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
         ExecutionVertex vertex1 = graph.getJobVertex(jobVertexID1).getTaskVertices()[0];
         ExecutionVertex vertex2 = graph.getJobVertex(jobVertexID2).getTaskVertices()[0];
         final ExecutionAttemptID attemptID1 = vertex1.getCurrentExecutionAttempt().getAttemptId();
@@ -682,7 +684,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
                 new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
                         .addJobVertex(new JobVertexID())
                         .addJobVertex(new JobVertexID())
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
 
         final String expectedErrorMessage = "Expected Error Message";
         CheckpointFailureManager checkpointFailureManager =
@@ -744,7 +746,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
                         .setFailureManager(new CheckpointFailureManager(0, failureCallback))
                         .setCheckpointStorage(new IOExceptionCheckpointStorage())
                         .setTimer(manuallyTriggeredScheduledExecutor)
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
         // when: The checkpoint is triggered.
         testTriggerCheckpoint(checkpointCoordinator, IO_EXCEPTION);
 
@@ -764,15 +766,14 @@ public class CheckpointCoordinatorTest extends TestLogger {
                 new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
                         .addJobVertex(jobVertexID1)
                         .addJobVertex(jobVertexID2, false)
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
 
         // set up the coordinator
         CheckpointCoordinator checkpointCoordinator =
                 new CheckpointCoordinatorBuilder()
-                        .setExecutionGraph(graph)
                         .setCheckpointStorage(new IOExceptionCheckpointStorage())
                         .setTimer(manuallyTriggeredScheduledExecutor)
-                        .build();
+                        .build(graph);
 
         Arrays.stream(graph.getJobVertex(jobVertexID1).getTaskVertices())
                 .forEach(task -> task.getCurrentExecutionAttempt().markFinished());
@@ -803,7 +804,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
                 new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
                         .addJobVertex(new JobVertexID())
                         .addJobVertex(new JobVertexID())
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
 
         final String errorMsg = "Exceeded checkpoint failure tolerance number!";
         CheckpointFailureManager checkpointFailureManager = getCheckpointFailureManager(errorMsg);
@@ -856,7 +857,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
                         .addJobVertex(jobVertexID1)
                         .addJobVertex(jobVertexID2)
                         .setTaskManagerGateway(gateway)
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
 
         ExecutionVertex vertex1 = graph.getJobVertex(jobVertexID1).getTaskVertices()[0];
         ExecutionVertex vertex2 = graph.getJobVertex(jobVertexID2).getTaskVertices()[0];
@@ -868,7 +869,6 @@ public class CheckpointCoordinatorTest extends TestLogger {
         // set up the coordinator and validate the initial state
         CheckpointCoordinator checkpointCoordinator =
                 new CheckpointCoordinatorBuilder()
-                        .setExecutionGraph(graph)
                         .setCheckpointCoordinatorConfiguration(
                                 CheckpointCoordinatorConfiguration.builder()
                                         .setAlignedCheckpointTimeout(Long.MAX_VALUE)
@@ -877,7 +877,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
                         .setTimer(manuallyTriggeredScheduledExecutor)
                         .setCheckpointFailureManager(
                                 new CheckpointFailureManager(0, failJobCallback))
-                        .build();
+                        .build(graph);
 
         assertEquals(0, checkpointCoordinator.getNumberOfPendingCheckpoints());
         assertEquals(0, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
@@ -986,7 +986,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
                         .addJobVertex(jobVertexID1)
                         .addJobVertex(jobVertexID2)
                         .setTaskManagerGateway(gateway)
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
 
         ExecutionVertex vertex1 = graph.getJobVertex(jobVertexID1).getTaskVertices()[0];
         ExecutionVertex vertex2 = graph.getJobVertex(jobVertexID2).getTaskVertices()[0];
@@ -1136,7 +1136,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
                         .addJobVertex(jobVertexID1)
                         .addJobVertex(jobVertexID2)
                         .setTaskManagerGateway(gateway)
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
 
         ExecutionVertex vertex1 = graph.getJobVertex(jobVertexID1).getTaskVertices()[0];
         ExecutionVertex vertex2 = graph.getJobVertex(jobVertexID2).getTaskVertices()[0];
@@ -1310,7 +1310,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
                         .addJobVertex(jobVertexID2)
                         .addJobVertex(jobVertexID3, false)
                         .setTaskManagerGateway(gateway)
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
 
         ExecutionVertex vertex1 = graph.getJobVertex(jobVertexID1).getTaskVertices()[0];
         ExecutionVertex vertex2 = graph.getJobVertex(jobVertexID2).getTaskVertices()[0];
@@ -1323,14 +1323,13 @@ public class CheckpointCoordinatorTest extends TestLogger {
         // set up the coordinator and validate the initial state
         CheckpointCoordinator checkpointCoordinator =
                 new CheckpointCoordinatorBuilder()
-                        .setExecutionGraph(graph)
                         .setCheckpointCoordinatorConfiguration(
                                 CheckpointCoordinatorConfiguration.builder()
                                         .setMaxConcurrentCheckpoints(Integer.MAX_VALUE)
                                         .build())
                         .setCompletedCheckpointStore(new StandaloneCompletedCheckpointStore(2))
                         .setTimer(manuallyTriggeredScheduledExecutor)
-                        .build();
+                        .build(graph);
 
         assertEquals(0, checkpointCoordinator.getNumberOfPendingCheckpoints());
         assertEquals(0, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
@@ -1466,7 +1465,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
                         .addJobVertex(jobVertexID2)
                         .addJobVertex(jobVertexID3, false)
                         .setTaskManagerGateway(gateway)
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
 
         ExecutionVertex vertex1 = graph.getJobVertex(jobVertexID1).getTaskVertices()[0];
         ExecutionVertex vertex2 = graph.getJobVertex(jobVertexID2).getTaskVertices()[0];
@@ -1481,14 +1480,13 @@ public class CheckpointCoordinatorTest extends TestLogger {
                 new StandaloneCompletedCheckpointStore(10);
         CheckpointCoordinator checkpointCoordinator =
                 new CheckpointCoordinatorBuilder()
-                        .setExecutionGraph(graph)
                         .setCheckpointCoordinatorConfiguration(
                                 CheckpointCoordinatorConfiguration.builder()
                                         .setMaxConcurrentCheckpoints(Integer.MAX_VALUE)
                                         .build())
                         .setCompletedCheckpointStore(completedCheckpointStore)
                         .setTimer(manuallyTriggeredScheduledExecutor)
-                        .build();
+                        .build(graph);
 
         assertEquals(0, checkpointCoordinator.getNumberOfPendingCheckpoints());
         assertEquals(0, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
@@ -1680,7 +1678,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
                         .addJobVertex(jobVertexID1)
                         .addJobVertex(jobVertexID2, false)
                         .setTaskManagerGateway(gateway)
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
 
         ExecutionVertex vertex1 = graph.getJobVertex(jobVertexID1).getTaskVertices()[0];
         ExecutionVertex vertex2 = graph.getJobVertex(jobVertexID2).getTaskVertices()[0];
@@ -1690,10 +1688,9 @@ public class CheckpointCoordinatorTest extends TestLogger {
         // set up the coordinator
         CheckpointCoordinator checkpointCoordinator =
                 new CheckpointCoordinatorBuilder()
-                        .setExecutionGraph(graph)
                         .setCompletedCheckpointStore(new StandaloneCompletedCheckpointStore(2))
                         .setTimer(manuallyTriggeredScheduledExecutor)
-                        .build();
+                        .build(graph);
 
         // trigger a checkpoint, partially acknowledged
         final CompletableFuture<CompletedCheckpoint> checkpointFuture =
@@ -1753,7 +1750,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
                         .addJobVertex(jobVertexID1)
                         .addJobVertex(jobVertexID2, false)
                         .setTaskManagerGateway(gateway)
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
 
         ExecutionVertex vertex1 = graph.getJobVertex(jobVertexID1).getTaskVertices()[0];
 
@@ -1761,10 +1758,9 @@ public class CheckpointCoordinatorTest extends TestLogger {
 
         CheckpointCoordinator checkpointCoordinator =
                 new CheckpointCoordinatorBuilder()
-                        .setExecutionGraph(graph)
                         .setCompletedCheckpointStore(new StandaloneCompletedCheckpointStore(2))
                         .setTimer(manuallyTriggeredScheduledExecutor)
-                        .build();
+                        .build(graph);
 
         final CompletableFuture<CompletedCheckpoint> checkpointFuture =
                 checkpointCoordinator.triggerCheckpoint(false);
@@ -1817,7 +1813,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
                         .addJobVertex(jobVertexID1)
                         .addJobVertex(jobVertexID2, false)
                         .setTaskManagerGateway(gateway)
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
 
         ExecutionVertex vertex1 = graph.getJobVertex(jobVertexID1).getTaskVertices()[0];
         ExecutionVertex vertex2 = graph.getJobVertex(jobVertexID2).getTaskVertices()[0];
@@ -1831,10 +1827,9 @@ public class CheckpointCoordinatorTest extends TestLogger {
                         .build();
         CheckpointCoordinator checkpointCoordinator =
                 new CheckpointCoordinatorBuilder()
-                        .setExecutionGraph(graph)
                         .setCheckpointCoordinatorConfiguration(chkConfig)
                         .setTimer(manuallyTriggeredScheduledExecutor)
-                        .build();
+                        .build(graph);
 
         final CompletableFuture<CompletedCheckpoint> checkpointFuture =
                 checkpointCoordinator.triggerCheckpoint(false);
@@ -2001,7 +1996,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
                         .addJobVertex(jobVertexID1)
                         .addJobVertex(jobVertexID2)
                         .setTaskManagerGateway(gateway)
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
 
         ExecutionVertex vertex1 = graph.getJobVertex(jobVertexID1).getTaskVertices()[0];
         ExecutionVertex vertex2 = graph.getJobVertex(jobVertexID2).getTaskVertices()[0];
@@ -2013,7 +2008,6 @@ public class CheckpointCoordinatorTest extends TestLogger {
         // set up the coordinator and validate the initial state
         CheckpointCoordinator checkpointCoordinator =
                 new CheckpointCoordinatorBuilder()
-                        .setExecutionGraph(graph)
                         .setCheckpointCoordinatorConfiguration(
                                 CheckpointCoordinatorConfiguration.builder()
                                         .setAlignedCheckpointTimeout(Long.MAX_VALUE)
@@ -2021,7 +2015,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
                                         .build())
                         .setTimer(manuallyTriggeredScheduledExecutor)
                         .setCheckpointStatsTracker(statsTracker)
-                        .build();
+                        .build(graph);
 
         assertEquals(0, checkpointCoordinator.getNumberOfPendingCheckpoints());
         assertEquals(0, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
@@ -2138,7 +2132,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
                 new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
                         .addJobVertex(jobVertexID1)
                         .addJobVertex(jobVertexID2)
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
 
         ExecutionVertex vertex1 = graph.getJobVertex(jobVertexID1).getTaskVertices()[0];
         ExecutionVertex vertex2 = graph.getJobVertex(jobVertexID2).getTaskVertices()[0];
@@ -2152,7 +2146,6 @@ public class CheckpointCoordinatorTest extends TestLogger {
         CheckpointCoordinator checkpointCoordinator =
                 spy(
                         new CheckpointCoordinatorBuilder()
-                                .setExecutionGraph(graph)
                                 .setCheckpointCoordinatorConfiguration(
                                         CheckpointCoordinatorConfiguration.builder()
                                                 .setMaxConcurrentCheckpoints(Integer.MAX_VALUE)
@@ -2161,7 +2154,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
                                 .setCompletedCheckpointStore(
                                         new StandaloneCompletedCheckpointStore(1))
                                 .setTimer(manuallyTriggeredScheduledExecutor)
-                                .build());
+                                .build(graph));
 
         String savepointDir = tmpFolder.newFolder().getAbsolutePath();
 
@@ -2283,7 +2276,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
                     new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
                             .addJobVertex(jobVertexID1)
                             .setTaskManagerGateway(gateway)
-                            .build();
+                            .build(EXECUTOR_RESOURCE.getExecutor());
 
             ExecutionVertex vertex1 = graph.getJobVertex(jobVertexID1).getTaskVertices()[0];
 
@@ -2299,11 +2292,10 @@ public class CheckpointCoordinatorTest extends TestLogger {
                             .build();
             CheckpointCoordinator checkpointCoordinator =
                     new CheckpointCoordinatorBuilder()
-                            .setExecutionGraph(graph)
                             .setCheckpointCoordinatorConfiguration(chkConfig)
                             .setCompletedCheckpointStore(new StandaloneCompletedCheckpointStore(2))
                             .setTimer(manuallyTriggeredScheduledExecutor)
-                            .build();
+                            .build(graph);
 
             checkpointCoordinator.startCheckpointScheduler();
 
@@ -2352,7 +2344,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
         ExecutionGraph graph =
                 new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
                         .addJobVertex(jobVertexID1)
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
 
         ExecutionVertex vertex1 = graph.getJobVertex(jobVertexID1).getTaskVertices()[0];
 
@@ -2367,11 +2359,10 @@ public class CheckpointCoordinatorTest extends TestLogger {
                         .build();
         CheckpointCoordinator checkpointCoordinator =
                 new CheckpointCoordinatorBuilder()
-                        .setExecutionGraph(graph)
                         .setCheckpointCoordinatorConfiguration(chkConfig)
                         .setCompletedCheckpointStore(new StandaloneCompletedCheckpointStore(2))
                         .setTimer(manuallyTriggeredScheduledExecutor)
-                        .build();
+                        .build(graph);
 
         checkpointCoordinator.startCheckpointScheduler();
 
@@ -2426,7 +2417,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
                 new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
                         .addJobVertex(jobVertexID1)
                         .setTransitToRunning(false)
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
 
         ExecutionVertex vertex1 = graph.getJobVertex(jobVertexID1).getTaskVertices()[0];
 
@@ -2440,13 +2431,12 @@ public class CheckpointCoordinatorTest extends TestLogger {
         CheckpointIDCounterWithOwner checkpointIDCounter = new CheckpointIDCounterWithOwner();
         CheckpointCoordinator checkpointCoordinator =
                 new CheckpointCoordinatorBuilder()
-                        .setExecutionGraph(graph)
                         .setCheckpointCoordinatorConfiguration(chkConfig)
                         .setCompletedCheckpointStore(new StandaloneCompletedCheckpointStore(2))
                         .setCheckpointStorage(checkpointStorage)
                         .setTimer(manuallyTriggeredScheduledExecutor)
                         .setCheckpointIDCounter(checkpointIDCounter)
-                        .build();
+                        .build(graph);
         checkpointIDCounter.setOwner(checkpointCoordinator);
 
         checkpointCoordinator.startCheckpointScheduler();
@@ -2476,7 +2466,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
         ExecutionGraph graph =
                 new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
                         .addJobVertex(jobVertexID1)
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
 
         ExecutionVertex vertex1 = graph.getJobVertex(jobVertexID1).getTaskVertices()[0];
 
@@ -2491,12 +2481,11 @@ public class CheckpointCoordinatorTest extends TestLogger {
                         .build();
         CheckpointCoordinator checkpointCoordinator =
                 new CheckpointCoordinatorBuilder()
-                        .setExecutionGraph(graph)
                         .setCheckpointCoordinatorConfiguration(chkConfig)
                         .setCheckpointIDCounter(checkpointIDCounter)
                         .setCompletedCheckpointStore(new StandaloneCompletedCheckpointStore(2))
                         .setTimer(manuallyTriggeredScheduledExecutor)
-                        .build();
+                        .build(graph);
 
         List<CompletableFuture<CompletedCheckpoint>> savepointFutures = new ArrayList<>();
 
@@ -2544,7 +2533,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
                         .setCheckpointCoordinatorConfiguration(chkConfig)
                         .setCompletedCheckpointStore(new StandaloneCompletedCheckpointStore(2))
                         .setTimer(manuallyTriggeredScheduledExecutor)
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
 
         String savepointDir = tmpFolder.newFolder().getAbsolutePath();
 
@@ -2563,7 +2552,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
         ExecutionGraph graph =
                 new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
                         .addJobVertex(new JobVertexID())
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
 
         // set up the coordinator and validate the initial state
         CheckpointCoordinatorConfiguration chkConfig =
@@ -2572,10 +2561,9 @@ public class CheckpointCoordinatorTest extends TestLogger {
                         .build();
         CheckpointCoordinator checkpointCoordinator =
                 new CheckpointCoordinatorBuilder()
-                        .setExecutionGraph(graph)
                         .setCheckpointCoordinatorConfiguration(chkConfig)
                         .setTimer(manuallyTriggeredScheduledExecutor)
-                        .build();
+                        .build(graph);
 
         CompletableFuture<CompletedCheckpoint> checkpointFuture =
                 checkpointCoordinator.triggerCheckpoint(false);
@@ -2812,7 +2800,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
                 new CheckpointCoordinatorBuilder()
                         .setTimer(manuallyTriggeredScheduledExecutor)
                         .setCheckpointStatsTracker(tracker)
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
 
         when(tracker.reportPendingCheckpoint(
                         anyLong(), anyLong(), any(CheckpointProperties.class), any(Map.class)))
@@ -2846,7 +2834,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
                         .setCompletedCheckpointStore(store)
                         .setTimer(manuallyTriggeredScheduledExecutor)
                         .setCheckpointStatsTracker(tracker)
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
 
         store.addCheckpointAndSubsumeOldestOne(
                 new CompletedCheckpoint(
@@ -2880,7 +2868,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
         ExecutionGraph graph =
                 new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
                         .addJobVertex(jobVertexID1, parallelism1, maxParallelism1)
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
 
         ExecutionJobVertex jobVertex1 = graph.getJobVertex(jobVertexID1);
 
@@ -2893,11 +2881,9 @@ public class CheckpointCoordinatorTest extends TestLogger {
 
         // set up the coordinator and validate the initial state
         final CheckpointCoordinatorBuilder coordinatorBuilder =
-                new CheckpointCoordinatorBuilder()
-                        .setExecutionGraph(graph)
-                        .setTimer(manuallyTriggeredScheduledExecutor);
+                new CheckpointCoordinatorBuilder().setTimer(manuallyTriggeredScheduledExecutor);
         final CheckpointCoordinator coordinator =
-                coordinatorBuilder.setCompletedCheckpointStore(store).build();
+                coordinatorBuilder.setCompletedCheckpointStore(store).build(graph);
 
         final int numCheckpoints = 3;
 
@@ -2989,7 +2975,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
         final EmbeddedCompletedCheckpointStore secondStore =
                 new EmbeddedCompletedCheckpointStore(10, store.getAllCheckpoints(), secondInstance);
         final CheckpointCoordinator secondCoordinator =
-                coordinatorBuilder.setCompletedCheckpointStore(secondStore).build();
+                coordinatorBuilder.setCompletedCheckpointStore(secondStore).build(graph);
         assertTrue(secondCoordinator.restoreLatestCheckpointedStateToAll(tasks, false));
 
         // validate that all shared states are registered again after the recovery.
@@ -3043,7 +3029,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
                 new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
                         .addJobVertex(jobVertexID1)
                         .addJobVertex(jobVertexID2)
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
 
         ExecutionVertex vertex1 = graph.getJobVertex(jobVertexID1).getTaskVertices()[0];
         ExecutionVertex vertex2 = graph.getJobVertex(jobVertexID2).getTaskVertices()[0];
@@ -3113,7 +3099,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
                 new CheckpointCoordinatorBuilder()
                         .setCheckpointIDCounter(testingCounter)
                         .setTimer(manuallyTriggeredScheduledExecutor)
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
         testingCounter.setOwner(checkpointCoordinator);
 
         testTriggerCheckpoint(checkpointCoordinator, PERIODIC_SCHEDULER_SHUTDOWN);
@@ -3135,7 +3121,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
                         .setFailureManager(new CheckpointFailureManager(0, failureCallback))
                         .setTimer(manuallyTriggeredScheduledExecutor)
                         .setCheckpointStatsTracker(statsTracker)
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
         testingCounter.setOwner(checkpointCoordinator);
 
         // when: The checkpoint is triggered.
@@ -3196,7 +3182,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
         ExecutionGraph graph =
                 new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
                         .addJobVertex(new JobVertexID())
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
         CheckpointCoordinator coordinator =
                 new CheckpointCoordinatorBuilder()
                         .setCheckpointCoordinatorConfiguration(
@@ -3204,9 +3190,8 @@ public class CheckpointCoordinatorTest extends TestLogger {
                                         .setUnalignedCheckpointsEnabled(true)
                                         .setMaxConcurrentCheckpoints(maxConcurrentCheckpoints)
                                         .build())
-                        .setExecutionGraph(graph)
                         .setTimer(manuallyTriggeredScheduledExecutor)
-                        .build();
+                        .build(graph);
         try {
             List<Future<?>> checkpointFutures = new ArrayList<>(checkpointRequestsToSend);
             coordinator.startCheckpointScheduler();
@@ -3267,7 +3252,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
                         .addJobVertex(jobVertexID1)
                         .addJobVertex(jobVertexID2)
                         .setTaskManagerGateway(gateway)
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
 
         ExecutionVertex vertex1 = graph.getJobVertex(jobVertexID1).getTaskVertices()[0];
         ExecutionVertex vertex2 = graph.getJobVertex(jobVertexID2).getTaskVertices()[0];
@@ -3301,7 +3286,6 @@ public class CheckpointCoordinatorTest extends TestLogger {
         // set up the coordinator and validate the initial state
         CheckpointCoordinator checkpointCoordinator =
                 new CheckpointCoordinatorBuilder()
-                        .setExecutionGraph(graph)
                         .setCheckpointCoordinatorConfiguration(
                                 CheckpointCoordinatorConfiguration.builder()
                                         .setMaxConcurrentCheckpoints(Integer.MAX_VALUE)
@@ -3309,7 +3293,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
                         .setTimer(manuallyTriggeredScheduledExecutor)
                         .setCoordinatorsToCheckpoint(
                                 Collections.singleton(coordinatorCheckpointContext))
-                        .build();
+                        .build(graph);
         AtomicReference<Long> checkpointIdRef = new AtomicReference<>();
 
         // Add a master hook which triggers and acks the task checkpoint immediately.
@@ -3421,7 +3405,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
                 new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
                         .addJobVertex(jobVertexID1)
                         .addJobVertex(jobVertexID2)
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
 
         ExecutionVertex vertex1 = graph.getJobVertex(jobVertexID1).getTaskVertices()[0];
         ExecutionVertex vertex2 = graph.getJobVertex(jobVertexID2).getTaskVertices()[0];
@@ -3455,7 +3439,6 @@ public class CheckpointCoordinatorTest extends TestLogger {
         // set up the coordinator and validate the initial state
         CheckpointCoordinator checkpointCoordinator =
                 new CheckpointCoordinatorBuilder()
-                        .setExecutionGraph(graph)
                         .setCheckpointCoordinatorConfiguration(
                                 CheckpointCoordinatorConfiguration.builder()
                                         .setMaxConcurrentCheckpoints(Integer.MAX_VALUE)
@@ -3492,7 +3475,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
                                         };
                                     }
                                 })
-                        .build();
+                        .build(graph);
         AtomicReference<Long> checkpointIdRef = new AtomicReference<>();
 
         // Add a master hook which triggers and acks the task checkpoint immediately.
@@ -3577,7 +3560,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
         CheckpointCoordinator checkpointCoordinator =
                 new CheckpointCoordinatorBuilder()
                         .setTimer(manuallyTriggeredScheduledExecutor)
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
 
         TestResetHook hook = new TestResetHook("id");
 
@@ -3593,7 +3576,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
         ExecutionGraph graph =
                 new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
                         .addJobVertex(jobVertexID)
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
 
         ExecutionVertex executionVertex = graph.getJobVertex(jobVertexID).getTaskVertices()[0];
         ExecutionAttemptID attemptID = executionVertex.getCurrentExecutionAttempt().getAttemptId();
@@ -3609,14 +3592,13 @@ public class CheckpointCoordinatorTest extends TestLogger {
         // set up the coordinator and validate the initial state
         CheckpointCoordinator checkpointCoordinator =
                 new CheckpointCoordinatorBuilder()
-                        .setExecutionGraph(graph)
                         .setCheckpointCoordinatorConfiguration(
                                 CheckpointCoordinatorConfiguration.builder()
                                         .setMaxConcurrentCheckpoints(Integer.MAX_VALUE)
                                         .build())
                         .setTimer(manuallyTriggeredScheduledExecutor)
                         .setCoordinatorsToCheckpoint(Collections.singleton(context))
-                        .build();
+                        .build(graph);
         try {
             // Trigger checkpoint 1.
             checkpointCoordinator.triggerCheckpoint(false);
@@ -3654,7 +3636,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
                 new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
                         .addJobVertex(jobVertexID)
                         .setTransitToRunning(false)
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
 
         ExecutionVertex task = graph.getJobVertex(jobVertexID).getTaskVertices()[0];
 
@@ -3679,10 +3661,9 @@ public class CheckpointCoordinatorTest extends TestLogger {
 
         CheckpointCoordinator checkpointCoordinator =
                 new CheckpointCoordinatorBuilder()
-                        .setExecutionGraph(graph)
                         .setTimer(manuallyTriggeredScheduledExecutor)
                         .setAllowCheckpointsAfterTasksFinished(true)
-                        .build();
+                        .build(graph);
 
         // Trigger a successful checkpoint
         CompletableFuture<CompletedCheckpoint> result =
@@ -3725,16 +3706,15 @@ public class CheckpointCoordinatorTest extends TestLogger {
                 new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
                         .addJobVertex(jobVertexID)
                         .setTransitToRunning(false)
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
         CheckpointCoordinator checkpointCoordinator =
                 new CheckpointCoordinatorBuilder()
-                        .setExecutionGraph(graph)
                         .setCheckpointCoordinatorConfiguration(
                                 CheckpointCoordinatorConfiguration.builder()
                                         .setCheckpointInterval(Long.MAX_VALUE)
                                         .build())
                         .setCheckpointStorage(new FsStateBackend(checkpointDir.toURI()))
-                        .build();
+                        .build(graph);
         Path jobCheckpointPath =
                 new Path(checkpointDir.getAbsolutePath(), graph.getJobID().toString());
         FileSystem fs = FileSystem.get(checkpointDir.toURI());
@@ -3745,24 +3725,22 @@ public class CheckpointCoordinatorTest extends TestLogger {
 
     private CheckpointCoordinator getCheckpointCoordinator(ExecutionGraph graph) throws Exception {
         return new CheckpointCoordinatorBuilder()
-                .setExecutionGraph(graph)
                 .setCheckpointCoordinatorConfiguration(
                         CheckpointCoordinatorConfiguration.builder()
                                 .setAlignedCheckpointTimeout(Long.MAX_VALUE)
                                 .setMaxConcurrentCheckpoints(Integer.MAX_VALUE)
                                 .build())
                 .setTimer(manuallyTriggeredScheduledExecutor)
-                .build();
+                .build(graph);
     }
 
     private CheckpointCoordinator getCheckpointCoordinator(
             ExecutionGraph graph, CheckpointFailureManager failureManager) throws Exception {
 
         return new CheckpointCoordinatorBuilder()
-                .setExecutionGraph(graph)
                 .setTimer(manuallyTriggeredScheduledExecutor)
                 .setFailureManager(failureManager)
-                .build();
+                .build(graph);
     }
 
     private CheckpointCoordinator getCheckpointCoordinator(ScheduledExecutor timer)
@@ -3771,10 +3749,10 @@ public class CheckpointCoordinatorTest extends TestLogger {
                 new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
                         .addJobVertex(new JobVertexID())
                         .addJobVertex(new JobVertexID())
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
 
         // set up the coordinator and validate the initial state
-        return new CheckpointCoordinatorBuilder().setExecutionGraph(graph).setTimer(timer).build();
+        return new CheckpointCoordinatorBuilder().setTimer(timer).build(graph);
     }
 
     private CheckpointFailureManager getCheckpointFailureManager(String errorMsg) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTriggeringTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTriggeringTest.java
@@ -32,6 +32,8 @@ import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration.CheckpointCoordinatorConfigurationBuilder;
 import org.apache.flink.runtime.messages.checkpoint.AcknowledgeCheckpoint;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.ExecutorUtils;
 import org.apache.flink.util.TestLogger;
@@ -40,6 +42,7 @@ import org.apache.flink.util.concurrent.ManuallyTriggeredScheduledExecutor;
 import org.apache.flink.util.concurrent.ScheduledExecutorServiceAdapter;
 
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -68,6 +71,11 @@ import static org.junit.Assert.fail;
 
 /** Tests for checkpoint coordinator triggering. */
 public class CheckpointCoordinatorTriggeringTest extends TestLogger {
+
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
+
     private static final String TASK_MANAGER_LOCATION_INFO = "Unknown location";
 
     private ManuallyTriggeredScheduledExecutor manuallyTriggeredScheduledExecutor;
@@ -92,7 +100,7 @@ public class CheckpointCoordinatorTriggeringTest extends TestLogger {
                     new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
                             .addJobVertex(jobVertexID)
                             .setTaskManagerGateway(gateway)
-                            .build();
+                            .build(EXECUTOR_RESOURCE.getExecutor());
 
             ExecutionVertex vertex = graph.getJobVertex(jobVertexID).getTaskVertices()[0];
             ExecutionAttemptID attemptID = vertex.getCurrentExecutionAttempt().getAttemptId();
@@ -105,12 +113,11 @@ public class CheckpointCoordinatorTriggeringTest extends TestLogger {
                             .build();
             CheckpointCoordinator checkpointCoordinator =
                     new CheckpointCoordinatorBuilder()
-                            .setExecutionGraph(graph)
                             .setCheckpointCoordinatorConfiguration(
                                     checkpointCoordinatorConfiguration)
                             .setCompletedCheckpointStore(new StandaloneCompletedCheckpointStore(2))
                             .setTimer(manuallyTriggeredScheduledExecutor)
-                            .build();
+                            .build(graph);
 
             checkpointCoordinator.startCheckpointScheduler();
 
@@ -186,7 +193,7 @@ public class CheckpointCoordinatorTriggeringTest extends TestLogger {
                 new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
                         .addJobVertex(jobVertexID)
                         .setTaskManagerGateway(gateway)
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
 
         ExecutionVertex vertex = graph.getJobVertex(jobVertexID).getTaskVertices()[0];
         ExecutionAttemptID attemptID = vertex.getCurrentExecutionAttempt().getAttemptId();
@@ -238,7 +245,7 @@ public class CheckpointCoordinatorTriggeringTest extends TestLogger {
                 new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
                         .addJobVertex(jobVertexID)
                         .setTaskManagerGateway(gateway)
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
 
         ExecutionVertex vertex = graph.getJobVertex(jobVertexID).getTaskVertices()[0];
         ExecutionAttemptID attemptID = vertex.getCurrentExecutionAttempt().getAttemptId();
@@ -320,12 +327,11 @@ public class CheckpointCoordinatorTriggeringTest extends TestLogger {
                         .setMaxConcurrentCheckpoints(Integer.MAX_VALUE)
                         .build();
         return new CheckpointCoordinatorBuilder()
-                .setExecutionGraph(graph)
                 .setCheckpointCoordinatorConfiguration(checkpointCoordinatorConfiguration)
                 .setCompletedCheckpointStore(checkpointStore)
                 .setCheckpointIDCounter(checkpointIDCounter)
                 .setTimer(manuallyTriggeredScheduledExecutor)
-                .build();
+                .build(graph);
     }
 
     /**
@@ -343,7 +349,7 @@ public class CheckpointCoordinatorTriggeringTest extends TestLogger {
                 new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
                         .addJobVertex(jobVertexID)
                         .setTaskManagerGateway(gateway)
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
 
         ExecutionVertex vertex = graph.getJobVertex(jobVertexID).getTaskVertices()[0];
         ExecutionAttemptID attemptID = vertex.getCurrentExecutionAttempt().getAttemptId();
@@ -360,11 +366,10 @@ public class CheckpointCoordinatorTriggeringTest extends TestLogger {
                         .build();
         final CheckpointCoordinator checkpointCoordinator =
                 new CheckpointCoordinatorBuilder()
-                        .setExecutionGraph(graph)
                         .setCheckpointCoordinatorConfiguration(checkpointCoordinatorConfiguration)
                         .setCompletedCheckpointStore(new StandaloneCompletedCheckpointStore(2))
                         .setTimer(manuallyTriggeredScheduledExecutor)
-                        .build();
+                        .build(graph);
 
         try {
             checkpointCoordinator.startCheckpointScheduler();
@@ -477,7 +482,7 @@ public class CheckpointCoordinatorTriggeringTest extends TestLogger {
                 new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
                         .addJobVertex(jobVertexID)
                         .setTaskManagerGateway(gateway)
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
 
         ExecutionVertex vertex = graph.getJobVertex(jobVertexID).getTaskVertices()[0];
         ExecutionAttemptID attemptID = vertex.getCurrentExecutionAttempt().getAttemptId();
@@ -517,7 +522,7 @@ public class CheckpointCoordinatorTriggeringTest extends TestLogger {
                 new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
                         .addJobVertex(jobVertexID)
                         .setTaskManagerGateway(gateway)
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
 
         ExecutionVertex vertex = graph.getJobVertex(jobVertexID).getTaskVertices()[0];
         ExecutionAttemptID attemptID = vertex.getCurrentExecutionAttempt().getAttemptId();
@@ -525,10 +530,9 @@ public class CheckpointCoordinatorTriggeringTest extends TestLogger {
         // set up the coordinator and validate the initial state
         CheckpointCoordinator checkpointCoordinator =
                 new CheckpointCoordinatorBuilder()
-                        .setExecutionGraph(graph)
                         .setCheckpointIDCounter(new UnstableCheckpointIDCounter(id -> id == 0))
                         .setTimer(manuallyTriggeredScheduledExecutor)
-                        .build();
+                        .build(graph);
 
         checkpointCoordinator.startCheckpointScheduler();
         // start a periodic checkpoint first
@@ -568,7 +572,7 @@ public class CheckpointCoordinatorTriggeringTest extends TestLogger {
                 new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
                         .addJobVertex(jobVertexID)
                         .setTaskManagerGateway(gateway)
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
 
         ExecutionVertex vertex = graph.getJobVertex(jobVertexID).getTaskVertices()[0];
         ExecutionAttemptID attemptID = vertex.getCurrentExecutionAttempt().getAttemptId();
@@ -619,7 +623,7 @@ public class CheckpointCoordinatorTriggeringTest extends TestLogger {
                 new CheckpointCoordinatorBuilder()
                         .setCheckpointIDCounter(new UnstableCheckpointIDCounter(id -> id == 0))
                         .setTimer(manuallyTriggeredScheduledExecutor)
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
 
         checkpointCoordinator.startCheckpointScheduler();
         final CompletableFuture<CompletedCheckpoint> onCompletionPromise1 =
@@ -662,7 +666,7 @@ public class CheckpointCoordinatorTriggeringTest extends TestLogger {
                 new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
                         .addJobVertex(jobVertexID)
                         .setTaskManagerGateway(gateway)
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
 
         ExecutionVertex vertex = graph.getJobVertex(jobVertexID).getTaskVertices()[0];
         ExecutionAttemptID attemptID = vertex.getCurrentExecutionAttempt().getAttemptId();
@@ -712,7 +716,7 @@ public class CheckpointCoordinatorTriggeringTest extends TestLogger {
                         .setTimer(new ScheduledExecutorServiceAdapter(scheduledExecutorService))
                         .setCheckpointCoordinatorConfiguration(
                                 CheckpointCoordinatorConfiguration.builder().build())
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
 
         final CompletableFuture<String> masterHookCheckpointFuture = new CompletableFuture<>();
         final OneShotLatch triggerCheckpointLatch = new OneShotLatch();
@@ -750,15 +754,14 @@ public class CheckpointCoordinatorTriggeringTest extends TestLogger {
     private CheckpointCoordinator createCheckpointCoordinator() throws Exception {
         return new CheckpointCoordinatorBuilder()
                 .setTimer(manuallyTriggeredScheduledExecutor)
-                .build();
+                .build(EXECUTOR_RESOURCE.getExecutor());
     }
 
     private CheckpointCoordinator createCheckpointCoordinator(ExecutionGraph graph)
             throws Exception {
         return new CheckpointCoordinatorBuilder()
-                .setExecutionGraph(graph)
                 .setTimer(manuallyTriggeredScheduledExecutor)
-                .build();
+                .build(graph);
     }
 
     private CompletableFuture<CompletedCheckpoint> triggerPeriodicCheckpoint(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointSettingsSerializableTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointSettingsSerializableTest.java
@@ -42,10 +42,13 @@ import org.apache.flink.runtime.state.OperatorStateHandle;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 import org.apache.flink.testutils.ClassLoaderUtils;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.TernaryBoolean;
 import org.apache.flink.util.TestLogger;
 
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import javax.annotation.Nonnull;
@@ -53,6 +56,7 @@ import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Collection;
+import java.util.concurrent.ScheduledExecutorService;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -64,6 +68,9 @@ import static org.mockito.Mockito.when;
  * user-defined objects.
  */
 public class CheckpointSettingsSerializableTest extends TestLogger {
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     @Test
     public void testDeserializationOfUserCodeWithUserClassLoader() throws Exception {
@@ -107,7 +114,7 @@ public class CheckpointSettingsSerializableTest extends TestLogger {
                 TestingDefaultExecutionGraphBuilder.newBuilder()
                         .setJobGraph(copy)
                         .setUserClassLoader(classLoader)
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
 
         assertEquals(1, eg.getCheckpointCoordinator().getNumberOfRegisteredMasterHooks());
         assertTrue(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStatsTrackerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStatsTrackerTest.java
@@ -25,7 +25,10 @@ import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -34,6 +37,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
 
 import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertEquals;
@@ -44,6 +48,10 @@ import static org.junit.Assert.assertTrue;
 
 public class CheckpointStatsTrackerTest {
 
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
+
     /** Tests that the number of remembered checkpoints configuration is respected. */
     @Test
     public void testTrackerWithoutHistory() throws Exception {
@@ -51,7 +59,7 @@ public class CheckpointStatsTrackerTest {
         ExecutionGraph graph =
                 new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
                         .addJobVertex(jobVertexID, 3, 256)
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
         ExecutionJobVertex jobVertex = graph.getJobVertex(jobVertexID);
 
         CheckpointStatsTracker tracker =
@@ -97,7 +105,7 @@ public class CheckpointStatsTrackerTest {
         ExecutionGraph graph =
                 new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
                         .addJobVertex(jobVertexID, 3, 256)
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
         ExecutionJobVertex jobVertex = graph.getJobVertex(jobVertexID);
         Map<JobVertexID, Integer> vertexToDop =
                 singletonMap(jobVertexID, jobVertex.getParallelism());
@@ -331,7 +339,7 @@ public class CheckpointStatsTrackerTest {
         ExecutionGraph graph =
                 new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
                         .addJobVertex(jobVertexID)
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
         ExecutionJobVertex jobVertex = graph.getJobVertex(jobVertexID);
 
         CheckpointStatsTracker stats = new CheckpointStatsTracker(0, metricGroup);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/DefaultCheckpointPlanTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/DefaultCheckpointPlanTest.java
@@ -26,6 +26,8 @@ import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.state.TestingStreamStateHandle;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.FlinkRuntimeException;
 
 import org.junit.ClassRule;
@@ -38,6 +40,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
 
 import static org.apache.flink.runtime.checkpoint.CheckpointCoordinatorTestingUtils.createSubtaskStateWithUnionListState;
 import static org.junit.Assert.assertEquals;
@@ -46,6 +49,10 @@ import static org.junit.Assert.assertTrue;
 
 /** Tests the behavior of the {@link DefaultCheckpointPlan}. */
 public class DefaultCheckpointPlanTest {
+
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     @ClassRule public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
 
@@ -65,7 +72,7 @@ public class DefaultCheckpointPlanTest {
                                 Collections.singletonList(
                                         OperatorIDPair.generatedIDOnly(operatorId)),
                                 true)
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
         ExecutionVertex[] tasks = executionGraph.getJobVertex(jobVertexId).getTaskVertices();
         tasks[0].getCurrentExecutionAttempt().markFinished();
 
@@ -100,7 +107,7 @@ public class DefaultCheckpointPlanTest {
                                 Collections.singletonList(
                                         OperatorIDPair.generatedIDOnly(operatorId)),
                                 true)
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
         ExecutionVertex[] tasks = executionGraph.getJobVertex(jobVertexId).getTaskVertices();
 
         CheckpointPlan checkpointPlan = createCheckpointPlan(executionGraph);
@@ -156,7 +163,7 @@ public class DefaultCheckpointPlanTest {
                                         OperatorIDPair.generatedIDOnly(
                                                 partiallyFinishedOperatorId)),
                                 true)
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
         ExecutionVertex[] fullyFinishedVertexTasks =
                 executionGraph.getJobVertex(fullyFinishedVertexId).getTaskVertices();
         ExecutionVertex[] finishedOnRestoreVertexTasks =
@@ -196,7 +203,7 @@ public class DefaultCheckpointPlanTest {
                                 Collections.singletonList(
                                         OperatorIDPair.generatedIDOnly(finishedOperatorID)),
                                 true)
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
         executionGraph
                 .getJobVertex(finishedJobVertexID)
                 .getTaskVertices()[0]

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/DefaultSchedulerCheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/DefaultSchedulerCheckpointCoordinatorTest.java
@@ -35,12 +35,16 @@ import org.apache.flink.runtime.scheduler.DefaultScheduler;
 import org.apache.flink.runtime.scheduler.SchedulerBase;
 import org.apache.flink.runtime.scheduler.SchedulerTestingUtils;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.TestLogger;
 
 import org.hamcrest.Matchers;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -50,6 +54,10 @@ import static org.junit.Assert.assertThat;
  * {@link CheckpointCoordinator}.
  */
 public class DefaultSchedulerCheckpointCoordinatorTest extends TestLogger {
+
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     /** Tests that the checkpoint coordinator is shut down if the execution graph is failed. */
     @Test
@@ -200,8 +208,10 @@ public class DefaultSchedulerCheckpointCoordinatorTest extends TestLogger {
                         .setJobCheckpointingSettings(checkpointingSettings)
                         .build();
 
-        return SchedulerTestingUtils.newSchedulerBuilder(
-                        jobGraph, ComponentMainThreadExecutorServiceAdapter.forMainThread())
+        return new SchedulerTestingUtils.DefaultSchedulerBuilder(
+                        jobGraph,
+                        ComponentMainThreadExecutorServiceAdapter.forMainThread(),
+                        EXECUTOR_RESOURCE.getExecutor())
                 .setCheckpointRecoveryFactory(new TestingCheckpointRecoveryFactory(store, counter))
                 .setRpcTimeout(timeout)
                 .build();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/FailoverStrategyCheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/FailoverStrategyCheckpointCoordinatorTest.java
@@ -24,14 +24,18 @@ import org.apache.flink.runtime.executiongraph.ExecutionGraphCheckpointPlanCalcu
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.concurrent.Executors;
 import org.apache.flink.util.concurrent.ManuallyTriggeredScheduledExecutor;
 
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.Collections;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static org.junit.Assert.assertEquals;
@@ -40,6 +44,11 @@ import static org.mockito.Mockito.mock;
 
 /** Tests for actions of {@link CheckpointCoordinator} on task failures. */
 public class FailoverStrategyCheckpointCoordinatorTest extends TestLogger {
+
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
+
     private ManuallyTriggeredScheduledExecutor manualThreadExecutor;
 
     @Before
@@ -58,7 +67,7 @@ public class FailoverStrategyCheckpointCoordinatorTest extends TestLogger {
                 new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
                         .addJobVertex(new JobVertexID())
                         .setTransitToRunning(false)
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
         CheckpointCoordinatorConfiguration checkpointCoordinatorConfiguration =
                 new CheckpointCoordinatorConfiguration(
                         Integer.MAX_VALUE,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/StateAssignmentOperationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/StateAssignmentOperationTest.java
@@ -43,9 +43,12 @@ import org.apache.flink.runtime.state.OperatorStateHandle;
 import org.apache.flink.runtime.state.OperatorStreamStateHandle;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Assert;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -57,6 +60,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -86,6 +90,9 @@ import static org.junit.Assert.assertEquals;
 
 /** Tests to verify state assignment operation. */
 public class StateAssignmentOperationTest extends TestLogger {
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     private static final int MAX_P = 256;
 
@@ -926,7 +933,9 @@ public class StateAssignmentOperationTest extends TestLogger {
             throws JobException, JobExecutionException {
         JobGraph jobGraph = JobGraphTestUtils.streamingJobGraph(jobVertices);
         ExecutionGraph eg =
-                TestingDefaultExecutionGraphBuilder.newBuilder().setJobGraph(jobGraph).build();
+                TestingDefaultExecutionGraphBuilder.newBuilder()
+                        .setJobGraph(jobGraph)
+                        .build(EXECUTOR_RESOURCE.getExecutor());
         return Arrays.stream(jobVertices)
                 .collect(
                         Collectors.toMap(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/VertexFinishedStateCheckerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/VertexFinishedStateCheckerTest.java
@@ -27,8 +27,11 @@ import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.FlinkRuntimeException;
 
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -36,6 +39,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ScheduledExecutorService;
 
 import static java.util.Collections.singletonList;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -45,6 +49,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /** This tests verifies the checking logic of {@link VertexFinishedStateChecker}. */
 public class VertexFinishedStateCheckerTest {
+
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     @Test
     public void testRestoringPartiallyFinishedChainsFailsWithoutUidHash() throws Exception {
@@ -72,7 +80,7 @@ public class VertexFinishedStateCheckerTest {
                 new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
                         .addJobVertex(jobVertexID2, 1, 1, singletonList(op3), true)
                         .addJobVertex(jobVertexID1, 1, 1, Arrays.asList(op1, op2), true)
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
 
         Map<OperatorID, OperatorState> operatorStates = new HashMap<>();
         operatorStates.put(
@@ -261,7 +269,7 @@ public class VertexFinishedStateCheckerTest {
                         .addJobVertex(vertex1, true)
                         .addJobVertex(vertex2, false)
                         .setDistributionPattern(distributionPatterns[0])
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
 
         // Adds the additional edges
         for (int i = 1; i < distributionPatterns.length; ++i) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorFactoryTest.java
@@ -40,9 +40,12 @@ import org.apache.flink.runtime.jobgraph.JobGraphBuilder;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.CompressedSerializedValue;
 import org.apache.flink.util.TestLogger;
 
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -50,6 +53,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -57,6 +61,9 @@ import static org.junit.Assert.assertEquals;
 
 /** Tests for {@link TaskDeploymentDescriptorFactory}. */
 public class TaskDeploymentDescriptorFactoryTest extends TestLogger {
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     private static final int PARALLELISM = 4;
 
@@ -150,7 +157,7 @@ public class TaskDeploymentDescriptorFactoryTest extends TestLogger {
         return TestingDefaultExecutionGraphBuilder.newBuilder()
                 .setJobGraph(jobGraph)
                 .setBlobWriter(blobWriter)
-                .build();
+                .build(EXECUTOR_RESOURCE.getExecutor());
     }
 
     private static TaskDeploymentDescriptor createTaskDeploymentDescriptor(ExecutionVertex ev)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/ExecutionGraphInfoStoreTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/ExecutionGraphInfoStoreTestUtils.java
@@ -42,8 +42,8 @@ import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.scheduler.ExecutionGraphInfo;
 import org.apache.flink.runtime.security.token.DelegationTokenManager;
 import org.apache.flink.runtime.webmonitor.retriever.MetricQueryServiceRetriever;
-import org.apache.flink.testutils.TestingUtils;
 import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.concurrent.ScheduledExecutor;
 
 import org.apache.flink.shaded.guava30.com.google.common.base.Ticker;
 
@@ -175,15 +175,21 @@ public class ExecutionGraphInfoStoreTestUtils {
     /** MiniCluster with specified {@link ExecutionGraphInfoStore}. */
     static class PersistingMiniCluster extends MiniCluster {
         @Nullable private final File rootDir;
+        private final ScheduledExecutor scheduledExecutor;
 
-        PersistingMiniCluster(MiniClusterConfiguration miniClusterConfiguration) {
-            this(miniClusterConfiguration, null);
+        PersistingMiniCluster(
+                MiniClusterConfiguration miniClusterConfiguration,
+                ScheduledExecutor scheduledExecutor) {
+            this(miniClusterConfiguration, null, scheduledExecutor);
         }
 
         PersistingMiniCluster(
-                MiniClusterConfiguration miniClusterConfiguration, @Nullable File rootDir) {
+                MiniClusterConfiguration miniClusterConfiguration,
+                @Nullable File rootDir,
+                ScheduledExecutor scheduledExecutor) {
             super(miniClusterConfiguration);
             this.rootDir = rootDir;
+            this.scheduledExecutor = scheduledExecutor;
         }
 
         @Override
@@ -210,7 +216,8 @@ public class ExecutionGraphInfoStoreTestUtils {
             switch (jobStoreType) {
                 case File:
                     {
-                        executionGraphInfoStore = createDefaultExecutionGraphInfoStore(rootDir);
+                        executionGraphInfoStore =
+                                createDefaultExecutionGraphInfoStore(rootDir, scheduledExecutor);
                         break;
                     }
                 case Memory:
@@ -242,14 +249,14 @@ public class ExecutionGraphInfoStoreTestUtils {
         }
     }
 
-    static FileExecutionGraphInfoStore createDefaultExecutionGraphInfoStore(File storageDirectory)
-            throws IOException {
+    static FileExecutionGraphInfoStore createDefaultExecutionGraphInfoStore(
+            File storageDirectory, ScheduledExecutor scheduledExecutor) throws IOException {
         return new FileExecutionGraphInfoStore(
                 storageDirectory,
                 Time.hours(1L),
                 Integer.MAX_VALUE,
                 10000L,
-                TestingUtils.defaultScheduledExecutor(),
+                scheduledExecutor,
                 Ticker.systemTicker());
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/FileExecutionGraphInfoStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/FileExecutionGraphInfoStoreTest.java
@@ -33,8 +33,10 @@ import org.apache.flink.runtime.rest.handler.legacy.utils.ArchivedExecutionGraph
 import org.apache.flink.runtime.scheduler.ExecutionGraphInfo;
 import org.apache.flink.runtime.util.ManualTicker;
 import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.concurrent.ManuallyTriggeredScheduledExecutor;
+import org.apache.flink.util.concurrent.ScheduledExecutorServiceAdapter;
 
 import org.apache.flink.shaded.guava30.com.google.common.base.Ticker;
 import org.apache.flink.shaded.guava30.com.google.common.cache.LoadingCache;
@@ -50,6 +52,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -62,6 +65,11 @@ import static org.junit.Assert.assertTrue;
 
 /** Tests for the {@link FileExecutionGraphInfoStore}. */
 public class FileExecutionGraphInfoStoreTest extends TestLogger {
+
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
+
     @ClassRule public static TemporaryFolder temporaryFolder = new TemporaryFolder();
 
     /**
@@ -85,7 +93,9 @@ public class FileExecutionGraphInfoStoreTest extends TestLogger {
         final File rootDir = temporaryFolder.newFolder();
 
         try (final FileExecutionGraphInfoStore executionGraphStore =
-                createDefaultExecutionGraphInfoStore(rootDir)) {
+                createDefaultExecutionGraphInfoStore(
+                        rootDir,
+                        new ScheduledExecutorServiceAdapter(EXECUTOR_RESOURCE.getExecutor()))) {
             assertThat(executionGraphStore.get(new JobID()), Matchers.nullValue());
         }
     }
@@ -108,7 +118,9 @@ public class FileExecutionGraphInfoStoreTest extends TestLogger {
         final File rootDir = temporaryFolder.newFolder();
 
         try (final FileExecutionGraphInfoStore executionGraphInfoStore =
-                createDefaultExecutionGraphInfoStore(rootDir)) {
+                createDefaultExecutionGraphInfoStore(
+                        rootDir,
+                        new ScheduledExecutorServiceAdapter(EXECUTOR_RESOURCE.getExecutor()))) {
             for (ExecutionGraphInfo executionGraphInfo : executionGraphInfos) {
                 executionGraphInfoStore.put(executionGraphInfo);
             }
@@ -131,7 +143,9 @@ public class FileExecutionGraphInfoStoreTest extends TestLogger {
         final File rootDir = temporaryFolder.newFolder();
 
         try (final FileExecutionGraphInfoStore executionGraphInfoStore =
-                createDefaultExecutionGraphInfoStore(rootDir)) {
+                createDefaultExecutionGraphInfoStore(
+                        rootDir,
+                        new ScheduledExecutorServiceAdapter(EXECUTOR_RESOURCE.getExecutor()))) {
             for (ExecutionGraphInfo executionGraphInfo : executionGraphInfos) {
                 executionGraphInfoStore.put(executionGraphInfo);
             }
@@ -200,7 +214,9 @@ public class FileExecutionGraphInfoStoreTest extends TestLogger {
         assertThat(rootDir.listFiles().length, Matchers.equalTo(0));
 
         try (final FileExecutionGraphInfoStore executionGraphInfoStore =
-                createDefaultExecutionGraphInfoStore(rootDir)) {
+                createDefaultExecutionGraphInfoStore(
+                        rootDir,
+                        new ScheduledExecutorServiceAdapter(EXECUTOR_RESOURCE.getExecutor()))) {
 
             assertThat(rootDir.listFiles().length, Matchers.equalTo(1));
 
@@ -231,7 +247,7 @@ public class FileExecutionGraphInfoStoreTest extends TestLogger {
                         Time.hours(1L),
                         Integer.MAX_VALUE,
                         100L << 10,
-                        TestingUtils.defaultScheduledExecutor(),
+                        new ScheduledExecutorServiceAdapter(EXECUTOR_RESOURCE.getExecutor()),
                         Ticker.systemTicker())) {
 
             final LoadingCache<JobID, ExecutionGraphInfo> executionGraphInfoCache =
@@ -296,7 +312,7 @@ public class FileExecutionGraphInfoStoreTest extends TestLogger {
                         Time.hours(1L),
                         maxCapacity,
                         10000L,
-                        TestingUtils.defaultScheduledExecutor(),
+                        new ScheduledExecutorServiceAdapter(EXECUTOR_RESOURCE.getExecutor()),
                         Ticker.systemTicker())) {
 
             for (ExecutionGraphInfo executionGraphInfo : oldExecutionGraphInfos) {
@@ -324,7 +340,9 @@ public class FileExecutionGraphInfoStoreTest extends TestLogger {
         File rootDir = temporaryFolder.newFolder();
         try (final MiniCluster miniCluster =
                 new ExecutionGraphInfoStoreTestUtils.PersistingMiniCluster(
-                        new MiniClusterConfiguration.Builder().build(), rootDir)) {
+                        new MiniClusterConfiguration.Builder().build(),
+                        rootDir,
+                        new ScheduledExecutorServiceAdapter(EXECUTOR_RESOURCE.getExecutor()))) {
             miniCluster.start();
             final JobVertex vertex = new JobVertex("blockingVertex");
             // The adaptive scheduler expects that every vertex has a configured parallelism
@@ -344,7 +362,9 @@ public class FileExecutionGraphInfoStoreTest extends TestLogger {
         final File rootDir = temporaryFolder.newFolder();
 
         try (final FileExecutionGraphInfoStore executionGraphStore =
-                createDefaultExecutionGraphInfoStore(rootDir)) {
+                createDefaultExecutionGraphInfoStore(
+                        rootDir,
+                        new ScheduledExecutorServiceAdapter(EXECUTOR_RESOURCE.getExecutor()))) {
 
             final File storageDirectory = executionGraphStore.getStorageDir();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/JobDispatcherITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/JobDispatcherITCase.java
@@ -46,12 +46,14 @@ import org.apache.flink.runtime.rest.JobRestEndpointFactory;
 import org.apache.flink.runtime.scheduler.adaptive.AdaptiveSchedulerClusterITCase;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorExtension;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.TestLoggerExtension;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
@@ -62,6 +64,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Supplier;
 
 import static java.nio.file.StandardOpenOption.CREATE;
@@ -70,6 +73,9 @@ import static org.apache.flink.runtime.entrypoint.component.FileJobGraphRetrieve
 /** An integration test which recovers from checkpoint after regaining the leadership. */
 @ExtendWith(TestLoggerExtension.class)
 public class JobDispatcherITCase {
+    @RegisterExtension
+    static final TestExecutorExtension<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorExtension();
 
     private Supplier<DispatcherResourceManagerComponentFactory>
             createJobModeDispatcherResourceManagerComponentFactorySupplier(
@@ -98,7 +104,7 @@ public class JobDispatcherITCase {
                         .setConfiguration(configuration)
                         .build();
         final EmbeddedHaServicesWithLeadershipControl haServices =
-                new EmbeddedHaServicesWithLeadershipControl(TestingUtils.defaultExecutor());
+                new EmbeddedHaServicesWithLeadershipControl(EXECUTOR_RESOURCE.getExecutor());
 
         final Configuration newConfiguration =
                 new Configuration(clusterConfiguration.getConfiguration());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/DefaultDispatcherRunnerITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/DefaultDispatcherRunnerITCase.java
@@ -53,6 +53,7 @@ import org.apache.flink.runtime.util.BlobServerResource;
 import org.apache.flink.runtime.util.LeaderConnectionInfo;
 import org.apache.flink.runtime.util.TestingFatalErrorHandler;
 import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.TestLogger;
 
 import org.apache.flink.shaded.guava30.com.google.common.collect.Iterables;
@@ -67,6 +68,7 @@ import org.slf4j.LoggerFactory;
 import java.util.Collection;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.Matchers.contains;
@@ -86,6 +88,10 @@ public class DefaultDispatcherRunnerITCase extends TestLogger {
     public static TestingRpcServiceResource rpcServiceResource = new TestingRpcServiceResource();
 
     @ClassRule public static BlobServerResource blobServerResource = new BlobServerResource();
+
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     private JobGraph jobGraph;
 
@@ -266,7 +272,7 @@ public class DefaultDispatcherRunnerITCase extends TestLogger {
                 dispatcherLeaderElectionService,
                 fatalErrorHandler,
                 new TestingJobPersistenceComponentFactory(jobGraphStore, jobResultStore),
-                TestingUtils.defaultExecutor(),
+                EXECUTOR_RESOURCE.getExecutor(),
                 rpcServiceResource.getTestingRpcService(),
                 partialDispatcherServices);
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/ZooKeeperDefaultDispatcherRunnerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/ZooKeeperDefaultDispatcherRunnerTest.java
@@ -55,6 +55,7 @@ import org.apache.flink.runtime.util.TestingFatalErrorHandler;
 import org.apache.flink.runtime.util.ZooKeeperUtils;
 import org.apache.flink.runtime.zookeeper.ZooKeeperResource;
 import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.TestLogger;
 
@@ -73,6 +74,7 @@ import java.io.IOException;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ScheduledExecutorService;
 
 import static org.hamcrest.Matchers.emptyArray;
 import static org.hamcrest.Matchers.is;
@@ -89,6 +91,10 @@ public class ZooKeeperDefaultDispatcherRunnerTest extends TestLogger {
     @ClassRule public static ZooKeeperResource zooKeeperResource = new ZooKeeperResource();
 
     @ClassRule public static TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     @ClassRule
     public static TestingRpcServiceResource testingRpcServiceResource =
@@ -240,7 +246,7 @@ public class ZooKeeperDefaultDispatcherRunnerTest extends TestLogger {
                 dispatcherLeaderElectionService,
                 fatalErrorHandler,
                 jobPersistenceComponentFactory,
-                TestingUtils.defaultExecutor(),
+                EXECUTOR_RESOURCE.getExecutor(),
                 rpcService,
                 partialDispatcherServices);
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/AllVerticesIteratorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/AllVerticesIteratorTest.java
@@ -20,13 +20,21 @@ package org.apache.flink.runtime.executiongraph;
 
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 
 import org.junit.Assert;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.concurrent.ScheduledExecutorService;
 
 public class AllVerticesIteratorTest {
+
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     @Test
     public void testAllVertices() {
@@ -47,7 +55,9 @@ public class AllVerticesIteratorTest {
             v3.setParallelism(3);
             v4.setParallelism(2);
 
-            ExecutionGraph eg = ExecutionGraphTestUtils.createSimpleTestGraph(v1, v2, v3, v4);
+            ExecutionGraph eg =
+                    ExecutionGraphTestUtils.createExecutionGraph(
+                            EXECUTOR_RESOURCE.getExecutor(), v1, v2, v3, v4);
             ExecutionJobVertex ejv1 = eg.getJobVertex(v1.getID());
             ExecutionJobVertex ejv2 = eg.getJobVertex(v2.getID());
             ExecutionJobVertex ejv3 = eg.getJobVertex(v3.getID());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraphTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraphTest.java
@@ -41,11 +41,14 @@ import org.apache.flink.runtime.jobgraph.tasks.JobCheckpointingSettings;
 import org.apache.flink.runtime.scheduler.SchedulerBase;
 import org.apache.flink.runtime.scheduler.SchedulerTestingUtils;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.OptionalFailure;
 import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -54,6 +57,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Function;
 
 import static java.util.Arrays.asList;
@@ -67,6 +71,10 @@ import static org.junit.Assert.assertTrue;
 
 /** Tests for the {@link ArchivedExecutionGraph}. */
 public class ArchivedExecutionGraphTest extends TestLogger {
+
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     private static ExecutionGraph runtimeGraph;
 
@@ -118,7 +126,9 @@ public class ArchivedExecutionGraphTest extends TestLogger {
 
         SchedulerBase scheduler =
                 SchedulerTestingUtils.createScheduler(
-                        jobGraph, ComponentMainThreadExecutorServiceAdapter.forMainThread());
+                        jobGraph,
+                        ComponentMainThreadExecutorServiceAdapter.forMainThread(),
+                        EXECUTOR_RESOURCE.getExecutor());
 
         runtimeGraph = scheduler.getExecutionGraph();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphConstructionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphConstructionTest.java
@@ -32,9 +32,12 @@ import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.scheduler.SchedulerBase;
 import org.apache.flink.runtime.scheduler.strategy.ConsumedPartitionGroup;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 
 import org.apache.flink.shaded.guava30.com.google.common.collect.Sets;
 
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.mockito.Matchers;
 
@@ -46,6 +49,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ScheduledExecutorService;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -62,17 +66,20 @@ import static org.mockito.Mockito.when;
  * builds {@link DistributionPattern#ALL_TO_ALL} connections correctly.
  */
 public class DefaultExecutionGraphConstructionTest {
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     private ExecutionGraph createDefaultExecutionGraph(List<JobVertex> vertices) throws Exception {
         return TestingDefaultExecutionGraphBuilder.newBuilder()
                 .setVertexParallelismStore(SchedulerBase.computeVertexParallelismStore(vertices))
-                .build();
+                .build(EXECUTOR_RESOURCE.getExecutor());
     }
 
     private ExecutionGraph createDynamicExecutionGraph(List<JobVertex> vertices) throws Exception {
         return TestingDefaultExecutionGraphBuilder.newBuilder()
                 .setVertexParallelismStore(SchedulerBase.computeVertexParallelismStore(vertices))
-                .buildDynamicGraph();
+                .buildDynamicGraph(EXECUTOR_RESOURCE.getExecutor());
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphDeploymentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphDeploymentTest.java
@@ -64,11 +64,14 @@ import org.apache.flink.runtime.taskmanager.TaskExecutionState;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
 import org.apache.flink.runtime.testutils.DirectScheduledExecutorService;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.function.FunctionUtils;
 
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -81,6 +84,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
 
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
@@ -91,6 +95,10 @@ import static org.junit.Assert.fail;
 
 /** Tests for {@link DefaultExecutionGraph} deployment. */
 public class DefaultExecutionGraphDeploymentTest extends TestLogger {
+
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     /** BLOB server instance to use for the job graph. */
     protected BlobWriter blobWriter = VoidBlobWriter.getInstance();
@@ -159,10 +167,8 @@ public class DefaultExecutionGraphDeploymentTest extends TestLogger {
         DefaultExecutionGraph eg =
                 TestingDefaultExecutionGraphBuilder.newBuilder()
                         .setJobGraph(jobGraph)
-                        .setFutureExecutor(executor)
-                        .setIoExecutor(executor)
                         .setBlobWriter(blobWriter)
-                        .build();
+                        .build(executor);
 
         eg.start(ComponentMainThreadExecutorServiceAdapter.forMainThread());
 
@@ -471,8 +477,10 @@ public class DefaultExecutionGraphDeploymentTest extends TestLogger {
 
         // execution graph that executes actions synchronously
         final SchedulerBase scheduler =
-                SchedulerTestingUtils.newSchedulerBuilder(
-                                graph, ComponentMainThreadExecutorServiceAdapter.forMainThread())
+                new SchedulerTestingUtils.DefaultSchedulerBuilder(
+                                graph,
+                                ComponentMainThreadExecutorServiceAdapter.forMainThread(),
+                                EXECUTOR_RESOURCE.getExecutor())
                         .setExecutionSlotAllocatorFactory(
                                 SchedulerTestingUtils.newSlotSharingExecutionSlotAllocatorFactory(
                                         TestingPhysicalSlotProvider
@@ -530,9 +538,10 @@ public class DefaultExecutionGraphDeploymentTest extends TestLogger {
 
         // execution graph that executes actions synchronously
         final SchedulerBase scheduler =
-                SchedulerTestingUtils.newSchedulerBuilder(
+                new SchedulerTestingUtils.DefaultSchedulerBuilder(
                                 JobGraphTestUtils.streamingJobGraph(v1, v2),
-                                ComponentMainThreadExecutorServiceAdapter.forMainThread())
+                                ComponentMainThreadExecutorServiceAdapter.forMainThread(),
+                                EXECUTOR_RESOURCE.getExecutor())
                         .setExecutionSlotAllocatorFactory(
                                 SchedulerTestingUtils.newSlotSharingExecutionSlotAllocatorFactory())
                         .setFutureExecutor(executorService)
@@ -615,8 +624,10 @@ public class DefaultExecutionGraphDeploymentTest extends TestLogger {
         final TestingPhysicalSlotProvider physicalSlotProvider =
                 TestingPhysicalSlotProvider.createWithoutImmediatePhysicalSlotCreation();
         final SchedulerBase scheduler =
-                SchedulerTestingUtils.newSchedulerBuilder(
-                                jobGraph, ComponentMainThreadExecutorServiceAdapter.forMainThread())
+                new SchedulerTestingUtils.DefaultSchedulerBuilder(
+                                jobGraph,
+                                ComponentMainThreadExecutorServiceAdapter.forMainThread(),
+                                EXECUTOR_RESOURCE.getExecutor())
                         .setExecutionSlotAllocatorFactory(
                                 SchedulerTestingUtils.newSlotSharingExecutionSlotAllocatorFactory(
                                         physicalSlotProvider))
@@ -681,7 +692,7 @@ public class DefaultExecutionGraphDeploymentTest extends TestLogger {
                 .setJobGraph(jobGraph)
                 .setJobMasterConfig(configuration)
                 .setBlobWriter(blobWriter)
-                .build();
+                .build(EXECUTOR_RESOURCE.getExecutor());
     }
 
     private static final class ExecutionStageMatcher

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphDeploymentWithSmallBlobCacheSizeLimitTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphDeploymentWithSmallBlobCacheSizeLimitTest.java
@@ -176,10 +176,8 @@ public class DefaultExecutionGraphDeploymentWithSmallBlobCacheSizeLimitTest
         final DefaultExecutionGraph eg =
                 TestingDefaultExecutionGraphBuilder.newBuilder()
                         .setJobGraph(jobGraph)
-                        .setFutureExecutor(executor)
-                        .setIoExecutor(executor)
                         .setBlobWriter(blobWriter)
-                        .build();
+                        .build(executor);
 
         eg.start(ComponentMainThreadExecutorServiceAdapter.forMainThread());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/EdgeManagerBuildUtilTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/EdgeManagerBuildUtilTest.java
@@ -24,13 +24,17 @@ import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.scheduler.SchedulerBase;
 import org.apache.flink.runtime.scheduler.strategy.ConsumerVertexGroup;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 
 import org.apache.commons.lang3.tuple.Pair;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
 
 import static org.apache.flink.runtime.jobgraph.DistributionPattern.ALL_TO_ALL;
 import static org.apache.flink.runtime.jobgraph.DistributionPattern.POINTWISE;
@@ -42,6 +46,9 @@ import static org.junit.Assert.assertEquals;
  * DistributionPattern#ALL_TO_ALL}.
  */
 public class EdgeManagerBuildUtilTest {
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     @Test
     public void testGetMaxNumEdgesToTargetInPointwiseConnection() throws Exception {
@@ -120,7 +127,7 @@ public class EdgeManagerBuildUtilTest {
                 TestingDefaultExecutionGraphBuilder.newBuilder()
                         .setVertexParallelismStore(
                                 SchedulerBase.computeVertexParallelismStore(ordered))
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
         eg.attachJobGraph(ordered);
         return Pair.of(eg.getAllVertices().get(v1.getID()), eg.getAllVertices().get(v2.getID()));
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/EdgeManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/EdgeManagerTest.java
@@ -28,15 +28,23 @@ import org.apache.flink.runtime.scheduler.SchedulerBase;
 import org.apache.flink.runtime.scheduler.SchedulerTestingUtils;
 import org.apache.flink.runtime.scheduler.strategy.ConsumedPartitionGroup;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.Objects;
+import java.util.concurrent.ScheduledExecutorService;
 
 import static org.junit.Assert.assertEquals;
 
 /** Tests for {@link EdgeManager}. */
 public class EdgeManagerTest {
+
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     @Test
     public void testGetConsumedPartitionGroup() throws Exception {
@@ -55,7 +63,9 @@ public class EdgeManagerTest {
         JobGraph jobGraph = JobGraphTestUtils.batchJobGraph(v1, v2);
         SchedulerBase scheduler =
                 SchedulerTestingUtils.createScheduler(
-                        jobGraph, ComponentMainThreadExecutorServiceAdapter.forMainThread());
+                        jobGraph,
+                        ComponentMainThreadExecutorServiceAdapter.forMainThread(),
+                        EXECUTOR_RESOURCE.getExecutor());
         ExecutionGraph eg = scheduler.getExecutionGraph();
 
         ConsumedPartitionGroup groupRetrievedByDownstreamVertex =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphCoLocationRestartTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphCoLocationRestartTest.java
@@ -34,11 +34,15 @@ import org.apache.flink.runtime.scheduler.SchedulerTestingUtils;
 import org.apache.flink.runtime.scheduler.TestingPhysicalSlot;
 import org.apache.flink.runtime.scheduler.TestingPhysicalSlotProvider;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.FlinkException;
 
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Predicate;
 
 import static org.apache.flink.api.common.JobStatus.FINISHED;
@@ -48,6 +52,10 @@ import static org.junit.Assert.assertThat;
 
 /** Tests that co-location constraints work as expected in the case of task restarts. */
 public class ExecutionGraphCoLocationRestartTest {
+
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     private static final int NUM_TASKS = 31;
 
@@ -72,8 +80,10 @@ public class ExecutionGraphCoLocationRestartTest {
         final ManuallyTriggeredScheduledExecutorService delayExecutor =
                 new ManuallyTriggeredScheduledExecutorService();
         final SchedulerBase scheduler =
-                SchedulerTestingUtils.newSchedulerBuilder(
-                                jobGraph, ComponentMainThreadExecutorServiceAdapter.forMainThread())
+                new SchedulerTestingUtils.DefaultSchedulerBuilder(
+                                jobGraph,
+                                ComponentMainThreadExecutorServiceAdapter.forMainThread(),
+                                EXECUTOR_RESOURCE.getExecutor())
                         .setExecutionSlotAllocatorFactory(
                                 SchedulerTestingUtils.newSlotSharingExecutionSlotAllocatorFactory(
                                         TestingPhysicalSlotProvider.create(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphFinishTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphFinishTest.java
@@ -25,18 +25,26 @@ import org.apache.flink.runtime.jobgraph.JobGraphTestUtils;
 import org.apache.flink.runtime.scheduler.SchedulerBase;
 import org.apache.flink.runtime.scheduler.SchedulerTestingUtils;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.TestLogger;
 
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
 
 import static org.junit.Assert.assertEquals;
 
 /** Tests the finish behaviour of the {@link ExecutionGraph}. */
 public class ExecutionGraphFinishTest extends TestLogger {
+
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     @Test
     public void testJobFinishes() throws Exception {
@@ -47,8 +55,10 @@ public class ExecutionGraphFinishTest extends TestLogger {
                         ExecutionGraphTestUtils.createJobVertex("Task2", 2, NoOpInvokable.class));
 
         SchedulerBase scheduler =
-                SchedulerTestingUtils.newSchedulerBuilder(
-                                jobGraph, ComponentMainThreadExecutorServiceAdapter.forMainThread())
+                new SchedulerTestingUtils.DefaultSchedulerBuilder(
+                                jobGraph,
+                                ComponentMainThreadExecutorServiceAdapter.forMainThread(),
+                                EXECUTOR_RESOURCE.getExecutor())
                         .build();
 
         ExecutionGraph eg = scheduler.getExecutionGraph();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphPartitionReleaseTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphPartitionReleaseTest.java
@@ -32,8 +32,11 @@ import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.scheduler.SchedulerBase;
 import org.apache.flink.runtime.scheduler.SchedulerTestingUtils;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.TestLogger;
 
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.ArrayDeque;
@@ -51,6 +54,10 @@ import static org.hamcrest.core.IsEqual.equalTo;
  * PartitionGroupReleaseStrategy}.
  */
 public class ExecutionGraphPartitionReleaseTest extends TestLogger {
+
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     private static final ScheduledExecutorService scheduledExecutorService =
             Executors.newSingleThreadScheduledExecutor();
@@ -251,8 +258,10 @@ public class ExecutionGraphPartitionReleaseTest extends TestLogger {
 
         final JobGraph jobGraph = JobGraphTestUtils.batchJobGraph(vertices);
         final SchedulerBase scheduler =
-                SchedulerTestingUtils.newSchedulerBuilder(
-                                jobGraph, mainThreadExecutor.getMainThreadExecutor())
+                new SchedulerTestingUtils.DefaultSchedulerBuilder(
+                                jobGraph,
+                                mainThreadExecutor.getMainThreadExecutor(),
+                                EXECUTOR_RESOURCE.getExecutor())
                         .setExecutionSlotAllocatorFactory(
                                 SchedulerTestingUtils.newSlotSharingExecutionSlotAllocatorFactory())
                         .setPartitionTracker(partitionTracker)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.java
@@ -44,15 +44,19 @@ import org.apache.flink.runtime.scheduler.ExecutionSlotAllocatorFactory;
 import org.apache.flink.runtime.scheduler.SchedulerBase;
 import org.apache.flink.runtime.scheduler.SchedulerTestingUtils;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.concurrent.ManuallyTriggeredScheduledExecutor;
 
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
 
 import static org.hamcrest.Matchers.is;
@@ -64,6 +68,10 @@ import static org.junit.Assert.assertThat;
 public class ExecutionGraphRestartTest extends TestLogger {
 
     private static final int NUM_TASKS = 31;
+
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     private static final ComponentMainThreadExecutor mainThreadExecutor =
             ComponentMainThreadExecutorServiceAdapter.forMainThread();
@@ -99,7 +107,8 @@ public class ExecutionGraphRestartTest extends TestLogger {
                             "Task", NUM_TASKS + numTasksExceedSlotPool, NoOpInvokable.class);
             JobGraph graph = JobGraphTestUtils.streamingJobGraph(sender);
             SchedulerBase scheduler =
-                    SchedulerTestingUtils.newSchedulerBuilder(graph, mainThreadExecutor)
+                    new SchedulerTestingUtils.DefaultSchedulerBuilder(
+                                    graph, mainThreadExecutor, EXECUTOR_RESOURCE.getExecutor())
                             .setExecutionSlotAllocatorFactory(
                                     createExecutionSlotAllocatorFactory(slotPool))
                             .build();
@@ -127,7 +136,8 @@ public class ExecutionGraphRestartTest extends TestLogger {
                             "Task", NUM_TASKS + numTasksExceedSlotPool, NoOpInvokable.class);
             JobGraph graph = JobGraphTestUtils.streamingJobGraph(sender);
             SchedulerBase scheduler =
-                    SchedulerTestingUtils.newSchedulerBuilder(graph, mainThreadExecutor)
+                    new SchedulerTestingUtils.DefaultSchedulerBuilder(
+                                    graph, mainThreadExecutor, EXECUTOR_RESOURCE.getExecutor())
                             .setExecutionSlotAllocatorFactory(
                                     createExecutionSlotAllocatorFactory(slotPool))
                             .build();
@@ -149,7 +159,10 @@ public class ExecutionGraphRestartTest extends TestLogger {
         // We want to manually control the restart and delay
         try (SlotPool slotPool = SlotPoolUtils.createDeclarativeSlotPoolBridge()) {
             SchedulerBase scheduler =
-                    SchedulerTestingUtils.newSchedulerBuilder(createJobGraph(), mainThreadExecutor)
+                    new SchedulerTestingUtils.DefaultSchedulerBuilder(
+                                    createJobGraph(),
+                                    mainThreadExecutor,
+                                    EXECUTOR_RESOURCE.getExecutor())
                             .setExecutionSlotAllocatorFactory(
                                     createExecutionSlotAllocatorFactory(slotPool))
                             .setRestartBackoffTimeStrategy(
@@ -189,7 +202,10 @@ public class ExecutionGraphRestartTest extends TestLogger {
     public void testCancelWhileFailing() throws Exception {
         try (SlotPool slotPool = SlotPoolUtils.createDeclarativeSlotPoolBridge()) {
             SchedulerBase scheduler =
-                    SchedulerTestingUtils.newSchedulerBuilder(createJobGraph(), mainThreadExecutor)
+                    new SchedulerTestingUtils.DefaultSchedulerBuilder(
+                                    createJobGraph(),
+                                    mainThreadExecutor,
+                                    EXECUTOR_RESOURCE.getExecutor())
                             .setExecutionSlotAllocatorFactory(
                                     createExecutionSlotAllocatorFactory(slotPool))
                             .setRestartBackoffTimeStrategy(
@@ -224,7 +240,10 @@ public class ExecutionGraphRestartTest extends TestLogger {
     public void testFailWhileCanceling() throws Exception {
         try (SlotPool slotPool = SlotPoolUtils.createDeclarativeSlotPoolBridge()) {
             SchedulerBase scheduler =
-                    SchedulerTestingUtils.newSchedulerBuilder(createJobGraph(), mainThreadExecutor)
+                    new SchedulerTestingUtils.DefaultSchedulerBuilder(
+                                    createJobGraph(),
+                                    mainThreadExecutor,
+                                    EXECUTOR_RESOURCE.getExecutor())
                             .setExecutionSlotAllocatorFactory(
                                     createExecutionSlotAllocatorFactory(slotPool))
                             .setRestartBackoffTimeStrategy(
@@ -272,7 +291,8 @@ public class ExecutionGraphRestartTest extends TestLogger {
 
         try (SlotPool slotPool = SlotPoolUtils.createDeclarativeSlotPoolBridge()) {
             SchedulerBase scheduler =
-                    SchedulerTestingUtils.newSchedulerBuilder(jobGraph, mainThreadExecutor)
+                    new SchedulerTestingUtils.DefaultSchedulerBuilder(
+                                    jobGraph, mainThreadExecutor, EXECUTOR_RESOURCE.getExecutor())
                             .setExecutionSlotAllocatorFactory(
                                     createExecutionSlotAllocatorFactory(slotPool))
                             .setRestartBackoffTimeStrategy(
@@ -331,8 +351,10 @@ public class ExecutionGraphRestartTest extends TestLogger {
     public void testFailExecutionAfterCancel() throws Exception {
         try (SlotPool slotPool = SlotPoolUtils.createDeclarativeSlotPoolBridge()) {
             SchedulerBase scheduler =
-                    SchedulerTestingUtils.newSchedulerBuilder(
-                                    createJobGraphToCancel(), mainThreadExecutor)
+                    new SchedulerTestingUtils.DefaultSchedulerBuilder(
+                                    createJobGraphToCancel(),
+                                    mainThreadExecutor,
+                                    EXECUTOR_RESOURCE.getExecutor())
                             .setExecutionSlotAllocatorFactory(
                                     createExecutionSlotAllocatorFactory(slotPool))
                             .setRestartBackoffTimeStrategy(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphSuspendTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphSuspendTest.java
@@ -29,10 +29,15 @@ import org.apache.flink.runtime.scheduler.SchedulerBase;
 import org.apache.flink.runtime.scheduler.SchedulerTestingUtils;
 import org.apache.flink.runtime.scheduler.TestingPhysicalSlotProvider;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.concurrent.ManuallyTriggeredScheduledExecutor;
 
+import org.junit.ClassRule;
 import org.junit.Test;
+
+import java.util.concurrent.ScheduledExecutorService;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
@@ -40,6 +45,10 @@ import static org.junit.Assert.assertThat;
 
 /** Validates that suspending out of various states works correctly. */
 public class ExecutionGraphSuspendTest extends TestLogger {
+
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     /**
      * Going into SUSPENDED out of CREATED should immediately cancel everything and not send out RPC
@@ -228,9 +237,10 @@ public class ExecutionGraphSuspendTest extends TestLogger {
         final ManuallyTriggeredScheduledExecutor taskRestartExecutor =
                 new ManuallyTriggeredScheduledExecutor();
         final SchedulerBase scheduler =
-                SchedulerTestingUtils.newSchedulerBuilder(
+                new SchedulerTestingUtils.DefaultSchedulerBuilder(
                                 JobGraphTestUtils.emptyJobGraph(),
-                                ComponentMainThreadExecutorServiceAdapter.forMainThread())
+                                ComponentMainThreadExecutorServiceAdapter.forMainThread(),
+                                EXECUTOR_RESOURCE.getExecutor())
                         .setRestartBackoffTimeStrategy(
                                 new TestRestartBackoffTimeStrategy(true, Long.MAX_VALUE))
                         .setDelayExecutor(taskRestartExecutor)
@@ -308,9 +318,10 @@ public class ExecutionGraphSuspendTest extends TestLogger {
         vertex.setParallelism(parallelism);
 
         final SchedulerBase scheduler =
-                SchedulerTestingUtils.newSchedulerBuilder(
+                new SchedulerTestingUtils.DefaultSchedulerBuilder(
                                 JobGraphTestUtils.streamingJobGraph(vertex),
-                                ComponentMainThreadExecutorServiceAdapter.forMainThread())
+                                ComponentMainThreadExecutorServiceAdapter.forMainThread(),
+                                EXECUTOR_RESOURCE.getExecutor())
                         .setExecutionSlotAllocatorFactory(
                                 SchedulerTestingUtils.newSlotSharingExecutionSlotAllocatorFactory(
                                         TestingPhysicalSlotProvider

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphVariousFailuesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphVariousFailuesTest.java
@@ -25,9 +25,14 @@ import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.jobgraph.JobGraphTestUtils;
 import org.apache.flink.runtime.scheduler.SchedulerBase;
 import org.apache.flink.runtime.scheduler.SchedulerTestingUtils;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.TestLogger;
 
+import org.junit.ClassRule;
 import org.junit.Test;
+
+import java.util.concurrent.ScheduledExecutorService;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
@@ -36,6 +41,10 @@ import static org.junit.Assert.fail;
 
 public class ExecutionGraphVariousFailuesTest extends TestLogger {
 
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
+
     /**
      * Tests that a failing notifyPartitionDataAvailable call with a non-existing execution attempt
      * id, will not fail the execution graph.
@@ -43,9 +52,10 @@ public class ExecutionGraphVariousFailuesTest extends TestLogger {
     @Test
     public void testFailingNotifyPartitionDataAvailable() throws Exception {
         final SchedulerBase scheduler =
-                SchedulerTestingUtils.newSchedulerBuilder(
+                new SchedulerTestingUtils.DefaultSchedulerBuilder(
                                 JobGraphTestUtils.emptyJobGraph(),
-                                ComponentMainThreadExecutorServiceAdapter.forMainThread())
+                                ComponentMainThreadExecutorServiceAdapter.forMainThread(),
+                                EXECUTOR_RESOURCE.getExecutor())
                         .build();
         scheduler.startScheduling();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertexTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertexTest.java
@@ -28,11 +28,15 @@ import org.apache.flink.runtime.operators.coordination.CoordinatorStoreImpl;
 import org.apache.flink.runtime.scheduler.VertexParallelismInformation;
 import org.apache.flink.runtime.scheduler.VertexParallelismStore;
 import org.apache.flink.runtime.scheduler.adaptivebatch.AdaptiveBatchScheduler;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 
 import org.junit.Assert;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.Collections;
+import java.util.concurrent.ScheduledExecutorService;
 
 import static org.apache.flink.core.testutils.CommonTestUtils.assertThrows;
 import static org.hamcrest.CoreMatchers.is;
@@ -40,6 +44,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 /** Test for {@link ExecutionJobVertex} */
 public class ExecutionJobVertexTest {
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
+
     @Test
     public void testParallelismGreaterThanMaxParallelism() {
         JobVertex jobVertex = new JobVertex("testVertex");
@@ -209,7 +217,9 @@ public class ExecutionJobVertexTest {
             jobVertex.setParallelism(parallelism);
         }
 
-        final DefaultExecutionGraph eg = TestingDefaultExecutionGraphBuilder.newBuilder().build();
+        final DefaultExecutionGraph eg =
+                TestingDefaultExecutionGraphBuilder.newBuilder()
+                        .build(EXECUTOR_RESOURCE.getExecutor());
         final VertexParallelismStore vertexParallelismStore =
                 AdaptiveBatchScheduler.computeVertexParallelismStoreForDynamicGraph(
                         Collections.singletonList(jobVertex), defaultMaxParallelism);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionPartitionLifecycleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionPartitionLifecycleTest.java
@@ -48,6 +48,8 @@ import org.apache.flink.runtime.shuffle.ShuffleTestUtils;
 import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.ClassRule;
@@ -61,6 +63,7 @@ import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
 
 import static org.hamcrest.Matchers.contains;
@@ -74,8 +77,8 @@ import static org.junit.Assert.assertTrue;
 public class ExecutionPartitionLifecycleTest extends TestLogger {
 
     @ClassRule
-    public static final TestingComponentMainThreadExecutor.Resource EXECUTOR_RESOURCE =
-            new TestingComponentMainThreadExecutor.Resource();
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     private Execution execution;
     private ResultPartitionDeploymentDescriptor descriptor;
@@ -276,8 +279,10 @@ public class ExecutionPartitionLifecycleTest extends TestLogger {
 
         final JobGraph jobGraph = JobGraphTestUtils.batchJobGraph(producerVertex, consumerVertex);
         final SchedulerBase scheduler =
-                SchedulerTestingUtils.newSchedulerBuilder(
-                                jobGraph, ComponentMainThreadExecutorServiceAdapter.forMainThread())
+                new SchedulerTestingUtils.DefaultSchedulerBuilder(
+                                jobGraph,
+                                ComponentMainThreadExecutorServiceAdapter.forMainThread(),
+                                EXECUTOR_RESOURCE.getExecutor())
                         .setExecutionSlotAllocatorFactory(
                                 SchedulerTestingUtils.newSlotSharingExecutionSlotAllocatorFactory(
                                         physicalSlotProvider))

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionTest.java
@@ -31,6 +31,8 @@ import org.apache.flink.runtime.scheduler.SchedulerTestingUtils;
 import org.apache.flink.runtime.scheduler.TestingPhysicalSlot;
 import org.apache.flink.runtime.scheduler.TestingPhysicalSlotProvider;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TestLogger;
 
@@ -40,6 +42,7 @@ import org.junit.Test;
 import javax.annotation.Nonnull;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -51,11 +54,15 @@ import static org.junit.Assert.assertTrue;
 public class ExecutionTest extends TestLogger {
 
     @ClassRule
-    public static final TestingComponentMainThreadExecutor.Resource EXECUTOR_RESOURCE =
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
+
+    @ClassRule
+    public static final TestingComponentMainThreadExecutor.Resource MAIN_EXECUTOR_RESOURCE =
             new TestingComponentMainThreadExecutor.Resource();
 
     private final TestingComponentMainThreadExecutor testMainThreadUtil =
-            EXECUTOR_RESOURCE.getComponentMainThreadTestExecutor();
+            MAIN_EXECUTOR_RESOURCE.getComponentMainThreadTestExecutor();
 
     /**
      * Checks that the {@link Execution} termination future is only completed after the assigned
@@ -72,9 +79,10 @@ public class ExecutionTest extends TestLogger {
         final TestingPhysicalSlotProvider physicalSlotProvider =
                 TestingPhysicalSlotProvider.createWithLimitedAmountOfPhysicalSlots(1);
         final SchedulerBase scheduler =
-                SchedulerTestingUtils.newSchedulerBuilder(
+                new SchedulerTestingUtils.DefaultSchedulerBuilder(
                                 JobGraphTestUtils.streamingJobGraph(jobVertex),
-                                ComponentMainThreadExecutorServiceAdapter.forMainThread())
+                                ComponentMainThreadExecutorServiceAdapter.forMainThread(),
+                                EXECUTOR_RESOURCE.getExecutor())
                         .setExecutionSlotAllocatorFactory(
                                 SchedulerTestingUtils.newSlotSharingExecutionSlotAllocatorFactory(
                                         physicalSlotProvider))
@@ -115,9 +123,10 @@ public class ExecutionTest extends TestLogger {
         final JobVertexID jobVertexId = jobVertex.getID();
 
         final SchedulerBase scheduler =
-                SchedulerTestingUtils.newSchedulerBuilder(
+                new SchedulerTestingUtils.DefaultSchedulerBuilder(
                                 JobGraphTestUtils.streamingJobGraph(jobVertex),
-                                ComponentMainThreadExecutorServiceAdapter.forMainThread())
+                                ComponentMainThreadExecutorServiceAdapter.forMainThread(),
+                                EXECUTOR_RESOURCE.getExecutor())
                         .setExecutionSlotAllocatorFactory(
                                 SchedulerTestingUtils.newSlotSharingExecutionSlotAllocatorFactory(
                                         TestingPhysicalSlotProvider
@@ -159,9 +168,10 @@ public class ExecutionTest extends TestLogger {
                                                 .withTaskManagerGateway(taskManagerGateway)
                                                 .build()));
         final SchedulerBase scheduler =
-                SchedulerTestingUtils.newSchedulerBuilder(
+                new SchedulerTestingUtils.DefaultSchedulerBuilder(
                                 JobGraphTestUtils.streamingJobGraph(jobVertex),
-                                testMainThreadUtil.getMainThreadExecutor())
+                                testMainThreadUtil.getMainThreadExecutor(),
+                                EXECUTOR_RESOURCE.getExecutor())
                         .setExecutionSlotAllocatorFactory(
                                 SchedulerTestingUtils.newSlotSharingExecutionSlotAllocatorFactory(
                                         physicalSlotProvider))
@@ -198,9 +208,10 @@ public class ExecutionTest extends TestLogger {
         final TestingPhysicalSlotProvider physicalSlotProvider =
                 TestingPhysicalSlotProvider.createWithLimitedAmountOfPhysicalSlots(1);
         final SchedulerBase scheduler =
-                SchedulerTestingUtils.newSchedulerBuilder(
+                new SchedulerTestingUtils.DefaultSchedulerBuilder(
                                 JobGraphTestUtils.streamingJobGraph(jobVertex),
-                                testMainThreadUtil.getMainThreadExecutor())
+                                testMainThreadUtil.getMainThreadExecutor(),
+                                EXECUTOR_RESOURCE.getExecutor())
                         .setExecutionSlotAllocatorFactory(
                                 SchedulerTestingUtils.newSlotSharingExecutionSlotAllocatorFactory(
                                         physicalSlotProvider))

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexCancelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexCancelTest.java
@@ -29,13 +29,17 @@ import org.apache.flink.runtime.jobmaster.TestingLogicalSlotBuilder;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.scheduler.SchedulerBase;
 import org.apache.flink.runtime.scheduler.SchedulerTestingUtils;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.concurrent.FutureUtils;
 
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
 
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.createNoOpVertex;
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.getExecutionVertex;
@@ -48,6 +52,10 @@ import static org.junit.Assert.fail;
 
 /** Tests for cancelling {@link ExecutionVertex ExecutionVertices}. */
 public class ExecutionVertexCancelTest extends TestLogger {
+
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     // --------------------------------------------------------------------------------------------
     //  Canceling in different states
@@ -242,7 +250,8 @@ public class ExecutionVertexCancelTest extends TestLogger {
         final SchedulerBase scheduler =
                 SchedulerTestingUtils.createScheduler(
                         JobGraphTestUtils.streamingJobGraph(createNoOpVertex(10)),
-                        ComponentMainThreadExecutorServiceAdapter.forMainThread());
+                        ComponentMainThreadExecutorServiceAdapter.forMainThread(),
+                        EXECUTOR_RESOURCE.getExecutor());
         final ExecutionGraph graph = scheduler.getExecutionGraph();
 
         scheduler.startScheduling();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexTest.java
@@ -33,18 +33,26 @@ import org.apache.flink.runtime.scheduler.SchedulerTestingUtils;
 import org.apache.flink.runtime.scheduler.TestingPhysicalSlot;
 import org.apache.flink.runtime.scheduler.TestingPhysicalSlotProvider;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.TestLogger;
 
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertFalse;
 
 /** Tests for the {@link ExecutionVertex}. */
 public class ExecutionVertexTest extends TestLogger {
+
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     @Test
     public void testResetForNewExecutionReleasesPartitions() throws Exception {
@@ -64,8 +72,10 @@ public class ExecutionVertexTest extends TestLogger {
         final JobGraph jobGraph =
                 JobGraphTestUtils.streamingJobGraph(producerJobVertex, consumerJobVertex);
         final SchedulerBase scheduler =
-                SchedulerTestingUtils.newSchedulerBuilder(
-                                jobGraph, ComponentMainThreadExecutorServiceAdapter.forMainThread())
+                new SchedulerTestingUtils.DefaultSchedulerBuilder(
+                                jobGraph,
+                                ComponentMainThreadExecutorServiceAdapter.forMainThread(),
+                                EXECUTOR_RESOURCE.getExecutor())
                         .setPartitionTracker(partitionTracker)
                         .build();
 
@@ -107,8 +117,10 @@ public class ExecutionVertexTest extends TestLogger {
         final TestingPhysicalSlotProvider withLimitedAmountOfPhysicalSlots =
                 TestingPhysicalSlotProvider.createWithLimitedAmountOfPhysicalSlots(1);
         final SchedulerBase scheduler =
-                SchedulerTestingUtils.newSchedulerBuilder(
-                                jobGraph, ComponentMainThreadExecutorServiceAdapter.forMainThread())
+                new SchedulerTestingUtils.DefaultSchedulerBuilder(
+                                jobGraph,
+                                ComponentMainThreadExecutorServiceAdapter.forMainThread(),
+                                EXECUTOR_RESOURCE.getExecutor())
                         .setExecutionSlotAllocatorFactory(
                                 SchedulerTestingUtils.newSlotSharingExecutionSlotAllocatorFactory(
                                         withLimitedAmountOfPhysicalSlots))

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/FinalizeOnMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/FinalizeOnMasterTest.java
@@ -24,9 +24,14 @@ import org.apache.flink.runtime.jobgraph.JobGraphTestUtils;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.scheduler.SchedulerBase;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.TestLogger;
 
+import org.junit.ClassRule;
 import org.junit.Test;
+
+import java.util.concurrent.ScheduledExecutorService;
 
 import static org.apache.flink.runtime.scheduler.SchedulerTestingUtils.createScheduler;
 import static org.junit.Assert.assertEquals;
@@ -41,6 +46,10 @@ import static org.mockito.Mockito.verify;
  */
 public class FinalizeOnMasterTest extends TestLogger {
 
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
+
     @Test
     public void testFinalizeIsCalledUponSuccess() throws Exception {
         final JobVertex vertex1 = spy(new JobVertex("test vertex 1"));
@@ -54,7 +63,8 @@ public class FinalizeOnMasterTest extends TestLogger {
         final SchedulerBase scheduler =
                 createScheduler(
                         JobGraphTestUtils.streamingJobGraph(vertex1, vertex2),
-                        ComponentMainThreadExecutorServiceAdapter.forMainThread());
+                        ComponentMainThreadExecutorServiceAdapter.forMainThread(),
+                        EXECUTOR_RESOURCE.getExecutor());
         scheduler.startScheduling();
 
         final ExecutionGraph eg = scheduler.getExecutionGraph();
@@ -82,7 +92,8 @@ public class FinalizeOnMasterTest extends TestLogger {
         final SchedulerBase scheduler =
                 createScheduler(
                         JobGraphTestUtils.streamingJobGraph(vertex),
-                        ComponentMainThreadExecutorServiceAdapter.forMainThread());
+                        ComponentMainThreadExecutorServiceAdapter.forMainThread(),
+                        EXECUTOR_RESOURCE.getExecutor());
         scheduler.startScheduling();
 
         final ExecutionGraph eg = scheduler.getExecutionGraph();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/PointwisePatternTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/PointwisePatternTest.java
@@ -26,12 +26,16 @@ import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.scheduler.SchedulerBase;
 import org.apache.flink.runtime.scheduler.strategy.ConsumedPartitionGroup;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -42,6 +46,9 @@ import static org.junit.Assert.fail;
  * EdgeManagerBuildUtil#connectVertexToResult}.
  */
 public class PointwisePatternTest {
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     @Test
     public void testNToN() throws Exception {
@@ -256,7 +263,7 @@ public class PointwisePatternTest {
                 TestingDefaultExecutionGraphBuilder.newBuilder()
                         .setVertexParallelismStore(
                                 SchedulerBase.computeVertexParallelismStore(ordered))
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
         try {
             eg.attachJobGraph(ordered);
         } catch (JobException e) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/RemoveCachedShuffleDescriptorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/RemoveCachedShuffleDescriptorTest.java
@@ -42,10 +42,13 @@ import org.apache.flink.runtime.scheduler.DefaultScheduler;
 import org.apache.flink.runtime.scheduler.SchedulerTestingUtils;
 import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -70,6 +73,10 @@ import static org.junit.Assert.assertNull;
 public class RemoveCachedShuffleDescriptorTest extends TestLogger {
 
     private static final int PARALLELISM = 4;
+
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     private ScheduledExecutorService scheduledExecutorService;
     private ComponentMainThreadExecutor mainThreadExecutor;
@@ -386,7 +393,8 @@ public class RemoveCachedShuffleDescriptorTest extends TestLogger {
                         .addJobVertices(jobVertices)
                         .build();
 
-        return SchedulerTestingUtils.newSchedulerBuilder(jobGraph, mainThreadExecutor)
+        return new SchedulerTestingUtils.DefaultSchedulerBuilder(
+                        jobGraph, mainThreadExecutor, EXECUTOR_RESOURCE.getExecutor())
                 .setRestartBackoffTimeStrategy(new TestRestartBackoffTimeStrategy(true, 0))
                 .setBlobWriter(blobWriter)
                 .setIoExecutor(ioExecutor)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/VertexSlotSharingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/VertexSlotSharingTest.java
@@ -24,12 +24,16 @@ import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
 import org.apache.flink.runtime.scheduler.SchedulerBase;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -39,6 +43,9 @@ import static org.junit.Assert.fail;
 
 /** Tests creating and initializing {@link SlotSharingGroup}. */
 public class VertexSlotSharingTest {
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     /**
      * Test setup: - v1 is isolated, no slot sharing. - v2 and v3 (not connected) share slots. - v4
@@ -84,7 +91,7 @@ public class VertexSlotSharingTest {
                     TestingDefaultExecutionGraphBuilder.newBuilder()
                             .setVertexParallelismStore(
                                     SchedulerBase.computeVertexParallelismStore(vertices))
-                            .build();
+                            .build(EXECUTOR_RESOURCE.getExecutor());
             eg.attachJobGraph(vertices);
 
             // verify that the vertices are all in the same slot sharing group

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/heartbeat/HeartbeatManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/heartbeat/HeartbeatManagerTest.java
@@ -23,12 +23,14 @@ import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.rpc.exceptions.RecipientUnreachableException;
 import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.concurrent.FutureUtils;
 import org.apache.flink.util.concurrent.ManuallyTriggeredScheduledExecutor;
 import org.apache.flink.util.concurrent.ScheduledExecutorServiceAdapter;
 
 import org.hamcrest.Matcher;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,6 +44,7 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -59,6 +62,11 @@ import static org.junit.Assert.fail;
 
 /** Tests for the {@link HeartbeatManager}. */
 public class HeartbeatManagerTest extends TestLogger {
+
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
+
     private static final Logger LOG = LoggerFactory.getLogger(HeartbeatManagerTest.class);
     public static final long HEARTBEAT_INTERVAL = 50L;
     public static final long HEARTBEAT_TIMEOUT = 200L;
@@ -89,7 +97,7 @@ public class HeartbeatManagerTest extends TestLogger {
                         FAILED_RPC_THRESHOLD,
                         ownResourceID,
                         heartbeatListener,
-                        TestingUtils.defaultScheduledExecutor(),
+                        new ScheduledExecutorServiceAdapter(EXECUTOR_RESOURCE.getExecutor()),
                         LOG);
 
         final ArrayBlockingQueue<Integer> reportedPayloadsHeartbeatTarget =
@@ -176,7 +184,7 @@ public class HeartbeatManagerTest extends TestLogger {
                         FAILED_RPC_THRESHOLD,
                         ownResourceID,
                         heartbeatListener,
-                        TestingUtils.defaultScheduledExecutor(),
+                        new ScheduledExecutorServiceAdapter(EXECUTOR_RESOURCE.getExecutor()),
                         LOG);
 
         final HeartbeatTarget<Integer> heartbeatTarget =
@@ -238,7 +246,7 @@ public class HeartbeatManagerTest extends TestLogger {
                         FAILED_RPC_THRESHOLD,
                         resourceIdTarget,
                         heartbeatListenerTarget,
-                        TestingUtils.defaultScheduledExecutor(),
+                        new ScheduledExecutorServiceAdapter(EXECUTOR_RESOURCE.getExecutor()),
                         LOG);
 
         HeartbeatManagerSenderImpl<Integer, String> heartbeatManagerSender =
@@ -248,7 +256,7 @@ public class HeartbeatManagerTest extends TestLogger {
                         FAILED_RPC_THRESHOLD,
                         resourceIDSender,
                         heartbeatListenerSender,
-                        TestingUtils.defaultScheduledExecutor(),
+                        new ScheduledExecutorServiceAdapter(EXECUTOR_RESOURCE.getExecutor()),
                         LOG);
 
         heartbeatManagerTarget.monitorTarget(resourceIDSender, heartbeatManagerSender);
@@ -294,7 +302,7 @@ public class HeartbeatManagerTest extends TestLogger {
                         FAILED_RPC_THRESHOLD,
                         resourceID,
                         heartbeatListener,
-                        TestingUtils.defaultScheduledExecutor(),
+                        new ScheduledExecutorServiceAdapter(EXECUTOR_RESOURCE.getExecutor()),
                         LOG);
 
         final HeartbeatTarget<Integer> heartbeatTarget =
@@ -325,7 +333,7 @@ public class HeartbeatManagerTest extends TestLogger {
                         FAILED_RPC_THRESHOLD,
                         resourceId,
                         heartbeatListener,
-                        TestingUtils.defaultScheduledExecutor(),
+                        new ScheduledExecutorServiceAdapter(EXECUTOR_RESOURCE.getExecutor()),
                         LOG);
 
         try {
@@ -348,7 +356,7 @@ public class HeartbeatManagerTest extends TestLogger {
                         FAILED_RPC_THRESHOLD,
                         resourceId,
                         new TestingHeartbeatListenerBuilder<>().createNewTestingHeartbeatListener(),
-                        TestingUtils.defaultScheduledExecutor(),
+                        new ScheduledExecutorServiceAdapter(EXECUTOR_RESOURCE.getExecutor()),
                         LOG);
 
         try {
@@ -413,7 +421,7 @@ public class HeartbeatManagerTest extends TestLogger {
                         FAILED_RPC_THRESHOLD,
                         ResourceID.generate(),
                         testingHeartbeatListener,
-                        TestingUtils.defaultScheduledExecutor(),
+                        new ScheduledExecutorServiceAdapter(EXECUTOR_RESOURCE.getExecutor()),
                         LOG);
 
         try {
@@ -511,7 +519,7 @@ public class HeartbeatManagerTest extends TestLogger {
                         1,
                         ResourceID.generate(),
                         testingHeartbeatListener,
-                        TestingUtils.defaultScheduledExecutor(),
+                        new ScheduledExecutorServiceAdapter(EXECUTOR_RESOURCE.getExecutor()),
                         LOG);
 
         try {
@@ -551,7 +559,7 @@ public class HeartbeatManagerTest extends TestLogger {
                         failedRpcRequestsUntilUnreachable,
                         ResourceID.generate(),
                         testingHeartbeatListener,
-                        TestingUtils.defaultScheduledExecutor(),
+                        new ScheduledExecutorServiceAdapter(EXECUTOR_RESOURCE.getExecutor()),
                         LOG);
 
         try {
@@ -601,7 +609,7 @@ public class HeartbeatManagerTest extends TestLogger {
                         -1, // disable rpc request checking
                         ResourceID.generate(),
                         testingHeartbeatListener,
-                        TestingUtils.defaultScheduledExecutor(),
+                        new ScheduledExecutorServiceAdapter(EXECUTOR_RESOURCE.getExecutor()),
                         LOG);
 
         try {
@@ -650,7 +658,7 @@ public class HeartbeatManagerTest extends TestLogger {
                         3,
                         ResourceID.generate(),
                         testingHeartbeatListener,
-                        TestingUtils.defaultScheduledExecutor(),
+                        new ScheduledExecutorServiceAdapter(EXECUTOR_RESOURCE.getExecutor()),
                         LOG);
 
         try {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/AbstractHAJobRunITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/AbstractHAJobRunITCase.java
@@ -31,8 +31,10 @@ import org.apache.flink.runtime.minicluster.MiniCluster;
 import org.apache.flink.runtime.zookeeper.ZooKeeperExtension;
 import org.apache.flink.test.junit5.InjectMiniCluster;
 import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorExtension;
 import org.apache.flink.util.TestLoggerExtension;
 import org.apache.flink.util.concurrent.FutureUtils;
+import org.apache.flink.util.concurrent.ScheduledExecutorServiceAdapter;
 
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -40,6 +42,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.time.Duration;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -53,6 +56,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @ExtendWith(TestLoggerExtension.class)
 public abstract class AbstractHAJobRunITCase {
+
+    @RegisterExtension
+    static final TestExecutorExtension<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorExtension();
 
     @RegisterExtension
     @Order(1)
@@ -92,7 +99,8 @@ public abstract class AbstractHAJobRunITCase {
                                 Time.milliseconds(10),
                                 deadline,
                                 status -> flinkCluster.isRunning() && status == JobStatus.FINISHED,
-                                TestingUtils.defaultScheduledExecutor())
+                                new ScheduledExecutorServiceAdapter(
+                                        EXECUTOR_RESOURCE.getExecutor()))
                         .get(deadline.timeLeft().toMillis(), TimeUnit.MILLISECONDS);
 
         assertThat(jobStatus).isEqualTo(JobStatus.FINISHED);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedLeaderServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedLeaderServiceTest.java
@@ -20,12 +20,15 @@ package org.apache.flink.runtime.highavailability.nonha.embedded;
 
 import org.apache.flink.runtime.leaderelection.LeaderElectionService;
 import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Assert;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -34,6 +37,9 @@ import static org.hamcrest.Matchers.is;
 /** Tests for the {@link EmbeddedLeaderService}. */
 public class EmbeddedLeaderServiceTest extends TestLogger {
 
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
     /**
      * Tests that the {@link EmbeddedLeaderService} can handle a concurrent grant leadership call
      * and a shutdown.
@@ -41,7 +47,7 @@ public class EmbeddedLeaderServiceTest extends TestLogger {
     @Test
     public void testConcurrentGrantLeadershipAndShutdown() throws Exception {
         final EmbeddedLeaderService embeddedLeaderService =
-                new EmbeddedLeaderService(TestingUtils.defaultExecutor());
+                new EmbeddedLeaderService(EXECUTOR_RESOURCE.getExecutor());
 
         try {
             final LeaderElectionService leaderElectionService =
@@ -73,7 +79,7 @@ public class EmbeddedLeaderServiceTest extends TestLogger {
     @Test
     public void testConcurrentRevokeLeadershipAndShutdown() throws Exception {
         final EmbeddedLeaderService embeddedLeaderService =
-                new EmbeddedLeaderService(TestingUtils.defaultExecutor());
+                new EmbeddedLeaderService(EXECUTOR_RESOURCE.getExecutor());
 
         try {
             final LeaderElectionService leaderElectionService =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
@@ -57,12 +57,15 @@ import org.apache.flink.runtime.operators.testutils.ExpectedTestException;
 import org.apache.flink.runtime.taskexecutor.PartitionProducerStateChecker;
 import org.apache.flink.runtime.taskmanager.Task;
 import org.apache.flink.runtime.taskmanager.TestTaskBuilder;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.CloseableIterator;
 import org.apache.flink.util.ExceptionUtils;
 
 import org.apache.flink.shaded.guava30.com.google.common.collect.Lists;
 
 import org.junit.Assert;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import javax.annotation.Nullable;
@@ -80,6 +83,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -116,6 +120,9 @@ import static org.mockito.Mockito.when;
 
 /** Tests for the {@link RemoteInputChannel}. */
 public class RemoteInputChannelTest {
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     private static final long CHECKPOINT_ID = 1L;
     private static final CheckpointOptions UNALIGNED =
@@ -1797,7 +1804,7 @@ public class RemoteInputChannelTest {
         final Task task =
                 new TestTaskBuilder(shuffleEnvironment)
                         .setPartitionProducerStateChecker(partitionProducerStateChecker)
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
         final SingleInputGate inputGate =
                 new SingleInputGateBuilder().setPartitionProducerStateProvider(task).build();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/UpdatePartitionConsumersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/UpdatePartitionConsumersTest.java
@@ -38,14 +38,18 @@ import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.shuffle.NettyShuffleDescriptor;
 import org.apache.flink.runtime.shuffle.UnknownShuffleDescriptor;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.IterableUtils;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -57,6 +61,10 @@ import static org.junit.Assert.assertThat;
 
 /** Tests for the updating of consumers depending on the producers result. */
 public class UpdatePartitionConsumersTest extends TestLogger {
+
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     private static final long TIMEOUT = 5000L;
 
@@ -124,8 +132,10 @@ public class UpdatePartitionConsumersTest extends TestLogger {
                 new SimpleAckingTaskManagerGateway();
 
         final SchedulerBase scheduler =
-                SchedulerTestingUtils.newSchedulerBuilder(
-                                jobGraph, ComponentMainThreadExecutorServiceAdapter.forMainThread())
+                new SchedulerTestingUtils.DefaultSchedulerBuilder(
+                                jobGraph,
+                                ComponentMainThreadExecutorServiceAdapter.forMainThread(),
+                                EXECUTOR_RESOURCE.getExecutor())
                         .setExecutionSlotAllocatorFactory(
                                 new TestExecutionSlotAllocatorFactory(taskManagerGateway))
                         .build();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterPartitionReleaseTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterPartitionReleaseTest.java
@@ -250,8 +250,6 @@ public class JobMasterPartitionReleaseTest extends TestLogger {
                     new JobMasterBuilder(jobGraph, rpcService)
                             .withConfiguration(configuration)
                             .withHighAvailabilityServices(haServices)
-                            .withJobManagerSharedServices(
-                                    new TestingJobManagerSharedServicesBuilder().build())
                             .withFatalErrorHandler(fatalErrorHandler)
                             .withHeartbeatServices(heartbeatServices)
                             .withPartitionTrackerFactory(ignored -> partitionTracker)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -1550,7 +1550,6 @@ public class JobMasterTest extends TestLogger {
                 new JobMasterBuilder(jobGraph, rpcService)
                         .withConfiguration(configuration)
                         .withHighAvailabilityServices(haServices)
-                        .withJobManagerSharedServices(jobManagerSharedServices)
                         .withHeartbeatServices(heartbeatServices)
                         .withPartitionTrackerFactory(ignored -> partitionTracker)
                         .createJobMaster()) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestingJobManagerSharedServicesBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestingJobManagerSharedServicesBuilder.java
@@ -24,16 +24,12 @@ import org.apache.flink.runtime.execution.librarycache.ContextClassLoaderLibrary
 import org.apache.flink.runtime.execution.librarycache.LibraryCacheManager;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
 import org.apache.flink.runtime.shuffle.ShuffleTestUtils;
-import org.apache.flink.testutils.TestingUtils;
 
+import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
 /** Builder for the {@link JobManagerSharedServices}. */
 public class TestingJobManagerSharedServicesBuilder {
-
-    private ScheduledExecutorService futureExecutor;
-
-    private ScheduledExecutorService ioExecutor;
 
     private LibraryCacheManager libraryCacheManager;
 
@@ -42,22 +38,9 @@ public class TestingJobManagerSharedServicesBuilder {
     private BlobWriter blobWriter;
 
     public TestingJobManagerSharedServicesBuilder() {
-        futureExecutor = TestingUtils.defaultExecutor();
-        ioExecutor = TestingUtils.defaultExecutor();
         libraryCacheManager = ContextClassLoaderLibraryCacheManager.INSTANCE;
         shuffleMaster = ShuffleTestUtils.DEFAULT_SHUFFLE_MASTER;
         blobWriter = VoidBlobWriter.getInstance();
-    }
-
-    public TestingJobManagerSharedServicesBuilder futureExecutor(
-            ScheduledExecutorService futureExecutor) {
-        this.futureExecutor = futureExecutor;
-        return this;
-    }
-
-    public TestingJobManagerSharedServicesBuilder ioExecutor(ScheduledExecutorService ioExecutor) {
-        this.ioExecutor = ioExecutor;
-        return this;
     }
 
     public TestingJobManagerSharedServicesBuilder setShuffleMaster(ShuffleMaster<?> shuffleMaster) {
@@ -76,7 +59,10 @@ public class TestingJobManagerSharedServicesBuilder {
     }
 
     public JobManagerSharedServices build() {
+        final ScheduledExecutorService executorService =
+                Executors.newSingleThreadScheduledExecutor();
+
         return new JobManagerSharedServices(
-                futureExecutor, ioExecutor, libraryCacheManager, shuffleMaster, blobWriter);
+                executorService, executorService, libraryCacheManager, shuffleMaster, blobWriter);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/JobMasterBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/JobMasterBuilder.java
@@ -65,8 +65,7 @@ public class JobMasterBuilder {
 
     private HighAvailabilityServices highAvailabilityServices;
 
-    private JobManagerSharedServices jobManagerSharedServices =
-            new TestingJobManagerSharedServicesBuilder().build();
+    private JobManagerSharedServices jobManagerSharedServices = null;
 
     private HeartbeatServices heartbeatServices = DEFAULT_HEARTBEAT_SERVICES;
 
@@ -188,7 +187,9 @@ public class JobMasterBuilder {
                         ? slotPoolServiceSchedulerFactory
                         : DefaultSlotPoolServiceSchedulerFactory.fromConfiguration(
                                 configuration, jobGraph.getJobType()),
-                jobManagerSharedServices,
+                jobManagerSharedServices != null
+                        ? jobManagerSharedServices
+                        : new TestingJobManagerSharedServicesBuilder().build(),
                 heartbeatServices,
                 UnregisteredJobManagerJobMetricGroupFactory.INSTANCE,
                 onCompletionActions,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderChangeClusterComponentsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderChangeClusterComponentsTest.java
@@ -34,15 +34,18 @@ import org.apache.flink.runtime.minicluster.TestingMiniClusterConfiguration;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.runtime.util.LeaderRetrievalUtils;
 import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -58,6 +61,10 @@ public class LeaderChangeClusterComponentsTest extends TestLogger {
     private static final int NUM_TMS = 2;
     public static final int PARALLELISM = SLOTS_PER_TM * NUM_TMS;
 
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
+
     private static TestingMiniCluster miniCluster;
 
     private static EmbeddedHaServicesWithLeadershipControl highAvailabilityServices;
@@ -70,7 +77,7 @@ public class LeaderChangeClusterComponentsTest extends TestLogger {
     public static void setupClass() throws Exception {
 
         highAvailabilityServices =
-                new EmbeddedHaServicesWithLeadershipControl(TestingUtils.defaultExecutor());
+                new EmbeddedHaServicesWithLeadershipControl(EXECUTOR_RESOURCE.getExecutor());
 
         miniCluster =
                 TestingMiniCluster.newBuilder(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderElectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderElectionTest.java
@@ -26,11 +26,13 @@ import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.util.TestingFatalErrorHandlerResource;
 import org.apache.flink.runtime.util.ZooKeeperUtils;
 import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.TestLogger;
 
 import org.apache.curator.test.TestingServer;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -40,6 +42,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.UUID;
 import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -47,6 +50,10 @@ import static org.junit.Assert.assertThat;
 /** Tests for leader election. */
 @RunWith(Parameterized.class)
 public class LeaderElectionTest extends TestLogger {
+
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     @Rule
     public final TestingFatalErrorHandlerResource testingFatalErrorHandlerResource =
@@ -218,7 +225,7 @@ public class LeaderElectionTest extends TestLogger {
 
         @Override
         public void setup(FatalErrorHandler fatalErrorHandler) {
-            embeddedLeaderService = new EmbeddedLeaderService(TestingUtils.defaultExecutor());
+            embeddedLeaderService = new EmbeddedLeaderService(EXECUTOR_RESOURCE.getExecutor());
         }
 
         @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderretrieval/ZooKeeperLeaderRetrievalTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderretrieval/ZooKeeperLeaderRetrievalTest.java
@@ -32,11 +32,13 @@ import org.apache.flink.runtime.util.LeaderRetrievalUtils;
 import org.apache.flink.runtime.util.TestingFatalErrorHandlerResource;
 import org.apache.flink.runtime.util.ZooKeeperUtils;
 import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.TestLogger;
 
 import org.apache.curator.test.TestingServer;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -48,6 +50,7 @@ import java.net.Socket;
 import java.net.SocketAddress;
 import java.net.UnknownHostException;
 import java.time.Duration;
+import java.util.concurrent.ScheduledExecutorService;
 
 import static org.junit.Assert.assertEquals;
 
@@ -55,6 +58,10 @@ import static org.junit.Assert.assertEquals;
 public class ZooKeeperLeaderRetrievalTest extends TestLogger {
 
     private static final RpcSystem RPC_SYSTEM = RpcSystem.load();
+
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     private TestingServer testingServer;
 
@@ -79,7 +86,7 @@ public class ZooKeeperLeaderRetrievalTest extends TestLogger {
                 new ZooKeeperHaServices(
                         ZooKeeperUtils.startCuratorFramework(
                                 config, testingFatalErrorHandlerResource.getFatalErrorHandler()),
-                        TestingUtils.defaultExecutor(),
+                        EXECUTOR_RESOURCE.getExecutor(),
                         config,
                         new VoidBlobStore());
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTaskExecutorTest.java
@@ -38,6 +38,7 @@ import org.apache.flink.runtime.taskexecutor.TaskExecutorRegistrationSuccess;
 import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGateway;
 import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
 import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TestLogger;
@@ -46,12 +47,14 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.Collection;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
@@ -73,6 +76,10 @@ public class ResourceManagerTaskExecutorTest extends TestLogger {
 
     private static final ResourceProfile DEFAULT_SLOT_PROFILE =
             ResourceProfile.fromResources(1.0, 1234);
+
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     private static TestingRpcService rpcService;
 
@@ -219,7 +226,7 @@ public class ResourceManagerTaskExecutorTest extends TestLogger {
                                         }
                                         return rpcGateway;
                                     },
-                                    TestingUtils.defaultExecutor()));
+                                    EXECUTOR_RESOURCE.getExecutor()));
 
             TaskExecutorRegistration taskExecutorRegistration =
                     new TaskExecutorRegistration(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTest.java
@@ -640,8 +640,7 @@ public class ResourceManagerTest extends TestLogger {
 
             if (slotManager == null) {
                 slotManager =
-                        DeclarativeSlotManagerBuilder.newBuilder()
-                                .setScheduledExecutor(rpcService.getScheduledExecutor())
+                        DeclarativeSlotManagerBuilder.newBuilder(rpcService.getScheduledExecutor())
                                 .build();
             }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManagerBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManagerBuilder.java
@@ -35,7 +35,7 @@ import java.util.concurrent.Executor;
 /** Builder for {@link DeclarativeSlotManager}. */
 public class DeclarativeSlotManagerBuilder {
     private SlotMatchingStrategy slotMatchingStrategy;
-    private ScheduledExecutor scheduledExecutor;
+    private final ScheduledExecutor scheduledExecutor;
     private Time taskManagerRequestTimeout;
     private Time slotRequestTimeout;
     private Time taskManagerTimeout;
@@ -48,9 +48,9 @@ public class DeclarativeSlotManagerBuilder {
     private ResourceTracker resourceTracker;
     private SlotTracker slotTracker;
 
-    private DeclarativeSlotManagerBuilder() {
+    private DeclarativeSlotManagerBuilder(ScheduledExecutor scheduledExecutor) {
         this.slotMatchingStrategy = AnyMatchingSlotMatchingStrategy.INSTANCE;
-        this.scheduledExecutor = TestingUtils.defaultScheduledExecutor();
+        this.scheduledExecutor = scheduledExecutor;
         this.taskManagerRequestTimeout = TestingUtils.infiniteTime();
         this.slotRequestTimeout = TestingUtils.infiniteTime();
         this.taskManagerTimeout = TestingUtils.infiniteTime();
@@ -66,13 +66,8 @@ public class DeclarativeSlotManagerBuilder {
         this.slotTracker = new DefaultSlotTracker();
     }
 
-    public static DeclarativeSlotManagerBuilder newBuilder() {
-        return new DeclarativeSlotManagerBuilder();
-    }
-
-    public DeclarativeSlotManagerBuilder setScheduledExecutor(ScheduledExecutor scheduledExecutor) {
-        this.scheduledExecutor = scheduledExecutor;
-        return this;
+    public static DeclarativeSlotManagerBuilder newBuilder(ScheduledExecutor scheduledExecutor) {
+        return new DeclarativeSlotManagerBuilder(scheduledExecutor);
     }
 
     public DeclarativeSlotManagerBuilder setTaskManagerRequestTimeout(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManagerTest.java
@@ -46,16 +46,19 @@ import org.apache.flink.runtime.taskexecutor.exceptions.SlotAllocationException;
 import org.apache.flink.runtime.taskexecutor.exceptions.SlotOccupiedException;
 import org.apache.flink.runtime.testutils.SystemExitTrackingSecurityManager;
 import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.concurrent.FutureUtils;
 import org.apache.flink.util.concurrent.ManuallyTriggeredScheduledExecutor;
 import org.apache.flink.util.concurrent.ScheduledExecutor;
+import org.apache.flink.util.concurrent.ScheduledExecutorServiceAdapter;
 import org.apache.flink.util.function.FunctionUtils;
 import org.apache.flink.util.function.ThrowingConsumer;
 
 import org.apache.flink.shaded.guava30.com.google.common.collect.Iterators;
 
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -70,6 +73,7 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -92,6 +96,10 @@ import static org.junit.Assert.assertTrue;
 
 /** Tests for the {@link DeclarativeSlotManager}. */
 public class DeclarativeSlotManagerTest extends TestLogger {
+
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     private static final FlinkException TEST_EXCEPTION = new FlinkException("Test exception");
 
@@ -616,7 +624,7 @@ public class DeclarativeSlotManagerTest extends TestLogger {
 
         final SlotReport slotReport = createSlotReport(taskManagerConnection.getResourceID(), 2);
 
-        final Executor mainThreadExecutor = TestingUtils.defaultExecutor();
+        final Executor mainThreadExecutor = EXECUTOR_RESOURCE.getExecutor();
 
         try (DeclarativeSlotManager slotManager = createDeclarativeSlotManagerBuilder().build()) {
 
@@ -752,9 +760,7 @@ public class DeclarativeSlotManagerTest extends TestLogger {
         final ScheduledExecutor mainThreadExecutor = new ManuallyTriggeredScheduledExecutor();
 
         try (final DeclarativeSlotManager slotManager =
-                createDeclarativeSlotManagerBuilder()
-                        .setScheduledExecutor(mainThreadExecutor)
-                        .build()) {
+                createDeclarativeSlotManagerBuilder(mainThreadExecutor).build()) {
 
             slotManager.start(
                     ResourceManagerId.generate(),
@@ -1526,14 +1532,21 @@ public class DeclarativeSlotManagerTest extends TestLogger {
             ResourceManagerId resourceManagerId,
             ResourceActions resourceManagerActions,
             int numSlotsPerWorker) {
-        return createDeclarativeSlotManagerBuilder()
+        return createDeclarativeSlotManagerBuilder(
+                        new ScheduledExecutorServiceAdapter(EXECUTOR_RESOURCE.getExecutor()))
                 .setNumSlotsPerWorker(numSlotsPerWorker)
                 .setRedundantTaskManagerNum(0)
                 .buildAndStartWithDirectExec(resourceManagerId, resourceManagerActions);
     }
 
     private static DeclarativeSlotManagerBuilder createDeclarativeSlotManagerBuilder() {
-        return DeclarativeSlotManagerBuilder.newBuilder()
+        return createDeclarativeSlotManagerBuilder(
+                new ScheduledExecutorServiceAdapter(EXECUTOR_RESOURCE.getExecutor()));
+    }
+
+    private static DeclarativeSlotManagerBuilder createDeclarativeSlotManagerBuilder(
+            ScheduledExecutor executor) {
+        return DeclarativeSlotManagerBuilder.newBuilder(executor)
                 .setDefaultWorkerResourceSpec(WORKER_RESOURCE_SPEC);
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultSlotStatusSyncerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultSlotStatusSyncerTest.java
@@ -33,13 +33,16 @@ import org.apache.flink.runtime.taskexecutor.SlotStatus;
 import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGateway;
 import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
 import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.concurrent.FutureUtils;
 
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeoutException;
 
 import static org.hamcrest.Matchers.contains;
@@ -58,6 +61,10 @@ public class DefaultSlotStatusSyncerTest extends TestLogger {
             new TaskExecutorConnection(
                     ResourceID.generate(),
                     new TestingTaskExecutorGatewayBuilder().createTestingTaskExecutorGateway());
+
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     @Test
     public void testAllocateSlot() throws Exception {
@@ -93,7 +100,7 @@ public class DefaultSlotStatusSyncerTest extends TestLogger {
                 taskManagerTracker,
                 resourceTracker,
                 ResourceManagerId.generate(),
-                TestingUtils.defaultExecutor());
+                EXECUTOR_RESOURCE.getExecutor());
 
         final CompletableFuture<Void> allocatedFuture =
                 slotStatusSyncer.allocateSlot(
@@ -140,7 +147,7 @@ public class DefaultSlotStatusSyncerTest extends TestLogger {
                 taskManagerTracker,
                 resourceTracker,
                 ResourceManagerId.generate(),
-                TestingUtils.defaultExecutor());
+                EXECUTOR_RESOURCE.getExecutor());
 
         final CompletableFuture<Void> allocatedFuture =
                 slotStatusSyncer.allocateSlot(
@@ -176,7 +183,7 @@ public class DefaultSlotStatusSyncerTest extends TestLogger {
                 taskManagerTracker,
                 resourceTracker,
                 ResourceManagerId.generate(),
-                TestingUtils.defaultExecutor());
+                EXECUTOR_RESOURCE.getExecutor());
         taskManagerTracker.addTaskManager(
                 TASK_EXECUTOR_CONNECTION, ResourceProfile.ANY, ResourceProfile.ANY);
         taskManagerTracker.notifySlotStatus(
@@ -209,7 +216,7 @@ public class DefaultSlotStatusSyncerTest extends TestLogger {
                 taskManagerTracker,
                 resourceTracker,
                 ResourceManagerId.generate(),
-                TestingUtils.defaultExecutor());
+                EXECUTOR_RESOURCE.getExecutor());
         final TestingTaskExecutorGateway taskExecutorGateway =
                 new TestingTaskExecutorGatewayBuilder()
                         .setRequestSlotFunction(ignored -> new CompletableFuture<>())

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTestBase.java
@@ -39,6 +39,7 @@ import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.concurrent.FutureUtils;
 import org.apache.flink.util.concurrent.ScheduledExecutor;
+import org.apache.flink.util.concurrent.ScheduledExecutorServiceAdapter;
 import org.apache.flink.util.function.RunnableWithException;
 
 import org.junit.ClassRule;
@@ -48,8 +49,7 @@ import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -58,8 +58,8 @@ import static org.junit.Assert.fail;
 /** Base class for the tests of {@link FineGrainedSlotManager}. */
 public abstract class FineGrainedSlotManagerTestBase extends TestLogger {
     @ClassRule
-    public static final TestExecutorResource<ExecutorService> EXECUTOR_RESOURCE =
-            new TestExecutorResource<>(() -> Executors.newSingleThreadExecutor());
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     private static final long FUTURE_TIMEOUT_SECOND = 5;
     private static final long FUTURE_EXPECT_TIMEOUT_MS = 50;
@@ -146,7 +146,8 @@ public abstract class FineGrainedSlotManagerTestBase extends TestLogger {
                 new DefaultSlotStatusSyncer(Time.seconds(10L));
         private SlotManagerMetricGroup slotManagerMetricGroup =
                 UnregisteredMetricGroups.createUnregisteredSlotManagerMetricGroup();
-        private final ScheduledExecutor scheduledExecutor = TestingUtils.defaultScheduledExecutor();
+        private final ScheduledExecutor scheduledExecutor =
+                new ScheduledExecutorServiceAdapter(EXECUTOR_RESOURCE.getExecutor());
         private final Executor mainThreadExecutor = EXECUTOR_RESOURCE.getExecutor();
         private FineGrainedSlotManager slotManager;
         private long requirementCheckDelay = 0;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskExecutorManagerBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskExecutorManagerBuilder.java
@@ -19,7 +19,6 @@ package org.apache.flink.runtime.resourcemanager.slotmanager;
 
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
-import org.apache.flink.testutils.TestingUtils;
 import org.apache.flink.util.concurrent.Executors;
 import org.apache.flink.util.concurrent.ScheduledExecutor;
 
@@ -34,9 +33,13 @@ public class TaskExecutorManagerBuilder {
     private boolean waitResultConsumedBeforeRelease = true;
     private int redundantTaskManagerNum = 0;
     private Time taskManagerTimeout = Time.seconds(5);
-    private ScheduledExecutor scheduledExecutor = TestingUtils.defaultScheduledExecutor();
+    private final ScheduledExecutor scheduledExecutor;
     private Executor mainThreadExecutor = Executors.directExecutor();
     private ResourceActions newResourceActions = new TestingResourceActionsBuilder().build();
+
+    public TaskExecutorManagerBuilder(ScheduledExecutor scheduledExecutor) {
+        this.scheduledExecutor = scheduledExecutor;
+    }
 
     public TaskExecutorManagerBuilder setDefaultWorkerResourceSpec(
             WorkerResourceSpec defaultWorkerResourceSpec) {
@@ -67,11 +70,6 @@ public class TaskExecutorManagerBuilder {
 
     public TaskExecutorManagerBuilder setTaskManagerTimeout(Time taskManagerTimeout) {
         this.taskManagerTimeout = taskManagerTimeout;
-        return this;
-    }
-
-    public TaskExecutorManagerBuilder setScheduledExecutor(ScheduledExecutor scheduledExecutor) {
-        this.scheduledExecutor = scheduledExecutor;
         return this;
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskExecutorManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskExecutorManagerTest.java
@@ -30,13 +30,17 @@ import org.apache.flink.runtime.taskexecutor.SlotReport;
 import org.apache.flink.runtime.taskexecutor.SlotStatus;
 import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
 import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.concurrent.ScheduledExecutorServiceAdapter;
 
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -49,6 +53,10 @@ import static org.junit.Assert.assertThat;
 
 /** Tests for the {@link TaskExecutorManager}. */
 public class TaskExecutorManagerTest extends TestLogger {
+
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     /** Tests that a pending slot is only fulfilled by an exactly matching received slot. */
     @Test
@@ -141,7 +149,7 @@ public class TaskExecutorManagerTest extends TestLogger {
                                 (instanceId, ignored) -> releaseResourceFuture.complete(instanceId))
                         .build();
 
-        final Executor mainThreadExecutor = TestingUtils.defaultExecutor();
+        final Executor mainThreadExecutor = EXECUTOR_RESOURCE.getExecutor();
 
         try (final TaskExecutorManager taskExecutorManager =
                 createTaskExecutorManagerBuilder()
@@ -193,7 +201,7 @@ public class TaskExecutorManagerTest extends TestLogger {
                                 (instanceID, e) -> releaseResourceFuture.complete(instanceID))
                         .build();
 
-        final Executor mainThreadExecutor = TestingUtils.defaultExecutor();
+        final Executor mainThreadExecutor = EXECUTOR_RESOURCE.getExecutor();
 
         try (final TaskExecutorManager taskExecutorManager =
                 createTaskExecutorManagerBuilder()
@@ -366,7 +374,8 @@ public class TaskExecutorManagerTest extends TestLogger {
     }
 
     private static TaskExecutorManagerBuilder createTaskExecutorManagerBuilder() {
-        return new TaskExecutorManagerBuilder()
+        return new TaskExecutorManagerBuilder(
+                        new ScheduledExecutorServiceAdapter(EXECUTOR_RESOURCE.getExecutor()))
                 .setResourceActions(createResourceActionsBuilder().build());
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/utils/MockResourceManagerRuntimeServices.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/utils/MockResourceManagerRuntimeServices.java
@@ -51,8 +51,7 @@ public class MockResourceManagerRuntimeServices {
         this(
                 rpcService,
                 timeout,
-                DeclarativeSlotManagerBuilder.newBuilder()
-                        .setScheduledExecutor(
+                DeclarativeSlotManagerBuilder.newBuilder(
                                 new ScheduledExecutorServiceAdapter(
                                         new DirectScheduledExecutorService()))
                         .setTaskManagerRequestTimeout(Time.seconds(10))

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestClientMultipartTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestClientMultipartTest.java
@@ -23,9 +23,9 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
 import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
 import org.apache.flink.runtime.rest.messages.EmptyResponseBody;
-import org.apache.flink.testutils.TestingUtils;
 import org.apache.flink.util.ConfigurationException;
 import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.concurrent.Executors;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -50,7 +50,7 @@ public class RestClientMultipartTest extends TestLogger {
 
     @BeforeClass
     public static void setupClient() throws ConfigurationException {
-        restClient = new RestClient(new Configuration(), TestingUtils.defaultExecutor());
+        restClient = new RestClient(new Configuration(), Executors.directExecutor());
     }
 
     @After

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestClientTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestClientTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.rest.messages.EmptyResponseBody;
 import org.apache.flink.runtime.rest.messages.MessageHeaders;
 import org.apache.flink.runtime.rest.versioning.RestAPIVersion;
 import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.NetUtils;
 import org.apache.flink.util.TestLogger;
@@ -36,6 +37,7 @@ import org.apache.flink.shaded.netty4.io.netty.channel.ConnectTimeoutException;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
 
 import org.junit.Assert;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -44,6 +46,7 @@ import java.net.Socket;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -53,6 +56,9 @@ import static org.junit.Assert.assertThat;
 
 /** Tests for {@link RestClient}. */
 public class RestClientTest extends TestLogger {
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     private static final String unroutableIp = "240.0.0.0";
 
@@ -104,7 +110,7 @@ public class RestClientTest extends TestLogger {
         config.setLong(RestOptions.IDLENESS_TIMEOUT, 5000L);
         try (final ServerSocket serverSocket = new ServerSocket(0);
                 final RestClient restClient =
-                        new RestClient(config, TestingUtils.defaultExecutor())) {
+                        new RestClient(config, EXECUTOR_RESOURCE.getExecutor())) {
 
             final String targetAddress = "localhost";
             final int targetPort = serverSocket.getLocalPort();
@@ -158,7 +164,7 @@ public class RestClientTest extends TestLogger {
 
         try (final ServerSocket serverSocket = new ServerSocket(0);
                 final RestClient restClient =
-                        new RestClient(config, TestingUtils.defaultExecutor())) {
+                        new RestClient(config, EXECUTOR_RESOURCE.getExecutor())) {
 
             final String targetAddress = "localhost";
             final int targetPort = serverSocket.getLocalPort();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerSSLAuthITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerSSLAuthITCase.java
@@ -33,6 +33,7 @@ import org.apache.flink.runtime.webmonitor.RestfulGateway;
 import org.apache.flink.runtime.webmonitor.TestingRestfulGateway;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.concurrent.Executors;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -114,7 +115,7 @@ public class RestServerSSLAuthITCase extends TestLogger {
                     TestRestServerEndpoint.builder(serverConfig)
                             .withHandler(testVersionHandler.getMessageHeaders(), testVersionHandler)
                             .buildAndStart();
-            restClient = new RestServerEndpointITCase.TestRestClient(clientConfig);
+            restClient = new RestClient(clientConfig, Executors.directExecutor());
 
             CompletableFuture<EmptyResponseBody> response =
                     restClient.sendRequest(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobConfigHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobConfigHandlerTest.java
@@ -34,6 +34,7 @@ import org.apache.flink.runtime.rest.messages.JobIDPathParameter;
 import org.apache.flink.runtime.rest.messages.JobMessageParameters;
 import org.apache.flink.testutils.TestingUtils;
 import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.concurrent.Executors;
 
 import org.junit.Test;
 
@@ -58,7 +59,7 @@ public class JobConfigHandlerTest extends TestLogger {
                         Collections.emptyMap(),
                         JobConfigHeaders.getInstance(),
                         new DefaultExecutionGraphCache(TestingUtils.TIMEOUT, TestingUtils.TIMEOUT),
-                        TestingUtils.defaultExecutor());
+                        Executors.directExecutor());
 
         final Map<String, String> globalJobParameters = new HashMap<>();
         globalJobParameters.put("foobar", "barfoo");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobExceptionsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobExceptionsHandlerTest.java
@@ -52,6 +52,7 @@ import org.apache.flink.testutils.TestingUtils;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.SerializedThrowable;
 import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.concurrent.Executors;
 
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
@@ -89,7 +90,7 @@ public class JobExceptionsHandlerTest extends TestLogger {
                     Collections.emptyMap(),
                     JobExceptionsHeaders.getInstance(),
                     new DefaultExecutionGraphCache(TestingUtils.TIMEOUT, TestingUtils.TIMEOUT),
-                    TestingUtils.defaultExecutor());
+                    Executors.directExecutor());
 
     @Test
     public void testNoExceptions() throws HandlerRequestException {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobSubmitHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobSubmitHandlerTest.java
@@ -34,9 +34,9 @@ import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
 import org.apache.flink.runtime.rest.messages.job.JobSubmitRequestBody;
 import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.webmonitor.TestingDispatcherGateway;
-import org.apache.flink.testutils.TestingUtils;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.concurrent.Executors;
 import org.apache.flink.util.concurrent.FutureUtils;
 
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
@@ -115,7 +115,7 @@ public class JobSubmitHandlerTest extends TestLogger {
                         () -> CompletableFuture.completedFuture(mockGateway),
                         RpcUtils.INF_TIMEOUT,
                         Collections.emptyMap(),
-                        TestingUtils.defaultExecutor(),
+                        Executors.directExecutor(),
                         configuration);
 
         JobSubmitRequestBody request =
@@ -151,7 +151,7 @@ public class JobSubmitHandlerTest extends TestLogger {
                         () -> CompletableFuture.completedFuture(mockGateway),
                         RpcUtils.INF_TIMEOUT,
                         Collections.emptyMap(),
-                        TestingUtils.defaultExecutor(),
+                        Executors.directExecutor(),
                         configuration);
 
         JobSubmitRequestBody request =
@@ -189,7 +189,7 @@ public class JobSubmitHandlerTest extends TestLogger {
                         () -> CompletableFuture.completedFuture(mockGateway),
                         RpcUtils.INF_TIMEOUT,
                         Collections.emptyMap(),
-                        TestingUtils.defaultExecutor(),
+                        Executors.directExecutor(),
                         configuration);
 
         JobSubmitRequestBody request =
@@ -236,7 +236,7 @@ public class JobSubmitHandlerTest extends TestLogger {
                         () -> CompletableFuture.completedFuture(dispatcherGateway),
                         RpcUtils.INF_TIMEOUT,
                         Collections.emptyMap(),
-                        TestingUtils.defaultExecutor(),
+                        Executors.directExecutor(),
                         configuration);
 
         final Path jobGraphFile = TEMPORARY_FOLDER.newFile().toPath();
@@ -294,7 +294,7 @@ public class JobSubmitHandlerTest extends TestLogger {
                         () -> CompletableFuture.completedFuture(mockGateway),
                         RpcUtils.INF_TIMEOUT,
                         Collections.emptyMap(),
-                        TestingUtils.defaultExecutor(),
+                        Executors.directExecutor(),
                         configuration);
 
         final Path jobGraphFile = TEMPORARY_FOLDER.newFile().toPath();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/SubtaskCurrentAttemptDetailsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/SubtaskCurrentAttemptDetailsHandlerTest.java
@@ -44,8 +44,8 @@ import org.apache.flink.runtime.rest.messages.job.SubtaskMessageParameters;
 import org.apache.flink.runtime.rest.messages.job.metrics.IOMetricsInfo;
 import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
 import org.apache.flink.runtime.util.EvictingBoundedList;
-import org.apache.flink.testutils.TestingUtils;
 import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.concurrent.Executors;
 
 import org.junit.Test;
 
@@ -114,7 +114,7 @@ public class SubtaskCurrentAttemptDetailsHandlerTest extends TestLogger {
                 new MetricFetcherImpl<>(
                         () -> null,
                         address -> null,
-                        TestingUtils.defaultExecutor(),
+                        Executors.directExecutor(),
                         Time.milliseconds(1000L),
                         MetricOptions.METRIC_FETCHER_UPDATE_INTERVAL.defaultValue());
 
@@ -127,7 +127,7 @@ public class SubtaskCurrentAttemptDetailsHandlerTest extends TestLogger {
                         new DefaultExecutionGraphCache(
                                 restHandlerConfiguration.getTimeout(),
                                 Time.milliseconds(restHandlerConfiguration.getRefreshInterval())),
-                        TestingUtils.defaultExecutor(),
+                        Executors.directExecutor(),
                         metricFetcher);
 
         final HashMap<String, String> receivedPathParameters = new HashMap<>(2);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/SubtaskExecutionAttemptAccumulatorsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/SubtaskExecutionAttemptAccumulatorsHandlerTest.java
@@ -35,10 +35,10 @@ import org.apache.flink.runtime.rest.messages.job.SubtaskAttemptMessageParameter
 import org.apache.flink.runtime.rest.messages.job.SubtaskExecutionAttemptAccumulatorsHeaders;
 import org.apache.flink.runtime.rest.messages.job.SubtaskExecutionAttemptAccumulatorsInfo;
 import org.apache.flink.runtime.rest.messages.job.UserAccumulator;
-import org.apache.flink.testutils.TestingUtils;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.OptionalFailure;
 import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.concurrent.Executors;
 
 import org.junit.Test;
 
@@ -68,7 +68,7 @@ public class SubtaskExecutionAttemptAccumulatorsHandlerTest extends TestLogger {
                         new DefaultExecutionGraphCache(
                                 restHandlerConfiguration.getTimeout(),
                                 Time.milliseconds(restHandlerConfiguration.getRefreshInterval())),
-                        TestingUtils.defaultExecutor());
+                        Executors.directExecutor());
 
         // Instance a empty request.
         final HandlerRequest<EmptyRequestBody> request =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/SubtaskExecutionAttemptDetailsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/SubtaskExecutionAttemptDetailsHandlerTest.java
@@ -46,8 +46,8 @@ import org.apache.flink.runtime.rest.messages.job.SubtaskExecutionAttemptDetails
 import org.apache.flink.runtime.rest.messages.job.SubtaskExecutionAttemptDetailsInfo;
 import org.apache.flink.runtime.rest.messages.job.metrics.IOMetricsInfo;
 import org.apache.flink.runtime.util.EvictingBoundedList;
-import org.apache.flink.testutils.TestingUtils;
 import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.concurrent.Executors;
 
 import org.junit.Test;
 
@@ -112,7 +112,7 @@ public class SubtaskExecutionAttemptDetailsHandlerTest extends TestLogger {
                 new MetricFetcherImpl<>(
                         () -> null,
                         address -> null,
-                        TestingUtils.defaultExecutor(),
+                        Executors.directExecutor(),
                         Time.milliseconds(1000L),
                         MetricOptions.METRIC_FETCHER_UPDATE_INTERVAL.defaultValue());
 
@@ -129,7 +129,7 @@ public class SubtaskExecutionAttemptDetailsHandlerTest extends TestLogger {
                         new DefaultExecutionGraphCache(
                                 restHandlerConfiguration.getTimeout(),
                                 Time.milliseconds(restHandlerConfiguration.getRefreshInterval())),
-                        TestingUtils.defaultExecutor(),
+                        Executors.directExecutor(),
                         metricFetcher);
 
         final HashMap<String, String> receivedPathParameters = new HashMap<>(4);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/metrics/AggregatingMetricsHandlerTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/metrics/AggregatingMetricsHandlerTestBase.java
@@ -67,7 +67,6 @@ public abstract class AggregatingMetricsHandlerTestBase<
     private static final GatewayRetriever<DispatcherGateway> LEADER_RETRIEVER;
     private static final Time TIMEOUT = Time.milliseconds(50);
     private static final Map<String, String> TEST_HEADERS = Collections.emptyMap();
-    private static final Executor EXECUTOR = TestingUtils.defaultExecutor();
 
     static {
         TEST_REST_ADDRESS = CompletableFuture.completedFuture("localhost:12345");
@@ -103,7 +102,13 @@ public abstract class AggregatingMetricsHandlerTestBase<
             store.add(dump);
         }
 
-        handler = getHandler(LEADER_RETRIEVER, TIMEOUT, TEST_HEADERS, EXECUTOR, fetcher);
+        handler =
+                getHandler(
+                        LEADER_RETRIEVER,
+                        TIMEOUT,
+                        TEST_HEADERS,
+                        Executors.directExecutor(),
+                        fetcher);
         pathParameters = getPathParameters();
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultExecutionGraphFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultExecutionGraphFactoryTest.java
@@ -39,6 +39,7 @@ import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.shuffle.ShuffleTestUtils;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
 import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.TestLogger;
 
 import org.hamcrest.MatcherAssert;
@@ -51,6 +52,7 @@ import javax.annotation.Nonnull;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.concurrent.ScheduledExecutorService;
 
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
@@ -60,6 +62,10 @@ import static org.junit.Assert.fail;
 public class DefaultExecutionGraphFactoryTest extends TestLogger {
 
     @ClassRule public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     @Test
     public void testRestoringModifiedJobFromSavepointFails() throws Exception {
@@ -123,8 +129,8 @@ public class DefaultExecutionGraphFactoryTest extends TestLogger {
                         new Configuration(),
                         ClassLoader.getSystemClassLoader(),
                         new DefaultExecutionDeploymentTracker(),
-                        TestingUtils.defaultExecutor(),
-                        TestingUtils.defaultExecutor(),
+                        EXECUTOR_RESOURCE.getExecutor(),
+                        EXECUTOR_RESOURCE.getExecutor(),
                         Time.milliseconds(0L),
                         UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup(),
                         VoidBlobWriter.getInstance(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultOperatorCoordinatorHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultOperatorCoordinatorHandlerTest.java
@@ -29,11 +29,15 @@ import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.operators.coordination.TestingOperatorCoordinator;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.SerializedValue;
 
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.concurrent.ScheduledExecutorService;
 
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.createNoOpVertex;
 import static org.apache.flink.runtime.io.network.partition.ResultPartitionType.BLOCKING;
@@ -43,6 +47,9 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 
 /** Test for {@link DefaultOperatorCoordinatorHandler}. */
 public class DefaultOperatorCoordinatorHandlerTest {
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     @Test
     public void testRegisterAndStartNewCoordinators() throws Exception {
@@ -94,6 +101,6 @@ public class DefaultOperatorCoordinatorHandlerTest {
     private DefaultExecutionGraph createDynamicGraph(JobVertex... jobVertices) throws Exception {
         return TestingDefaultExecutionGraphBuilder.newBuilder()
                 .setJobGraph(new JobGraph(new JobID(), "TestJob", jobVertices))
-                .buildDynamicGraph();
+                .buildDynamicGraph(EXECUTOR_RESOURCE.getExecutor());
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerBatchSchedulingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerBatchSchedulingTest.java
@@ -42,11 +42,14 @@ import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGateway;
 import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.function.CheckedSupplier;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -65,6 +68,10 @@ import static org.junit.Assert.fail;
 public class DefaultSchedulerBatchSchedulingTest extends TestLogger {
 
     protected final Logger log = LoggerFactory.getLogger(getClass());
+
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     private static ScheduledExecutorService singleThreadScheduledExecutorService;
     private static ComponentMainThreadExecutor mainThreadExecutor;
@@ -198,7 +205,8 @@ public class DefaultSchedulerBatchSchedulingTest extends TestLogger {
             Time slotRequestTimeout,
             JobStatusListener jobStatusListener)
             throws Exception {
-        return SchedulerTestingUtils.newSchedulerBuilder(jobGraph, mainThreadExecutor)
+        return new SchedulerTestingUtils.DefaultSchedulerBuilder(
+                        jobGraph, mainThreadExecutor, EXECUTOR_RESOURCE.getExecutor())
                 .setExecutionSlotAllocatorFactory(
                         SchedulerTestingUtils.newSlotSharingExecutionSlotAllocatorFactory(
                                 physicalSlotProvider, slotRequestTimeout))

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerTest.java
@@ -1598,10 +1598,11 @@ public class DefaultSchedulerTest extends TestLogger {
                         final JobGraph jobGraph = singleJobVertexJobGraph(1);
                         enableCheckpointing(jobGraph);
                         try {
-                            return SchedulerTestingUtils.newSchedulerBuilder(
+                            return new SchedulerTestingUtils.DefaultSchedulerBuilder(
                                             jobGraph,
                                             ComponentMainThreadExecutorServiceAdapter
-                                                    .forSingleThreadExecutor(executorService))
+                                                    .forSingleThreadExecutor(executorService),
+                                            executorService)
                                     .setCheckpointRecoveryFactory(checkpointRecoveryFactory)
                                     .setCheckpointCleaner(checkpointCleaner)
                                     .build();
@@ -1845,12 +1846,14 @@ public class DefaultSchedulerTest extends TestLogger {
     private SchedulerTestingUtils.DefaultSchedulerBuilder createSchedulerBuilder(
             final JobGraph jobGraph, final ComponentMainThreadExecutor mainThreadExecutor)
             throws Exception {
-        return SchedulerTestingUtils.newSchedulerBuilder(jobGraph, mainThreadExecutor)
+        return new SchedulerTestingUtils.DefaultSchedulerBuilder(
+                        jobGraph,
+                        mainThreadExecutor,
+                        executor,
+                        scheduledExecutorService,
+                        taskRestartExecutor)
                 .setLogger(log)
-                .setIoExecutor(executor)
                 .setJobMasterConfiguration(configuration)
-                .setFutureExecutor(scheduledExecutorService)
-                .setDelayExecutor(taskRestartExecutor)
                 .setSchedulingStrategyFactory(new PipelinedRegionSchedulingStrategy.Factory())
                 .setFailoverStrategyFactory(new RestartPipelinedRegionFailoverStrategy.Factory())
                 .setRestartBackoffTimeStrategy(testRestartBackoffTimeStrategy)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/ExecutionGraphToInputsLocationsRetrieverAdapterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/ExecutionGraphToInputsLocationsRetrieverAdapterTest.java
@@ -30,14 +30,18 @@ import org.apache.flink.runtime.jobmaster.TestingLogicalSlot;
 import org.apache.flink.runtime.jobmaster.TestingLogicalSlotBuilder;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.TestLogger;
 
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
 
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasItem;
@@ -51,6 +55,10 @@ import static org.junit.Assert.fail;
 /** Tests for {@link ExecutionGraphToInputsLocationsRetrieverAdapter}. */
 public class ExecutionGraphToInputsLocationsRetrieverAdapterTest extends TestLogger {
 
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
+
     /** Tests that can get the producers of consumed result partitions. */
     @Test
     public void testGetConsumedResultPartitionsProducers() throws Exception {
@@ -63,7 +71,8 @@ public class ExecutionGraphToInputsLocationsRetrieverAdapterTest extends TestLog
                 producer2, DistributionPattern.ALL_TO_ALL, ResultPartitionType.PIPELINED);
 
         final ExecutionGraph eg =
-                ExecutionGraphTestUtils.createSimpleTestGraph(producer1, producer2, consumer);
+                ExecutionGraphTestUtils.createExecutionGraph(
+                        EXECUTOR_RESOURCE.getExecutor(), producer1, producer2, consumer);
         final ExecutionGraphToInputsLocationsRetrieverAdapter inputsLocationsRetriever =
                 new ExecutionGraphToInputsLocationsRetrieverAdapter(eg);
 
@@ -90,7 +99,9 @@ public class ExecutionGraphToInputsLocationsRetrieverAdapterTest extends TestLog
     public void testGetEmptyTaskManagerLocationIfVertexNotScheduled() throws Exception {
         final JobVertex jobVertex = ExecutionGraphTestUtils.createNoOpVertex(1);
 
-        final ExecutionGraph eg = ExecutionGraphTestUtils.createSimpleTestGraph(jobVertex);
+        final ExecutionGraph eg =
+                ExecutionGraphTestUtils.createExecutionGraph(
+                        EXECUTOR_RESOURCE.getExecutor(), jobVertex);
         final ExecutionGraphToInputsLocationsRetrieverAdapter inputsLocationsRetriever =
                 new ExecutionGraphToInputsLocationsRetrieverAdapter(eg);
 
@@ -108,7 +119,9 @@ public class ExecutionGraphToInputsLocationsRetrieverAdapterTest extends TestLog
 
         final TestingLogicalSlot testingLogicalSlot =
                 new TestingLogicalSlotBuilder().createTestingLogicalSlot();
-        final ExecutionGraph eg = ExecutionGraphTestUtils.createSimpleTestGraph(jobVertex);
+        final ExecutionGraph eg =
+                ExecutionGraphTestUtils.createExecutionGraph(
+                        EXECUTOR_RESOURCE.getExecutor(), jobVertex);
         final ExecutionGraphToInputsLocationsRetrieverAdapter inputsLocationsRetriever =
                 new ExecutionGraphToInputsLocationsRetrieverAdapter(eg);
 
@@ -136,7 +149,9 @@ public class ExecutionGraphToInputsLocationsRetrieverAdapterTest extends TestLog
     public void testGetNonExistingExecutionVertexWillThrowException() throws Exception {
         final JobVertex jobVertex = ExecutionGraphTestUtils.createNoOpVertex(1);
 
-        final ExecutionGraph eg = ExecutionGraphTestUtils.createSimpleTestGraph(jobVertex);
+        final ExecutionGraph eg =
+                ExecutionGraphTestUtils.createExecutionGraph(
+                        EXECUTOR_RESOURCE.getExecutor(), jobVertex);
         final ExecutionGraphToInputsLocationsRetrieverAdapter inputsLocationsRetriever =
                 new ExecutionGraphToInputsLocationsRetrieverAdapter(eg);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/LocalInputPreferredSlotSharingStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/LocalInputPreferredSlotSharingStrategyTest.java
@@ -35,9 +35,12 @@ import org.apache.flink.runtime.scheduler.strategy.SchedulingTopology;
 import org.apache.flink.runtime.scheduler.strategy.TestingSchedulingExecutionVertex;
 import org.apache.flink.runtime.scheduler.strategy.TestingSchedulingTopology;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -46,6 +49,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ScheduledExecutorService;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -56,6 +60,9 @@ import static org.junit.Assert.assertEquals;
 
 /** Tests for {@link LocalInputPreferredSlotSharingStrategy}. */
 public class LocalInputPreferredSlotSharingStrategyTest extends TestLogger {
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     private TestingSchedulingTopology topology;
 
@@ -280,7 +287,9 @@ public class LocalInputPreferredSlotSharingStrategyTest extends TestLogger {
 
         final JobGraph jobGraph = JobGraphTestUtils.batchJobGraph(v1, v2);
         final ExecutionGraph executionGraph =
-                TestingDefaultExecutionGraphBuilder.newBuilder().setJobGraph(jobGraph).build();
+                TestingDefaultExecutionGraphBuilder.newBuilder()
+                        .setJobGraph(jobGraph)
+                        .build(EXECUTOR_RESOURCE.getExecutor());
         final SchedulingTopology topology = executionGraph.getSchedulingTopology();
 
         final SlotSharingStrategy strategy =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SsgNetworkMemoryCalculationUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SsgNetworkMemoryCalculationUtilsTest.java
@@ -41,7 +41,10 @@ import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
 import org.apache.flink.runtime.shuffle.TaskInputsOutputsDescriptor;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -49,6 +52,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -56,6 +60,9 @@ import static org.junit.Assert.assertEquals;
 
 /** Tests for {@link SsgNetworkMemoryCalculationUtils}. */
 public class SsgNetworkMemoryCalculationUtilsTest {
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     private static final TestShuffleMaster SHUFFLE_MASTER = new TestShuffleMaster();
 
@@ -180,7 +187,8 @@ public class SsgNetworkMemoryCalculationUtilsTest {
                                 -1,
                                 consumerMaxParallelism,
                                 distributionPattern,
-                                true);
+                                true,
+                                EXECUTOR_RESOURCE.getExecutor());
 
         final Iterator<ExecutionJobVertex> vertexIterator =
                 eg.getVerticesTopologically().iterator();
@@ -215,7 +223,7 @@ public class SsgNetworkMemoryCalculationUtilsTest {
                 .setJobGraph(jobGraph)
                 .setVertexParallelismStore(vertexParallelismStore)
                 .setShuffleMaster(SHUFFLE_MASTER)
-                .buildDynamicGraph();
+                .buildDynamicGraph(EXECUTOR_RESOURCE.getExecutor());
     }
 
     private void createExecutionGraphAndEnrichNetworkMemory(
@@ -223,7 +231,7 @@ public class SsgNetworkMemoryCalculationUtilsTest {
         TestingDefaultExecutionGraphBuilder.newBuilder()
                 .setJobGraph(createStreamingGraph(slotSharingGroups, Arrays.asList(4, 5, 6)))
                 .setShuffleMaster(SHUFFLE_MASTER)
-                .build();
+                .build(EXECUTOR_RESOURCE.getExecutor());
     }
 
     private static JobGraph createStreamingGraph(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adapter/DefaultSchedulingPipelinedRegionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adapter/DefaultSchedulingPipelinedRegionTest.java
@@ -29,10 +29,13 @@ import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.scheduler.strategy.ConsumedPartitionGroup;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.TestLogger;
 
 import org.apache.flink.shaded.guava30.com.google.common.collect.Iterables;
 
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -40,6 +43,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ScheduledExecutorService;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
@@ -50,6 +54,10 @@ import static org.junit.Assert.fail;
 
 /** Unit tests for {@link DefaultSchedulingPipelinedRegion}. */
 public class DefaultSchedulingPipelinedRegionTest extends TestLogger {
+
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     @Test
     public void gettingUnknownVertexThrowsException() {
@@ -121,7 +129,8 @@ public class DefaultSchedulingPipelinedRegionTest extends TestLogger {
         e.connectNewDataSetAsInput(d, DistributionPattern.POINTWISE, ResultPartitionType.PIPELINED);
 
         final DefaultExecutionGraph simpleTestGraph =
-                ExecutionGraphTestUtils.createSimpleTestGraph(a, b, c, d, e);
+                ExecutionGraphTestUtils.createExecutionGraph(
+                        EXECUTOR_RESOURCE.getExecutor(), a, b, c, d, e);
         final DefaultExecutionTopology topology =
                 DefaultExecutionTopology.fromExecutionGraph(simpleTestGraph);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/ExecutingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/ExecutingTest.java
@@ -64,10 +64,13 @@ import org.apache.flink.runtime.scheduler.exceptionhistory.TestingAccessExecutio
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.types.Either;
 import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.TestLogger;
 
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.slf4j.Logger;
 
@@ -82,6 +85,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -96,6 +100,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 /** Tests for {@link AdaptiveScheduler AdaptiveScheduler's} {@link Executing} state. */
 public class ExecutingTest extends TestLogger {
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     @Test
     public void testExecutionGraphDeploymentOnEnter() throws Exception {
@@ -361,7 +368,8 @@ public class ExecutingTest extends TestLogger {
     public void testTransitionToStopWithSavepointState() throws Exception {
         try (MockExecutingContext ctx = new MockExecutingContext()) {
             CheckpointCoordinator coordinator =
-                    new CheckpointCoordinatorTestingUtils.CheckpointCoordinatorBuilder().build();
+                    new CheckpointCoordinatorTestingUtils.CheckpointCoordinatorBuilder()
+                            .build(EXECUTOR_RESOURCE.getExecutor());
             StateTrackingMockExecutionGraph mockedExecutionGraphWithCheckpointCoordinator =
                     new StateTrackingMockExecutionGraph() {
                         @Nullable
@@ -384,7 +392,8 @@ public class ExecutingTest extends TestLogger {
     public void testCheckpointSchedulerIsStoppedOnStopWithSavepoint() throws Exception {
         try (MockExecutingContext ctx = new MockExecutingContext()) {
             CheckpointCoordinator coordinator =
-                    new CheckpointCoordinatorTestingUtils.CheckpointCoordinatorBuilder().build();
+                    new CheckpointCoordinatorTestingUtils.CheckpointCoordinatorBuilder()
+                            .build(EXECUTOR_RESOURCE.getExecutor());
             StateTrackingMockExecutionGraph mockedExecutionGraphWithCheckpointCoordinator =
                     new StateTrackingMockExecutionGraph() {
                         @Nullable
@@ -474,7 +483,8 @@ public class ExecutingTest extends TestLogger {
 
     private final class ExecutingStateBuilder {
         private ExecutionGraph executionGraph =
-                TestingDefaultExecutionGraphBuilder.newBuilder().build();
+                TestingDefaultExecutionGraphBuilder.newBuilder()
+                        .build(EXECUTOR_RESOURCE.getExecutor());
         private OperatorCoordinatorHandler operatorCoordinatorHandler;
 
         private ExecutingStateBuilder() throws JobException, JobExecutionException {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchSchedulerTest.java
@@ -38,13 +38,17 @@ import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.scheduler.SchedulerBase;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.TestLogger;
 
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -55,6 +59,10 @@ public class AdaptiveBatchSchedulerTest extends TestLogger {
 
     private static final int SOURCE_PARALLELISM_1 = 6;
     private static final int SOURCE_PARALLELISM_2 = 4;
+
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     private static final ComponentMainThreadExecutor mainThreadExecutor =
             ComponentMainThreadExecutorServiceAdapter.forMainThread();
@@ -172,7 +180,9 @@ public class AdaptiveBatchSchedulerTest extends TestLogger {
         final AdaptiveBatchSchedulerTestUtils.AdaptiveBatchSchedulerBuilder schedulerBuilder =
                 (AdaptiveBatchSchedulerTestUtils.AdaptiveBatchSchedulerBuilder)
                         new AdaptiveBatchSchedulerTestUtils.AdaptiveBatchSchedulerBuilder(
-                                        jobGraph, mainThreadExecutor)
+                                        jobGraph,
+                                        mainThreadExecutor,
+                                        EXECUTOR_RESOURCE.getExecutor())
                                 .setJobMasterConfiguration(configuration);
         schedulerBuilder.setVertexParallelismDecider((ignored) -> 10);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchSchedulerTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchSchedulerTestUtils.java
@@ -28,6 +28,8 @@ import org.apache.flink.runtime.scheduler.ExecutionGraphFactory;
 import org.apache.flink.runtime.scheduler.SchedulerTestingUtils;
 import org.apache.flink.runtime.scheduler.strategy.VertexwiseSchedulingStrategy;
 
+import java.util.concurrent.ScheduledExecutorService;
+
 /** A utility class to create {@link AdaptiveBatchScheduler} instances for testing. */
 public class AdaptiveBatchSchedulerTestUtils {
 
@@ -41,8 +43,10 @@ public class AdaptiveBatchSchedulerTestUtils {
                 JobManagerOptions.ADAPTIVE_BATCH_SCHEDULER_MAX_PARALLELISM.defaultValue();
 
         public AdaptiveBatchSchedulerBuilder(
-                JobGraph jobGraph, ComponentMainThreadExecutor mainThreadExecutor) {
-            super(jobGraph, mainThreadExecutor);
+                JobGraph jobGraph,
+                ComponentMainThreadExecutor mainThreadExecutor,
+                ScheduledExecutorService executorService) {
+            super(jobGraph, mainThreadExecutor, executorService);
             setSchedulingStrategyFactory(new VertexwiseSchedulingStrategy.Factory());
         }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/forwardgroup/ForwardGroupComputeUtilTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/forwardgroup/ForwardGroupComputeUtilTest.java
@@ -28,13 +28,17 @@ import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.scheduler.adaptivebatch.AdaptiveBatchScheduler;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.TestLogger;
 
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -42,6 +46,10 @@ import static org.junit.Assert.assertEquals;
 
 /** Unit tests for {@link ForwardGroupComputeUtil}. */
 public class ForwardGroupComputeUtilTest extends TestLogger {
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
+
     /**
      * Tests that the computation of the job graph with isolated vertices works correctly.
      *
@@ -200,6 +208,6 @@ public class ForwardGroupComputeUtilTest extends TestLogger {
                         .setVertexParallelismStore(
                                 AdaptiveBatchScheduler.computeVertexParallelismStoreForDynamicGraph(
                                         Arrays.asList(vertices), 10));
-        return builder.buildDynamicGraph();
+        return builder.buildDynamicGraph(EXECUTOR_RESOURCE.getExecutor());
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/SchedulerBenchmarkBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/SchedulerBenchmarkBase.java
@@ -18,8 +18,9 @@
 
 package org.apache.flink.runtime.scheduler.benchmark;
 
-import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.util.concurrent.ExecutorThreadFactory;
 
+import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
 /** Base class of all scheduler benchmarks. */
@@ -27,7 +28,9 @@ public class SchedulerBenchmarkBase {
     public ScheduledExecutorService scheduledExecutorService;
 
     public void setup() {
-        scheduledExecutorService = TestingUtils.defaultExecutor();
+        scheduledExecutorService =
+                Executors.newSingleThreadScheduledExecutor(
+                        new ExecutorThreadFactory("flink-benchmarks"));
     }
 
     public void teardown() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/SchedulerBenchmarkUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/SchedulerBenchmarkUtils.java
@@ -104,7 +104,8 @@ public class SchedulerBenchmarkUtils {
                 ComponentMainThreadExecutorServiceAdapter.forMainThread();
 
         final DefaultScheduler scheduler =
-                SchedulerTestingUtils.createSchedulerBuilder(jobGraph, mainThreadExecutor)
+                SchedulerTestingUtils.createSchedulerBuilder(
+                                jobGraph, mainThreadExecutor, scheduledExecutorService)
                         .setIoExecutor(scheduledExecutorService)
                         .setFutureExecutor(scheduledExecutorService)
                         .setDelayExecutor(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/e2e/SchedulerEndToEndBenchmarkBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/e2e/SchedulerEndToEndBenchmarkBase.java
@@ -31,7 +31,6 @@ import org.apache.flink.runtime.scheduler.DefaultScheduler;
 import org.apache.flink.runtime.scheduler.SchedulerTestingUtils;
 import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
 import org.apache.flink.runtime.scheduler.benchmark.SchedulerBenchmarkBase;
-import org.apache.flink.util.concurrent.ScheduledExecutorServiceAdapter;
 
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
@@ -77,10 +76,8 @@ public class SchedulerEndToEndBenchmarkBase extends SchedulerBenchmarkBase {
             ComponentMainThreadExecutor mainThreadExecutor,
             ScheduledExecutorService executorService)
             throws Exception {
-        return SchedulerTestingUtils.newSchedulerBuilder(jobGraph, mainThreadExecutor)
-                .setFutureExecutor(executorService)
-                .setIoExecutor(executorService)
-                .setDelayExecutor(new ScheduledExecutorServiceAdapter(executorService))
+        return new SchedulerTestingUtils.DefaultSchedulerBuilder(
+                        jobGraph, mainThreadExecutor, executorService)
                 .setExecutionSlotAllocatorFactory(
                         SchedulerTestingUtils.newSlotSharingExecutionSlotAllocatorFactory(
                                 physicalSlotProvider))

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/topology/BuildExecutionGraphBenchmark.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/topology/BuildExecutionGraphBenchmark.java
@@ -54,9 +54,7 @@ public class BuildExecutionGraphBenchmark extends SchedulerBenchmarkBase {
                 TestingDefaultExecutionGraphBuilder.newBuilder()
                         .setVertexParallelismStore(parallelismStore)
                         .setJobGraph(jobGraph)
-                        .setFutureExecutor(scheduledExecutorService)
-                        .setIoExecutor(scheduledExecutorService)
-                        .build();
+                        .build(scheduledExecutorService);
     }
 
     public void buildTopology() throws Exception {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/exceptionhistory/FailureHandlingResultSnapshotTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/exceptionhistory/FailureHandlingResultSnapshotTest.java
@@ -35,6 +35,8 @@ import org.apache.flink.runtime.jobgraph.JobGraphTestUtils;
 import org.apache.flink.runtime.jobmaster.TestingLogicalSlotBuilder;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.SerializedThrowable;
 import org.apache.flink.util.TestLogger;
@@ -45,9 +47,11 @@ import org.hamcrest.collection.IsIterableContainingInAnyOrder;
 import org.hamcrest.collection.IsIterableContainingInOrder;
 import org.hamcrest.core.IsInstanceOf;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.Collections;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -59,6 +63,9 @@ import static org.junit.Assert.assertThat;
  * FailureHandlingResultSnapshot}.
  */
 public class FailureHandlingResultSnapshotTest extends TestLogger {
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     private ExecutionGraph executionGraph;
 
@@ -68,7 +75,9 @@ public class FailureHandlingResultSnapshotTest extends TestLogger {
         jobGraph.getVertices().forEach(v -> v.setParallelism(3));
 
         executionGraph =
-                TestingDefaultExecutionGraphBuilder.newBuilder().setJobGraph(jobGraph).build();
+                TestingDefaultExecutionGraphBuilder.newBuilder()
+                        .setJobGraph(jobGraph)
+                        .build(EXECUTOR_RESOURCE.getExecutor());
         executionGraph.start(ComponentMainThreadExecutorServiceAdapter.forMainThread());
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/exceptionhistory/RootExceptionHistoryEntryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/exceptionhistory/RootExceptionHistoryEntryTest.java
@@ -30,6 +30,8 @@ import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobGraphTestUtils;
 import org.apache.flink.runtime.jobmaster.TestingLogicalSlotBuilder;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.TestLogger;
 
 import org.apache.flink.shaded.guava30.com.google.common.collect.Iterables;
@@ -37,9 +39,11 @@ import org.apache.flink.shaded.guava30.com.google.common.collect.Iterables;
 import org.hamcrest.collection.IsIterableContainingInAnyOrder;
 import org.hamcrest.collection.IsIterableContainingInOrder;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.Collections;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -49,6 +53,9 @@ import static org.junit.Assert.assertThat;
  * {@code RootExceptionHistoryEntryTest} tests the creation of {@link RootExceptionHistoryEntry}.
  */
 public class RootExceptionHistoryEntryTest extends TestLogger {
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     private ExecutionGraph executionGraph;
 
@@ -58,7 +65,9 @@ public class RootExceptionHistoryEntryTest extends TestLogger {
         jobGraph.getVertices().forEach(v -> v.setParallelism(3));
 
         executionGraph =
-                TestingDefaultExecutionGraphBuilder.newBuilder().setJobGraph(jobGraph).build();
+                TestingDefaultExecutionGraphBuilder.newBuilder()
+                        .setJobGraph(jobGraph)
+                        .build(EXECUTOR_RESOURCE.getExecutor());
         executionGraph.start(ComponentMainThreadExecutorServiceAdapter.forMainThread());
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/PipelinedRegionSchedulingStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/PipelinedRegionSchedulingStrategyTest.java
@@ -29,9 +29,12 @@ import org.apache.flink.runtime.jobgraph.JobGraphBuilder;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.scheduler.ExecutionVertexDeploymentOption;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -39,6 +42,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -50,6 +54,9 @@ import static org.junit.Assert.assertTrue;
 
 /** Unit tests for {@link PipelinedRegionSchedulingStrategy}. */
 public class PipelinedRegionSchedulingStrategyTest extends TestLogger {
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     private TestingSchedulerOperations testingSchedulerOperation;
 
@@ -200,7 +207,9 @@ public class PipelinedRegionSchedulingStrategyTest extends TestLogger {
         final JobGraph jobGraph =
                 JobGraphBuilder.newBatchJobGraphBuilder().addJobVertices(ordered).build();
         final ExecutionGraph executionGraph =
-                TestingDefaultExecutionGraphBuilder.newBuilder().setJobGraph(jobGraph).build();
+                TestingDefaultExecutionGraphBuilder.newBuilder()
+                        .setJobGraph(jobGraph)
+                        .build(EXECUTOR_RESOURCE.getExecutor());
 
         final SchedulingTopology schedulingTopology = executionGraph.getSchedulingTopology();
 
@@ -262,7 +271,9 @@ public class PipelinedRegionSchedulingStrategyTest extends TestLogger {
         final JobGraph jobGraph =
                 JobGraphBuilder.newBatchJobGraphBuilder().addJobVertices(ordered).build();
         final ExecutionGraph executionGraph =
-                TestingDefaultExecutionGraphBuilder.newBuilder().setJobGraph(jobGraph).build();
+                TestingDefaultExecutionGraphBuilder.newBuilder()
+                        .setJobGraph(jobGraph)
+                        .build(EXECUTOR_RESOURCE.getExecutor());
 
         final SchedulingTopology schedulingTopology = executionGraph.getSchedulingTopology();
 
@@ -328,7 +339,9 @@ public class PipelinedRegionSchedulingStrategyTest extends TestLogger {
         final JobGraph jobGraph =
                 JobGraphBuilder.newBatchJobGraphBuilder().addJobVertices(ordered).build();
         final ExecutionGraph executionGraph =
-                TestingDefaultExecutionGraphBuilder.newBuilder().setJobGraph(jobGraph).build();
+                TestingDefaultExecutionGraphBuilder.newBuilder()
+                        .setJobGraph(jobGraph)
+                        .build(EXECUTOR_RESOURCE.getExecutor());
 
         final SchedulingTopology schedulingTopology = executionGraph.getSchedulingTopology();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorExecutionDeploymentReconciliationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorExecutionDeploymentReconciliationTest.java
@@ -55,6 +55,8 @@ import org.apache.flink.runtime.rpc.TestingRpcServiceResource;
 import org.apache.flink.runtime.taskexecutor.slot.TaskSlotUtils;
 import org.apache.flink.runtime.util.TestingFatalErrorHandlerResource;
 import org.apache.flink.testutils.TestFileUtils;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.concurrent.FutureUtils;
 
@@ -73,6 +75,7 @@ import java.util.UUID;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.StreamSupport;
 
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
@@ -92,6 +95,10 @@ public class TaskExecutorExecutionDeploymentReconciliationTest extends TestLogge
     private final SettableLeaderRetrievalService resourceManagerLeaderRetriever =
             new SettableLeaderRetrievalService();
     private final JobID jobId = new JobID();
+
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     @ClassRule
     public static final TestingRpcServiceResource RPC_SERVICE_RESOURCE =
@@ -132,7 +139,9 @@ public class TaskExecutorExecutionDeploymentReconciliationTest extends TestLogge
 
         final TaskManagerServices taskManagerServices =
                 new TaskManagerServicesBuilder()
-                        .setTaskSlotTable(TaskSlotUtils.createTaskSlotTable(1, timeout))
+                        .setTaskSlotTable(
+                                TaskSlotUtils.createTaskSlotTable(
+                                        1, timeout, EXECUTOR_RESOURCE.getExecutor()))
                         .setShuffleEnvironment(new NettyShuffleEnvironmentBuilder().build())
                         .build();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorOperatorEventHandlingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorOperatorEventHandlingTest.java
@@ -39,12 +39,15 @@ import org.apache.flink.runtime.operators.coordination.TestingCoordinationReques
 import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.taskmanager.Task;
 import org.apache.flink.runtime.testutils.CancelableInvokable;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -52,6 +55,7 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
 
 import static org.apache.flink.core.testutils.FlinkMatchers.futureWillCompleteExceptionally;
 import static org.junit.Assert.assertEquals;
@@ -59,6 +63,10 @@ import static org.junit.Assert.assertThat;
 
 /** Test for the (failure handling of the) delivery of Operator Events. */
 public class TaskExecutorOperatorEventHandlingTest extends TestLogger {
+
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     private MetricRegistryImpl metricRegistry;
 
@@ -169,7 +177,7 @@ public class TaskExecutorOperatorEventHandlingTest extends TestLogger {
                                                     throw new RuntimeException();
                                                 })
                                         .build())
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
 
         env.getTaskSlotTable().allocateSlot(0, jobId, tdd.getAllocationId(), Time.seconds(60));
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorPartitionLifecycleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorPartitionLifecycleTest.java
@@ -66,6 +66,7 @@ import org.apache.flink.runtime.taskmanager.NoOpTaskManagerActions;
 import org.apache.flink.runtime.taskmanager.Task;
 import org.apache.flink.runtime.util.TestingFatalErrorHandler;
 import org.apache.flink.testutils.TestFileUtils;
+import org.apache.flink.testutils.TestingUtils;
 import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.Reference;
 import org.apache.flink.util.SerializedValue;
@@ -91,6 +92,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.StreamSupport;
@@ -119,8 +121,8 @@ public class TaskExecutorPartitionLifecycleTest extends TestLogger {
     @Rule public final TemporaryFolder tmp = new TemporaryFolder();
 
     @ClassRule
-    public static final TestExecutorResource<?> TEST_EXECUTOR_SERVICE_RESOURCE =
-            new TestExecutorResource<>(() -> java.util.concurrent.Executors.newFixedThreadPool(1));
+    public static final TestExecutorResource<ScheduledExecutorService>
+            TEST_EXECUTOR_SERVICE_RESOURCE = TestingUtils.defaultExecutorResource();
 
     @Before
     public void setup() {
@@ -612,7 +614,8 @@ public class TaskExecutorPartitionLifecycleTest extends TestLogger {
     }
 
     private static TaskSlotTable<Task> createTaskSlotTable() {
-        return TaskSlotUtils.createTaskSlotTable(1, timeout);
+        return TaskSlotUtils.createTaskSlotTable(
+                1, timeout, TEST_EXECUTOR_SERVICE_RESOURCE.getExecutor());
     }
 
     @FunctionalInterface

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorSlotLifetimeTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorSlotLifetimeTest.java
@@ -49,6 +49,8 @@ import org.apache.flink.runtime.taskmanager.LocalUnresolvedTaskManagerLocation;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
 import org.apache.flink.runtime.util.TestingFatalErrorHandlerResource;
 import org.apache.flink.testutils.TestFileUtils;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.function.FunctionUtils;
 
@@ -62,12 +64,17 @@ import java.net.InetAddress;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
 
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.junit.Assert.assertThat;
 
 /** Tests for the {@link TaskExecutor TaskExecutor's} slot lifetime and its dependencies. */
 public class TaskExecutorSlotLifetimeTest extends TestLogger {
+
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     @ClassRule
     public static final TestingRpcServiceResource TESTING_RPC_SERVICE_RESOURCE =
@@ -210,7 +217,9 @@ public class TaskExecutorSlotLifetimeTest extends TestLogger {
                         TestFileUtils.createTempDir()),
                 haServices,
                 new TaskManagerServicesBuilder()
-                        .setTaskSlotTable(TaskSlotUtils.createTaskSlotTable(1))
+                        .setTaskSlotTable(
+                                TaskSlotUtils.createTaskSlotTable(
+                                        1, EXECUTOR_RESOURCE.getExecutor()))
                         .setUnresolvedTaskManagerLocation(unresolvedTaskManagerLocation)
                         .build(),
                 ExternalResourceInfoProvider.NO_EXTERNAL_RESOURCES,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorSubmissionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorSubmissionTest.java
@@ -58,6 +58,8 @@ import org.apache.flink.runtime.taskexecutor.slot.TaskSlotTable;
 import org.apache.flink.runtime.taskmanager.Task;
 import org.apache.flink.runtime.testtasks.BlockingNoOpInvokable;
 import org.apache.flink.runtime.util.NettyShuffleDescriptorBuilder;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.NetUtils;
 import org.apache.flink.util.Preconditions;
@@ -65,6 +67,7 @@ import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.concurrent.FutureUtils;
 
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -76,6 +79,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
 
 import static org.apache.flink.runtime.util.NettyShuffleDescriptorBuilder.createRemoteWithIdAndLocation;
 import static org.hamcrest.CoreMatchers.is;
@@ -88,6 +92,10 @@ import static org.mockito.Mockito.mock;
 
 /** Tests for submission logic of the {@link TaskExecutor}. */
 public class TaskExecutorSubmissionTest extends TestLogger {
+
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     @Rule public final TestName testName = new TestName();
 
@@ -113,7 +121,7 @@ public class TaskExecutorSubmissionTest extends TestLogger {
                         .setSlotSize(1)
                         .addTaskManagerActionListener(
                                 eid, ExecutionState.RUNNING, taskRunningFuture)
-                        .build()) {
+                        .build(EXECUTOR_RESOURCE.getExecutor())) {
             TaskExecutorGateway tmGateway = env.getTaskExecutorGateway();
             TaskSlotTable taskSlotTable = env.getTaskSlotTable();
 
@@ -141,7 +149,8 @@ public class TaskExecutorSubmissionTest extends TestLogger {
         // must be >= 1
 
         try (TaskSubmissionTestEnvironment env =
-                new TaskSubmissionTestEnvironment.Builder(jobId).build()) {
+                new TaskSubmissionTestEnvironment.Builder(jobId)
+                        .build(EXECUTOR_RESOURCE.getExecutor())) {
             TaskExecutorGateway tmGateway = env.getTaskExecutorGateway();
             TaskSlotTable taskSlotTable = env.getTaskSlotTable();
 
@@ -176,7 +185,7 @@ public class TaskExecutorSubmissionTest extends TestLogger {
                                 eid2, ExecutionState.RUNNING, task2RunningFuture)
                         .addTaskManagerActionListener(
                                 eid1, ExecutionState.CANCELED, task1CanceledFuture)
-                        .build()) {
+                        .build(EXECUTOR_RESOURCE.getExecutor())) {
             TaskExecutorGateway tmGateway = env.getTaskExecutorGateway();
             TaskSlotTable<Task> taskSlotTable = env.getTaskSlotTable();
 
@@ -231,7 +240,7 @@ public class TaskExecutorSubmissionTest extends TestLogger {
                         .addTaskManagerActionListener(
                                 eid2, ExecutionState.FAILED, task2FailedFuture)
                         .setSlotSize(2)
-                        .build()) {
+                        .build(EXECUTOR_RESOURCE.getExecutor())) {
             TaskExecutorGateway tmGateway = env.getTaskExecutorGateway();
             TaskSlotTable<Task> taskSlotTable = env.getTaskSlotTable();
 
@@ -292,7 +301,7 @@ public class TaskExecutorSubmissionTest extends TestLogger {
                         .setJobMasterId(jobMasterId)
                         .setJobMasterGateway(testingJobMasterGateway)
                         .useRealNonMockShuffleEnvironment()
-                        .build()) {
+                        .build(EXECUTOR_RESOURCE.getExecutor())) {
             TaskExecutorGateway tmGateway = env.getTaskExecutorGateway();
             TaskSlotTable<Task> taskSlotTable = env.getTaskSlotTable();
 
@@ -369,7 +378,7 @@ public class TaskExecutorSubmissionTest extends TestLogger {
                         .setJobMasterId(jobMasterId)
                         .setJobMasterGateway(testingJobMasterGateway)
                         .useRealNonMockShuffleEnvironment()
-                        .build()) {
+                        .build(EXECUTOR_RESOURCE.getExecutor())) {
             TaskExecutorGateway tmGateway = env.getTaskExecutorGateway();
             TaskSlotTable<Task> taskSlotTable = env.getTaskSlotTable();
 
@@ -423,7 +432,7 @@ public class TaskExecutorSubmissionTest extends TestLogger {
                             .setConfiguration(config)
                             .setLocalCommunication(false)
                             .useRealNonMockShuffleEnvironment()
-                            .build()) {
+                            .build(EXECUTOR_RESOURCE.getExecutor())) {
                 TaskExecutorGateway tmGateway = env.getTaskExecutorGateway();
                 TaskSlotTable<Task> taskSlotTable = env.getTaskSlotTable();
 
@@ -459,7 +468,7 @@ public class TaskExecutorSubmissionTest extends TestLogger {
                         .addTaskManagerActionListener(
                                 eid, ExecutionState.RUNNING, taskRunningFuture)
                         .addTaskManagerActionListener(eid, ExecutionState.FAILED, taskFailedFuture)
-                        .build()) {
+                        .build(EXECUTOR_RESOURCE.getExecutor())) {
             TaskExecutorGateway tmGateway = env.getTaskExecutorGateway();
             TaskSlotTable<Task> taskSlotTable = env.getTaskSlotTable();
 
@@ -517,7 +526,7 @@ public class TaskExecutorSubmissionTest extends TestLogger {
                         .addTaskManagerActionListener(eid, ExecutionState.FAILED, taskFailedFuture)
                         .setConfiguration(config)
                         .useRealNonMockShuffleEnvironment()
-                        .build()) {
+                        .build(EXECUTOR_RESOURCE.getExecutor())) {
             TaskExecutorGateway tmGateway = env.getTaskExecutorGateway();
             TaskSlotTable<Task> taskSlotTable = env.getTaskSlotTable();
 
@@ -582,7 +591,7 @@ public class TaskExecutorSubmissionTest extends TestLogger {
                         .setJobMasterId(jobMasterId)
                         .setJobMasterGateway(testingJobMasterGateway)
                         .useRealNonMockShuffleEnvironment()
-                        .build()) {
+                        .build(EXECUTOR_RESOURCE.getExecutor())) {
             TaskExecutorGateway tmGateway = env.getTaskExecutorGateway();
             TaskSlotTable<Task> taskSlotTable = env.getTaskSlotTable();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -101,6 +101,8 @@ import org.apache.flink.runtime.testtasks.NoOpInvokable;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.runtime.util.TestingFatalErrorHandler;
 import org.apache.flink.testutils.TestFileUtils;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.ExecutorUtils;
 import org.apache.flink.util.FlinkException;
@@ -118,6 +120,7 @@ import org.apache.flink.shaded.guava30.com.google.common.collect.Lists;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -185,6 +188,10 @@ public class TaskExecutorTest extends TestLogger {
                     MemorySize.parse("3m"),
                     MemorySize.parse("4m"),
                     Collections.emptyList());
+
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     @Rule public final TemporaryFolder tmp = new TemporaryFolder();
 
@@ -255,7 +262,8 @@ public class TaskExecutorTest extends TestLogger {
 
     @Test
     public void testShouldShutDownTaskManagerServicesInPostStop() throws Exception {
-        final TaskSlotTableImpl<Task> taskSlotTable = TaskSlotUtils.createTaskSlotTable(1);
+        final TaskSlotTableImpl<Task> taskSlotTable =
+                TaskSlotUtils.createTaskSlotTable(1, EXECUTOR_RESOURCE.getExecutor());
 
         final JobLeaderService jobLeaderService =
                 new DefaultJobLeaderService(
@@ -382,7 +390,9 @@ public class TaskExecutorTest extends TestLogger {
         final TaskManagerServices taskManagerServices =
                 new TaskManagerServicesBuilder()
                         .setUnresolvedTaskManagerLocation(unresolvedTaskManagerLocation)
-                        .setTaskSlotTable(TaskSlotUtils.createTaskSlotTable(1))
+                        .setTaskSlotTable(
+                                TaskSlotUtils.createTaskSlotTable(
+                                        1, EXECUTOR_RESOURCE.getExecutor()))
                         .setJobLeaderService(jobLeaderService)
                         .setTaskStateManager(localStateStoresManager)
                         .build();
@@ -725,7 +735,9 @@ public class TaskExecutorTest extends TestLogger {
         final TaskManagerServices taskManagerServices =
                 new TaskManagerServicesBuilder()
                         .setUnresolvedTaskManagerLocation(unresolvedTaskManagerLocation)
-                        .setTaskSlotTable(TaskSlotUtils.createTaskSlotTable(1))
+                        .setTaskSlotTable(
+                                TaskSlotUtils.createTaskSlotTable(
+                                        1, EXECUTOR_RESOURCE.getExecutor()))
                         .setTaskStateManager(createTaskExecutorLocalStateStoresManager())
                         .build();
 
@@ -881,7 +893,8 @@ public class TaskExecutorTest extends TestLogger {
      */
     @Test
     public void testJobLeaderDetection() throws Exception {
-        final TaskSlotTable<Task> taskSlotTable = TaskSlotUtils.createTaskSlotTable(1);
+        final TaskSlotTable<Task> taskSlotTable =
+                TaskSlotUtils.createTaskSlotTable(1, EXECUTOR_RESOURCE.getExecutor());
         final JobLeaderService jobLeaderService =
                 new DefaultJobLeaderService(
                         unresolvedTaskManagerLocation,
@@ -992,7 +1005,8 @@ public class TaskExecutorTest extends TestLogger {
         rpc.registerGateway(resourceManagerGateway.getAddress(), resourceManagerGateway);
         rpc.registerGateway(jobMasterGateway.getAddress(), jobMasterGateway);
 
-        final TaskSlotTable<Task> taskSlotTable = TaskSlotUtils.createTaskSlotTable(2);
+        final TaskSlotTable<Task> taskSlotTable =
+                TaskSlotUtils.createTaskSlotTable(2, EXECUTOR_RESOURCE.getExecutor());
         final TaskManagerServices taskManagerServices =
                 createTaskManagerServicesWithTaskSlotTable(taskSlotTable);
         final TestingTaskExecutor taskManager = createTestingTaskExecutor(taskManagerServices);
@@ -1117,7 +1131,8 @@ public class TaskExecutorTest extends TestLogger {
         rpc.registerGateway(resourceManagerGateway.getAddress(), resourceManagerGateway);
         rpc.registerGateway(jobMasterGateway.getAddress(), jobMasterGateway);
 
-        final TaskSlotTable<Task> taskSlotTable = TaskSlotUtils.createTaskSlotTable(2);
+        final TaskSlotTable<Task> taskSlotTable =
+                TaskSlotUtils.createTaskSlotTable(2, EXECUTOR_RESOURCE.getExecutor());
         final TaskManagerServices taskManagerServices =
                 createTaskManagerServicesWithTaskSlotTable(taskSlotTable);
         final TestingTaskExecutor taskExecutor = createTestingTaskExecutor(taskManagerServices);
@@ -1237,7 +1252,8 @@ public class TaskExecutorTest extends TestLogger {
         rpc.registerGateway(jobMasterGateway1.getAddress(), jobMasterGateway1);
         rpc.registerGateway(jobMasterGateway2.getAddress(), jobMasterGateway2);
 
-        final TaskSlotTable<Task> taskSlotTable = TaskSlotUtils.createTaskSlotTable(2);
+        final TaskSlotTable<Task> taskSlotTable =
+                TaskSlotUtils.createTaskSlotTable(2, EXECUTOR_RESOURCE.getExecutor());
         final TaskManagerServices taskManagerServices =
                 createTaskManagerServicesWithTaskSlotTable(taskSlotTable);
         final TestingTaskExecutor taskExecutor = createTestingTaskExecutor(taskManagerServices);
@@ -1331,7 +1347,8 @@ public class TaskExecutorTest extends TestLogger {
 
         rpc.registerGateway(jobMasterGateway.getAddress(), jobMasterGateway);
 
-        final TaskSlotTable<Task> taskSlotTable = TaskSlotUtils.createTaskSlotTable(1);
+        final TaskSlotTable<Task> taskSlotTable =
+                TaskSlotUtils.createTaskSlotTable(1, EXECUTOR_RESOURCE.getExecutor());
         final TaskExecutorLocalStateStoresManager localStateStoresManager =
                 createTaskExecutorLocalStateStoresManager();
         final TaskManagerServices taskManagerServices =
@@ -1408,7 +1425,8 @@ public class TaskExecutorTest extends TestLogger {
         rpc.registerGateway(resourceManagerGateway.getAddress(), resourceManagerGateway);
         rpc.registerGateway(jobMasterGateway.getAddress(), jobMasterGateway);
 
-        final TaskSlotTable<Task> taskSlotTable = TaskSlotUtils.createTaskSlotTable(2);
+        final TaskSlotTable<Task> taskSlotTable =
+                TaskSlotUtils.createTaskSlotTable(2, EXECUTOR_RESOURCE.getExecutor());
         final TaskManagerServices taskManagerServices =
                 createTaskManagerServicesWithTaskSlotTable(taskSlotTable);
         final TestingTaskExecutor taskManager = createTestingTaskExecutor(taskManagerServices);
@@ -1551,7 +1569,8 @@ public class TaskExecutorTest extends TestLogger {
                 new RecordingHeartbeatServices(heartbeatInterval, heartbeatTimeout);
         final ResourceID rmResourceID = ResourceID.generate();
 
-        final TaskSlotTable<Task> taskSlotTable = TaskSlotUtils.createTaskSlotTable(1);
+        final TaskSlotTable<Task> taskSlotTable =
+                TaskSlotUtils.createTaskSlotTable(1, EXECUTOR_RESOURCE.getExecutor());
 
         final String rmAddress = "rm";
         final TestingResourceManagerGateway rmGateway =
@@ -1609,7 +1628,8 @@ public class TaskExecutorTest extends TestLogger {
      */
     @Test
     public void testRemoveJobFromJobLeaderService() throws Exception {
-        final TaskSlotTable<Task> taskSlotTable = TaskSlotUtils.createTaskSlotTable(1);
+        final TaskSlotTable<Task> taskSlotTable =
+                TaskSlotUtils.createTaskSlotTable(1, EXECUTOR_RESOURCE.getExecutor());
 
         final TaskExecutorLocalStateStoresManager localStateStoresManager =
                 createTaskExecutorLocalStateStoresManager();
@@ -1715,7 +1735,8 @@ public class TaskExecutorTest extends TestLogger {
     public void testMaximumRegistrationDurationAfterConnectionLoss() throws Exception {
         configuration.set(
                 TaskManagerOptions.REGISTRATION_TIMEOUT, TimeUtils.parseDuration("100 ms"));
-        final TaskSlotTable<Task> taskSlotTable = TaskSlotUtils.createTaskSlotTable(1);
+        final TaskSlotTable<Task> taskSlotTable =
+                TaskSlotUtils.createTaskSlotTable(1, EXECUTOR_RESOURCE.getExecutor());
 
         final TaskManagerServices taskManagerServices =
                 new TaskManagerServicesBuilder().setTaskSlotTable(taskSlotTable).build();
@@ -1837,7 +1858,8 @@ public class TaskExecutorTest extends TestLogger {
      */
     @Test
     public void testReconnectionAttemptIfExplicitlyDisconnected() throws Exception {
-        final TaskSlotTable<Task> taskSlotTable = TaskSlotUtils.createTaskSlotTable(1);
+        final TaskSlotTable<Task> taskSlotTable =
+                TaskSlotUtils.createTaskSlotTable(1, EXECUTOR_RESOURCE.getExecutor());
         final UnresolvedTaskManagerLocation unresolvedTaskManagerLocation =
                 new LocalUnresolvedTaskManagerLocation();
         final TaskExecutor taskExecutor =
@@ -1972,7 +1994,8 @@ public class TaskExecutorTest extends TestLogger {
     /** Tests that the {@link TaskExecutor} tries to reconnect if the initial slot report fails. */
     @Test
     public void testInitialSlotReportFailure() throws Exception {
-        final TaskSlotTable<Task> taskSlotTable = TaskSlotUtils.createTaskSlotTable(1);
+        final TaskSlotTable<Task> taskSlotTable =
+                TaskSlotUtils.createTaskSlotTable(1, EXECUTOR_RESOURCE.getExecutor());
         final UnresolvedTaskManagerLocation unresolvedTaskManagerLocation =
                 new LocalUnresolvedTaskManagerLocation();
         final TaskManagerServices taskManagerServices =
@@ -2034,7 +2057,8 @@ public class TaskExecutorTest extends TestLogger {
     /** Tests that offers slots to job master timeout and retry. */
     @Test
     public void testOfferSlotToJobMasterAfterTimeout() throws Exception {
-        final TaskSlotTable<Task> taskSlotTable = TaskSlotUtils.createTaskSlotTable(2);
+        final TaskSlotTable<Task> taskSlotTable =
+                TaskSlotUtils.createTaskSlotTable(2, EXECUTOR_RESOURCE.getExecutor());
         final TaskManagerServices taskManagerServices =
                 new TaskManagerServicesBuilder().setTaskSlotTable(taskSlotTable).build();
 
@@ -2112,7 +2136,9 @@ public class TaskExecutorTest extends TestLogger {
     public void testDisconnectFromJobMasterWhenNewLeader() throws Exception {
         final TaskManagerServices taskManagerServices =
                 new TaskManagerServicesBuilder()
-                        .setTaskSlotTable(TaskSlotUtils.createTaskSlotTable(1))
+                        .setTaskSlotTable(
+                                TaskSlotUtils.createTaskSlotTable(
+                                        1, EXECUTOR_RESOURCE.getExecutor()))
                         .build();
         final TaskExecutor taskExecutor = createTaskExecutor(taskManagerServices);
 
@@ -2197,7 +2223,7 @@ public class TaskExecutorTest extends TestLogger {
                     new Builder(jobId)
                             .setConfiguration(configuration)
                             .setLocalCommunication(false)
-                            .build()) {
+                            .build(EXECUTOR_RESOURCE.getExecutor())) {
                 TaskExecutorGateway tmGateway = env.getTaskExecutorGateway();
                 try {
                     CompletableFuture<TransientBlobKey> logFuture =
@@ -2215,7 +2241,9 @@ public class TaskExecutorTest extends TestLogger {
     @Test(timeout = 10000L)
     public void testTerminationOnFatalError() throws Throwable {
         try (TaskSubmissionTestEnvironment env =
-                new Builder(jobId).setConfiguration(configuration).build()) {
+                new Builder(jobId)
+                        .setConfiguration(configuration)
+                        .build(EXECUTOR_RESOURCE.getExecutor())) {
             String testExceptionMsg = "Test exception of fatal error.";
 
             env.getTaskExecutor().onFatalError(new Exception(testExceptionMsg));
@@ -2567,7 +2595,9 @@ public class TaskExecutorTest extends TestLogger {
     public void testReleaseOfJobResourcesIfJobMasterIsNotCorrect() throws Exception {
         final TaskManagerServices taskManagerServices =
                 new TaskManagerServicesBuilder()
-                        .setTaskSlotTable(TaskSlotUtils.createTaskSlotTable(1))
+                        .setTaskSlotTable(
+                                TaskSlotUtils.createTaskSlotTable(
+                                        1, EXECUTOR_RESOURCE.getExecutor()))
                         .build();
 
         final TestingTaskExecutorPartitionTracker taskExecutorPartitionTracker =
@@ -2646,7 +2676,9 @@ public class TaskExecutorTest extends TestLogger {
     public void testReleaseInactiveSlots() throws Exception {
         final TaskManagerServices taskManagerServices =
                 new TaskManagerServicesBuilder()
-                        .setTaskSlotTable(TaskSlotUtils.createTaskSlotTable(1))
+                        .setTaskSlotTable(
+                                TaskSlotUtils.createTaskSlotTable(
+                                        1, EXECUTOR_RESOURCE.getExecutor()))
                         .build();
 
         final TaskExecutor taskExecutor =
@@ -2712,7 +2744,8 @@ public class TaskExecutorTest extends TestLogger {
     }
 
     private TaskExecutor createTaskExecutor(int numberOFSlots) throws IOException {
-        final TaskSlotTable<Task> taskSlotTable = TaskSlotUtils.createTaskSlotTable(numberOFSlots);
+        final TaskSlotTable<Task> taskSlotTable =
+                TaskSlotUtils.createTaskSlotTable(numberOFSlots, EXECUTOR_RESOURCE.getExecutor());
         final UnresolvedTaskManagerLocation unresolvedTaskManagerLocation =
                 new LocalUnresolvedTaskManagerLocation();
         final TaskManagerServices taskManagerServices =
@@ -2799,7 +2832,8 @@ public class TaskExecutorTest extends TestLogger {
 
     private TaskExecutorTestingContext createTaskExecutorTestingContext(int numberOfSlots)
             throws IOException {
-        return createTaskExecutorTestingContext(TaskSlotUtils.createTaskSlotTable(numberOfSlots));
+        return createTaskExecutorTestingContext(
+                TaskSlotUtils.createTaskSlotTable(numberOfSlots, EXECUTOR_RESOURCE.getExecutor()));
     }
 
     private TaskExecutorTestingContext createTaskExecutorTestingContext(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesBuilder.java
@@ -36,10 +36,9 @@ import org.apache.flink.runtime.taskexecutor.slot.TestingTaskSlotTable;
 import org.apache.flink.runtime.taskmanager.LocalUnresolvedTaskManagerLocation;
 import org.apache.flink.runtime.taskmanager.Task;
 import org.apache.flink.runtime.taskmanager.UnresolvedTaskManagerLocation;
-import org.apache.flink.testutils.TestingUtils;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import static org.mockito.Mockito.mock;
 
@@ -59,7 +58,6 @@ public class TaskManagerServicesBuilder {
     private TaskExecutorLocalStateStoresManager taskStateManager;
     private TaskExecutorStateChangelogStoragesManager taskChangelogStoragesManager;
     private TaskEventDispatcher taskEventDispatcher;
-    private ExecutorService ioExecutor;
     private LibraryCacheManager libraryCacheManager;
     private long managedMemorySize;
     private SlotAllocationSnapshotPersistenceService slotAllocationSnapshotPersistenceService;
@@ -82,7 +80,6 @@ public class TaskManagerServicesBuilder {
                         RetryingRegistrationConfiguration.defaultConfiguration());
         taskStateManager = mock(TaskExecutorLocalStateStoresManager.class);
         taskChangelogStoragesManager = mock(TaskExecutorStateChangelogStoragesManager.class);
-        ioExecutor = TestingUtils.defaultExecutor();
         libraryCacheManager = TestingLibraryCacheManager.newBuilder().build();
         managedMemorySize = MemoryManager.MIN_PAGE_SIZE;
         this.slotAllocationSnapshotPersistenceService =
@@ -144,11 +141,6 @@ public class TaskManagerServicesBuilder {
         return this;
     }
 
-    public TaskManagerServicesBuilder setIOExecutorService(ExecutorService ioExecutor) {
-        this.ioExecutor = ioExecutor;
-        return this;
-    }
-
     public TaskManagerServicesBuilder setLibraryCacheManager(
             LibraryCacheManager libraryCacheManager) {
         this.libraryCacheManager = libraryCacheManager;
@@ -180,7 +172,7 @@ public class TaskManagerServicesBuilder {
                 taskStateManager,
                 taskChangelogStoragesManager,
                 taskEventDispatcher,
-                ioExecutor,
+                Executors.newSingleThreadScheduledExecutor(),
                 libraryCacheManager,
                 slotAllocationSnapshotPersistenceService);
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskSubmissionTestEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskSubmissionTestEnvironment.java
@@ -330,6 +330,8 @@ class TaskSubmissionTestEnvironment implements AutoCloseable {
         temporaryFolder.delete();
 
         testingFatalErrorHandler.rethrowError();
+
+        taskExecutor.close();
     }
 
     public static final class Builder {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskSubmissionTestEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskSubmissionTestEnvironment.java
@@ -60,7 +60,6 @@ import org.apache.flink.runtime.taskmanager.TestCheckpointResponder;
 import org.apache.flink.runtime.util.ConfigurationParserUtils;
 import org.apache.flink.runtime.util.TestingFatalErrorHandler;
 import org.apache.flink.testutils.TestFileUtils;
-import org.apache.flink.testutils.TestingUtils;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.Reference;
 import org.apache.flink.util.concurrent.Executors;
@@ -79,6 +78,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
 
 import static org.mockito.Mockito.mock;
 
@@ -92,8 +92,7 @@ class TaskSubmissionTestEnvironment implements AutoCloseable {
     private final Time timeout = Time.milliseconds(10000L);
     private final TestingFatalErrorHandler testingFatalErrorHandler =
             new TestingFatalErrorHandler();
-    private final TimerService<AllocationID> timerService =
-            new DefaultTimerService<>(TestingUtils.defaultExecutor(), timeout.toMilliseconds());
+    private final TimerService<AllocationID> timerService;
 
     private final TestingHighAvailabilityServices haServices;
     private final TemporaryFolder temporaryFolder;
@@ -112,8 +111,14 @@ class TaskSubmissionTestEnvironment implements AutoCloseable {
                     taskManagerActionListeners,
             @Nullable String metricQueryServiceAddress,
             TestingRpcService testingRpcService,
-            ShuffleEnvironment<?, ?> shuffleEnvironment)
+            ShuffleEnvironment<?, ?> shuffleEnvironment,
+            ScheduledExecutorService executor)
             throws Exception {
+
+        this.timerService =
+                new DefaultTimerService<>(
+                        java.util.concurrent.Executors.newSingleThreadScheduledExecutor(),
+                        timeout.toMilliseconds());
 
         this.haServices = new TestingHighAvailabilityServices();
         this.haServices.setResourceManagerLeaderRetriever(new SettableLeaderRetrievalService());
@@ -126,7 +131,7 @@ class TaskSubmissionTestEnvironment implements AutoCloseable {
 
         final TaskSlotTable<Task> taskSlotTable =
                 slotSize > 0
-                        ? TaskSlotUtils.createTaskSlotTable(slotSize)
+                        ? TaskSlotUtils.createTaskSlotTable(slotSize, executor)
                         : TestingTaskSlotTable.<Task>newBuilder()
                                 .tryMarkSlotActiveReturns(true)
                                 .addTaskReturns(true)
@@ -412,7 +417,8 @@ class TaskSubmissionTestEnvironment implements AutoCloseable {
             return this;
         }
 
-        public TaskSubmissionTestEnvironment build() throws Exception {
+        public TaskSubmissionTestEnvironment build(ScheduledExecutorService executorService)
+                throws Exception {
             final TestingRpcService testingRpcService = new TestingRpcService();
             final ShuffleEnvironment<?, ?> network =
                     optionalShuffleEnvironment.orElseGet(
@@ -438,7 +444,8 @@ class TaskSubmissionTestEnvironment implements AutoCloseable {
                     taskManagerActionListeners,
                     metricQueryServiceAddress,
                     testingRpcService,
-                    network);
+                    network,
+                    executorService);
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotUtils.java
@@ -23,8 +23,9 @@ import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.memory.MemoryManager;
-import org.apache.flink.testutils.TestingUtils;
-import org.apache.flink.util.concurrent.Executors;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 
 /** Testing utility and factory methods for {@link TaskSlotTable} and {@link TaskSlot}s. */
 public enum TaskSlotUtils {
@@ -42,25 +43,30 @@ public enum TaskSlotUtils {
                     .build();
 
     public static <T extends TaskSlotPayload> TaskSlotTableImpl<T> createTaskSlotTable(
-            int numberOfSlots) {
-        return createTaskSlotTable(numberOfSlots, createDefaultTimerService());
+            int numberOfSlots, ScheduledExecutorService executorService) {
+        return createTaskSlotTable(
+                numberOfSlots, createDefaultTimerService(DEFAULT_SLOT_TIMEOUT), executorService);
     }
 
     public static <T extends TaskSlotPayload> TaskSlotTable<T> createTaskSlotTable(
-            int numberOfSlots, Time timeout) {
+            int numberOfSlots, Time timeout, ScheduledExecutorService executorService) {
         return createTaskSlotTable(
-                numberOfSlots, createDefaultTimerService(timeout.toMilliseconds()));
+                numberOfSlots,
+                createDefaultTimerService(timeout.toMilliseconds()),
+                executorService);
     }
 
     public static <T extends TaskSlotPayload> TaskSlotTableImpl<T> createTaskSlotTable(
-            int numberOfSlots, TimerService<AllocationID> timerService) {
+            int numberOfSlots,
+            TimerService<AllocationID> timerService,
+            ScheduledExecutorService executorService) {
         return new TaskSlotTableImpl<>(
                 numberOfSlots,
                 createTotalResourceProfile(numberOfSlots),
                 DEFAULT_RESOURCE_PROFILE,
                 MemoryManager.MIN_PAGE_SIZE,
                 timerService,
-                Executors.newDirectExecutorService());
+                executorService);
     }
 
     public static ResourceProfile createTotalResourceProfile(int numberOfSlots) {
@@ -71,11 +77,8 @@ public enum TaskSlotUtils {
         return result;
     }
 
-    public static TimerService<AllocationID> createDefaultTimerService() {
-        return createDefaultTimerService(DEFAULT_SLOT_TIMEOUT);
-    }
-
     public static TimerService<AllocationID> createDefaultTimerService(long shutdownTimeout) {
-        return new DefaultTimerService<>(TestingUtils.defaultExecutor(), shutdownTimeout);
+        return new DefaultTimerService<>(
+                Executors.newSingleThreadScheduledExecutor(), shutdownTimeout);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
@@ -49,6 +49,8 @@ import org.apache.flink.runtime.shuffle.ShuffleEnvironment;
 import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
 import org.apache.flink.runtime.taskexecutor.PartitionProducerStateChecker;
 import org.apache.flink.runtime.util.NettyShuffleDescriptorBuilder;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.WrappingRuntimeException;
@@ -73,6 +75,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -105,6 +108,10 @@ public class TaskTest extends TestLogger {
 
     private ShuffleEnvironment<?, ?> shuffleEnvironment;
 
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
+
     @ClassRule public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
 
     private static boolean wasCleanedUp = false;
@@ -132,19 +139,28 @@ public class TaskTest extends TestLogger {
 
     @Test
     public void testCleanupWhenRestoreFails() throws Exception {
-        createTaskBuilder().setInvokable(InvokableWithExceptionInRestore.class).build().run();
+        createTaskBuilder()
+                .setInvokable(InvokableWithExceptionInRestore.class)
+                .build(Executors.directExecutor())
+                .run();
         assertTrue(wasCleanedUp);
     }
 
     @Test
     public void testCleanupWhenInvokeFails() throws Exception {
-        createTaskBuilder().setInvokable(InvokableWithExceptionInInvoke.class).build().run();
+        createTaskBuilder()
+                .setInvokable(InvokableWithExceptionInInvoke.class)
+                .build(Executors.directExecutor())
+                .run();
         assertTrue(wasCleanedUp);
     }
 
     @Test
     public void testCleanupWhenCancelledAfterRestore() throws Exception {
-        Task task = createTaskBuilder().setInvokable(InvokableBlockingInRestore.class).build();
+        Task task =
+                createTaskBuilder()
+                        .setInvokable(InvokableBlockingInRestore.class)
+                        .build(Executors.directExecutor());
         task.startTaskThread();
         awaitLatch.await();
         task.cancelExecution();
@@ -154,7 +170,10 @@ public class TaskTest extends TestLogger {
 
     @Test
     public void testCleanupWhenAfterInvokeSucceeded() throws Exception {
-        createTaskBuilder().setInvokable(TestInvokableCorrect.class).build().run();
+        createTaskBuilder()
+                .setInvokable(TestInvokableCorrect.class)
+                .build(Executors.directExecutor())
+                .run();
         assertTrue(wasCleanedUp);
     }
 
@@ -173,7 +192,7 @@ public class TaskTest extends TestLogger {
                                 }
                             }
                         })
-                .build()
+                .build(Executors.directExecutor())
                 .run();
         assertTrue(wasCleanedUp);
     }
@@ -185,7 +204,7 @@ public class TaskTest extends TestLogger {
                 createTaskBuilder()
                         .setInvokable(TestInvokableCorrect.class)
                         .setTaskManagerActions(taskManagerActions)
-                        .build();
+                        .build(Executors.directExecutor());
 
         // task should be new and perfect
         assertEquals(ExecutionState.CREATED, task.getExecutionState());
@@ -209,7 +228,7 @@ public class TaskTest extends TestLogger {
 
     @Test
     public void testCancelRightAway() throws Exception {
-        final Task task = createTaskBuilder().build();
+        final Task task = createTaskBuilder().build(Executors.directExecutor());
         task.cancelExecution();
 
         assertEquals(ExecutionState.CANCELING, task.getExecutionState());
@@ -224,7 +243,7 @@ public class TaskTest extends TestLogger {
 
     @Test
     public void testFailExternallyRightAway() throws Exception {
-        final Task task = createTaskBuilder().build();
+        final Task task = createTaskBuilder().build(Executors.directExecutor());
         task.failExternally(new Exception("fail externally"));
 
         assertEquals(ExecutionState.FAILED, task.getExecutionState());
@@ -249,7 +268,7 @@ public class TaskTest extends TestLogger {
                                                     throw testException;
                                                 })
                                         .build())
-                        .build();
+                        .build(Executors.directExecutor());
 
         // task should be new and perfect
         assertEquals(ExecutionState.CREATED, task.getExecutionState());
@@ -315,7 +334,7 @@ public class TaskTest extends TestLogger {
                         .setPartitionProducerStateChecker(partitionProducerStateChecker)
                         .setResultPartitions(resultPartitions)
                         .setInputGates(inputGates)
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
 
         // shut down the network to make the following task registration failure
         shuffleEnvironment.close();
@@ -339,7 +358,7 @@ public class TaskTest extends TestLogger {
                 createTaskBuilder()
                         .setTaskManagerActions(taskManagerActions)
                         .setInvokable(InvokableNonInstantiable.class)
-                        .build();
+                        .build(Executors.directExecutor());
 
         // should fail
         task.run();
@@ -362,7 +381,7 @@ public class TaskTest extends TestLogger {
                 createTaskBuilder()
                         .setInvokable(InvokableWithExceptionInRestore.class)
                         .setTaskManagerActions(taskManagerActions)
-                        .build();
+                        .build(Executors.directExecutor());
 
         task.run();
 
@@ -384,7 +403,7 @@ public class TaskTest extends TestLogger {
                 createTaskBuilder()
                         .setInvokable(InvokableWithExceptionInInvoke.class)
                         .setTaskManagerActions(taskManagerActions)
-                        .build();
+                        .build(Executors.directExecutor());
 
         task.run();
 
@@ -407,7 +426,7 @@ public class TaskTest extends TestLogger {
                 createTaskBuilder()
                         .setInvokable(FailingInvokableWithChainedException.class)
                         .setTaskManagerActions(taskManagerActions)
-                        .build();
+                        .build(Executors.directExecutor());
 
         task.run();
 
@@ -430,7 +449,7 @@ public class TaskTest extends TestLogger {
                 createTaskBuilder()
                         .setInvokable(InvokableBlockingInRestore.class)
                         .setTaskManagerActions(taskManagerActions)
-                        .build();
+                        .build(Executors.directExecutor());
 
         // run the task asynchronous
         task.startTaskThread();
@@ -460,7 +479,7 @@ public class TaskTest extends TestLogger {
                 createTaskBuilder()
                         .setInvokable(InvokableBlockingInInvoke.class)
                         .setTaskManagerActions(taskManagerActions)
-                        .build();
+                        .build(Executors.directExecutor());
 
         // run the task asynchronous
         task.startTaskThread();
@@ -491,7 +510,7 @@ public class TaskTest extends TestLogger {
                 createTaskBuilder()
                         .setInvokable(InvokableBlockingInRestore.class)
                         .setTaskManagerActions(taskManagerActions)
-                        .build();
+                        .build(Executors.directExecutor());
 
         // run the task asynchronous
         task.startTaskThread();
@@ -519,7 +538,7 @@ public class TaskTest extends TestLogger {
                 createTaskBuilder()
                         .setInvokable(InvokableBlockingInInvoke.class)
                         .setTaskManagerActions(taskManagerActions)
-                        .build();
+                        .build(Executors.directExecutor());
 
         // run the task asynchronous
         task.startTaskThread();
@@ -548,7 +567,7 @@ public class TaskTest extends TestLogger {
                 createTaskBuilder()
                         .setInvokable(InvokableWithExceptionInInvoke.class)
                         .setTaskManagerActions(taskManagerActions)
-                        .build();
+                        .build(Executors.directExecutor());
 
         task.run();
 
@@ -572,7 +591,7 @@ public class TaskTest extends TestLogger {
                 createTaskBuilder()
                         .setInvokable(InvokableWithExceptionOnTrigger.class)
                         .setTaskManagerActions(taskManagerActions)
-                        .build();
+                        .build(Executors.directExecutor());
 
         // run the task asynchronous
         task.startTaskThread();
@@ -605,7 +624,7 @@ public class TaskTest extends TestLogger {
                 createTaskBuilder()
                         .setInvokable(InvokableWithExceptionOnTrigger.class)
                         .setTaskManagerActions(taskManagerActions)
-                        .build();
+                        .build(Executors.directExecutor());
 
         // run the task asynchronous
         task.startTaskThread();
@@ -636,7 +655,7 @@ public class TaskTest extends TestLogger {
         final Task task =
                 createTaskBuilder()
                         .setInvokable(InvokableWithCancelTaskExceptionInInvoke.class)
-                        .build();
+                        .build(Executors.directExecutor());
 
         // Cause CancelTaskException.
         triggerLatch.trigger();
@@ -651,7 +670,7 @@ public class TaskTest extends TestLogger {
         final Task task =
                 createTaskBuilder()
                         .setInvokable(InvokableWithCancelTaskExceptionInInvoke.class)
-                        .build();
+                        .build(Executors.directExecutor());
 
         task.startTaskThread();
 
@@ -691,7 +710,10 @@ public class TaskTest extends TestLogger {
     public void testOnPartitionStateUpdate(ExecutionState initialTaskState) throws Exception {
         final ResultPartitionID partitionId = new ResultPartitionID();
 
-        final Task task = createTaskBuilder().setInvokable(InvokableBlockingInInvoke.class).build();
+        final Task task =
+                createTaskBuilder()
+                        .setInvokable(InvokableBlockingInInvoke.class)
+                        .build(Executors.directExecutor());
 
         RemoteChannelStateChecker checker = new RemoteChannelStateChecker(partitionId, "test task");
 
@@ -759,8 +781,7 @@ public class TaskTest extends TestLogger {
                             .setInvokable(InvokableBlockingInInvoke.class)
                             .setConsumableNotifier(consumableNotifier)
                             .setPartitionProducerStateChecker(partitionChecker)
-                            .setExecutor(Executors.directExecutor())
-                            .build();
+                            .build(Executors.directExecutor());
             TestTaskBuilder.setTaskState(task, ExecutionState.RUNNING);
 
             final CompletableFuture<ExecutionState> promise = new CompletableFuture<>();
@@ -791,8 +812,7 @@ public class TaskTest extends TestLogger {
                             .setInvokable(InvokableBlockingInInvoke.class)
                             .setConsumableNotifier(consumableNotifier)
                             .setPartitionProducerStateChecker(partitionChecker)
-                            .setExecutor(Executors.directExecutor())
-                            .build();
+                            .build(Executors.directExecutor());
             TestTaskBuilder.setTaskState(task, ExecutionState.RUNNING);
 
             final CompletableFuture<ExecutionState> promise = new CompletableFuture<>();
@@ -827,8 +847,7 @@ public class TaskTest extends TestLogger {
                             .setInvokable(InvokableBlockingInInvoke.class)
                             .setConsumableNotifier(consumableNotifier)
                             .setPartitionProducerStateChecker(partitionChecker)
-                            .setExecutor(Executors.directExecutor())
-                            .build();
+                            .build(Executors.directExecutor());
 
             try {
                 task.startTaskThread();
@@ -872,8 +891,7 @@ public class TaskTest extends TestLogger {
                             .setInvokable(InvokableBlockingInInvoke.class)
                             .setConsumableNotifier(consumableNotifier)
                             .setPartitionProducerStateChecker(partitionChecker)
-                            .setExecutor(Executors.directExecutor())
-                            .build();
+                            .build(Executors.directExecutor());
 
             try {
                 task.startTaskThread();
@@ -923,7 +941,7 @@ public class TaskTest extends TestLogger {
                         .setInvokable(InvokableBlockingInCancel.class)
                         .setTaskManagerConfig(config)
                         .setTaskManagerActions(taskManagerActions)
-                        .build();
+                        .build(Executors.directExecutor());
 
         task.startTaskThread();
 
@@ -951,7 +969,7 @@ public class TaskTest extends TestLogger {
                         .setInvokable(InvokableInterruptibleSharedLockInInvokeAndCancel.class)
                         .setTaskManagerConfig(config)
                         .setTaskManagerActions(taskManagerActions)
-                        .build();
+                        .build(Executors.directExecutor());
 
         task.startTaskThread();
 
@@ -982,7 +1000,7 @@ public class TaskTest extends TestLogger {
                         .setInvokable(InvokableUnInterruptibleBlockingInvoke.class)
                         .setTaskManagerConfig(config)
                         .setTaskManagerActions(taskManagerActions)
-                        .build();
+                        .build(Executors.directExecutor());
 
         try {
             task.startTaskThread();
@@ -1022,7 +1040,7 @@ public class TaskTest extends TestLogger {
                                 .setInvokable(InvokableBlockingWithTrigger.class)
                                 .setTaskManagerConfig(config)
                                 .setTaskManagerActions(taskManagerActions)
-                                .build());
+                                .build(Executors.directExecutor()));
 
         final Class<OutOfMemoryError> fatalErrorType = OutOfMemoryError.class;
         doThrow(fatalErrorType)
@@ -1063,7 +1081,7 @@ public class TaskTest extends TestLogger {
                         .setInvokable(InvokableBlockingInInvoke.class)
                         .setTaskManagerConfig(config)
                         .setExecutionConfig(executionConfig)
-                        .build();
+                        .build(Executors.directExecutor());
 
         assertEquals(interval, task.getTaskCancellationInterval());
         assertEquals(timeout, task.getTaskCancellationTimeout());
@@ -1087,7 +1105,7 @@ public class TaskTest extends TestLogger {
                 createTaskBuilder()
                         .setInvokable(InvokableBlockingWithTrigger.class)
                         .setTaskManagerActions(new NoOpTaskManagerActions())
-                        .build();
+                        .build(Executors.directExecutor());
 
         // run the task asynchronous
         task.startTaskThread();
@@ -1110,7 +1128,7 @@ public class TaskTest extends TestLogger {
                 createTaskBuilder()
                         .setInvokable(InvokableBlockingInInvoke.class)
                         .setTaskManagerActions(new NoOpTaskManagerActions())
-                        .build();
+                        .build(Executors.directExecutor());
 
         task.cancelExecution();
 
@@ -1130,7 +1148,7 @@ public class TaskTest extends TestLogger {
                 createTaskBuilder()
                         .setInvokable(InvokableWithExceptionInInvoke.class)
                         .setTaskManagerActions(new NoOpTaskManagerActions())
-                        .build();
+                        .build(Executors.directExecutor());
 
         // run the task asynchronous
         task.startTaskThread();
@@ -1142,7 +1160,7 @@ public class TaskTest extends TestLogger {
 
     @Test
     public void testNoBackPressureIfTaskNotStarted() throws Exception {
-        final Task task = createTaskBuilder().build();
+        final Task task = createTaskBuilder().build(Executors.directExecutor());
         assertFalse(task.isBackPressured());
     }
 
@@ -1153,7 +1171,7 @@ public class TaskTest extends TestLogger {
                 createTaskBuilder()
                         .setInvokable(InvokableDeclingingCheckpoints.class)
                         .setCheckpointResponder(testCheckpointResponder)
-                        .build();
+                        .build(Executors.directExecutor());
         assertCheckpointDeclined(
                 task,
                 testCheckpointResponder,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TestTaskBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TestTaskBuilder.java
@@ -53,7 +53,6 @@ import org.apache.flink.runtime.taskexecutor.NoOpPartitionProducerStateChecker;
 import org.apache.flink.runtime.taskexecutor.PartitionProducerStateChecker;
 import org.apache.flink.runtime.taskexecutor.TestGlobalAggregateManager;
 import org.apache.flink.runtime.util.TestingTaskManagerRuntimeInfo;
-import org.apache.flink.testutils.TestingUtils;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.SerializedValue;
 
@@ -78,7 +77,6 @@ public final class TestTaskBuilder {
             new NoOpPartitionProducerStateChecker();
     private final ShuffleEnvironment<?, ?> shuffleEnvironment;
     private KvStateService kvStateService = new KvStateService(new KvStateRegistry(), null, null);
-    private Executor executor = TestingUtils.defaultExecutor();
     private Configuration taskManagerConfig = new Configuration();
     private Configuration taskConfig = new Configuration();
     private ExecutionConfig executionConfig = new ExecutionConfig();
@@ -126,11 +124,6 @@ public final class TestTaskBuilder {
 
     public TestTaskBuilder setKvStateService(KvStateService kvStateService) {
         this.kvStateService = kvStateService;
-        return this;
-    }
-
-    public TestTaskBuilder setExecutor(Executor executor) {
-        this.executor = executor;
         return this;
     }
 
@@ -192,7 +185,7 @@ public final class TestTaskBuilder {
         return this;
     }
 
-    public Task build() throws Exception {
+    public Task build(Executor executor) throws Exception {
         final JobVertexID jobVertexId = new JobVertexID();
 
         final SerializedValue<ExecutionConfig> serializedExecutionConfig =

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractUdfStreamOperatorLifecycleTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractUdfStreamOperatorLifecycleTest.java
@@ -40,8 +40,11 @@ import org.apache.flink.streaming.runtime.tasks.OperatorChain;
 import org.apache.flink.streaming.runtime.tasks.SourceStreamTask;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
 import org.apache.flink.streaming.runtime.tasks.StreamTaskTest;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 
 import org.junit.Assert;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.io.Serializable;
@@ -50,11 +53,15 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
 
 import static org.junit.Assert.assertEquals;
 
 /** This test secures the lifecycle of AbstractUdfStreamOperator, including it's UDF handling. */
 public class AbstractUdfStreamOperatorLifecycleTest {
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     private static final List<String> EXPECTED_CALL_ORDER_FULL =
             Arrays.asList(
@@ -156,7 +163,11 @@ public class AbstractUdfStreamOperatorLifecycleTest {
         try (ShuffleEnvironment shuffleEnvironment = new NettyShuffleEnvironmentBuilder().build()) {
             Task task =
                     StreamTaskTest.createTask(
-                            SourceStreamTask.class, shuffleEnvironment, cfg, taskManagerConfig);
+                            SourceStreamTask.class,
+                            shuffleEnvironment,
+                            cfg,
+                            taskManagerConfig,
+                            EXECUTOR_RESOURCE.getExecutor());
 
             task.startTaskThread();
 
@@ -183,7 +194,11 @@ public class AbstractUdfStreamOperatorLifecycleTest {
         try (ShuffleEnvironment shuffleEnvironment = new NettyShuffleEnvironmentBuilder().build()) {
             Task task =
                     StreamTaskTest.createTask(
-                            SourceStreamTask.class, shuffleEnvironment, cfg, taskManagerConfig);
+                            SourceStreamTask.class,
+                            shuffleEnvironment,
+                            cfg,
+                            taskManagerConfig,
+                            EXECUTOR_RESOURCE.getExecutor());
 
             task.startTaskThread();
             LifecycleTrackingStreamSource.runStarted.await();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/partitioner/RescalePartitionerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/partitioner/RescalePartitionerTest.java
@@ -34,8 +34,11 @@ import org.apache.flink.runtime.scheduler.SchedulerBase;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.source.ParallelSourceFunction;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.Collector;
 
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.HashMap;
@@ -43,6 +46,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ScheduledExecutorService;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -51,6 +55,9 @@ import static org.junit.Assert.fail;
 /** Tests for {@link RescalePartitioner}. */
 @SuppressWarnings("serial")
 public class RescalePartitionerTest extends StreamPartitionerTest {
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     @Override
     public StreamPartitioner<Tuple> createPartitioner() {
@@ -121,7 +128,7 @@ public class RescalePartitionerTest extends StreamPartitionerTest {
                 TestingDefaultExecutionGraphBuilder.newBuilder()
                         .setVertexParallelismStore(
                                 SchedulerBase.computeVertexParallelismStore(jobGraph))
-                        .build();
+                        .build(EXECUTOR_RESOURCE.getExecutor());
 
         try {
             eg.attachJobGraph(jobVertices);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskCancellationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskCancellationTest.java
@@ -31,11 +31,15 @@ import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.mailbox.MailboxDefaultAction;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.TestLogger;
 
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.io.Closeable;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.apache.flink.api.common.typeinfo.BasicTypeInfo.STRING_TYPE_INFO;
@@ -45,6 +49,9 @@ import static org.junit.Assert.assertFalse;
 
 /** Tests for the StreamTask cancellation. */
 public class StreamTaskCancellationTest extends TestLogger {
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     @Test
     public void testDoNotInterruptWhileClosing() throws Exception {
@@ -91,7 +98,11 @@ public class StreamTaskCancellationTest extends TestLogger {
 
             Task task =
                     createTask(
-                            CancelFailingTask.class, shuffleEnvironment, cfg, new Configuration());
+                            CancelFailingTask.class,
+                            shuffleEnvironment,
+                            cfg,
+                            new Configuration(),
+                            EXECUTOR_RESOURCE.getExecutor());
 
             // start the task and wait until it runs
             // execution state RUNNING is not enough, we need to wait until the stream task's run()
@@ -217,7 +228,11 @@ public class StreamTaskCancellationTest extends TestLogger {
                 new NettyShuffleEnvironmentBuilder().build()) {
             Task task =
                     createTask(
-                            CancelThrowingTask.class, shuffleEnvironment, cfg, new Configuration());
+                            CancelThrowingTask.class,
+                            shuffleEnvironment,
+                            cfg,
+                            new Configuration(),
+                            EXECUTOR_RESOURCE.getExecutor());
 
             task.startTaskThread();
             task.getExecutingThread().join();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTerminationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTerminationTest.java
@@ -78,12 +78,14 @@ import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.runtime.tasks.mailbox.MailboxDefaultAction;
 import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.concurrent.Executors;
 
 import org.junit.Assert;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import javax.annotation.Nonnull;
@@ -94,6 +96,7 @@ import java.util.Collections;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.FutureTask;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -105,6 +108,10 @@ import static org.mockito.Mockito.when;
 
 /** Tests for the StreamTask termination. */
 public class StreamTaskTerminationTest extends TestLogger {
+
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     private static final OneShotLatch RUN_LATCH = new OneShotLatch();
     private static final AtomicBoolean SNAPSHOT_HAS_STARTED = new AtomicBoolean();
@@ -186,7 +193,7 @@ public class StreamTaskTerminationTest extends TestLogger {
                         Executors.directExecutor());
 
         CompletableFuture<Void> taskRun =
-                CompletableFuture.runAsync(() -> task.run(), TestingUtils.defaultExecutor());
+                CompletableFuture.runAsync(() -> task.run(), EXECUTOR_RESOURCE.getExecutor());
 
         // wait until the stream task started running
         RUN_LATCH.await();

--- a/flink-tests/src/test/java/org/apache/flink/test/accumulators/AccumulatorLiveITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/accumulators/AccumulatorLiveITCase.java
@@ -43,9 +43,11 @@ import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
 import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.concurrent.FutureUtils;
+import org.apache.flink.util.concurrent.ScheduledExecutorServiceAdapter;
 
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -58,6 +60,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.flink.test.util.TestUtils.submitJobAndWaitForResult;
@@ -66,6 +69,10 @@ import static org.apache.flink.test.util.TestUtils.submitJobAndWaitForResult;
 public class AccumulatorLiveITCase extends TestLogger {
 
     private static final Logger LOG = LoggerFactory.getLogger(AccumulatorLiveITCase.class);
+
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     // name of user accumulator
     private static final String ACCUMULATOR_NAME = "test";
@@ -199,7 +206,7 @@ public class AccumulatorLiveITCase extends TestLogger {
                                         && accumulators.containsKey(ACCUMULATOR_NAME)
                                         && (int) accumulators.get(ACCUMULATOR_NAME)
                                                 == NUM_ITERATIONS,
-                        TestingUtils.defaultScheduledExecutor())
+                        new ScheduledExecutorServiceAdapter(EXECUTOR_RESOURCE.getExecutor()))
                 .get(deadline.timeLeft().toMillis(), TimeUnit.MILLISECONDS);
     }
 

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RescalingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RescalingITCase.java
@@ -54,10 +54,12 @@ import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunctio
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
 import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.concurrent.FixedRetryStrategy;
 import org.apache.flink.util.concurrent.FutureUtils;
+import org.apache.flink.util.concurrent.ScheduledExecutorServiceAdapter;
 
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -79,6 +81,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -90,6 +93,10 @@ import static org.junit.Assert.assertTrue;
 /** Test savepoint rescaling. */
 @RunWith(Parameterized.class)
 public class RescalingITCase extends TestLogger {
+
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     private static final int numTaskManagers = 2;
     private static final int slotsPerTaskManager = 2;
@@ -559,7 +566,7 @@ public class RescalingITCase extends TestLogger {
                                     (int) deadline.timeLeft().getSeconds() / 10,
                                     Duration.ofSeconds(10)),
                             (throwable) -> true,
-                            TestingUtils.defaultScheduledExecutor());
+                            new ScheduledExecutorServiceAdapter(EXECUTOR_RESOURCE.getExecutor()));
 
             final String savepointPath =
                     savepointPathFuture.get(deadline.timeLeft().toMillis(), TimeUnit.MILLISECONDS);

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
@@ -91,6 +91,7 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
 import org.apache.flink.testutils.EntropyInjectingTestFileSystem;
 import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.testutils.junit.SharedObjects;
 import org.apache.flink.testutils.junit.SharedReference;
 import org.apache.flink.util.Collector;
@@ -98,12 +99,14 @@ import org.apache.flink.util.FileUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.concurrent.FutureUtils;
+import org.apache.flink.util.concurrent.ScheduledExecutorServiceAdapter;
 
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -133,6 +136,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
@@ -160,6 +164,10 @@ import static org.junit.Assert.fail;
 public class SavepointITCase extends TestLogger {
 
     private static final Logger LOG = LoggerFactory.getLogger(SavepointITCase.class);
+
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     @Rule public final TemporaryFolder folder = new TemporaryFolder();
 
@@ -706,7 +714,7 @@ public class SavepointITCase extends TestLogger {
                     Time.milliseconds(50),
                     Deadline.now().plus(Duration.ofSeconds(30)),
                     status -> status == JobStatus.CANCELED,
-                    TestingUtils.defaultScheduledExecutor());
+                    new ScheduledExecutorServiceAdapter(EXECUTOR_RESOURCE.getExecutor()));
 
             postCancelChecks.check(cluster);
         } finally {

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/JobManagerHAProcessFailureRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/JobManagerHAProcessFailureRecoveryITCase.java
@@ -51,6 +51,7 @@ import org.apache.flink.runtime.testutils.DispatcherProcess;
 import org.apache.flink.runtime.testutils.ZooKeeperTestUtils;
 import org.apache.flink.runtime.zookeeper.ZooKeeperTestEnvironment;
 import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.concurrent.FutureUtils;
@@ -60,6 +61,7 @@ import org.apache.commons.io.FileUtils;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -74,6 +76,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -100,6 +103,10 @@ public class JobManagerHAProcessFailureRecoveryITCase extends TestLogger {
     private static ZooKeeperTestEnvironment zooKeeper;
 
     private static final Duration TEST_TIMEOUT = Duration.ofMinutes(5);
+
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
@@ -289,7 +296,9 @@ public class JobManagerHAProcessFailureRecoveryITCase extends TestLogger {
 
             highAvailabilityServices =
                     HighAvailabilityServicesUtils.createAvailableOrEmbeddedServices(
-                            config, TestingUtils.defaultExecutor(), NoOpFatalErrorHandler.INSTANCE);
+                            config,
+                            EXECUTOR_RESOURCE.getExecutor(),
+                            NoOpFatalErrorHandler.INSTANCE);
 
             final PluginManager pluginManager =
                     PluginUtils.createPluginManagerFromRootFolder(config);

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
@@ -57,10 +57,12 @@ import org.apache.flink.test.recovery.utils.TaskExecutorProcessEntryPoint;
 import org.apache.flink.test.util.TestProcessBuilder;
 import org.apache.flink.test.util.TestProcessBuilder.TestProcess;
 import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Assume;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -84,6 +86,10 @@ public class ProcessFailureCancelingITCase extends TestLogger {
 
     private static final String TASK_DEPLOYED_MARKER = "deployed";
     private static final Duration TIMEOUT = Duration.ofMinutes(2);
+
+    @ClassRule
+    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorResource();
 
     @Rule public final BlobServerResource blobServerResource = new BlobServerResource();
 
@@ -127,7 +133,7 @@ public class ProcessFailureCancelingITCase extends TestLogger {
                         StandaloneResourceManagerFactory.getInstance());
         DispatcherResourceManagerComponent dispatcherResourceManagerComponent = null;
 
-        final ScheduledExecutorService ioExecutor = TestingUtils.defaultExecutor();
+        final ScheduledExecutorService ioExecutor = EXECUTOR_RESOURCE.getExecutor();
         final HighAvailabilityServices haServices =
                 HighAvailabilityServicesUtils.createHighAvailabilityServices(
                         config,

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnConfigurationITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnConfigurationITCase.java
@@ -37,7 +37,7 @@ import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
 import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerInfo;
 import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagersHeaders;
 import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagersInfo;
-import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.util.concurrent.Executors;
 
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
@@ -125,7 +125,7 @@ public class YarnConfigurationITCase extends YarnTestBase {
                         final ApplicationId clusterId = clusterClient.getClusterId();
 
                         final RestClient restClient =
-                                new RestClient(configuration, TestingUtils.defaultExecutor());
+                                new RestClient(configuration, Executors.directExecutor());
 
                         try {
                             final ApplicationReport applicationReport =

--- a/tools/maven/suppressions-runtime.xml
+++ b/tools/maven/suppressions-runtime.xml
@@ -138,6 +138,6 @@ under the License.
 		files="(.*)runtime[/\\]zookeeper[/\\](.*)"
 		checks="RedundantModifier|JavadocParagraph|JavadocType|JavadocStyle|MemberNameCheck|LocalFinalVariableName|LocalVariableName|UpperEll|reliefPattern|EmptyStatement|EmptyLineSeparator"/>
 	<suppress
-		files="(.*)StateBackendTestBase.java"
+		files="(.*)(StateBackendTestBase|TaskExecutorTest).java"
 		checks="FileLength"/>
 </suppressions>


### PR DESCRIPTION
Sharing an executor can lead to surprising behaviors, especially since the ownership of the executor isn't well-defined.