### PR TITLE
[FLINK-27217][hive] Fix partition filter push down issue when there exists default partition in Hive source

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/parse/HiveParserDDLSemanticAnalyzer.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/parse/HiveParserDDLSemanticAnalyzer.java
@@ -1738,7 +1738,10 @@ public class HiveParserDDLSemanticAnalyzer {
         if (partSpec != null && !partSpec.isEmpty()) {
             spec = new CatalogPartitionSpec(new HashMap<>(partSpec));
         }
-        return new ShowPartitionsOperation(tableIdentifier, spec);
+        return new ShowPartitionsOperation(
+                tableIdentifier,
+                spec,
+                HiveConf.getVar(conf, HiveConf.ConfVars.DEFAULTPARTITIONNAME));
     }
 
     private Operation convertShowDatabases() {

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceITCase.java
@@ -226,7 +226,7 @@ public class HiveTableSourceITCase extends BatchAbstractTestBase {
                 .executeSql(
                         "insert into source_db.test_table_pt_1 values ('2014', 1, null), ('2015', 2, null)")
                 .await();
-        // currently, the expression "is null" is supported HiveCatalog#listPartitionsByFilter,
+        // currently, the expression "is null" is not supported HiveCatalog#listPartitionsByFilter,
         // then the planer will list all partitions and then prue the partitions.
         // the test is to cover such case
         src =

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -1298,7 +1298,11 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
                     List<String> partitionKVs = new ArrayList<>(spec.getPartitionSpec().size());
                     for (Map.Entry<String, String> partitionKV :
                             spec.getPartitionSpec().entrySet()) {
-                        partitionKVs.add(partitionKV.getKey() + "=" + partitionKV.getValue());
+                        String partitionValue =
+                                partitionKV.getValue() == null
+                                        ? showPartitionsOperation.getDefaultPartitionName()
+                                        : partitionKV.getValue();
+                        partitionKVs.add(partitionKV.getKey() + "=" + partitionValue);
                     }
                     partitionNames.add(String.join("/", partitionKVs));
                 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ShowPartitionsOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ShowPartitionsOperation.java
@@ -21,16 +21,29 @@ package org.apache.flink.table.operations;
 import org.apache.flink.table.catalog.CatalogPartitionSpec;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 
+import javax.annotation.Nullable;
+
 /** Operation to describe a SHOW PARTITIONS statement. */
 public class ShowPartitionsOperation implements ShowOperation {
 
     protected final ObjectIdentifier tableIdentifier;
     private final CatalogPartitionSpec partitionSpec;
+    // the name for the default partition, which usually means the partition's value is null or
+    // empty string
+    @Nullable private final String defaultPartitionName;
 
     public ShowPartitionsOperation(
             ObjectIdentifier tableIdentifier, CatalogPartitionSpec partitionSpec) {
+        this(tableIdentifier, partitionSpec, null);
+    }
+
+    public ShowPartitionsOperation(
+            ObjectIdentifier tableIdentifier,
+            CatalogPartitionSpec partitionSpec,
+            @Nullable String defaultPartitionName) {
         this.tableIdentifier = tableIdentifier;
         this.partitionSpec = partitionSpec;
+        this.defaultPartitionName = defaultPartitionName;
     }
 
     public ObjectIdentifier getTableIdentifier() {
@@ -39,6 +52,10 @@ public class ShowPartitionsOperation implements ShowOperation {
 
     public CatalogPartitionSpec getPartitionSpec() {
         return partitionSpec;
+    }
+
+    public String getDefaultPartitionName() {
+        return defaultPartitionName;
     }
 
     @Override


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
To fix the partition filter push down issue when there exsits default partition in Hive soruce.


## Brief change log
  - *When the partition value is equal to `HiveConf.ConfVars.DEFAULTPARTITIONNAME`, convert it to null in method HiveCatalog#listPartitions*
  - *To make `show partitions` also works for default partition in Hive , add a field `defaultPartitionName` in `ShowPartitionsOperation`. Then when the partition value is null, `ShowPartitionsOperation` should use the `defaultPartitionName`.


## Verifying this change
- Added [test](https://github.com/apache/flink/pull/19450/files#diff-e7e74972bb3dbbd76ce12f31dd2315433102943a1bf6ae15deac4f648cfc228aR222) for the issue of partition filter push down when there exists default partition.
- Added [test](https://github.com/apache/flink/pull/19450/files#diff-748a9fa63f15b3bd3ea5426a5b42179cadee77ecf3359c83f846aedb27d96871R975) for `show partitions` for the case that there exists default partition

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper:  no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
