### PR TITLE
[FLINK-26762][network] Add the overdraft buffer in ResultPartition

### DIFF
--- a/docs/content.zh/docs/ops/metrics.md
+++ b/docs/content.zh/docs/ops/metrics.md
@@ -840,7 +840,7 @@ Deprecated: use [Default shuffle service metrics](#default-shuffle-service)
     </tr>
     <tr>
       <td>outPoolUsage</td>
-      <td>An estimate of the output buffers usage.</td>
+      <td>An estimate of the output buffers usage. The pool usage can be > 100% if overdraft buffers are being used.</td>
       <td>Gauge</td>
     </tr>
     <tr>
@@ -960,7 +960,7 @@ Metrics related to data exchange between task executors using netty network comm
     </tr>
     <tr>
       <td>outPoolUsage</td>
-      <td>An estimate of the output buffers usage.</td>
+      <td>An estimate of the output buffers usage. The pool usage can be > 100% if overdraft buffers are being used.</td>
       <td>Gauge</td>
     </tr>
     <tr>

--- a/docs/content/docs/ops/metrics.md
+++ b/docs/content/docs/ops/metrics.md
@@ -840,7 +840,7 @@ Deprecated: use [Default shuffle service metrics](#default-shuffle-service)
     </tr>
     <tr>
       <td>outPoolUsage</td>
-      <td>An estimate of the output buffers usage.</td>
+      <td>An estimate of the output buffers usage. The pool usage can be > 100% if overdraft buffers are being used.</td>
       <td>Gauge</td>
     </tr>
     <tr>
@@ -960,7 +960,7 @@ Metrics related to data exchange between task executors using netty network comm
     </tr>
     <tr>
       <td>outPoolUsage</td>
-      <td>An estimate of the output buffers usage.</td>
+      <td>An estimate of the output buffers usage. The pool usage can be > 100% if overdraft buffers are being used.</td>
       <td>Gauge</td>
     </tr>
     <tr>

--- a/docs/layouts/shortcodes/generated/all_taskmanager_network_section.html
+++ b/docs/layouts/shortcodes/generated/all_taskmanager_network_section.html
@@ -81,6 +81,12 @@
             <td>Number of max buffers that can be used for each channel. If a channel exceeds the number of max buffers, it will make the task become unavailable, cause the back pressure and block the data processing. This might speed up checkpoint alignment by preventing excessive growth of the buffered in-flight data in case of data skew and high number of configured floating buffers. This limit is not strictly guaranteed, and can be ignored by things like flatMap operators, records spanning multiple buffers or single timer producing large amount of data.</td>
         </tr>
         <tr>
+            <td><h5>taskmanager.network.memory.max-overdraft-buffers-per-gate</h5></td>
+            <td style="word-wrap: break-word;">5</td>
+            <td>Integer</td>
+            <td>Number of max overdraft network buffers to use for each ResultPartition. The overdraft buffers will be used when the subtask cannot apply to the normal buffers  due to back pressure, while subtask is performing an action that can not be interrupted in the middle,  like serializing a large record, flatMap operator producing multiple records for one single input record or processing time timer producing large output. In situations like that system will allow subtask to request overdraft buffers, so that the subtask can finish such uninterruptible action, without blocking unaligned checkpoints for long period of time. Overdraft buffers are provided on best effort basis only if the system has some unused buffers available. Subtask that has used overdraft buffers won't be allowed to process any more records until the overdraft buffers are returned to the pool.</td>
+        </tr>
+        <tr>
             <td><h5>taskmanager.network.netty.client.connectTimeoutSec</h5></td>
             <td style="word-wrap: break-word;">120</td>
             <td>Integer</td>

--- a/docs/layouts/shortcodes/generated/netty_shuffle_environment_configuration.html
+++ b/docs/layouts/shortcodes/generated/netty_shuffle_environment_configuration.html
@@ -69,6 +69,12 @@
             <td>Number of max buffers that can be used for each channel. If a channel exceeds the number of max buffers, it will make the task become unavailable, cause the back pressure and block the data processing. This might speed up checkpoint alignment by preventing excessive growth of the buffered in-flight data in case of data skew and high number of configured floating buffers. This limit is not strictly guaranteed, and can be ignored by things like flatMap operators, records spanning multiple buffers or single timer producing large amount of data.</td>
         </tr>
         <tr>
+            <td><h5>taskmanager.network.memory.max-overdraft-buffers-per-gate</h5></td>
+            <td style="word-wrap: break-word;">5</td>
+            <td>Integer</td>
+            <td>Number of max overdraft network buffers to use for each ResultPartition. The overdraft buffers will be used when the subtask cannot apply to the normal buffers  due to back pressure, while subtask is performing an action that can not be interrupted in the middle,  like serializing a large record, flatMap operator producing multiple records for one single input record or processing time timer producing large output. In situations like that system will allow subtask to request overdraft buffers, so that the subtask can finish such uninterruptible action, without blocking unaligned checkpoints for long period of time. Overdraft buffers are provided on best effort basis only if the system has some unused buffers available. Subtask that has used overdraft buffers won't be allowed to process any more records until the overdraft buffers are returned to the pool.</td>
+        </tr>
+        <tr>
             <td><h5>taskmanager.network.netty.client.connectTimeoutSec</h5></td>
             <td style="word-wrap: break-word;">120</td>
             <td>Integer</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
@@ -274,6 +274,24 @@ public class NettyShuffleEnvironmentOptions {
                                     + " and can be ignored by things like flatMap operators, records spanning multiple buffers or single timer"
                                     + " producing large amount of data.");
 
+    /** Number of max overdraft network buffers to use for each ResultPartition. */
+    @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER_NETWORK)
+    public static final ConfigOption<Integer> NETWORK_MAX_OVERDRAFT_BUFFERS_PER_GATE =
+            key("taskmanager.network.memory.max-overdraft-buffers-per-gate")
+                    .intType()
+                    .defaultValue(5)
+                    .withDescription(
+                            "Number of max overdraft network buffers to use for each ResultPartition. The overdraft buffers"
+                                    + " will be used when the subtask cannot apply to the normal buffers  due to back pressure,"
+                                    + " while subtask is performing an action that can not be interrupted in the middle,  like"
+                                    + " serializing a large record, flatMap operator producing multiple records for one single"
+                                    + " input record or processing time timer producing large output. In situations like that"
+                                    + " system will allow subtask to request overdraft buffers, so that the subtask can finish"
+                                    + " such uninterruptible action, without blocking unaligned checkpoints for long period of"
+                                    + " time. Overdraft buffers are provided on best effort basis only if the system has some"
+                                    + " unused buffers available. Subtask that has used overdraft buffers won't be allowed to"
+                                    + " process any more records until the overdraft buffers are returned to the pool.");
+
     /** The timeout for requesting exclusive buffers for each channel. */
     @Documentation.ExcludeFromDocumentation(
             "This option is purely implementation related, and may be removed as the implementation changes.")

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleServiceFactory.java
@@ -198,7 +198,8 @@ public class NettyShuffleServiceFactory
                         config.getMaxBuffersPerChannel(),
                         config.sortShuffleMinBuffers(),
                         config.sortShuffleMinParallelism(),
-                        config.isSSLEnabled());
+                        config.isSSLEnabled(),
+                        config.getMaxOverdraftBuffersPerGate());
 
         SingleInputGateFactory singleInputGateFactory =
                 new SingleInputGateFactory(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferPoolFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferPoolFactory.java
@@ -44,12 +44,14 @@ public interface BufferPoolFactory {
      * @param maxUsedBuffers maximum number of network buffers this pool offers
      * @param numSubpartitions number of subpartitions in this pool
      * @param maxBuffersPerChannel maximum number of buffers to use for each channel
+     * @param maxOverdraftBuffersPerGate maximum number of overdraft buffers to use for each gate
      */
     BufferPool createBufferPool(
             int numRequiredBuffers,
             int maxUsedBuffers,
             int numSubpartitions,
-            int maxBuffersPerChannel)
+            int maxBuffersPerChannel,
+            int maxOverdraftBuffersPerGate)
             throws IOException;
 
     /** Destroy callback for updating factory book keeping. */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPool.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.io.network.buffer;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.execution.CancelTaskException;
 import org.apache.flink.util.ExceptionUtils;
@@ -118,6 +119,11 @@ class LocalBufferPool implements BufferPool {
     @GuardedBy("availableMemorySegments")
     private int unavailableSubpartitionsCount = 0;
 
+    private final int maxOverdraftBuffersPerGate;
+
+    @GuardedBy("availableMemorySegments")
+    private int numberOfRequestedOverdraftMemorySegments;
+
     @GuardedBy("availableMemorySegments")
     private boolean isDestroyed;
 
@@ -141,7 +147,8 @@ class LocalBufferPool implements BufferPool {
                 numberOfRequiredMemorySegments,
                 Integer.MAX_VALUE,
                 0,
-                Integer.MAX_VALUE);
+                Integer.MAX_VALUE,
+                0);
     }
 
     /**
@@ -162,7 +169,8 @@ class LocalBufferPool implements BufferPool {
                 numberOfRequiredMemorySegments,
                 maxNumberOfMemorySegments,
                 0,
-                Integer.MAX_VALUE);
+                Integer.MAX_VALUE,
+                0);
     }
 
     /**
@@ -174,13 +182,15 @@ class LocalBufferPool implements BufferPool {
      * @param maxNumberOfMemorySegments maximum number of network buffers to allocate
      * @param numberOfSubpartitions number of subpartitions
      * @param maxBuffersPerChannel maximum number of buffers to use for each channel
+     * @param maxOverdraftBuffersPerGate maximum number of overdraft buffers to use for each gate
      */
     LocalBufferPool(
             NetworkBufferPool networkBufferPool,
             int numberOfRequiredMemorySegments,
             int maxNumberOfMemorySegments,
             int numberOfSubpartitions,
-            int maxBuffersPerChannel)
+            int maxBuffersPerChannel,
+            int maxOverdraftBuffersPerGate)
             throws IOException {
         checkArgument(
                 numberOfRequiredMemorySegments > 0,
@@ -208,6 +218,10 @@ class LocalBufferPool implements BufferPool {
                     maxBuffersPerChannel > 0,
                     "Maximum number of buffers for each channel (%s) should be larger than 0.",
                     maxBuffersPerChannel);
+            checkArgument(
+                    maxOverdraftBuffersPerGate >= 0,
+                    "Maximum number of overdraft buffers for each gate (%s) should not be less than 0.",
+                    maxOverdraftBuffersPerGate);
         }
 
         this.subpartitionBuffersCount = new int[numberOfSubpartitions];
@@ -216,6 +230,7 @@ class LocalBufferPool implements BufferPool {
             subpartitionBufferRecyclers[i] = new SubpartitionBufferRecycler(i, this);
         }
         this.maxBuffersPerChannel = maxBuffersPerChannel;
+        this.maxOverdraftBuffersPerGate = maxOverdraftBuffersPerGate;
 
         // Lock is only taken, because #checkAvailability asserts it. It's a small penalty for
         // thread safety.
@@ -282,6 +297,11 @@ class LocalBufferPool implements BufferPool {
         }
     }
 
+    @VisibleForTesting
+    public int getNumberOfRequestedOverdraftMemorySegments() {
+        return numberOfRequestedOverdraftMemorySegments;
+    }
+
     @Override
     public int getNumberOfAvailableMemorySegments() {
         synchronized (availableMemorySegments) {
@@ -298,7 +318,11 @@ class LocalBufferPool implements BufferPool {
 
     @Override
     public int bestEffortGetNumOfUsedBuffers() {
-        return Math.max(0, numberOfRequestedMemorySegments - availableMemorySegments.size());
+        return Math.max(
+                0,
+                numberOfRequestedMemorySegments
+                        + numberOfRequestedOverdraftMemorySegments
+                        - availableMemorySegments.size());
     }
 
     @Override
@@ -372,7 +396,11 @@ class LocalBufferPool implements BufferPool {
         synchronized (availableMemorySegments) {
             checkDestroyed();
 
-            segment = availableMemorySegments.poll();
+            if (availableMemorySegments.isEmpty()) {
+                segment = requestOverdraftMemorySegmentFromGlobal();
+            } else {
+                segment = availableMemorySegments.poll();
+            }
 
             if (segment == null) {
                 return null;
@@ -424,6 +452,24 @@ class LocalBufferPool implements BufferPool {
         return false;
     }
 
+    private MemorySegment requestOverdraftMemorySegmentFromGlobal() {
+        assert Thread.holdsLock(availableMemorySegments);
+
+        if (numberOfRequestedOverdraftMemorySegments >= maxOverdraftBuffersPerGate) {
+            return null;
+        }
+
+        checkState(
+                !isDestroyed,
+                "Destroyed buffer pools should never acquire segments - this will lead to buffer leaks.");
+
+        MemorySegment segment = networkBufferPool.requestPooledMemorySegment();
+        if (segment != null) {
+            numberOfRequestedOverdraftMemorySegments++;
+        }
+        return segment;
+    }
+
     /**
      * Tries to obtain a buffer from global pool as soon as one pool is available. Note that
      * multiple {@link LocalBufferPool}s might wait on the future of the global pool, hence this
@@ -466,24 +512,26 @@ class LocalBufferPool implements BufferPool {
     private boolean shouldBeAvailable() {
         assert Thread.holdsLock(availableMemorySegments);
 
-        return !availableMemorySegments.isEmpty() && unavailableSubpartitionsCount == 0;
+        return !availableMemorySegments.isEmpty()
+                && unavailableSubpartitionsCount == 0
+                && numberOfRequestedOverdraftMemorySegments == 0;
     }
 
     private boolean checkAvailability() {
         assert Thread.holdsLock(availableMemorySegments);
 
         if (!availableMemorySegments.isEmpty()) {
-            return unavailableSubpartitionsCount == 0;
+            return shouldBeAvailable();
         }
-        if (!isRequestedSizeReached()) {
-            if (requestMemorySegmentFromGlobal()) {
-                return unavailableSubpartitionsCount == 0;
-            } else {
-                requestMemorySegmentFromGlobalWhenAvailable();
-                return shouldBeAvailable();
-            }
+        if (isRequestedSizeReached()) {
+            return false;
         }
-        return false;
+
+        // There aren't availableMemorySegments and we continue to request new memory segment.
+        if (!requestMemorySegmentFromGlobal()) {
+            requestMemorySegmentFromGlobalWhenAvailable();
+        }
+        return shouldBeAvailable();
     }
 
     private void checkConsistentAvailability() {
@@ -518,10 +566,7 @@ class LocalBufferPool implements BufferPool {
                     listener = registeredListeners.poll();
                     if (listener == null) {
                         availableMemorySegments.add(segment);
-                        // only need to check unavailableSubpartitionsCount here because
-                        // availableMemorySegments is not empty
-                        if (!availabilityHelper.isApproximatelyAvailable()
-                                && unavailableSubpartitionsCount == 0) {
+                        if (!availabilityHelper.isApproximatelyAvailable() && shouldBeAvailable()) {
                             toNotify = availabilityHelper.getUnavailableToResetAvailable();
                         }
                         break;
@@ -658,7 +703,12 @@ class LocalBufferPool implements BufferPool {
     private void returnMemorySegment(MemorySegment segment) {
         assert Thread.holdsLock(availableMemorySegments);
 
-        numberOfRequestedMemorySegments--;
+        // When using the overdraft buffer, return the overdraft buffer first.
+        if (numberOfRequestedOverdraftMemorySegments > 0) {
+            numberOfRequestedOverdraftMemorySegments--;
+        } else {
+            numberOfRequestedMemorySegments--;
+        }
         networkBufferPool.recyclePooledMemorySegment(segment);
     }
 
@@ -676,7 +726,8 @@ class LocalBufferPool implements BufferPool {
     }
 
     private boolean hasExcessBuffers() {
-        return numberOfRequestedMemorySegments > currentPoolSize;
+        return numberOfRequestedOverdraftMemorySegments > 0
+                || numberOfRequestedMemorySegments > currentPoolSize;
     }
 
     private boolean isRequestedSizeReached() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
@@ -448,7 +448,8 @@ public class NetworkBufferPool
     @Override
     public BufferPool createBufferPool(int numRequiredBuffers, int maxUsedBuffers)
             throws IOException {
-        return internalCreateBufferPool(numRequiredBuffers, maxUsedBuffers, 0, Integer.MAX_VALUE);
+        return internalCreateBufferPool(
+                numRequiredBuffers, maxUsedBuffers, 0, Integer.MAX_VALUE, 0);
     }
 
     @Override
@@ -456,17 +457,23 @@ public class NetworkBufferPool
             int numRequiredBuffers,
             int maxUsedBuffers,
             int numSubpartitions,
-            int maxBuffersPerChannel)
+            int maxBuffersPerChannel,
+            int maxOverdraftBuffersPerGate)
             throws IOException {
         return internalCreateBufferPool(
-                numRequiredBuffers, maxUsedBuffers, numSubpartitions, maxBuffersPerChannel);
+                numRequiredBuffers,
+                maxUsedBuffers,
+                numSubpartitions,
+                maxBuffersPerChannel,
+                maxOverdraftBuffersPerGate);
     }
 
     private BufferPool internalCreateBufferPool(
             int numRequiredBuffers,
             int maxUsedBuffers,
             int numSubpartitions,
-            int maxBuffersPerChannel)
+            int maxBuffersPerChannel,
+            int maxOverdraftBuffersPerGate)
             throws IOException {
 
         // It is necessary to use a separate lock from the one used for buffer
@@ -498,7 +505,8 @@ public class NetworkBufferPool
                             numRequiredBuffers,
                             maxUsedBuffers,
                             numSubpartitions,
-                            maxBuffersPerChannel);
+                            maxBuffersPerChannel,
+                            maxOverdraftBuffersPerGate);
 
             allBufferPools.add(localBufferPool);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactory.java
@@ -75,6 +75,8 @@ public class ResultPartitionFactory {
 
     private final boolean sslEnabled;
 
+    private final int maxOverdraftBuffersPerGate;
+
     public ResultPartitionFactory(
             ResultPartitionManager partitionManager,
             FileChannelManager channelManager,
@@ -90,7 +92,8 @@ public class ResultPartitionFactory {
             int maxBuffersPerChannel,
             int sortShuffleMinBuffers,
             int sortShuffleMinParallelism,
-            boolean sslEnabled) {
+            boolean sslEnabled,
+            int maxOverdraftBuffersPerGate) {
 
         this.partitionManager = partitionManager;
         this.channelManager = channelManager;
@@ -107,6 +110,7 @@ public class ResultPartitionFactory {
         this.sortShuffleMinBuffers = sortShuffleMinBuffers;
         this.sortShuffleMinParallelism = sortShuffleMinParallelism;
         this.sslEnabled = sslEnabled;
+        this.maxOverdraftBuffersPerGate = maxOverdraftBuffersPerGate;
     }
 
     public ResultPartition create(
@@ -278,7 +282,11 @@ public class ResultPartitionFactory {
                             type);
 
             return bufferPoolFactory.createBufferPool(
-                    pair.getLeft(), pair.getRight(), numberOfSubpartitions, maxBuffersPerChannel);
+                    pair.getLeft(),
+                    pair.getRight(),
+                    numberOfSubpartitions,
+                    maxBuffersPerChannel,
+                    maxOverdraftBuffersPerGate);
         };
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NettyShuffleEnvironmentConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NettyShuffleEnvironmentConfiguration.java
@@ -97,6 +97,8 @@ public class NettyShuffleEnvironmentConfiguration {
 
     private final boolean connectionReuseEnabled;
 
+    private final int maxOverdraftBuffersPerGate;
+
     public NettyShuffleEnvironmentConfiguration(
             int numNetworkBuffers,
             int networkBufferSize,
@@ -117,7 +119,8 @@ public class NettyShuffleEnvironmentConfiguration {
             int sortShuffleMinParallelism,
             BufferDebloatConfiguration debloatConfiguration,
             int maxNumberOfConnections,
-            boolean connectionReuseEnabled) {
+            boolean connectionReuseEnabled,
+            int maxOverdraftBuffersPerGate) {
 
         this.numNetworkBuffers = numNetworkBuffers;
         this.networkBufferSize = networkBufferSize;
@@ -139,6 +142,7 @@ public class NettyShuffleEnvironmentConfiguration {
         this.debloatConfiguration = debloatConfiguration;
         this.maxNumberOfConnections = maxNumberOfConnections;
         this.connectionReuseEnabled = connectionReuseEnabled;
+        this.maxOverdraftBuffersPerGate = maxOverdraftBuffersPerGate;
     }
 
     // ------------------------------------------------------------------------
@@ -227,6 +231,10 @@ public class NettyShuffleEnvironmentConfiguration {
         return maxNumberOfConnections;
     }
 
+    public int getMaxOverdraftBuffersPerGate() {
+        return maxOverdraftBuffersPerGate;
+    }
+
     // ------------------------------------------------------------------------
 
     /**
@@ -277,6 +285,10 @@ public class NettyShuffleEnvironmentConfiguration {
         int maxBuffersPerChannel =
                 configuration.getInteger(
                         NettyShuffleEnvironmentOptions.NETWORK_MAX_BUFFERS_PER_CHANNEL);
+
+        int maxOverdraftBuffersPerGate =
+                configuration.getInteger(
+                        NettyShuffleEnvironmentOptions.NETWORK_MAX_OVERDRAFT_BUFFERS_PER_GATE);
 
         long batchShuffleReadMemoryBytes =
                 configuration.get(TaskManagerOptions.NETWORK_BATCH_SHUFFLE_READ_MEMORY).getBytes();
@@ -342,7 +354,8 @@ public class NettyShuffleEnvironmentConfiguration {
                 sortShuffleMinParallelism,
                 BufferDebloatConfiguration.fromConfiguration(configuration),
                 maxNumConnections,
-                connectionReuseEnabled);
+                connectionReuseEnabled,
+                maxOverdraftBuffersPerGate);
     }
 
     /**
@@ -481,6 +494,7 @@ public class NettyShuffleEnvironmentConfiguration {
         result = 31 * result + sortShuffleMinParallelism;
         result = 31 * result + maxNumberOfConnections;
         result = 31 * result + (connectionReuseEnabled ? 1 : 0);
+        result = 31 * result + maxOverdraftBuffersPerGate;
         return result;
     }
 
@@ -513,7 +527,8 @@ public class NettyShuffleEnvironmentConfiguration {
                     && this.maxBuffersPerChannel == that.maxBuffersPerChannel
                     && Objects.equals(this.compressionCodec, that.compressionCodec)
                     && this.maxNumberOfConnections == that.maxNumberOfConnections
-                    && this.connectionReuseEnabled == that.connectionReuseEnabled;
+                    && this.connectionReuseEnabled == that.connectionReuseEnabled
+                    && this.maxOverdraftBuffersPerGate == that.maxOverdraftBuffersPerGate;
         }
     }
 
@@ -554,6 +569,8 @@ public class NettyShuffleEnvironmentConfiguration {
                 + maxNumberOfConnections
                 + ", connectionReuseEnabled="
                 + connectionReuseEnabled
+                + ", maxOverdraftBuffersPerGate="
+                + maxOverdraftBuffersPerGate
                 + '}';
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentBuilder.java
@@ -68,6 +68,8 @@ public class NettyShuffleEnvironmentBuilder {
 
     private boolean connectionReuseEnabled = true;
 
+    private int maxOverdraftBuffersPerGate = 0;
+
     private String compressionCodec = "LZ4";
 
     private ResourceID taskManagerLocation = ResourceID.generate();
@@ -158,6 +160,12 @@ public class NettyShuffleEnvironmentBuilder {
         return this;
     }
 
+    public NettyShuffleEnvironmentBuilder setMaxOverdraftBuffersPerGate(
+            int maxOverdraftBuffersPerGate) {
+        this.maxOverdraftBuffersPerGate = maxOverdraftBuffersPerGate;
+        return this;
+    }
+
     public NettyShuffleEnvironmentBuilder setCompressionCodec(String compressionCodec) {
         this.compressionCodec = compressionCodec;
         return this;
@@ -217,7 +225,8 @@ public class NettyShuffleEnvironmentBuilder {
                         sortShuffleMinParallelism,
                         debloatConfiguration,
                         maxNumberOfConnections,
-                        connectionReuseEnabled),
+                        connectionReuseEnabled,
+                        maxOverdraftBuffersPerGate),
                 taskManagerLocation,
                 new TaskEventDispatcher(),
                 resultPartitionManager,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/RecordWriterDelegateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/RecordWriterDelegateTest.java
@@ -127,7 +127,7 @@ public class RecordWriterDelegateTest extends TestLogger {
     }
 
     private RecordWriter createRecordWriter(NetworkBufferPool globalPool) throws Exception {
-        final BufferPool localPool = globalPool.createBufferPool(1, 1, 1, Integer.MAX_VALUE);
+        final BufferPool localPool = globalPool.createBufferPool(1, 1, 1, Integer.MAX_VALUE, 0);
         final ResultPartitionWriter partition =
                 new ResultPartitionBuilder().setBufferPoolFactory(() -> localPool).build();
         partition.setup();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/RecordWriterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/RecordWriterTest.java
@@ -300,7 +300,7 @@ public class RecordWriterTest {
     public void testIsAvailableOrNot() throws Exception {
         // setup
         final NetworkBufferPool globalPool = new NetworkBufferPool(10, 128);
-        final BufferPool localPool = globalPool.createBufferPool(1, 1, 1, Integer.MAX_VALUE);
+        final BufferPool localPool = globalPool.createBufferPool(1, 1, 1, Integer.MAX_VALUE, 0);
         final ResultPartitionWriter resultPartition =
                 new ResultPartitionBuilder().setBufferPoolFactory(() -> localPool).build();
         resultPartition.setup();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPoolTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.io.network.buffer;
 
+import org.apache.flink.core.fs.AutoCloseableRegistry;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.execution.CancelTaskException;
 import org.apache.flink.testutils.executor.TestExecutorResource;
@@ -36,7 +37,9 @@ import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -45,6 +48,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -439,7 +443,7 @@ public class LocalBufferPoolTest extends TestLogger {
     @Test
     public void testMaxBuffersPerChannelAndAvailability() throws Exception {
         localBufferPool.lazyDestroy();
-        localBufferPool = new LocalBufferPool(networkBufferPool, 1, Integer.MAX_VALUE, 3, 2);
+        localBufferPool = new LocalBufferPool(networkBufferPool, 1, Integer.MAX_VALUE, 3, 2, 0);
         localBufferPool.setNumBuffers(10);
 
         assertTrue(localBufferPool.getAvailableFuture().isDone());
@@ -547,6 +551,105 @@ public class LocalBufferPoolTest extends TestLogger {
         } finally {
             globalPool.destroy();
         }
+    }
+
+    @Test
+    public void testOverdraftBufferAndAvailability() throws Exception {
+        for (int maxOverdraftBuffers = 0; maxOverdraftBuffers < 3; maxOverdraftBuffers++) {
+            useAllOverdraftBuffersAndCheckIsLegal(4, 3, maxOverdraftBuffers, 2, 1);
+            useAllOverdraftBuffersAndCheckIsLegal(4, 3, maxOverdraftBuffers, 2, 2);
+            useAllOverdraftBuffersAndCheckIsLegal(4, 3, maxOverdraftBuffers, 3, 2);
+
+            useAllOverdraftBuffersAndCheckIsLegal(8, 5, maxOverdraftBuffers, 2, 1);
+            useAllOverdraftBuffersAndCheckIsLegal(8, 5, maxOverdraftBuffers, 2, 2);
+            useAllOverdraftBuffersAndCheckIsLegal(8, 5, maxOverdraftBuffers, 3, 2);
+
+            useAllOverdraftBuffersAndCheckIsLegal(12, 10, maxOverdraftBuffers, 2, 1);
+            useAllOverdraftBuffersAndCheckIsLegal(12, 10, maxOverdraftBuffers, 2, 2);
+            useAllOverdraftBuffersAndCheckIsLegal(12, 10, maxOverdraftBuffers, 3, 2);
+        }
+    }
+
+    private void useAllOverdraftBuffersAndCheckIsLegal(
+            int poolSize,
+            int maxBuffersPerChannel,
+            int maxOverdraftBuffers,
+            int numberOfChannels,
+            int availableChannels)
+            throws Exception {
+        checkArgument(maxBuffersPerChannel > poolSize / numberOfChannels);
+        checkArgument(numberOfChannels >= availableChannels);
+        LocalBufferPool bufferPool =
+                new LocalBufferPool(
+                        networkBufferPool,
+                        1,
+                        Integer.MAX_VALUE,
+                        numberOfChannels,
+                        maxBuffersPerChannel,
+                        maxOverdraftBuffers);
+        bufferPool.setNumBuffers(poolSize);
+
+        // Request all buffers inside the buffer pool
+        Map<Integer, AutoCloseableRegistry> closeableRegistryMap = new HashMap<>();
+        for (int i = 0; i < poolSize; i++) {
+            int targetChannel = i % availableChannels;
+            BufferBuilder bufferBuilder = bufferPool.requestBufferBuilder(targetChannel);
+            assertNotNull(bufferBuilder);
+            closeableRegistryMap
+                    .computeIfAbsent(targetChannel, channel -> new AutoCloseableRegistry())
+                    .registerCloseable(bufferBuilder);
+            boolean isAvailable =
+                    (i + 1 < poolSize) && i < availableChannels * (maxBuffersPerChannel - 1);
+            assertRequestedBufferAndIsAvailable(bufferPool, 0, i + 1, isAvailable);
+        }
+
+        // request overdraft buffer
+        AutoCloseableRegistry overdraftCloseableRegistry = new AutoCloseableRegistry();
+        for (int i = 0; i < maxOverdraftBuffers; i++) {
+            int targetChannel = i % availableChannels;
+            BufferBuilder bufferBuilder = bufferPool.requestBufferBuilder(targetChannel);
+            assertNotNull(bufferBuilder);
+            overdraftCloseableRegistry.registerCloseable(bufferBuilder);
+            int numberOfRequestedOverdraftBuffer = i + 1;
+            assertRequestedBufferAndIsAvailable(
+                    bufferPool,
+                    numberOfRequestedOverdraftBuffer,
+                    poolSize + numberOfRequestedOverdraftBuffer,
+                    false);
+        }
+
+        for (int i = 0; i < numberOfChannels; i++) {
+            assertNull(bufferPool.requestBufferBuilder(i));
+            assertRequestedBufferAndIsAvailable(
+                    bufferPool, maxOverdraftBuffers, poolSize + maxOverdraftBuffers, false);
+        }
+
+        // release all bufferBuilder
+        overdraftCloseableRegistry.close();
+        assertRequestedBufferAndIsAvailable(bufferPool, 0, poolSize, false);
+        int numberOfRequestedBuffer = poolSize;
+        for (AutoCloseableRegistry closeableRegistry : closeableRegistryMap.values()) {
+            numberOfRequestedBuffer =
+                    numberOfRequestedBuffer - closeableRegistry.getNumberOfRegisteredCloseables();
+            closeableRegistry.close();
+            assertRequestedBufferAndIsAvailable(bufferPool, 0, numberOfRequestedBuffer, true);
+        }
+        bufferPool.lazyDestroy();
+    }
+
+    private void assertRequestedBufferAndIsAvailable(
+            LocalBufferPool bufferPool,
+            int numberOfRequestedOverdraftBuffer,
+            int numberOfRequestedBuffer,
+            boolean isAvailable) {
+        if (numberOfRequestedOverdraftBuffer > 0) {
+            checkArgument(!isAvailable);
+        }
+        assertEquals(
+                numberOfRequestedOverdraftBuffer,
+                bufferPool.getNumberOfRequestedOverdraftMemorySegments());
+        assertEquals(numberOfRequestedBuffer, bufferPool.bestEffortGetNumOfUsedBuffers());
+        assertEquals(isAvailable, bufferPool.getAvailableFuture().isDone());
     }
 
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionBuilder.java
@@ -80,6 +80,8 @@ public class ResultPartitionBuilder {
 
     private String compressionCodec = "LZ4";
 
+    private int maxOverdraftBuffersPerGate = 5;
+
     public ResultPartitionBuilder setResultPartitionIndex(int partitionIndex) {
         this.partitionIndex = partitionIndex;
         return this;
@@ -203,6 +205,11 @@ public class ResultPartitionBuilder {
         return this;
     }
 
+    public ResultPartitionBuilder setMaxOverdraftBuffersPerGate(int maxOverdraftBuffersPerGate) {
+        this.maxOverdraftBuffersPerGate = maxOverdraftBuffersPerGate;
+        return this;
+    }
+
     public ResultPartition build() {
         ResultPartitionFactory resultPartitionFactory =
                 new ResultPartitionFactory(
@@ -220,7 +227,8 @@ public class ResultPartitionBuilder {
                         maxBuffersPerChannel,
                         sortShuffleMinBuffers,
                         sortShuffleMinParallelism,
-                        sslEnabled);
+                        sslEnabled,
+                        maxOverdraftBuffersPerGate);
 
         SupplierWithException<BufferPool, IOException> factory =
                 bufferPoolFactory.orElseGet(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactoryTest.java
@@ -125,7 +125,8 @@ public class ResultPartitionFactoryTest extends TestLogger {
                         Integer.MAX_VALUE,
                         10,
                         sortShuffleMinParallelism,
-                        false);
+                        false,
+                        0);
 
         final ResultPartitionDeploymentDescriptor descriptor =
                 new ResultPartitionDeploymentDescriptor(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
@@ -373,7 +373,7 @@ public class ResultPartitionTest {
         // setup
         int bufferSize = 1024;
         NetworkBufferPool globalPool = new NetworkBufferPool(10, bufferSize);
-        BufferPool localPool = globalPool.createBufferPool(1, 1, 1, Integer.MAX_VALUE);
+        BufferPool localPool = globalPool.createBufferPool(1, 1, 1, Integer.MAX_VALUE, 0);
         BufferWritingResultPartition resultPartition =
                 (BufferWritingResultPartition)
                         new ResultPartitionBuilder().setBufferPoolFactory(() -> localPool).build();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
@@ -173,7 +173,8 @@ public class LocalInputChannelTest {
                                                     producerBufferPoolSize,
                                                     producerBufferPoolSize,
                                                     parallelism,
-                                                    Integer.MAX_VALUE))
+                                                    Integer.MAX_VALUE,
+                                                    0))
                             .build();
 
             // Create a buffer pool for this partition

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ChannelPersistenceITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ChannelPersistenceITCase.java
@@ -180,7 +180,8 @@ public class ChannelPersistenceITCase {
                                                 numberOfSubpartitions,
                                                 Integer.MAX_VALUE,
                                                 numberOfSubpartitions,
-                                                Integer.MAX_VALUE))
+                                                Integer.MAX_VALUE,
+                                                0))
                         .build();
         resultPartition.setup();
         return (BufferWritingResultPartition) resultPartition;


### PR DESCRIPTION
## What is the purpose of the change

Add the overdraft buffer in ResultPartition to reduce unaligned checkpoint being blocked

## Brief change log

- Add overdraft buffer in LocalBufferPool
- Add configuration : taskmanager.network.memory.max-overdraft-buffers-per-gate

## Verifying this change

This change added tests and can be verified as follows:

  - Added testOverdraftBuffer in LocalBufferPoolTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
