### PR TITLE
[FLINK-27224][build] Drop 'flink.forkCountTestPackage' property

### DIFF
--- a/flink-end-to-end-tests/run-nightly-tests.sh
+++ b/flink-end-to-end-tests/run-nightly-tests.sh
@@ -258,7 +258,7 @@ function run_group_2 {
     LOG4J_PROPERTIES=${END_TO_END_DIR}/../tools/ci/log4j.properties
 
     MVN_LOGGING_OPTIONS="-Dlog.dir=${DEBUG_FILES_OUTPUT_DIR} -DlogBackupDir=${DEBUG_FILES_OUTPUT_DIR} -Dlog4j.configurationFile=file://$LOG4J_PROPERTIES"
-    MVN_COMMON_OPTIONS="-Dflink.forkCount=2 -Dflink.forkCountTestPackage=2 -Dfast -Pskip-webui-build"
+    MVN_COMMON_OPTIONS="-Dflink.forkCount=2 -Dfast -Pskip-webui-build"
     e2e_modules=$(find flink-end-to-end-tests -mindepth 2 -maxdepth 5 -name 'pom.xml' -printf '%h\n' | sort -u | tr '\n' ',')
     e2e_modules="${e2e_modules},$(find flink-walkthroughs -mindepth 2 -maxdepth 2 -name 'pom.xml' -printf '%h\n' | sort -u | tr '\n' ',')"
 

--- a/flink-tests/pom.xml
+++ b/flink-tests/pom.xml
@@ -404,7 +404,7 @@ under the License.
 					</classpathDependencyExcludes>
 					<!-- We override the fork behaviour for those expensive tests to avoid process
 					kills due to container limits on travis -->
-					<forkCount>${flink.forkCountTestPackage}</forkCount>
+					<forkCount>${flink.forkCount}</forkCount>
 					<environmentVariables>
 						<!-- Make sure external hadoop environment will not affect maven building -->
 						<HADOOP_HOME />

--- a/flink-tests/pom.xml
+++ b/flink-tests/pom.xml
@@ -402,9 +402,6 @@ under the License.
 						<classpathDependencyExclude>org.apache.curator:curator-client</classpathDependencyExclude>
 						<classpathDependencyExclude>org.apache.curator:curator-framework</classpathDependencyExclude>
 					</classpathDependencyExcludes>
-					<!-- We override the fork behaviour for those expensive tests to avoid process
-					kills due to container limits on travis -->
-					<forkCount>${flink.forkCount}</forkCount>
 					<environmentVariables>
 						<!-- Make sure external hadoop environment will not affect maven building -->
 						<HADOOP_HOME />

--- a/pom.xml
+++ b/pom.xml
@@ -99,9 +99,6 @@ under the License.
 			 forkCount is not exposed as a property. With this we can set
 			 it on the "mvn" commandline in travis. -->
 		<flink.forkCount>1C</flink.forkCount>
-		<!-- Allow overriding the fork behaviour for the expensive tests in flink-tests
-			 to avoid process kills due to container limits on TravisCI -->
-		<flink.forkCountTestPackage>${flink.forkCount}</flink.forkCountTestPackage>
 		<flink.reuseForks>true</flink.reuseForks>
 		<flink.shaded.version>15.0</flink.shaded.version>
 		<flink.shaded.jackson.version>2.12.4</flink.shaded.jackson.version>

--- a/tools/ci/compile.sh
+++ b/tools/ci/compile.sh
@@ -48,7 +48,7 @@ echo "==========================================================================
 EXIT_CODE=0
 
 run_mvn clean deploy -DaltDeploymentRepository=validation_repository::default::file:$MVN_VALIDATION_DIR -Dflink.convergence.phase=install -Pcheck-convergence -Dflink.forkCount=2 \
-    -Dflink.forkCountTestPackage=2 -Dmaven.javadoc.skip=true -U -DskipTests | tee $MVN_CLEAN_COMPILE_OUT
+    -Dmaven.javadoc.skip=true -U -DskipTests | tee $MVN_CLEAN_COMPILE_OUT
 
 EXIT_CODE=${PIPESTATUS[0]}
 

--- a/tools/ci/test_controller.sh
+++ b/tools/ci/test_controller.sh
@@ -80,7 +80,7 @@ source "${HERE}/watchdog.sh"
 export LOG4J_PROPERTIES=${HERE}/log4j.properties
 MVN_LOGGING_OPTIONS="-Dlog.dir=${DEBUG_FILES_OUTPUT_DIR} -Dlog4j.configurationFile=file://$LOG4J_PROPERTIES"
 
-MVN_COMMON_OPTIONS="-Dflink.forkCount=2 -Dflink.forkCountTestPackage=2 -Dfast -Pskip-webui-build $MVN_LOGGING_OPTIONS"
+MVN_COMMON_OPTIONS="-Dflink.forkCount=2 -Dfast -Pskip-webui-build $MVN_LOGGING_OPTIONS"
 MVN_COMPILE_OPTIONS="-DskipTests"
 MVN_COMPILE_MODULES=$(get_compile_modules_for_stage ${STAGE})
 


### PR DESCRIPTION
This property no longer provides any value because not only has it been identical to flink.forkCount for as long as I can remember, various other modules now contain tests that are likely even heavier than flink-tests.