### PR TITLE
[FLINK-27223][python] Fix the state access problem when python.state.cache-size is set to 0

### DIFF
--- a/flink-python/pyflink/fn_execution/state_impl.py
+++ b/flink-python/pyflink/fn_execution/state_impl.py
@@ -149,7 +149,8 @@ class SynchronousBagKvRuntimeState(SynchronousKvRuntimeState, ABC):
         return self._internal_state
 
     def _maybe_clear_write_cache(self):
-        if self._cache_type == SynchronousKvRuntimeState.CacheType.DISABLE_CACHE:
+        if self._cache_type == SynchronousKvRuntimeState.CacheType.DISABLE_CACHE or \
+                self._remote_state_backend._state_cache_size <= 0:
             self._internal_state.commit()
             self._internal_state._cleared = False
             self._internal_state._added_elements = []


### PR DESCRIPTION

## What is the purpose of the change

*This pull request fixes the state access problem when python.state.cache-size is set to 0*


## Verifying this change

This change is covered by existing tests in test_data_stream.py.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
