### PR TITLE
[FLINK-25097][table-planner] Fix bug in inner join when the filter co…

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/ColumnIntervalUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/ColumnIntervalUtil.scala
@@ -232,34 +232,37 @@ object ColumnIntervalUtil {
   }
 
   private def columnIntervalOfSinglePredicate(condition: RexNode): ValueInterval = {
-    val convertedCondition = condition.asInstanceOf[RexCall]
-    if (convertedCondition == null || convertedCondition.operands.size() != 2) {
-      null
-    } else {
-      val (literalValue, op) =
-        (convertedCondition.operands.head, convertedCondition.operands.last) match {
-          case (_: RexInputRef, literal: RexLiteral) =>
-            (getLiteralValueByBroadType(literal), convertedCondition.getKind)
-          case (rex: RexCall, literal: RexLiteral) if rex.getKind == SqlKind.AS =>
-            (getLiteralValueByBroadType(literal), convertedCondition.getKind)
-          case (literal: RexLiteral, _: RexInputRef) =>
-            (getLiteralValueByBroadType(literal), convertedCondition.getKind.reverse())
-          case (literal: RexLiteral, rex: RexCall) if rex.getKind == SqlKind.AS =>
-            (getLiteralValueByBroadType(literal), convertedCondition.getKind.reverse())
-          case _ => (null, null)
+    condition match {
+      case call : RexCall =>
+        if (call.operands.size() != 2) {
+          null
+        } else {
+          val (literalValue, op) =
+            (call.operands.head, call.operands.last) match {
+              case (_: RexInputRef, literal: RexLiteral) =>
+                (getLiteralValueByBroadType(literal), call.getKind)
+              case (rex: RexCall, literal: RexLiteral) if rex.getKind == SqlKind.AS =>
+                (getLiteralValueByBroadType(literal), call.getKind)
+              case (literal: RexLiteral, _: RexInputRef) =>
+                (getLiteralValueByBroadType(literal), call.getKind.reverse())
+              case (literal: RexLiteral, rex: RexCall) if rex.getKind == SqlKind.AS =>
+                (getLiteralValueByBroadType(literal), call.getKind.reverse())
+              case _ => (null, null)
+            }
+          if (op == null || literalValue == null) {
+            null
+          } else {
+            op match {
+              case EQUALS => ValueInterval(literalValue, literalValue)
+              case LESS_THAN => ValueInterval(null, literalValue, includeUpper = false)
+              case LESS_THAN_OR_EQUAL => ValueInterval(null, literalValue)
+              case GREATER_THAN => ValueInterval(literalValue, null, includeLower = false)
+              case GREATER_THAN_OR_EQUAL => ValueInterval(literalValue, null)
+              case _ => null
+            }
+          }
         }
-      if (op == null || literalValue == null) {
-        null
-      } else {
-        op match {
-          case EQUALS => ValueInterval(literalValue, literalValue)
-          case LESS_THAN => ValueInterval(null, literalValue, includeUpper = false)
-          case LESS_THAN_OR_EQUAL => ValueInterval(null, literalValue)
-          case GREATER_THAN => ValueInterval(literalValue, null, includeLower = false)
-          case GREATER_THAN_OR_EQUAL => ValueInterval(literalValue, null)
-          case _ => null
-        }
-      }
+      case _ => null
     }
   }
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/TestData.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/TestData.scala
@@ -170,6 +170,18 @@ object TestData {
 
   val nullablesOfSmallData3 = Array(true, true, true)
 
+  lazy val smallTupleData3_1: Seq[(Int, Long, String, Boolean)] = {
+    val data = new mutable.MutableList[(Int, Long, String, Boolean)]
+    data.+=((1, 1L, "Hi", true))
+    data.+=((2, 2L, "Hello", false))
+    data.+=((3, 2L, "Hello world", true))
+    data
+  }
+
+  lazy val smallData3_1: Seq[Row] = smallTupleData3_1.map(d => row(d.productIterator.toList: _*))
+
+  val nullablesOfSmallData3_1 = Array(true, true, true, true)
+
   lazy val smallTupleData5: Seq[(Int, Long, Int, String, Long)] = {
     val data = new mutable.MutableList[(Int, Long, Int, String, Long)]
     data.+=((1, 1L, 0, "Hallo", 1L))
@@ -390,6 +402,18 @@ object TestData {
   lazy val data5: Seq[Row] = tupleData5.map(d => row(d.productIterator.toList: _*))
 
   val nullablesOfData5 = Array(true, true, true, true, true)
+
+  lazy val tupleData5_1: Seq[(Int, Long, Int, String, Long, Boolean)] = {
+    val data = new mutable.MutableList[(Int, Long, Int, String, Long, Boolean)]
+    data.+=((1, 1L, 0, "Hallo", 1L, true))
+    data.+=((2, 2L, 1, "Hallo Welt", 2L, false))
+    data.+=((2, 3L, 2, "Hallo Welt wie", 1L, true))
+    data
+  }
+
+  lazy val data5_1: Seq[Row] = tupleData5_1.map(d => row(d.productIterator.toList: _*))
+
+  val nullablesOfData5_1 = Array(true, true, true, true, true, true)
 
   lazy val data6: Seq[Row] = Seq(
     row(


### PR DESCRIPTION
…ndition is boolean type

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This pr aims to fix bug in inner join when filter condition is boolean type.


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
