### PR TITLE
[FLINK-27225][build] Remove redundant reuseForks settings 

### DIFF
--- a/flink-connectors/flink-connector-cassandra/pom.xml
+++ b/flink-connectors/flink-connector-cassandra/pom.xml
@@ -48,7 +48,6 @@ under the License.
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>
-					<reuseForks>true</reuseForks>
 					<forkCount>1</forkCount>
 				</configuration>
 			</plugin>

--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -604,7 +604,6 @@ under the License.
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>
-					<reuseForks>false</reuseForks>
 					<!-- <workingDirectory>${project.build.testOutputDirectory}</workingDirectory> -->
 					<systemPropertyVariables>
 						<log.level>WARN</log.level>

--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -598,19 +598,7 @@ under the License.
 				</executions>
 			</plugin>
 
-			<!--unit tests-->
 			<!--plugin must appear BEFORE the shade-plugin to not mess up package order and include the non-uber JAR into the assembly-->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-plugin</artifactId>
-				<configuration>
-					<!-- <workingDirectory>${project.build.testOutputDirectory}</workingDirectory> -->
-					<systemPropertyVariables>
-						<log.level>WARN</log.level>
-					</systemPropertyVariables>
-				</configuration>
-			</plugin>
-
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>

--- a/flink-kubernetes/pom.xml
+++ b/flink-kubernetes/pom.xml
@@ -104,7 +104,6 @@ under the License.
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>
-					<reuseForks>true</reuseForks>
 					<forkCount>1</forkCount>
 				</configuration>
 			</plugin>


### PR DESCRIPTION
reuseForks is true by default so some settings are redundant. flink-dist contains no unit tests that would justify disabling reuseForks.