### PR TITLE
[FLINK-27108][python] Fix the state cache clean up logic

### DIFF
--- a/flink-python/pyflink/fn_execution/state_impl.py
+++ b/flink-python/pyflink/fn_execution/state_impl.py
@@ -87,6 +87,9 @@ class LRUCache(object):
     def __iter__(self):
         return iter(self._cache.values())
 
+    def __contains__(self, key):
+        return key in self._cache
+
 
 class SynchronousKvRuntimeState(InternalKvState, ABC):
     """

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/runners/python/beam/BeamPythonFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/runners/python/beam/BeamPythonFunctionRunner.java
@@ -216,15 +216,17 @@ public abstract class BeamPythonFunctionRunner implements PythonFunctionRunner {
         PortablePipelineOptions portableOptions =
                 PipelineOptionsFactory.as(PortablePipelineOptions.class);
 
-        if (jobOptions.containsKey(PythonOptions.STATE_CACHE_SIZE.key())) {
+        int stateCacheSize =
+                Integer.parseInt(
+                        jobOptions.getOrDefault(
+                                PythonOptions.STATE_CACHE_SIZE.key(),
+                                PythonOptions.STATE_CACHE_SIZE.defaultValue().toString()));
+        if (stateCacheSize > 0) {
             portableOptions
                     .as(ExperimentalOptions.class)
                     .setExperiments(
                             Collections.singletonList(
-                                    ExperimentalOptions.STATE_CACHE_SIZE
-                                            + "="
-                                            + jobOptions.get(
-                                                    PythonOptions.STATE_CACHE_SIZE.key())));
+                                    ExperimentalOptions.STATE_CACHE_SIZE + "=" + stateCacheSize));
         }
 
         Struct pipelineOptions = PipelineOptionsTranslation.toProto(portableOptions);


### PR DESCRIPTION

## What is the purpose of the change

*This pull request fixes the the state cache clean up logic. The test case test_session_window_late_merge failed when working on PR #19333. After digging into this problem, I found that the reason should be that the logic to determine [whether a key & namespace exists in state cache is wrong](https://github.com/apache/flink/blob/master/flink-python/pyflink/fn_execution/state_impl.py#L1183). It causes the state cache isn't clean up when it becomes invalidate. *


## Verifying this change

This change is already covered by existing tests, such as *test_session_window_late_merge*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
