### PR TITLE
[FLINK-27222][coordination] Decouple last (al)location from execution history

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -288,9 +288,10 @@ public class Execution
                             && !taskManagerLocationFuture.isDone()) {
                         taskManagerLocationFuture.complete(logicalSlot.getTaskManagerLocation());
                         assignedAllocationID = logicalSlot.getAllocationId();
-                        getVertex().setLatestPriorAllocation(logicalSlot.getAllocationId());
                         getVertex()
-                                .setLatestPriorLocation(assignedResource.getTaskManagerLocation());
+                                .setLatestPriorSlotAllocation(
+                                        assignedResource.getTaskManagerLocation(),
+                                        logicalSlot.getAllocationId());
                         return true;
                     } else {
                         // free assigned resource and return false

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -288,6 +288,9 @@ public class Execution
                             && !taskManagerLocationFuture.isDone()) {
                         taskManagerLocationFuture.complete(logicalSlot.getTaskManagerLocation());
                         assignedAllocationID = logicalSlot.getAllocationId();
+                        getVertex().setLatestPriorAllocation(logicalSlot.getAllocationId());
+                        getVertex()
+                                .setLatestPriorLocation(assignedResource.getTaskManagerLocation());
                         return true;
                     } else {
                         // free assigned resource and return false

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -287,7 +287,7 @@ public class ExecutionVertex
 
     void setLatestPriorSlotAllocation(
             TaskManagerLocation taskManagerLocation, AllocationID lastAssignedAllocationID) {
-        this.lastAssignedLocation = Preconditions.checkNotNull(lastAssignedLocation);
+        this.lastAssignedLocation = Preconditions.checkNotNull(taskManagerLocation);
         this.lastAssignedAllocationID = Preconditions.checkNotNull(lastAssignedAllocationID);
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -292,16 +292,15 @@ public class ExecutionVertex
     }
 
     /**
-     * Gets the location where the latest completed/canceled/failed execution of the vertex's task
-     * happened.
+     * Gets the location that an execution of this vertex was assigned to.
      *
-     * @return The latest prior execution location, or null, if there is none, yet.
+     * @return The last execution location, or null, if there is none, yet.
      */
-    public Optional<TaskManagerLocation> findLatestPriorLocation() {
+    public Optional<TaskManagerLocation> findLastLocation() {
         return Optional.ofNullable(lastAssignedLocation);
     }
 
-    public Optional<AllocationID> findLatestPriorAllocation() {
+    public Optional<AllocationID> findLastAllocation() {
         return Optional.ofNullable(lastAssignedAllocationID);
     }
 
@@ -338,7 +337,7 @@ public class ExecutionVertex
         // only restore to same execution if it has state
         if (currentExecution.getTaskRestore() != null
                 && currentExecution.getTaskRestore().getTaskStateSnapshot().hasState()) {
-            return findLatestPriorLocation();
+            return findLastLocation();
         }
 
         return Optional.empty();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -36,6 +36,7 @@ import org.apache.flink.runtime.scheduler.strategy.ConsumedPartitionGroup;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.util.EvictingBoundedList;
+import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nullable;
 
@@ -47,7 +48,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Function;
 
 import static org.apache.flink.runtime.execution.ExecutionState.FINISHED;
 import static org.apache.flink.util.Preconditions.checkArgument;
@@ -83,6 +83,11 @@ public class ExecutionVertex
     private Execution currentExecution; // this field must never be null
 
     private final ArrayList<InputSplit> inputSplits;
+
+    /** This field holds the allocation id of the last successful assignment. */
+    @Nullable private TaskManagerLocation lastAssignedLocation;
+
+    @Nullable private AllocationID lastAssignedAllocationID;
 
     // --------------------------------------------------------------------------------------------
 
@@ -280,30 +285,8 @@ public class ExecutionVertex
         }
     }
 
-    /**
-     * Gets the latest property from a prior execution that is not null.
-     *
-     * @param extractor defining the property to extract
-     * @param <T> type of the property
-     * @return Optional containing the latest property if it exists; otherwise {@code
-     *     Optional.empty()}.
-     */
-    private <T> Optional<T> getLatestPriorProperty(Function<ArchivedExecution, T> extractor) {
-        int index = priorExecutions.size() - 1;
-
-        while (index >= 0 && !priorExecutions.isDroppedIndex(index)) {
-            final ArchivedExecution archivedExecution = priorExecutions.get(index);
-
-            final T extractedValue = extractor.apply(archivedExecution);
-
-            if (extractedValue != null) {
-                return Optional.of(extractedValue);
-            }
-
-            index -= 1;
-        }
-
-        return Optional.empty();
+    void setLatestPriorLocation(TaskManagerLocation lastAssignedLocation) {
+        this.lastAssignedLocation = Preconditions.checkNotNull(lastAssignedLocation);
     }
 
     /**
@@ -313,11 +296,15 @@ public class ExecutionVertex
      * @return The latest prior execution location, or null, if there is none, yet.
      */
     public Optional<TaskManagerLocation> findLatestPriorLocation() {
-        return getLatestPriorProperty(ArchivedExecution::getAssignedResourceLocation);
+        return Optional.ofNullable(lastAssignedLocation);
+    }
+
+    void setLatestPriorAllocation(AllocationID lastAssignedAllocationID) {
+        this.lastAssignedAllocationID = Preconditions.checkNotNull(lastAssignedAllocationID);
     }
 
     public Optional<AllocationID> findLatestPriorAllocation() {
-        return getLatestPriorProperty(ArchivedExecution::getAssignedAllocationID);
+        return Optional.ofNullable(lastAssignedAllocationID);
     }
 
     EvictingBoundedList<ArchivedExecution> getCopyOfPriorExecutionsList() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -285,8 +285,10 @@ public class ExecutionVertex
         }
     }
 
-    void setLatestPriorLocation(TaskManagerLocation lastAssignedLocation) {
+    void setLatestPriorSlotAllocation(
+            TaskManagerLocation taskManagerLocation, AllocationID lastAssignedAllocationID) {
         this.lastAssignedLocation = Preconditions.checkNotNull(lastAssignedLocation);
+        this.lastAssignedAllocationID = Preconditions.checkNotNull(lastAssignedAllocationID);
     }
 
     /**
@@ -297,10 +299,6 @@ public class ExecutionVertex
      */
     public Optional<TaskManagerLocation> findLatestPriorLocation() {
         return Optional.ofNullable(lastAssignedLocation);
-    }
-
-    void setLatestPriorAllocation(AllocationID lastAssignedAllocationID) {
-        this.lastAssignedAllocationID = Preconditions.checkNotNull(lastAssignedAllocationID);
     }
 
     public Optional<AllocationID> findLatestPriorAllocation() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
@@ -732,7 +732,7 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
         @Override
         public Optional<AllocationID> findPriorAllocationId(
                 final ExecutionVertexID executionVertexId) {
-            return getExecutionVertex(executionVertexId).findLatestPriorAllocation();
+            return getExecutionVertex(executionVertexId).findLastAllocation();
         }
 
         @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.executiongraph;
 
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
@@ -116,11 +118,15 @@ public class ExecutionVertexTest extends TestLogger {
         final JobGraph jobGraph = JobGraphTestUtils.streamingJobGraph(source);
         final TestingPhysicalSlotProvider withLimitedAmountOfPhysicalSlots =
                 TestingPhysicalSlotProvider.createWithLimitedAmountOfPhysicalSlots(1);
+        final Configuration configuration = new Configuration();
+        // make sure that retrieving the last (al)location is independent from the history size
+        configuration.set(JobManagerOptions.MAX_ATTEMPTS_HISTORY_SIZE, 1);
         final SchedulerBase scheduler =
                 new SchedulerTestingUtils.DefaultSchedulerBuilder(
                                 jobGraph,
                                 ComponentMainThreadExecutorServiceAdapter.forMainThread(),
                                 EXECUTOR_RESOURCE.getExecutor())
+                        .setJobMasterConfiguration(configuration)
                         .setExecutionSlotAllocatorFactory(
                                 SchedulerTestingUtils.newSlotSharingExecutionSlotAllocatorFactory(
                                         withLimitedAmountOfPhysicalSlots))

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexTest.java
@@ -148,15 +148,15 @@ public class ExecutionVertexTest extends TestLogger {
         cancelExecution(firstExecution);
         sourceExecutionVertex.resetForNewExecution();
 
-        assertThat(sourceExecutionVertex.findLatestPriorAllocation()).hasValue(allocationId);
-        assertThat(sourceExecutionVertex.findLatestPriorLocation()).hasValue(taskManagerLocation);
+        assertThat(sourceExecutionVertex.findLastAllocation()).hasValue(allocationId);
+        assertThat(sourceExecutionVertex.findLastLocation()).hasValue(taskManagerLocation);
 
         final Execution secondExecution = sourceExecutionVertex.getCurrentExecutionAttempt();
         cancelExecution(secondExecution);
         sourceExecutionVertex.resetForNewExecution();
 
-        assertThat(sourceExecutionVertex.findLatestPriorAllocation()).hasValue(allocationId);
-        assertThat(sourceExecutionVertex.findLatestPriorLocation()).hasValue(taskManagerLocation);
+        assertThat(sourceExecutionVertex.findLastAllocation()).hasValue(allocationId);
+        assertThat(sourceExecutionVertex.findLastLocation()).hasValue(taskManagerLocation);
     }
 
     private void cancelExecution(Execution execution) {


### PR DESCRIPTION
Prevents loss of information that is critical to local recovery due to evictions from the execution history.
Previously a fast restart loop on TM loss could result in local recovery never kicking in because all the information was lost.

Instead we store the last (al)location in the vertex.