### PR TITLE
[hotfix][test] rename to replace "Product" with "Production" for cons…

### DIFF
--- a/flink-architecture-tests/flink-architecture-tests-production/src/main/java/org/apache/flink/architecture/ProductionCodeArchitectureBase.java
+++ b/flink-architecture-tests/flink-architecture-tests-production/src/main/java/org/apache/flink/architecture/ProductionCodeArchitectureBase.java
@@ -30,7 +30,7 @@ import com.tngtech.archunit.junit.ArchTests;
  * <p>Architectural tests should include this class via {@link ArchTests#in(Class)} to cover the
  * common part.
  */
-public class ProductCodeArchitectureBase {
+public class ProductionCodeArchitectureBase {
     @ArchTest
     public static final ArchTests API_ANNOTATIONS = ArchTests.in(ApiAnnotationRules.class);
 

--- a/flink-architecture-tests/flink-architecture-tests-production/src/test/java/org/apache/flink/architecture/ArchitectureTest.java
+++ b/flink-architecture-tests/flink-architecture-tests-production/src/test/java/org/apache/flink/architecture/ArchitectureTest.java
@@ -36,5 +36,5 @@ import com.tngtech.archunit.junit.ArchTests;
 public class ArchitectureTest {
 
     @ArchTest
-    public static final ArchTests COMMON_TESTS = ArchTests.in(ProductCodeArchitectureBase.class);
+    public static final ArchTests COMMON_TESTS = ArchTests.in(ProductionCodeArchitectureBase.class);
 }


### PR DESCRIPTION
## What is the purpose of the change

This is a follow-up PR of #19365 

Since `ProductionCodeArchitectureBase` will be used by external connector repos, a consistent naming convention should be used.

## Brief change log

  - rename from `ProductCodeArchitectureBase` to `ProductionCodeArchitectureBase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)