### PR TITLE
[FLINK-25872][state] Support restore from non-changelog checkpoint with changelog enabled in CLAIM mode

### DIFF
--- a/docs/content.zh/docs/ops/state/state_backends.md
+++ b/docs/content.zh/docs/ops/state/state_backends.md
@@ -433,9 +433,9 @@ env.enable_changelog_statebackend(true)
 
 **开启 Changelog**
 
-仅支持从标准格式的 savepoint 恢复：
+支持从 savepoint 或 checkpoint 恢复：
 - 给定一个没有开启 Changelog 的作业
-- 创建一个 [savepoint]({{< ref "docs/ops/state/savepoints#resuming-from-savepoints" >}}) （默认为标准格式）
+- 创建一个 [savepoint]({{< ref "docs/ops/state/savepoints#resuming-from-savepoints" >}}) 或一个 [checkpoint]({{< ref "docs/ops/state/checkpoints#resuming-from-a-retained-checkpoint" >}})
 - 更改配置（开启 Changelog）
 - 从创建的 snapshot 恢复
 

--- a/docs/content/docs/ops/state/state_backends.md
+++ b/docs/content/docs/ops/state/state_backends.md
@@ -429,9 +429,9 @@ If a task is backpressured by writing state changes, it will be shown as busy (r
 
 **Enabling Changelog**
 
-Resuming only from savepoints in canonical format is supported:
+Resuming from both savepoints and checkpoints is supported:
 - given an existing non-changelog job
-- take a [savepoint]({{< ref "docs/ops/state/savepoints#resuming-from-savepoints" >}}) (canonical format is the default)
+- take either a [savepoint]({{< ref "docs/ops/state/savepoints#resuming-from-savepoints" >}}) or a [checkpoint]({{< ref "docs/ops/state/checkpoints#resuming-from-a-retained-checkpoint" >}})
 - alter configuration (enable Changelog)
 - resume from the taken snapshot
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/AbstractCompleteCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/AbstractCompleteCheckpointStore.java
@@ -57,7 +57,7 @@ public abstract class AbstractCompleteCheckpointStore implements CompletedCheckp
         findLowest(unSubsumedCheckpoints).ifPresent(sharedStateRegistry::unregisterUnusedState);
     }
 
-    private static Optional<Long> findLowest(Deque<CompletedCheckpoint> unSubsumedCheckpoints) {
+    protected static Optional<Long> findLowest(Deque<CompletedCheckpoint> unSubsumedCheckpoints) {
         for (CompletedCheckpoint p : unSubsumedCheckpoints) {
             if (!p.getProperties().isSavepoint()) {
                 return Optional.of(p.getCheckpointID());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointsCleaner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointsCleaner.java
@@ -29,6 +29,10 @@ import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
@@ -43,15 +47,23 @@ public class CheckpointsCleaner implements Serializable, AutoCloseableAsync {
     private static final Logger LOG = LoggerFactory.getLogger(CheckpointsCleaner.class);
     private static final long serialVersionUID = 2545865801947537790L;
 
-    @GuardedBy("this")
+    private final Object lock = new Object();
+
+    @GuardedBy("lock")
     private int numberOfCheckpointsToClean;
 
-    @GuardedBy("this")
+    @GuardedBy("lock")
     @Nullable
     private CompletableFuture<Void> cleanUpFuture;
 
-    synchronized int getNumberOfCheckpointsToClean() {
-        return numberOfCheckpointsToClean;
+    /** All subsumed checkpoints. */
+    @GuardedBy("lock")
+    private final List<CompletedCheckpoint> subsumedCheckpoints = new ArrayList<>();
+
+    int getNumberOfCheckpointsToClean() {
+        synchronized (lock) {
+            return numberOfCheckpointsToClean;
+        }
     }
 
     public void cleanCheckpoint(
@@ -63,6 +75,50 @@ public class CheckpointsCleaner implements Serializable, AutoCloseableAsync {
                 shouldDiscard ? checkpoint.markAsDiscarded() : Checkpoint.NOOP_DISCARD_OBJECT;
 
         cleanup(checkpoint, discardObject::discard, postCleanAction, executor);
+    }
+
+    /**
+     * Add one subsumed checkpoint to CheckpointsCleaner, the subsumed checkpoint would be discarded
+     * at {@link #cleanSubsumedCheckpoints(long, Set, Runnable, Executor)}.
+     *
+     * @param completedCheckpoint which is subsumed.
+     */
+    public void addSubsumedCheckpoint(CompletedCheckpoint completedCheckpoint) {
+        synchronized (lock) {
+            subsumedCheckpoints.add(completedCheckpoint);
+        }
+    }
+
+    /**
+     * Clean checkpoint that is not in the given {@param stillInUse}.
+     *
+     * @param upTo lowest CheckpointID which is still valid.
+     * @param stillInUse the state of those checkpoints are still referenced.
+     * @param postCleanAction post action after cleaning.
+     * @param executor is used to perform the cleanup logic.
+     */
+    public void cleanSubsumedCheckpoints(
+            long upTo, Set<Long> stillInUse, Runnable postCleanAction, Executor executor) {
+        synchronized (lock) {
+            Iterator<CompletedCheckpoint> iterator = subsumedCheckpoints.iterator();
+            while (iterator.hasNext()) {
+                CompletedCheckpoint checkpoint = iterator.next();
+                if (checkpoint.getCheckpointID() < upTo
+                        && !stillInUse.contains(checkpoint.getCheckpointID())) {
+                    try {
+                        LOG.debug("Try to discard checkpoint {}.", checkpoint.getCheckpointID());
+                        cleanCheckpoint(
+                                checkpoint,
+                                checkpoint.shouldBeDiscardedOnSubsume(),
+                                postCleanAction,
+                                executor);
+                        iterator.remove();
+                    } catch (Exception e) {
+                        LOG.warn("Fail to discard the old checkpoint {}.", checkpoint);
+                    }
+                }
+            }
+        }
     }
 
     public void cleanCheckpointOnFailedStoring(
@@ -93,14 +149,18 @@ public class CheckpointsCleaner implements Serializable, AutoCloseableAsync {
                 });
     }
 
-    private synchronized void incrementNumberOfCheckpointsToClean() {
-        checkState(cleanUpFuture == null, "CheckpointsCleaner has already been closed");
-        numberOfCheckpointsToClean++;
+    private void incrementNumberOfCheckpointsToClean() {
+        synchronized (lock) {
+            checkState(cleanUpFuture == null, "CheckpointsCleaner has already been closed");
+            numberOfCheckpointsToClean++;
+        }
     }
 
-    private synchronized void decrementNumberOfCheckpointsToClean() {
-        numberOfCheckpointsToClean--;
-        maybeCompleteCloseUnsafe();
+    private void decrementNumberOfCheckpointsToClean() {
+        synchronized (lock) {
+            numberOfCheckpointsToClean--;
+            maybeCompleteCloseUnsafe();
+        }
     }
 
     private void maybeCompleteCloseUnsafe() {
@@ -110,11 +170,14 @@ public class CheckpointsCleaner implements Serializable, AutoCloseableAsync {
     }
 
     @Override
-    public synchronized CompletableFuture<Void> closeAsync() {
-        if (cleanUpFuture == null) {
-            cleanUpFuture = new CompletableFuture<>();
+    public CompletableFuture<Void> closeAsync() {
+        synchronized (lock) {
+            if (cleanUpFuture == null) {
+                cleanUpFuture = new CompletableFuture<>();
+            }
+            maybeCompleteCloseUnsafe();
+            subsumedCheckpoints.clear();
+            return cleanUpFuture;
         }
-        maybeCompleteCloseUnsafe();
-        return cleanUpFuture;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/EmbeddedCompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/EmbeddedCompletedCheckpointStore.java
@@ -31,6 +31,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicReference;
 
 /** An embedded in-memory checkpoint store, which supports shutdown and suspend. */
@@ -46,6 +47,8 @@ public class EmbeddedCompletedCheckpointStore extends AbstractCompleteCheckpoint
     private final AtomicReference<JobStatus> shutdownStatus = new AtomicReference<>();
 
     private final int maxRetainedCheckpoints;
+
+    private final Executor ioExecutor = Executors.directExecutor();
 
     @VisibleForTesting
     public EmbeddedCompletedCheckpointStore() {
@@ -97,11 +100,20 @@ public class EmbeddedCompletedCheckpointStore extends AbstractCompleteCheckpoint
                 CheckpointSubsumeHelper.subsume(
                                 checkpoints,
                                 maxRetainedCheckpoints,
-                                cc -> cc.markAsDiscardedOnSubsume().discard())
+                                cc -> {
+                                    cc.markAsDiscardedOnSubsume();
+                                    checkpointsCleaner.addSubsumedCheckpoint(cc);
+                                })
                         .orElse(null);
 
-        unregisterUnusedState(checkpoints);
-
+        findLowest(checkpoints)
+                .ifPresent(
+                        id ->
+                                checkpointsCleaner.cleanSubsumedCheckpoints(
+                                        id,
+                                        getSharedStateRegistry().unregisterUnusedState(id),
+                                        postCleanup,
+                                        ioExecutor));
         return completedCheckpoint;
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorSubtaskState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorSubtaskState.java
@@ -25,6 +25,8 @@ import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.OperatorStateHandle;
 import org.apache.flink.runtime.state.ResultSubpartitionStateHandle;
 import org.apache.flink.runtime.state.SharedStateRegistry;
+import org.apache.flink.runtime.state.SharedStateRegistryImpl.EmptyDiscardStateObjectForRegister;
+import org.apache.flink.runtime.state.SharedStateRegistryKey;
 import org.apache.flink.runtime.state.StateObject;
 import org.apache.flink.runtime.state.StateUtil;
 
@@ -226,6 +228,13 @@ public class OperatorSubtaskState implements CompositeStateHandle {
             long checkpointID) {
         for (KeyedStateHandle stateHandle : stateHandles) {
             if (stateHandle != null) {
+                // Registering state handle to the given sharedStateRegistry serves one purpose:
+                // update the status of the checkpoint in sharedStateRegistry to which the state
+                // handle belongs.
+                sharedStateRegistry.registerReference(
+                        new SharedStateRegistryKey(stateHandle.getStateHandleId().getKeyString()),
+                        new EmptyDiscardStateObjectForRegister(stateHandle.getStateHandleId()),
+                        checkpointID);
                 stateHandle.registerSharedStates(sharedStateRegistry, checkpointID);
             }
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/SharedStateRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/SharedStateRegistry.java
@@ -21,6 +21,8 @@ package org.apache.flink.runtime.state;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
 import org.apache.flink.runtime.jobgraph.RestoreMode;
 
+import java.util.Set;
+
 /**
  * This registry manages state that is shared across (incremental) checkpoints, and is responsible
  * for deleting shared state that is no longer used in any valid checkpoint.
@@ -57,12 +59,14 @@ public interface SharedStateRegistry extends AutoCloseable {
      */
     StreamStateHandle registerReference(
             SharedStateRegistryKey registrationKey, StreamStateHandle state, long checkpointID);
+
     /**
      * Unregister state that is not referenced by the given checkpoint ID or any newer.
      *
-     * @param lowestCheckpointID which is still valid
+     * @param lowestCheckpointID which is still valid.
+     * @return a set of checkpointID which is still in use.
      */
-    void unregisterUnusedState(long lowestCheckpointID);
+    Set<Long> unregisterUnusedState(long lowestCheckpointID);
 
     /**
      * Register given shared states in the registry.

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorFailureTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorFailureTest.java
@@ -37,6 +37,7 @@ import org.apache.flink.runtime.state.OperatorStateHandle;
 import org.apache.flink.runtime.state.OperatorStreamStateHandle;
 import org.apache.flink.runtime.state.ResultSubpartitionStateHandle;
 import org.apache.flink.runtime.state.SharedStateRegistry;
+import org.apache.flink.runtime.state.StateHandleID;
 import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.testutils.TestingUtils;
 import org.apache.flink.testutils.executor.TestExecutorResource;
@@ -116,7 +117,9 @@ public class CheckpointCoordinatorFailureTest extends TestLogger {
         final long checkpointId = coord.getPendingCheckpoints().keySet().iterator().next();
 
         KeyedStateHandle managedKeyedHandle = mock(KeyedStateHandle.class);
+        when(managedKeyedHandle.getStateHandleId()).thenReturn(StateHandleID.randomStateHandleId());
         KeyedStateHandle rawKeyedHandle = mock(KeyedStateHandle.class);
+        when(rawKeyedHandle.getStateHandleId()).thenReturn(StateHandleID.randomStateHandleId());
         OperatorStateHandle managedOpHandle = mock(OperatorStreamStateHandle.class);
         OperatorStateHandle rawOpHandle = mock(OperatorStreamStateHandle.class);
         InputChannelStateHandle inputChannelStateHandle =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointsCleanerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointsCleanerTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint;
+
+import org.apache.flink.runtime.checkpoint.CompletedCheckpointStoreTest.TestCompletedCheckpoint;
+import org.apache.flink.runtime.state.SharedStateRegistry;
+import org.apache.flink.runtime.state.SharedStateRegistryImpl;
+import org.apache.flink.util.concurrent.Executors;
+
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.apache.flink.runtime.checkpoint.CompletedCheckpointStoreTest.createCheckpoint;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/** {@link CheckpointsCleaner} test. */
+public class CheckpointsCleanerTest {
+
+    @Test
+    public void testNotCleanCheckpointInUse() {
+        SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
+        CheckpointsCleaner checkpointsCleaner = new CheckpointsCleaner();
+        TestCompletedCheckpoint cp1 = createCheckpoint(1, sharedStateRegistry);
+        checkpointsCleaner.addSubsumedCheckpoint(cp1);
+        TestCompletedCheckpoint cp2 = createCheckpoint(2, sharedStateRegistry);
+        checkpointsCleaner.addSubsumedCheckpoint(cp2);
+        TestCompletedCheckpoint cp3 = createCheckpoint(3, sharedStateRegistry);
+        checkpointsCleaner.addSubsumedCheckpoint(cp3);
+        checkpointsCleaner.cleanSubsumedCheckpoints(
+                3, Collections.singleton(1L), () -> {}, Executors.directExecutor());
+        // cp 1 is in use, shouldn't discard.
+        assertFalse(cp1.isDiscarded());
+        assertTrue(cp2.isDiscarded());
+    }
+
+    @Test
+    public void testNotCleanHigherCheckpoint() {
+        SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
+        CheckpointsCleaner checkpointsCleaner = new CheckpointsCleaner();
+        TestCompletedCheckpoint cp1 = createCheckpoint(1, sharedStateRegistry);
+        checkpointsCleaner.addSubsumedCheckpoint(cp1);
+        TestCompletedCheckpoint cp2 = createCheckpoint(2, sharedStateRegistry);
+        checkpointsCleaner.addSubsumedCheckpoint(cp2);
+        TestCompletedCheckpoint cp3 = createCheckpoint(3, sharedStateRegistry);
+        checkpointsCleaner.addSubsumedCheckpoint(cp3);
+        checkpointsCleaner.cleanSubsumedCheckpoints(
+                2, Collections.emptySet(), () -> {}, Executors.directExecutor());
+        assertTrue(cp1.isDiscarded());
+        // cp2 is the lowest checkpoint that is still valid, shouldn't discard.
+        assertFalse(cp2.isDiscarded());
+        // cp3 is higher than cp2, shouldn't discard.
+        assertFalse(cp3.isDiscarded());
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStoreTest.java
@@ -100,7 +100,7 @@ public abstract class CompletedCheckpointStoreTest extends TestLogger {
     public void testAddCheckpointMoreThanMaxRetained() throws Exception {
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
         CompletedCheckpointStore checkpoints = createRecoveredCompletedCheckpointStore(1);
-
+        CheckpointsCleaner checkpointsCleaner = new CheckpointsCleaner();
         TestCompletedCheckpoint[] expected =
                 new TestCompletedCheckpoint[] {
                     createCheckpoint(0, sharedStateRegistry),
@@ -110,13 +110,11 @@ public abstract class CompletedCheckpointStoreTest extends TestLogger {
                 };
 
         // Add checkpoints
-        checkpoints.addCheckpointAndSubsumeOldestOne(
-                expected[0], new CheckpointsCleaner(), () -> {});
+        checkpoints.addCheckpointAndSubsumeOldestOne(expected[0], checkpointsCleaner, () -> {});
         assertEquals(1, checkpoints.getNumberOfRetainedCheckpoints());
 
         for (int i = 1; i < expected.length; i++) {
-            checkpoints.addCheckpointAndSubsumeOldestOne(
-                    expected[i], new CheckpointsCleaner(), () -> {});
+            checkpoints.addCheckpointAndSubsumeOldestOne(expected[i], checkpointsCleaner, () -> {});
 
             // The ZooKeeper implementation discards asynchronously
             expected[i - 1].awaitDiscard();

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/AbstractChangelogStateBackend.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/AbstractChangelogStateBackend.java
@@ -21,19 +21,16 @@ package org.apache.flink.state.changelog;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
-import org.apache.flink.runtime.state.CheckpointBoundKeyedStateHandle;
 import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.OperatorStateBackend;
 import org.apache.flink.runtime.state.OperatorStateHandle;
-import org.apache.flink.runtime.state.SavepointKeyedStateHandle;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.changelog.ChangelogStateBackendHandle;
 import org.apache.flink.runtime.state.changelog.ChangelogStateBackendHandle.ChangelogStateBackendHandleImpl;
@@ -50,9 +47,6 @@ import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.stream.Collectors;
-
-import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
 
 /**
  * An abstract base implementation of the {@link StateBackend} interface whose subclasses use
@@ -197,41 +191,11 @@ public abstract class AbstractChangelogStateBackend
     private Collection<ChangelogStateBackendHandle> castHandles(
             Collection<KeyedStateHandle> stateHandles) {
         if (stateHandles.stream().anyMatch(h -> !(h instanceof ChangelogStateBackendHandle))) {
-            LOG.warn(
-                    "Some state handles do not contain changelog: {} (ok if recovery from a savepoint)",
-                    stateHandles);
+            LOG.warn("Some state handles do not contain changelog: {}.", stateHandles);
         }
         return stateHandles.stream()
                 .filter(Objects::nonNull)
-                .map(this::getChangelogStateBackendHandle)
+                .map(ChangelogStateBackendHandleImpl::getChangelogStateBackendHandle)
                 .collect(Collectors.toList());
-    }
-
-    private ChangelogStateBackendHandle getChangelogStateBackendHandle(
-            KeyedStateHandle keyedStateHandle) {
-        if (keyedStateHandle instanceof ChangelogStateBackendHandle) {
-            return (ChangelogStateBackendHandle) keyedStateHandle;
-        } else if (keyedStateHandle instanceof SavepointKeyedStateHandle) {
-            return new ChangelogStateBackendHandleImpl(
-                    singletonList(keyedStateHandle),
-                    emptyList(),
-                    keyedStateHandle.getKeyGroupRange(),
-                    getMaterializationID(keyedStateHandle),
-                    getMaterializationID(keyedStateHandle),
-                    0L);
-        } else {
-            throw new IllegalStateException(
-                    String.format(
-                            "Recovery not supported from %s with Changelog enabled. Consider taking a savepoint in %s format.",
-                            keyedStateHandle.getClass(), SavepointFormatType.CANONICAL));
-        }
-    }
-
-    private long getMaterializationID(KeyedStateHandle keyedStateHandle) {
-        if (keyedStateHandle instanceof CheckpointBoundKeyedStateHandle) {
-            return ((CheckpointBoundKeyedStateHandle) keyedStateHandle).getCheckpointId();
-        } else {
-            return 0L;
-        }
     }
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ChangelogPeriodicMaterializationSwitchEnvTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ChangelogPeriodicMaterializationSwitchEnvTestBase.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.minicluster.MiniCluster;
 import org.apache.flink.runtime.state.AbstractStateBackend;
 import org.apache.flink.runtime.state.StateHandleID;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.test.util.InfiniteIntegerSource;
 import org.apache.flink.testutils.junit.SharedReference;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.Preconditions;
@@ -129,5 +130,16 @@ public abstract class ChangelogPeriodicMaterializationSwitchEnvTestBase
                     }
                 },
                 jobID.get());
+    }
+
+    // Infinite job for triggering checkpoint.
+    protected JobGraph buildJobGraph(StreamExecutionEnvironment env) {
+        env.addSource(new InfiniteIntegerSource())
+                .setParallelism(1)
+                .keyBy(element -> element)
+                .process(new CountFunction())
+                .addSink(new CollectionSink())
+                .setParallelism(1);
+        return env.getStreamGraph().getJobGraph();
     }
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ChangelogPeriodicMaterializationSwitchStateBackendITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ChangelogPeriodicMaterializationSwitchStateBackendITCase.java
@@ -17,11 +17,28 @@
 
 package org.apache.flink.test.checkpointing;
 
+import org.apache.flink.changelog.fs.FsStateChangelogStorageFactory;
+import org.apache.flink.configuration.CheckpointingOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.RestoreMode;
+import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
+import org.apache.flink.runtime.minicluster.MiniCluster;
 import org.apache.flink.runtime.state.AbstractStateBackend;
+import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.streaming.api.environment.CheckpointConfig;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
 
+import org.junit.Before;
 import org.junit.Test;
+
+import java.io.File;
+import java.time.Duration;
+
+import static org.apache.flink.runtime.testutils.CommonTestUtils.getLatestCompletedCheckpointPath;
+import static org.apache.flink.runtime.testutils.CommonTestUtils.waitForAllTaskRunning;
 
 /**
  * This verifies that switching state backend works correctly for Changelog state backend with
@@ -33,6 +50,24 @@ public class ChangelogPeriodicMaterializationSwitchStateBackendITCase
     public ChangelogPeriodicMaterializationSwitchStateBackendITCase(
             AbstractStateBackend delegatedStateBackend) {
         super(delegatedStateBackend);
+    }
+
+    @Before
+    @Override
+    public void setup() throws Exception {
+        Configuration configuration = new Configuration();
+        configuration.setInteger(CheckpointingOptions.MAX_RETAINED_CHECKPOINTS, 1);
+        FsStateChangelogStorageFactory.configure(
+                configuration, TEMPORARY_FOLDER.newFolder(), Duration.ofMinutes(1), 10);
+        cluster =
+                new MiniClusterWithClientResource(
+                        new MiniClusterResourceConfiguration.Builder()
+                                .setConfiguration(configuration)
+                                .setNumberTaskManagers(1)
+                                .setNumberSlotsPerTaskManager(4)
+                                .build());
+        cluster.before();
+        cluster.getMiniCluster().overrideRestoreModeForChangelogStateBackend();
     }
 
     @Test
@@ -50,6 +85,47 @@ public class ChangelogPeriodicMaterializationSwitchStateBackendITCase
         testSwitchEnv(getEnv(true, NUM_SLOTS), getEnv(false, NUM_SLOTS / 2));
     }
 
+    @Test
+    public void testSwitchFromDisablingToEnablingInClaimMode() throws Exception {
+        File firstCheckpointFolder = TEMPORARY_FOLDER.newFolder();
+        MiniCluster miniCluster = cluster.getMiniCluster();
+        StreamExecutionEnvironment env1 =
+                getEnv(delegatedStateBackend, firstCheckpointFolder, false, 100, 600000);
+        JobGraph firstJobGraph = buildJobGraph(env1);
+
+        miniCluster.submitJob(firstJobGraph).get();
+        waitForAllTaskRunning(miniCluster, firstJobGraph.getJobID(), true);
+        miniCluster.triggerCheckpoint(firstJobGraph.getJobID()).get();
+        miniCluster.cancelJob(firstJobGraph.getJobID()).get();
+        String firstRestorePath =
+                getLatestCompletedCheckpointPath(firstJobGraph.getJobID(), miniCluster).get();
+
+        // 1st restore, switch from disable to enable
+        File secondCheckpointFolder = TEMPORARY_FOLDER.newFolder();
+        StreamExecutionEnvironment env2 =
+                getEnv(delegatedStateBackend, secondCheckpointFolder, true, 100, 600000);
+        JobGraph secondJobGraph = buildJobGraph(env2);
+        setSavepointRestoreSettings(secondJobGraph, firstRestorePath);
+
+        miniCluster.submitJob(secondJobGraph).get();
+        waitForAllTaskRunning(miniCluster, secondJobGraph.getJobID(), true);
+        miniCluster.triggerCheckpoint(secondJobGraph.getJobID()).get();
+        miniCluster.cancelJob(secondJobGraph.getJobID()).get();
+        String secondRestorePath =
+                getLatestCompletedCheckpointPath(secondJobGraph.getJobID(), miniCluster).get();
+
+        // 2nd restore, private state of first restore checkpoint still exist.
+        File thirdCheckpointFolder = TEMPORARY_FOLDER.newFolder();
+        StreamExecutionEnvironment env3 =
+                getEnv(delegatedStateBackend, thirdCheckpointFolder, true, 100, 100);
+        JobGraph thirdJobGraph = buildJobGraph(env3);
+        setSavepointRestoreSettings(thirdJobGraph, secondRestorePath);
+        miniCluster.submitJob(thirdJobGraph).get();
+        waitForAllTaskRunning(miniCluster, thirdJobGraph.getJobID(), true);
+        miniCluster.triggerCheckpoint(thirdJobGraph.getJobID()).get();
+        miniCluster.cancelJob(thirdJobGraph.getJobID()).get();
+    }
+
     private StreamExecutionEnvironment getEnv(boolean enableChangelog) {
         return getEnv(enableChangelog, NUM_SLOTS);
     }
@@ -62,5 +138,34 @@ public class ChangelogPeriodicMaterializationSwitchStateBackendITCase
                 .setExternalizedCheckpointCleanup(
                         CheckpointConfig.ExternalizedCheckpointCleanup.RETAIN_ON_CANCELLATION);
         return env;
+    }
+
+    private StreamExecutionEnvironment getEnv(
+            StateBackend stateBackend,
+            File checkpointFile,
+            boolean changelogEnabled,
+            long checkpointInterval,
+            long materializationInterval) {
+        StreamExecutionEnvironment env =
+                getEnv(
+                        stateBackend,
+                        checkpointFile,
+                        checkpointInterval,
+                        0,
+                        materializationInterval,
+                        0);
+        env.enableChangelogStateBackend(changelogEnabled);
+        env.getCheckpointConfig()
+                .setExternalizedCheckpointCleanup(
+                        CheckpointConfig.ExternalizedCheckpointCleanup.RETAIN_ON_CANCELLATION);
+        Configuration configuration = new Configuration();
+        configuration.setInteger(CheckpointingOptions.MAX_RETAINED_CHECKPOINTS, 1);
+        env.configure(configuration);
+        return env;
+    }
+
+    private void setSavepointRestoreSettings(JobGraph jobGraph, String restorePath) {
+        jobGraph.setSavepointRestoreSettings(
+                SavepointRestoreSettings.forPath(restorePath, false, RestoreMode.CLAIM));
     }
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/LegacyStatefulJobSavepointMigrationITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/LegacyStatefulJobSavepointMigrationITCase.java
@@ -170,7 +170,6 @@ public class LegacyStatefulJobSavepointMigrationITCase extends SnapshotMigration
             default:
                 throw new UnsupportedOperationException();
         }
-        env.enableChangelogStateBackend(false);
 
         env.enableCheckpointing(500);
         env.setParallelism(4);

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/StatefulJobWBroadcastStateMigrationITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/StatefulJobWBroadcastStateMigrationITCase.java
@@ -141,7 +141,6 @@ public class StatefulJobWBroadcastStateMigrationITCase extends SnapshotMigration
             default:
                 throw new UnsupportedOperationException();
         }
-        env.enableChangelogStateBackend(false);
 
         env.enableCheckpointing(500);
         env.setParallelism(parallelism);

--- a/flink-tests/src/test/java/org/apache/flink/test/migration/TypeSerializerSnapshotMigrationITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/migration/TypeSerializerSnapshotMigrationITCase.java
@@ -143,7 +143,6 @@ public class TypeSerializerSnapshotMigrationITCase extends SnapshotMigrationTest
             default:
                 throw new UnsupportedOperationException();
         }
-        env.enableChangelogStateBackend(false);
 
         env.enableCheckpointing(500);
         env.setParallelism(parallelism);

--- a/flink-tests/src/test/java/org/apache/flink/test/state/ChangelogCompatibilityITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/ChangelogCompatibilityITCase.java
@@ -82,12 +82,11 @@ public class ChangelogCompatibilityITCase {
                         .restoreWithChangelog(true)
                         .from(RestoreSource.CANONICAL_SAVEPOINT)
                         .allowRestore(true),
-                // explicitly disallow recovery from  non-changelog checkpoints
-                // https://issues.apache.org/jira/browse/FLINK-26079
+                // enable recovery from  non-changelog checkpoints
                 TestCase.startWithChangelog(false)
                         .restoreWithChangelog(true)
                         .from(RestoreSource.CHECKPOINT)
-                        .allowRestore(false),
+                        .allowRestore(true),
                 // normal cases: changelog enabled before and after recovery
                 TestCase.startWithChangelog(true)
                         .restoreWithChangelog(true)

--- a/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/AbstractOperatorRestoreTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/AbstractOperatorRestoreTestBase.java
@@ -224,7 +224,6 @@ public abstract class AbstractOperatorRestoreTestBase extends TestLogger {
         env.enableCheckpointing(500, CheckpointingMode.EXACTLY_ONCE);
         env.setRestartStrategy(RestartStrategies.noRestart());
         env.setStateBackend((StateBackend) new MemoryStateBackend());
-        env.enableChangelogStateBackend(false);
 
         switch (mode) {
             case MIGRATE:

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/migration/StatefulJobSavepointMigrationITCase.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/migration/StatefulJobSavepointMigrationITCase.scala
@@ -153,7 +153,6 @@ class StatefulJobSavepointMigrationITCase(snapshotSpec: SnapshotSpec)
       case _ => throw new UnsupportedOperationException
     }
 
-    env.enableChangelogStateBackend(false)
     env.enableCheckpointing(500)
     env.setParallelism(4)
     env.setMaxParallelism(4)

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/migration/StatefulJobWBroadcastStateMigrationITCase.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/migration/StatefulJobWBroadcastStateMigrationITCase.scala
@@ -155,7 +155,6 @@ class StatefulJobWBroadcastStateMigrationITCase(snapshotSpec: SnapshotSpec)
         env.setStateBackend(new HashMapStateBackend())
       case _ => throw new UnsupportedOperationException
     }
-    env.enableChangelogStateBackend(false)
 
     lazy val firstBroadcastStateDesc = new MapStateDescriptor[Long, Long](
       "broadcast-state-1",


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*Nowadays, recovering from non-changelog checkpoints is disallowed. Because when restoring from a non-changelog checkpoint with changelog state-backend enabled in CLAIM mode, the restored checkpoint may be discarded on subsuming. And the subsumed checkpoint might cause materialized artifacts to be dropped. This PR wants to support restore from non-changelog checkpoint with changelog enabled in CLAIM mode.*


## Brief change log

  - *Revert https://github.com/apache/flink/pull/18735*
  - *Cast `keyedStateHandle` to `ChangelogStateBackendHandle` on JM when changelog is enabled*
  


## Verifying this change

This change added one test and can be verified as follows:
  - *`ChangelogRestoreITCase#testSwitchFromDisablingToEnablingInClaimMode()`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes, recovery on JM)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
