### PR TITLE
[FLINK-27187][state/changelog] Add changelog storage metric totalAttemptsPerUpload

### DIFF
--- a/docs/content.zh/docs/ops/metrics.md
+++ b/docs/content.zh/docs/ops/metrics.md
@@ -1293,6 +1293,11 @@ Note that the metrics are only available via reporters.
       <td>Histogram</td>
     </tr>
     <tr>
+      <td>totalAttemptsPerUpload</td>
+      <td>The total count distributions of attempts for per upload</td>
+      <td>Histogram</td>
+    </tr>
+    <tr>
       <td>uploadBatchSizes</td>
       <td>The number of upload tasks (coming from one or more writers, i.e. backends/tasks) that were grouped together and form a single upload resulting in a single file</td>
       <td>Histogram</td>

--- a/docs/content/docs/ops/metrics.md
+++ b/docs/content/docs/ops/metrics.md
@@ -1286,6 +1286,11 @@ Note that the metrics are only available via reporters.
       <td>Histogram</td>
     </tr>
     <tr>
+      <td>totalAttemptsPerUpload</td>
+      <td>The total count distributions of attempts for per upload</td>
+      <td>Histogram</td>
+    </tr>
+    <tr>
       <td>uploadBatchSizes</td>
       <td>The number of upload tasks (coming from one or more writers, i.e. backends/tasks) that were grouped together and form a single upload resulting in a single file</td>
       <td>Histogram</td>

--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/BatchingStateChangeUploadScheduler.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/BatchingStateChangeUploadScheduler.java
@@ -114,7 +114,10 @@ class BatchingStateChangeUploadScheduler implements StateChangeUploadScheduler {
                 retryPolicy,
                 delegate,
                 SchedulerFactory.create(1, "ChangelogUploadScheduler", LOG),
-                new RetryingExecutor(numUploadThreads, metricGroup.getAttemptsPerUpload()),
+                new RetryingExecutor(
+                        numUploadThreads,
+                        metricGroup.getAttemptsPerUpload(),
+                        metricGroup.getTotalAttemptsPerUpload()),
                 metricGroup);
     }
 

--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/ChangelogStorageMetricGroup.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/ChangelogStorageMetricGroup.java
@@ -42,6 +42,7 @@ public class ChangelogStorageMetricGroup extends ProxyMetricGroup<MetricGroup> {
     private final Histogram uploadSizes;
     private final Histogram uploadLatenciesNanos;
     private final Histogram attemptsPerUpload;
+    private final Histogram totalAttemptsPerUpload;
 
     public ChangelogStorageMetricGroup(MetricGroup parent) {
         super(parent);
@@ -54,6 +55,10 @@ public class ChangelogStorageMetricGroup extends ProxyMetricGroup<MetricGroup> {
         this.attemptsPerUpload =
                 histogram(
                         CHANGELOG_STORAGE_ATTEMPTS_PER_UPLOAD,
+                        new DescriptiveStatisticsHistogram(WINDOW_SIZE));
+        this.totalAttemptsPerUpload =
+                histogram(
+                        CHANGELOG_STORAGE_TOTAL_ATTEMPTS_PER_UPLOAD,
                         new DescriptiveStatisticsHistogram(WINDOW_SIZE));
         this.uploadSizes =
                 histogram(
@@ -77,6 +82,10 @@ public class ChangelogStorageMetricGroup extends ProxyMetricGroup<MetricGroup> {
 
     public Histogram getAttemptsPerUpload() {
         return attemptsPerUpload;
+    }
+
+    public Histogram getTotalAttemptsPerUpload() {
+        return totalAttemptsPerUpload;
     }
 
     /**
@@ -138,6 +147,8 @@ public class ChangelogStorageMetricGroup extends ProxyMetricGroup<MetricGroup> {
             PREFIX + ".uploadLatenciesNanos";
     public static final String CHANGELOG_STORAGE_ATTEMPTS_PER_UPLOAD =
             PREFIX + ".attemptsPerUpload";
+    public static final String CHANGELOG_STORAGE_TOTAL_ATTEMPTS_PER_UPLOAD =
+            PREFIX + ".totalAttemptsPerUpload";
     public static final String CHANGELOG_STORAGE_UPLOAD_BATCH_SIZES = PREFIX + ".uploadBatchSizes";
     public static final String CHANGELOG_STORAGE_UPLOAD_QUEUE_SIZE = PREFIX + ".uploadQueueSize";
 }

--- a/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/ChangelogStorageMetricsTest.java
+++ b/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/ChangelogStorageMetricsTest.java
@@ -39,6 +39,8 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -145,7 +147,10 @@ public class ChangelogStorageMetricsTest {
                         RetryPolicy.NONE,
                         uploader,
                         scheduler,
-                        new RetryingExecutor(1, metrics.getAttemptsPerUpload()),
+                        new RetryingExecutor(
+                                1,
+                                metrics.getAttemptsPerUpload(),
+                                metrics.getTotalAttemptsPerUpload()),
                         metrics);
 
         FsStateChangelogStorage storage = new FsStateChangelogStorage(batcher, Integer.MAX_VALUE);
@@ -192,7 +197,10 @@ public class ChangelogStorageMetricsTest {
                         RetryPolicy.fixed(maxAttempts, Long.MAX_VALUE, 0),
                         new MaxAttemptUploader(maxAttempts),
                         newSingleThreadScheduledExecutor(),
-                        new RetryingExecutor(1, metrics.getAttemptsPerUpload()),
+                        new RetryingExecutor(
+                                1,
+                                metrics.getAttemptsPerUpload(),
+                                metrics.getTotalAttemptsPerUpload()),
                         metrics);
 
         FsStateChangelogStorage storage = new FsStateChangelogStorage(batcher, Integer.MAX_VALUE);
@@ -208,6 +216,46 @@ public class ChangelogStorageMetricsTest {
             storage.close();
         }
         HistogramStatistics histogram = metrics.getAttemptsPerUpload().getStatistics();
+        assertThat(histogram.getMin()).isEqualTo(maxAttempts);
+        assertThat(histogram.getMax()).isEqualTo(maxAttempts);
+    }
+
+    @Test
+    void testTotalAttemptsPerUpload() throws Exception {
+        int numUploads = 20, maxAttempts = 3;
+        long timeout = 20;
+        int numUploadThreads = 4; // must bigger or equal than maxAttempts
+
+        ChangelogStorageMetricGroup metrics =
+                new ChangelogStorageMetricGroup(createUnregisteredTaskManagerJobMetricGroup());
+
+        BatchingStateChangeUploadScheduler batcher =
+                new BatchingStateChangeUploadScheduler(
+                        Long.MAX_VALUE,
+                        1,
+                        Long.MAX_VALUE,
+                        RetryPolicy.fixed(maxAttempts, timeout, 0),
+                        new WaitingMaxAttemptUploader(maxAttempts),
+                        newSingleThreadScheduledExecutor(),
+                        new RetryingExecutor(
+                                numUploadThreads,
+                                metrics.getAttemptsPerUpload(),
+                                metrics.getTotalAttemptsPerUpload()),
+                        metrics);
+
+        FsStateChangelogStorage storage = new FsStateChangelogStorage(batcher, Integer.MAX_VALUE);
+        FsStateChangelogWriter writer = createWriter(storage);
+
+        try {
+            for (int upload = 0; upload < numUploads; upload++) {
+                SequenceNumber from = writer.nextSequenceNumber();
+                writer.append(0, new byte[] {0, 1, 2, 3});
+                writer.persist(from).get();
+            }
+        } finally {
+            storage.close();
+        }
+        HistogramStatistics histogram = metrics.getTotalAttemptsPerUpload().getStatistics();
         assertThat(histogram.getMin()).isEqualTo(maxAttempts);
         assertThat(histogram.getMax()).isEqualTo(maxAttempts);
     }
@@ -244,7 +292,10 @@ public class ChangelogStorageMetricsTest {
                         RetryPolicy.NONE,
                         delegate,
                         scheduler,
-                        new RetryingExecutor(1, metrics.getAttemptsPerUpload()),
+                        new RetryingExecutor(
+                                1,
+                                metrics.getAttemptsPerUpload(),
+                                metrics.getTotalAttemptsPerUpload()),
                         metrics);
         try (FsStateChangelogStorage storage =
                 new FsStateChangelogStorage(batcher, Long.MAX_VALUE)) {
@@ -292,6 +343,59 @@ public class ChangelogStorageMetricsTest {
         @Override
         public void close() {
             attemptsPerTask.clear();
+        }
+    }
+
+    private static class WaitingMaxAttemptUploader implements StateChangeUploader {
+        private final ConcurrentHashMap<UploadTask, CountDownLatch> remainingAttemptsPerTask;
+        private final Map<UploadTask, Integer> attemptsPerTask;
+        private final int maxAttempts;
+
+        public WaitingMaxAttemptUploader(int maxAttempts) {
+            if (maxAttempts < 1) {
+                throw new IllegalArgumentException("maxAttempts < 0");
+            }
+            this.maxAttempts = maxAttempts;
+            this.remainingAttemptsPerTask = new ConcurrentHashMap<>();
+            this.attemptsPerTask = new ConcurrentHashMap<>();
+        }
+
+        @Override
+        public UploadTasksResult upload(Collection<UploadTask> tasks) throws IOException {
+            int currentAttempt = 0;
+            for (UploadTask uploadTask : tasks) {
+                remainingAttemptsPerTask
+                        .computeIfAbsent(uploadTask, ign -> new CountDownLatch(maxAttempts))
+                        .countDown();
+                currentAttempt = 1 + attemptsPerTask.getOrDefault(uploadTask, 0);
+                attemptsPerTask.put(uploadTask, currentAttempt);
+            }
+            if (currentAttempt > 1 && currentAttempt < maxAttempts) {
+                throw new IOException();
+            }
+
+            for (UploadTask uploadTask : tasks) {
+                try {
+                    remainingAttemptsPerTask.get(uploadTask).await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IOException(e);
+                }
+            }
+
+            Map<UploadTask, Map<StateChangeSet, Long>> map = new HashMap<>();
+            for (UploadTask uploadTask : tasks) {
+                map.put(
+                        uploadTask,
+                        uploadTask.changeSets.stream()
+                                .collect(Collectors.toMap(Function.identity(), ign -> 0L)));
+            }
+            return new UploadTasksResult(map, new EmptyStreamStateHandle());
+        }
+
+        @Override
+        public void close() throws Exception {
+            // nothing to close
         }
     }
 

--- a/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/RetryingExecutorTest.java
+++ b/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/RetryingExecutorTest.java
@@ -75,10 +75,12 @@ class RetryingExecutorTest {
         List<Integer> discarded = new CopyOnWriteArrayList<>();
         AtomicBoolean executionBlocked = new AtomicBoolean(true);
         Deadline deadline = Deadline.fromNow(Duration.ofMinutes(5));
+        ChangelogStorageMetricGroup metrics = createUnregisteredChangelogStorageMetricGroup();
         try (RetryingExecutor executor =
                 new RetryingExecutor(
                         numAttempts,
-                        createUnregisteredChangelogStorageMetricGroup().getAttemptsPerUpload())) {
+                        metrics.getAttemptsPerUpload(),
+                        metrics.getTotalAttemptsPerUpload())) {
             executor.execute(
                     RetryPolicy.fixed(numAttempts, timeoutMs, 0),
                     new RetriableAction<Integer>() {
@@ -228,10 +230,12 @@ class RetryingExecutorTest {
             throws Exception {
         AtomicInteger attemptsMade = new AtomicInteger(0);
         CountDownLatch firstAttemptCompletedLatch = new CountDownLatch(1);
+        ChangelogStorageMetricGroup metrics = createUnregisteredChangelogStorageMetricGroup();
         try (RetryingExecutor executor =
                 new RetryingExecutor(
                         scheduler,
-                        createUnregisteredChangelogStorageMetricGroup().getAttemptsPerUpload())) {
+                        metrics.getAttemptsPerUpload(),
+                        metrics.getTotalAttemptsPerUpload())) {
             executor.execute(
                     policy,
                     runnableToAction(


### PR DESCRIPTION
## What is the purpose of the change

As [FLINK-27187](https://issues.apache.org/jira/browse/FLINK-27187) discussed, add changelog storage metric "totalAttemptsPerUpload" representing the total number distributions of attempts per upload. 

## Brief change log

  - add totalAttemptsPerUpload to ChangelogStorageMetricGroup
  - RetryingExecutor record total attempts and update totalAttemptsPerUpload with it


## Verifying this change

This change added tests and can be verified as follows:
  - *Added test ChangelogStorageMetricGroup.testTotalAttemptsPerUpload() that validates that totalAttemptsPerUpload calculate correctly*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
