### PR TITLE
[FLINK-27206][metrics] Deprecate reflection-based reporter instantiation 

### DIFF
--- a/docs/content.zh/docs/deployment/metric_reporters.md
+++ b/docs/content.zh/docs/deployment/metric_reporters.md
@@ -49,7 +49,7 @@ metrics.reporter.my_jmx_reporter.port: 9020-9040
 metrics.reporter.my_jmx_reporter.scope.variables.excludes: job_id;task_attempt_num
 metrics.reporter.my_jmx_reporter.scope.variables.additional: cluster_name:my_test_cluster,tag_name:tag_value
 
-metrics.reporter.my_other_reporter.class: org.apache.flink.metrics.graphite.GraphiteReporter
+metrics.reporter.my_other_reporter.factory.class: org.apache.flink.metrics.graphite.GraphiteReporterFactory
 metrics.reporter.my_other_reporter.host: 192.168.1.1
 metrics.reporter.my_other_reporter.port: 10000
 ```
@@ -180,7 +180,7 @@ Parameters:
 Example configuration:
 
 ```yaml
-metrics.reporter.prom.class: org.apache.flink.metrics.prometheus.PrometheusReporter
+metrics.reporter.prom.factory.class: org.apache.flink.metrics.prometheus.PrometheusReporterFactory
 ```
 
 Flink metric types are mapped to Prometheus metric types as follows: 
@@ -206,7 +206,7 @@ Parameters:
 Example configuration:
 
 ```yaml
-metrics.reporter.promgateway.class: org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporter
+metrics.reporter.promgateway.factory.class: org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterFactory
 metrics.reporter.promgateway.hostUrl: http://localhost:9091
 metrics.reporter.promgateway.jobName: myJob
 metrics.reporter.promgateway.randomJobNameSuffix: true

--- a/docs/content.zh/docs/deployment/metric_reporters.md
+++ b/docs/content.zh/docs/deployment/metric_reporters.md
@@ -36,7 +36,7 @@ Below is a list of parameters that are generally applicable to all reporters. Al
 
 {{< include_reporter_config "layouts/shortcodes/generated/metric_reporters_section.html" >}}
 
-All reporters must at least have either the `class` or `factory.class` property. Which property may/should be used depends on the reporter implementation. See the individual reporter configuration sections for more information.
+All reporter configurations must contain the `factory.class` property.
 Some reporters (referred to as `Scheduled`) allow specifying a reporting `interval`.
 
 Example reporter configuration that specifies multiple reporters:
@@ -54,10 +54,9 @@ metrics.reporter.my_other_reporter.host: 192.168.1.1
 metrics.reporter.my_other_reporter.port: 10000
 ```
 
-**Important:** The jar containing the reporter must be accessible when Flink is started. Reporters that support the
- `factory.class` property can be loaded as [plugins]({{< ref "docs/deployment/filesystems/plugins" >}}). Otherwise the jar must be placed
- in the /lib folder. Reporters that are shipped with Flink (i.e., all reporters documented on this page) are available
- by default.
+**Important:** The jar containing the reporter must be accessible when Flink is started.
+ Reporters are loaded as [plugins]({{< ref "docs/deployment/filesystems/plugins" >}}). 
+ All reporters documented on this page are available by default.
 
 You can write your own `Reporter` by implementing the `org.apache.flink.metrics.reporter.MetricReporter` interface.
 If the Reporter should send out reports regularly you have to implement the `Scheduled` interface as well.

--- a/docs/content/docs/deployment/metric_reporters.md
+++ b/docs/content/docs/deployment/metric_reporters.md
@@ -49,7 +49,7 @@ metrics.reporter.my_jmx_reporter.port: 9020-9040
 metrics.reporter.my_jmx_reporter.scope.variables.excludes: job_id;task_attempt_num
 metrics.reporter.my_jmx_reporter.scope.variables.additional: cluster_name:my_test_cluster,tag_name:tag_value
 
-metrics.reporter.my_other_reporter.class: org.apache.flink.metrics.graphite.GraphiteReporter
+metrics.reporter.my_other_reporter.factory.class: org.apache.flink.metrics.graphite.GraphiteReporterFactory
 metrics.reporter.my_other_reporter.host: 192.168.1.1
 metrics.reporter.my_other_reporter.port: 10000
 ```
@@ -180,7 +180,7 @@ Parameters:
 Example configuration:
 
 ```yaml
-metrics.reporter.prom.class: org.apache.flink.metrics.prometheus.PrometheusReporter
+metrics.reporter.prom.factory.class: org.apache.flink.metrics.prometheus.PrometheusReporterFactory
 ```
 
 Flink metric types are mapped to Prometheus metric types as follows: 
@@ -206,7 +206,7 @@ Parameters:
 Example configuration:
 
 ```yaml
-metrics.reporter.promgateway.class: org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporter
+metrics.reporter.promgateway.factory.class: org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterFactory
 metrics.reporter.promgateway.hostUrl: http://localhost:9091
 metrics.reporter.promgateway.jobName: myJob
 metrics.reporter.promgateway.randomJobNameSuffix: true

--- a/docs/content/docs/deployment/metric_reporters.md
+++ b/docs/content/docs/deployment/metric_reporters.md
@@ -36,7 +36,7 @@ Below is a list of parameters that are generally applicable to all reporters. Al
 
 {{< include_reporter_config "layouts/shortcodes/generated/metric_reporters_section.html" >}}
 
-All reporters must at least have either the `class` or `factory.class` property. Which property may/should be used depends on the reporter implementation. See the individual reporter configuration sections for more information.
+All reporter configurations must contain the `factory.class` property.
 Some reporters (referred to as `Scheduled`) allow specifying a reporting `interval`.
 
 Example reporter configuration that specifies multiple reporters:
@@ -54,10 +54,9 @@ metrics.reporter.my_other_reporter.host: 192.168.1.1
 metrics.reporter.my_other_reporter.port: 10000
 ```
 
-**Important:** The jar containing the reporter must be accessible when Flink is started. Reporters that support the
- `factory.class` property can be loaded as [plugins]({{< ref "docs/deployment/filesystems/plugins" >}}). Otherwise the jar must be placed
- in the /lib folder. Reporters that are shipped with Flink (i.e., all reporters documented on this page) are available
- by default.
+**Important:** The jar containing the reporter must be accessible when Flink is started.
+ Reporters are loaded as [plugins]({{< ref "docs/deployment/filesystems/plugins" >}}).
+ All reporters documented on this page are available by default.
 
 You can write your own `Reporter` by implementing the `org.apache.flink.metrics.reporter.MetricReporter` interface.
 If the Reporter should send out reports regularly you have to implement the `Scheduled` interface as well.

--- a/docs/layouts/shortcodes/generated/metric_configuration.html
+++ b/docs/layouts/shortcodes/generated/metric_configuration.html
@@ -57,12 +57,6 @@
             <td>Configures the parameter &lt;parameter&gt; for the reporter named &lt;name&gt;.</td>
         </tr>
         <tr>
-            <td><h5>metrics.reporter.&lt;name&gt;.class</h5></td>
-            <td style="word-wrap: break-word;">(none)</td>
-            <td>String</td>
-            <td>The reporter class to use for the reporter named &lt;name&gt;.</td>
-        </tr>
-        <tr>
             <td><h5>metrics.reporter.&lt;name&gt;.factory.class</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/docs/layouts/shortcodes/generated/metric_reporters_section.html
+++ b/docs/layouts/shortcodes/generated/metric_reporters_section.html
@@ -9,12 +9,6 @@
     </thead>
     <tbody>
         <tr>
-            <td><h5>metrics.reporter.&lt;name&gt;.class</h5></td>
-            <td style="word-wrap: break-word;">(none)</td>
-            <td>String</td>
-            <td>The reporter class to use for the reporter named &lt;name&gt;.</td>
-        </tr>
-        <tr>
             <td><h5>metrics.reporter.&lt;name&gt;.factory.class</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/MetricOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/MetricOptions.java
@@ -67,8 +67,8 @@ public class MetricOptions {
                                     + " any of the names in the list will be started. Otherwise, all reporters that could be found in"
                                     + " the configuration will be started.");
 
-    @Documentation.SuffixOption(NAMED_REPORTER_CONFIG_PREFIX)
-    @Documentation.Section(value = Documentation.Sections.METRIC_REPORTERS, position = 1)
+    /** @deprecated use {@link MetricOptions#REPORTER_FACTORY_CLASS} instead. */
+    @Deprecated
     public static final ConfigOption<String> REPORTER_CLASS =
             key("class")
                     .stringType()

--- a/flink-end-to-end-tests/flink-metrics-reporter-prometheus-test/src/test/java/org/apache/flink/metrics/prometheus/tests/PrometheusReporterEndToEndITCase.java
+++ b/flink-end-to-end-tests/flink-metrics-reporter-prometheus-test/src/test/java/org/apache/flink/metrics/prometheus/tests/PrometheusReporterEndToEndITCase.java
@@ -21,7 +21,6 @@ package org.apache.flink.metrics.prometheus.tests;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MetricOptions;
-import org.apache.flink.metrics.prometheus.PrometheusReporter;
 import org.apache.flink.metrics.prometheus.PrometheusReporterFactory;
 import org.apache.flink.tests.util.AutoClosableProcess;
 import org.apache.flink.tests.util.CommandLineWrapper;
@@ -60,8 +59,6 @@ import java.util.function.Consumer;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import static org.apache.flink.metrics.prometheus.tests.PrometheusReporterEndToEndITCase.TestParams.InstantiationType.FACTORY;
-import static org.apache.flink.metrics.prometheus.tests.PrometheusReporterEndToEndITCase.TestParams.InstantiationType.REFLECTION;
 import static org.apache.flink.tests.util.AutoClosableProcess.runBlocking;
 import static org.apache.flink.tests.util.AutoClosableProcess.runNonBlocking;
 
@@ -131,32 +128,14 @@ public class PrometheusReporterEndToEndITCase extends TestLogger {
                                 builder.moveJar(
                                         PROMETHEUS_JAR_PREFIX,
                                         JarLocation.PLUGINS,
-                                        JarLocation.LIB),
-                        REFLECTION),
-                TestParams.from(
-                        "Jar in 'lib'",
-                        builder ->
-                                builder.moveJar(
-                                        PROMETHEUS_JAR_PREFIX,
-                                        JarLocation.PLUGINS,
-                                        JarLocation.LIB),
-                        FACTORY),
-                TestParams.from("Jar in 'plugins'", builder -> {}, REFLECTION),
-                TestParams.from("Jar in 'plugins'", builder -> {}, FACTORY),
+                                        JarLocation.LIB)),
+                TestParams.from("Jar in 'plugins'", builder -> {}),
                 TestParams.from(
                         "Jar in 'lib' and 'plugins'",
                         builder -> {
                             builder.copyJar(
                                     PROMETHEUS_JAR_PREFIX, JarLocation.PLUGINS, JarLocation.LIB);
-                        },
-                        REFLECTION),
-                TestParams.from(
-                        "Jar in 'lib' and 'plugins'",
-                        builder -> {
-                            builder.copyJar(
-                                    PROMETHEUS_JAR_PREFIX, JarLocation.PLUGINS, JarLocation.LIB);
-                        },
-                        FACTORY));
+                        }));
     }
 
     @Rule public final FlinkResource dist;
@@ -164,7 +143,7 @@ public class PrometheusReporterEndToEndITCase extends TestLogger {
     public PrometheusReporterEndToEndITCase(TestParams params) {
         final FlinkResourceSetup.FlinkResourceSetupBuilder builder = FlinkResourceSetup.builder();
         params.getBuilderSetup().accept(builder);
-        builder.addConfiguration(getFlinkConfig(params.getInstantiationType()));
+        builder.addConfiguration(getFlinkConfig());
         dist = new LocalStandaloneFlinkResourceFactory().create(builder.build());
     }
 
@@ -172,24 +151,14 @@ public class PrometheusReporterEndToEndITCase extends TestLogger {
 
     @Rule public final DownloadCache downloadCache = DownloadCache.get();
 
-    private static Configuration getFlinkConfig(TestParams.InstantiationType instantiationType) {
+    private static Configuration getFlinkConfig() {
         final Configuration config = new Configuration();
 
-        switch (instantiationType) {
-            case FACTORY:
-                config.setString(
-                        ConfigConstants.METRICS_REPORTER_PREFIX
-                                + "prom."
-                                + MetricOptions.REPORTER_FACTORY_CLASS.key(),
-                        PrometheusReporterFactory.class.getName());
-                break;
-            case REFLECTION:
-                config.setString(
-                        ConfigConstants.METRICS_REPORTER_PREFIX
-                                + "prom."
-                                + MetricOptions.REPORTER_CLASS.key(),
-                        PrometheusReporter.class.getCanonicalName());
-        }
+        config.setString(
+                ConfigConstants.METRICS_REPORTER_PREFIX
+                        + "prom."
+                        + MetricOptions.REPORTER_FACTORY_CLASS.key(),
+                PrometheusReporterFactory.class.getName());
 
         config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "prom.port", "9000-9100");
         return config;
@@ -324,42 +293,27 @@ public class PrometheusReporterEndToEndITCase extends TestLogger {
     static class TestParams {
         private final String jarLocationDescription;
         private final Consumer<FlinkResourceSetup.FlinkResourceSetupBuilder> builderSetup;
-        private final InstantiationType instantiationType;
 
         private TestParams(
                 String jarLocationDescription,
-                Consumer<FlinkResourceSetup.FlinkResourceSetupBuilder> builderSetup,
-                InstantiationType instantiationType) {
+                Consumer<FlinkResourceSetup.FlinkResourceSetupBuilder> builderSetup) {
             this.jarLocationDescription = jarLocationDescription;
             this.builderSetup = builderSetup;
-            this.instantiationType = instantiationType;
         }
 
         public static TestParams from(
                 String jarLocationDesription,
-                Consumer<FlinkResourceSetup.FlinkResourceSetupBuilder> builderSetup,
-                InstantiationType instantiationType) {
-            return new TestParams(jarLocationDesription, builderSetup, instantiationType);
+                Consumer<FlinkResourceSetup.FlinkResourceSetupBuilder> builderSetup) {
+            return new TestParams(jarLocationDesription, builderSetup);
         }
 
         public Consumer<FlinkResourceSetup.FlinkResourceSetupBuilder> getBuilderSetup() {
             return builderSetup;
         }
 
-        public InstantiationType getInstantiationType() {
-            return instantiationType;
-        }
-
         @Override
         public String toString() {
-            return jarLocationDescription
-                    + ", instantiated via "
-                    + instantiationType.name().toLowerCase();
-        }
-
-        public enum InstantiationType {
-            REFLECTION,
-            FACTORY
+            return jarLocationDescription;
         }
     }
 }

--- a/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/reporter/InstantiateViaFactory.java
+++ b/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/reporter/InstantiateViaFactory.java
@@ -34,10 +34,13 @@ import java.lang.annotation.Target;
  *
  * <p>Attention: This annotation does not work if the reporter is loaded as a plugin. For these
  * cases, annotate the factory with {@link InterceptInstantiationViaReflection} instead.
+ *
+ * @deprecated Will be removed in a future version. Users should use all reporters as plugins.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 @Public
+@Deprecated
 public @interface InstantiateViaFactory {
     String factoryClassName();
 }

--- a/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/reporter/InterceptInstantiationViaReflection.java
+++ b/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/reporter/InterceptInstantiationViaReflection.java
@@ -32,10 +32,12 @@ import java.lang.annotation.Target;
  * instead.
  *
  * @see InstantiateViaFactory
+ * @deprecated Will be removed in a future version. Users should use all reporters as plugins.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 @Public
+@Deprecated
 public @interface InterceptInstantiationViaReflection {
     String reporterClassName();
 }

--- a/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/reporter/MetricReporter.java
+++ b/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/reporter/MetricReporter.java
@@ -26,11 +26,7 @@ import org.apache.flink.metrics.MetricGroup;
 /**
  * Reporters are used to export {@link Metric Metrics} to an external backend.
  *
- * <p>Reporters are instantiated either a) via reflection, in which case they must be public,
- * non-abstract, and have a public no-argument constructor. b) via a {@link MetricReporterFactory},
- * in which case no restrictions apply. (recommended)
- *
- * <p>Reporters are neither required nor encouraged to support both instantiation paths.
+ * <p>Reporters are instantiated via a {@link MetricReporterFactory}.
  */
 @Public
 public interface MetricReporter {

--- a/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/reporter/MetricReporterFactory.java
+++ b/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/reporter/MetricReporterFactory.java
@@ -29,10 +29,6 @@ import java.util.Properties;
  * plugin, so long as the reporter jar is self-contained (excluding Flink dependencies) and contains
  * a {@code META-INF/services/org.apache.flink.metrics.reporter.MetricReporterFactory} file
  * containing the qualified class name of the factory.
- *
- * <p>Reporters that previously relied on reflection for instantiation can use the {@link
- * InstantiateViaFactory} annotation to redirect reflection-base instantiation attempts to the
- * factory instead.
  */
 @Public
 public interface MetricReporterFactory {

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporter.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporter.java
@@ -25,7 +25,6 @@ import org.apache.flink.metrics.Meter;
 import org.apache.flink.metrics.Metric;
 import org.apache.flink.metrics.MetricConfig;
 import org.apache.flink.metrics.MetricGroup;
-import org.apache.flink.metrics.reporter.InstantiateViaFactory;
 import org.apache.flink.metrics.reporter.MetricReporter;
 import org.apache.flink.metrics.reporter.Scheduled;
 
@@ -44,8 +43,6 @@ import java.util.concurrent.ConcurrentHashMap;
  *
  * <p>Variables in metrics scope will be sent to Datadog as tags.
  */
-@InstantiateViaFactory(
-        factoryClassName = "org.apache.flink.metrics.datadog.DatadogHttpReporterFactory")
 public class DatadogHttpReporter implements MetricReporter, Scheduled {
     private static final Logger LOGGER = LoggerFactory.getLogger(DatadogHttpReporter.class);
     private static final String HOST_VARIABLE = "<host>";

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporterFactory.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporterFactory.java
@@ -18,15 +18,12 @@
 
 package org.apache.flink.metrics.datadog;
 
-import org.apache.flink.metrics.reporter.InterceptInstantiationViaReflection;
 import org.apache.flink.metrics.reporter.MetricReporter;
 import org.apache.flink.metrics.reporter.MetricReporterFactory;
 
 import java.util.Properties;
 
 /** {@link MetricReporterFactory} for {@link DatadogHttpReporter}. */
-@InterceptInstantiationViaReflection(
-        reporterClassName = "org.apache.flink.metrics.datadog.DatadogHttpReporter")
 public class DatadogHttpReporterFactory implements MetricReporterFactory {
 
     @Override

--- a/flink-metrics/flink-metrics-graphite/src/main/java/org/apache/flink/metrics/graphite/GraphiteReporter.java
+++ b/flink-metrics/flink-metrics-graphite/src/main/java/org/apache/flink/metrics/graphite/GraphiteReporter.java
@@ -21,7 +21,6 @@ package org.apache.flink.metrics.graphite;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.dropwizard.ScheduledDropwizardReporter;
 import org.apache.flink.metrics.MetricConfig;
-import org.apache.flink.metrics.reporter.InstantiateViaFactory;
 
 import com.codahale.metrics.ScheduledReporter;
 import com.codahale.metrics.graphite.Graphite;
@@ -34,8 +33,6 @@ import java.util.concurrent.TimeUnit;
  * allows using it as a Flink reporter.
  */
 @PublicEvolving
-@InstantiateViaFactory(
-        factoryClassName = "org.apache.flink.metrics.graphite.GraphiteReporterFactory")
 public class GraphiteReporter extends ScheduledDropwizardReporter {
 
     public static final String ARG_PROTOCOL = "protocol";

--- a/flink-metrics/flink-metrics-graphite/src/main/java/org/apache/flink/metrics/graphite/GraphiteReporterFactory.java
+++ b/flink-metrics/flink-metrics-graphite/src/main/java/org/apache/flink/metrics/graphite/GraphiteReporterFactory.java
@@ -18,15 +18,12 @@
 
 package org.apache.flink.metrics.graphite;
 
-import org.apache.flink.metrics.reporter.InterceptInstantiationViaReflection;
 import org.apache.flink.metrics.reporter.MetricReporter;
 import org.apache.flink.metrics.reporter.MetricReporterFactory;
 
 import java.util.Properties;
 
 /** {@link MetricReporterFactory} for {@link GraphiteReporter}. */
-@InterceptInstantiationViaReflection(
-        reporterClassName = "org.apache.flink.metrics.graphite.GraphiteReporter")
 public class GraphiteReporterFactory implements MetricReporterFactory {
 
     @Override

--- a/flink-metrics/flink-metrics-influxdb/src/main/java/org/apache/flink/metrics/influxdb/InfluxdbReporter.java
+++ b/flink-metrics/flink-metrics-influxdb/src/main/java/org/apache/flink/metrics/influxdb/InfluxdbReporter.java
@@ -24,7 +24,6 @@ import org.apache.flink.metrics.Histogram;
 import org.apache.flink.metrics.Meter;
 import org.apache.flink.metrics.Metric;
 import org.apache.flink.metrics.MetricConfig;
-import org.apache.flink.metrics.reporter.InstantiateViaFactory;
 import org.apache.flink.metrics.reporter.MetricReporter;
 import org.apache.flink.metrics.reporter.Scheduled;
 import org.apache.flink.util.NetUtils;
@@ -57,8 +56,6 @@ import static org.apache.flink.metrics.influxdb.InfluxdbReporterOptions.getSchem
 import static org.apache.flink.metrics.influxdb.InfluxdbReporterOptions.getString;
 
 /** {@link MetricReporter} that exports {@link Metric Metrics} via InfluxDB. */
-@InstantiateViaFactory(
-        factoryClassName = "org.apache.flink.metrics.influxdb.InfluxdbReporterFactory")
 public class InfluxdbReporter extends AbstractReporter<MeasurementInfo> implements Scheduled {
 
     private String database;

--- a/flink-metrics/flink-metrics-influxdb/src/main/java/org/apache/flink/metrics/influxdb/InfluxdbReporterFactory.java
+++ b/flink-metrics/flink-metrics-influxdb/src/main/java/org/apache/flink/metrics/influxdb/InfluxdbReporterFactory.java
@@ -18,15 +18,12 @@
 
 package org.apache.flink.metrics.influxdb;
 
-import org.apache.flink.metrics.reporter.InterceptInstantiationViaReflection;
 import org.apache.flink.metrics.reporter.MetricReporter;
 import org.apache.flink.metrics.reporter.MetricReporterFactory;
 
 import java.util.Properties;
 
 /** {@link MetricReporterFactory} for {@link InfluxdbReporter}. */
-@InterceptInstantiationViaReflection(
-        reporterClassName = "org.apache.flink.metrics.influxdb.InfluxdbReporter")
 public class InfluxdbReporterFactory implements MetricReporterFactory {
 
     @Override

--- a/flink-metrics/flink-metrics-jmx/src/main/java/org/apache/flink/metrics/jmx/JMXReporter.java
+++ b/flink-metrics/flink-metrics-jmx/src/main/java/org/apache/flink/metrics/jmx/JMXReporter.java
@@ -29,7 +29,6 @@ import org.apache.flink.metrics.Meter;
 import org.apache.flink.metrics.Metric;
 import org.apache.flink.metrics.MetricConfig;
 import org.apache.flink.metrics.MetricGroup;
-import org.apache.flink.metrics.reporter.InstantiateViaFactory;
 import org.apache.flink.metrics.reporter.MetricReporter;
 
 import org.slf4j.Logger;
@@ -55,7 +54,6 @@ import java.util.Optional;
  * <p>Largely based on the JmxReporter class of the dropwizard metrics library
  * https://github.com/dropwizard/metrics/blob/master/metrics-core/src/main/java/io/dropwizard/metrics/JmxReporter.java
  */
-@InstantiateViaFactory(factoryClassName = "org.apache.flink.metrics.jmx.JMXReporterFactory")
 public class JMXReporter implements MetricReporter {
 
     static final String JMX_DOMAIN_PREFIX = "org.apache.flink.";

--- a/flink-metrics/flink-metrics-jmx/src/main/java/org/apache/flink/metrics/jmx/JMXReporterFactory.java
+++ b/flink-metrics/flink-metrics-jmx/src/main/java/org/apache/flink/metrics/jmx/JMXReporterFactory.java
@@ -17,13 +17,11 @@
 
 package org.apache.flink.metrics.jmx;
 
-import org.apache.flink.metrics.reporter.InterceptInstantiationViaReflection;
 import org.apache.flink.metrics.reporter.MetricReporterFactory;
 
 import java.util.Properties;
 
 /** {@link MetricReporterFactory} for {@link JMXReporter}. */
-@InterceptInstantiationViaReflection(reporterClassName = "org.apache.flink.metrics.jmx.JMXReporter")
 public class JMXReporterFactory implements MetricReporterFactory {
 
     static final String ARG_PORT = "port";

--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporter.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporter.java
@@ -21,7 +21,6 @@ package org.apache.flink.metrics.prometheus;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.metrics.Metric;
-import org.apache.flink.metrics.reporter.InstantiateViaFactory;
 import org.apache.flink.metrics.reporter.MetricReporter;
 import org.apache.flink.metrics.reporter.Scheduled;
 import org.apache.flink.util.Preconditions;
@@ -37,9 +36,6 @@ import java.util.Map;
  * {@link MetricReporter} that exports {@link Metric Metrics} via Prometheus {@link PushGateway}.
  */
 @PublicEvolving
-@InstantiateViaFactory(
-        factoryClassName =
-                "org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterFactory")
 public class PrometheusPushGatewayReporter extends AbstractPrometheusReporter implements Scheduled {
 
     private final PushGateway pushGateway;

--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterFactory.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterFactory.java
@@ -19,7 +19,6 @@ package org.apache.flink.metrics.prometheus;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.metrics.MetricConfig;
-import org.apache.flink.metrics.reporter.InterceptInstantiationViaReflection;
 import org.apache.flink.metrics.reporter.MetricReporterFactory;
 import org.apache.flink.util.AbstractID;
 import org.apache.flink.util.StringUtils;
@@ -43,8 +42,6 @@ import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterO
 import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterOptions.RANDOM_JOB_NAME_SUFFIX;
 
 /** {@link MetricReporterFactory} for {@link PrometheusPushGatewayReporter}. */
-@InterceptInstantiationViaReflection(
-        reporterClassName = "org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporter")
 public class PrometheusPushGatewayReporterFactory implements MetricReporterFactory {
 
     private static final Logger LOG =

--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusReporter.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusReporter.java
@@ -21,7 +21,6 @@ package org.apache.flink.metrics.prometheus;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.metrics.Metric;
-import org.apache.flink.metrics.reporter.InstantiateViaFactory;
 import org.apache.flink.metrics.reporter.MetricReporter;
 import org.apache.flink.util.Preconditions;
 
@@ -32,8 +31,6 @@ import java.util.Iterator;
 
 /** {@link MetricReporter} that exports {@link Metric Metrics} via Prometheus. */
 @PublicEvolving
-@InstantiateViaFactory(
-        factoryClassName = "org.apache.flink.metrics.prometheus.PrometheusReporterFactory")
 public class PrometheusReporter extends AbstractPrometheusReporter {
 
     private HTTPServer httpServer;

--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusReporterFactory.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusReporterFactory.java
@@ -18,7 +18,6 @@
 package org.apache.flink.metrics.prometheus;
 
 import org.apache.flink.metrics.MetricConfig;
-import org.apache.flink.metrics.reporter.InterceptInstantiationViaReflection;
 import org.apache.flink.metrics.reporter.MetricReporterFactory;
 import org.apache.flink.util.NetUtils;
 
@@ -26,8 +25,6 @@ import java.util.Iterator;
 import java.util.Properties;
 
 /** {@link MetricReporterFactory} for {@link PrometheusReporter}. */
-@InterceptInstantiationViaReflection(
-        reporterClassName = "org.apache.flink.metrics.prometheus.PrometheusReporter")
 public class PrometheusReporterFactory implements MetricReporterFactory {
 
     static final String ARG_PORT = "port";

--- a/flink-metrics/flink-metrics-slf4j/src/main/java/org/apache/flink/metrics/slf4j/Slf4jReporter.java
+++ b/flink-metrics/flink-metrics-slf4j/src/main/java/org/apache/flink/metrics/slf4j/Slf4jReporter.java
@@ -27,7 +27,6 @@ import org.apache.flink.metrics.Meter;
 import org.apache.flink.metrics.Metric;
 import org.apache.flink.metrics.MetricConfig;
 import org.apache.flink.metrics.reporter.AbstractReporter;
-import org.apache.flink.metrics.reporter.InstantiateViaFactory;
 import org.apache.flink.metrics.reporter.MetricReporter;
 import org.apache.flink.metrics.reporter.Scheduled;
 
@@ -39,7 +38,6 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 
 /** {@link MetricReporter} that exports {@link Metric Metrics} via SLF4J {@link Logger}. */
-@InstantiateViaFactory(factoryClassName = "org.apache.flink.metrics.slf4j.Slf4jReporterFactory")
 public class Slf4jReporter extends AbstractReporter implements Scheduled {
     private static final Logger LOG = LoggerFactory.getLogger(Slf4jReporter.class);
     private static final String lineSeparator = System.lineSeparator();

--- a/flink-metrics/flink-metrics-slf4j/src/main/java/org/apache/flink/metrics/slf4j/Slf4jReporterFactory.java
+++ b/flink-metrics/flink-metrics-slf4j/src/main/java/org/apache/flink/metrics/slf4j/Slf4jReporterFactory.java
@@ -17,15 +17,12 @@
 
 package org.apache.flink.metrics.slf4j;
 
-import org.apache.flink.metrics.reporter.InterceptInstantiationViaReflection;
 import org.apache.flink.metrics.reporter.MetricReporter;
 import org.apache.flink.metrics.reporter.MetricReporterFactory;
 
 import java.util.Properties;
 
 /** {@link MetricReporterFactory} for {@link Slf4jReporter}. */
-@InterceptInstantiationViaReflection(
-        reporterClassName = "org.apache.flink.metrics.slf4j.Slf4jReporter")
 public class Slf4jReporterFactory implements MetricReporterFactory {
 
     @Override

--- a/flink-metrics/flink-metrics-statsd/src/main/java/org/apache/flink/metrics/statsd/StatsDReporter.java
+++ b/flink-metrics/flink-metrics-statsd/src/main/java/org/apache/flink/metrics/statsd/StatsDReporter.java
@@ -26,7 +26,6 @@ import org.apache.flink.metrics.HistogramStatistics;
 import org.apache.flink.metrics.Meter;
 import org.apache.flink.metrics.MetricConfig;
 import org.apache.flink.metrics.reporter.AbstractReporter;
-import org.apache.flink.metrics.reporter.InstantiateViaFactory;
 import org.apache.flink.metrics.reporter.Scheduled;
 
 import org.slf4j.Logger;
@@ -50,7 +49,6 @@ import java.util.NoSuchElementException;
  * <p>Ported since it was not present in maven central.
  */
 @PublicEvolving
-@InstantiateViaFactory(factoryClassName = "org.apache.flink.metrics.statsd.StatsDReporterFactory")
 public class StatsDReporter extends AbstractReporter implements Scheduled {
 
     private static final Logger LOG = LoggerFactory.getLogger(StatsDReporter.class);

--- a/flink-metrics/flink-metrics-statsd/src/main/java/org/apache/flink/metrics/statsd/StatsDReporterFactory.java
+++ b/flink-metrics/flink-metrics-statsd/src/main/java/org/apache/flink/metrics/statsd/StatsDReporterFactory.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.metrics.statsd;
 
-import org.apache.flink.metrics.reporter.InterceptInstantiationViaReflection;
 import org.apache.flink.metrics.reporter.MetricReporter;
 import org.apache.flink.metrics.reporter.MetricReporterFactory;
 
@@ -27,8 +26,6 @@ import java.util.Properties;
 /**
  * A {@link MetricReporterFactory} implementation that creates a {@link StatsDReporter} instance.
  */
-@InterceptInstantiationViaReflection(
-        reporterClassName = "org.apache.flink.metrics.statsd.StatsDReporter")
 public class StatsDReporterFactory implements MetricReporterFactory {
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/ReporterSetup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/ReporterSetup.java
@@ -71,6 +71,7 @@ public final class ReporterSetup {
 
     // regex pattern to extract the name from reporter configuration keys, e.g. "rep" from
     // "metrics.reporter.rep.class"
+    @SuppressWarnings("deprecation")
     private static final Pattern reporterClassPattern =
             Pattern.compile(
                     Pattern.quote(ConfigConstants.METRICS_REPORTER_PREFIX)
@@ -360,6 +361,7 @@ public final class ReporterSetup {
         return reporterSetups;
     }
 
+    @SuppressWarnings("deprecation")
     private static Optional<MetricReporter> loadReporter(
             final String reporterName,
             final Configuration reporterConfig,
@@ -375,6 +377,15 @@ public final class ReporterSetup {
         }
 
         if (reporterClassName != null) {
+            LOG.warn(
+                    "The reporter configuration of '{}' configures the reporter class, which is a deprecated approach to configure reporters."
+                            + " Please configure a factory class instead: '{}{}.{}: <factoryClass>' to ensure that the configuration"
+                            + " continues to work with future versions.",
+                    reporterName,
+                    ConfigConstants.METRICS_REPORTER_PREFIX,
+                    reporterName,
+                    MetricOptions.REPORTER_FACTORY_CLASS.key());
+
             final Optional<MetricReporterFactory> interceptingFactory =
                     reporterFactories.values().stream()
                             .filter(
@@ -434,6 +445,7 @@ public final class ReporterSetup {
         return Optional.of(factory.createMetricReporter(metricConfig));
     }
 
+    @SuppressWarnings("deprecation")
     private static Optional<MetricReporter> loadViaReflection(
             final String reporterClassName,
             final String reporterName,
@@ -448,15 +460,6 @@ public final class ReporterSetup {
         if (alternativeFactoryAnnotation != null) {
             final String alternativeFactoryClassName =
                     alternativeFactoryAnnotation.factoryClassName();
-            LOG.info(
-                    "The reporter configuration of {} is out-dated (but still supported)."
-                            + " Please configure a factory class instead: '{}{}.{}: {}' to ensure that the configuration"
-                            + " continues to work with future versions.",
-                    reporterName,
-                    MetricOptions.REPORTER_CLASS.key(),
-                    reporterName,
-                    MetricOptions.REPORTER_FACTORY_CLASS.key(),
-                    alternativeFactoryClassName);
             return loadViaFactory(
                     alternativeFactoryClassName, reporterName, reporterConfig, reporterFactories);
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/ReporterSetupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/ReporterSetupTest.java
@@ -306,7 +306,8 @@ class ReporterSetupTest {
      * are configured.
      */
     @Test
-    void testFactoryPrioritization() throws Exception {
+    @SuppressWarnings("deprecation")
+    public void testFactoryPrioritization() throws Exception {
         final Configuration config = new Configuration();
         config.setString(
                 ConfigConstants.METRICS_REPORTER_PREFIX
@@ -352,7 +353,8 @@ class ReporterSetupTest {
 
     /** Verifies that factory/reflection approaches can be mixed freely. */
     @Test
-    void testMixedSetupsFactoryParsing() throws Exception {
+    @SuppressWarnings("deprecation")
+    public void testMixedSetupsFactoryParsing() throws Exception {
         final Configuration config = new Configuration();
         config.setString(
                 ConfigConstants.METRICS_REPORTER_PREFIX
@@ -401,7 +403,8 @@ class ReporterSetupTest {
      * InstantiateViaFactory}.
      */
     @Test
-    void testFactoryAnnotation() {
+    @SuppressWarnings("deprecation")
+    public void testFactoryAnnotation() {
         final Configuration config = new Configuration();
         config.setString(
                 ConfigConstants.METRICS_REPORTER_PREFIX
@@ -425,7 +428,8 @@ class ReporterSetupTest {
      * org.apache.flink.metrics.reporter.InterceptInstantiationViaReflection}.
      */
     @Test
-    void testReflectionInterception() {
+    @SuppressWarnings("deprecation")
+    public void testReflectionInterception() {
         final Configuration config = new Configuration();
         config.setString(
                 ConfigConstants.METRICS_REPORTER_PREFIX
@@ -534,6 +538,7 @@ class ReporterSetupTest {
     @InterceptInstantiationViaReflection(
             reporterClassName =
                     "org.apache.flink.runtime.metrics.ReporterSetupTest$InstantiationTypeTrackingTestReporter")
+    @SuppressWarnings("deprecation")
     public static class InterceptingInstantiationTypeTrackingTestReporterFactory
             implements MetricReporterFactory {
 
@@ -565,6 +570,7 @@ class ReporterSetupTest {
     @InstantiateViaFactory(
             factoryClassName =
                     "org.apache.flink.runtime.metrics.ReporterSetupTest$InstantiationTypeTrackingTestReporterFactory")
+    @SuppressWarnings("deprecation")
     protected static class InstantiationTypeTrackingTestReporter2
             extends InstantiationTypeTrackingTestReporter {}
 }


### PR DESCRIPTION
Based on #17228.

Metric reporters can currently be instantiated in one of 2 ways:
a) the reporter class is loaded via reflection
b) the reporter factory is loaded via reflection/ServiceLoader (aka, plugins)

All reporters provided by Flink use the factory approach, and it is preferable because it supports plugins. The plugin approach also has been available 1.11, and I think it's fair to deprecate the old approach by now.
