### PR TITLE
[FLINK-26043][runtime][security] Add periodic kerberos relogin to KerberosDelegationTokenManager

### DIFF
--- a/docs/layouts/shortcodes/generated/security_auth_kerberos_section.html
+++ b/docs/layouts/shortcodes/generated/security_auth_kerberos_section.html
@@ -38,5 +38,11 @@
             <td>Boolean</td>
             <td>Indicates whether to read from your Kerberos ticket cache.</td>
         </tr>
+        <tr>
+            <td><h5>security.kerberos.relogin.period</h5></td>
+            <td style="word-wrap: break-word;">1 min</td>
+            <td>Duration</td>
+            <td>The time period when keytab login happens automatically in order to always have a valid TGT.</td>
+        </tr>
     </tbody>
 </table>

--- a/docs/layouts/shortcodes/generated/security_configuration.html
+++ b/docs/layouts/shortcodes/generated/security_configuration.html
@@ -51,6 +51,12 @@
             <td>Indicates whether to read from your Kerberos ticket cache.</td>
         </tr>
         <tr>
+            <td><h5>security.kerberos.relogin.period</h5></td>
+            <td style="word-wrap: break-word;">1 min</td>
+            <td>Duration</td>
+            <td>The time period when keytab login happens automatically in order to always have a valid TGT.</td>
+        </tr>
+        <tr>
             <td><h5>security.module.factory.classes</h5></td>
             <td style="word-wrap: break-word;">"org.apache.flink.runtime.security.modules.HadoopModuleFactory";<wbr>"org.apache.flink.runtime.security.modules.JaasModuleFactory";<wbr>"org.apache.flink.runtime.security.modules.ZookeeperModuleFactory"</td>
             <td>List&lt;String&gt;</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/SecurityOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/SecurityOptions.java
@@ -21,6 +21,7 @@ package org.apache.flink.configuration;
 import org.apache.flink.annotation.docs.Documentation;
 import org.apache.flink.configuration.description.Description;
 
+import java.time.Duration;
 import java.util.List;
 
 import static org.apache.flink.configuration.ConfigOptions.key;
@@ -122,6 +123,14 @@ public class SecurityOptions {
                                     + "As a consequence, it will not fetch delegation tokens for HDFS and HBase. "
                                     + "You may need to disable this option, if you rely on submission mechanisms, e.g. Apache Oozie, "
                                     + "to handle delegation tokens.");
+
+    @Documentation.Section(Documentation.Sections.SECURITY_AUTH_KERBEROS)
+    public static final ConfigOption<Duration> KERBEROS_RELOGIN_PERIOD =
+            key("security.kerberos.relogin.period")
+                    .durationType()
+                    .defaultValue(Duration.ofMinutes(1))
+                    .withDescription(
+                            "The time period when keytab login happens automatically in order to always have a valid TGT.");
 
     // ------------------------------------------------------------------------
     //  ZooKeeper Security Options

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -32,7 +32,6 @@ import org.apache.flink.configuration.JMXServerOptions;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.configuration.SchedulerExecutionMode;
-import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.configuration.WebOptions;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.plugin.PluginManager;
@@ -48,7 +47,6 @@ import org.apache.flink.runtime.dispatcher.MiniDispatcher;
 import org.apache.flink.runtime.entrypoint.component.DispatcherResourceManagerComponent;
 import org.apache.flink.runtime.entrypoint.component.DispatcherResourceManagerComponentFactory;
 import org.apache.flink.runtime.entrypoint.parser.CommandLineParser;
-import org.apache.flink.runtime.hadoop.HadoopDependency;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServicesUtils;
@@ -68,8 +66,7 @@ import org.apache.flink.runtime.security.SecurityConfiguration;
 import org.apache.flink.runtime.security.SecurityUtils;
 import org.apache.flink.runtime.security.contexts.SecurityContext;
 import org.apache.flink.runtime.security.token.DelegationTokenManager;
-import org.apache.flink.runtime.security.token.KerberosDelegationTokenManager;
-import org.apache.flink.runtime.security.token.NoOpDelegationTokenManager;
+import org.apache.flink.runtime.security.token.KerberosDelegationTokenManagerFactory;
 import org.apache.flink.runtime.util.ZooKeeperUtils;
 import org.apache.flink.runtime.webmonitor.retriever.impl.RpcMetricQueryServiceRetriever;
 import org.apache.flink.util.AutoCloseableAsync;
@@ -392,11 +389,11 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
             configuration.setString(BlobServerOptions.PORT, String.valueOf(blobServer.getPort()));
             heartbeatServices = createHeartbeatServices(configuration);
             delegationTokenManager =
-                    configuration.getBoolean(SecurityOptions.KERBEROS_FETCH_DELEGATION_TOKEN)
-                                    && HadoopDependency.isHadoopCommonOnClasspath(
-                                            getClass().getClassLoader())
-                            ? new KerberosDelegationTokenManager(configuration)
-                            : new NoOpDelegationTokenManager();
+                    KerberosDelegationTokenManagerFactory.create(
+                            getClass().getClassLoader(),
+                            configuration,
+                            commonRpcService.getScheduledExecutor(),
+                            ioExecutor);
             metricRegistry = createMetricRegistry(configuration, pluginManager, rpcSystem);
 
             final RpcService metricQueryServiceRpcService =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DelegationTokenManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DelegationTokenManager.java
@@ -38,7 +38,7 @@ public interface DelegationTokenManager {
      * Creates a re-occurring task which obtains new tokens and automatically distributes them to
      * task managers.
      */
-    void start();
+    void start() throws Exception;
 
     /** Stops re-occurring token obtain task. */
     void stop();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/KerberosDelegationTokenManagerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/KerberosDelegationTokenManagerFactory.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.security.token;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.SecurityOptions;
+import org.apache.flink.runtime.hadoop.HadoopDependency;
+import org.apache.flink.util.concurrent.ScheduledExecutor;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.util.concurrent.ExecutorService;
+
+/** A factory for {@link KerberosDelegationTokenManager}. */
+public class KerberosDelegationTokenManagerFactory {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(KerberosDelegationTokenManagerFactory.class);
+
+    public static DelegationTokenManager create(
+            ClassLoader classLoader,
+            Configuration configuration,
+            @Nullable ScheduledExecutor scheduledExecutor,
+            @Nullable ExecutorService ioExecutor) {
+
+        if (configuration.getBoolean(SecurityOptions.KERBEROS_FETCH_DELEGATION_TOKEN)) {
+            if (HadoopDependency.isHadoopCommonOnClasspath(classLoader)) {
+                return new KerberosDelegationTokenManager(
+                        configuration, scheduledExecutor, ioExecutor);
+            } else {
+                LOG.info(
+                        "Cannot use kerberos delegation token manager because Hadoop cannot be found in the Classpath.");
+                return new NoOpDelegationTokenManager();
+            }
+        } else {
+            return new NoOpDelegationTokenManager();
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/KerberosRenewalPossibleProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/KerberosRenewalPossibleProvider.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.security.token;
+
+import org.apache.flink.runtime.security.SecurityConfiguration;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** It checks whether kerberos credentials can be renewed. */
+public class KerberosRenewalPossibleProvider {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(KerberosRenewalPossibleProvider.class);
+
+    private final SecurityConfiguration securityConfiguration;
+
+    public KerberosRenewalPossibleProvider(SecurityConfiguration securityConfiguration) {
+        this.securityConfiguration =
+                checkNotNull(
+                        securityConfiguration, "Flink security configuration must not be null");
+    }
+
+    public boolean isRenewalPossible() throws IOException {
+        if (!StringUtils.isBlank(securityConfiguration.getKeytab())
+                && !StringUtils.isBlank(securityConfiguration.getPrincipal())) {
+            LOG.debug("Login from keytab is possible");
+            return true;
+        }
+        LOG.debug("Login from keytab is NOT possible");
+
+        if (securityConfiguration.useTicketCache() && hasCurrentUserCredentials()) {
+            LOG.debug("Login from ticket cache is possible");
+            return true;
+        }
+        LOG.debug("Login from ticket cache is NOT possible");
+
+        return false;
+    }
+
+    protected boolean hasCurrentUserCredentials() throws IOException {
+        return UserGroupInformation.getCurrentUser().hasKerberosCredentials();
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/FileUploadHandlerITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/FileUploadHandlerITCase.java
@@ -58,6 +58,7 @@ import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -471,8 +472,17 @@ public class FileUploadHandlerITCase extends TestLogger {
             Class<?> clazz = Class.forName("java.io.DeleteOnExitHook");
             Field field = clazz.getDeclaredField("files");
             field.setAccessible(true);
-            LinkedHashSet files = (LinkedHashSet) field.get(null);
-            assertTrue(files.isEmpty());
+            LinkedHashSet<String> files = (LinkedHashSet<String>) field.get(null);
+            boolean fileFound = false;
+            // Mockito automatically registers mockitoboot*.jar for on-exit removal. Verify that
+            // there are no other files registered.
+            for (String file : files) {
+                if (!file.contains("mockitoboot")) {
+                    fileFound = true;
+                    break;
+                }
+            }
+            assertFalse(fileFound);
         } catch (ClassNotFoundException | IllegalAccessException | NoSuchFieldException e) {
             fail("This should never happen.");
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/KerberosRenewalPossibleProviderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/KerberosRenewalPossibleProviderTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.security.token;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.security.SecurityConfiguration;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.apache.flink.configuration.SecurityOptions.KERBEROS_LOGIN_KEYTAB;
+import static org.apache.flink.configuration.SecurityOptions.KERBEROS_LOGIN_PRINCIPAL;
+import static org.apache.flink.configuration.SecurityOptions.KERBEROS_LOGIN_USETICKETCACHE;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class KerberosRenewalPossibleProviderTest {
+    @Test
+    public void isRenewalPossibleMustGiveBackFalseByDefault() throws IOException {
+        Configuration configuration = new Configuration();
+        configuration.setBoolean(KERBEROS_LOGIN_USETICKETCACHE, false);
+        SecurityConfiguration securityConfiguration = new SecurityConfiguration(configuration);
+        KerberosRenewalPossibleProvider kerberosRenewalPossibleProvider =
+                new KerberosRenewalPossibleProvider(securityConfiguration);
+
+        assertFalse(kerberosRenewalPossibleProvider.isRenewalPossible());
+    }
+
+    @Test
+    public void isRenewalPossibleMustGiveBackTrueWhenKeytab(@TempDir Path tmpDir)
+            throws IOException {
+        Configuration configuration = new Configuration();
+        configuration.setString(KERBEROS_LOGIN_PRINCIPAL, "principal");
+        final Path keyTab = Files.createFile(tmpDir.resolve("test.keytab"));
+        configuration.setString(KERBEROS_LOGIN_KEYTAB, keyTab.toAbsolutePath().toString());
+        SecurityConfiguration securityConfiguration = new SecurityConfiguration(configuration);
+        KerberosRenewalPossibleProvider kerberosRenewalPossibleProvider =
+                new KerberosRenewalPossibleProvider(securityConfiguration);
+
+        assertTrue(kerberosRenewalPossibleProvider.isRenewalPossible());
+    }
+
+    @Test
+    public void isRenewalPossibleMustGiveBackTrueWhenTGT() throws IOException {
+        Configuration configuration = new Configuration();
+        configuration.setBoolean(KERBEROS_LOGIN_USETICKETCACHE, true);
+        SecurityConfiguration securityConfiguration = new SecurityConfiguration(configuration);
+        KerberosRenewalPossibleProvider kerberosRenewalPossibleProvider =
+                new KerberosRenewalPossibleProvider(securityConfiguration) {
+                    @Override
+                    protected boolean hasCurrentUserCredentials() {
+                        return true;
+                    }
+                };
+
+        assertTrue(kerberosRenewalPossibleProvider.isRenewalPossible());
+    }
+}

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -1294,7 +1294,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
         Credentials credentials = UserGroupInformation.getCurrentUser().getCredentials();
 
         DelegationTokenManager delegationTokenManager =
-                new KerberosDelegationTokenManager(flinkConfiguration);
+                new KerberosDelegationTokenManager(flinkConfiguration, null, null);
         delegationTokenManager.obtainDelegationTokens(credentials);
 
         ByteBuffer tokens = ByteBuffer.wrap(DelegationTokenConverter.serialize(credentials));

--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@ under the License.
 		<junit4.version>4.13.2</junit4.version>
 		<junit5.version>5.8.1</junit5.version>
 		<archunit.version>0.22.0</archunit.version>
-		<mockito.version>2.21.0</mockito.version>
+		<mockito.version>3.4.6</mockito.version>
 		<powermock.version>2.0.9</powermock.version>
 		<hamcrest.version>1.3</hamcrest.version>
 		<assertj.version>3.21.0</assertj.version>
@@ -224,6 +224,14 @@ under the License.
 		<dependency>
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-inline</artifactId>
+			<version>${mockito.version}</version>
+			<type>jar</type>
 			<scope>test</scope>
 		</dependency>
 
@@ -537,14 +545,14 @@ under the License.
 				<!-- mockito/powermock mismatch -->
 				<groupId>net.bytebuddy</groupId>
 				<artifactId>byte-buddy</artifactId>
-				<version>1.8.22</version>
+				<version>1.10.14</version>
 			</dependency>
 
 			<dependency>
 				<!-- mockito/powermock mismatch -->
 				<groupId>net.bytebuddy</groupId>
 				<artifactId>byte-buddy-agent</artifactId>
-				<version>1.8.22</version>
+				<version>1.10.14</version>
 			</dependency>
 
 			<!-- For dependency convergence -->


### PR DESCRIPTION
## What is the purpose of the change

`KerberosDelegationTokenManager` needs a valid TGT in order to obtain delegation tokens. In this PR I've added periodic kerberos relogin when configured properly.

## Brief change log

* Added `security.kerberos.relogin.period` config with default 1 minute.
* Added TGT renew thread when user uses keytab.
* Updated Mockito version to 3.4.6 in order to use static method mocking in `testStartTGTRenewalShouldScheduleRenewal`.
* Updated Byte Buddy version to 1.10.14 to match with Mockito.

## Verifying this change

* Additional unit tests
* Manually on YARN and K8S cluster

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? All documentation is intended to be added in [FLINK-25911](https://issues.apache.org/jira/browse/FLINK-25911) when everything works as a whole
