### PR TITLE
[hotfix][build] Fix issue with scalafmt config file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1873,7 +1873,7 @@ under the License.
 						<goals>
 							<goal>directory-of</goal>
 						</goals>
-						<phase>initialize</phase>
+						<phase>validate</phase>
 						<configuration>
 							<property>rootDir</property>
 							<project>
@@ -1919,7 +1919,7 @@ under the License.
 					<executions>
 						<execution>
 							<id>validate</id>
-							<phase>validate</phase>
+							<phase>process-sources</phase>
 							<goals>
 								<goal>check</goal>
 							</goals>
@@ -1956,7 +1956,7 @@ under the License.
 							<scalafmt>
 								<version>3.4.3</version>
 								<!-- This file is in the root of the project to make sure IntelliJ picks it up automatically -->
-								<file>.scalafmt.conf</file>
+								<file>${rootDir}/.scalafmt.conf</file>
 							</scalafmt>
 							<licenseHeader>
 								<content>/*
@@ -1984,7 +1984,7 @@ under the License.
 					<executions>
 						<execution>
 							<id>spotless-check</id>
-							<phase>validate</phase>
+							<phase>process-sources</phase>
 							<goals>
 								<goal>check</goal>
 							</goals>


### PR DESCRIPTION
`.scalafmt.conf` resides on the root directory, so for the other
modules to find it we need to use the `rootDir` property which is
set by the `directory-maven-plugin`.

Previously, the `directory-maven-plugin` goal to set this property
was bound to `initialize` phase, and the `spotless:check` to `validate`
phase which comes before `initialize` and therefore the `rootDir`
property was not available.

Bind the `directory-maven-plugin` goal to `validate` which is the 1st
phase in the maven lifycycle, and bind `spotless:check` to the
`process-sources` phase which anyway makes more sense. This way users
can run `mvn test, mvn clean install, mvn verify`, etc. from within any
module and still be able to run also the bound `spotless:check` goal.

This way, the only downside of introducing the `scalafmt` is that if a
user wants to run `spotless:check/spotless:apply` autonomously inside
any module, he/she just needs to prefix it with the `validate` goal
which sets the `rootDir` property, i.e.:
`flink/flink-table/flink-table-planner$ mvn validate spotless:apply`

Follows: 3ea3fee5ac996f6ae8836c3cba252f974d20bd2e
Follows: #19025
