### PR TITLE
[FLINK-27068][python][tests] Fix test_keyed_min_and_max and test_keyed_min_by_and_max_by failed in py36,37

### DIFF
--- a/flink-python/pyflink/datastream/tests/test_data_stream.py
+++ b/flink-python/pyflink/datastream/tests/test_data_stream.py
@@ -1094,6 +1094,8 @@ class StreamingModeDataStreamTests(DataStreamTests, PyFlinkStreamingTestCase):
         self.assert_equals_sorted(expected, results)
 
     def test_keyed_min_and_max(self):
+        original_parallelism = self.env.get_parallelism()
+        self.env.set_parallelism(1)
         ds = self.env.from_collection([('a', 3, 0), ('a', 1, 1), ('b', 5, 1), ('b', 3, 1)],
                                       type_info=Types.ROW_NAMED(
                                           ["v1", "v2", "v3"],
@@ -1121,8 +1123,11 @@ class StreamingModeDataStreamTests(DataStreamTests, PyFlinkStreamingTestCase):
         results = self.test_sink.get_results(False)
         expected = ['a', 'a', 'b', 'b']
         self.assert_equals_sorted(expected, results)
+        self.env.set_parallelism(original_parallelism)
 
     def test_keyed_min_by_and_max_by(self):
+        original_parallelism = self.env.get_parallelism()
+        self.env.set_parallelism(1)
         ds = self.env.from_collection([('a', 3, 0), ('a', 1, 1), ('b', 5, 0), ('b', 3, 1)],
                                       type_info=Types.ROW_NAMED(
                                           ["v1", "v2", "v3"],
@@ -1149,6 +1154,7 @@ class StreamingModeDataStreamTests(DataStreamTests, PyFlinkStreamingTestCase):
         results = self.test_sink.get_results(False)
         expected = ['a', 'a', 'a', 'a']
         self.assert_equals_sorted(expected, results)
+        self.env.set_parallelism(original_parallelism)
 
     def test_function_with_error(self):
         ds = self.env.from_collection([('a', 0), ('b', 0), ('c', 1), ('d', 1), ('e', 1)],

--- a/flink-python/pyflink/datastream/tests/test_data_stream.py
+++ b/flink-python/pyflink/datastream/tests/test_data_stream.py
@@ -1094,7 +1094,6 @@ class StreamingModeDataStreamTests(DataStreamTests, PyFlinkStreamingTestCase):
         self.assert_equals_sorted(expected, results)
 
     def test_keyed_min_and_max(self):
-        original_parallelism = self.env.get_parallelism()
         self.env.set_parallelism(1)
         ds = self.env.from_collection([('a', 3, 0), ('a', 1, 1), ('b', 5, 1), ('b', 3, 1)],
                                       type_info=Types.ROW_NAMED(
@@ -1123,10 +1122,8 @@ class StreamingModeDataStreamTests(DataStreamTests, PyFlinkStreamingTestCase):
         results = self.test_sink.get_results(False)
         expected = ['a', 'a', 'b', 'b']
         self.assert_equals_sorted(expected, results)
-        self.env.set_parallelism(original_parallelism)
 
     def test_keyed_min_by_and_max_by(self):
-        original_parallelism = self.env.get_parallelism()
         self.env.set_parallelism(1)
         ds = self.env.from_collection([('a', 3, 0), ('a', 1, 1), ('b', 5, 0), ('b', 3, 1)],
                                       type_info=Types.ROW_NAMED(
@@ -1154,7 +1151,6 @@ class StreamingModeDataStreamTests(DataStreamTests, PyFlinkStreamingTestCase):
         results = self.test_sink.get_results(False)
         expected = ['a', 'a', 'a', 'a']
         self.assert_equals_sorted(expected, results)
-        self.env.set_parallelism(original_parallelism)
 
     def test_function_with_error(self):
         ds = self.env.from_collection([('a', 0), ('b', 0), ('c', 1), ('d', 1), ('e', 1)],
@@ -1263,6 +1259,7 @@ class BatchModeDataStreamTests(DataStreamTests, PyFlinkBatchTestCase):
         self.assert_equals_sorted(expected, results)
 
     def test_keyed_sum(self):
+        self.env.set_parallelism(1)
         ds = self.env.from_collection(
             [(1, 1), (1, 2), (1, 3), (5, 1), (5, 5)],
             type_info=Types.ROW_NAMED(["v1", "v2"], [Types.INT(), Types.INT()])
@@ -1298,6 +1295,7 @@ class BatchModeDataStreamTests(DataStreamTests, PyFlinkBatchTestCase):
         self.assertEqual(expected, results)
 
     def test_keyed_min_and_max(self):
+        self.env.set_parallelism(1)
         ds = self.env.from_collection(
             [(1, '9', 0), (1, '5', 1), (1, '6', 2), (5, '5', 0), (5, '3', 1)],
             type_info=Types.ROW_NAMED(["v1", "v2", "v3"],
@@ -1327,6 +1325,7 @@ class BatchModeDataStreamTests(DataStreamTests, PyFlinkBatchTestCase):
         self.assert_equals_sorted(expected, results)
 
     def test_keyed_min_by_and_max_by(self):
+        self.env.set_parallelism(1)
         ds = self.env.from_collection(
             [(1, '9', 0), (1, '5', 1), (1, '6', 2), (5, '5', 0), (5, '3', 1)],
             type_info=Types.ROW_NAMED(["v1", "v2", "v3"],


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

[FLINK-27068] test_keyed_min_and_max and test_keyed_min_by_and_max_by failed in py36,37
This PR will fix it.


## Brief change log

- Set parallelism to 1 in unit test case to avoid the deterministic introduced of order.


## Verifying this change
Passed in pytest (Local env)、flake8
