### PR TITLE
[FLINK-27299][Runtime/Configuration] flink parsing parameter bug fixed.

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/GlobalConfiguration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/GlobalConfiguration.java
@@ -174,7 +174,7 @@ public final class GlobalConfiguration {
             while ((line = reader.readLine()) != null) {
                 lineNo++;
                 // 1. check for comments
-                String[] comments = line.split("#", 2);
+                String[] comments = line.split("\\s+#", 2);
                 String conf = comments[0].trim();
 
                 // 2. get key and value

--- a/flink-core/src/test/java/org/apache/flink/configuration/GlobalConfigurationTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/GlobalConfigurationTest.java
@@ -61,7 +61,6 @@ public class GlobalConfigurationTest extends TestLogger {
                 pw.println(" :  "); // SKIP
                 pw.println("   "); // SKIP (silently)
                 pw.println(" "); // SKIP (silently)
-                pw.println("mykey4: myvalue4# some comments"); // OK, skip comments only
                 pw.println("   mykey5    :    myvalue5    "); // OK, trim unnecessary whitespace
                 pw.println("mykey6: my: value6"); // OK, only use first ': ' as separator
                 pw.println("mykey7: "); // SKIP, no value provided
@@ -69,7 +68,9 @@ public class GlobalConfigurationTest extends TestLogger {
 
                 pw.println("mykey9: myvalue9"); // OK
                 pw.println("mykey9: myvalue10"); // OK, overwrite last value
-
+                pw.println("mykey10: myvalue10 #some comments"); // with comments
+                pw.println("mykey11: myvalue11#123"); // OK
+                pw.println("mykey12: myvalue12#123 #some comments"); // with comments
             } catch (FileNotFoundException e) {
                 e.printStackTrace();
             }
@@ -77,18 +78,20 @@ public class GlobalConfigurationTest extends TestLogger {
             Configuration conf = GlobalConfiguration.loadConfiguration(tmpDir.getAbsolutePath());
 
             // all distinct keys from confFile1 + confFile2 key
-            assertEquals(6, conf.keySet().size());
+            assertEquals(9, conf.keySet().size());
 
             // keys 1, 2, 4, 5, 6, 7, 8 should be OK and match the expected values
             assertEquals("myvalue1", conf.getString("mykey1", null));
             assertEquals("myvalue2", conf.getString("mykey2", null));
             assertEquals("null", conf.getString("mykey3", "null"));
-            assertEquals("myvalue4", conf.getString("mykey4", null));
             assertEquals("myvalue5", conf.getString("mykey5", null));
             assertEquals("my: value6", conf.getString("mykey6", null));
             assertEquals("null", conf.getString("mykey7", "null"));
             assertEquals("null", conf.getString("mykey8", "null"));
             assertEquals("myvalue10", conf.getString("mykey9", null));
+            assertEquals("myvalue10", conf.getString("mykey10", null));
+            assertEquals("myvalue11#123", conf.getString("mykey11", null));
+            assertEquals("myvalue12#123", conf.getString("mykey12", null));
         } finally {
             confFile.delete();
             tmpDir.delete();


### PR DESCRIPTION


## What is the purpose of the change

When I am running a flink job, I specify a running parameter with a "#" sign in it. The parsing fails.

e.g: flink run com.myJob --sink.password db@123#123 

only parse the content in front of "#", after reading the source code It is found that the parameters are intercepted according to "#" in the loadYAMLResource method of GlobalConfiguration. This part needs to be improved

## Brief change log
  -  before: `line.split("#", 2) ` after: `line.split("\\s+#", 2)` Following yaml's parameter parsing rules, the content after " #" ( space + #) is the real comment part, which should be discarded when parsing parameters

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): don't know
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature?  no
  - If yes, how is the feature documented?  not applicable
