### PR TITLE
[FLINK-27247][table-planner] ScalarOperatorGens.numericCasting is not compatible with legacy behavior

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
@@ -1719,19 +1719,24 @@ object ScalarOperatorGens {
       operandType: LogicalType,
       resultType: LogicalType): String => String = {
 
-    // All numeric rules are assumed to be instance of AbstractExpressionCodeGeneratorCastRule
-    val rule = CastRuleProvider.resolve(operandType, resultType)
-    rule match {
-      case codeGeneratorCastRule: ExpressionCodeGeneratorCastRule[_, _] =>
-        operandTerm =>
-          codeGeneratorCastRule.generateExpression(
-            toCodegenCastContext(ctx),
-            operandTerm,
-            operandType,
-            resultType
-          )
-      case _ =>
-        throw new CodeGenException(s"Unsupported casting from $operandType to $resultType.")
+    // no casting necessary
+    if (isInteroperable(operandType, resultType)) {
+      operandTerm => s"$operandTerm"
+    } else {
+      // All numeric rules are assumed to be instance of AbstractExpressionCodeGeneratorCastRule
+      val rule = CastRuleProvider.resolve(operandType, resultType)
+      rule match {
+        case codeGeneratorCastRule: ExpressionCodeGeneratorCastRule[_, _] =>
+          operandTerm =>
+            codeGeneratorCastRule.generateExpression(
+              toCodegenCastContext(ctx),
+              operandTerm,
+              operandType,
+              resultType
+            )
+        case _ =>
+          throw new CodeGenException(s"Unsupported casting from $operandType to $resultType.")
+      }
     }
   }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
@@ -1720,9 +1720,8 @@ object ScalarOperatorGens {
       resultType: LogicalType): String => String = {
 
     // no casting necessary
-    if (isInteroperable(operandType, resultType)) {
-      operandTerm => s"$operandTerm"
-    } else {
+    if (isInteroperable(operandType, resultType)) { operandTerm => s"$operandTerm" }
+    else {
       // All numeric rules are assumed to be instance of AbstractExpressionCodeGeneratorCastRule
       val rule = CastRuleProvider.resolve(operandType, resultType)
       rule match {

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
@@ -1515,6 +1515,25 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
       randInteger('f7, 'f4.cast(DataTypes.INT)),
       "RAND_INTEGER(f7, CAST(f4 AS INT))",
       random4.nextInt(44).toString)
+
+    val random5 = new java.util.Random(1)
+    testAllApis(
+      rand(1).plus(1),
+      "RAND(1) + 1",
+      (random5.nextDouble() + 1).toString)
+
+    val random6 = new java.util.Random(1)
+    val random7 = new java.util.Random(2)
+    testAllApis(
+      rand(1).plus(rand(2)),
+      "RAND(1) + RAND(2)",
+      (random6.nextDouble() + random7.nextDouble()).toString)
+
+    // the f21 is null
+    testAllApis(
+      rand('f21.cast(DataTypes.INT())).plus(1),
+      "rand(cast(null as int)) + 1",
+      "NULL")
   }
 
   @Test

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
@@ -1517,10 +1517,7 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
       random4.nextInt(44).toString)
 
     val random5 = new java.util.Random(1)
-    testAllApis(
-      rand(1).plus(1),
-      "RAND(1) + 1",
-      (random5.nextDouble() + 1).toString)
+    testAllApis(rand(1).plus(1), "RAND(1) + 1", (random5.nextDouble() + 1).toString)
 
     val random6 = new java.util.Random(1)
     val random7 = new java.util.Random(2)
@@ -1530,10 +1527,7 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
       (random6.nextDouble() + random7.nextDouble()).toString)
 
     // the f21 is null
-    testAllApis(
-      rand('f21.cast(DataTypes.INT())).plus(1),
-      "rand(cast(null as int)) + 1",
-      "NULL")
+    testAllApis(rand('f21.cast(DataTypes.INT())).plus(1), "rand(cast(null as int)) + 1", "NULL")
   }
 
   @Test


### PR DESCRIPTION
## What is the purpose of the change

In [FLINK-24779], some logics are lost in ScalarOperatorGens.numericCasting. This pr aims to add the lost code in it.

## Brief change log
  - Check if casting is unnecessary first before applying casting rules in numericCasting
  - Add some tests to verify this pr

## Verifying this change

Some test cases are added to verify it.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: (no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? 
