### PR TITLE
[FLINK-27218] fix the problem that the internal Serializer in Operato…

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/HeapBroadcastState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/HeapBroadcastState.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.state;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.state.BroadcastState;
 import org.apache.flink.api.common.typeutils.base.MapSerializer;
 import org.apache.flink.core.fs.FSDataOutputStream;
@@ -46,7 +47,7 @@ public class HeapBroadcastState<K, V> implements BackendWritableBroadcastState<K
     private final Map<K, V> backingMap;
 
     /** A serializer that allows to perform deep copies of internal map state. */
-    private final MapSerializer<K, V> internalMapCopySerializer;
+    private MapSerializer<K, V> internalMapCopySerializer;
 
     HeapBroadcastState(RegisteredBroadcastStateBackendMetaInfo<K, V> stateMetaInfo) {
         this(stateMetaInfo, new HashMap<>());
@@ -71,6 +72,9 @@ public class HeapBroadcastState<K, V> implements BackendWritableBroadcastState<K
 
     @Override
     public void setStateMetaInfo(RegisteredBroadcastStateBackendMetaInfo<K, V> stateMetaInfo) {
+        this.internalMapCopySerializer =
+                new MapSerializer<>(
+                        stateMetaInfo.getKeySerializer(), stateMetaInfo.getValueSerializer());
         this.stateMetaInfo = stateMetaInfo;
     }
 
@@ -153,5 +157,10 @@ public class HeapBroadcastState<K, V> implements BackendWritableBroadcastState<K
     @Override
     public Iterable<Map.Entry<K, V>> immutableEntries() {
         return Collections.unmodifiableSet(backingMap.entrySet());
+    }
+
+    @VisibleForTesting
+    public MapSerializer<K, V> getInternalMapCopySerializer() {
+        return internalMapCopySerializer;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/PartitionableListState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/PartitionableListState.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.state;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.core.fs.FSDataOutputStream;
 import org.apache.flink.core.memory.DataOutputView;
@@ -42,7 +43,7 @@ public final class PartitionableListState<S> implements ListState<S> {
     private final ArrayList<S> internalList;
 
     /** A typeSerializer that allows to perform deep copies of internalList */
-    private final ArrayListSerializer<S> internalListCopySerializer;
+    private ArrayListSerializer<S> internalListCopySerializer;
 
     PartitionableListState(RegisteredOperatorStateBackendMetaInfo<S> stateMetaInfo) {
         this(stateMetaInfo, new ArrayList<S>());
@@ -65,6 +66,8 @@ public final class PartitionableListState<S> implements ListState<S> {
     }
 
     public void setStateMetaInfo(RegisteredOperatorStateBackendMetaInfo<S> stateMetaInfo) {
+        this.internalListCopySerializer =
+                new ArrayListSerializer<>(stateMetaInfo.getPartitionStateSerializer());
         this.stateMetaInfo = stateMetaInfo;
     }
 
@@ -129,5 +132,10 @@ public final class PartitionableListState<S> implements ListState<S> {
         if (values != null && !values.isEmpty()) {
             internalList.addAll(values);
         }
+    }
+
+    @VisibleForTesting
+    public ArrayListSerializer<S> getInternalListCopySerializer() {
+        return internalListCopySerializer;
     }
 }


### PR DESCRIPTION

## What is the purpose of the change

Fix the problem that the internal Serializer in OperatorState may have not been updated when schema changes

## Brief change log

When `DefaultOperatorStateBackend` creates `ListState` or `BroadcastState`, if new Serializers are NOT incompatible, while updating `StateMetaInfo`, it also updates the internalSerializer inside State, such as `internalMapCopySerializer` in `BroadcastState` or `internalListCopySerializer` in `PartitionableListState`


## Verifying this change

Added test that internal Serializer has been updated when schema changes in `org.apache.flink.runtime.state.StateBackendMigrationTestBase`
  
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
