### PR TITLE
[FLINK-26761][table]invoke getTargetTableID to avoid type conversion exception

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/calcite/PreValidateReWriter.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/calcite/PreValidateReWriter.scala
@@ -119,7 +119,7 @@ object PreValidateReWriter {
       source: SqlCall,
       partitions: SqlNodeList): SqlCall = {
     val calciteCatalogReader = validator.getCatalogReader.unwrap(classOf[CalciteCatalogReader])
-    val names = sqlInsert.getTargetTable.asInstanceOf[SqlIdentifier].names
+    val names = sqlInsert.getTargetTableID.asInstanceOf[SqlIdentifier].names
     val table = calciteCatalogReader.getTable(names)
     if (table == null) {
       // There is no table exists in current catalog,

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/PartitionableSinkTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/PartitionableSinkTest.xml
@@ -35,6 +35,44 @@ Sink(table=[default_catalog.default_database.sink], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testStaticWithDynamicOptions">
+    <Resource name="sql">
+      <![CDATA[INSERT INTO sink/*+ OPTIONS('path'='/tmp/test') */ PARTITION (b=1, c=1) SELECT a FROM MyTable]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink], fields=[a, EXPR$1, EXPR$2], hints=[[[OPTIONS options:{path=/tmp/test}]]])
++- LogicalProject(a=[$0], EXPR$1=[1:BIGINT], EXPR$2=[1:BIGINT])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink], fields=[a, EXPR$1, EXPR$2], hints=[[[OPTIONS options:{path=/tmp/test}]]])
++- Calc(select=[a, 1 AS EXPR$1, 1 AS EXPR$2])
+   +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testOverwriteWithDynamicOptions">
+    <Resource name="sql">
+      <![CDATA[INSERT OVERWRITE sink/*+ OPTIONS('path'='/tmp/test') */ PARTITION (b=1, c=1) SELECT a FROM MyTable]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink], fields=[a, EXPR$1, EXPR$2], hints=[[[OPTIONS options:{path=/tmp/test}]]])
++- LogicalProject(a=[$0], EXPR$1=[1:BIGINT], EXPR$2=[1:BIGINT])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink], fields=[a, EXPR$1, EXPR$2], hints=[[[OPTIONS options:{path=/tmp/test}]]])
++- Calc(select=[a, 1 AS EXPR$1, 1 AS EXPR$2])
+   +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testDynamicShuffleBy">
     <Resource name="sql">
       <![CDATA[INSERT INTO sinkShuffleBy SELECT a, b, c FROM MyTable]]>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/PartitionableSinkTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/PartitionableSinkTest.xml
@@ -34,6 +34,25 @@ Sink(table=[default_catalog.default_database.sink], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testStaticWithDynamicOptions">
+    <Resource name="sql">
+      <![CDATA[INSERT INTO sink/*+ OPTIONS('path'='/tmp/test') */ PARTITION (b=1, c=1) SELECT a FROM MyTable]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink], fields=[a, EXPR$1, EXPR$2], hints=[[[OPTIONS options:{path=/tmp/test}]]])
++- LogicalProject(a=[$0], EXPR$1=[1:BIGINT], EXPR$2=[1:BIGINT])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink], fields=[a, EXPR$1, EXPR$2], hints=[[[OPTIONS options:{path=/tmp/test}]]])
++- Calc(select=[a, 1 AS EXPR$1, 1 AS EXPR$2])
+   +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testDynamicShuffleBy">
     <Resource name="sql">
       <![CDATA[INSERT INTO sinkShuffleBy SELECT a, b, c FROM MyTable]]>

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/PartitionableSinkTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/PartitionableSinkTest.scala
@@ -51,6 +51,18 @@ class PartitionableSinkTest extends TableTestBase {
   }
 
   @Test
+  def testStaticWithDynamicOptions(): Unit = {
+    util.verifyExecPlanInsert(
+      "INSERT INTO sink/*+ OPTIONS('path'='/tmp/test') */ PARTITION (b=1, c=1) SELECT a FROM MyTable");
+  }
+
+  @Test
+  def testOverwriteWithDynamicOptions(): Unit = {
+    util.verifyExecPlanInsert(
+      "INSERT OVERWRITE sink/*+ OPTIONS('path'='/tmp/test') */ PARTITION (b=1, c=1) SELECT a FROM MyTable");
+  }
+
+  @Test
   def testDynamic(): Unit = {
     util.verifyExecPlanInsert("INSERT INTO sink SELECT a, b, c FROM MyTable")
   }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/PartitionableSinkTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/PartitionableSinkTest.scala
@@ -51,6 +51,12 @@ class PartitionableSinkTest extends TableTestBase {
   }
 
   @Test
+  def testStaticWithDynamicOptions(): Unit = {
+    util.verifyExecPlanInsert(
+      "INSERT INTO sink/*+ OPTIONS('path'='/tmp/test') */ PARTITION (b=1, c=1) SELECT a FROM MyTable");
+  }
+
+  @Test
   def testDynamic(): Unit = {
     util.verifyExecPlanInsert("INSERT INTO sink SELECT a, b, c FROM MyTable")
   }


### PR DESCRIPTION
## What is the purpose of the change
  invoke getTargetTableID in PreValidateReWriter#appendPartitionAndNullsProjects to avoid type conversion exception.

## Brief change log
 - use RichSqlInsert#getTargetTableID to get 'SqlIdentifier' instead of SqlInsert#getTargetTable.
 - add test to verify.

## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
