### PR TITLE
in hive_read_write.md, there is an extra backtick in the description

### DIFF
--- a/docs/content/docs/connectors/table/hive/hive_read_write.md
+++ b/docs/content/docs/connectors/table/hive/hive_read_write.md
@@ -64,7 +64,7 @@ of new files in the folder and read new files incrementally.
         <td><h5>streaming-source.partition.include</h5></td>
         <td style="word-wrap: break-word;">all</td>
         <td>String</td>
-        <td>Option to set the partitions to read, the supported option are `all` and `latest`, the `all` means read all partitions; the `latest` means read latest partition in order of 'streaming-source.partition.order', the `latest` only works` when the streaming hive source table used as temporal table. By default the option is `all`.
+        <td>Option to set the partitions to read, the supported option are `all` and `latest`, the `all` means read all partitions; the `latest` means read latest partition in order of 'streaming-source.partition.order', the `latest` only works when the streaming hive source table used as temporal table. By default the option is `all`.
             Flink supports temporal join the latest hive partition by enabling 'streaming-source.enable' and setting 'streaming-source.partition.include' to 'latest', at the same time, user can assign the partition compare order and data update interval by configuring following partition-related options.  
         </td>
     </tr>     


### PR DESCRIPTION
## What is the purpose of the change
in hive_read_write.md, there is an extra backtick in the description of 'streaming-source.partition.include'

## Brief change log
* in hive_read_write.md, there is an extra backtick in the description of 'streaming-source.partition.include'

## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

* yes

This change is already covered by existing tests, such as *(please describe tests)*.

* yes


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no