### PR TITLE
[FLINK-25548][flink-sql-parser] Migrate tests to JUnit5

### DIFF
--- a/flink-table/flink-sql-parser-hive/pom.xml
+++ b/flink-table/flink-sql-parser-hive/pom.xml
@@ -91,6 +91,10 @@ under the License.
 			<scope>test</scope>
 			<type>test-jar</type>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-test-utils-junit</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/flink-table/flink-sql-parser-hive/src/test/java/org/apache/flink/sql/parser/hive/FlinkHiveSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser-hive/src/test/java/org/apache/flink/sql/parser/hive/FlinkHiveSqlParserImplTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /** Tests for {@link FlinkHiveSqlParserImpl}. */
-public class FlinkHiveSqlParserImplTest extends SqlParserTest {
+class FlinkHiveSqlParserImplTest extends SqlParserTest {
 
     @Override
     protected SqlParserImplFactory parserImplFactory() {

--- a/flink-table/flink-sql-parser-hive/src/test/java/org/apache/flink/sql/parser/hive/FlinkHiveSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser-hive/src/test/java/org/apache/flink/sql/parser/hive/FlinkHiveSqlParserImplTest.java
@@ -22,8 +22,8 @@ import org.apache.flink.sql.parser.hive.impl.FlinkHiveSqlParserImpl;
 
 import org.apache.calcite.sql.parser.SqlParserImplFactory;
 import org.apache.calcite.sql.parser.SqlParserTest;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /** Tests for {@link FlinkHiveSqlParserImpl}. */
 public class FlinkHiveSqlParserImplTest extends SqlParserTest {
@@ -34,15 +34,15 @@ public class FlinkHiveSqlParserImplTest extends SqlParserTest {
     }
 
     // ignore test methods that we don't support
-    @Ignore
+    @Disabled
     @Test
     public void testDescribeStatement() {}
 
-    @Ignore
+    @Disabled
     @Test
     public void testTableHintsInInsert() {}
 
-    @Ignore
+    @Disabled
     @Test
     public void testDescribeSchema() {}
 

--- a/flink-table/flink-sql-parser-hive/src/test/java/org/apache/flink/sql/parser/hive/FlinkHiveSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser-hive/src/test/java/org/apache/flink/sql/parser/hive/FlinkHiveSqlParserImplTest.java
@@ -36,34 +36,34 @@ public class FlinkHiveSqlParserImplTest extends SqlParserTest {
     // ignore test methods that we don't support
     @Disabled
     @Test
-    public void testDescribeStatement() {}
+    void testDescribeStatement() {}
 
     @Disabled
     @Test
-    public void testTableHintsInInsert() {}
+    void testTableHintsInInsert() {}
 
     @Disabled
     @Test
-    public void testDescribeSchema() {}
+    void testDescribeSchema() {}
 
     @Test
-    public void testShowDatabases() {
+    void testShowDatabases() {
         sql("show databases").ok("SHOW DATABASES");
     }
 
     @Test
-    public void testShowCurrentDatabase() {
+    void testShowCurrentDatabase() {
         sql("show current database").ok("SHOW CURRENT DATABASE");
     }
 
     @Test
-    public void testUseDatabase() {
+    void testUseDatabase() {
         // use database
         sql("use db1").ok("USE `DB1`");
     }
 
     @Test
-    public void testCreateDatabase() {
+    void testCreateDatabase() {
         sql("create database db1").ok("CREATE DATABASE `DB1`");
         sql("create database db1 comment 'comment db1' location '/path/to/db1'")
                 .ok(
@@ -79,7 +79,7 @@ public class FlinkHiveSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testAlterDatabase() {
+    void testAlterDatabase() {
         sql("alter database db1 set dbproperties('k1'='v1')")
                 .ok("ALTER DATABASE `DB1` SET DBPROPERTIES (\n" + "  'k1' = 'v1'\n" + ")");
         sql("alter database db1 set location '/new/path'")
@@ -91,13 +91,13 @@ public class FlinkHiveSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testDropDatabase() {
+    void testDropDatabase() {
         sql("drop schema db1").ok("DROP DATABASE `DB1` RESTRICT");
         sql("drop database db1 cascade").ok("DROP DATABASE `DB1` CASCADE");
     }
 
     @Test
-    public void testDescribeDatabase() {
+    void testDescribeDatabase() {
         sql("describe schema db1").ok("DESCRIBE DATABASE `DB1`");
         sql("describe database extended db1").ok("DESCRIBE DATABASE EXTENDED `DB1`");
 
@@ -106,13 +106,13 @@ public class FlinkHiveSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testShowTables() {
+    void testShowTables() {
         // TODO: support SHOW TABLES IN 'db_name' 'regex_pattern'
         sql("show tables").ok("SHOW TABLES");
     }
 
     @Test
-    public void testDescribeTable() {
+    void testDescribeTable() {
         // TODO: support describe partition and columns
         sql("describe tbl").ok("DESCRIBE `TBL`");
         sql("describe extended tbl").ok("DESCRIBE EXTENDED `TBL`");
@@ -124,7 +124,7 @@ public class FlinkHiveSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testCreateTable() {
+    void testCreateTable() {
         sql("create table tbl (x int) row format delimited fields terminated by ',' escaped by '\\' "
                         + "collection items terminated by ',' map keys terminated by ':' lines terminated by '\n' "
                         + "null defined as 'null' location '/path/to/table'")
@@ -197,7 +197,7 @@ public class FlinkHiveSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testConstraints() {
+    void testConstraints() {
         sql("create table tbl (x int not null enable rely, y string not null disable novalidate norely)")
                 .ok(
                         "CREATE TABLE `TBL` (\n"
@@ -223,13 +223,13 @@ public class FlinkHiveSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testDropTable() {
+    void testDropTable() {
         sql("drop table tbl").ok("DROP TABLE `TBL`");
         sql("drop table if exists cat.tbl").ok("DROP TABLE IF EXISTS `CAT`.`TBL`");
     }
 
     @Test
-    public void testInsert() {
+    void testInsert() {
         sql("insert into tbl partition(p1=1,p2,p3) select * from src")
                 .ok(
                         "INSERT INTO `TBL`\n"
@@ -243,60 +243,60 @@ public class FlinkHiveSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testCreateFunction() {
+    void testCreateFunction() {
         sql("create function func as 'class.name'").ok("CREATE FUNCTION `FUNC` AS 'class.name'");
         sql("create temporary function func as 'class.name'")
                 .ok("CREATE TEMPORARY FUNCTION `FUNC` AS 'class.name'");
     }
 
     @Test
-    public void testDropFunction() {
+    void testDropFunction() {
         sql("drop function if exists func").ok("DROP FUNCTION IF EXISTS `FUNC`");
         sql("drop temporary function func").ok("DROP TEMPORARY FUNCTION `FUNC`");
     }
 
     @Test
-    public void testShowFunctions() {
+    void testShowFunctions() {
         sql("show functions").ok("SHOW FUNCTIONS");
         sql("show user functions").ok("SHOW USER FUNCTIONS");
     }
 
     @Test
-    public void testCreateCatalog() {
+    void testCreateCatalog() {
         sql("create catalog cat").ok("CREATE CATALOG `CAT`");
         sql("create catalog cat with ('k1'='v1')")
                 .ok("CREATE CATALOG `CAT` WITH (\n" + "  'k1' = 'v1'\n" + ")");
     }
 
     @Test
-    public void testShowCatalogs() {
+    void testShowCatalogs() {
         sql("show catalogs").ok("SHOW CATALOGS");
     }
 
     @Test
-    public void testShowCurrentCatalog() {
+    void testShowCurrentCatalog() {
         sql("show current catalog").ok("SHOW CURRENT CATALOG");
     }
 
     @Test
-    public void testUseCatalog() {
+    void testUseCatalog() {
         sql("use catalog cat").ok("USE CATALOG `CAT`");
     }
 
     @Test
-    public void testDescribeCatalog() {
+    void testDescribeCatalog() {
         sql("describe catalog cat").ok("DESCRIBE CATALOG `CAT`");
 
         sql("desc catalog cat").ok("DESCRIBE CATALOG `CAT`");
     }
 
     @Test
-    public void testAlterTableRename() {
+    void testAlterTableRename() {
         sql("alter table tbl rename to tbl1").ok("ALTER TABLE `TBL` RENAME TO `TBL1`");
     }
 
     @Test
-    public void testAlterTableSerDe() {
+    void testAlterTableSerDe() {
         sql("alter table tbl set serde 'serde.class' with serdeproperties ('field.delim'='\u0001')")
                 .ok(
                         "ALTER TABLE `TBL` SET SERDE 'serde.class' WITH SERDEPROPERTIES (\n"
@@ -307,7 +307,7 @@ public class FlinkHiveSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testAlterTableLocation() {
+    void testAlterTableLocation() {
         sql("alter table tbl set location '/new/table/path'")
                 .ok("ALTER TABLE `TBL` SET LOCATION '/new/table/path'");
         sql("alter table tbl partition (p1=1,p2='a') set location '/new/partition/location'")
@@ -318,7 +318,7 @@ public class FlinkHiveSqlParserImplTest extends SqlParserTest {
     // TODO: support ALTER CLUSTERED BY, SKEWED, STORED AS DIRECTORIES, column constraints
 
     @Test
-    public void testAlterPartitionRename() {
+    void testAlterPartitionRename() {
         sql("alter table tbl partition (p=1) rename to partition (p=2)")
                 .ok(
                         "ALTER TABLE `TBL` PARTITION (`P` = 1)\n"
@@ -327,7 +327,7 @@ public class FlinkHiveSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testAlterTableProperties() {
+    void testAlterTableProperties() {
         sql("alter table tbl set tblproperties('k1'='v1','k2'='v2')")
                 .ok(
                         "ALTER TABLE `TBL` SET TBLPROPERTIES (\n"
@@ -341,7 +341,7 @@ public class FlinkHiveSqlParserImplTest extends SqlParserTest {
     // TODO: support (UN)ARCHIVE PARTITION
 
     @Test
-    public void testAlterFileFormat() {
+    void testAlterFileFormat() {
         sql("alter table tbl set fileformat rcfile")
                 .ok("ALTER TABLE `TBL` SET FILEFORMAT `RCFILE`");
         sql("alter table tbl partition (p=1) set fileformat sequencefile")
@@ -351,7 +351,7 @@ public class FlinkHiveSqlParserImplTest extends SqlParserTest {
     // TODO: support ALTER TABLE/PARTITION TOUCH, PROTECTION, COMPACT, CONCATENATE, UPDATE COLUMNS
 
     @Test
-    public void testChangeColumn() {
+    void testChangeColumn() {
         sql("alter table tbl change c c1 struct<f0:timestamp,f1:array<char(5)>> restrict")
                 .ok(
                         "ALTER TABLE `TBL` CHANGE COLUMN `C` `C1` STRUCT< `F0` TIMESTAMP, `F1` ARRAY< CHAR(5) > > RESTRICT");
@@ -361,7 +361,7 @@ public class FlinkHiveSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testAddReplaceColumn() {
+    void testAddReplaceColumn() {
         sql("alter table tbl add columns (a float,b timestamp,c binary) cascade")
                 .ok(
                         "ALTER TABLE `TBL` ADD COLUMNS (\n"
@@ -379,7 +379,7 @@ public class FlinkHiveSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testCreateView() {
+    void testCreateView() {
         sql("create view db1.v1 as select x,y from tbl")
                 .ok("CREATE VIEW `DB1`.`V1`\n" + "AS\n" + "SELECT `X`, `Y`\n" + "FROM `TBL`");
         sql("create view if not exists v1 (c1,c2) as select * from tbl")
@@ -403,13 +403,13 @@ public class FlinkHiveSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testDropView() {
+    void testDropView() {
         sql("drop view v1").ok("DROP VIEW `V1`");
         sql("drop view if exists v1").ok("DROP VIEW IF EXISTS `V1`");
     }
 
     @Test
-    public void testAlterView() {
+    void testAlterView() {
         sql("alter view v1 rename to v2").ok("ALTER VIEW `V1` RENAME TO `V2`");
         sql("alter view v1 set tblproperties ('k1'='v1')")
                 .ok("ALTER VIEW `V1` SET TBLPROPERTIES (\n" + "  'k1' = 'v1'\n" + ")");
@@ -418,7 +418,7 @@ public class FlinkHiveSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testAddPartition() {
+    void testAddPartition() {
         sql("alter table tbl add partition (p1=1,p2='a') location '/part1/location'")
                 .ok(
                         "ALTER TABLE `TBL`\n"
@@ -433,7 +433,7 @@ public class FlinkHiveSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testDropPartition() {
+    void testDropPartition() {
         sql("alter table tbl drop if exists partition (p=1)")
                 .ok("ALTER TABLE `TBL`\n" + "DROP IF EXISTS\n" + "PARTITION (`P` = 1)");
         sql("alter table tbl drop partition (p1='a',p2=1), partition(p1='b',p2=2)")
@@ -454,20 +454,20 @@ public class FlinkHiveSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testShowPartitions() {
+    void testShowPartitions() {
         sql("show partitions tbl").ok("SHOW PARTITIONS `TBL`");
         sql("show partitions tbl partition (p=1)").ok("SHOW PARTITIONS `TBL` PARTITION (`P` = 1)");
     }
 
     @Test
-    public void testAddJar() {
+    void testAddJar() {
         sql("add Jar './test.sql'").ok("ADD JAR './test.sql'");
         sql("add JAR 'file:///path/to/\nwhatever'").ok("ADD JAR 'file:///path/to/\nwhatever'");
         sql("add JAR 'oss://path/helloworld.go'").ok("ADD JAR 'oss://path/helloworld.go'");
     }
 
     @Test
-    public void testRemoveJar() {
+    void testRemoveJar() {
         sql("remove Jar './test.sql'").ok("REMOVE JAR './test.sql'");
         sql("remove JAR 'file:///path/to/\nwhatever'")
                 .ok("REMOVE JAR 'file:///path/to/\nwhatever'");
@@ -475,12 +475,12 @@ public class FlinkHiveSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testShowJars() {
+    void testShowJars() {
         sql("show jars").ok("SHOW JARS");
     }
 
     @Test
-    public void testLoadModule() {
+    void testLoadModule() {
         sql("load module hive").ok("LOAD MODULE `HIVE`");
 
         sql("load module hive with ('hive-version' = '3.1.2')")
@@ -488,12 +488,12 @@ public class FlinkHiveSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testUnloadModule() {
+    void testUnloadModule() {
         sql("unload module hive").ok("UNLOAD MODULE `HIVE`");
     }
 
     @Test
-    public void testUseModules() {
+    void testUseModules() {
         sql("use modules hive").ok("USE MODULES `HIVE`");
 
         sql("use modules x, y, z").ok("USE MODULES `X`, `Y`, `Z`");
@@ -505,57 +505,57 @@ public class FlinkHiveSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testShowModules() {
+    void testShowModules() {
         sql("show modules").ok("SHOW MODULES");
 
         sql("show full modules").ok("SHOW FULL MODULES");
     }
 
     @Test
-    public void testExplain() {
+    void testExplain() {
         String sql = "explain plan for select * from emps";
         String expected = "EXPLAIN SELECT *\n" + "FROM `EMPS`";
         this.sql(sql).ok(expected);
     }
 
     @Test
-    public void testExplainJsonFormat() {
+    void testExplainJsonFormat() {
         // Unsupported feature. Escape the test.
     }
 
     @Test
-    public void testExplainWithImpl() {
+    void testExplainWithImpl() {
         // Unsupported feature. Escape the test.
     }
 
     @Test
-    public void testExplainWithoutImpl() {
+    void testExplainWithoutImpl() {
         // Unsupported feature. Escape the test.
     }
 
     @Test
-    public void testExplainWithType() {
+    void testExplainWithType() {
         // Unsupported feature. Escape the test.
     }
 
     @Test
-    public void testExplainAsXml() {
+    void testExplainAsXml() {
         // Unsupported feature. Escape the test.
     }
 
     @Test
-    public void testExplainAsJson() {
+    void testExplainAsJson() {
         // TODO: FLINK-20562
     }
 
     @Test
-    public void testExplainInsert() {
+    void testExplainInsert() {
         String expected = "EXPLAIN INSERT INTO `EMPS1`\n" + "(SELECT *\n" + "FROM `EMPS2`)";
         this.sql("explain plan for insert into emps1 select * from emps2").ok(expected);
     }
 
     @Test
-    public void testExplainUpsert() {
+    void testExplainUpsert() {
         String sql = "explain plan for upsert into emps1 values (1, 2)";
         String expected = "EXPLAIN UPSERT INTO `EMPS1`\n" + "VALUES (ROW(1, 2))";
         this.sql(sql).ok(expected);

--- a/flink-table/flink-sql-parser-hive/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/flink-table/flink-sql-parser-hive/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.util.TestLoggerExtension

--- a/flink-table/flink-sql-parser/pom.xml
+++ b/flink-table/flink-sql-parser/pom.xml
@@ -197,6 +197,10 @@ under the License.
 			<scope>test</scope>
 			<type>test-jar</type>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-test-utils-junit</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/CreateTableLikeTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/CreateTableLikeTest.java
@@ -32,14 +32,13 @@ import org.apache.calcite.sql.parser.SqlParseException;
 import org.apache.calcite.sql.parser.SqlParser;
 import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.HamcrestCondition.matching;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -47,8 +46,6 @@ import static org.hamcrest.Matchers.empty;
 
 /** Tests for parsing and validating {@link SqlTableLike} clause. */
 public class CreateTableLikeTest {
-
-    @Rule public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void testNoOptions() throws Exception {
@@ -114,9 +111,9 @@ public class CreateTableLikeTest {
                                                 + ")")
                                 .parseStmt();
 
-        thrown.expect(SqlValidateException.class);
-        thrown.expectMessage("Each like option feature can be declared only once.");
-        extendedSqlNode.validate();
+        assertThatThrownBy(extendedSqlNode::validate)
+                .isInstanceOf(SqlValidateException.class)
+                .hasMessageContaining("Each like option feature can be declared only once.");
     }
 
     @Test
@@ -132,9 +129,10 @@ public class CreateTableLikeTest {
                                                 + ")")
                                 .parseStmt();
 
-        thrown.expect(SqlValidateException.class);
-        thrown.expectMessage("Illegal merging strategy 'OVERWRITING' for 'PARTITIONS' option.");
-        extendedSqlNode.validate();
+        assertThatThrownBy(extendedSqlNode::validate)
+                .isInstanceOf(SqlValidateException.class)
+                .hasMessageContaining(
+                        "Illegal merging strategy 'OVERWRITING' for 'PARTITIONS' option.");
     }
 
     @Test
@@ -150,9 +148,9 @@ public class CreateTableLikeTest {
                                                 + ")")
                                 .parseStmt();
 
-        thrown.expect(SqlValidateException.class);
-        thrown.expectMessage("Illegal merging strategy 'OVERWRITING' for 'ALL' option.");
-        extendedSqlNode.validate();
+        assertThatThrownBy(extendedSqlNode::validate)
+                .isInstanceOf(SqlValidateException.class)
+                .hasMessageContaining("Illegal merging strategy 'OVERWRITING' for 'ALL' option.");
     }
 
     @Test
@@ -168,43 +166,53 @@ public class CreateTableLikeTest {
                                                 + ")")
                                 .parseStmt();
 
-        thrown.expect(SqlValidateException.class);
-        thrown.expectMessage("Illegal merging strategy 'OVERWRITING' for 'CONSTRAINTS' option.");
-        extendedSqlNode.validate();
+        assertThatThrownBy(extendedSqlNode::validate)
+                .isInstanceOf(SqlValidateException.class)
+                .hasMessageContaining(
+                        "Illegal merging strategy 'OVERWRITING' for 'CONSTRAINTS' option.");
     }
 
     @Test
-    public void testInvalidNoOptions() throws SqlParseException {
-        thrown.expect(SqlParseException.class);
-        thrown.expectMessage(
-                "Encountered \")\" at line 4, column 9.\n"
-                        + "Was expecting one of:\n"
-                        + "    \"EXCLUDING\" ...\n"
-                        + "    \"INCLUDING\" ...\n"
-                        + "    \"OVERWRITING\" ...");
-        createFlinkParser("CREATE TABLE t (\n" + "   a STRING\n" + ")\n" + "LIKE b ()").parseStmt();
+    public void testInvalidNoOptions() {
+        assertThatThrownBy(
+                        () ->
+                                createFlinkParser(
+                                                "CREATE TABLE t (\n"
+                                                        + "   a STRING\n"
+                                                        + ")\n"
+                                                        + "LIKE b ()")
+                                        .parseStmt())
+                .isInstanceOf(SqlParseException.class)
+                .hasMessageContaining(
+                        "Encountered \")\" at line 4, column 9.\n"
+                                + "Was expecting one of:\n"
+                                + "    \"EXCLUDING\" ...\n"
+                                + "    \"INCLUDING\" ...\n"
+                                + "    \"OVERWRITING\" ...");
     }
 
     @Test
-    public void testInvalidNoSourceTable() throws SqlParseException {
-        thrown.expect(SqlParseException.class);
-        thrown.expectMessage(
-                "Encountered \"(\" at line 4, column 6.\n"
-                        + "Was expecting one of:\n"
-                        + "    <BRACKET_QUOTED_IDENTIFIER> ...\n"
-                        + "    <QUOTED_IDENTIFIER> ...\n"
-                        + "    <BACK_QUOTED_IDENTIFIER> ...\n"
-                        + "    <HYPHENATED_IDENTIFIER> ...\n"
-                        + "    <IDENTIFIER> ...\n"
-                        + "    <UNICODE_QUOTED_IDENTIFIER> ...\n");
-        createFlinkParser(
-                        "CREATE TABLE t (\n"
-                                + "   a STRING\n"
-                                + ")\n"
-                                + "LIKE ("
-                                + "   INCLUDING ALL"
-                                + ")")
-                .parseStmt();
+    public void testInvalidNoSourceTable() {
+        assertThatThrownBy(
+                        () ->
+                                createFlinkParser(
+                                                "CREATE TABLE t (\n"
+                                                        + "   a STRING\n"
+                                                        + ")\n"
+                                                        + "LIKE ("
+                                                        + "   INCLUDING ALL"
+                                                        + ")")
+                                        .parseStmt())
+                .isInstanceOf(SqlParseException.class)
+                .hasMessageContaining(
+                        "Encountered \"(\" at line 4, column 6.\n"
+                                + "Was expecting one of:\n"
+                                + "    <BRACKET_QUOTED_IDENTIFIER> ...\n"
+                                + "    <QUOTED_IDENTIFIER> ...\n"
+                                + "    <BACK_QUOTED_IDENTIFIER> ...\n"
+                                + "    <HYPHENATED_IDENTIFIER> ...\n"
+                                + "    <IDENTIFIER> ...\n"
+                                + "    <UNICODE_QUOTED_IDENTIFIER> ...\n");
     }
 
     public static SqlTableLikeOption option(

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/CreateTableLikeTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/CreateTableLikeTest.java
@@ -45,7 +45,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.empty;
 
 /** Tests for parsing and validating {@link SqlTableLike} clause. */
-public class CreateTableLikeTest {
+class CreateTableLikeTest {
 
     @Test
     void testNoOptions() throws Exception {

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/CreateTableLikeTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/CreateTableLikeTest.java
@@ -48,7 +48,7 @@ import static org.hamcrest.Matchers.empty;
 public class CreateTableLikeTest {
 
     @Test
-    public void testNoOptions() throws Exception {
+    void testNoOptions() throws Exception {
         SqlNode actualNode =
                 createFlinkParser("CREATE TABLE t (\n" + "   a STRING\n" + ")\n" + "LIKE b")
                         .parseStmt();
@@ -58,7 +58,7 @@ public class CreateTableLikeTest {
     }
 
     @Test
-    public void testCreateTableLike() throws Exception {
+    void testCreateTableLike() throws Exception {
         SqlNode actualNode =
                 createFlinkParser(
                                 "CREATE TABLE t (\n"
@@ -98,7 +98,7 @@ public class CreateTableLikeTest {
     }
 
     @Test
-    public void testCreateTableLikeCannotDuplicateOptions() throws Exception {
+    void testCreateTableLikeCannotDuplicateOptions() throws Exception {
         ExtendedSqlNode extendedSqlNode =
                 (ExtendedSqlNode)
                         createFlinkParser(
@@ -117,7 +117,7 @@ public class CreateTableLikeTest {
     }
 
     @Test
-    public void testInvalidOverwritingForPartition() throws Exception {
+    void testInvalidOverwritingForPartition() throws Exception {
         ExtendedSqlNode extendedSqlNode =
                 (ExtendedSqlNode)
                         createFlinkParser(
@@ -136,7 +136,7 @@ public class CreateTableLikeTest {
     }
 
     @Test
-    public void testInvalidOverwritingForAll() throws Exception {
+    void testInvalidOverwritingForAll() throws Exception {
         ExtendedSqlNode extendedSqlNode =
                 (ExtendedSqlNode)
                         createFlinkParser(
@@ -154,7 +154,7 @@ public class CreateTableLikeTest {
     }
 
     @Test
-    public void testInvalidOverwritingForConstraints() throws Exception {
+    void testInvalidOverwritingForConstraints() throws Exception {
         ExtendedSqlNode extendedSqlNode =
                 (ExtendedSqlNode)
                         createFlinkParser(
@@ -173,7 +173,7 @@ public class CreateTableLikeTest {
     }
 
     @Test
-    public void testInvalidNoOptions() {
+    void testInvalidNoOptions() {
         assertThatThrownBy(
                         () ->
                                 createFlinkParser(
@@ -192,7 +192,7 @@ public class CreateTableLikeTest {
     }
 
     @Test
-    public void testInvalidNoSourceTable() {
+    void testInvalidNoSourceTable() {
         assertThatThrownBy(
                         () ->
                                 createFlinkParser(

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkDDLDataTypeTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkDDLDataTypeTest.java
@@ -52,153 +52,161 @@ import org.apache.calcite.test.MockSqlOperatorTable;
 import org.apache.calcite.test.catalog.MockCatalogReaderSimple;
 import org.apache.calcite.util.SourceStringReader;
 import org.apache.calcite.util.Util;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.annotation.Nullable;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.of;
 
 /** Tests for all the supported Flink DDL data types. */
-@RunWith(Parameterized.class)
 public class FlinkDDLDataTypeTest {
     private static final Fixture FIXTURE = new Fixture(TestFactory.INSTANCE.getTypeFactory());
     private static final String DDL_FORMAT =
             "create table t1 (\n" + "  f0 %s\n" + ") with (\n" + "  'k1' = 'v1'\n" + ")";
 
-    @Parameterized.Parameters(name = "{index}: {0}")
-    public static List<TestItem> testData() {
-        return Arrays.asList(
-                createTestItem("CHAR", nullable(FIXTURE.char1Type), "CHAR"),
-                createTestItem("CHAR NOT NULL", FIXTURE.char1Type, "CHAR NOT NULL"),
-                createTestItem("CHAR   NOT \t\nNULL", FIXTURE.char1Type, "CHAR NOT NULL"),
-                createTestItem("char not null", FIXTURE.char1Type, "CHAR NOT NULL"),
-                createTestItem("CHAR NULL", nullable(FIXTURE.char1Type), "CHAR"),
-                createTestItem("CHAR(33)", nullable(FIXTURE.char33Type), "CHAR(33)"),
-                createTestItem("VARCHAR", nullable(FIXTURE.varcharType), "VARCHAR"),
-                createTestItem("VARCHAR(33)", nullable(FIXTURE.varchar33Type), "VARCHAR(33)"),
-                createTestItem(
+    public static Stream<Arguments> testData() {
+        return Stream.of(
+                createArgumentsTestItem("CHAR", nullable(FIXTURE.char1Type), "CHAR"),
+                createArgumentsTestItem("CHAR NOT NULL", FIXTURE.char1Type, "CHAR NOT NULL"),
+                createArgumentsTestItem("CHAR   NOT \t\nNULL", FIXTURE.char1Type, "CHAR NOT NULL"),
+                createArgumentsTestItem("char not null", FIXTURE.char1Type, "CHAR NOT NULL"),
+                createArgumentsTestItem("CHAR NULL", nullable(FIXTURE.char1Type), "CHAR"),
+                createArgumentsTestItem("CHAR(33)", nullable(FIXTURE.char33Type), "CHAR(33)"),
+                createArgumentsTestItem("VARCHAR", nullable(FIXTURE.varcharType), "VARCHAR"),
+                createArgumentsTestItem(
+                        "VARCHAR(33)", nullable(FIXTURE.varchar33Type), "VARCHAR(33)"),
+                createArgumentsTestItem(
                         "STRING",
                         nullable(FIXTURE.createSqlType(SqlTypeName.VARCHAR, Integer.MAX_VALUE)),
                         "STRING"),
-                createTestItem("BOOLEAN", nullable(FIXTURE.booleanType), "BOOLEAN"),
-                createTestItem("BINARY", nullable(FIXTURE.binaryType), "BINARY"),
-                createTestItem("BINARY(33)", nullable(FIXTURE.binary33Type), "BINARY(33)"),
-                createTestItem("VARBINARY", nullable(FIXTURE.varbinaryType), "VARBINARY"),
-                createTestItem("VARBINARY(33)", nullable(FIXTURE.varbinary33Type), "VARBINARY(33)"),
-                createTestItem(
+                createArgumentsTestItem("BOOLEAN", nullable(FIXTURE.booleanType), "BOOLEAN"),
+                createArgumentsTestItem("BINARY", nullable(FIXTURE.binaryType), "BINARY"),
+                createArgumentsTestItem("BINARY(33)", nullable(FIXTURE.binary33Type), "BINARY(33)"),
+                createArgumentsTestItem("VARBINARY", nullable(FIXTURE.varbinaryType), "VARBINARY"),
+                createArgumentsTestItem(
+                        "VARBINARY(33)", nullable(FIXTURE.varbinary33Type), "VARBINARY(33)"),
+                createArgumentsTestItem(
                         "BYTES",
                         nullable(FIXTURE.createSqlType(SqlTypeName.VARBINARY, Integer.MAX_VALUE)),
                         "BYTES"),
-                createTestItem("DECIMAL", nullable(FIXTURE.decimalType), "DECIMAL"),
-                createTestItem("DEC", nullable(FIXTURE.decimalType), "DECIMAL"),
-                createTestItem("NUMERIC", nullable(FIXTURE.decimalType), "DECIMAL"),
-                createTestItem("DECIMAL(10)", nullable(FIXTURE.decimalP10S0Type), "DECIMAL(10)"),
-                createTestItem("DEC(10)", nullable(FIXTURE.decimalP10S0Type), "DECIMAL(10)"),
-                createTestItem("NUMERIC(10)", nullable(FIXTURE.decimalP10S0Type), "DECIMAL(10)"),
-                createTestItem(
+                createArgumentsTestItem("DECIMAL", nullable(FIXTURE.decimalType), "DECIMAL"),
+                createArgumentsTestItem("DEC", nullable(FIXTURE.decimalType), "DECIMAL"),
+                createArgumentsTestItem("NUMERIC", nullable(FIXTURE.decimalType), "DECIMAL"),
+                createArgumentsTestItem(
+                        "DECIMAL(10)", nullable(FIXTURE.decimalP10S0Type), "DECIMAL(10)"),
+                createArgumentsTestItem(
+                        "DEC(10)", nullable(FIXTURE.decimalP10S0Type), "DECIMAL(10)"),
+                createArgumentsTestItem(
+                        "NUMERIC(10)", nullable(FIXTURE.decimalP10S0Type), "DECIMAL(10)"),
+                createArgumentsTestItem(
                         "DECIMAL(10, 3)", nullable(FIXTURE.decimalP10S3Type), "DECIMAL(10, 3)"),
-                createTestItem("DEC(10, 3)", nullable(FIXTURE.decimalP10S3Type), "DECIMAL(10, 3)"),
-                createTestItem(
+                createArgumentsTestItem(
+                        "DEC(10, 3)", nullable(FIXTURE.decimalP10S3Type), "DECIMAL(10, 3)"),
+                createArgumentsTestItem(
                         "NUMERIC(10, 3)", nullable(FIXTURE.decimalP10S3Type), "DECIMAL(10, 3)"),
-                createTestItem("TINYINT", nullable(FIXTURE.tinyintType), "TINYINT"),
-                createTestItem("SMALLINT", nullable(FIXTURE.smallintType), "SMALLINT"),
-                createTestItem("INTEGER", nullable(FIXTURE.intType), "INTEGER"),
-                createTestItem("INT", nullable(FIXTURE.intType), "INTEGER"),
-                createTestItem("BIGINT", nullable(FIXTURE.bigintType), "BIGINT"),
-                createTestItem("FLOAT", nullable(FIXTURE.floatType), "FLOAT"),
-                createTestItem("DOUBLE", nullable(FIXTURE.doubleType), "DOUBLE"),
-                createTestItem("DOUBLE PRECISION", nullable(FIXTURE.doubleType), "DOUBLE"),
-                createTestItem("DATE", nullable(FIXTURE.dateType), "DATE"),
-                createTestItem("TIME", nullable(FIXTURE.timeType), "TIME"),
-                createTestItem("TIME WITHOUT TIME ZONE", nullable(FIXTURE.timeType), "TIME"),
-                createTestItem("TIME(3)", nullable(FIXTURE.time3Type), "TIME(3)"),
-                createTestItem("TIME(3) WITHOUT TIME ZONE", nullable(FIXTURE.time3Type), "TIME(3)"),
-                createTestItem("TIMESTAMP", nullable(FIXTURE.timestampType), "TIMESTAMP"),
-                createTestItem(
+                createArgumentsTestItem("TINYINT", nullable(FIXTURE.tinyintType), "TINYINT"),
+                createArgumentsTestItem("SMALLINT", nullable(FIXTURE.smallintType), "SMALLINT"),
+                createArgumentsTestItem("INTEGER", nullable(FIXTURE.intType), "INTEGER"),
+                createArgumentsTestItem("INT", nullable(FIXTURE.intType), "INTEGER"),
+                createArgumentsTestItem("BIGINT", nullable(FIXTURE.bigintType), "BIGINT"),
+                createArgumentsTestItem("FLOAT", nullable(FIXTURE.floatType), "FLOAT"),
+                createArgumentsTestItem("DOUBLE", nullable(FIXTURE.doubleType), "DOUBLE"),
+                createArgumentsTestItem("DOUBLE PRECISION", nullable(FIXTURE.doubleType), "DOUBLE"),
+                createArgumentsTestItem("DATE", nullable(FIXTURE.dateType), "DATE"),
+                createArgumentsTestItem("TIME", nullable(FIXTURE.timeType), "TIME"),
+                createArgumentsTestItem(
+                        "TIME WITHOUT TIME ZONE", nullable(FIXTURE.timeType), "TIME"),
+                createArgumentsTestItem("TIME(3)", nullable(FIXTURE.time3Type), "TIME(3)"),
+                createArgumentsTestItem(
+                        "TIME(3) WITHOUT TIME ZONE", nullable(FIXTURE.time3Type), "TIME(3)"),
+                createArgumentsTestItem("TIMESTAMP", nullable(FIXTURE.timestampType), "TIMESTAMP"),
+                createArgumentsTestItem(
                         "TIMESTAMP WITHOUT TIME ZONE",
                         nullable(FIXTURE.timestampType),
                         "TIMESTAMP"),
-                createTestItem("TIMESTAMP(3)", nullable(FIXTURE.timestamp3Type), "TIMESTAMP(3)"),
-                createTestItem(
+                createArgumentsTestItem(
+                        "TIMESTAMP(3)", nullable(FIXTURE.timestamp3Type), "TIMESTAMP(3)"),
+                createArgumentsTestItem(
                         "TIMESTAMP(3) WITHOUT TIME ZONE",
                         nullable(FIXTURE.timestamp3Type),
                         "TIMESTAMP(3)"),
-                createTestItem(
+                createArgumentsTestItem(
                         "TIMESTAMP WITH LOCAL TIME ZONE",
                         nullable(FIXTURE.timestampWithLocalTimeZoneType),
                         "TIMESTAMP WITH LOCAL TIME ZONE"),
-                createTestItem(
+                createArgumentsTestItem(
                         "TIMESTAMP_LTZ",
                         nullable(FIXTURE.timestampWithLocalTimeZoneType),
                         "TIMESTAMP_LTZ"),
-                createTestItem(
+                createArgumentsTestItem(
                         "TIMESTAMP(3) WITH LOCAL TIME ZONE",
                         nullable(FIXTURE.timestamp3WithLocalTimeZoneType),
                         "TIMESTAMP(3) WITH LOCAL TIME ZONE"),
-                createTestItem(
+                createArgumentsTestItem(
                         "TIMESTAMP_LTZ(3)",
                         nullable(FIXTURE.timestamp3WithLocalTimeZoneType),
                         "TIMESTAMP_LTZ(3)"),
-                createTestItem(
+                createArgumentsTestItem(
                         "ARRAY<TIMESTAMP(3) WITH LOCAL TIME ZONE>",
                         nullable(
                                 FIXTURE.createArrayType(
                                         nullable(FIXTURE.timestamp3WithLocalTimeZoneType))),
                         "ARRAY< TIMESTAMP(3) WITH LOCAL TIME ZONE >"),
-                createTestItem(
+                createArgumentsTestItem(
                         "ARRAY<TIMESTAMP_LTZ(3)>",
                         nullable(
                                 FIXTURE.createArrayType(
                                         nullable(FIXTURE.timestamp3WithLocalTimeZoneType))),
                         "ARRAY< TIMESTAMP_LTZ(3) >"),
-                createTestItem(
+                createArgumentsTestItem(
                         "ARRAY<INT NOT NULL>",
                         nullable(FIXTURE.createArrayType(FIXTURE.intType)),
                         "ARRAY< INTEGER NOT NULL >"),
-                createTestItem(
+                createArgumentsTestItem(
                         "INT ARRAY",
                         nullable(FIXTURE.createArrayType(nullable(FIXTURE.intType))),
                         "INTEGER ARRAY"),
-                createTestItem(
+                createArgumentsTestItem(
                         "INT NOT NULL ARRAY",
                         nullable(FIXTURE.createArrayType(FIXTURE.intType)),
                         "INTEGER NOT NULL ARRAY"),
-                createTestItem(
+                createArgumentsTestItem(
                         "INT ARRAY NOT NULL",
                         FIXTURE.createArrayType(nullable(FIXTURE.intType)),
                         "INTEGER ARRAY NOT NULL"),
-                createTestItem(
+                createArgumentsTestItem(
                         "MULTISET<INT NOT NULL>",
                         nullable(FIXTURE.createMultisetType(FIXTURE.intType)),
                         "MULTISET< INTEGER NOT NULL >"),
-                createTestItem(
+                createArgumentsTestItem(
                         "INT MULTISET",
                         nullable(FIXTURE.createMultisetType(nullable(FIXTURE.intType))),
                         "INTEGER MULTISET"),
-                createTestItem(
+                createArgumentsTestItem(
                         "INT NOT NULL MULTISET",
                         nullable(FIXTURE.createMultisetType(FIXTURE.intType)),
                         "INTEGER NOT NULL MULTISET"),
-                createTestItem(
+                createArgumentsTestItem(
                         "INT MULTISET NOT NULL",
                         FIXTURE.createMultisetType(nullable(FIXTURE.intType)),
                         "INTEGER MULTISET NOT NULL"),
-                createTestItem(
+                createArgumentsTestItem(
                         "MAP<BIGINT, BOOLEAN>",
                         nullable(
                                 FIXTURE.createMapType(
                                         nullable(FIXTURE.bigintType),
                                         nullable(FIXTURE.booleanType))),
                         "MAP< BIGINT, BOOLEAN >"),
-                createTestItem(
+                createArgumentsTestItem(
                         "ROW<f0 INT NOT NULL, f1 BOOLEAN>",
                         nullable(
                                 FIXTURE.createStructType(
@@ -206,7 +214,7 @@ public class FlinkDDLDataTypeTest {
                                                 FIXTURE.intType, nullable(FIXTURE.booleanType)),
                                         Arrays.asList("f0", "f1"))),
                         "ROW< `f0` INTEGER NOT NULL, `f1` BOOLEAN >"),
-                createTestItem(
+                createArgumentsTestItem(
                         "ROW(f0 INT NOT NULL, f1 BOOLEAN)",
                         nullable(
                                 FIXTURE.createStructType(
@@ -214,33 +222,33 @@ public class FlinkDDLDataTypeTest {
                                                 FIXTURE.intType, nullable(FIXTURE.booleanType)),
                                         Arrays.asList("f0", "f1"))),
                         "ROW(`f0` INTEGER NOT NULL, `f1` BOOLEAN)"),
-                createTestItem(
+                createArgumentsTestItem(
                         "ROW<`f0` INT>",
                         nullable(
                                 FIXTURE.createStructType(
                                         Collections.singletonList(nullable(FIXTURE.intType)),
                                         Collections.singletonList("f0"))),
                         "ROW< `f0` INTEGER >"),
-                createTestItem(
+                createArgumentsTestItem(
                         "ROW(`f0` INT)",
                         nullable(
                                 FIXTURE.createStructType(
                                         Collections.singletonList(nullable(FIXTURE.intType)),
                                         Collections.singletonList("f0"))),
                         "ROW(`f0` INTEGER)"),
-                createTestItem(
+                createArgumentsTestItem(
                         "ROW<>",
                         nullable(
                                 FIXTURE.createStructType(
                                         Collections.emptyList(), Collections.emptyList())),
                         "ROW<>"),
-                createTestItem(
+                createArgumentsTestItem(
                         "ROW()",
                         nullable(
                                 FIXTURE.createStructType(
                                         Collections.emptyList(), Collections.emptyList())),
                         "ROW()"),
-                createTestItem(
+                createArgumentsTestItem(
                         "ROW<f0 INT NOT NULL 'This is a comment.', "
                                 + "f1 BOOLEAN 'This as well.'>",
                         nullable(
@@ -250,7 +258,7 @@ public class FlinkDDLDataTypeTest {
                                         Arrays.asList("f0", "f1"))),
                         "ROW< `f0` INTEGER NOT NULL 'This is a comment.', "
                                 + "`f1` BOOLEAN 'This as well.' >"),
-                createTestItem(
+                createArgumentsTestItem(
                         "RAW(    '"
                                 + Fixture.RAW_TYPE_INT_CLASS
                                 + "'   ,   '"
@@ -262,7 +270,7 @@ public class FlinkDDLDataTypeTest {
                                 + "', '"
                                 + Fixture.RAW_TYPE_INT_SERIALIZER_STRING
                                 + "')"),
-                createTestItem(
+                createArgumentsTestItem(
                         "RAW('"
                                 + Fixture.RAW_TYPE_INT_CLASS
                                 + "', '"
@@ -274,7 +282,7 @@ public class FlinkDDLDataTypeTest {
                                 + "', '"
                                 + Fixture.RAW_TYPE_INT_SERIALIZER_STRING
                                 + "') NOT NULL"),
-                createTestItem(
+                createArgumentsTestItem(
                         "RAW('"
                                 + Fixture.RAW_TYPE_INT_CLASS
                                 + "', '"
@@ -286,23 +294,25 @@ public class FlinkDDLDataTypeTest {
                         FIXTURE.rawTypeOfInteger),
 
                 // Test parse throws error.
-                createTestItem("TIMESTAMP WITH ^TIME^ ZONE", "(?s).*Encountered \"TIME\" at .*"),
-                createTestItem("TIMESTAMP(3) WITH ^TIME^ ZONE", "(?s).*Encountered \"TIME\" at .*"),
-                createTestItem(
+                createArgumentsTestItem(
+                        "TIMESTAMP WITH ^TIME^ ZONE", "(?s).*Encountered \"TIME\" at .*"),
+                createArgumentsTestItem(
+                        "TIMESTAMP(3) WITH ^TIME^ ZONE", "(?s).*Encountered \"TIME\" at .*"),
+                createArgumentsTestItem(
                         "^NULL^",
                         "(?s).*Incorrect syntax near the keyword 'NULL' at line 2, column 6..*"),
-                createTestItem("cat.db.MyType", null, "`cat`.`db`.`MyType`"),
-                createTestItem("`db`.`MyType`", null, "`db`.`MyType`"),
-                createTestItem("MyType", null, "`MyType`"),
-                createTestItem("ARRAY<MyType>", null, "ARRAY< `MyType` >"),
-                createTestItem(
+                createArgumentsTestItem("cat.db.MyType", null, "`cat`.`db`.`MyType`"),
+                createArgumentsTestItem("`db`.`MyType`", null, "`db`.`MyType`"),
+                createArgumentsTestItem("MyType", null, "`MyType`"),
+                createArgumentsTestItem("ARRAY<MyType>", null, "ARRAY< `MyType` >"),
+                createArgumentsTestItem(
                         "ROW<f0 MyType, f1 `c`.`d`.`t`>",
                         null,
                         "ROW< `f0` `MyType`, `f1` `c`.`d`.`t` >"),
-                createTestItem(
+                createArgumentsTestItem(
                         "^INTERVAL^ YEAR",
                         "(?s).*Incorrect syntax near the keyword 'INTERVAL' at line 2, column 6..*"),
-                createTestItem(
+                createArgumentsTestItem(
                         "RAW(^)^",
                         "(?s).*Encountered \"\\)\" at line 2, column 10.\n.*"
                                 + "Was expecting one of:\n"
@@ -311,7 +321,7 @@ public class FlinkDDLDataTypeTest {
                                 + "    <PREFIXED_STRING_LITERAL> \\.\\.\\.\n"
                                 + "    <UNICODE_STRING_LITERAL> \\.\\.\\.\n"
                                 + ".*"),
-                createTestItem(
+                createArgumentsTestItem(
                         "RAW('java.lang.Integer', ^)^",
                         "(?s).*Encountered \"\\)\" at line 2, column 31\\.\n"
                                 + "Was expecting one of:\n"
@@ -322,7 +332,7 @@ public class FlinkDDLDataTypeTest {
                                 + ".*"));
     }
 
-    private static TestItem createTestItem(Object... args) {
+    private static Arguments createArgumentsTestItem(Object... args) {
         assertThat(args.length).isGreaterThanOrEqualTo(2);
         final String testExpr = (String) args[0];
         TestItem testItem = TestItem.fromTestExpr(testExpr);
@@ -334,27 +344,28 @@ public class FlinkDDLDataTypeTest {
         if (args.length == 3) {
             testItem.withExpectedUnparsed((String) args[2]);
         }
-        return testItem;
+        return of(testItem);
     }
 
-    @Parameterized.Parameter public TestItem testItem;
-
-    @Test
-    public void testDataTypeParsing() {
+    @ParameterizedTest
+    @MethodSource("testData")
+    public void testDataTypeParsing(TestItem testItem) {
         if (testItem.expectedType != null) {
             checkType(testItem.testExpr, testItem.expectedType);
         }
     }
 
-    @Test
-    public void testThrowsError() {
+    @ParameterizedTest
+    @MethodSource("testData")
+    public void testThrowsError(TestItem testItem) {
         if (testItem.expectedError != null) {
             checkFails(testItem.testExpr, testItem.expectedError);
         }
     }
 
-    @Test
-    public void testDataTypeUnparsing() {
+    @ParameterizedTest
+    @MethodSource("testData")
+    public void testDataTypeUnparsing(TestItem testItem) {
         if (testItem.expectedUnparsed != null) {
             checkUnparseTo(testItem.testExpr, testItem.expectedUnparsed);
         }

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkDDLDataTypeTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkDDLDataTypeTest.java
@@ -347,7 +347,7 @@ class FlinkDDLDataTypeTest {
         return of(testItem);
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{index}: {0}")
     @MethodSource("testData")
     void testDataTypeParsing(TestItem testItem) {
         if (testItem.expectedType != null) {

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkDDLDataTypeTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkDDLDataTypeTest.java
@@ -363,7 +363,7 @@ class FlinkDDLDataTypeTest {
         }
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{index}: {0}")
     @MethodSource("testData")
     void testDataTypeUnparsing(TestItem testItem) {
         if (testItem.expectedUnparsed != null) {

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkDDLDataTypeTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkDDLDataTypeTest.java
@@ -68,12 +68,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.of;
 
 /** Tests for all the supported Flink DDL data types. */
-public class FlinkDDLDataTypeTest {
+class FlinkDDLDataTypeTest {
     private static final Fixture FIXTURE = new Fixture(TestFactory.INSTANCE.getTypeFactory());
     private static final String DDL_FORMAT =
             "create table t1 (\n" + "  f0 %s\n" + ") with (\n" + "  'k1' = 'v1'\n" + ")";
 
-    public static Stream<Arguments> testData() {
+    static Stream<Arguments> testData() {
         return Stream.of(
                 createArgumentsTestItem("CHAR", nullable(FIXTURE.char1Type), "CHAR"),
                 createArgumentsTestItem("CHAR NOT NULL", FIXTURE.char1Type, "CHAR NOT NULL"),

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkDDLDataTypeTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkDDLDataTypeTest.java
@@ -355,7 +355,7 @@ class FlinkDDLDataTypeTest {
         }
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{index}: {0}")
     @MethodSource("testData")
     void testThrowsError(TestItem testItem) {
         if (testItem.expectedError != null) {

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkDDLDataTypeTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkDDLDataTypeTest.java
@@ -349,7 +349,7 @@ public class FlinkDDLDataTypeTest {
 
     @ParameterizedTest
     @MethodSource("testData")
-    public void testDataTypeParsing(TestItem testItem) {
+    void testDataTypeParsing(TestItem testItem) {
         if (testItem.expectedType != null) {
             checkType(testItem.testExpr, testItem.expectedType);
         }
@@ -357,7 +357,7 @@ public class FlinkDDLDataTypeTest {
 
     @ParameterizedTest
     @MethodSource("testData")
-    public void testThrowsError(TestItem testItem) {
+    void testThrowsError(TestItem testItem) {
         if (testItem.expectedError != null) {
             checkFails(testItem.testExpr, testItem.expectedError);
         }
@@ -365,7 +365,7 @@ public class FlinkDDLDataTypeTest {
 
     @ParameterizedTest
     @MethodSource("testData")
-    public void testDataTypeUnparsing(TestItem testItem) {
+    void testDataTypeUnparsing(TestItem testItem) {
         if (testItem.expectedUnparsed != null) {
             checkUnparseTo(testItem.testExpr, testItem.expectedUnparsed);
         }

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -40,7 +40,7 @@ import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
 /** FlinkSqlParserImpl tests. * */
 @Execution(CONCURRENT)
-public class FlinkSqlParserImplTest extends SqlParserTest {
+class FlinkSqlParserImplTest extends SqlParserTest {
 
     @Override
     protected SqlParserImplFactory parserImplFactory() {
@@ -48,17 +48,17 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testShowCatalogs() {
+    void testShowCatalogs() {
         sql("show catalogs").ok("SHOW CATALOGS");
     }
 
     @Test
-    public void testShowCurrentCatalog() {
+    void testShowCurrentCatalog() {
         sql("show current catalog").ok("SHOW CURRENT CATALOG");
     }
 
     @Test
-    public void testDescribeCatalog() {
+    void testDescribeCatalog() {
         sql("describe catalog a").ok("DESCRIBE CATALOG `A`");
 
         sql("desc catalog a").ok("DESCRIBE CATALOG `A`");
@@ -70,15 +70,15 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
      */
     @Disabled
     @Test
-    public void testDescribeSchema() {}
+    void testDescribeSchema() {}
 
     @Test
-    public void testUseCatalog() {
+    void testUseCatalog() {
         sql("use catalog a").ok("USE CATALOG `A`");
     }
 
     @Test
-    public void testCreateCatalog() {
+    void testCreateCatalog() {
         sql("create catalog c1\n"
                         + " WITH (\n"
                         + "  'key1'='value1',\n"
@@ -93,28 +93,28 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testDropCatalog() {
+    void testDropCatalog() {
         sql("drop catalog c1").ok("DROP CATALOG `C1`");
     }
 
     @Test
-    public void testShowDataBases() {
+    void testShowDataBases() {
         sql("show databases").ok("SHOW DATABASES");
     }
 
     @Test
-    public void testShowCurrentDatabase() {
+    void testShowCurrentDatabase() {
         sql("show current database").ok("SHOW CURRENT DATABASE");
     }
 
     @Test
-    public void testUseDataBase() {
+    void testUseDataBase() {
         sql("use default_db").ok("USE `DEFAULT_DB`");
         sql("use defaultCatalog.default_db").ok("USE `DEFAULTCATALOG`.`DEFAULT_DB`");
     }
 
     @Test
-    public void testCreateDatabase() {
+    void testCreateDatabase() {
         sql("create database db1").ok("CREATE DATABASE `DB1`");
         sql("create database if not exists db1").ok("CREATE DATABASE IF NOT EXISTS `DB1`");
         sql("create database catalog1.db1").ok("CREATE DATABASE `CATALOG1`.`DB1`");
@@ -134,7 +134,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testDropDatabase() {
+    void testDropDatabase() {
         sql("drop database db1").ok("DROP DATABASE `DB1` RESTRICT");
         sql("drop database catalog1.db1").ok("DROP DATABASE `CATALOG1`.`DB1` RESTRICT");
         sql("drop database db1 RESTRICT").ok("DROP DATABASE `DB1` RESTRICT");
@@ -142,7 +142,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testAlterDatabase() {
+    void testAlterDatabase() {
         final String sql = "alter database db1 set ('key1' = 'value1','key2.a' = 'value2.a')";
         final String expected =
                 "ALTER DATABASE `DB1` SET (\n"
@@ -153,7 +153,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testDescribeDatabase() {
+    void testDescribeDatabase() {
         sql("describe database db1").ok("DESCRIBE DATABASE `DB1`");
         sql("describe database catalog1.db1").ok("DESCRIBE DATABASE `CATALOG1`.`DB1`");
         sql("describe database extended db1").ok("DESCRIBE DATABASE EXTENDED `DB1`");
@@ -164,7 +164,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testAlterFunction() {
+    void testAlterFunction() {
         sql("alter function function1 as 'org.apache.fink.function.function1'")
                 .ok("ALTER FUNCTION `FUNCTION1` AS 'org.apache.fink.function.function1'");
 
@@ -185,13 +185,13 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testShowFunctions() {
+    void testShowFunctions() {
         sql("show functions").ok("SHOW FUNCTIONS");
         sql("show user functions").ok("SHOW USER FUNCTIONS");
     }
 
     @Test
-    public void testShowTables() {
+    void testShowTables() {
         sql("show tables").ok("SHOW TABLES");
         sql("show tables not like '%'").ok("SHOW TABLES NOT LIKE '%'");
 
@@ -228,20 +228,20 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testShowCreateTable() {
+    void testShowCreateTable() {
         sql("show create table tbl").ok("SHOW CREATE TABLE `TBL`");
         sql("show create table catalog1.db1.tbl").ok("SHOW CREATE TABLE `CATALOG1`.`DB1`.`TBL`");
     }
 
     @Test
-    public void testShowCreateView() {
+    void testShowCreateView() {
         sql("show create view v1").ok("SHOW CREATE VIEW `V1`");
         sql("show create view db1.v1").ok("SHOW CREATE VIEW `DB1`.`V1`");
         sql("show create view catalog1.db1.v1").ok("SHOW CREATE VIEW `CATALOG1`.`DB1`.`V1`");
     }
 
     @Test
-    public void testDescribeTable() {
+    void testDescribeTable() {
         sql("describe tbl").ok("DESCRIBE `TBL`");
         sql("describe catalog1.db1.tbl").ok("DESCRIBE `CATALOG1`.`DB1`.`TBL`");
         sql("describe extended db1").ok("DESCRIBE EXTENDED `DB1`");
@@ -252,7 +252,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testShowColumns() {
+    void testShowColumns() {
         sql("show columns from tbl").ok("SHOW COLUMNS FROM `TBL`");
         sql("show columns in tbl").ok("SHOW COLUMNS IN `TBL`");
 
@@ -292,10 +292,10 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
      */
     @Disabled
     @Test
-    public void testDescribeStatement() {}
+    void testDescribeStatement() {}
 
     @Test
-    public void testAlterTable() {
+    void testAlterTable() {
         sql("alter table t1 rename to t2").ok("ALTER TABLE `T1` RENAME TO `T2`");
         sql("alter table c1.d1.t1 rename to t2").ok("ALTER TABLE `C1`.`D1`.`T1` RENAME TO `T2`");
         final String sql0 = "alter table t1 set ('key1'='value1')";
@@ -314,7 +314,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testAlterTableReset() {
+    void testAlterTableReset() {
         sql("alter table t1 reset ('key1')").ok("ALTER TABLE `T1` RESET (\n  'key1'\n)");
 
         sql("alter table t1 reset ('key1', 'key2')")
@@ -324,7 +324,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testAlterTableCompact() {
+    void testAlterTableCompact() {
         sql("alter table t1 compact").ok("ALTER TABLE `T1` COMPACT");
 
         sql("alter table db1.t1 compact").ok("ALTER TABLE `DB1`.`T1` COMPACT");
@@ -339,7 +339,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testCreateTable() {
+    void testCreateTable() {
         final String sql =
                 "CREATE TABLE tbl1 (\n"
                         + "  a bigint,\n"
@@ -382,7 +382,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testCreateTableIfNotExists() {
+    void testCreateTableIfNotExists() {
         final String sql =
                 "CREATE TABLE IF NOT EXISTS tbl1 (\n"
                         + "  a bigint,\n"
@@ -417,7 +417,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testCreateTableWithComment() {
+    void testCreateTableWithComment() {
         final String sql =
                 "CREATE TABLE tbl1 (\n"
                         + "  a bigint comment 'test column comment AAA.',\n"
@@ -462,7 +462,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testCreateTableWithCommentOnComputedColumn() {
+    void testCreateTableWithCommentOnComputedColumn() {
         final String sql =
                 "CREATE TABLE tbl1 (\n"
                         + "  a bigint comment 'test column comment AAA.',\n"
@@ -499,7 +499,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testTableConstraints() {
+    void testTableConstraints() {
         final String sql =
                 "CREATE TABLE tbl1 (\n"
                         + "  a bigint,\n"
@@ -532,7 +532,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testTableConstraintsValidated() {
+    void testTableConstraintsValidated() {
         final String sql =
                 "CREATE TABLE tbl1 (\n"
                         + "  a bigint,\n"
@@ -565,7 +565,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testTableConstraintsWithEnforcement() {
+    void testTableConstraintsWithEnforcement() {
         final String sql =
                 "CREATE TABLE tbl1 (\n"
                         + "  a bigint primary key enforced comment 'test column comment AAA.',\n"
@@ -596,7 +596,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testDuplicatePk() {
+    void testDuplicatePk() {
         final String sql =
                 "CREATE TABLE tbl1 (\n"
                         + "  a bigint comment 'test column comment AAA.',\n"
@@ -614,7 +614,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testCreateTableWithWatermark() {
+    void testCreateTableWithWatermark() {
         final String sql =
                 "CREATE TABLE tbl1 (\n"
                         + "  ts timestamp(3),\n"
@@ -638,7 +638,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testCreateTableWithWatermarkOnComputedColumn() {
+    void testCreateTableWithWatermarkOnComputedColumn() {
         final String sql =
                 "CREATE TABLE tbl1 (\n"
                         + "  log_ts varchar,\n"
@@ -662,7 +662,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testCreateTableWithWatermarkOnNestedField() {
+    void testCreateTableWithWatermarkOnNestedField() {
         final String sql =
                 "CREATE TABLE tbl1 (\n"
                         + "  f1 row<q1 bigint, q2 row<t1 timestamp, t2 varchar>, q3 boolean>,\n"
@@ -684,7 +684,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testCreateTableWithMultipleWatermark() {
+    void testCreateTableWithMultipleWatermark() {
         String sql =
                 "CREATE TABLE tbl1 (\n"
                         + "  f0 bigint,\n"
@@ -701,7 +701,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testCreateTableWithQueryWatermarkExpression() {
+    void testCreateTableWithQueryWatermarkExpression() {
         String sql =
                 "CREATE TABLE tbl1 (\n"
                         + "  f0 bigint,\n"
@@ -717,7 +717,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testCreateTableWithComplexType() {
+    void testCreateTableWithComplexType() {
         final String sql =
                 "CREATE TABLE tbl1 (\n"
                         + "  a ARRAY<bigint>, \n"
@@ -744,7 +744,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testCreateTableWithNestedComplexType() {
+    void testCreateTableWithNestedComplexType() {
         final String sql =
                 "CREATE TABLE tbl1 (\n"
                         + "  a ARRAY<ARRAY<bigint>>, \n"
@@ -771,7 +771,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testCreateTableWithUserDefinedType() {
+    void testCreateTableWithUserDefinedType() {
         final String sql =
                 "create table t(\n"
                         + "  a catalog1.db1.MyType1,\n"
@@ -792,7 +792,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testInvalidComputedColumn() {
+    void testInvalidComputedColumn() {
         final String sql0 =
                 "CREATE TABLE t1 (\n"
                         + "  a bigint, \n"
@@ -826,7 +826,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testColumnSqlString() {
+    void testColumnSqlString() {
         final String sql =
                 "CREATE TABLE sls_stream (\n"
                         + "  a bigint, \n"
@@ -848,7 +848,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testCreateTableWithMinusInOptionKey() {
+    void testCreateTableWithMinusInOptionKey() {
         final String sql =
                 "create table source_table(\n"
                         + "  a int,\n"
@@ -876,7 +876,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testCreateTableWithOptionKeyAsIdentifier() {
+    void testCreateTableWithOptionKeyAsIdentifier() {
         final String sql =
                 "create table source_table(\n"
                         + "  a int,\n"
@@ -889,7 +889,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testCreateTableWithLikeClause() {
+    void testCreateTableWithLikeClause() {
         final String sql =
                 "create table source_table(\n"
                         + "  a int,\n"
@@ -920,7 +920,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testCreateTableWithLikeClauseWithoutColumns() {
+    void testCreateTableWithLikeClauseWithoutColumns() {
         final String sql =
                 ""
                         + "create TEMPORARY table source_table (\n"
@@ -949,7 +949,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testCreateTemporaryTable() {
+    void testCreateTemporaryTable() {
         final String sql =
                 "create temporary table source_table(\n"
                         + "  a int,\n"
@@ -972,7 +972,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testCreateTableWithNoColumns() {
+    void testCreateTableWithNoColumns() {
         final String sql =
                 "create table source_table with (\n" + "  'x' = 'y',\n" + "  'abc' = 'def'\n" + ")";
         final String expected =
@@ -984,7 +984,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testCreateTableWithOnlyWaterMark() {
+    void testCreateTableWithOnlyWaterMark() {
         final String sql =
                 "create table source_table (\n"
                         + "  watermark FOR ts AS ts - interval '3' second\n"
@@ -1003,35 +1003,35 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testDropTable() {
+    void testDropTable() {
         final String sql = "DROP table catalog1.db1.tbl1";
         final String expected = "DROP TABLE `CATALOG1`.`DB1`.`TBL1`";
         sql(sql).ok(expected);
     }
 
     @Test
-    public void testDropIfExists() {
+    void testDropIfExists() {
         final String sql = "DROP table IF EXISTS catalog1.db1.tbl1";
         final String expected = "DROP TABLE IF EXISTS `CATALOG1`.`DB1`.`TBL1`";
         sql(sql).ok(expected);
     }
 
     @Test
-    public void testTemporaryDropTable() {
+    void testTemporaryDropTable() {
         final String sql = "DROP temporary table catalog1.db1.tbl1";
         final String expected = "DROP TEMPORARY TABLE `CATALOG1`.`DB1`.`TBL1`";
         sql(sql).ok(expected);
     }
 
     @Test
-    public void testDropTemporaryIfExists() {
+    void testDropTemporaryIfExists() {
         final String sql = "DROP temporary table IF EXISTS catalog1.db1.tbl1";
         final String expected = "DROP TEMPORARY TABLE IF EXISTS `CATALOG1`.`DB1`.`TBL1`";
         sql(sql).ok(expected);
     }
 
     @Test
-    public void testInsertPartitionSpecs() {
+    void testInsertPartitionSpecs() {
         final String sql1 = "insert into emps partition (x='ab', y='bc') (x,y) select * from emps";
         final String expected =
                 "INSERT INTO `EMPS` "
@@ -1071,7 +1071,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testInsertCaseSensitivePartitionSpecs() {
+    void testInsertCaseSensitivePartitionSpecs() {
         final String expected =
                 "INSERT INTO `emps` "
                         + "PARTITION (`x` = 'ab', `y` = 'bc')\n"
@@ -1084,7 +1084,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testInsertExtendedColumnAsStaticPartition1() {
+    void testInsertExtendedColumnAsStaticPartition1() {
         final String expected =
                 "INSERT INTO `EMPS` EXTEND (`Z` BOOLEAN) "
                         + "PARTITION (`Z` = 'ab')\n"
@@ -1095,7 +1095,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testInsertExtendedColumnAsStaticPartition2() {
+    void testInsertExtendedColumnAsStaticPartition2() {
         assertThatThrownBy(
                         () ->
                                 sql("insert into emps(x, y, z boolean) partition (z='ab') select * from emps")
@@ -1107,7 +1107,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testInsertOverwrite() {
+    void testInsertOverwrite() {
         // non-partitioned
         final String sql = "INSERT OVERWRITE myDB.myTbl SELECT * FROM src";
         final String expected = "INSERT OVERWRITE `MYDB`.`MYTBL`\n" + "(SELECT *\n" + "FROM `SRC`)";
@@ -1125,20 +1125,20 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testInvalidUpsertOverwrite() {
+    void testInvalidUpsertOverwrite() {
         sql("UPSERT ^OVERWRITE^ myDB.myTbl SELECT * FROM src")
                 .fails("OVERWRITE expression is only used with INSERT statement.");
     }
 
     @Test
-    public void testCreateView() {
+    void testCreateView() {
         final String sql = "create view v as select col1 from tbl";
         final String expected = "CREATE VIEW `V`\n" + "AS\n" + "SELECT `COL1`\n" + "FROM `TBL`";
         sql(sql).ok(expected);
     }
 
     @Test
-    public void testCreateViewWithInvalidFieldList() {
+    void testCreateViewWithInvalidFieldList() {
         final String expected =
                 "(?s).*Encountered \"\\)\" at line 1, column 15.\n"
                         + "Was expecting one of:\n"
@@ -1151,7 +1151,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testCreateViewWithComment() {
+    void testCreateViewWithComment() {
         final String sql = "create view v COMMENT 'this is a view' as select col1 from tbl";
         final String expected =
                 "CREATE VIEW `V`\n"
@@ -1163,7 +1163,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testCreateViewWithFieldNames() {
+    void testCreateViewWithFieldNames() {
         final String sql = "create view v(col1, col2) as select col3, col4 from tbl";
         final String expected =
                 "CREATE VIEW `V` (`COL1`, `COL2`)\n"
@@ -1174,7 +1174,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testCreateViewWithInvalidName() {
+    void testCreateViewWithInvalidName() {
         final String sql = "create view v(^*^) COMMENT 'this is a view' as select col1 from tbl";
         final String expected = "(?s).*Encountered \"\\*\" at line 1, column 15.*";
 
@@ -1182,7 +1182,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testCreateTemporaryView() {
+    void testCreateTemporaryView() {
         final String sql = "create temporary view v as select col1 from tbl";
         final String expected =
                 "CREATE TEMPORARY VIEW `V`\n" + "AS\n" + "SELECT `COL1`\n" + "FROM `TBL`";
@@ -1190,7 +1190,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testCreateTemporaryViewIfNotExists() {
+    void testCreateTemporaryViewIfNotExists() {
         final String sql = "create temporary view if not exists v as select col1 from tbl";
         final String expected =
                 "CREATE TEMPORARY VIEW IF NOT EXISTS `V`\n"
@@ -1201,7 +1201,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testCreateViewIfNotExists() {
+    void testCreateViewIfNotExists() {
         final String sql = "create view if not exists v as select col1 from tbl";
         final String expected =
                 "CREATE VIEW IF NOT EXISTS `V`\n" + "AS\n" + "SELECT `COL1`\n" + "FROM `TBL`";
@@ -1209,35 +1209,35 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testDropView() {
+    void testDropView() {
         final String sql = "DROP VIEW IF EXISTS view_name";
         final String expected = "DROP VIEW IF EXISTS `VIEW_NAME`";
         sql(sql).ok(expected);
     }
 
     @Test
-    public void testDropTemporaryView() {
+    void testDropTemporaryView() {
         final String sql = "DROP TEMPORARY VIEW IF EXISTS view_name";
         final String expected = "DROP TEMPORARY VIEW IF EXISTS `VIEW_NAME`";
         sql(sql).ok(expected);
     }
 
     @Test
-    public void testAlterView() {
+    void testAlterView() {
         sql("ALTER VIEW v1 RENAME TO v2").ok("ALTER VIEW `V1` RENAME TO `V2`");
         sql("ALTER VIEW v1 AS SELECT c1, c2 FROM tbl")
                 .ok("ALTER VIEW `V1`\n" + "AS\n" + "SELECT `C1`, `C2`\n" + "FROM `TBL`");
     }
 
     @Test
-    public void testShowViews() {
+    void testShowViews() {
         sql("show views").ok("SHOW VIEWS");
     }
 
     // Override the test because our ROW field type default is nullable,
     // which is different with Calcite.
     @Test
-    public void testCastAsRowType() {
+    void testCastAsRowType() {
         final String expr = "cast(a as row(f0 int, f1 varchar))";
         final String expected = "CAST(`A` AS ROW(`F0` INTEGER, `F1` VARCHAR))";
         expr(expr).ok(expected);
@@ -1264,19 +1264,19 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testCreateTableWithNakedTableName() {
+    void testCreateTableWithNakedTableName() {
         String sql = "CREATE TABLE tbl1";
         sql(sql).node(new ValidationMatcher());
     }
 
     @Test
-    public void testCreateViewWithEmptyFields() {
+    void testCreateViewWithEmptyFields() {
         String sql = "CREATE VIEW v1 AS SELECT 1";
         sql(sql).ok("CREATE VIEW `V1`\n" + "AS\n" + "SELECT 1");
     }
 
     @Test
-    public void testCreateFunction() {
+    void testCreateFunction() {
         sql("create function catalog1.db1.function1 as 'org.apache.fink.function.function1'")
                 .ok(
                         "CREATE FUNCTION `CATALOG1`.`DB1`.`FUNCTION1` AS 'org.apache.fink.function.function1'");
@@ -1317,7 +1317,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testDropTemporaryFunction() {
+    void testDropTemporaryFunction() {
         sql("drop temporary function catalog1.db1.function1")
                 .ok("DROP TEMPORARY FUNCTION `CATALOG1`.`DB1`.`FUNCTION1`");
 
@@ -1332,7 +1332,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testLoadModule() {
+    void testLoadModule() {
         sql("load module core").ok("LOAD MODULE `CORE`");
 
         sql("load module dummy with ('k1' = 'v1', 'k2' = 'v2')")
@@ -1348,7 +1348,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testUnloadModule() {
+    void testUnloadModule() {
         sql("unload module core").ok("UNLOAD MODULE `CORE`");
 
         sql("unload module ^'core'^")
@@ -1356,7 +1356,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testUseModules() {
+    void testUseModules() {
         sql("use modules core").ok("USE MODULES `CORE`");
 
         sql("use modules x, y, z").ok("USE MODULES `X`, `Y`, `Z`");
@@ -1368,24 +1368,24 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testShowModules() {
+    void testShowModules() {
         sql("show modules").ok("SHOW MODULES");
 
         sql("show full modules").ok("SHOW FULL MODULES");
     }
 
     @Test
-    public void testBeginStatementSet() {
+    void testBeginStatementSet() {
         sql("begin statement set").ok("BEGIN STATEMENT SET");
     }
 
     @Test
-    public void testEnd() {
+    void testEnd() {
         sql("end").ok("END");
     }
 
     @Test
-    public void testExecuteStatementSet() {
+    void testExecuteStatementSet() {
         sql("execute statement set begin insert into t1 select * from t2; insert into t2 select * from t3; end")
                 .ok(
                         "EXECUTE STATEMENT SET BEGIN\n"
@@ -1401,7 +1401,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testExplainStatementSet() {
+    void testExplainStatementSet() {
         sql("explain statement set begin insert into t1 select * from t2; insert into t2 select * from t3; end")
                 .ok(
                         "EXPLAIN STATEMENT SET BEGIN\n"
@@ -1417,42 +1417,42 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testExplain() {
+    void testExplain() {
         String sql = "explain select * from emps";
         String expected = "EXPLAIN SELECT *\nFROM `EMPS`";
         this.sql(sql).ok(expected);
     }
 
     @Test
-    public void testExecuteSelect() {
+    void testExecuteSelect() {
         String sql = "execute select * from emps";
         String expected = "EXECUTE SELECT *\nFROM `EMPS`";
         this.sql(sql).ok(expected);
     }
 
     @Test
-    public void testExplainPlanFor() {
+    void testExplainPlanFor() {
         String sql = "explain plan for select * from emps";
         String expected = "EXPLAIN SELECT *\nFROM `EMPS`";
         this.sql(sql).ok(expected);
     }
 
     @Test
-    public void testExplainChangelogMode() {
+    void testExplainChangelogMode() {
         String sql = "explain changelog_mode select * from emps";
         String expected = "EXPLAIN CHANGELOG_MODE SELECT *\nFROM `EMPS`";
         this.sql(sql).ok(expected);
     }
 
     @Test
-    public void testExplainEstimatedCost() {
+    void testExplainEstimatedCost() {
         String sql = "explain estimated_cost select * from emps";
         String expected = "EXPLAIN ESTIMATED_COST SELECT *\nFROM `EMPS`";
         this.sql(sql).ok(expected);
     }
 
     @Test
-    public void testExplainUnion() {
+    void testExplainUnion() {
         String sql = "explain estimated_cost select * from emps union all select * from emps";
         String expected =
                 "EXPLAIN ESTIMATED_COST (SELECT *\n"
@@ -1464,44 +1464,44 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testExplainJsonFormat() {
+    void testExplainJsonFormat() {
         // Unsupported feature. Escape the test.
     }
 
     @Test
-    public void testExplainWithImpl() {
+    void testExplainWithImpl() {
         // Unsupported feature. Escape the test.
     }
 
     @Test
-    public void testExplainWithoutImpl() {
+    void testExplainWithoutImpl() {
         // Unsupported feature. Escape the test.
     }
 
     @Test
-    public void testExplainWithType() {
+    void testExplainWithType() {
         // Unsupported feature. Escape the test.
     }
 
     @Test
-    public void testExplainAsXml() {
+    void testExplainAsXml() {
         // Unsupported feature. Escape the test.
     }
 
     @Test
-    public void testSqlOptions() {
+    void testSqlOptions() {
         // SET/RESET are overridden for Flink SQL
     }
 
     @Test
-    public void testExplainAsJson() {
+    void testExplainAsJson() {
         String sql = "explain json_execution_plan select * from emps";
         String expected = "EXPLAIN JSON_EXECUTION_PLAN SELECT *\n" + "FROM `EMPS`";
         this.sql(sql).ok(expected);
     }
 
     @Test
-    public void testExplainAllDetails() {
+    void testExplainAllDetails() {
         String sql = "explain changelog_mode,json_execution_plan,estimated_cost select * from emps";
         String expected =
                 "EXPLAIN JSON_EXECUTION_PLAN, CHANGELOG_MODE, ESTIMATED_COST SELECT *\n"
@@ -1510,26 +1510,26 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testExplainInsert() {
+    void testExplainInsert() {
         String expected = "EXPLAIN INSERT INTO `EMPS1`\n" + "(SELECT *\n" + "FROM `EMPS2`)";
         this.sql("explain plan for insert into emps1 select * from emps2").ok(expected);
     }
 
     @Test
-    public void testExecuteInsert() {
+    void testExecuteInsert() {
         String expected = "EXECUTE INSERT INTO `EMPS1`\n" + "(SELECT *\n" + "FROM `EMPS2`)";
         this.sql("execute insert into emps1 select * from emps2").ok(expected);
     }
 
     @Test
-    public void testExecutePlan() {
+    void testExecutePlan() {
         sql("execute plan './test.json'").ok("EXECUTE PLAN './test.json'");
         sql("execute plan '/some/absolute/dir/plan.json'")
                 .ok("EXECUTE PLAN '/some/absolute/dir/plan.json'");
     }
 
     @Test
-    public void testCompilePlan() {
+    void testCompilePlan() {
         sql("compile plan './test.json' for insert into t1 select * from t2")
                 .ok(
                         "COMPILE PLAN './test.json' FOR INSERT INTO `T1`\n"
@@ -1570,7 +1570,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testCompileAndExecutePlan() {
+    void testCompileAndExecutePlan() {
         sql("compile and execute plan './test.json' for insert into t1 select * from t2")
                 .ok(
                         "COMPILE AND EXECUTE PLAN './test.json' FOR INSERT INTO `T1`\n"
@@ -1593,33 +1593,33 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testExplainUpsert() {
+    void testExplainUpsert() {
         String sql = "explain plan for upsert into emps1 values (1, 2)";
         String expected = "EXPLAIN UPSERT INTO `EMPS1`\n" + "VALUES (ROW(1, 2))";
         this.sql(sql).ok(expected);
     }
 
     @Test
-    public void testExplainPlanForWithExplainDetails() {
+    void testExplainPlanForWithExplainDetails() {
         String sql = "explain plan for ^json_execution_plan^ upsert into emps1 values (1, 2)";
         this.sql(sql).fails("Non-query expression encountered in illegal context");
     }
 
     @Test
-    public void testExplainDuplicateExplainDetails() {
+    void testExplainDuplicateExplainDetails() {
         String sql = "explain changelog_mode,^changelog_mode^ select * from emps";
         this.sql(sql).fails("Duplicate EXPLAIN DETAIL is not allowed.");
     }
 
     @Test
-    public void testAddJar() {
+    void testAddJar() {
         sql("add Jar './test.sql'").ok("ADD JAR './test.sql'");
         sql("add JAR 'file:///path/to/\nwhatever'").ok("ADD JAR 'file:///path/to/\nwhatever'");
         sql("add JAR 'oss://path/helloworld.go'").ok("ADD JAR 'oss://path/helloworld.go'");
     }
 
     @Test
-    public void testRemoveJar() {
+    void testRemoveJar() {
         sql("remove Jar './test.sql'").ok("REMOVE JAR './test.sql'");
         sql("remove JAR 'file:///path/to/\nwhatever'")
                 .ok("REMOVE JAR 'file:///path/to/\nwhatever'");
@@ -1627,12 +1627,12 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testShowJars() {
+    void testShowJars() {
         sql("show jars").ok("SHOW JARS");
     }
 
     @Test
-    public void testSetReset() {
+    void testSetReset() {
         sql("SET").ok("SET");
         sql("SET 'test-key' = 'test-value'").ok("SET 'test-key' = 'test-value'");
         sql("RESET").ok("RESET");
@@ -1640,7 +1640,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
-    public void testTryCast() {
+    void testTryCast() {
         // Simple types
         expr("try_cast(a as timestamp)").ok("TRY_CAST(`A` AS TIMESTAMP)");
         expr("try_cast('abc' as timestamp)").ok("TRY_CAST('abc' AS TIMESTAMP)");

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlUnParserTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlUnParserTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
  * successfully.
  */
 @Execution(CONCURRENT)
-public class FlinkSqlUnParserTest extends FlinkSqlParserImplTest {
+class FlinkSqlUnParserTest extends FlinkSqlParserImplTest {
     // ~ Constructors -----------------------------------------------------------
 
     public FlinkSqlUnParserTest() {}

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/ReservedKeywordTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/ReservedKeywordTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
 /** Test class to check parser keywords. */
 @Execution(CONCURRENT)
-public class ReservedKeywordTest {
+class ReservedKeywordTest {
 
     private static final SqlAbstractParserImpl.Metadata PARSER_METADATA =
             FlinkSqlParserImpl.FACTORY.getParser(new StringReader("")).getMetadata();

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/TableApiIdentifierParsingTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/TableApiIdentifierParsingTest.java
@@ -26,40 +26,39 @@ import org.apache.calcite.config.Lex;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.parser.SqlAbstractParserImpl;
 import org.apache.calcite.util.SourceStringReader;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.runners.Parameterized;
 
 import java.util.List;
+import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.of;
 
 /** Tests for parsing a Table API specific SqlIdentifier. */
-@RunWith(Parameterized.class)
 public class TableApiIdentifierParsingTest {
 
     private static final String ANTHROPOS_IN_GREEK_IN_UNICODE =
             "#03B1#03BD#03B8#03C1#03C9#03C0#03BF#03C2";
     private static final String ANTHROPOS_IN_GREEK = "ανθρωπος";
 
-    @Parameterized.Parameters(name = "Parsing: {0}. Expected identifier: {1}")
-    public static Object[][] parameters() {
-        return new Object[][] {
-            new Object[] {"array", singletonList("array")},
-            new Object[] {"table", singletonList("table")},
-            new Object[] {"cat.db.array", asList("cat", "db", "array")},
-            new Object[] {"`cat.db`.table", asList("cat.db", "table")},
-            new Object[] {"db.table", asList("db", "table")},
-            new Object[] {"`ta``ble`", singletonList("ta`ble")},
-            new Object[] {"`c``at`.`d``b`.`ta``ble`", asList("c`at", "d`b", "ta`ble")},
-            new Object[] {
-                "db.U&\"" + ANTHROPOS_IN_GREEK_IN_UNICODE + "\" UESCAPE '#'",
-                asList("db", ANTHROPOS_IN_GREEK)
-            },
-            new Object[] {"db.ανθρωπος", asList("db", ANTHROPOS_IN_GREEK)}
-        };
+    public static Stream<Arguments> parameters() {
+        return Stream.of(
+                of("array", singletonList("array")),
+                of("table", singletonList("table")),
+                of("cat.db.array", asList("cat", "db", "array")),
+                of("`cat.db`.table", asList("cat.db", "table")),
+                of("db.table", asList("db", "table")),
+                of("`ta``ble`", singletonList("ta`ble")),
+                of("`c``at`.`d``b`.`ta``ble`", asList("c`at", "d`b", "ta`ble")),
+                of(
+                        "db.U&\"" + ANTHROPOS_IN_GREEK_IN_UNICODE + "\" UESCAPE '#'",
+                        asList("db", ANTHROPOS_IN_GREEK)),
+                of("db.ανθρωπος", asList("db", ANTHROPOS_IN_GREEK)));
     }
 
     @Parameterized.Parameter public String stringIdentifier;
@@ -67,8 +66,10 @@ public class TableApiIdentifierParsingTest {
     @Parameterized.Parameter(1)
     public List<String> expectedParsedIdentifier;
 
-    @Test
-    public void testTableApiIdentifierParsing() throws ParseException {
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testTableApiIdentifierParsing(
+            String stringIdentifier, List<String> expectedParsedIdentifier) throws ParseException {
         FlinkSqlParserImpl parser = createFlinkParser(stringIdentifier);
 
         SqlIdentifier sqlIdentifier = parser.TableApiIdentifier();

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/TableApiIdentifierParsingTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/TableApiIdentifierParsingTest.java
@@ -60,7 +60,7 @@ public class TableApiIdentifierParsingTest {
                 of("db.ανθρωπος", asList("db", ANTHROPOS_IN_GREEK)));
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "Parsing: {0}. Expected identifier: {1}")
     @MethodSource("parameters")
     void testTableApiIdentifierParsing(
             String stringIdentifier, List<String> expectedParsedIdentifier) throws ParseException {

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/TableApiIdentifierParsingTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/TableApiIdentifierParsingTest.java
@@ -45,7 +45,7 @@ public class TableApiIdentifierParsingTest {
             "#03B1#03BD#03B8#03C1#03C9#03C0#03BF#03C2";
     private static final String ANTHROPOS_IN_GREEK = "ανθρωπος";
 
-    public static Stream<Arguments> parameters() {
+    static Stream<Arguments> parameters() {
         return Stream.of(
                 of("array", singletonList("array")),
                 of("table", singletonList("table")),

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/TableApiIdentifierParsingTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/TableApiIdentifierParsingTest.java
@@ -29,7 +29,6 @@ import org.apache.calcite.util.SourceStringReader;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.runners.Parameterized;
 
 import java.util.List;
 import java.util.stream.Stream;
@@ -61,14 +60,9 @@ public class TableApiIdentifierParsingTest {
                 of("db.ανθρωπος", asList("db", ANTHROPOS_IN_GREEK)));
     }
 
-    @Parameterized.Parameter public String stringIdentifier;
-
-    @Parameterized.Parameter(1)
-    public List<String> expectedParsedIdentifier;
-
     @ParameterizedTest
     @MethodSource("parameters")
-    public void testTableApiIdentifierParsing(
+    void testTableApiIdentifierParsing(
             String stringIdentifier, List<String> expectedParsedIdentifier) throws ParseException {
         FlinkSqlParserImpl parser = createFlinkParser(stringIdentifier);
 

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/TableApiIdentifierParsingTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/TableApiIdentifierParsingTest.java
@@ -39,7 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.of;
 
 /** Tests for parsing a Table API specific SqlIdentifier. */
-public class TableApiIdentifierParsingTest {
+class TableApiIdentifierParsingTest {
 
     private static final String ANTHROPOS_IN_GREEK_IN_UNICODE =
             "#03B1#03BD#03B8#03C1#03C9#03C0#03BF#03C2";

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/TestRelDataTypeFactory.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/TestRelDataTypeFactory.java
@@ -27,8 +27,7 @@ import org.apache.calcite.rel.type.RelDataTypeSystem;
 import org.apache.calcite.sql.type.SqlTypeFactoryImpl;
 
 /** {@link RelDataTypeFactory} for testing purposes. */
-final class TestRelDataTypeFactory extends SqlTypeFactoryImpl
-        implements ExtendedRelTypeFactory {
+final class TestRelDataTypeFactory extends SqlTypeFactoryImpl implements ExtendedRelTypeFactory {
 
     TestRelDataTypeFactory(RelDataTypeSystem typeSystem) {
         super(typeSystem);

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/TestRelDataTypeFactory.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/TestRelDataTypeFactory.java
@@ -27,7 +27,7 @@ import org.apache.calcite.rel.type.RelDataTypeSystem;
 import org.apache.calcite.sql.type.SqlTypeFactoryImpl;
 
 /** {@link RelDataTypeFactory} for testing purposes. */
-public final class TestRelDataTypeFactory extends SqlTypeFactoryImpl
+final class TestRelDataTypeFactory extends SqlTypeFactoryImpl
         implements ExtendedRelTypeFactory {
 
     TestRelDataTypeFactory(RelDataTypeSystem typeSystem) {

--- a/flink-table/flink-sql-parser/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/flink-table/flink-sql-parser/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.util.TestLoggerExtension


### PR DESCRIPTION
## What is the purpose of the change

Update the flink-table/flink-sql-parser and flink-table/flink-sql-parser-hive modules to AssertJ and JUnit 5 following the [JUnit 5 Migration Guide](https://docs.google.com/document/d/1514Wa_aNB9bJUen4xm5uiuXOooOJTtXqS_Jqk9KJitU/edit)

## Brief change log

Use JUnit5 and AssertJ in tests instead of JUnit4 and Hamcrest

## Verifying this change

This change is a code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
