### PR TITLE
[FLINK-24660][Connectors / Kafka] allow setting KafkaSubscriber in KafkaSourceBuilder

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSource.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSource.java
@@ -76,7 +76,10 @@ import java.util.function.Supplier;
  *     .build();
  * }</pre>
  *
- * <p>See {@link KafkaSourceBuilder} for more details.
+ * <p>{@link org.apache.flink.connector.kafka.source.enumerator.KafkaSourceEnumerator} only supports
+ * adding new splits and not removing splits in split discovery.
+ *
+ * <p>See {@link KafkaSourceBuilder} for more details on how to configure this source.
  *
  * @param <OUT> the output type of the source.
  */
@@ -224,5 +227,10 @@ public class KafkaSource<OUT>
     @VisibleForTesting
     Configuration getConfiguration() {
         return toConfiguration(props);
+    }
+
+    @VisibleForTesting
+    KafkaSubscriber getKafkaSubscriber() {
+        return subscriber;
     }
 }

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSourceBuilder.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSourceBuilder.java
@@ -185,6 +185,18 @@ public class KafkaSourceBuilder<OUT> {
     }
 
     /**
+     * Set the Kafka subscriber to use to discover new splits.
+     *
+     * @param kafkaSubscriber the {@link KafkaSubscriber} to use for split discovery.
+     * @return this KafkaSourceBuilder.
+     */
+    public KafkaSourceBuilder<OUT> setKafkaSubscriber(KafkaSubscriber kafkaSubscriber) {
+        ensureSubscriberIsNull("subscriber");
+        this.subscriber = kafkaSubscriber;
+        return this;
+    }
+
+    /**
      * Specify from which offsets the KafkaSource should start consume from by providing an {@link
      * OffsetsInitializer}.
      *

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSourceBuilder.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSourceBuilder.java
@@ -185,14 +185,14 @@ public class KafkaSourceBuilder<OUT> {
     }
 
     /**
-     * Set the Kafka subscriber to use to discover new splits.
+     * Set a custom Kafka subscriber to use to discover new splits.
      *
      * @param kafkaSubscriber the {@link KafkaSubscriber} to use for split discovery.
      * @return this KafkaSourceBuilder.
      */
     public KafkaSourceBuilder<OUT> setKafkaSubscriber(KafkaSubscriber kafkaSubscriber) {
-        ensureSubscriberIsNull("subscriber");
-        this.subscriber = kafkaSubscriber;
+        ensureSubscriberIsNull("custom");
+        this.subscriber = checkNotNull(kafkaSubscriber);
         return this;
     }
 

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/KafkaSubscriber.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/KafkaSubscriber.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.connector.kafka.source.enumerator.subscriber;
 
-import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.PublicEvolving;
 
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.common.TopicPartition;
@@ -38,9 +38,11 @@ import java.util.regex.Pattern;
  * </ol>
  *
  * <p>The KafkaSubscriber provides a unified interface for the Kafka source to support all these
- * three types of subscribing mode.
+ * three types of subscribing mode. {@link
+ * org.apache.flink.connector.kafka.source.enumerator.KafkaSourceEnumerator} only supports adding
+ * new splits and not removing splits in split discovery.
  */
-@Internal
+@PublicEvolving
 public interface KafkaSubscriber extends Serializable {
 
     /**

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/KafkaSubscriber.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/KafkaSubscriber.java
@@ -38,9 +38,7 @@ import java.util.regex.Pattern;
  * </ol>
  *
  * <p>The KafkaSubscriber provides a unified interface for the Kafka source to support all these
- * three types of subscribing mode. {@link
- * org.apache.flink.connector.kafka.source.enumerator.KafkaSourceEnumerator} only supports adding
- * new splits and not removing splits in split discovery.
+ * three types of subscribing mode.
  */
 @PublicEvolving
 public interface KafkaSubscriber extends Serializable {


### PR DESCRIPTION
## What is the purpose of the change

Allow setting KafkaSubscriber in KafkaSourceBuilder so that users can supply custom implementations.

## Brief change log

* Expose a setter for the subscriber and add javadocs

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? JavaDocs
