### PR TITLE
[FLINK-27209][build] Half the memory and double forkCount for running unit tests

### DIFF
--- a/flink-end-to-end-tests/run-nightly-tests.sh
+++ b/flink-end-to-end-tests/run-nightly-tests.sh
@@ -258,7 +258,7 @@ function run_group_2 {
     LOG4J_PROPERTIES=${END_TO_END_DIR}/../tools/ci/log4j.properties
 
     MVN_LOGGING_OPTIONS="-Dlog.dir=${DEBUG_FILES_OUTPUT_DIR} -DlogBackupDir=${DEBUG_FILES_OUTPUT_DIR} -Dlog4j.configurationFile=file://$LOG4J_PROPERTIES"
-    MVN_COMMON_OPTIONS="-Dflink.forkCount=2 -Dfast -Pskip-webui-build"
+    MVN_COMMON_OPTIONS="-Dfast -Pskip-webui-build"
     e2e_modules=$(find flink-end-to-end-tests -mindepth 2 -maxdepth 5 -name 'pom.xml' -printf '%h\n' | sort -u | tr '\n' ',')
     e2e_modules="${e2e_modules},$(find flink-walkthroughs -mindepth 2 -maxdepth 2 -name 'pom.xml' -printf '%h\n' | sort -u | tr '\n' ',')"
 

--- a/pom.xml
+++ b/pom.xml
@@ -95,10 +95,15 @@ under the License.
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<hadoop.version>2.8.5</hadoop.version>
+		<flink.XmxITCase>2048m</flink.XmxITCase>
+		<flink.XmxUnitTest>1024m</flink.XmxUnitTest>
 		<!-- Need to use a user property here because the surefire
 			 forkCount is not exposed as a property. With this we can set
 			 it on the "mvn" commandline in travis. -->
-		<flink.forkCount>2</flink.forkCount>
+		<!-- Number of forkCounts for ITCase and UnitTest should take into account allocated memory
+			 to the jvm (-Xmx) and the available memory on the machine running the test -->
+		<flink.forkCountITCase>2</flink.forkCountITCase>
+		<flink.forkCountUnitTest>4</flink.forkCountUnitTest>
 		<flink.reuseForks>true</flink.reuseForks>
 		<flink.shaded.version>15.0</flink.shaded.version>
 		<flink.shaded.jackson.version>2.12.4</flink.shaded.jackson.version>
@@ -1580,7 +1585,6 @@ under the License.
 				<configuration>
 					<!-- enables TCP/IP communication between surefire and forked JVM-->
 					<forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
-					<forkCount>${flink.forkCount}</forkCount>
 					<reuseForks>${flink.reuseForks}</reuseForks>
 					<trimStackTrace>false</trimStackTrace>
 					<systemPropertyVariables combine.children="append">
@@ -1617,7 +1621,8 @@ under the License.
 							<includes>
 								<include>${test.unit.pattern}</include>
 							</includes>
-							<argLine>-Xms256m -Xmx1792m -XX:+UseG1GC</argLine>
+							<forkCount>${flink.forkCountUnitTest}</forkCount>
+							<argLine>-Xms256m -Xmx${flink.XmxUnitTest} -XX:+UseG1GC</argLine>
 						</configuration>
 					</execution>
 					<!--execute all the integration tests-->
@@ -1637,7 +1642,8 @@ under the License.
 								     e.g., 'org.apache.flink.api.scala.typeutils.Foo$Bar$Foobar'. -->
 								<exclude>**/*$*</exclude>
 							</excludes>
-							<argLine>-Xms256m -Xmx2048m -XX:+UseG1GC</argLine>
+							<forkCount>${flink.forkCountITCase}</forkCount>
+							<argLine>-Xms256m -Xmx${flink.XmxITCase} -XX:+UseG1GC</argLine>
 							<reuseForks>false</reuseForks>
 						</configuration>
 					</execution>

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@ under the License.
 		<!-- Need to use a user property here because the surefire
 			 forkCount is not exposed as a property. With this we can set
 			 it on the "mvn" commandline in travis. -->
-		<flink.forkCount>1C</flink.forkCount>
+		<flink.forkCount>2</flink.forkCount>
 		<flink.reuseForks>true</flink.reuseForks>
 		<flink.shaded.version>15.0</flink.shaded.version>
 		<flink.shaded.jackson.version>2.12.4</flink.shaded.jackson.version>

--- a/tools/ci/compile.sh
+++ b/tools/ci/compile.sh
@@ -47,7 +47,7 @@ echo "==========================================================================
 
 EXIT_CODE=0
 
-run_mvn clean deploy -DaltDeploymentRepository=validation_repository::default::file:$MVN_VALIDATION_DIR -Dflink.convergence.phase=install -Pcheck-convergence -Dflink.forkCount=2 \
+run_mvn clean deploy -DaltDeploymentRepository=validation_repository::default::file:$MVN_VALIDATION_DIR -Dflink.convergence.phase=install -Pcheck-convergence \
     -Dmaven.javadoc.skip=true -U -DskipTests | tee $MVN_CLEAN_COMPILE_OUT
 
 EXIT_CODE=${PIPESTATUS[0]}

--- a/tools/ci/test_controller.sh
+++ b/tools/ci/test_controller.sh
@@ -80,7 +80,7 @@ source "${HERE}/watchdog.sh"
 export LOG4J_PROPERTIES=${HERE}/log4j.properties
 MVN_LOGGING_OPTIONS="-Dlog.dir=${DEBUG_FILES_OUTPUT_DIR} -Dlog4j.configurationFile=file://$LOG4J_PROPERTIES"
 
-MVN_COMMON_OPTIONS="-Dflink.forkCount=2 -Dfast -Pskip-webui-build $MVN_LOGGING_OPTIONS"
+MVN_COMMON_OPTIONS="-Dfast -Pskip-webui-build $MVN_LOGGING_OPTIONS"
 MVN_COMPILE_OPTIONS="-DskipTests"
 MVN_COMPILE_MODULES=$(get_compile_modules_for_stage ${STAGE})
 


### PR DESCRIPTION
Additionally mark TaskExecutorRecoveryTest as an ITCase due to memory consumption and starting up TaskManagers

## What is the purpose of the change

Purpose of this change is to decrease build times via increasing forkCounts.

## Verifying this change

Covered by existing test base.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
