### PR TITLE
[FLINK-27227][table] Add PlannerTimeIntervalUnits for MILLENNIUM, CEN…

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/expressions/time.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/expressions/time.scala
@@ -44,7 +44,10 @@ case class Extract(timeIntervalUnit: PlannerExpression, temporal: PlannerExpress
     }
 
     timeIntervalUnit match {
-      case SymbolPlannerExpression(PlannerTimeIntervalUnit.YEAR) | SymbolPlannerExpression(
+      case SymbolPlannerExpression(PlannerTimeIntervalUnit.MILLENNIUM) | SymbolPlannerExpression(
+            PlannerTimeIntervalUnit.CENTURY) | SymbolPlannerExpression(
+            PlannerTimeIntervalUnit.DECADE) | SymbolPlannerExpression(
+            PlannerTimeIntervalUnit.YEAR) | SymbolPlannerExpression(
             PlannerTimeIntervalUnit.QUARTER) | SymbolPlannerExpression(
             PlannerTimeIntervalUnit.MONTH) | SymbolPlannerExpression(PlannerTimeIntervalUnit.WEEK) |
           SymbolPlannerExpression(PlannerTimeIntervalUnit.DAY)
@@ -59,7 +62,10 @@ case class Extract(timeIntervalUnit: PlannerExpression, temporal: PlannerExpress
 
       case SymbolPlannerExpression(PlannerTimeIntervalUnit.HOUR) | SymbolPlannerExpression(
             PlannerTimeIntervalUnit.MINUTE) | SymbolPlannerExpression(
-            PlannerTimeIntervalUnit.SECOND)
+            PlannerTimeIntervalUnit.SECOND) | SymbolPlannerExpression(
+            PlannerTimeIntervalUnit.MILLISECOND) | SymbolPlannerExpression(
+            PlannerTimeIntervalUnit.MICROSECOND) | SymbolPlannerExpression(
+            PlannerTimeIntervalUnit.NANOSECOND)
           if temporal.resultType == SqlTimeTypeInfo.TIME
             || temporal.resultType == SqlTimeTypeInfo.TIMESTAMP
             || temporal.resultType == LocalTimeTypeInfo.LOCAL_TIME

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/expressions/time.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/expressions/time.scala
@@ -44,7 +44,8 @@ case class Extract(timeIntervalUnit: PlannerExpression, temporal: PlannerExpress
     }
 
     timeIntervalUnit match {
-      case SymbolPlannerExpression(PlannerTimeIntervalUnit.MILLENNIUM) | SymbolPlannerExpression(
+      case SymbolPlannerExpression(PlannerTimeIntervalUnit.EPOCH) | SymbolPlannerExpression(
+            PlannerTimeIntervalUnit.MILLENNIUM) | SymbolPlannerExpression(
             PlannerTimeIntervalUnit.CENTURY) | SymbolPlannerExpression(
             PlannerTimeIntervalUnit.DECADE) | SymbolPlannerExpression(
             PlannerTimeIntervalUnit.YEAR) | SymbolPlannerExpression(


### PR DESCRIPTION
## What is the purpose of the change

The PR adds support of `PlannerTimeIntervalUnits` required for https://github.com/apache/flink/pull/18179

## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.
_org.apache.flink.table.planner.expressions.ScalarFunctionsTest#testExtract_

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
