### PR TITLE
[FLINK-27118][yarn] TM ignores localhost BIND_HOST

### DIFF
--- a/flink-dist/src/main/resources/flink-conf.yaml
+++ b/flink-dist/src/main/resources/flink-conf.yaml
@@ -38,6 +38,8 @@ jobmanager.rpc.port: 6123
 
 # The host interface the JobManager will bind to. My default, this is localhost, and will prevent
 # the JobManager from communicating outside the machine/container it is running on.
+# On YARN this setting will be ignored if it is set to 'localhost', defaulting to 0.0.0.0.
+# On Kubernetes this setting will be ignored, defaulting to 0.0.0.0.
 #
 # To enable this, set the bind-host address to one that has access to an outside facing network
 # interface, such as 0.0.0.0.
@@ -53,6 +55,8 @@ jobmanager.memory.process.size: 1600m
 
 # The host interface the TaskManager will bind to. By default, this is localhost, and will prevent
 # the TaskManager from communicating outside the machine/container it is running on.
+# On YARN this setting will be ignored if it is set to 'localhost', defaulting to 0.0.0.0.
+# On Kubernetes this setting will be ignored, defaulting to 0.0.0.0.
 #
 # To enable this, set the bind-host address to one that has access to an outside facing network
 # interface, such as 0.0.0.0.

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnEntrypointUtils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnEntrypointUtils.java
@@ -25,7 +25,6 @@ import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.ResourceManagerOptions;
 import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.configuration.SecurityOptions;
-import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.configuration.WebOptions;
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
 import org.apache.flink.util.Preconditions;
@@ -65,9 +64,6 @@ public class YarnEntrypointUtils {
                 ApplicationConstants.Environment.NM_HOST.key());
 
         configuration.setString(JobManagerOptions.ADDRESS, hostname);
-        configuration.removeConfig(JobManagerOptions.BIND_HOST);
-        configuration.removeConfig(TaskManagerOptions.BIND_HOST);
-        configuration.removeConfig(TaskManagerOptions.HOST);
         configuration.setString(RestOptions.ADDRESS, hostname);
         configuration.setString(RestOptions.BIND_ADDRESS, hostname);
 


### PR DESCRIPTION
Modifies the yarn taskexecutor runner to drop BIND_HOST configurations set to localhost, as done by the default distribution. 

Localhost doesn't work out-of-the-box, and the TM still using it wasn't intentional.