### PR TITLE
[FLINK-27122] Remove FutureUtils#retryWithDelay variants without RetryStrategy

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
@@ -98,6 +98,7 @@ import org.apache.flink.util.ExecutorUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.concurrent.ExecutorThreadFactory;
+import org.apache.flink.util.concurrent.FixedRetryStrategy;
 import org.apache.flink.util.concurrent.FutureUtils;
 import org.apache.flink.util.concurrent.ScheduledExecutorServiceAdapter;
 import org.apache.flink.util.function.CheckedSupplier;
@@ -117,6 +118,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -891,8 +893,9 @@ public class RestClusterClient<T> implements ClusterClient<T> {
             CheckedSupplier<CompletableFuture<C>> operation, Predicate<Throwable> retryPredicate) {
         return FutureUtils.retryWithDelay(
                 CheckedSupplier.unchecked(operation),
-                restClusterClientConfiguration.getRetryMaxAttempts(),
-                Time.milliseconds(restClusterClientConfiguration.getRetryDelay()),
+                new FixedRetryStrategy(
+                        restClusterClientConfiguration.getRetryMaxAttempts(),
+                        Duration.ofMillis(restClusterClientConfiguration.getRetryDelay())),
                 retryPredicate,
                 new ScheduledExecutorServiceAdapter(retryExecutorService));
     }

--- a/flink-core/src/main/java/org/apache/flink/util/concurrent/FutureUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/concurrent/FutureUtils.java
@@ -211,31 +211,6 @@ public class FutureUtils {
      * Retry the given operation with the given delay in between failures.
      *
      * @param operation to retry
-     * @param retries number of retries
-     * @param retryDelay delay between retries
-     * @param retryPredicate Predicate to test whether an exception is retryable
-     * @param scheduledExecutor executor to be used for the retry operation
-     * @param <T> type of the result
-     * @return Future which retries the given operation a given amount of times and delays the retry
-     *     in case of failures
-     */
-    public static <T> CompletableFuture<T> retryWithDelay(
-            final Supplier<CompletableFuture<T>> operation,
-            final int retries,
-            final Time retryDelay,
-            final Predicate<Throwable> retryPredicate,
-            final ScheduledExecutor scheduledExecutor) {
-        return retryWithDelay(
-                operation,
-                new FixedRetryStrategy(retries, Duration.ofMillis(retryDelay.toMilliseconds())),
-                retryPredicate,
-                scheduledExecutor);
-    }
-
-    /**
-     * Retry the given operation with the given delay in between failures.
-     *
-     * @param operation to retry
      * @param retryStrategy the RetryStrategy
      * @param retryPredicate Predicate to test whether an exception is retryable
      * @param scheduledExecutor executor to be used for the retry operation
@@ -255,28 +230,6 @@ public class FutureUtils {
                 resultFuture, operation, retryStrategy, retryPredicate, scheduledExecutor);
 
         return resultFuture;
-    }
-
-    /**
-     * Retry the given operation with the given delay in between failures.
-     *
-     * @param operation to retry
-     * @param retries number of retries
-     * @param retryDelay delay between retries
-     * @param scheduledExecutor executor to be used for the retry operation
-     * @param <T> type of the result
-     * @return Future which retries the given operation a given amount of times and delays the retry
-     *     in case of failures
-     */
-    public static <T> CompletableFuture<T> retryWithDelay(
-            final Supplier<CompletableFuture<T>> operation,
-            final int retries,
-            final Time retryDelay,
-            final ScheduledExecutor scheduledExecutor) {
-        return retryWithDelay(
-                operation,
-                new FixedRetryStrategy(retries, Duration.ofMillis(retryDelay.toMilliseconds())),
-                scheduledExecutor);
     }
 
     /**

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RescalingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RescalingITCase.java
@@ -26,7 +26,6 @@ import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.time.Deadline;
-import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.tuple.Tuple2;
@@ -57,6 +56,7 @@ import org.apache.flink.test.util.MiniClusterWithClientResource;
 import org.apache.flink.testutils.TestingUtils;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.concurrent.FixedRetryStrategy;
 import org.apache.flink.util.concurrent.FutureUtils;
 
 import org.junit.AfterClass;
@@ -555,8 +555,9 @@ public class RescalingITCase extends TestLogger {
                             () ->
                                     client.triggerSavepoint(
                                             jobID, null, SavepointFormatType.CANONICAL),
-                            (int) deadline.timeLeft().getSeconds() / 10,
-                            Time.seconds(10),
+                            new FixedRetryStrategy(
+                                    (int) deadline.timeLeft().getSeconds() / 10,
+                                    Duration.ofSeconds(10)),
                             (throwable) -> true,
                             TestingUtils.defaultScheduledExecutor());
 


### PR DESCRIPTION
Cut out from #19351.