### PR TITLE
[FLINK-26481][python] Support side output in PyFlink DataStream API

### DIFF
--- a/docs/content.zh/docs/dev/datastream/operators/windows.md
+++ b/docs/content.zh/docs/dev/datastream/operators/windows.md
@@ -1449,6 +1449,16 @@ input
     .<windowed transformation>(<window function>)
 ```
 {{< /tab >}}
+{{< tab "Python" >}}
+```python
+input = ...  # type: DataStream
+input \
+    .key_by(<key selector>) \
+    .window(<window assigner>) \
+    .allowed_lateness(<time>) \
+    .<windowed transformation>(<window function>)
+```
+{{< /tab >}}
 {{< /tabs >}}
 
 {{< hint info >}}
@@ -1493,6 +1503,22 @@ val result = input
     .<windowed transformation>(<window function>)
 
 val lateStream = result.getSideOutput(lateOutputTag)
+```
+{{< /tab >}}
+{{< tab "Python" >}}
+```python
+late_output_tag = OutputTag("late-data", type_info)
+
+input = ...  # type: DataStream
+
+result = input \
+    .key_by(<key selector>) \
+    .window(<window assigner>) \
+    .allowed_lateness(<time>) \
+    .side_output_late_data(late_output_tag) \
+    .<windowed transformation>(<window function>)
+
+late_stream = result.get_side_output(late_output_tag)
 ```
 {{< /tab >}}
 {{< /tabs >}}

--- a/docs/content.zh/docs/dev/datastream/side_output.md
+++ b/docs/content.zh/docs/dev/datastream/side_output.md
@@ -46,6 +46,11 @@ OutputTag<String> outputTag = new OutputTag<String>("side-output") {};
 val outputTag = OutputTag[String]("side-output")
 ```
 {{< /tab >}}
+{{< tab "Python" >}}
+```python
+output_tag = OutputTag("side-output", Types.STRING())
+```
+{{< /tab >}}
 {{< /tabs >}}
 
 注意 `OutputTag` 是如何根据旁路输出流所包含的元素类型进行类型化的。
@@ -108,6 +113,25 @@ val mainDataStream = input
   })
 ```
 {{< /tab >}}
+{{< tab "Python" >}}
+```python
+input = ...  # type: DataStream
+output_tag = OutputTag("side-output", Types.STRING())
+
+class MyProcessFunction(ProcessFunction):
+    
+    def process_element(self, value: int, ctx: ProcessFunction.Context):
+        # emit data to regular output
+        yield value
+        
+        # emit data to side output
+        yield output_tag, "sideout-" + str(value)
+
+
+main_data_stream = input \
+    .process(MyProcessFunction(), Types.INT())
+```
+{{< /tab >}}
 {{< /tabs >}}
 
 你可以在 `DataStream` 运算结果上使用 `getSideOutput(OutputTag)` 方法获取旁路输出流。这将产生一个与旁路输出流结果类型一致的 `DataStream`：
@@ -131,6 +155,15 @@ val outputTag = OutputTag[String]("side-output")
 val mainDataStream = ...
 
 val sideOutputStream: DataStream[String] = mainDataStream.getSideOutput(outputTag)
+```
+{{< /tab >}}
+{{< tab "Python" >}}
+```python
+output_tag = OutputTag("side-output", Types.STRING())
+
+main_data_stream = ...  # type: DataStream
+
+side_output_stream = main_data_stream.get_side_output(output_tag)  # type: DataStream
 ```
 {{< /tab >}}
 {{< /tabs >}}

--- a/docs/content/docs/dev/datastream/operators/windows.md
+++ b/docs/content/docs/dev/datastream/operators/windows.md
@@ -1494,6 +1494,16 @@ input
     .<windowed transformation>(<window function>)
 ```
 {{< /tab >}}
+{{< tab "Python" >}}
+```python
+input = ...  # type: DataStream
+input \
+    .key_by(<key selector>) \
+    .window(<window assigner>) \
+    .allowed_lateness(<time>) \
+    .<windowed transformation>(<window function>)
+```
+{{< /tab >}}
 {{< /tabs >}}
 
 {{< hint info >}}
@@ -1540,6 +1550,22 @@ val result = input
     .<windowed transformation>(<window function>)
 
 val lateStream = result.getSideOutput(lateOutputTag)
+```
+{{< /tab >}}
+{{< tab "Python" >}}
+```python
+late_output_tag = OutputTag("late-data", type_info)
+
+input = ...  # type: DataStream
+
+result = input \
+    .key_by(<key selector>) \
+    .window(<window assigner>) \
+    .allowed_lateness(<time>) \
+    .side_output_late_data(late_output_tag) \
+    .<windowed transformation>(<window function>)
+
+late_stream = result.get_side_output(late_output_tag)
 ```
 {{< /tab >}}
 {{< /tabs >}}

--- a/docs/content/docs/dev/datastream/side_output.md
+++ b/docs/content/docs/dev/datastream/side_output.md
@@ -50,6 +50,11 @@ OutputTag<String> outputTag = new OutputTag<String>("side-output") {};
 val outputTag = OutputTag[String]("side-output")
 ```
 {{< /tab >}}
+{{< tab "Python" >}}
+```python
+output_tag = OutputTag("side-output", Types.STRING())
+```
+{{< /tab >}}
 {{< /tabs >}}
 
 Notice how the `OutputTag` is typed according to the type of elements that the side output stream
@@ -115,6 +120,25 @@ val mainDataStream = input
   })
 ```
 {{< /tab >}}
+{{< tab "Python" >}}
+```python
+input = ...  # type: DataStream
+output_tag = OutputTag("side-output", Types.STRING())
+
+class MyProcessFunction(ProcessFunction):
+    
+    def process_element(self, value: int, ctx: ProcessFunction.Context):
+        # emit data to regular output
+        yield value
+        
+        # emit data to side output
+        yield output_tag, "sideout-" + str(value)
+
+
+main_data_stream = input \
+    .process(MyProcessFunction(), Types.INT())
+```
+{{< /tab >}}
 {{< /tabs >}}
 
 For retrieving the side output stream you use `getSideOutput(OutputTag)`
@@ -140,6 +164,15 @@ val outputTag = OutputTag[String]("side-output")
 val mainDataStream = ...
 
 val sideOutputStream: DataStream[String] = mainDataStream.getSideOutput(outputTag)
+```
+{{< /tab >}}
+{{< tab "Python" >}}
+```python
+output_tag = OutputTag("side-output", Types.STRING())
+
+main_data_stream = ...  # type: DataStream
+
+side_output_stream = main_data_stream.get_side_output(output_tag)  # type: DataStream
 ```
 {{< /tab >}}
 {{< /tabs >}}

--- a/flink-python/pyflink/common/constants.py
+++ b/flink-python/pyflink/common/constants.py
@@ -24,4 +24,4 @@ A constant holding the minimum value a long can have, -2^63
 """
 MIN_LONG_VALUE = - MAX_LONG_VALUE - 1
 
-DEFAULT_OUTPUT_TAG = "output"
+DEFAULT_OUTPUT_TAG = ""

--- a/flink-python/pyflink/datastream/__init__.py
+++ b/flink-python/pyflink/datastream/__init__.py
@@ -183,6 +183,8 @@ Other important classes:
       Interface for implementing user defined sink functionality.
     - :class:`SourceFunction`:
       Interface for implementing user defined source functionality.
+    - :class:`OutputTag`:
+      Tag with a name and type for identifying side output of an operator
 """
 from pyflink.datastream.checkpoint_config import CheckpointConfig, ExternalizedCheckpointCleanup
 from pyflink.datastream.checkpointing_mode import CheckpointingMode
@@ -210,6 +212,7 @@ from pyflink.datastream.functions import ProcessFunction
 from pyflink.datastream.timerservice import TimerService
 from pyflink.datastream.window import Window, TimeWindow, CountWindow, WindowAssigner, \
     MergingWindowAssigner, TriggerResult, Trigger
+from pyflink.datastream.output_tag import OutputTag
 
 __all__ = [
     'StreamExecutionEnvironment',
@@ -263,5 +266,6 @@ __all__ = [
     'SourceFunction',
     'SinkFunction',
     'SlotSharingGroup',
-    'MemorySize'
+    'MemorySize',
+    'OutputTag'
 ]

--- a/flink-python/pyflink/datastream/data_stream.py
+++ b/flink-python/pyflink/datastream/data_stream.py
@@ -1680,6 +1680,16 @@ class WindowedStream(object):
         You can get the stream of late data using :func:`~DataStream.get_side_output` on the
         :class:`DataStream` resulting from the windowed operation with the same :class:`OutputTag`.
 
+        Example:
+        ::
+
+            >>> tag = OutputTag("late-data", Types.TUPLE([Types.INT(), Types.STRING()]))
+            >>> main_stream = ds.key_by(lambda x: x[1]) \\
+            ...                 .window(TumblingEventTimeWindows.of(Time.seconds(5))) \\
+            ...                 .side_output_late_data(tag) \\
+            ...                 .reduce(lambda a, b: a[0] + b[0], b[1])
+            >>> late_stream = main_stream.get_side_output(tag)
+
         .. versionadded:: 1.16.0
         """
         self._late_data_output_tag = output_tag

--- a/flink-python/pyflink/datastream/data_stream.py
+++ b/flink-python/pyflink/datastream/data_stream.py
@@ -760,6 +760,7 @@ class DataStream(object):
         :param limit: The limit for the collected elements.
         """
         JPythonConfigUtil = get_gateway().jvm.org.apache.flink.python.util.PythonConfigUtil
+        JPythonConfigUtil.preprocessSideOutput(self._j_data_stream.getExecutionEnvironment())
         JPythonConfigUtil.configPythonOperator(self._j_data_stream.getExecutionEnvironment())
         self._apply_chaining_optimization()
         if job_execution_name is None and limit is None:

--- a/flink-python/pyflink/datastream/output_tag.py
+++ b/flink-python/pyflink/datastream/output_tag.py
@@ -15,6 +15,8 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
+from typing import List, Optional, Union
+
 from pyflink.common.typeinfo import TypeInformation, Types, RowTypeInfo
 from pyflink.java_gateway import get_gateway
 
@@ -26,11 +28,18 @@ class OutputTag(object):
     Example:
     ::
 
+        # Explicitly specify output type
         >>> info = OutputTag("late-data", Types.TUPLE([Types.STRING(), Types.LONG()]))
+        # Implicitly wrap list to Types.ROW
+        >>> info_row = OutputTag("row", [Types.STRING(), Types.LONG()])
+        # Implicitly use pickle serialization
+        >>> info_side = OutputTag("side")
+        # ERROR: tag id cannot be empty string (extra requirement for Python API)
+        >>> info_error = OutputTag("")
 
     """
 
-    def __init__(self, tag_id: str, type_info: TypeInformation = None):
+    def __init__(self, tag_id: str, type_info: Optional[Union[TypeInformation, List]] = None):
         if not tag_id:
             raise ValueError("OutputTag tag_id cannot be None or empty string")
         self.tag_id = tag_id
@@ -38,6 +47,8 @@ class OutputTag(object):
             self.type_info = Types.PICKLED_BYTE_ARRAY()
         elif isinstance(type_info, list):
             self.type_info = RowTypeInfo(type_info)
+        elif not isinstance(type_info, TypeInformation):
+            raise TypeError("OutputTag type_info must be None, list or TypeInformation")
         else:
             self.type_info = type_info
 

--- a/flink-python/pyflink/datastream/output_tag.py
+++ b/flink-python/pyflink/datastream/output_tag.py
@@ -31,7 +31,7 @@ class OutputTag(object):
     """
 
     def __init__(self, tag_id: str, type_info: TypeInformation = None):
-        if tag_id == "":
+        if not tag_id:
             raise ValueError("tag_id cannot be empty string")
         self.tag_id = tag_id
         if type_info is None:

--- a/flink-python/pyflink/datastream/output_tag.py
+++ b/flink-python/pyflink/datastream/output_tag.py
@@ -15,13 +15,26 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
-"""
-A constant holding the maximum value a long can have, 2^63 – 1.
-"""
-MAX_LONG_VALUE = 0x7fffffffffffffff
-"""
-A constant holding the minimum value a long can have, -2^63
-"""
-MIN_LONG_VALUE = - MAX_LONG_VALUE - 1
+from pyflink.common.typeinfo import TypeInformation, Types, RowTypeInfo
+from pyflink.java_gateway import get_gateway
 
-DEFAULT_OUTPUT_TAG = "output"
+
+class OutputTag(object):
+
+    def __init__(self, tag_id: str, type_info: TypeInformation = None):
+        if tag_id == "":
+            raise ValueError("tag_id cannot be empty string")
+        self.tag_id = tag_id
+        if type_info is None:
+            self.type_info = Types.PICKLED_BYTE_ARRAY()
+        elif isinstance(type_info, list):
+            self.type_info = RowTypeInfo(type_info)
+        else:
+            self.type_info = type_info
+
+    def get_java_output_tag(self):
+        gateway = get_gateway()
+        j_obj = gateway.jvm.org.apache.flink.util.OutputTag(self.tag_id,
+                                                            self.type_info.get_java_type_info())
+        self.type_info._j_typeinfo = None
+        return j_obj

--- a/flink-python/pyflink/datastream/output_tag.py
+++ b/flink-python/pyflink/datastream/output_tag.py
@@ -15,7 +15,7 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 from pyflink.common.typeinfo import TypeInformation, Types, RowTypeInfo
 from pyflink.java_gateway import get_gateway
@@ -39,7 +39,7 @@ class OutputTag(object):
 
     """
 
-    def __init__(self, tag_id: str, type_info: Optional[Union[TypeInformation, List]] = None):
+    def __init__(self, tag_id: str, type_info: Optional[Union[TypeInformation, list]] = None):
         if not tag_id:
             raise ValueError("OutputTag tag_id cannot be None or empty string")
         self.tag_id = tag_id

--- a/flink-python/pyflink/datastream/output_tag.py
+++ b/flink-python/pyflink/datastream/output_tag.py
@@ -20,6 +20,15 @@ from pyflink.java_gateway import get_gateway
 
 
 class OutputTag(object):
+    """
+    An :class:`OutputTag` is a typed and named tag to use for tagging side outputs of an operator.
+
+    Example:
+    ::
+
+        >>> info = OutputTag("late-data", Types.TUPLE([Types.STRING(), Types.LONG()]))
+
+    """
 
     def __init__(self, tag_id: str, type_info: TypeInformation = None):
         if tag_id == "":
@@ -36,5 +45,6 @@ class OutputTag(object):
         gateway = get_gateway()
         j_obj = gateway.jvm.org.apache.flink.util.OutputTag(self.tag_id,
                                                             self.type_info.get_java_type_info())
+        # deal with serializability
         self.type_info._j_typeinfo = None
         return j_obj

--- a/flink-python/pyflink/datastream/output_tag.py
+++ b/flink-python/pyflink/datastream/output_tag.py
@@ -32,7 +32,7 @@ class OutputTag(object):
 
     def __init__(self, tag_id: str, type_info: TypeInformation = None):
         if not tag_id:
-            raise ValueError("tag_id cannot be empty string")
+            raise ValueError("OutputTag tag_id cannot be None or empty string")
         self.tag_id = tag_id
         if type_info is None:
             self.type_info = Types.PICKLED_BYTE_ARRAY()

--- a/flink-python/pyflink/datastream/stream_execution_environment.py
+++ b/flink-python/pyflink/datastream/stream_execution_environment.py
@@ -957,6 +957,7 @@ class StreamExecutionEnvironment(object):
         gateway = get_gateway()
         JPythonConfigUtil = gateway.jvm.org.apache.flink.python.util.PythonConfigUtil
 
+        JPythonConfigUtil.preprocessSideOutput(self._j_stream_execution_environment)
         JPythonConfigUtil.configPythonOperator(self._j_stream_execution_environment)
 
         gateway.jvm.org.apache.flink.python.chain.PythonOperatorChainingOptimizer.apply(

--- a/flink-python/pyflink/datastream/tests/test_window.py
+++ b/flink-python/pyflink/datastream/tests/test_window.py
@@ -397,14 +397,15 @@ class WindowTests(PyFlinkStreamingTestCase):
             .window(TumblingEventTimeWindows.of(Time.milliseconds(5))) \
             .allowed_lateness(0) \
             .side_output_late_data(tag) \
-            .process(CountWindowProcessFunction(), Types.TUPLE([Types.STRING(), Types.INT()]))
+            .process(CountWindowProcessFunction(),
+                     Types.TUPLE([Types.STRING(), Types.LONG(), Types.LONG(), Types.INT()]))
         main_sink = DataStreamTestSinkFunction()
         ds2.add_sink(main_sink)
         side_sink = DataStreamTestSinkFunction()
         ds2.get_side_output(tag).add_sink(side_sink)
 
         self.env.execute('test_side_output_late_data')
-        main_expected = ['(a,1)', '(a,2)']
+        main_expected = ['(a,0,5,1)', '(a,5,10,2)']
         self.assert_equals_sorted(main_expected, main_sink.get_results())
         side_expected = ['+I[a, 4]']
         self.assert_equals_sorted(side_expected, side_sink.get_results())

--- a/flink-python/pyflink/datastream/tests/test_window.py
+++ b/flink-python/pyflink/datastream/tests/test_window.py
@@ -398,11 +398,16 @@ class WindowTests(PyFlinkStreamingTestCase):
             .allowed_lateness(0) \
             .side_output_late_data(tag) \
             .process(CountWindowProcessFunction(), Types.TUPLE([Types.STRING(), Types.INT()]))
-        ds2.get_side_output(tag).add_sink(self.test_sink)
-        ds2.add_sink(self.test_sink)
+        main_sink = DataStreamTestSinkFunction()
+        ds2.add_sink(main_sink)
+        side_sink = DataStreamTestSinkFunction()
+        ds2.get_side_output(tag).add_sink(side_sink)
+
         self.env.execute('test_side_output_late_data')
-        expected = ['(a,1)', '(a,2)', '+I[a, 4]']
-        self.assert_equals_sorted(expected, self.test_sink.get_results())
+        main_expected = ['(a,1)', '(a,2)']
+        self.assert_equals_sorted(main_expected, main_sink.get_results())
+        side_expected = ['+I[a, 4]']
+        self.assert_equals_sorted(side_expected, side_sink.get_results())
 
 
 class SecondColumnTimestampAssigner(TimestampAssigner):

--- a/flink-python/pyflink/datastream/tests/test_window.py
+++ b/flink-python/pyflink/datastream/tests/test_window.py
@@ -15,20 +15,23 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
-
 from typing import Iterable, Tuple, Dict
 
+from pyflink.common import Configuration
 from pyflink.common.time import Time
 from pyflink.common.typeinfo import Types
 from pyflink.common.watermark_strategy import WatermarkStrategy, TimestampAssigner
 from pyflink.datastream.data_stream import DataStream
 from pyflink.datastream.functions import (ProcessWindowFunction, WindowFunction, AggregateFunction)
+from pyflink.datastream.output_tag import OutputTag
 from pyflink.datastream.window import (TumblingEventTimeWindows,
                                        SlidingEventTimeWindows, EventTimeSessionWindows,
                                        CountSlidingWindowAssigner, SessionWindowTimeGapExtractor,
                                        CountWindow, PurgingTrigger, EventTimeTrigger, TimeWindow)
 from pyflink.datastream.tests.test_util import DataStreamTestSinkFunction
+from pyflink.java_gateway import get_gateway
 from pyflink.testing.test_case_utils import PyFlinkStreamingTestCase
+from pyflink.util.java_utils import get_j_env_configuration
 
 
 class WindowTests(PyFlinkStreamingTestCase):
@@ -371,6 +374,35 @@ class WindowTests(PyFlinkStreamingTestCase):
         results = self.test_sink.get_results()
         expected = ['(hi,1,7,4)', '(hi,8,12,2)', '(hi,15,18,1)']
         self.assert_equals_sorted(expected, results)
+
+    def test_side_output_late_data(self):
+        self.env.set_parallelism(1)
+        config = Configuration(
+            j_configuration=get_j_env_configuration(self.env._j_stream_execution_environment)
+        )
+        config.set_integer('python.fn-execution.bundle.size', 1)
+        jvm = get_gateway().jvm
+        watermark_strategy = WatermarkStrategy(
+            jvm.org.apache.flink.api.common.eventtime.WatermarkStrategy.forGenerator(
+                jvm.org.apache.flink.streaming.api.functions.python.eventtime.
+                PerElementWatermarkGenerator.getSupplier()
+            )
+        ).with_timestamp_assigner(SecondColumnTimestampAssigner())
+
+        tag = OutputTag('late-data', type_info=Types.ROW([Types.STRING(), Types.INT()]))
+        ds1 = self.env.from_collection([('a', 0), ('a', 8), ('a', 4), ('a', 6)],
+                                       type_info=Types.ROW([Types.STRING(), Types.INT()]))
+        ds2 = ds1.assign_timestamps_and_watermarks(watermark_strategy) \
+            .key_by(lambda e: e[0]) \
+            .window(TumblingEventTimeWindows.of(Time.milliseconds(5))) \
+            .allowed_lateness(0) \
+            .side_output_late_data(tag) \
+            .process(CountWindowProcessFunction(), Types.TUPLE([Types.STRING(), Types.INT()]))
+        ds2.get_side_output(tag).add_sink(self.test_sink)
+        ds2.add_sink(self.test_sink)
+        self.env.execute('test_side_output_late_data')
+        expected = ['(a,1)', '(a,2)', '+I[a, 4]']
+        self.assert_equals_sorted(expected, self.test_sink.get_results())
 
 
 class SecondColumnTimestampAssigner(TimestampAssigner):

--- a/flink-python/pyflink/datastream/window.py
+++ b/flink-python/pyflink/datastream/window.py
@@ -19,12 +19,13 @@ import math
 from abc import ABC, abstractmethod
 from enum import Enum
 from io import BytesIO
-from typing import TypeVar, Generic, Iterable, Collection, Any, cast
+from typing import TypeVar, Generic, Iterable, Collection, Any, cast, Optional
 
 from pyflink.common import Time, Types
 from pyflink.common.constants import MAX_LONG_VALUE, MIN_LONG_VALUE
 from pyflink.common.serializer import TypeSerializer
 from pyflink.datastream.functions import RuntimeContext, InternalWindowFunction, ReduceFunction
+from pyflink.datastream.output_tag import OutputTag
 from pyflink.datastream.state import StateDescriptor, ReducingStateDescriptor, \
     ValueStateDescriptor, State, ReducingState
 from pyflink.metrics import MetricGroup
@@ -560,12 +561,14 @@ class WindowOperationDescriptor(object):
                  assigner: WindowAssigner,
                  trigger: Trigger,
                  allowed_lateness: int,
+                 late_data_output_tag: Optional[OutputTag],
                  window_state_descriptor: StateDescriptor,
                  window_serializer: TypeSerializer,
                  internal_window_function: InternalWindowFunction):
         self.assigner = assigner
         self.trigger = trigger
         self.allowed_lateness = allowed_lateness
+        self.late_data_output_tag = late_data_output_tag
         self.window_state_descriptor = window_state_descriptor
         self.internal_window_function = internal_window_function
         self.window_serializer = window_serializer

--- a/flink-python/pyflink/fn_execution/beam/beam_operations_fast.pxd
+++ b/flink-python/pyflink/fn_execution/beam/beam_operations_fast.pxd
@@ -46,7 +46,7 @@ cdef class IntermediateOutputProcessor(OutputProcessor):
     pass
 
 cdef class FunctionOperation(Operation):
-    cdef OutputProcessor _output_processor
+    cdef dict _output_processors
     cdef bint _is_python_coder
     cdef object process_element
     cdef object operation

--- a/flink-python/pyflink/fn_execution/beam/beam_operations_fast.pxd
+++ b/flink-python/pyflink/fn_execution/beam/beam_operations_fast.pxd
@@ -47,6 +47,8 @@ cdef class IntermediateOutputProcessor(OutputProcessor):
 
 cdef class FunctionOperation(Operation):
     cdef dict _output_processors
+    cdef OutputProcessor _only_processor
+    cdef bint _side_output_enabled
     cdef bint _is_python_coder
     cdef object process_element
     cdef object operation

--- a/flink-python/pyflink/fn_execution/beam/beam_operations_fast.pyx
+++ b/flink-python/pyflink/fn_execution/beam/beam_operations_fast.pyx
@@ -28,6 +28,7 @@ from apache_beam.utils.windowed_value cimport WindowedValue
 
 from pyflink.common.constants import DEFAULT_OUTPUT_TAG
 from pyflink.fn_execution.coder_impl_fast cimport InputStreamWrapper
+from pyflink.fn_execution.flink_fn_execution_pb2 import UserDefinedDataStreamFunction
 from pyflink.fn_execution.table.operations import BundleOperation, BaseOperation as TableOperation
 from pyflink.fn_execution.profiler import Profiler
 
@@ -124,7 +125,12 @@ cdef class FunctionOperation(Operation):
             self._profiler = Profiler()
         else:
             self._profiler = None
-        job_parameters = {p.key: p.value for p in spec.serialized_fn.runtime_context.job_parameters}
+        if isinstance(spec.serialized_fn, UserDefinedDataStreamFunction):
+            job_parameters = {
+                p.key: p.value for p in spec.serialized_fn.runtime_context.job_parameters
+            }
+        else:
+            job_parameters = {}
         if job_parameters.get("SIDE_OUTPUT_ENABLED") is not None:
             self._side_output_enabled = True
         else:

--- a/flink-python/pyflink/fn_execution/beam/beam_operations_slow.py
+++ b/flink-python/pyflink/fn_execution/beam/beam_operations_slow.py
@@ -25,7 +25,7 @@ from apache_beam.utils import windowed_value
 from apache_beam.utils.windowed_value import WindowedValue
 
 from pyflink.common.constants import DEFAULT_OUTPUT_TAG
-from pyflink.fn_execution.table.operations import BundleOperation
+from pyflink.fn_execution.table.operations import BundleOperation, BaseOperation as TableOperation
 from pyflink.fn_execution.profiler import Profiler
 
 
@@ -128,6 +128,10 @@ class FunctionOperation(Operation):
                     self.process_element(value)
                 for p in self._output_processors.get(DEFAULT_OUTPUT_TAG, []):
                     p.process_outputs(o, self.operation.finish_bundle())
+            elif isinstance(self.operation, TableOperation):
+                for value in o.value:
+                    for p in self._output_processors.get(DEFAULT_OUTPUT_TAG, []):
+                        p.process_outputs(o, self.operation.process_element(value))
             else:
                 for value in o.value:
                     # TODO: do we need tag grouping?

--- a/flink-python/pyflink/fn_execution/beam/beam_operations_slow.py
+++ b/flink-python/pyflink/fn_execution/beam/beam_operations_slow.py
@@ -25,6 +25,7 @@ from apache_beam.utils import windowed_value
 from apache_beam.utils.windowed_value import WindowedValue
 
 from pyflink.common.constants import DEFAULT_OUTPUT_TAG
+from pyflink.fn_execution.flink_fn_execution_pb2 import UserDefinedDataStreamFunction
 from pyflink.fn_execution.table.operations import (
     BundleOperation,
     BaseOperation as TableOperation,
@@ -85,9 +86,12 @@ class FunctionOperation(Operation):
             self._profiler = Profiler()
         else:
             self._profiler = None
-        job_parameters = {
-            p.key: p.value for p in spec.serialized_fn.runtime_context.job_parameters
-        }
+        if isinstance(spec.serialized_fn, UserDefinedDataStreamFunction):
+            job_parameters = {
+                p.key: p.value for p in spec.serialized_fn.runtime_context.job_parameters
+            }
+        else:
+            job_parameters = {}
         if job_parameters.get("SIDE_OUTPUT_ENABLED") is not None:
             self._side_output_enabled = True
         else:

--- a/flink-python/pyflink/fn_execution/datastream/input_handler.py
+++ b/flink-python/pyflink/fn_execution/datastream/input_handler.py
@@ -18,8 +18,11 @@
 from abc import ABC
 from collections import Iterable
 from enum import Enum
+from typing import cast
 
 from pyflink.common import Row
+from pyflink.common.constants import DEFAULT_OUTPUT_TAG
+from pyflink.datastream.output_tag import OutputTag
 from pyflink.fn_execution.datastream.timerservice_impl import InternalTimerServiceImpl
 
 
@@ -99,4 +102,7 @@ class TimerHandler(ABC):
 def _emit_results(timestamp, watermark, results):
     if results:
         for result in results:
-            yield Row(timestamp, watermark, result)
+            if isinstance(result, tuple) and isinstance(result[0], OutputTag):
+                yield cast(OutputTag, result[0]).tag_id, Row(timestamp, watermark, result[1])
+            else:
+                yield DEFAULT_OUTPUT_TAG, Row(timestamp, watermark, result)

--- a/flink-python/pyflink/fn_execution/datastream/operations.py
+++ b/flink-python/pyflink/fn_execution/datastream/operations.py
@@ -18,6 +18,7 @@
 import abc
 
 from pyflink.common import Row
+from pyflink.common.constants import DEFAULT_OUTPUT_TAG
 from pyflink.common.serializer import VoidNamespaceSerializer
 from pyflink.datastream import TimeDomain, RuntimeContext
 from pyflink.fn_execution import pickle
@@ -147,7 +148,7 @@ def extract_stateless_function(user_defined_function_proto, runtime_context: Run
             # VALUE[CURRENT_TIMESTAMP, CURRENT_WATERMARK, NORMAL_DATA]
             timestamp = value[0]
             element = value[2]
-            yield Row(timestamp, element)
+            yield DEFAULT_OUTPUT_TAG, Row(timestamp, element)
 
         process_element_func = revise_output
 

--- a/flink-python/pyflink/fn_execution/datastream/operations.py
+++ b/flink-python/pyflink/fn_execution/datastream/operations.py
@@ -21,6 +21,7 @@ from pyflink.common import Row
 from pyflink.common.constants import DEFAULT_OUTPUT_TAG
 from pyflink.common.serializer import VoidNamespaceSerializer
 from pyflink.datastream import TimeDomain, RuntimeContext
+from pyflink.datastream.window import WindowOperationDescriptor
 from pyflink.fn_execution import pickle
 from pyflink.fn_execution.datastream.process_function import \
     InternalKeyedProcessFunctionOnTimerContext, InternalKeyedProcessFunctionContext, \
@@ -288,10 +289,11 @@ def extract_stateful_function(user_defined_function_proto,
             raise Exception("Unsupported func_type: " + str(func_type))
 
     elif func_type == UserDefinedDataStreamFunction.WINDOW:
-        window_operation_descriptor = user_defined_func
+        window_operation_descriptor = user_defined_func  # type: WindowOperationDescriptor
         window_assigner = window_operation_descriptor.assigner
         window_trigger = window_operation_descriptor.trigger
         allowed_lateness = window_operation_descriptor.allowed_lateness
+        late_data_output_tag = window_operation_descriptor.late_data_output_tag
         window_state_descriptor = window_operation_descriptor.window_state_descriptor
         internal_window_function = window_operation_descriptor.internal_window_function
         window_serializer = window_operation_descriptor.window_serializer
@@ -305,7 +307,8 @@ def extract_stateful_function(user_defined_function_proto,
             window_state_descriptor,
             internal_window_function,
             window_trigger,
-            allowed_lateness)
+            allowed_lateness,
+            late_data_output_tag)
         internal_timer_service.set_namespace_serializer(window_serializer)
 
         def open_func():

--- a/flink-python/pyflink/fn_execution/datastream/window/window_operator.py
+++ b/flink-python/pyflink/fn_execution/datastream/window/window_operator.py
@@ -16,11 +16,12 @@
 # limitations under the License.
 ################################################################################
 import typing
-from typing import TypeVar, Iterable, Collection
+from typing import TypeVar, Iterable, Collection, Optional
 
 from pyflink.common.constants import MAX_LONG_VALUE
 from pyflink.datastream import WindowAssigner, Trigger, MergingWindowAssigner, TriggerResult
 from pyflink.datastream.functions import KeyedStateStore, RuntimeContext, InternalWindowFunction
+from pyflink.datastream.output_tag import OutputTag
 from pyflink.datastream.state import StateDescriptor, ListStateDescriptor, \
     ReducingStateDescriptor, AggregatingStateDescriptor, ValueStateDescriptor, MapStateDescriptor, \
     State, AggregatingState, ReducingState, MapState, ListState, ValueState, AppendingState
@@ -273,7 +274,8 @@ class WindowOperator(object):
                  window_state_descriptor: StateDescriptor,
                  window_function: InternalWindowFunction,
                  trigger: Trigger,
-                 allowed_lateness: int):
+                 allowed_lateness: int,
+                 late_data_output_tag: Optional[OutputTag]):
         self.window_assigner = window_assigner
         self.keyed_state_backend = keyed_state_backend
         self.user_key_selector = user_key_selector
@@ -281,6 +283,7 @@ class WindowOperator(object):
         self.window_function = window_function
         self.trigger = trigger
         self.allowed_lateness = allowed_lateness
+        self.late_data_output_tag = late_data_output_tag
 
         self.num_late_records_dropped = None
         self.internal_timer_service = None  # type: InternalTimerService
@@ -408,7 +411,10 @@ class WindowOperator(object):
                 self.register_cleanup_timer(window)
 
         if is_skipped_element and self.is_element_late(value, timestamp):
-            self.num_late_records_dropped.inc()
+            if self.late_data_output_tag is not None:
+                yield self.late_data_output_tag, value
+            else:
+                self.num_late_records_dropped.inc()
 
     def on_event_time(self, timestamp, key, namespace) -> None:
         self.trigger_context.user_key = self.user_key_selector(key)

--- a/flink-python/src/main/java/org/apache/flink/python/Constants.java
+++ b/flink-python/src/main/java/org/apache/flink/python/Constants.java
@@ -31,12 +31,13 @@ public class Constants {
     // execution graph
     public static final String TRANSFORM_ID = "transform";
     public static final String MAIN_INPUT_NAME = "input";
-    public static final String MAIN_OUTPUT_NAME = "output";
+    public static final String MAIN_OUTPUT_NAME = "";
     public static final String WINDOW_STRATEGY = "windowing_strategy";
 
     public static final String INPUT_COLLECTION_ID = "input";
-    public static final String OUTPUT_COLLECTION_ID = "output";
+    public static final String OUTPUT_COLLECTION_ID = "";
 
+    public static final String SIDE_OUTPUT_CODER_PREFIX = "side_coder-";
     public static final String WINDOW_CODER_ID = "window_coder";
     public static final String TIMER_ID = "timer";
     public static final String TIMER_CODER_ID = "timer_coder";

--- a/flink-python/src/main/java/org/apache/flink/python/PythonFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/python/PythonFunctionRunner.java
@@ -19,7 +19,7 @@
 package org.apache.flink.python;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.configuration.ReadableConfig;
 
 /** The base interface of runner which is responsible for the execution of Python functions. */
@@ -51,7 +51,7 @@ public interface PythonFunctionRunner {
      *     empty. f0 means the byte array buffer which stores the Python function result. f1 means
      *     the length of the Python function result byte array.
      */
-    Tuple2<byte[], Integer> pollResult() throws Exception;
+    Tuple3<String, byte[], Integer> pollResult() throws Exception;
 
     /**
      * Retrieves the Python function result, waiting if necessary until an element becomes
@@ -61,7 +61,7 @@ public interface PythonFunctionRunner {
      *     stores the Python function result. f1 means the length of the Python function result byte
      *     array.
      */
-    Tuple2<byte[], Integer> takeResult() throws Exception;
+    Tuple3<String, byte[], Integer> takeResult() throws Exception;
 
     /**
      * Forces to finish the processing of the current bundle of elements. It will flush the data

--- a/flink-python/src/main/java/org/apache/flink/python/chain/PythonOperatorChainingOptimizer.java
+++ b/flink-python/src/main/java/org/apache/flink/python/chain/PythonOperatorChainingOptimizer.java
@@ -50,9 +50,7 @@ import org.apache.flink.streaming.api.transformations.TimestampsAndWatermarksTra
 import org.apache.flink.streaming.api.transformations.TwoInputTransformation;
 import org.apache.flink.streaming.api.transformations.UnionTransformation;
 import org.apache.flink.streaming.runtime.partitioner.ForwardPartitioner;
-import org.apache.flink.util.OutputTag;
 
-import org.apache.flink.shaded.guava30.com.google.common.collect.Iterables;
 import org.apache.flink.shaded.guava30.com.google.common.collect.Lists;
 import org.apache.flink.shaded.guava30.com.google.common.collect.Queues;
 import org.apache.flink.shaded.guava30.com.google.common.collect.Sets;
@@ -68,6 +66,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
+
+import static org.apache.flink.python.util.PythonConfigUtil.getOperatorFactory;
 
 /**
  * A util class which attempts to chain all available Python functions.
@@ -100,15 +100,12 @@ public class PythonOperatorChainingOptimizer {
      */
     @SuppressWarnings("unchecked")
     public static void apply(StreamExecutionEnvironment env) throws Exception {
-        final Field transformationsField =
-                StreamExecutionEnvironment.class.getDeclaredField("transformations");
-        transformationsField.setAccessible(true);
-        final List<Transformation<?>> transformations =
-                (List<Transformation<?>>) transformationsField.get(env);
-
-        preprocessSideOutput(transformations);
-
         if (env.getConfiguration().get(PythonOptions.PYTHON_OPERATOR_CHAINING_ENABLED)) {
+            final Field transformationsField =
+                    StreamExecutionEnvironment.class.getDeclaredField("transformations");
+            transformationsField.setAccessible(true);
+            final List<Transformation<?>> transformations =
+                    (List<Transformation<?>>) transformationsField.get(env);
             transformationsField.set(env, optimize(transformations));
         }
     }
@@ -121,15 +118,12 @@ public class PythonOperatorChainingOptimizer {
     @SuppressWarnings("unchecked")
     public static Transformation<?> apply(
             StreamExecutionEnvironment env, Transformation<?> transformation) throws Exception {
-        final Field transformationsField =
-                StreamExecutionEnvironment.class.getDeclaredField("transformations");
-        transformationsField.setAccessible(true);
-        final List<Transformation<?>> transformations =
-                (List<Transformation<?>>) transformationsField.get(env);
-
-        preprocessSideOutput(transformations);
-
         if (env.getConfiguration().get(PythonOptions.PYTHON_OPERATOR_CHAINING_ENABLED)) {
+            final Field transformationsField =
+                    StreamExecutionEnvironment.class.getDeclaredField("transformations");
+            transformationsField.setAccessible(true);
+            final List<Transformation<?>> transformations =
+                    (List<Transformation<?>>) transformationsField.get(env);
             final Tuple2<List<Transformation<?>>, Transformation<?>> resultTuple =
                     optimize(transformations, transformation);
             transformationsField.set(env, resultTuple.f0);
@@ -225,41 +219,6 @@ public class PythonOperatorChainingOptimizer {
             }
         }
         return outputMap;
-    }
-
-    /**
-     * Preprocess {@link SideOutputTransformation}s, if the branching operator is a python operator,
-     * {@link OutputTag}s related to {@link SideOutputTransformation}s will be added to the python
-     * operator.
-     */
-    private static void preprocessSideOutput(List<Transformation<?>> transformations) {
-        final Set<Transformation<?>> visitedTransforms = Sets.newIdentityHashSet();
-        final Queue<Transformation<?>> queue = Queues.newArrayDeque(transformations);
-
-        while (!queue.isEmpty()) {
-            Transformation<?> transform = queue.poll();
-            visitedTransforms.add(transform);
-
-            if (transform instanceof SideOutputTransformation) {
-                final SideOutputTransformation<?> sideTransform =
-                        (SideOutputTransformation<?>) transform;
-                final Transformation<?> upTransform =
-                        Iterables.getOnlyElement(sideTransform.getInputs());
-                if (PythonConfigUtil.isPythonDataStreamOperator(upTransform)) {
-                    final AbstractDataStreamPythonFunctionOperator<?> upOperator =
-                            (AbstractDataStreamPythonFunctionOperator<?>)
-                                    ((SimpleOperatorFactory<?>) getOperatorFactory(upTransform))
-                                            .getOperator();
-                    upOperator.addSideOutputTag(sideTransform.getOutputTag());
-                }
-            }
-
-            for (Transformation<?> upTransform : transform.getInputs()) {
-                if (!visitedTransforms.contains(upTransform)) {
-                    queue.add(upTransform);
-                }
-            }
-        }
     }
 
     private static ChainInfo chainWithInputIfPossible(
@@ -497,18 +456,6 @@ public class PythonOperatorChainingOptimizer {
     }
 
     // ----------------------- Utility Methods -----------------------
-
-    private static StreamOperatorFactory<?> getOperatorFactory(Transformation<?> transform) {
-        if (transform instanceof OneInputTransformation) {
-            return ((OneInputTransformation<?, ?>) transform).getOperatorFactory();
-        } else if (transform instanceof TwoInputTransformation) {
-            return ((TwoInputTransformation<?, ?, ?>) transform).getOperatorFactory();
-        } else if (transform instanceof AbstractMultipleInputTransformation) {
-            return ((AbstractMultipleInputTransformation<?>) transform).getOperatorFactory();
-        } else {
-            return null;
-        }
-    }
 
     private static void replaceInput(
             Transformation<?> transformation,

--- a/flink-python/src/main/java/org/apache/flink/python/chain/PythonOperatorChainingOptimizer.java
+++ b/flink-python/src/main/java/org/apache/flink/python/chain/PythonOperatorChainingOptimizer.java
@@ -249,6 +249,19 @@ public class PythonOperatorChainingOptimizer {
             }
         }
 
+        if (transform instanceof SideOutputTransformation) {
+            final SideOutputTransformation<?> sideTransform =
+                    (SideOutputTransformation<?>) transform;
+            final Transformation<?> upTransform = transform.getInputs().get(0);
+            if (PythonConfigUtil.isPythonDataStreamOperator(upTransform)) {
+                final AbstractDataStreamPythonFunctionOperator<?> upOperator =
+                        (AbstractDataStreamPythonFunctionOperator<?>)
+                                ((SimpleOperatorFactory<?>) getOperatorFactory(upTransform))
+                                        .getOperator();
+                upOperator.addSideOutputTag(sideTransform.getOutputTag());
+            }
+        }
+
         if (chainInfo == null) {
             chainInfo = ChainInfo.of(transform);
         }

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/functions/python/eventtime/PerElementWatermarkGenerator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/functions/python/eventtime/PerElementWatermarkGenerator.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.functions.python.eventtime;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.eventtime.Watermark;
+import org.apache.flink.api.common.eventtime.WatermarkGenerator;
+import org.apache.flink.api.common.eventtime.WatermarkGeneratorSupplier;
+import org.apache.flink.api.common.eventtime.WatermarkOutput;
+
+/** PerElementWatermarkGenerator that generates max watermark for every arriving time. */
+@Internal
+public class PerElementWatermarkGenerator implements WatermarkGenerator<Object> {
+
+    private long maxTimestamp;
+
+    public PerElementWatermarkGenerator() {
+        maxTimestamp = Long.MIN_VALUE;
+    }
+
+    @Override
+    public void onEvent(Object event, long eventTimestamp, WatermarkOutput output) {
+        if (eventTimestamp > maxTimestamp) {
+            maxTimestamp = eventTimestamp;
+            output.emitWatermark(new Watermark(eventTimestamp));
+        }
+    }
+
+    @Override
+    public void onPeriodicEmit(WatermarkOutput output) {}
+
+    public static WatermarkGeneratorSupplier<Object> getSupplier() {
+        return (ctx) -> new PerElementWatermarkGenerator();
+    }
+}

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/AbstractDataStreamPythonFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/AbstractDataStreamPythonFunctionOperator.java
@@ -49,6 +49,8 @@ public abstract class AbstractDataStreamPythonFunctionOperator<OUT>
 
     private static final String NUM_PARTITIONS = "NUM_PARTITIONS";
 
+    private static final String SIDE_OUTPUT_ENABLED = "SIDE_OUTPUT_ENABLED";
+
     /** The number of partitions for the partition custom function. */
     @Nullable private Integer numPartitions = null;
 
@@ -107,6 +109,9 @@ public abstract class AbstractDataStreamPythonFunctionOperator<OUT>
         Map<String, String> internalParameters = new HashMap<>();
         if (numPartitions != null) {
             internalParameters.put(NUM_PARTITIONS, String.valueOf(numPartitions));
+        }
+        if (sideOutputTags.size() > 0) {
+            internalParameters.put(SIDE_OUTPUT_ENABLED, "");
         }
         return internalParameters;
     }

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/AbstractDataStreamPythonFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/AbstractDataStreamPythonFunctionOperator.java
@@ -20,16 +20,24 @@ package org.apache.flink.streaming.api.operators.python;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.fnexecution.v1.FlinkFnApi;
 import org.apache.flink.streaming.api.functions.python.DataStreamPythonFunctionInfo;
+import org.apache.flink.streaming.api.utils.PythonTypeUtils;
 import org.apache.flink.table.functions.python.PythonEnv;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.OutputTag;
 import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nullable;
 
 import java.util.HashMap;
 import java.util.Map;
+
+import static org.apache.flink.streaming.api.utils.ProtoUtils.createRawTypeCoderInfoDescriptorProto;
 
 /** Base class for all Python DataStream operators. */
 @Internal
@@ -55,6 +63,10 @@ public abstract class AbstractDataStreamPythonFunctionOperator<OUT>
     /** The TypeInformation of output data. */
     private final TypeInformation<OUT> outputTypeInfo;
 
+    private final Map<String, OutputTag<?>> sideOutputTags;
+
+    private transient Map<String, TypeSerializer<Row>> sideOutputSerializers;
+
     public AbstractDataStreamPythonFunctionOperator(
             Configuration config,
             DataStreamPythonFunctionInfo pythonFunctionInfo,
@@ -62,6 +74,19 @@ public abstract class AbstractDataStreamPythonFunctionOperator<OUT>
         super(config);
         this.pythonFunctionInfo = Preconditions.checkNotNull(pythonFunctionInfo);
         this.outputTypeInfo = Preconditions.checkNotNull(outputTypeInfo);
+        sideOutputTags = new HashMap<>();
+    }
+
+    @Override
+    public void open() throws Exception {
+        sideOutputSerializers = new HashMap<>();
+        for (Map.Entry<String, OutputTag<?>> entry : sideOutputTags.entrySet()) {
+            sideOutputSerializers.put(
+                    entry.getKey(),
+                    PythonTypeUtils.TypeInfoToSerializerConverter.typeInfoSerializerConverter(
+                            getSideOutputTypeInfo(entry.getValue())));
+        }
+        super.open();
     }
 
     @Override
@@ -95,6 +120,37 @@ public abstract class AbstractDataStreamPythonFunctionOperator<OUT>
 
     public boolean containsPartitionCustom() {
         return this.containsPartitionCustom;
+    }
+
+    public void addSideOutputTag(OutputTag<?> outputTag) {
+        sideOutputTags.put(outputTag.getId(), outputTag);
+    }
+
+    protected Map<String, FlinkFnApi.CoderInfoDescriptor> createSideOutputCoderDescriptors() {
+        Map<String, FlinkFnApi.CoderInfoDescriptor> descriptorMap = new HashMap<>();
+        for (Map.Entry<String, OutputTag<?>> entry : sideOutputTags.entrySet()) {
+            descriptorMap.put(
+                    entry.getKey(),
+                    createRawTypeCoderInfoDescriptorProto(
+                            getSideOutputTypeInfo(entry.getValue()),
+                            FlinkFnApi.CoderInfoDescriptor.Mode.MULTIPLE,
+                            false));
+        }
+        return descriptorMap;
+    }
+
+    protected OutputTag<?> getOutputTagById(String id) {
+        Preconditions.checkArgument(sideOutputTags.containsKey(id));
+        return sideOutputTags.get(id);
+    }
+
+    protected TypeInformation<Row> getSideOutputTypeInfo(OutputTag<?> outputTag) {
+        return Types.ROW(Types.LONG, outputTag.getTypeInfo());
+    }
+
+    protected TypeSerializer<Row> getSideOutputTypeSerializer(String id) {
+        Preconditions.checkArgument(sideOutputSerializers.containsKey(id));
+        return sideOutputSerializers.get(id);
     }
 
     // ----------------------------------------------------------------------

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/AbstractDataStreamPythonFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/AbstractDataStreamPythonFunctionOperator.java
@@ -34,6 +34,7 @@ import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nullable;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -74,7 +75,7 @@ public abstract class AbstractDataStreamPythonFunctionOperator<OUT>
         super(config);
         this.pythonFunctionInfo = Preconditions.checkNotNull(pythonFunctionInfo);
         this.outputTypeInfo = Preconditions.checkNotNull(outputTypeInfo);
-        sideOutputTags = new HashMap<>();
+        this.sideOutputTags = new HashMap<>();
     }
 
     @Override
@@ -126,6 +127,14 @@ public abstract class AbstractDataStreamPythonFunctionOperator<OUT>
         sideOutputTags.put(outputTag.getId(), outputTag);
     }
 
+    public void addSideOutputTags(Collection<OutputTag<?>> outputTags) {
+        outputTags.forEach(this::addSideOutputTag);
+    }
+
+    public Collection<OutputTag<?>> getSideOutputTags() {
+        return sideOutputTags.values();
+    }
+
     protected Map<String, FlinkFnApi.CoderInfoDescriptor> createSideOutputCoderDescriptors() {
         Map<String, FlinkFnApi.CoderInfoDescriptor> descriptorMap = new HashMap<>();
         for (Map.Entry<String, OutputTag<?>> entry : sideOutputTags.entrySet()) {
@@ -144,13 +153,13 @@ public abstract class AbstractDataStreamPythonFunctionOperator<OUT>
         return sideOutputTags.get(id);
     }
 
-    protected TypeInformation<Row> getSideOutputTypeInfo(OutputTag<?> outputTag) {
-        return Types.ROW(Types.LONG, outputTag.getTypeInfo());
-    }
-
-    protected TypeSerializer<Row> getSideOutputTypeSerializer(String id) {
+    protected TypeSerializer<Row> getSideOutputTypeSerializerById(String id) {
         Preconditions.checkArgument(sideOutputSerializers.containsKey(id));
         return sideOutputSerializers.get(id);
+    }
+
+    private TypeInformation<Row> getSideOutputTypeInfo(OutputTag<?> outputTag) {
+        return Types.ROW(Types.LONG, outputTag.getTypeInfo());
     }
 
     // ----------------------------------------------------------------------

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/AbstractExternalPythonFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/AbstractExternalPythonFunctionOperator.java
@@ -19,7 +19,7 @@
 package org.apache.flink.streaming.api.operators.python;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.python.PythonFunctionRunner;
 import org.apache.flink.python.env.PythonDependencyInfo;
@@ -92,10 +92,10 @@ public abstract class AbstractExternalPythonFunctionOperator<OUT>
                             ((BeamPythonFunctionRunner) pythonFunctionRunner).notifyNoMoreResults();
                         }
                     });
-            Tuple2<byte[], Integer> resultTuple;
+            Tuple3<String, byte[], Integer> resultTuple;
             while (!flushThreadFinish.get()) {
                 resultTuple = pythonFunctionRunner.takeResult();
-                if (resultTuple.f1 != 0) {
+                if (resultTuple.f2 != 0) {
                     emitResult(resultTuple);
                     emitResults();
                 }
@@ -136,14 +136,14 @@ public abstract class AbstractExternalPythonFunctionOperator<OUT>
     }
 
     protected void emitResults() throws Exception {
-        Tuple2<byte[], Integer> resultTuple;
-        while ((resultTuple = pythonFunctionRunner.pollResult()) != null && resultTuple.f1 != 0) {
+        Tuple3<String, byte[], Integer> resultTuple;
+        while ((resultTuple = pythonFunctionRunner.pollResult()) != null && resultTuple.f2 != 0) {
             emitResult(resultTuple);
         }
     }
 
     /** Sends the execution result to the downstream operator. */
-    public abstract void emitResult(Tuple2<byte[], Integer> resultTuple) throws Exception;
+    public abstract void emitResult(Tuple3<String, byte[], Integer> resultTuple) throws Exception;
 
     /**
      * Creates the {@link PythonFunctionRunner} which is responsible for Python user-defined

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/AbstractOneInputPythonFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/AbstractOneInputPythonFunctionOperator.java
@@ -132,8 +132,8 @@ public abstract class AbstractOneInputPythonFunctionOperator<IN, OUT>
             Row runnerOutput = runnerOutputTypeSerializer.deserialize(baisWrapper);
             runnerOutputCollector.collect(runnerOutput);
         } else {
-            Row runnerOutput = getSideOutputTypeSerializer(tag).deserialize(baisWrapper);
-            runnerOutputCollector.collect(runnerOutput, getOutputTagById(tag));
+            Row runnerOutput = getSideOutputTypeSerializerById(tag).deserialize(baisWrapper);
+            runnerOutputCollector.collect(getOutputTagById(tag), runnerOutput);
         }
     }
 

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/AbstractOneInputPythonFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/AbstractOneInputPythonFunctionOperator.java
@@ -22,7 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.memory.ByteArrayInputStreamWithPos;
 import org.apache.flink.core.memory.ByteArrayOutputStreamWithPos;
@@ -38,6 +38,7 @@ import org.apache.flink.streaming.api.utils.PythonTypeUtils;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.Preconditions;
 
+import static org.apache.flink.python.Constants.OUTPUT_COLLECTION_ID;
 import static org.apache.flink.streaming.api.utils.ProtoUtils.createRawTypeCoderInfoDescriptorProto;
 
 /**
@@ -122,12 +123,18 @@ public abstract class AbstractOneInputPythonFunctionOperator<IN, OUT>
     }
 
     @Override
-    public void emitResult(Tuple2<byte[], Integer> resultTuple) throws Exception {
-        byte[] rawResult = resultTuple.f0;
-        int length = resultTuple.f1;
+    public void emitResult(Tuple3<String, byte[], Integer> resultTuple) throws Exception {
+        String tag = resultTuple.f0;
+        byte[] rawResult = resultTuple.f1;
+        int length = resultTuple.f2;
         bais.setBuffer(rawResult, 0, length);
-        Row runnerOutput = runnerOutputTypeSerializer.deserialize(baisWrapper);
-        runnerOutputCollector.collect(runnerOutput);
+        if (tag.equals(OUTPUT_COLLECTION_ID)) {
+            Row runnerOutput = runnerOutputTypeSerializer.deserialize(baisWrapper);
+            runnerOutputCollector.collect(runnerOutput);
+        } else {
+            Row runnerOutput = getSideOutputTypeSerializer(tag).deserialize(baisWrapper);
+            runnerOutputCollector.collect(runnerOutput, getOutputTagById(tag));
+        }
     }
 
     public void processElement(long timestamp, long watermark, Object element) throws Exception {

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/AbstractTwoInputPythonFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/AbstractTwoInputPythonFunctionOperator.java
@@ -22,7 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.memory.ByteArrayInputStreamWithPos;
@@ -38,6 +38,7 @@ import org.apache.flink.streaming.api.operators.python.collector.RunnerOutputCol
 import org.apache.flink.types.Row;
 import org.apache.flink.util.Preconditions;
 
+import static org.apache.flink.python.Constants.OUTPUT_COLLECTION_ID;
 import static org.apache.flink.streaming.api.utils.ProtoUtils.createRawTypeCoderInfoDescriptorProto;
 import static org.apache.flink.streaming.api.utils.PythonTypeUtils.TypeInfoToSerializerConverter.typeInfoSerializerConverter;
 
@@ -113,12 +114,18 @@ public abstract class AbstractTwoInputPythonFunctionOperator<IN1, IN2, OUT>
     }
 
     @Override
-    public void emitResult(Tuple2<byte[], Integer> resultTuple) throws Exception {
-        byte[] rawResult = resultTuple.f0;
-        int length = resultTuple.f1;
+    public void emitResult(Tuple3<String, byte[], Integer> resultTuple) throws Exception {
+        String tag = resultTuple.f0;
+        byte[] rawResult = resultTuple.f1;
+        int length = resultTuple.f2;
         bais.setBuffer(rawResult, 0, length);
-        Row runnerOutput = runnerOutputTypeSerializer.deserialize(baisWrapper);
-        runnerOutputCollector.collect(runnerOutput);
+        if (tag.equals(OUTPUT_COLLECTION_ID)) {
+            Row runnerOutput = runnerOutputTypeSerializer.deserialize(baisWrapper);
+            runnerOutputCollector.collect(runnerOutput);
+        } else {
+            Row runnerOutput = getSideOutputTypeSerializer(tag).deserialize(baisWrapper);
+            runnerOutputCollector.collect(runnerOutput, getOutputTagById(tag));
+        }
     }
 
     public void processElement(boolean isLeft, long timestamp, long watermark, Object element)

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/AbstractTwoInputPythonFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/AbstractTwoInputPythonFunctionOperator.java
@@ -123,8 +123,8 @@ public abstract class AbstractTwoInputPythonFunctionOperator<IN1, IN2, OUT>
             Row runnerOutput = runnerOutputTypeSerializer.deserialize(baisWrapper);
             runnerOutputCollector.collect(runnerOutput);
         } else {
-            Row runnerOutput = getSideOutputTypeSerializer(tag).deserialize(baisWrapper);
-            runnerOutputCollector.collect(runnerOutput, getOutputTagById(tag));
+            Row runnerOutput = getSideOutputTypeSerializerById(tag).deserialize(baisWrapper);
+            runnerOutputCollector.collect(getOutputTagById(tag), runnerOutput);
         }
     }
 

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/PythonCoProcessOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/PythonCoProcessOperator.java
@@ -103,7 +103,8 @@ public class PythonCoProcessOperator<IN1, IN2, OUT>
                                         .asClassLoader()),
                 createInputCoderInfoDescriptor(),
                 createOutputCoderInfoDescriptor(),
-                null);
+                null,
+                createSideOutputCoderDescriptors());
     }
 
     @Override

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/PythonKeyedCoProcessOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/PythonKeyedCoProcessOperator.java
@@ -148,7 +148,8 @@ public class PythonKeyedCoProcessOperator<OUT>
                                         .asClassLoader()),
                 createInputCoderInfoDescriptor(),
                 createOutputCoderInfoDescriptor(),
-                createTimerDataCoderInfoDescriptorProto(timerDataTypeInfo));
+                createTimerDataCoderInfoDescriptorProto(timerDataTypeInfo),
+                createSideOutputCoderDescriptors());
     }
 
     @Override

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/PythonKeyedProcessOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/PythonKeyedProcessOperator.java
@@ -177,7 +177,8 @@ public class PythonKeyedProcessOperator<OUT>
                                         .asClassLoader()),
                 createInputCoderInfoDescriptor(),
                 createOutputCoderInfoDescriptor(),
-                createTimerDataCoderInfoDescriptorProto(timerDataTypeInfo));
+                createTimerDataCoderInfoDescriptorProto(timerDataTypeInfo),
+                createSideOutputCoderDescriptors());
     }
 
     @Override

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/PythonProcessOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/PythonProcessOperator.java
@@ -100,7 +100,8 @@ public class PythonProcessOperator<IN, OUT>
                                         .asClassLoader()),
                 createInputCoderInfoDescriptor(),
                 createOutputCoderInfoDescriptor(),
-                null);
+                null,
+                createSideOutputCoderDescriptors());
     }
 
     @Override

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/collector/RunnerOutputCollector.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/collector/RunnerOutputCollector.java
@@ -22,8 +22,10 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.streaming.api.operators.TimestampedCollector;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.Collector;
+import org.apache.flink.util.OutputTag;
 
 /** Output collector for Python UDF runner. */
 @Internal
@@ -45,6 +47,16 @@ public final class RunnerOutputCollector<OUT> implements Collector<Row> {
             collector.eraseTimestamp();
         }
         collector.collect((OUT) runnerOutput.getField(1));
+    }
+
+    @SuppressWarnings("unchecked")
+    public <X> void collect(Row runnerOutput, OutputTag<X> outputTag) {
+        long ts = (long) runnerOutput.getField(0);
+        if (ts != Long.MIN_VALUE) {
+            collector.collect(outputTag, new StreamRecord<>((X) (runnerOutput.getField(1)), ts));
+        } else {
+            collector.collect(outputTag, new StreamRecord<>((X) (runnerOutput.getField(1))));
+        }
     }
 
     @Override

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/runners/python/beam/BeamDataStreamPythonFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/runners/python/beam/BeamDataStreamPythonFunctionRunner.java
@@ -37,6 +37,7 @@ import javax.annotation.Nullable;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.apache.flink.python.Constants.INPUT_COLLECTION_ID;

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/runners/python/beam/BeamPythonFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/runners/python/beam/BeamPythonFunctionRunner.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.fnexecution.v1.FlinkFnApi;
 import org.apache.flink.python.PythonFunctionRunner;
@@ -77,7 +78,7 @@ import javax.annotation.Nullable;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -131,6 +132,7 @@ public abstract class BeamPythonFunctionRunner implements PythonFunctionRunner {
 
     protected final FlinkFnApi.CoderInfoDescriptor inputCoderDescriptor;
     protected final FlinkFnApi.CoderInfoDescriptor outputCoderDescriptor;
+    protected final Map<String, FlinkFnApi.CoderInfoDescriptor> sideOutputCoderDescriptors;
 
     // ------------------------------------------------------------------------
 
@@ -165,10 +167,10 @@ public abstract class BeamPythonFunctionRunner implements PythonFunctionRunner {
     private transient RemoteBundle remoteBundle;
 
     /** The Python function execution result tuple: (raw bytes, length). */
-    private transient Tuple2<byte[], Integer> reusableResultTuple;
+    private transient Tuple3<String, byte[], Integer> reusableResultTuple;
 
     /** Buffers the Python function execution result which has still not been processed. */
-    @VisibleForTesting protected transient LinkedBlockingQueue<byte[]> resultBuffer;
+    @VisibleForTesting protected transient LinkedBlockingQueue<Tuple2<String, byte[]>> resultBuffer;
 
     /** The receiver which forwards the input elements to a remote environment for processing. */
     @VisibleForTesting protected transient FnDataReceiver<WindowedValue<byte[]>> mainInputReceiver;
@@ -190,7 +192,8 @@ public abstract class BeamPythonFunctionRunner implements PythonFunctionRunner {
             MemoryManager memoryManager,
             double managedMemoryFraction,
             FlinkFnApi.CoderInfoDescriptor inputCoderDescriptor,
-            FlinkFnApi.CoderInfoDescriptor outputCoderDescriptor) {
+            FlinkFnApi.CoderInfoDescriptor outputCoderDescriptor,
+            @Nullable Map<String, FlinkFnApi.CoderInfoDescriptor> sideOutputCoderDescriptors) {
         this.taskName = Preconditions.checkNotNull(taskName);
         this.environmentManager = Preconditions.checkNotNull(environmentManager);
         this.flinkMetricContainer = flinkMetricContainer;
@@ -202,6 +205,7 @@ public abstract class BeamPythonFunctionRunner implements PythonFunctionRunner {
         this.managedMemoryFraction = managedMemoryFraction;
         this.inputCoderDescriptor = Preconditions.checkNotNull(inputCoderDescriptor);
         this.outputCoderDescriptor = Preconditions.checkNotNull(outputCoderDescriptor);
+        this.sideOutputCoderDescriptors = sideOutputCoderDescriptors;
     }
 
     // ------------------------------------------------------------------------
@@ -210,7 +214,7 @@ public abstract class BeamPythonFunctionRunner implements PythonFunctionRunner {
     public void open(ReadableConfig config) throws Exception {
         this.bundleStarted = false;
         this.resultBuffer = new LinkedBlockingQueue<>();
-        this.reusableResultTuple = new Tuple2<>();
+        this.reusableResultTuple = new Tuple3<>();
 
         stateRequestHandler =
                 getStateRequestHandler(
@@ -340,23 +344,24 @@ public abstract class BeamPythonFunctionRunner implements PythonFunctionRunner {
     }
 
     @Override
-    public Tuple2<byte[], Integer> pollResult() throws Exception {
-        byte[] result = resultBuffer.poll();
+    public Tuple3<String, byte[], Integer> pollResult() throws Exception {
+        Tuple2<String, byte[]> result = resultBuffer.poll();
         if (result == null) {
             return null;
-        } else {
-            this.reusableResultTuple.f0 = result;
-            this.reusableResultTuple.f1 = result.length;
-            return this.reusableResultTuple;
         }
+        reusableResultTuple.f0 = result.f0;
+        reusableResultTuple.f1 = result.f1;
+        reusableResultTuple.f2 = result.f1.length;
+        return reusableResultTuple;
     }
 
     @Override
-    public Tuple2<byte[], Integer> takeResult() throws Exception {
-        byte[] result = resultBuffer.take();
-        this.reusableResultTuple.f0 = result;
-        this.reusableResultTuple.f1 = result.length;
-        return this.reusableResultTuple;
+    public Tuple3<String, byte[], Integer> takeResult() throws Exception {
+        Tuple2<String, byte[]> result = resultBuffer.take();
+        reusableResultTuple.f0 = result.f0;
+        reusableResultTuple.f1 = result.f1;
+        reusableResultTuple.f2 = result.f1.length;
+        return reusableResultTuple;
     }
 
     @Override
@@ -372,7 +377,7 @@ public abstract class BeamPythonFunctionRunner implements PythonFunctionRunner {
 
     /** Interrupts the progress of takeResult. */
     public void notifyNoMoreResults() {
-        resultBuffer.add(new byte[0]);
+        resultBuffer.add(Tuple2.of(null, new byte[0]));
     }
 
     private void finishBundle() {
@@ -444,6 +449,21 @@ public abstract class BeamPythonFunctionRunner implements PythonFunctionRunner {
                         .putCoders(OUTPUT_CODER_ID, createCoderProto(outputCoderDescriptor))
                         .putCoders(WINDOW_CODER_ID, getWindowCoderProto());
 
+        if (sideOutputCoderDescriptors != null) {
+            for (Map.Entry<String, FlinkFnApi.CoderInfoDescriptor> entry :
+                    sideOutputCoderDescriptors.entrySet()) {
+                String collectionId = entry.getKey();
+                String collectionCoderId = "side_coder-" + collectionId;
+                componentsBuilder.putPcollections(
+                        collectionId,
+                        RunnerApi.PCollection.newBuilder()
+                                .setWindowingStrategyId(WINDOW_STRATEGY)
+                                .setCoderId(collectionCoderId)
+                                .build());
+                componentsBuilder.putCoders(collectionCoderId, createCoderProto(entry.getValue()));
+            }
+        }
+
         getOptionalTimerCoderProto()
                 .ifPresent(
                         timerCoderProto -> {
@@ -475,11 +495,20 @@ public abstract class BeamPythonFunctionRunner implements PythonFunctionRunner {
                 components.getTransformsMap().keySet().stream()
                         .map(id -> PipelineNode.pTransform(id, components.getTransformsOrThrow(id)))
                         .collect(Collectors.toList());
-        List<PipelineNode.PCollectionNode> outputs =
-                Collections.singletonList(
+        List<PipelineNode.PCollectionNode> outputs = new ArrayList<>();
+        outputs.add(
+                PipelineNode.pCollection(
+                        OUTPUT_COLLECTION_ID,
+                        components.getPcollectionsOrThrow(OUTPUT_COLLECTION_ID)));
+        if (sideOutputCoderDescriptors != null) {
+            for (Map.Entry<String, FlinkFnApi.CoderInfoDescriptor> entry :
+                    sideOutputCoderDescriptors.entrySet()) {
+                String collectionId = entry.getKey();
+                outputs.add(
                         PipelineNode.pCollection(
-                                OUTPUT_COLLECTION_ID,
-                                components.getPcollectionsOrThrow(OUTPUT_COLLECTION_ID)));
+                                collectionId, components.getPcollectionsOrThrow(collectionId)));
+            }
+        }
         return ImmutableExecutableStage.of(
                 components,
                 environment,
@@ -501,14 +530,16 @@ public abstract class BeamPythonFunctionRunner implements PythonFunctionRunner {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         windowedValueCoder.encode(value, baos);
 
-        return Arrays.asList(
+        List<RunnerApi.ExecutableStagePayload.WireCoderSetting> settings = new ArrayList<>();
+        settings.add(
                 RunnerApi.ExecutableStagePayload.WireCoderSetting.newBuilder()
                         .setUrn(getUrn(RunnerApi.StandardCoders.Enum.PARAM_WINDOWED_VALUE))
                         .setPayload(
                                 org.apache.beam.vendor.grpc.v1p26p0.com.google.protobuf.ByteString
                                         .copyFrom(baos.toByteArray()))
                         .setInputOrOutputId(INPUT_COLLECTION_ID)
-                        .build(),
+                        .build());
+        settings.add(
                 RunnerApi.ExecutableStagePayload.WireCoderSetting.newBuilder()
                         .setUrn(getUrn(RunnerApi.StandardCoders.Enum.PARAM_WINDOWED_VALUE))
                         .setPayload(
@@ -516,6 +547,20 @@ public abstract class BeamPythonFunctionRunner implements PythonFunctionRunner {
                                         .copyFrom(baos.toByteArray()))
                         .setInputOrOutputId(OUTPUT_COLLECTION_ID)
                         .build());
+        if (sideOutputCoderDescriptors != null) {
+            for (Map.Entry<String, FlinkFnApi.CoderInfoDescriptor> entry :
+                    sideOutputCoderDescriptors.entrySet()) {
+                settings.add(
+                        RunnerApi.ExecutableStagePayload.WireCoderSetting.newBuilder()
+                                .setUrn(getUrn(RunnerApi.StandardCoders.Enum.PARAM_WINDOWED_VALUE))
+                                .setPayload(
+                                        org.apache.beam.vendor.grpc.v1p26p0.com.google.protobuf
+                                                .ByteString.copyFrom(baos.toByteArray()))
+                                .setInputOrOutputId(entry.getKey())
+                                .build());
+            }
+        }
+        return settings;
     }
 
     /** Gets the proto representation of the window coder. */
@@ -546,7 +591,7 @@ public abstract class BeamPythonFunctionRunner implements PythonFunctionRunner {
             @Override
             public FnDataReceiver<WindowedValue<byte[]>> create(String pCollectionId) {
                 return input -> {
-                    resultBuffer.add(input.getValue());
+                    resultBuffer.add(Tuple2.of(pCollectionId, input.getValue()));
                 };
             }
         };

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/runners/python/beam/BeamPythonFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/runners/python/beam/BeamPythonFunctionRunner.java
@@ -91,6 +91,7 @@ import java.util.stream.Collectors;
 import static org.apache.beam.runners.core.construction.BeamUrns.getUrn;
 import static org.apache.flink.python.Constants.INPUT_COLLECTION_ID;
 import static org.apache.flink.python.Constants.OUTPUT_COLLECTION_ID;
+import static org.apache.flink.python.Constants.SIDE_OUTPUT_CODER_PREFIX;
 import static org.apache.flink.python.Constants.TIMER_CODER_ID;
 import static org.apache.flink.python.Constants.WINDOW_CODER_ID;
 import static org.apache.flink.python.Constants.WINDOW_STRATEGY;
@@ -453,7 +454,7 @@ public abstract class BeamPythonFunctionRunner implements PythonFunctionRunner {
             for (Map.Entry<String, FlinkFnApi.CoderInfoDescriptor> entry :
                     sideOutputCoderDescriptors.entrySet()) {
                 String collectionId = entry.getKey();
-                String collectionCoderId = "side_coder-" + collectionId;
+                String collectionCoderId = SIDE_OUTPUT_CODER_PREFIX + collectionId;
                 componentsBuilder.putPcollections(
                         collectionId,
                         RunnerApi.PCollection.newBuilder()

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/runners/python/beam/BeamPythonFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/runners/python/beam/BeamPythonFunctionRunner.java
@@ -167,7 +167,7 @@ public abstract class BeamPythonFunctionRunner implements PythonFunctionRunner {
      */
     private transient RemoteBundle remoteBundle;
 
-    /** The Python function execution result tuple: (raw bytes, length). */
+    /** The Python function execution result tuple: (output tag, raw bytes, length). */
     private transient Tuple3<String, byte[], Integer> reusableResultTuple;
 
     /** Buffers the Python function execution result which has still not been processed. */

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/AbstractPythonStreamGroupAggregateOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/AbstractPythonStreamGroupAggregateOperator.java
@@ -22,7 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeinfo.Types;
-import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.fnexecution.v1.FlinkFnApi;
 import org.apache.flink.runtime.state.VoidNamespace;
@@ -146,9 +146,9 @@ public abstract class AbstractPythonStreamGroupAggregateOperator
     }
 
     @Override
-    public void emitResult(Tuple2<byte[], Integer> resultTuple) throws Exception {
-        byte[] rawUdfResult = resultTuple.f0;
-        int length = resultTuple.f1;
+    public void emitResult(Tuple3<String, byte[], Integer> resultTuple) throws Exception {
+        byte[] rawUdfResult = resultTuple.f1;
+        int length = resultTuple.f2;
         bais.setBuffer(rawUdfResult, 0, length);
         RowData udfResult = udfOutputTypeSerializer.deserialize(baisWrapper);
         rowDataWrapper.collect(udfResult);

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/PythonStreamGroupWindowAggregateOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/PythonStreamGroupWindowAggregateOperator.java
@@ -22,7 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.fnexecution.v1.FlinkFnApi;
 import org.apache.flink.streaming.api.operators.InternalTimer;
@@ -363,9 +363,9 @@ public class PythonStreamGroupWindowAggregateOperator<K, W extends Window>
     }
 
     @Override
-    public void emitResult(Tuple2<byte[], Integer> resultTuple) throws Exception {
-        byte[] rawUdfResult = resultTuple.f0;
-        int length = resultTuple.f1;
+    public void emitResult(Tuple3<String, byte[], Integer> resultTuple) throws Exception {
+        byte[] rawUdfResult = resultTuple.f1;
+        int length = resultTuple.f2;
         bais.setBuffer(rawUdfResult, 0, length);
         RowData udfResult = udfOutputTypeSerializer.deserialize(baisWrapper);
         byte recordType = udfResult.getByte(0);

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/batch/BatchArrowPythonGroupAggregateFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/batch/BatchArrowPythonGroupAggregateFunctionOperator.java
@@ -19,7 +19,7 @@
 package org.apache.flink.table.runtime.operators.python.aggregate.arrow.batch;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.binary.BinaryRowData;
@@ -89,9 +89,9 @@ public class BatchArrowPythonGroupAggregateFunctionOperator
 
     @Override
     @SuppressWarnings("ConstantConditions")
-    public void emitResult(Tuple2<byte[], Integer> resultTuple) throws Exception {
-        byte[] udafResult = resultTuple.f0;
-        int length = resultTuple.f1;
+    public void emitResult(Tuple3<String, byte[], Integer> resultTuple) throws Exception {
+        byte[] udafResult = resultTuple.f1;
+        int length = resultTuple.f2;
         bais.setBuffer(udafResult, 0, length);
         int rowCount = arrowSerializer.load();
         for (int i = 0; i < rowCount; i++) {

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/batch/BatchArrowPythonGroupWindowAggregateFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/batch/BatchArrowPythonGroupWindowAggregateFunctionOperator.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.runtime.operators.python.aggregate.arrow.batch;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
@@ -158,9 +159,9 @@ public class BatchArrowPythonGroupWindowAggregateFunctionOperator
 
     @Override
     @SuppressWarnings("ConstantConditions")
-    public void emitResult(Tuple2<byte[], Integer> resultTuple) throws Exception {
-        byte[] udafResult = resultTuple.f0;
-        int length = resultTuple.f1;
+    public void emitResult(Tuple3<String, byte[], Integer> resultTuple) throws Exception {
+        byte[] udafResult = resultTuple.f1;
+        int length = resultTuple.f2;
         bais.setBuffer(udafResult, 0, length);
         int rowCount = arrowSerializer.load();
         for (int i = 0; i < rowCount; i++) {

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/batch/BatchArrowPythonOverWindowAggregateFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/batch/BatchArrowPythonOverWindowAggregateFunctionOperator.java
@@ -20,7 +20,7 @@ package org.apache.flink.table.runtime.operators.python.aggregate.arrow.batch;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
-import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.memory.ByteArrayOutputStreamWithPos;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
@@ -236,9 +236,9 @@ public class BatchArrowPythonOverWindowAggregateFunctionOperator
 
     @Override
     @SuppressWarnings("ConstantConditions")
-    public void emitResult(Tuple2<byte[], Integer> resultTuple) throws Exception {
-        byte[] udafResult = resultTuple.f0;
-        int length = resultTuple.f1;
+    public void emitResult(Tuple3<String, byte[], Integer> resultTuple) throws Exception {
+        byte[] udafResult = resultTuple.f1;
+        int length = resultTuple.f2;
         bais.setBuffer(udafResult, 0, length);
         int rowCount = arrowSerializer.load();
         for (int i = 0; i < rowCount; i++) {

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/AbstractStreamArrowPythonBoundedRangeOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/AbstractStreamArrowPythonBoundedRangeOperator.java
@@ -19,7 +19,7 @@
 package org.apache.flink.table.runtime.operators.python.aggregate.arrow.stream;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.state.VoidNamespace;
 import org.apache.flink.streaming.api.TimeDomain;
@@ -113,9 +113,9 @@ public abstract class AbstractStreamArrowPythonBoundedRangeOperator<K>
 
     @Override
     @SuppressWarnings("ConstantConditions")
-    public void emitResult(Tuple2<byte[], Integer> resultTuple) throws Exception {
-        byte[] udafResult = resultTuple.f0;
-        int length = resultTuple.f1;
+    public void emitResult(Tuple3<String, byte[], Integer> resultTuple) throws Exception {
+        byte[] udafResult = resultTuple.f1;
+        int length = resultTuple.f2;
         bais.setBuffer(udafResult, 0, length);
         int rowCount = arrowSerializer.load();
         for (int i = 0; i < rowCount; i++) {

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/AbstractStreamArrowPythonBoundedRowsOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/AbstractStreamArrowPythonBoundedRowsOperator.java
@@ -19,7 +19,7 @@
 package org.apache.flink.table.runtime.operators.python.aggregate.arrow.stream;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.state.VoidNamespace;
 import org.apache.flink.streaming.api.operators.InternalTimer;
@@ -144,9 +144,9 @@ public abstract class AbstractStreamArrowPythonBoundedRowsOperator<K>
 
     @Override
     @SuppressWarnings("ConstantConditions")
-    public void emitResult(Tuple2<byte[], Integer> resultTuple) throws Exception {
-        byte[] udafResult = resultTuple.f0;
-        int length = resultTuple.f1;
+    public void emitResult(Tuple3<String, byte[], Integer> resultTuple) throws Exception {
+        byte[] udafResult = resultTuple.f1;
+        int length = resultTuple.f2;
         bais.setBuffer(udafResult, 0, length);
         int rowCount = arrowSerializer.load();
         for (int i = 0; i < rowCount; i++) {

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/StreamArrowPythonGroupWindowAggregateFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/StreamArrowPythonGroupWindowAggregateFunctionOperator.java
@@ -26,6 +26,7 @@ import org.apache.flink.api.common.state.State;
 import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.state.internal.InternalListState;
@@ -240,9 +241,9 @@ public class StreamArrowPythonGroupWindowAggregateFunctionOperator<K, W extends 
 
     @Override
     @SuppressWarnings("ConstantConditions")
-    public void emitResult(Tuple2<byte[], Integer> resultTuple) throws Exception {
-        byte[] udafResult = resultTuple.f0;
-        int length = resultTuple.f1;
+    public void emitResult(Tuple3<String, byte[], Integer> resultTuple) throws Exception {
+        byte[] udafResult = resultTuple.f1;
+        int length = resultTuple.f2;
         bais.setBuffer(udafResult, 0, length);
         int rowCount = arrowSerializer.load();
         for (int i = 0; i < rowCount; i++) {

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/scalar/PythonScalarFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/scalar/PythonScalarFunctionOperator.java
@@ -20,7 +20,7 @@ package org.apache.flink.table.runtime.operators.python.scalar;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.fnexecution.v1.FlinkFnApi;
 import org.apache.flink.table.data.RowData;
@@ -100,9 +100,9 @@ public class PythonScalarFunctionOperator extends AbstractPythonScalarFunctionOp
 
     @Override
     @SuppressWarnings("ConstantConditions")
-    public void emitResult(Tuple2<byte[], Integer> resultTuple) throws IOException {
-        byte[] rawUdfResult = resultTuple.f0;
-        int length = resultTuple.f1;
+    public void emitResult(Tuple3<String, byte[], Integer> resultTuple) throws IOException {
+        byte[] rawUdfResult = resultTuple.f1;
+        int length = resultTuple.f2;
         RowData input = forwardedInputQueue.poll();
         reuseJoinedRow.setRowKind(input.getRowKind());
         bais.setBuffer(rawUdfResult, 0, length);

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/scalar/arrow/ArrowPythonScalarFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/scalar/arrow/ArrowPythonScalarFunctionOperator.java
@@ -19,7 +19,7 @@
 package org.apache.flink.table.runtime.operators.python.scalar.arrow;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.fnexecution.v1.FlinkFnApi;
 import org.apache.flink.table.data.RowData;
@@ -116,9 +116,9 @@ public class ArrowPythonScalarFunctionOperator extends AbstractPythonScalarFunct
 
     @Override
     @SuppressWarnings("ConstantConditions")
-    public void emitResult(Tuple2<byte[], Integer> resultTuple) throws Exception {
-        byte[] udfResult = resultTuple.f0;
-        int length = resultTuple.f1;
+    public void emitResult(Tuple3<String, byte[], Integer> resultTuple) throws Exception {
+        byte[] udfResult = resultTuple.f1;
+        int length = resultTuple.f2;
         bais.setBuffer(udfResult, 0, length);
         int rowCount = arrowSerializer.load();
         for (int i = 0; i < rowCount; i++) {

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/table/PythonTableFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/table/PythonTableFunctionOperator.java
@@ -20,7 +20,7 @@ package org.apache.flink.table.runtime.operators.python.table;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.fnexecution.v1.FlinkFnApi;
 import org.apache.flink.streaming.api.utils.ProtoUtils;
@@ -186,7 +186,7 @@ public class PythonTableFunctionOperator
 
     @Override
     @SuppressWarnings("ConstantConditions")
-    public void emitResult(Tuple2<byte[], Integer> resultTuple) throws Exception {
+    public void emitResult(Tuple3<String, byte[], Integer> resultTuple) throws Exception {
         byte[] rawUdtfResult;
         int length;
         if (isFinishResult) {
@@ -194,8 +194,8 @@ public class PythonTableFunctionOperator
             hasJoined = false;
         }
         do {
-            rawUdtfResult = resultTuple.f0;
-            length = resultTuple.f1;
+            rawUdtfResult = resultTuple.f1;
+            length = resultTuple.f2;
             isFinishResult = isFinishResult(rawUdtfResult, length);
             if (!isFinishResult) {
                 reuseJoinedRow.setRowKind(input.getRowKind());

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/beam/BeamTablePythonFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/beam/BeamTablePythonFunctionRunner.java
@@ -75,7 +75,8 @@ public class BeamTablePythonFunctionRunner extends BeamPythonFunctionRunner {
                 memoryManager,
                 managedMemoryFraction,
                 inputCoderDescriptor,
-                outputCoderDescriptor);
+                outputCoderDescriptor,
+                null);
         this.functionUrn = Preconditions.checkNotNull(functionUrn);
         this.userDefinedFunctionProto = Preconditions.checkNotNull(userDefinedFunctionProto);
     }

--- a/flink-python/src/test/java/org/apache/flink/streaming/api/functions/python/eventtime/PerElementWatermarkGenerator.java
+++ b/flink-python/src/test/java/org/apache/flink/streaming/api/functions/python/eventtime/PerElementWatermarkGenerator.java
@@ -24,7 +24,7 @@ import org.apache.flink.api.common.eventtime.WatermarkGenerator;
 import org.apache.flink.api.common.eventtime.WatermarkGeneratorSupplier;
 import org.apache.flink.api.common.eventtime.WatermarkOutput;
 
-/** PerElementWatermarkGenerator that generates max watermark for every arriving time. */
+/** PerElementWatermarkGenerator that generates max watermark for every arriving item. */
 @Internal
 public class PerElementWatermarkGenerator implements WatermarkGenerator<Object> {
 

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/PassThroughPythonStreamGroupWindowAggregateOperator.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/PassThroughPythonStreamGroupWindowAggregateOperator.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.runtime.operators.python.aggregate;
 
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.memory.ByteArrayOutputStreamWithPos;
 import org.apache.flink.core.memory.DataInputDeserializer;
@@ -68,6 +69,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.python.Constants.OUTPUT_COLLECTION_ID;
 import static org.apache.flink.table.runtime.util.TimeWindowUtil.toEpochMillsForTimer;
 
 /** PassThroughPythonStreamGroupWindowAggregateOperator. */
@@ -85,7 +87,7 @@ public class PassThroughPythonStreamGroupWindowAggregateOperator<K>
 
     private transient UpdatableRowData reusePythonTimerRowData;
     private transient UpdatableRowData reusePythonTimerData;
-    private transient LinkedBlockingQueue<byte[]> resultBuffer;
+    private transient LinkedBlockingQueue<Tuple2<String, byte[]>> resultBuffer;
     private Projection<RowData, BinaryRowData> groupKeyProjection;
     private Function<RowData, RowData> aggExtracter;
     private Function<TimeWindow, RowData> windowExtractor;
@@ -294,7 +296,7 @@ public class PassThroughPythonStreamGroupWindowAggregateOperator<K>
         }
     }
 
-    public void setResultBuffer(LinkedBlockingQueue<byte[]> resultBuffer) {
+    public void setResultBuffer(LinkedBlockingQueue<Tuple2<String, byte[]>> resultBuffer) {
         this.resultBuffer = resultBuffer;
     }
 
@@ -342,7 +344,7 @@ public class PassThroughPythonStreamGroupWindowAggregateOperator<K>
                     reuseJoinedRow.replace(windowAggResult, windowProperty);
                     reusePythonRowData.setField(1, reuseJoinedRow);
                     udfOutputTypeSerializer.serialize(reusePythonRowData, output);
-                    resultBuffer.add(output.getCopyOfBuffer());
+                    resultBuffer.add(Tuple2.of(OUTPUT_COLLECTION_ID, output.getCopyOfBuffer()));
                     break;
                 }
             }
@@ -425,7 +427,7 @@ public class PassThroughPythonStreamGroupWindowAggregateOperator<K>
         windowBaos.reset();
         DataOutputSerializer output = new DataOutputSerializer(1);
         udfOutputTypeSerializer.serialize(reusePythonTimerRowData, output);
-        resultBuffer.add(output.getCopyOfBuffer());
+        resultBuffer.add(Tuple2.of(OUTPUT_COLLECTION_ID, output.getCopyOfBuffer()));
     }
 
     private void cleanWindowIfNeeded(RowData key, TimeWindow window, long currentTime)
@@ -446,7 +448,7 @@ public class PassThroughPythonStreamGroupWindowAggregateOperator<K>
             reuseJoinedRow.replace(windowAggResult, windowProperty);
             reusePythonRowData.setField(1, reuseJoinedRow);
             udfOutputTypeSerializer.serialize(reusePythonRowData, output);
-            resultBuffer.add(output.getCopyOfBuffer());
+            resultBuffer.add(Tuple2.of(OUTPUT_COLLECTION_ID, output.getCopyOfBuffer()));
             // 2. delete window timer
             if (windowAssigner.isEventTime()) {
                 deleteEventTimeTimer(key, window);

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/utils/PassThroughPythonAggregateFunctionRunner.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/utils/PassThroughPythonAggregateFunctionRunner.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.runtime.utils;
 
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.core.memory.ByteArrayInputStreamWithPos;
 import org.apache.flink.core.memory.ByteArrayOutputStreamWithPos;
@@ -37,6 +38,7 @@ import org.apache.beam.vendor.grpc.v1p26p0.com.google.protobuf.Struct;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.streaming.api.utils.ProtoUtils.createArrowTypeCoderInfoDescriptorProto;
 
@@ -144,7 +146,10 @@ public class PassThroughPythonAggregateFunctionRunner extends BeamTablePythonFun
     @Override
     public void flush() throws Exception {
         super.flush();
-        resultBuffer.addAll(buffer);
+        resultBuffer.addAll(
+                buffer.stream()
+                        .map(b -> Tuple2.<String, byte[]>of(null, b))
+                        .collect(Collectors.toList()));
         buffer.clear();
     }
 

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/utils/PassThroughPythonAggregateFunctionRunner.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/utils/PassThroughPythonAggregateFunctionRunner.java
@@ -40,6 +40,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.python.Constants.OUTPUT_COLLECTION_ID;
 import static org.apache.flink.streaming.api.utils.ProtoUtils.createArrowTypeCoderInfoDescriptorProto;
 
 /**
@@ -148,7 +149,7 @@ public class PassThroughPythonAggregateFunctionRunner extends BeamTablePythonFun
         super.flush();
         resultBuffer.addAll(
                 buffer.stream()
-                        .map(b -> Tuple2.<String, byte[]>of(null, b))
+                        .map(b -> Tuple2.of(OUTPUT_COLLECTION_ID, b))
                         .collect(Collectors.toList()));
         buffer.clear();
     }

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/utils/PassThroughPythonScalarFunctionRunner.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/utils/PassThroughPythonScalarFunctionRunner.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.runtime.utils;
 
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.fnexecution.v1.FlinkFnApi;
 import org.apache.flink.python.env.process.ProcessPythonEnvironmentManager;
 import org.apache.flink.python.metric.FlinkMetricContainer;
@@ -29,6 +30,7 @@ import org.apache.beam.vendor.grpc.v1p26p0.com.google.protobuf.Struct;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.streaming.api.utils.ProtoUtils.createFlattenRowTypeCoderInfoDescriptorProto;
 
@@ -75,7 +77,10 @@ public class PassThroughPythonScalarFunctionRunner extends BeamTablePythonFuncti
     @Override
     public void flush() throws Exception {
         super.flush();
-        resultBuffer.addAll(buffer);
+        resultBuffer.addAll(
+                buffer.stream()
+                        .map(b -> Tuple2.<String, byte[]>of(null, b))
+                        .collect(Collectors.toList()));
         buffer.clear();
     }
 

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/utils/PassThroughPythonScalarFunctionRunner.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/utils/PassThroughPythonScalarFunctionRunner.java
@@ -32,6 +32,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.python.Constants.OUTPUT_COLLECTION_ID;
 import static org.apache.flink.streaming.api.utils.ProtoUtils.createFlattenRowTypeCoderInfoDescriptorProto;
 
 /**
@@ -79,7 +80,7 @@ public class PassThroughPythonScalarFunctionRunner extends BeamTablePythonFuncti
         super.flush();
         resultBuffer.addAll(
                 buffer.stream()
-                        .map(b -> Tuple2.<String, byte[]>of(null, b))
+                        .map(b -> Tuple2.of(OUTPUT_COLLECTION_ID, b))
                         .collect(Collectors.toList()));
         buffer.clear();
     }

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/utils/PassThroughPythonTableFunctionRunner.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/utils/PassThroughPythonTableFunctionRunner.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.runtime.utils;
 
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.fnexecution.v1.FlinkFnApi;
 import org.apache.flink.python.env.process.ProcessPythonEnvironmentManager;
 import org.apache.flink.python.metric.FlinkMetricContainer;
@@ -29,6 +30,7 @@ import org.apache.beam.vendor.grpc.v1p26p0.com.google.protobuf.Struct;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.streaming.api.utils.ProtoUtils.createFlattenRowTypeCoderInfoDescriptorProto;
 
@@ -84,7 +86,10 @@ public class PassThroughPythonTableFunctionRunner extends BeamTablePythonFunctio
     @Override
     public void flush() throws Exception {
         super.flush();
-        resultBuffer.addAll(buffer);
+        resultBuffer.addAll(
+                buffer.stream()
+                        .map(b -> Tuple2.<String, byte[]>of(null, b))
+                        .collect(Collectors.toList()));
         buffer.clear();
     }
 

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/utils/PassThroughPythonTableFunctionRunner.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/utils/PassThroughPythonTableFunctionRunner.java
@@ -32,6 +32,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.python.Constants.OUTPUT_COLLECTION_ID;
 import static org.apache.flink.streaming.api.utils.ProtoUtils.createFlattenRowTypeCoderInfoDescriptorProto;
 
 /**
@@ -88,7 +89,7 @@ public class PassThroughPythonTableFunctionRunner extends BeamTablePythonFunctio
         super.flush();
         resultBuffer.addAll(
                 buffer.stream()
-                        .map(b -> Tuple2.<String, byte[]>of(null, b))
+                        .map(b -> Tuple2.of(OUTPUT_COLLECTION_ID, b))
                         .collect(Collectors.toList()));
         buffer.clear();
     }

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/utils/PassThroughStreamAggregatePythonFunctionRunner.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/utils/PassThroughStreamAggregatePythonFunctionRunner.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.python.Constants.OUTPUT_COLLECTION_ID;
 import static org.apache.flink.streaming.api.utils.ProtoUtils.createRowTypeCoderInfoDescriptorProto;
 
 /**
@@ -89,7 +90,7 @@ public class PassThroughStreamAggregatePythonFunctionRunner extends BeamTablePyt
         super.flush();
         resultBuffer.addAll(
                 buffer.stream()
-                        .map(b -> Tuple2.<String, byte[]>of(null, b))
+                        .map(b -> Tuple2.of(OUTPUT_COLLECTION_ID, b))
                         .collect(Collectors.toList()));
         buffer.clear();
     }

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/utils/PassThroughStreamAggregatePythonFunctionRunner.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/utils/PassThroughStreamAggregatePythonFunctionRunner.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.runtime.utils;
 
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.fnexecution.v1.FlinkFnApi;
 import org.apache.flink.python.env.process.ProcessPythonEnvironmentManager;
 import org.apache.flink.python.metric.FlinkMetricContainer;
@@ -32,6 +33,7 @@ import org.apache.beam.vendor.grpc.v1p26p0.com.google.protobuf.Struct;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.streaming.api.utils.ProtoUtils.createRowTypeCoderInfoDescriptorProto;
 
@@ -85,7 +87,10 @@ public class PassThroughStreamAggregatePythonFunctionRunner extends BeamTablePyt
     @Override
     public void flush() throws Exception {
         super.flush();
-        resultBuffer.addAll(buffer);
+        resultBuffer.addAll(
+                buffer.stream()
+                        .map(b -> Tuple2.<String, byte[]>of(null, b))
+                        .collect(Collectors.toList()));
         buffer.clear();
     }
 

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/utils/PassThroughStreamTableAggregatePythonFunctionRunner.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/utils/PassThroughStreamTableAggregatePythonFunctionRunner.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.runtime.utils;
 
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.fnexecution.v1.FlinkFnApi;
 import org.apache.flink.python.env.process.ProcessPythonEnvironmentManager;
 import org.apache.flink.python.metric.FlinkMetricContainer;
@@ -33,6 +34,7 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.streaming.api.utils.ProtoUtils.createRowTypeCoderInfoDescriptorProto;
 
@@ -91,7 +93,10 @@ public class PassThroughStreamTableAggregatePythonFunctionRunner
     @Override
     public void flush() throws Exception {
         super.flush();
-        resultBuffer.addAll(buffer);
+        resultBuffer.addAll(
+                buffer.stream()
+                        .map(b -> Tuple2.<String, byte[]>of(null, b))
+                        .collect(Collectors.toList()));
         buffer.clear();
     }
 

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/utils/PassThroughStreamTableAggregatePythonFunctionRunner.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/utils/PassThroughStreamTableAggregatePythonFunctionRunner.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.python.Constants.OUTPUT_COLLECTION_ID;
 import static org.apache.flink.streaming.api.utils.ProtoUtils.createRowTypeCoderInfoDescriptorProto;
 
 /**
@@ -95,7 +96,7 @@ public class PassThroughStreamTableAggregatePythonFunctionRunner
         super.flush();
         resultBuffer.addAll(
                 buffer.stream()
-                        .map(b -> Tuple2.<String, byte[]>of(null, b))
+                        .map(b -> Tuple2.of(OUTPUT_COLLECTION_ID, b))
                         .collect(Collectors.toList()));
         buffer.clear();
     }


### PR DESCRIPTION
## What is the purpose of the change

This pr introduces side output support in PyFlink DataStream API, where one can use `yield tag, data` to push data to side stream, and use `DataStream.get_side_output(tag)` to get the corresponding stream. `WindowedStream.side_output_late_data(tag)` is also supported.

## Brief change log

- introduce multiple output PCollections in Beam executable stage, each assgined to the main stream or a side output stream
- tag side output data with user tag and main stream data with default tag, dispatch data to different PCollections according to the tag
- add `late_data_output_tag` in `WindowOperator` and yield late data with this tag


## Verifying this change


This change added tests and can be verified as follows:

- added integration tests in test_data_stream.py and test_window.py, which checks if main stream and side stream are correctly follow to different sinks


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
