### PR TITLE
[FLINK-27175][hive] Fix fail to call Hive UDAF when the UDAF accepts one parameter with array type

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveGenericUDTF.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveGenericUDTF.java
@@ -115,7 +115,7 @@ public class HiveGenericUDTF extends TableFunction<Row> implements HiveFunction<
 
         // When the parameter is (Integer, Array[Double]), Flink calls udf.eval(Integer,
         // Array[Double]), which is not a problem.
-        // But when the parameter is an single array, Flink calls udf.eval(Array[Double]),
+        // But when the parameter is a single array, Flink calls udf.eval(Array[Double]),
         // at this point java's var-args will cast Array[Double] to Array[Object] and let it be
         // Object... args, So we need wrap it.
         if (isArgsSingleArray) {

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveScalarFunction.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveScalarFunction.java
@@ -79,7 +79,7 @@ public abstract class HiveScalarFunction<UDFType> extends ScalarFunction
 
         // When the parameter is (Integer, Array[Double]), Flink calls udf.eval(Integer,
         // Array[Double]), which is not a problem.
-        // But when the parameter is an single array, Flink calls udf.eval(Array[Double]),
+        // But when the parameter is a single array, Flink calls udf.eval(Array[Double]),
         // at this point java's var-args will cast Array[Double] to Array[Object] and let it be
         // Object... args, So we need wrap it.
         if (isArgsSingleArray) {

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/util/HiveFunctionUtil.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/util/HiveFunctionUtil.java
@@ -19,52 +19,15 @@
 package org.apache.flink.table.functions.hive.util;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.table.functions.hive.FlinkHiveUDFException;
 import org.apache.flink.table.functions.hive.HiveFunctionArguments;
 import org.apache.flink.table.types.DataType;
-import org.apache.flink.table.types.logical.ArrayType;
-import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
 
 /** Util for Hive functions. */
 @Internal
 public class HiveFunctionUtil {
     public static boolean isSingleBoxedArray(HiveFunctionArguments arguments) {
-        for (int i = 0; i < arguments.size(); i++) {
-            if (HiveFunctionUtil.isPrimitiveArray(arguments.getDataType(i))) {
-                throw new FlinkHiveUDFException(
-                        "Flink doesn't support primitive array for Hive function yet.");
-            }
-        }
         return arguments.size() == 1 && HiveFunctionUtil.isArrayType(arguments.getDataType(0));
-    }
-
-    private static boolean isPrimitiveArray(DataType dataType) {
-        if (isArrayType(dataType)) {
-            ArrayType arrayType = (ArrayType) dataType.getLogicalType();
-
-            LogicalType elementType = arrayType.getElementType();
-            return !(elementType.isNullable() || !isPrimitive(elementType));
-        } else {
-            return false;
-        }
-    }
-
-    // This is copied from PlannerTypeUtils in flink-table-runtime that we shouldn't depend on
-    // TODO: remove this and use the original code when it's moved to accessible, dependable module
-    private static boolean isPrimitive(LogicalType type) {
-        switch (type.getTypeRoot()) {
-            case BOOLEAN:
-            case TINYINT:
-            case SMALLINT:
-            case INTEGER:
-            case BIGINT:
-            case FLOAT:
-            case DOUBLE:
-                return true;
-            default:
-                return false;
-        }
     }
 
     private static boolean isArrayType(DataType dataType) {

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/functions/hive/HiveGenericUDAFTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/functions/hive/HiveGenericUDAFTest.java
@@ -24,6 +24,8 @@ import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.inference.utils.CallContextMock;
 import org.apache.flink.types.Row;
 
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFCollectList;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFCollectSet;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFContextNGrams;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFCount;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFEvaluator;
@@ -40,6 +42,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 /** Test for {@link HiveGenericUDAF}. */
 public class HiveGenericUDAFTest {
@@ -137,6 +140,38 @@ public class HiveGenericUDAFTest {
 
         udaf.merge(acc, Collections.emptyList());
         assertThat(Arrays.toString((Row[]) udaf.getValue(acc))).isEqualTo("[+I[[think], 1.0]]");
+    }
+
+    @Test
+    public void testUDAFWithSingleArrayAsParameter() throws Exception {
+        Object[] constantArgs = new Object[] {null};
+
+        DataType[] argTypes = new DataType[] {DataTypes.ARRAY(DataTypes.INT().notNull())};
+
+        // test CollectList
+        HiveGenericUDAF udf = init(GenericUDAFCollectList.class, constantArgs, argTypes);
+        GenericUDAFEvaluator.AggregationBuffer acc = udf.createAccumulator();
+
+        udf.accumulate(acc, new Integer[] {1, 2});
+        udf.accumulate(acc, new Integer[] {2, 3});
+
+        udf.merge(acc, Collections.emptyList());
+
+        Integer[][] expectedResult = new Integer[][] {new Integer[] {1, 2}, new Integer[] {2, 3}};
+        assertArrayEquals(expectedResult, (Integer[][]) udf.getValue(acc));
+
+        // test CollectSet
+        udf = init(GenericUDAFCollectSet.class, constantArgs, argTypes);
+        acc = udf.createAccumulator();
+
+        udf.accumulate(acc, new Integer[] {1, 2});
+        udf.accumulate(acc, new Integer[] {2, 3});
+        udf.accumulate(acc, new Integer[] {1, 2});
+
+        udf.merge(acc, Collections.emptySet());
+
+        expectedResult = new Integer[][] {new Integer[] {1, 2}, new Integer[] {2, 3}};
+        assertArrayEquals(expectedResult, (Integer[][]) udf.getValue(acc));
     }
 
     private static HiveGenericUDAF init(

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/functions/hive/HiveGenericUDAFTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/functions/hive/HiveGenericUDAFTest.java
@@ -149,7 +149,8 @@ public class HiveGenericUDAFTest {
         DataType[] argTypes = new DataType[] {DataTypes.ARRAY(DataTypes.INT().notNull())};
 
         // test CollectList
-        HiveGenericUDAF udf = init(GenericUDAFCollectList.class, constantArgs, argTypes);
+        HiveGenericUDAF udf =
+                init(GenericUDAFCollectList.class, constantArgs, argTypes, false, false);
         GenericUDAFEvaluator.AggregationBuffer acc = udf.createAccumulator();
 
         udf.accumulate(acc, new Integer[] {1, 2});
@@ -161,7 +162,7 @@ public class HiveGenericUDAFTest {
         assertArrayEquals(expectedResult, (Integer[][]) udf.getValue(acc));
 
         // test CollectSet
-        udf = init(GenericUDAFCollectSet.class, constantArgs, argTypes);
+        udf = init(GenericUDAFCollectSet.class, constantArgs, argTypes, false, false);
         acc = udf.createAccumulator();
 
         udf.accumulate(acc, new Integer[] {1, 2});

--- a/flink-connectors/flink-connector-hive/src/test/resources/query-test/udaf.q
+++ b/flink-connectors/flink-connector-hive/src/test/resources/query-test/udaf.q
@@ -7,3 +7,6 @@ select sum(x) from foo;
 select percentile_approx(x, 0.5) from foo;
 
 [+I[2.5]]
+
+select i, collect_list(array(s)) from bar group by i;
+[+I[1, [[a], [aa]]], +I[2, [[b]]]]


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
To fix fail to call Hive UDAF when the UDAF accepts one parameter with array type


## Brief change log
When  the parameter is a single array, wrap it to an array.


## Verifying this change
Added test method `testUDAFCollectList`  in  [HiveGenericUDAFTest.java](https://github.com/apache/flink/compare/master...luoyuxia:fix-call-hive-collect-list-issue?expand=1#diff-347c8a1c08423da764ef8547e503d5772bf26cbdc72e281ed2cf7959085104be)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? N/A
