### PR TITLE
[FLINK-27213][API/Python]Add PurgingTrigger

### DIFF
--- a/flink-python/pyflink/datastream/tests/test_window.py
+++ b/flink-python/pyflink/datastream/tests/test_window.py
@@ -26,7 +26,7 @@ from pyflink.datastream.functions import (ProcessWindowFunction, WindowFunction,
 from pyflink.datastream.window import (TumblingEventTimeWindows,
                                        SlidingEventTimeWindows, EventTimeSessionWindows,
                                        CountSlidingWindowAssigner, SessionWindowTimeGapExtractor,
-                                       CountWindow)
+                                       CountWindow, ContinuousEventTimeTrigger, PurgingTrigger)
 from pyflink.datastream.tests.test_util import DataStreamTestSinkFunction
 from pyflink.testing.test_case_utils import PyFlinkStreamingTestCase
 
@@ -344,6 +344,25 @@ class WindowTests(PyFlinkStreamingTestCase):
         self.env.execute('test_session_window_late_merge')
         results = self.test_sink.get_results()
         expected = ['(hi,3)']
+        self.assert_equals_sorted(expected, results)
+
+    def test_event_time_tumbling_window_with_purging_trigger(self):
+        data_stream = self.env.from_collection([
+            ('hi', 1), ('hi', 2), ('hi', 3), ('hi', 4), ('hi', 5), ('hi', 8), ('hi', 9),
+            ('hi', 15)],
+            type_info=Types.TUPLE([Types.STRING(), Types.INT()]))  # type: DataStream
+        watermark_strategy = WatermarkStrategy.for_monotonous_timestamps() \
+            .with_timestamp_assigner(SecondColumnTimestampAssigner())
+        data_stream.assign_timestamps_and_watermarks(watermark_strategy) \
+            .key_by(lambda x: x[0], key_type=Types.STRING()) \
+            .window(TumblingEventTimeWindows.of(Time.milliseconds(10))) \
+            .trigger(PurgingTrigger.of(ContinuousEventTimeTrigger.of(Time.milliseconds(5)))) \
+            .process(CountWindowProcessFunction(), Types.TUPLE([Types.STRING(), Types.INT()])) \
+            .add_sink(self.test_sink)
+
+        self.env.execute('test_event_time_tumbling_window_with_purging_trigger')
+        results = self.test_sink.get_results()
+        expected = ['(hi,7)', '(hi,1)']
         self.assert_equals_sorted(expected, results)
 
 

--- a/flink-python/pyflink/datastream/tests/test_window.py
+++ b/flink-python/pyflink/datastream/tests/test_window.py
@@ -26,7 +26,7 @@ from pyflink.datastream.functions import (ProcessWindowFunction, WindowFunction,
 from pyflink.datastream.window import (TumblingEventTimeWindows,
                                        SlidingEventTimeWindows, EventTimeSessionWindows,
                                        CountSlidingWindowAssigner, SessionWindowTimeGapExtractor,
-                                       CountWindow)
+                                       CountWindow, PurgingTrigger, EventTimeTrigger, CountTrigger)
 from pyflink.datastream.tests.test_util import DataStreamTestSinkFunction
 from pyflink.testing.test_case_utils import PyFlinkStreamingTestCase
 
@@ -344,6 +344,25 @@ class WindowTests(PyFlinkStreamingTestCase):
         self.env.execute('test_session_window_late_merge')
         results = self.test_sink.get_results()
         expected = ['(hi,3)']
+        self.assert_equals_sorted(expected, results)
+
+    def test_event_time_tumbling_window_with_purging_trigger(self):
+        data_stream = self.env.from_collection([
+            ('hi', 1), ('hi', 2), ('hi', 3), ('hi', 4), ('hi', 5), ('hi', 8), ('hi', 9),
+            ('hi', 15)],
+            type_info=Types.TUPLE([Types.STRING(), Types.INT()]))  # type: DataStream
+        watermark_strategy = WatermarkStrategy.for_monotonous_timestamps() \
+            .with_timestamp_assigner(SecondColumnTimestampAssigner())
+        data_stream.assign_timestamps_and_watermarks(watermark_strategy) \
+            .key_by(lambda x: x[0], key_type=Types.STRING()) \
+            .window(TumblingEventTimeWindows.of(Time.milliseconds(10))) \
+            .trigger(PurgingTrigger.of(EventTimeTrigger.create())) \
+            .process(CountWindowProcessFunction(), Types.TUPLE([Types.STRING(), Types.INT()])) \
+            .add_sink(self.test_sink)
+
+        self.env.execute('test_event_time_tumbling_window_with_purging_trigger')
+        results = self.test_sink.get_results()
+        expected = ['(hi,7)', '(hi,1)']
         self.assert_equals_sorted(expected, results)
 
 

--- a/flink-python/pyflink/datastream/tests/test_window.py
+++ b/flink-python/pyflink/datastream/tests/test_window.py
@@ -26,7 +26,7 @@ from pyflink.datastream.functions import (ProcessWindowFunction, WindowFunction,
 from pyflink.datastream.window import (TumblingEventTimeWindows,
                                        SlidingEventTimeWindows, EventTimeSessionWindows,
                                        CountSlidingWindowAssigner, SessionWindowTimeGapExtractor,
-                                       CountWindow, PurgingTrigger, EventTimeTrigger, CountTrigger)
+                                       CountWindow, PurgingTrigger, EventTimeTrigger)
 from pyflink.datastream.tests.test_util import DataStreamTestSinkFunction
 from pyflink.testing.test_case_utils import PyFlinkStreamingTestCase
 

--- a/flink-python/pyflink/datastream/tests/test_window.py
+++ b/flink-python/pyflink/datastream/tests/test_window.py
@@ -26,7 +26,7 @@ from pyflink.datastream.functions import (ProcessWindowFunction, WindowFunction,
 from pyflink.datastream.window import (TumblingEventTimeWindows,
                                        SlidingEventTimeWindows, EventTimeSessionWindows,
                                        CountSlidingWindowAssigner, SessionWindowTimeGapExtractor,
-                                       CountWindow, ContinuousEventTimeTrigger, PurgingTrigger)
+                                       CountWindow)
 from pyflink.datastream.tests.test_util import DataStreamTestSinkFunction
 from pyflink.testing.test_case_utils import PyFlinkStreamingTestCase
 
@@ -344,25 +344,6 @@ class WindowTests(PyFlinkStreamingTestCase):
         self.env.execute('test_session_window_late_merge')
         results = self.test_sink.get_results()
         expected = ['(hi,3)']
-        self.assert_equals_sorted(expected, results)
-
-    def test_event_time_tumbling_window_with_purging_trigger(self):
-        data_stream = self.env.from_collection([
-            ('hi', 1), ('hi', 2), ('hi', 3), ('hi', 4), ('hi', 5), ('hi', 8), ('hi', 9),
-            ('hi', 15)],
-            type_info=Types.TUPLE([Types.STRING(), Types.INT()]))  # type: DataStream
-        watermark_strategy = WatermarkStrategy.for_monotonous_timestamps() \
-            .with_timestamp_assigner(SecondColumnTimestampAssigner())
-        data_stream.assign_timestamps_and_watermarks(watermark_strategy) \
-            .key_by(lambda x: x[0], key_type=Types.STRING()) \
-            .window(TumblingEventTimeWindows.of(Time.milliseconds(10))) \
-            .trigger(PurgingTrigger.of(ContinuousEventTimeTrigger.of(Time.milliseconds(5)))) \
-            .process(CountWindowProcessFunction(), Types.TUPLE([Types.STRING(), Types.INT()])) \
-            .add_sink(self.test_sink)
-
-        self.env.execute('test_event_time_tumbling_window_with_purging_trigger')
-        results = self.test_sink.get_results()
-        expected = ['(hi,7)', '(hi,1)']
         self.assert_equals_sorted(expected, results)
 
 

--- a/flink-python/pyflink/datastream/window.py
+++ b/flink-python/pyflink/datastream/window.py
@@ -841,24 +841,24 @@ class ContinuousProcessingTimeTrigger(Trigger[T, TimeWindow]):
         ctx.register_processing_time_timer(next_fire_timestamp)
 
 
-class PurgingTrigger(Trigger[T, TimeWindow]):
+class PurgingTrigger(Trigger[T, Window]):
     """
     A trigger that can turn any Trigger into a purging Trigger.
     When the nested trigger fires, this will return a FIRE_AND_PURGE TriggerResult.
     """
 
     def __init__(self,
-                 nested_trigger: Trigger[T, TimeWindow]):
+                 nested_trigger: Trigger[T, Window]):
         self.nested_trigger = nested_trigger
 
     @staticmethod
-    def of(nested_trigger: Trigger[T, TimeWindow]) -> 'PurgingTrigger':
+    def of(nested_trigger: Trigger[T, Window]) -> 'PurgingTrigger':
         return PurgingTrigger(nested_trigger)
 
     def on_element(self,
                    element: T,
                    timestamp: int,
-                   window: TimeWindow,
+                   window: Window,
                    ctx: 'Trigger.TriggerContext') -> TriggerResult:
         trigger_result = self.nested_trigger.on_element(element, timestamp, window, ctx)
         if trigger_result.is_fire() is True:
@@ -868,7 +868,7 @@ class PurgingTrigger(Trigger[T, TimeWindow]):
 
     def on_event_time(self,
                       time: int,
-                      window: TimeWindow,
+                      window: Window,
                       ctx: 'Trigger.TriggerContext') -> TriggerResult:
         trigger_result = self.nested_trigger.on_event_time(time, window, ctx)
         if trigger_result.is_fire() is True:
@@ -878,7 +878,7 @@ class PurgingTrigger(Trigger[T, TimeWindow]):
 
     def on_processing_time(self,
                            time: int,
-                           window: TimeWindow,
+                           window: Window,
                            ctx: 'Trigger.TriggerContext') -> TriggerResult:
         trigger_result = self.nested_trigger.on_processing_time(time, window, ctx)
         if trigger_result.is_fire() is True:
@@ -887,7 +887,7 @@ class PurgingTrigger(Trigger[T, TimeWindow]):
             return trigger_result
 
     def clear(self,
-              window: TimeWindow,
+              window: Window,
               ctx: 'Trigger.TriggerContext') -> None:
         self.nested_trigger.clear(window, ctx)
 
@@ -895,7 +895,7 @@ class PurgingTrigger(Trigger[T, TimeWindow]):
         return self.nested_trigger.can_merge()
 
     def on_merge(self,
-                 window: TimeWindow,
+                 window: Window,
                  ctx: 'Trigger.OnMergeContext') -> None:
         self.nested_trigger.on_merge(window, ctx)
 

--- a/flink-python/pyflink/datastream/window.py
+++ b/flink-python/pyflink/datastream/window.py
@@ -637,6 +637,10 @@ class EventTimeTrigger(Trigger[T, TimeWindow]):
               ctx: 'Trigger.TriggerContext') -> None:
         ctx.delete_event_time_timer(window.max_timestamp())
 
+    @staticmethod
+    def create() -> 'EventTimeTrigger':
+        return EventTimeTrigger()
+
 
 class ContinuousEventTimeTrigger(Trigger[T, TimeWindow]):
     """
@@ -764,6 +768,10 @@ class ProcessingTimeTrigger(Trigger[T, TimeWindow]):
               window: TimeWindow,
               ctx: 'Trigger.TriggerContext') -> None:
         ctx.delete_processing_time_timer(window.max_timestamp())
+
+    @staticmethod
+    def create() -> 'ProcessingTimeTrigger':
+        return ProcessingTimeTrigger()
 
 
 class ContinuousProcessingTimeTrigger(Trigger[T, TimeWindow]):
@@ -909,6 +917,10 @@ class CountTrigger(Trigger[T, CountWindow]):
         self._window_size = window_size
         self._count_state_descriptor = ReducingStateDescriptor(
             "count", lambda a, b: a + b, Types.LONG())
+
+    @staticmethod
+    def of(window_size: int) -> 'CountTrigger':
+        return CountTrigger(window_size)
 
     def on_element(self,
                    element: T,

--- a/flink-python/pyflink/datastream/window.py
+++ b/flink-python/pyflink/datastream/window.py
@@ -50,6 +50,7 @@ __all__ = ['Window',
            'ProcessingTimeTrigger',
            'ContinuousEventTimeTrigger',
            'ContinuousProcessingTimeTrigger',
+           'PurgingTrigger',
            'CountTrigger',
            'TimeWindowSerializer',
            'CountWindowSerializer',
@@ -838,6 +839,65 @@ class ContinuousProcessingTimeTrigger(Trigger[T, TimeWindow]):
         next_fire_timestamp = min(time + self.interval, window.max_timestamp())
         fire_timestamp_state.add(next_fire_timestamp)
         ctx.register_processing_time_timer(next_fire_timestamp)
+
+
+class PurgingTrigger(Trigger[T, TimeWindow]):
+    """
+    A trigger that can turn any Trigger into a purging Trigger.
+    When the nested trigger fires, this will return a FIRE_AND_PURGE TriggerResult.
+    """
+
+    def __init__(self,
+                 nested_trigger: Trigger[T, TimeWindow]):
+        self.nested_trigger = nested_trigger
+
+    @staticmethod
+    def of(nested_trigger: Trigger[T, TimeWindow]) -> 'PurgingTrigger':
+        return PurgingTrigger(nested_trigger)
+
+    def on_element(self,
+                   element: T,
+                   timestamp: int,
+                   window: TimeWindow,
+                   ctx: 'Trigger.TriggerContext') -> TriggerResult:
+        trigger_result = self.nested_trigger.on_element(element, timestamp, window, ctx)
+        if trigger_result.is_fire() is True:
+            return TriggerResult.FIRE_AND_PURGE
+        else:
+            return trigger_result
+
+    def on_event_time(self,
+                      time: int,
+                      window: TimeWindow,
+                      ctx: 'Trigger.TriggerContext') -> TriggerResult:
+        trigger_result = self.nested_trigger.on_event_time(time, window, ctx)
+        if trigger_result.is_fire() is True:
+            return TriggerResult.FIRE_AND_PURGE
+        else:
+            return trigger_result
+
+    def on_processing_time(self,
+                           time: int,
+                           window: TimeWindow,
+                           ctx: 'Trigger.TriggerContext') -> TriggerResult:
+        trigger_result = self.nested_trigger.on_processing_time(time, window, ctx)
+        if trigger_result.is_fire() is True:
+            return TriggerResult.FIRE_AND_PURGE
+        else:
+            return trigger_result
+
+    def clear(self,
+              window: TimeWindow,
+              ctx: 'Trigger.TriggerContext') -> None:
+        self.nested_trigger.clear(window, ctx)
+
+    def can_merge(self) -> bool:
+        return self.nested_trigger.can_merge()
+
+    def on_merge(self,
+                 window: TimeWindow,
+                 ctx: 'Trigger.OnMergeContext') -> None:
+        self.nested_trigger.on_merge(window, ctx)
 
 
 class CountTrigger(Trigger[T, CountWindow]):


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
