### PR TITLE
[FLINK-27265][docs] Flink comes with five built-in BulkWriter factories instead of the mentioned four in filesystem.md.

### DIFF
--- a/docs/content/docs/connectors/datastream/filesystem.md
+++ b/docs/content/docs/connectors/datastream/filesystem.md
@@ -367,7 +367,7 @@ specifying an `Encoder`, we have to specify a {{< javadoc file="org/apache/flink
 The `BulkWriter` logic defines how new elements are added and flushed, and how a batch of records
 is finalized for further encoding purposes.
 
-Flink comes with four built-in BulkWriter factories:
+Flink comes with five built-in BulkWriter factories:
 
 * ParquetWriterFactory
 * AvroWriterFactory


### PR DESCRIPTION
## What is the purpose of the change
in filesystem.md, flink comes with four built-in BulkWriter factories, in fact, the list has five.


## Brief change log

in filesystem.md, flink comes with four built-in BulkWriter factories, in fact, the list has five.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

yes

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature?  no