### PR TITLE
[FLINK 26389][tests] update deprecated operators in e2e tests 

### DIFF
--- a/flink-end-to-end-tests/flink-cli-test/pom.xml
+++ b/flink-end-to-end-tests/flink-cli-test/pom.xml
@@ -40,6 +40,12 @@
 			<version>${project.version}</version>
 			<scope>provided</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-files</artifactId>
+			<version>1.16-SNAPSHOT</version>
+			<scope>compile</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/flink-end-to-end-tests/flink-cli-test/src/main/java/org/apache/flink/streaming/tests/PeriodicStreamingJob.java
+++ b/flink-end-to-end-tests/flink-cli-test/src/main/java/org/apache/flink/streaming/tests/PeriodicStreamingJob.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.tests;
 
+import org.apache.flink.api.common.serialization.SimpleStringEncoder;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
@@ -27,12 +28,13 @@ import org.apache.flink.api.java.tuple.Tuple;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.api.java.utils.ParameterTool;
-import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
 import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.api.windowing.assigners.TumblingProcessingTimeWindows;
 import org.apache.flink.streaming.api.windowing.time.Time;
@@ -65,9 +67,14 @@ public class PeriodicStreamingJob {
         DataStream<Tuple> rows = sEnv.addSource(generator);
 
         DataStream<Tuple> result =
-                rows.keyBy(1).window(TumblingProcessingTimeWindows.of(Time.seconds(5))).sum(0);
+                rows.keyBy(t -> t.getField(1))
+                        .window(TumblingProcessingTimeWindows.of(Time.seconds(5)))
+                        .sum(0);
 
-        result.writeAsText(outputPath + "/result.txt", FileSystem.WriteMode.OVERWRITE)
+        result.addSink(
+                        StreamingFileSink.forRowFormat(
+                                        new Path(outputPath), new SimpleStringEncoder<Tuple>())
+                                .build())
                 .setParallelism(1);
 
         sEnv.execute();

--- a/flink-end-to-end-tests/flink-cli-test/src/main/java/org/apache/flink/streaming/tests/PeriodicStreamingJob.java
+++ b/flink-end-to-end-tests/flink-cli-test/src/main/java/org/apache/flink/streaming/tests/PeriodicStreamingJob.java
@@ -28,13 +28,13 @@ import org.apache.flink.api.java.tuple.Tuple;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.connector.file.sink.FileSink;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
 import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.api.windowing.assigners.TumblingProcessingTimeWindows;
 import org.apache.flink.streaming.api.windowing.time.Time;
@@ -71,8 +71,8 @@ public class PeriodicStreamingJob {
                         .window(TumblingProcessingTimeWindows.of(Time.seconds(5)))
                         .sum(0);
 
-        result.addSink(
-                        StreamingFileSink.forRowFormat(
+        result.sinkTo(
+                        FileSink.forRowFormat(
                                         new Path(outputPath), new SimpleStringEncoder<Tuple>())
                                 .build())
                 .setParallelism(1);

--- a/flink-end-to-end-tests/flink-connector-gcp-pubsub-emulator-tests/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/EmulatedPubSubSourceTest.java
+++ b/flink-end-to-end-tests/flink-connector-gcp-pubsub-emulator-tests/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/EmulatedPubSubSourceTest.java
@@ -19,7 +19,6 @@ package org.apache.flink.streaming.connectors.gcp.pubsub;
 
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.streaming.api.datastream.DataStream;
-import org.apache.flink.streaming.api.datastream.DataStreamUtils;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.connectors.gcp.pubsub.emulator.EmulatorCredentials;
 import org.apache.flink.streaming.connectors.gcp.pubsub.emulator.GCloudUnitTestBase;
@@ -144,7 +143,7 @@ public class EmulatedPubSubSourceTest extends GCloudUnitTestBase {
                         .name("PubSub source");
 
         List<String> output = new ArrayList<>();
-        DataStreamUtils.collect(fromPubSub).forEachRemaining(output::add);
+        fromPubSub.executeAndCollect();
 
         assertEquals("Wrong number of elements", input.size(), output.size());
         for (String test : input) {

--- a/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/DataStreamAllroundTestJobFactory.java
+++ b/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/DataStreamAllroundTestJobFactory.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.tests;
 
+import org.apache.flink.api.common.eventtime.SerializableTimestampAssigner;
 import org.apache.flink.api.common.functions.FlatMapFunction;
 import org.apache.flink.api.common.functions.JoinFunction;
 import org.apache.flink.api.common.functions.MapFunction;
@@ -41,7 +42,6 @@ import org.apache.flink.streaming.api.datastream.WindowedStream;
 import org.apache.flink.streaming.api.environment.CheckpointConfig;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
-import org.apache.flink.streaming.api.functions.timestamps.BoundedOutOfOrdernessTimestampExtractor;
 import org.apache.flink.streaming.api.windowing.assigners.SlidingEventTimeWindows;
 import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
 import org.apache.flink.streaming.api.windowing.time.Time;
@@ -409,19 +409,13 @@ public class DataStreamAllroundTestJobFactory {
                         SEQUENCE_GENERATOR_SRC_SLEEP_AFTER_ELEMENTS.defaultValue()));
     }
 
-    static BoundedOutOfOrdernessTimestampExtractor<Event> createTimestampExtractor(
-            ParameterTool pt) {
-        return new BoundedOutOfOrdernessTimestampExtractor<Event>(
-                Time.milliseconds(
-                        pt.getLong(
-                                SEQUENCE_GENERATOR_SRC_EVENT_TIME_MAX_OUT_OF_ORDERNESS.key(),
-                                SEQUENCE_GENERATOR_SRC_EVENT_TIME_MAX_OUT_OF_ORDERNESS
-                                        .defaultValue()))) {
+    static SerializableTimestampAssigner<Event> createTimestampExtractor() {
+        return new SerializableTimestampAssigner<Event>() {
 
             private static final long serialVersionUID = -3154419724891779938L;
 
             @Override
-            public long extractTimestamp(Event element) {
+            public long extractTimestamp(Event element, long recordTimestamp) {
                 return element.getEventTime();
             }
         };

--- a/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/DataStreamAllroundTestJobFactory.java
+++ b/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/DataStreamAllroundTestJobFactory.java
@@ -54,7 +54,6 @@ import org.apache.flink.streaming.tests.artificialstate.builder.ArtificialValueS
 
 import java.io.IOException;
 import java.time.Duration;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -427,14 +426,12 @@ public class DataStreamAllroundTestJobFactory {
             }
         };
     }
+
     static Duration extractTimestamp(ParameterTool pt) {
-        Time maxOutOfOrderness =
-                Time.milliseconds(
-                        pt.getLong(
-                                SEQUENCE_GENERATOR_SRC_EVENT_TIME_MAX_OUT_OF_ORDERNESS.key(),
-                                SEQUENCE_GENERATOR_SRC_EVENT_TIME_MAX_OUT_OF_ORDERNESS
-                                        .defaultValue()));
-        return Duration.of(maxOutOfOrderness.getSize(), ChronoUnit.MILLIS);
+        return Duration.ofMillis(
+                pt.getLong(
+                        SEQUENCE_GENERATOR_SRC_EVENT_TIME_MAX_OUT_OF_ORDERNESS.key(),
+                        SEQUENCE_GENERATOR_SRC_EVENT_TIME_MAX_OUT_OF_ORDERNESS.defaultValue()));
     }
 
     static WindowedStream<Event, Integer, TimeWindow> applyTumblingWindows(

--- a/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/DataStreamAllroundTestJobFactory.java
+++ b/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/DataStreamAllroundTestJobFactory.java
@@ -53,6 +53,8 @@ import org.apache.flink.streaming.tests.artificialstate.builder.ArtificialStateB
 import org.apache.flink.streaming.tests.artificialstate.builder.ArtificialValueStateBuilder;
 
 import java.io.IOException;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -424,6 +426,15 @@ public class DataStreamAllroundTestJobFactory {
                 return element.getEventTime();
             }
         };
+    }
+    static Duration extractTimestamp(ParameterTool pt) {
+        Time maxOutOfOrderness =
+                Time.milliseconds(
+                        pt.getLong(
+                                SEQUENCE_GENERATOR_SRC_EVENT_TIME_MAX_OUT_OF_ORDERNESS.key(),
+                                SEQUENCE_GENERATOR_SRC_EVENT_TIME_MAX_OUT_OF_ORDERNESS
+                                        .defaultValue()));
+        return Duration.of(maxOutOfOrderness.getSize(), ChronoUnit.MILLIS);
     }
 
     static WindowedStream<Event, Integer, TimeWindow> applyTumblingWindows(

--- a/flink-end-to-end-tests/flink-distributed-cache-via-blob-test/pom.xml
+++ b/flink-end-to-end-tests/flink-distributed-cache-via-blob-test/pom.xml
@@ -40,7 +40,13 @@
 			<version>${project.version}</version>
 			<scope>provided</scope>
 		</dependency>
-	</dependencies>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-connector-files</artifactId>
+            <version>1.16-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
 
 	<build>
 		<plugins>

--- a/flink-end-to-end-tests/flink-distributed-cache-via-blob-test/src/main/java/org/apache/flink/streaming/tests/DistributedCacheViaBlobTestProgram.java
+++ b/flink-end-to-end-tests/flink-distributed-cache-via-blob-test/src/main/java/org/apache/flink/streaming/tests/DistributedCacheViaBlobTestProgram.java
@@ -20,8 +20,8 @@ package org.apache.flink.streaming.tests;
 import org.apache.flink.api.common.functions.RichMapFunction;
 import org.apache.flink.api.common.serialization.SimpleStringEncoder;
 import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.connector.file.sink.FileSink;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -67,12 +67,11 @@ public class DistributedCacheViaBlobTestProgram {
                                 Files.size(inputFile),
                                 inputDir.toAbsolutePath().toString(),
                                 containedFile.getFileName().toString()))
-                .addSink(
-                        StreamingFileSink.forRowFormat(
-                                        new org.apache.flink.core.fs.Path(
-                                                outputPath, SimpleStringEncoder<String>))
+                .sinkTo(
+                        FileSink.forRowFormat(
+                                        new org.apache.flink.core.fs.Path(outputPath),
+                                        new SimpleStringEncoder<String>("UTF-8"))
                                 .build());
-        // .writeAsText(params.getRequired("output"), FileSystem.WriteMode.OVERWRITE);
 
         env.execute("Distributed Cache Via Blob Test Program");
     }

--- a/flink-end-to-end-tests/flink-distributed-cache-via-blob-test/src/main/java/org/apache/flink/streaming/tests/DistributedCacheViaBlobTestProgram.java
+++ b/flink-end-to-end-tests/flink-distributed-cache-via-blob-test/src/main/java/org/apache/flink/streaming/tests/DistributedCacheViaBlobTestProgram.java
@@ -18,9 +18,10 @@
 package org.apache.flink.streaming.tests;
 
 import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.api.common.serialization.SimpleStringEncoder;
 import org.apache.flink.api.java.utils.ParameterTool;
-import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -38,6 +39,7 @@ public class DistributedCacheViaBlobTestProgram {
     public static void main(String[] args) throws Exception {
 
         final ParameterTool params = ParameterTool.fromArgs(args);
+        String outputPath = params.getRequired("outputPath");
 
         final Path inputFile = Paths.get(params.getRequired("inputFile"));
         final Path inputDir = Paths.get(params.getRequired("inputDir"));
@@ -65,7 +67,12 @@ public class DistributedCacheViaBlobTestProgram {
                                 Files.size(inputFile),
                                 inputDir.toAbsolutePath().toString(),
                                 containedFile.getFileName().toString()))
-                .writeAsText(params.getRequired("output"), FileSystem.WriteMode.OVERWRITE);
+                .addSink(
+                        StreamingFileSink.forRowFormat(
+                                        new org.apache.flink.core.fs.Path(
+                                                outputPath, SimpleStringEncoder<String>))
+                                .build());
+        // .writeAsText(params.getRequired("output"), FileSystem.WriteMode.OVERWRITE);
 
         env.execute("Distributed Cache Via Blob Test Program");
     }

--- a/flink-end-to-end-tests/flink-file-sink-test/src/main/java/org/apache/flink/connector/file/sink/FileSinkProgram.java
+++ b/flink-end-to-end-tests/flink-file-sink-test/src/main/java/org/apache/flink/connector/file/sink/FileSinkProgram.java
@@ -85,7 +85,7 @@ public enum FileSinkProgram {
                             .withRollingPolicy(OnCheckpointRollingPolicy.build())
                             .build();
 
-            source.keyBy(0).addSink(sink);
+            source.keyBy(t -> t.getField(0)).addSink(sink);
         } else if (sinkToTest.equalsIgnoreCase("FileSink")) {
             FileSink<Tuple2<Integer, Integer>> sink =
                     FileSink.forRowFormat(
@@ -98,7 +98,7 @@ public enum FileSinkProgram {
                             .withBucketAssigner(new KeyBucketAssigner())
                             .withRollingPolicy(OnCheckpointRollingPolicy.build())
                             .build();
-            source.keyBy(0).sinkTo(sink);
+            source.keyBy(t -> t.getField(0)).sinkTo(sink);
         } else {
             throw new UnsupportedOperationException("Unsupported sink type: " + sinkToTest);
         }

--- a/flink-end-to-end-tests/flink-stream-stateful-job-upgrade-test/src/main/java/org/apache/flink/streaming/tests/StatefulStreamJobUpgradeTestProgram.java
+++ b/flink-end-to-end-tests/flink-stream-stateful-job-upgrade-test/src/main/java/org/apache/flink/streaming/tests/StatefulStreamJobUpgradeTestProgram.java
@@ -38,7 +38,6 @@ import java.util.List;
 import static org.apache.flink.streaming.tests.DataStreamAllroundTestJobFactory.createArtificialKeyedStateMapper;
 import static org.apache.flink.streaming.tests.DataStreamAllroundTestJobFactory.createEventSource;
 import static org.apache.flink.streaming.tests.DataStreamAllroundTestJobFactory.createSemanticsCheckMapper;
-import static org.apache.flink.streaming.tests.DataStreamAllroundTestJobFactory.createTimestampExtractor;
 import static org.apache.flink.streaming.tests.DataStreamAllroundTestJobFactory.extractTimestamp;
 import static org.apache.flink.streaming.tests.DataStreamAllroundTestJobFactory.setupEnvironment;
 
@@ -95,11 +94,11 @@ public class StatefulStreamJobUpgradeTestProgram {
             throws Exception {
         Duration maxOutOfOrderness = extractTimestamp(pt);
         KeyedStream<Event, Integer> source =
-                env
-                        .addSource(createEventSource(pt))
+                env.addSource(createEventSource(pt))
                         .name("EventSource")
                         .uid("EventSource")
-                        .assignTimestampsAndWatermarks(WatermarkStrategy.forBoundedOutOfOrderness(maxOutOfOrderness))
+                        .assignTimestampsAndWatermarks(
+                                WatermarkStrategy.forBoundedOutOfOrderness(maxOutOfOrderness))
                         .keyBy(Event::getKey);
 
         List<TypeSerializer<ComplexPayload>> stateSer =
@@ -124,7 +123,8 @@ public class StatefulStreamJobUpgradeTestProgram {
                 env.addSource(createEventSource(pt))
                         .name("EventSource")
                         .uid("EventSource")
-                        .assignTimestampsAndWatermarks(WatermarkStrategy.forBoundedOutOfOrderness(maxOutOfOrderness))
+                        .assignTimestampsAndWatermarks(
+                                WatermarkStrategy.forBoundedOutOfOrderness(maxOutOfOrderness))
                         .map(new UpgradeEvent())
                         .keyBy(UpgradedEvent::getKey);
 

--- a/flink-end-to-end-tests/flink-stream-stateful-job-upgrade-test/src/main/java/org/apache/flink/streaming/tests/StatefulStreamJobUpgradeTestProgram.java
+++ b/flink-end-to-end-tests/flink-stream-stateful-job-upgrade-test/src/main/java/org/apache/flink/streaming/tests/StatefulStreamJobUpgradeTestProgram.java
@@ -38,6 +38,7 @@ import java.util.List;
 import static org.apache.flink.streaming.tests.DataStreamAllroundTestJobFactory.createArtificialKeyedStateMapper;
 import static org.apache.flink.streaming.tests.DataStreamAllroundTestJobFactory.createEventSource;
 import static org.apache.flink.streaming.tests.DataStreamAllroundTestJobFactory.createSemanticsCheckMapper;
+import static org.apache.flink.streaming.tests.DataStreamAllroundTestJobFactory.createTimestampExtractor;
 import static org.apache.flink.streaming.tests.DataStreamAllroundTestJobFactory.extractTimestamp;
 import static org.apache.flink.streaming.tests.DataStreamAllroundTestJobFactory.setupEnvironment;
 
@@ -98,7 +99,8 @@ public class StatefulStreamJobUpgradeTestProgram {
                         .name("EventSource")
                         .uid("EventSource")
                         .assignTimestampsAndWatermarks(
-                                WatermarkStrategy.forBoundedOutOfOrderness(maxOutOfOrderness))
+                                WatermarkStrategy.<Event>forBoundedOutOfOrderness(maxOutOfOrderness)
+                                        .withTimestampAssigner(createTimestampExtractor()))
                         .keyBy(Event::getKey);
 
         List<TypeSerializer<ComplexPayload>> stateSer =


### PR DESCRIPTION
## What is the purpose of the change

[FLINK-26389](https://issues.apache.org/jira/browse/FLINK-26389)

## Brief change log

Many operators of ”flink-end-to-end-tests“ have been deprecated and need to be updated.  More details are listed in the JIRA issue. 

My understanding is that this test here might need to be changed: https://github.com/apache/flink/pull/19152/files#diff-a1d544460dc1cb03e0b3c45584940f3dd6ffba0b13ffbe6c89b1e776447f7a44


## Verifying this change

This change is a code cleanup on existing e2e test.

This change is already covered by existing tests, such as CI tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
