### PR TITLE
(1.15) [FLINK-27231][FLINK-27230][FLINK-27233] Fix the remaining licence issues on 1.15

### DIFF
--- a/flink-connectors/flink-connector-kinesis/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-connector-kinesis/src/main/resources/META-INF/NOTICE
@@ -54,8 +54,6 @@ This project bundles the following dependencies under the Apache Software Licens
 - io.netty:netty-transport-native-unix-common:4.1.70.Final
 - com.typesafe.netty:netty-reactive-streams-http:2.0.5
 - com.typesafe.netty:netty-reactive-streams:2.0.5
-- commons-logging:commons-logging:1.1.3
-- com.fasterxml.jackson.core:jackson-core:2.13.2
 
 This project bundles the following dependencies under the BSD license.
 See bundled license files for details.

--- a/flink-connectors/flink-sql-connector-elasticsearch7/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-elasticsearch7/src/main/resources/META-INF/NOTICE
@@ -8,8 +8,6 @@ This project bundles the following dependencies under the Apache Software Licens
 
 - com.carrotsearch:hppc:0.8.1
 - com.fasterxml.jackson.core:jackson-core:2.13.2
-- com.fasterxml.jackson.core:jackson-databind:2.13.2.2
-- com.fasterxml.jackson.core:jackson-annotations:2.13.2
 - com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.2
 - com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.13.2
 - com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
@@ -31,7 +29,6 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.lucene:lucene-queries:8.7.0
 - org.apache.lucene:lucene-queryparser:8.7.0
 - org.apache.lucene:lucene-sandbox:8.7.0
-- org.apache.lucene:lucene-spatial:8.7.0
 - org.apache.lucene:lucene-spatial-extras:8.7.0
 - org.apache.lucene:lucene-spatial3d:8.7.0
 - org.apache.lucene:lucene-suggest:8.7.0
@@ -41,7 +38,6 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.elasticsearch:elasticsearch-geo:7.10.2
 - org.elasticsearch:elasticsearch-secure-sm:7.10.2
 - org.elasticsearch:elasticsearch-x-content:7.10.2
-- org.elasticsearch:elasticsearch-plugin-classloader:7.10.2
 - org.elasticsearch.client:elasticsearch-rest-high-level-client:7.10.2
 - org.elasticsearch.client:elasticsearch-rest-client:7.10.2
 - org.elasticsearch.plugin:aggs-matrix-stats-client:7.10.2
@@ -49,4 +45,3 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.elasticsearch.plugin:mapper-extras-client:7.10.2
 - org.elasticsearch.plugin:parent-join-client:7.10.2
 - org.elasticsearch.plugin:rank-eval-client:7.10.2
-- org.lz4:lz4-java:1.8.0

--- a/flink-connectors/flink-sql-connector-pulsar/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-pulsar/src/main/resources/META-INF/NOTICE
@@ -12,7 +12,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.pulsar:pulsar-client-api:2.9.1
 - org.slf4j:jul-to-slf4j:1.7.25
 
-This project bundles the following dependencies under the MIT license.
+This project bundles the following dependencies under the BouncyCastle license.
 See bundled license files for details.
 
 - org.bouncycastle:bcpkix-jdk15on:1.69

--- a/flink-connectors/flink-sql-connector-pulsar/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-pulsar/src/main/resources/META-INF/NOTICE
@@ -10,8 +10,12 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.pulsar:pulsar-client-admin-api:2.9.1
 - org.apache.pulsar:pulsar-client-all:2.9.1
 - org.apache.pulsar:pulsar-client-api:2.9.1
+- org.slf4j:jul-to-slf4j:1.7.25
+
+This project bundles the following dependencies under the MIT license.
+See bundled license files for details.
+
 - org.bouncycastle:bcpkix-jdk15on:1.69
 - org.bouncycastle:bcprov-ext-jdk15on:1.69
 - org.bouncycastle:bcprov-jdk15on:1.69
 - org.bouncycastle:bcutil-jdk15on:1.69
-- org.slf4j:jul-to-slf4j:1.7.25

--- a/flink-connectors/flink-sql-connector-pulsar/src/main/resources/META-INF/licences/LICENSE.bouncycastle
+++ b/flink-connectors/flink-sql-connector-pulsar/src/main/resources/META-INF/licences/LICENSE.bouncycastle
@@ -1,0 +1,7 @@
+Copyright (c) 2000 - 2021 The Legion of the Bouncy Castle Inc. (https://www.bouncycastle.org)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes the remaining licence issues in 1.15. I'll pick the PR to master after it is accepted. 

## Brief change log

- Fix the wrong licence of the SQL Pulsar issue
- Remove unused entries from Kinesis and elasticsearch7 connector.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
