### PR TITLE
[FLINK-26810][connectors/elasticsearch] Use local timezone for TIMETAMP_WITH_LOCAL_TIMEZONE fields in dynamic index

### DIFF
--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/table/IndexGeneratorFactory.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/table/IndexGeneratorFactory.java
@@ -33,7 +33,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -133,7 +132,8 @@ final class IndexGeneratorFactory {
             final String dateTimeFormat =
                     indexHelper.extractDateFormat(index, indexFieldLogicalTypeRoot);
             DynamicFormatter formatFunction =
-                    createFormatFunction(indexFieldType, indexFieldLogicalTypeRoot);
+                    createFormatFunction(
+                            indexFieldType, indexFieldLogicalTypeRoot, localTimeZoneId);
 
             return new AbstractTimeIndexGenerator(index, dateTimeFormat) {
                 @Override
@@ -163,7 +163,9 @@ final class IndexGeneratorFactory {
     }
 
     private static DynamicFormatter createFormatFunction(
-            LogicalType indexFieldType, LogicalTypeRoot indexFieldLogicalTypeRoot) {
+            LogicalType indexFieldType,
+            LogicalTypeRoot indexFieldLogicalTypeRoot,
+            ZoneId localTimeZoneId) {
         switch (indexFieldLogicalTypeRoot) {
             case DATE:
                 return (value, dateTimeFormatter) -> {
@@ -186,7 +188,7 @@ final class IndexGeneratorFactory {
             case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
                 return (value, dateTimeFormatter) -> {
                     TimestampData indexField = (TimestampData) value;
-                    return indexField.toInstant().atZone(ZoneOffset.UTC).format(dateTimeFormatter);
+                    return indexField.toInstant().atZone(localTimeZoneId).format(dateTimeFormatter);
                 };
             default:
                 throw new TableException(

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/IndexGeneratorFactory.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/IndexGeneratorFactory.java
@@ -34,7 +34,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -130,7 +129,8 @@ final class IndexGeneratorFactory {
             final String dateTimeFormat =
                     indexHelper.extractDateFormat(index, indexFieldLogicalTypeRoot);
             DynamicFormatter formatFunction =
-                    createFormatFunction(indexFieldType, indexFieldLogicalTypeRoot);
+                    createFormatFunction(
+                            indexFieldType, indexFieldLogicalTypeRoot, localTimeZoneId);
 
             return new AbstractTimeIndexGenerator(index, dateTimeFormat) {
                 @Override
@@ -160,7 +160,9 @@ final class IndexGeneratorFactory {
     }
 
     private static DynamicFormatter createFormatFunction(
-            LogicalType indexFieldType, LogicalTypeRoot indexFieldLogicalTypeRoot) {
+            LogicalType indexFieldType,
+            LogicalTypeRoot indexFieldLogicalTypeRoot,
+            ZoneId localTimeZoneId) {
         switch (indexFieldLogicalTypeRoot) {
             case DATE:
                 return (value, dateTimeFormatter) -> {
@@ -183,7 +185,7 @@ final class IndexGeneratorFactory {
             case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
                 return (value, dateTimeFormatter) -> {
                     TimestampData indexField = (TimestampData) value;
-                    return indexField.toInstant().atZone(ZoneOffset.UTC).format(dateTimeFormatter);
+                    return indexField.toInstant().atZone(localTimeZoneId).format(dateTimeFormatter);
                 };
             default:
                 throw new TableException(

--- a/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/connector/elasticsearch/table/IndexGeneratorTest.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/connector/elasticsearch/table/IndexGeneratorTest.java
@@ -35,10 +35,13 @@ import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.UnsupportedTemporalTypeException;
 import java.util.Arrays;
 import java.util.List;
+
+import static org.junit.jupiter.api.Assumptions.assumingThat;
 
 /** Suite tests for {@link IndexGenerator}. */
 public class IndexGeneratorTest {
@@ -54,6 +57,7 @@ public class IndexGeneratorTest {
                     "local_datetime",
                     "local_date",
                     "local_time",
+                    "local_timestamp",
                     "note",
                     "status");
 
@@ -68,6 +72,7 @@ public class IndexGeneratorTest {
                     DataTypes.TIMESTAMP().bridgedTo(LocalDateTime.class),
                     DataTypes.DATE().bridgedTo(LocalDate.class),
                     DataTypes.TIME().bridgedTo(LocalTime.class),
+                    DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(),
                     DataTypes.STRING(),
                     DataTypes.BOOLEAN());
 
@@ -86,6 +91,10 @@ public class IndexGeneratorTest {
                                     LocalDateTime.of(2020, 3, 18, 12, 12, 14, 1000)),
                             (int) LocalDate.of(2020, 3, 18).toEpochDay(),
                             (int) (LocalTime.of(12, 13, 14, 2000).toNanoOfDay() / 1_000_000L),
+                            TimestampData.fromInstant(
+                                    LocalDateTime.of(2020, 3, 18, 3, 12, 14, 1000)
+                                            .atZone(ZoneId.of("Asia/Shanghai"))
+                                            .toInstant()),
                             "test1",
                             true),
                     GenericRowData.of(
@@ -101,8 +110,43 @@ public class IndexGeneratorTest {
                                     LocalDateTime.of(2020, 3, 19, 12, 22, 14, 1000)),
                             (int) LocalDate.of(2020, 3, 19).toEpochDay(),
                             (int) (LocalTime.of(12, 13, 14, 2000).toNanoOfDay() / 1_000_000L),
+                            TimestampData.fromInstant(
+                                    LocalDateTime.of(2020, 3, 19, 20, 22, 14, 1000)
+                                            .atZone(ZoneId.of("America/Los_Angeles"))
+                                            .toInstant()),
                             "test2",
                             false));
+
+    @Test
+    public void testDynamicIndexFromTimestampTzUTC() {
+        assumingThat(
+                ZoneId.systemDefault().equals(ZoneId.of("UTC")),
+                () -> {
+                    IndexGenerator indexGenerator =
+                            IndexGeneratorFactory.createIndexGenerator(
+                                    "{local_timestamp|yyyy_MM_dd_HH-ss}_index",
+                                    fieldNames,
+                                    dataTypes);
+                    indexGenerator.open();
+                    Assertions.assertEquals(
+                            "2020_03_17_19-14_index", indexGenerator.generate(rows.get(0)));
+                    Assertions.assertEquals(
+                            "2020_03_20_03-14_index", indexGenerator.generate(rows.get(1)));
+                });
+    }
+
+    @Test
+    public void testDynamicIndexFromTimestampTzWithSpecificTimezone() {
+        IndexGenerator indexGenerator =
+                IndexGeneratorFactory.createIndexGenerator(
+                        "{local_timestamp|yyyy_MM_dd_HH-ss}_index",
+                        fieldNames,
+                        dataTypes,
+                        ZoneId.of("Europe/Berlin"));
+        indexGenerator.open();
+        Assertions.assertEquals("2020_03_17_20-14_index", indexGenerator.generate(rows.get(0)));
+        Assertions.assertEquals("2020_03_20_04-14_index", indexGenerator.generate(rows.get(1)));
+    }
 
     @Test
     public void testDynamicIndexFromTimestamp() {


### PR DESCRIPTION
Unchanged backport of #19302 for 1.15
