### PR TITLE
[FLINK-26864][metrics] Fix performance regression from mailbox latency measuement

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxMetricsController.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxMetricsController.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks.mailbox;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.operators.MailboxExecutor;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.Histogram;
+import org.apache.flink.streaming.runtime.tasks.TimerService;
+import org.apache.flink.util.clock.SystemClock;
+
+import javax.annotation.Nullable;
+
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * Mailbox metrics controller class. The use of mailbox metrics, in particular scheduling latency
+ * measurements that require a {@link TimerService}, induce (cyclic) dependencies between {@link
+ * MailboxProcessor} and {@link org.apache.flink.streaming.runtime.tasks.StreamTask}. An instance of
+ * this class contains and gives control over these dependencies.
+ */
+@Internal
+public class MailboxMetricsController {
+    /** Default timer interval in milliseconds for triggering mailbox latency measurement. */
+    public final int defaultLatencyMeasurementInterval = 1000;
+
+    private final Histogram latencyHistogram;
+    private final Counter mailCounter;
+
+    @Nullable private TimerService timerService;
+    @Nullable private MailboxExecutor mailboxExecutor;
+    private int measurementInterval = defaultLatencyMeasurementInterval;
+    private boolean started = false;
+
+    /**
+     * Creates instance of {@link MailboxMetricsController} with references to metrics provided as
+     * parameters.
+     *
+     * @param latencyHistogram Histogram of mailbox latency measurements.
+     * @param mailCounter Counter for number of mails processed.
+     */
+    public MailboxMetricsController(Histogram latencyHistogram, Counter mailCounter) {
+        this.timerService = null;
+        this.mailboxExecutor = null;
+        this.latencyHistogram = latencyHistogram;
+        this.mailCounter = mailCounter;
+    }
+
+    /**
+     * Sets up latency measurement with required {@link TimerService} and {@link MailboxExecutor}.
+     *
+     * <p>Note: For each instance, latency measurement can be set up only once.
+     *
+     * @param timerService {@link TimerService} used for latency measurement.
+     * @param mailboxExecutor {@link MailboxExecutor} used for latency measurement.
+     */
+    public void setupLatencyMeasurement(
+            TimerService timerService, MailboxExecutor mailboxExecutor) {
+        checkState(
+                !isLatencyMeasurementSetup(),
+                "latency measurement has already been setup and cannot be setup twice");
+        this.timerService = timerService;
+        this.mailboxExecutor = mailboxExecutor;
+    }
+
+    /**
+     * Starts mailbox latency measurement. This requires setup of latency measurement via {@link
+     * MailboxMetricsController#setupLatencyMeasurement(TimerService, MailboxExecutor)}. Latency is
+     * measured through execution of a mail that is triggered by default in the interval defined by
+     * {@link MailboxMetricsController#defaultLatencyMeasurementInterval}.
+     *
+     * <p>Note: For each instance, latency measurement can be started only once.
+     */
+    public void startLatencyMeasurement() {
+        checkState(!isLatencyMeasurementStarted(), "latency measurement has already been started");
+        checkState(
+                isLatencyMeasurementSetup(),
+                "timer service and mailbox executor must be setup for latency measurement");
+        scheduleLatencyMeasurement();
+        started = true;
+    }
+
+    /**
+     * Indicates if latency mesurement has been started.
+     *
+     * @return True if latency measurement has been started.
+     */
+    public boolean isLatencyMeasurementStarted() {
+        return started;
+    }
+
+    /**
+     * Indicates if latency measurement has been setup.
+     *
+     * @return True if latency measurement has been setup.
+     */
+    public boolean isLatencyMeasurementSetup() {
+        return this.timerService != null && this.mailboxExecutor != null;
+    }
+
+    /**
+     * Gets {@link Counter} for number of mails processed.
+     *
+     * @return {@link Counter} for number of mails processed.
+     */
+    public Counter getMailCounter() {
+        return this.mailCounter;
+    }
+
+    @VisibleForTesting
+    public void setLatencyMeasurementInterval(int measurementInterval) {
+        this.measurementInterval = measurementInterval;
+    }
+
+    @VisibleForTesting
+    public void measureMailboxLatency() {
+        assert mailboxExecutor != null;
+        long startTime = SystemClock.getInstance().relativeTimeMillis();
+        mailboxExecutor.execute(
+                () -> {
+                    long endTime = SystemClock.getInstance().relativeTimeMillis();
+                    long latency = endTime - startTime;
+                    latencyHistogram.update(latency);
+                    scheduleLatencyMeasurement();
+                },
+                "Measure mailbox latency metric");
+    }
+
+    private void scheduleLatencyMeasurement() {
+        assert timerService != null;
+        timerService.registerTimer(
+                timerService.getCurrentProcessingTime() + measurementInterval,
+                timestamp -> measureMailboxLatency());
+    }
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -1685,7 +1685,9 @@ public class StreamTaskTest extends TestLogger {
                             new StreamTask<Object, StreamOperator<Object>>(mockEnvironment) {
                                 @Override
                                 protected void init() {
-                                    this.mailboxMetricsInterval = 2;
+                                    this.mailboxProcessor
+                                            .getMailboxMetricsControl()
+                                            .setLatencyMeasurementInterval(2);
                                 }
 
                                 @Override
@@ -1741,12 +1743,12 @@ public class StreamTaskTest extends TestLogger {
                             .getIOMetricGroup()
                             .getMailboxSize();
             long startTime = SystemClock.getInstance().relativeTimeMillis();
-            harness.streamTask.measureMailboxLatency();
+            harness.streamTask.mailboxProcessor.getMailboxMetricsControl().measureMailboxLatency();
             for (int i = 0; i < numMails; ++i) {
                 harness.streamTask.mainMailboxExecutor.execute(
                         () -> Thread.sleep(sleepTime), "add value");
             }
-            harness.streamTask.measureMailboxLatency();
+            harness.streamTask.mailboxProcessor.getMailboxMetricsControl().measureMailboxLatency();
 
             assertThat(mailboxSizeMetric.getValue(), greaterThanOrEqualTo(numMails));
             assertThat(mailboxLatencyMetric.getCount(), equalTo(0L));

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/mailbox/TaskMailboxProcessorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/mailbox/TaskMailboxProcessorTest.java
@@ -122,7 +122,9 @@ public class TaskMailboxProcessorTest {
         mailboxProcessor.getMailboxExecutor(DEFAULT_PRIORITY).execute(() -> stop.set(true), "stop");
         mailboxThread.join();
         assertThat(counter.get(), greaterThan(0));
-        assertThat(mailboxProcessor.getNumMailsProcessedCounter().getCount(), greaterThan(0L));
+        assertThat(
+                mailboxProcessor.getMailboxMetricsControl().getMailCounter().getCount(),
+                greaterThan(0L));
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

* Fix performance regression from mailbox latency measuement
* __Note:__ The performance implications, i.e., recovery of performance values, are documented in https://issues.apache.org/jira/browse/FLINK-26864. (Please review the performance results in the linked issue.) 

## Brief change log

* Trigger mailbox latency measurement from `MailboxProcessor` class instead from `StreamTask` class. This way, measurement can be initiated selectively only when mails are executed which is, in particular, on any non-poison mail.
* To resolve cyclic dependencies between `MailboxProcessor` which starts mailbox measurement with `StreamTask` which holds references to `MailboxExecutor` and `TimerServices` that are both needed for scheduling mailbox latency measurements an additional class `MailboxMetricsController` is introduced that holds the dependencies and provides control functions. 

## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

This change is already covered by existing tests that are updated respectively. The relevant tests are:
* StreamTaskTest#testMailboxMetricsScheduling
* StreamTaskTest#testMailboxMetricsMeasurement
* TaskMailboxProcessorTest#testRunDefaultActionAndMails

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): __no__
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: __no__
  - The serializers: __no__
  - The runtime per-record code paths (performance sensitive): __yes__
  - Anything that affects deployment or recovery: __no__
  - The S3 file system connector: __no__

## Documentation

  - Does this pull request introduce a new feature? __no__
  - If yes, how is the feature documented? __not applicable__
