### PR TITLE
[FLINK-22732][table] Restrict ALTER TABLE from setting empty table op…

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
@@ -580,10 +580,10 @@ public class SqlToOperationConverter {
             ObjectIdentifier tableIdentifier,
             CatalogTable oldTable,
             SqlAlterTableOptions alterTableOptions) {
-        Map<String, String> setOptions =
+        Map<String, String> changeOptions =
                 OperationConverterUtils.extractProperties(alterTableOptions.getPropertyList());
-        if (setOptions.isEmpty()) {
-            throw new ValidationException("ALTER TABLE SET does not support empty key.");
+        if (changeOptions.isEmpty()) {
+            throw new ValidationException("ALTER TABLE SET does not support empty option.");
         }
 
         LinkedHashMap<String, String> partitionKVs = alterTableOptions.getPartitionKVs();
@@ -601,15 +601,13 @@ public class SqlToOperationConverter {
                                                             partitionSpec.getPartitionSpec(),
                                                             tableIdentifier)));
             Map<String, String> newProps = new HashMap<>(catalogPartition.getProperties());
-            newProps.putAll(setOptions);
+            newProps.putAll(changeOptions);
             return new AlterPartitionPropertiesOperation(
                     tableIdentifier,
                     partitionSpec,
                     new CatalogPartitionImpl(newProps, catalogPartition.getComment()));
         } else {
             // it's altering a table
-            Map<String, String> changeOptions =
-                    OperationConverterUtils.extractProperties(alterTableOptions.getPropertyList());
             Map<String, String> newOptions = new HashMap<>(oldTable.getOptions());
             newOptions.putAll(changeOptions);
             return new AlterTableChangeOperation(

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
@@ -580,6 +580,12 @@ public class SqlToOperationConverter {
             ObjectIdentifier tableIdentifier,
             CatalogTable oldTable,
             SqlAlterTableOptions alterTableOptions) {
+        Map<String, String> setOptions =
+                OperationConverterUtils.extractProperties(alterTableOptions.getPropertyList());
+        if (setOptions.isEmpty()) {
+            throw new ValidationException("ALTER TABLE SET does not support empty key.");
+        }
+
         LinkedHashMap<String, String> partitionKVs = alterTableOptions.getPartitionKVs();
         // it's altering partitions
         if (partitionKVs != null) {
@@ -595,8 +601,7 @@ public class SqlToOperationConverter {
                                                             partitionSpec.getPartitionSpec(),
                                                             tableIdentifier)));
             Map<String, String> newProps = new HashMap<>(catalogPartition.getProperties());
-            newProps.putAll(
-                    OperationConverterUtils.extractProperties(alterTableOptions.getPropertyList()));
+            newProps.putAll(setOptions);
             return new AlterPartitionPropertiesOperation(
                     tableIdentifier,
                     partitionSpec,

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
@@ -1256,9 +1256,9 @@ public class SqlToOperationConverterTest {
                 Arrays.asList(TableChange.set("k1", "v1"), TableChange.set("K2", "V2")),
                 "ALTER TABLE IF EXISTS cat1.db1.tb1\n  SET 'k1' = 'v1',\n  SET 'K2' = 'V2'");
 
-        assertThatThrownBy(() -> parse("alter table cat1.db1.tb1 set ()", SqlDialect.DEFAULT))
+        assertThatThrownBy(() -> parse("alter table cat1.db1.tb1 set ()"))
                 .isInstanceOf(ValidationException.class)
-                .hasMessageContaining("ALTER TABLE SET does not support empty key.");
+                .hasMessageContaining("ALTER TABLE SET does not support empty option.");
 
         // test alter table reset
         checkAlterNonExistTable("alter table %s nonexistent reset ('k')");

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
@@ -1256,6 +1256,10 @@ public class SqlToOperationConverterTest {
                 Arrays.asList(TableChange.set("k1", "v1"), TableChange.set("K2", "V2")),
                 "ALTER TABLE IF EXISTS cat1.db1.tb1\n  SET 'k1' = 'v1',\n  SET 'K2' = 'V2'");
 
+        assertThatThrownBy(() -> parse("alter table cat1.db1.tb1 set ()", SqlDialect.DEFAULT))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("ALTER TABLE SET does not support empty key.");
+
         // test alter table reset
         checkAlterNonExistTable("alter table %s nonexistent reset ('k')");
         operation = parse("alter table if exists cat1.db1.tb1 reset ('k')");


### PR DESCRIPTION
## What is the purpose of the change

Restrict ALTER TABLE SET syntax from setting empty table options

## Brief change log
  - *Restrict ALTER TABLE SET syntax from setting empty table options*

## Verifying this change

This change added tests and can be verified as follows:

*(example:)*
  - *Add unit test in SqlToOperationConverterTest*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes )
  - If yes, how is the feature documented? (not documented)
