### PR TITLE
[FLINK-25142][Connectors / Hive]Fix user-defined hive udtf initialize exception in hive dialect 

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveGenericUDTF.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveGenericUDTF.java
@@ -154,8 +154,10 @@ public class HiveGenericUDTF extends TableFunction<Row> implements HiveFunction<
                 "Getting result type of HiveGenericUDTF with {}",
                 hiveFunctionWrapper.getUDFClassName());
         ObjectInspector[] argumentInspectors = HiveInspectors.getArgInspectors(hiveShim, arguments);
+        StandardStructObjectInspector standardStructObjectInspector =
+                getStandardStructObjectInspector(argumentInspectors);
         return HiveTypeUtil.toFlinkType(
-                hiveFunctionWrapper.createFunction().initialize(argumentInspectors));
+                hiveFunctionWrapper.createFunction().initialize(standardStructObjectInspector));
     }
 
     @Override

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/functions/hive/HiveGenericUDTFTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/functions/hive/HiveGenericUDTFTest.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.hive.ql.udf.generic.GenericUDTFStack;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorConverters;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.StandardStructObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
 import org.junit.Test;
@@ -165,7 +166,10 @@ public class HiveGenericUDTFTest {
         ObjectInspector[] argumentInspectors =
                 HiveInspectors.getArgInspectors(
                         hiveShim, HiveFunctionArguments.create(callContext));
-        ObjectInspector returnInspector = wrapper.createFunction().initialize(argumentInspectors);
+        StandardStructObjectInspector standardStructObjectInspector =
+                HiveGenericUDTF.getStandardStructObjectInspector(argumentInspectors);
+        ObjectInspector returnInspector =
+                wrapper.createFunction().initialize(standardStructObjectInspector);
 
         udf.open(null);
 

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/functions/hive/util/TestSplitUDTFInitializeWithStructObjectInspector.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/functions/hive/util/TestSplitUDTFInitializeWithStructObjectInspector.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.functions.hive.util;
+
+import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDTF;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
+
+import java.util.Collections;
+
+/** Test split udtf initialize with StructObjectInspector. */
+public class TestSplitUDTFInitializeWithStructObjectInspector extends GenericUDTF {
+
+    @Override
+    public StructObjectInspector initialize(StructObjectInspector argOIs)
+            throws UDFArgumentException {
+        return ObjectInspectorFactory.getStandardStructObjectInspector(
+                Collections.singletonList("col1"),
+                Collections.singletonList(
+                        PrimitiveObjectInspectorFactory.javaStringObjectInspector));
+    }
+
+    @Override
+    public void process(Object[] args) throws HiveException {
+        String str = (String) args[0];
+        for (String s : str.split(",")) {
+            forward(s);
+        }
+    }
+
+    @Override
+    public void close() {}
+}


### PR DESCRIPTION
## What is the purpose of the change

Fix user-defined hive udtf initialize exception in hive dialect

## Brief change log

HiveGenericUDTF Compatible with new udtf implementations. Refer to this issue：
https://issues.apache.org/jira/browse/HIVE-5737


## Verifying this change

This change added tests and can be verified as follows:

* Added unit test HiveDialectITCase#testTemporaryFunctionUDTF

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
