### PR TITLE
[FLINK-27308][Filesystem][S3] Update the Hadoop implementation for filesystems to 3.3.2

### DIFF
--- a/flink-filesystems/flink-azure-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-azure-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -7,14 +7,10 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - com.fasterxml.jackson.core:jackson-core:2.13.2
-- com.google.errorprone:error_prone_annotations:2.2.0
-- com.google.guava:failureaccess:1.0
-- com.google.guava:guava:27.0-jre
-- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
-- com.google.j2objc:j2objc-annotations:1.1
+- com.google.guava:guava:20.0
 - commons-codec:commons-codec:1.15
 - commons-logging:commons-logging:1.1.3
-- org.apache.hadoop:hadoop-azure:3.2.2
+- org.apache.hadoop:hadoop-azure:3.3.2
 - org.apache.httpcomponents:httpclient:4.5.13
 - org.apache.httpcomponents:httpcore:4.4.14
 - org.codehaus.jackson:jackson-mapper-asl:1.9.13
@@ -22,10 +18,15 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.eclipse.jetty:jetty-util:9.3.24.v20180605
 - org.eclipse.jetty:jetty-util-ajax:9.3.24.v20180605
 - org.wildfly.openssl:wildfly-openssl:1.0.7.Final
+- org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.1.1
 
 This project bundles the following dependencies under the MIT (https://opensource.org/licenses/MIT)
 
 - com.microsoft.azure:azure-keyvault-core:1.0.0
-- com.microsoft.azure:azure-storage:7.0.0
-- org.checkerframework:checker-qual:2.5.2
-- org.codehaus.mojo:animal-sniffer-annotations:1.17
+- com.microsoft.azure:azure-storage:7.0.1
+
+The bundled Apache Hadoop Relocated (Shaded) Third-party Miscellaneous Libs
+org.apache.hadoop.thirdparty:hadoop-shaded-guava dependency bundles the following dependencies under
+the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+- com.google.guava:guava:30.1.1-jre

--- a/flink-filesystems/flink-fs-hadoop-shaded/pom.xml
+++ b/flink-filesystems/flink-fs-hadoop-shaded/pom.xml
@@ -155,10 +155,6 @@ under the License.
 				</exclusion>
 				<exclusion>
 					<groupId>org.apache.commons</groupId>
-					<artifactId>commons-compress</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.apache.commons</groupId>
 					<artifactId>commons-math3</artifactId>
 				</exclusion>
 				<exclusion>

--- a/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
@@ -6,18 +6,17 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- org.apache.hadoop:hadoop-annotations:3.2.2
-- org.apache.hadoop:hadoop-auth:3.2.2
-- org.apache.hadoop:hadoop-common:3.2.2
-- org.apache.htrace:htrace-core4:4.1.0-incubating
+- org.apache.hadoop:hadoop-annotations:3.3.2
+- org.apache.hadoop:hadoop-auth:3.3.2
+- org.apache.hadoop:hadoop-common:3.3.2
 - org.apache.commons:commons-configuration2:2.1.1
 - org.apache.commons:commons-lang3:3.3.2
 - org.apache.commons:commons-text:1.4
+- org.apache.commons:commons-compress:1.21
 - commons-collections:commons-collections:3.2.2
 - commons-io:commons-io:2.11.0
 - commons-logging:commons-logging:1.1.3
 - commons-beanutils:commons-beanutils:1.9.4
-- com.google.errorprone:error_prone_annotations:2.2.0
 - com.google.guava:failureaccess:1.0
 - com.google.guava:guava:27.0-jre
 - com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
@@ -25,7 +24,14 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.jackson.core:jackson-annotations:2.13.2
 - com.fasterxml.jackson.core:jackson-core:2.13.2
 - com.fasterxml.jackson.core:jackson-databind:2.13.2.2
-- com.fasterxml.woodstox:woodstox-core:5.0.3
+- com.fasterxml.woodstox:woodstox-core:5.3.0
+- org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_7:1.1.1
+- org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.1.1
+- org.apache.kerby:kerb-core:1.0.1
+- org.apache.kerby:kerby-pkix:1.0.1
+- org.apache.kerby:kerby-asn1:1.0.1
+- org.apache.kerby:kerby-util:1.0.1
+- org.xerial.snappy:snappy-java:1.1.8.3
 
 This project bundles the following dependencies under the MIT (https://opensource.org/licenses/MIT)
 
@@ -45,14 +51,21 @@ See bundled license files for details.
 This project bundles the following dependencies under BSD License (https://opensource.org/licenses/bsd-license.php).
 See bundled license files for details.
 
-- org.codehaus.woodstox:stax2-api:3.1.4 (https://github.com/FasterXML/stax2-api/tree/stax2-api-3.1.4)
+- org.codehaus.woodstox:stax2-api:4.2.1 (https://github.com/FasterXML/stax2-api/tree/stax2-api-4.2.1)
 
-This project bundles the following dependencies under the CDDL 1.1 license.
-See bundled license files for details.
+The bundled Apache Hadoop Relocated (Shaded) Third-party Miscellaneous Libs
+org.apache.hadoop.thirdparty:hadoop-shaded-guava dependency bundles the following dependencies under
+the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- javax.activation:javax.activation-api:1.2.0
+- com.google.guava:guava:30.1.1-jre
 
-This project bundles org.apache.hadoop:*:3.2.2 from which it inherits the following notices:
+The bundled Apache Hadoop Relocated (Shaded) Third-party Miscellaneous Libs
+org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_7 dependency bundles the following dependencies under
+the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+- com.google.protobuf:protobuf-java:3.7.1
+
+This project bundles org.apache.hadoop:*:3.3.2 from which it inherits the following notices:
 
 The Apache Hadoop project contains subcomponents with separate copyright
 notices and license terms. Your use of the source code for the these

--- a/flink-filesystems/flink-oss-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-oss-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -13,7 +13,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.aliyun:aliyun-java-sdk-sts:3.0.0
 - commons-codec:commons-codec:1.15
 - commons-logging:commons-logging:1.1.3
-- org.apache.hadoop:hadoop-aliyun:3.2.2
+- org.apache.hadoop:hadoop-aliyun:3.3.2
 - org.apache.httpcomponents:httpclient:4.5.13
 - org.apache.httpcomponents:httpcore:4.4.14
 - org.codehaus.jettison:jettison:1.1

--- a/flink-filesystems/flink-s3-fs-base/pom.xml
+++ b/flink-filesystems/flink-s3-fs-base/pom.xml
@@ -157,10 +157,6 @@ under the License.
 				</exclusion>
 				<exclusion>
 					<groupId>org.apache.commons</groupId>
-					<artifactId>commons-compress</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.apache.commons</groupId>
 					<artifactId>commons-math3</artifactId>
 				</exclusion>
 				<exclusion>

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -13,8 +13,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.jackson.core:jackson-core:2.13.2
 - com.fasterxml.jackson.core:jackson-databind:2.13.2.2
 - com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.2
-- com.fasterxml.woodstox:woodstox-core:5.0.3
-- com.google.errorprone:error_prone_annotations:2.2.0
+- com.fasterxml.woodstox:woodstox-core:5.3.0
 - com.google.guava:failureaccess:1.0
 - com.google.guava:guava:27.0-jre
 - com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
@@ -28,14 +27,22 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.commons:commons-configuration2:2.1.1
 - org.apache.commons:commons-lang3:3.3.2
 - org.apache.commons:commons-text:1.4
-- org.apache.hadoop:hadoop-auth:3.2.2
-- org.apache.hadoop:hadoop-annotations:3.2.2
-- org.apache.hadoop:hadoop-aws:3.2.2
-- org.apache.hadoop:hadoop-common:3.2.2
-- org.apache.htrace:htrace-core4:4.1.0-incubating
+- org.apache.commons:commons-compress:1.21
+- org.apache.hadoop:hadoop-auth:3.3.2
+- org.apache.hadoop:hadoop-annotations:3.3.2
+- org.apache.hadoop:hadoop-aws:3.3.2
+- org.apache.hadoop:hadoop-common:3.3.2
 - org.apache.httpcomponents:httpclient:4.5.13
 - org.apache.httpcomponents:httpcore:4.4.14
 - software.amazon.ion:ion-java:1.0.2
+- org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_7:1.1.1
+- org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.1.1
+- org.apache.kerby:kerb-core:1.0.1
+- org.apache.kerby:kerby-pkix:1.0.1
+- org.apache.kerby:kerby-asn1:1.0.1
+- org.apache.kerby:kerby-util:1.0.1
+- org.xerial.snappy:snappy-java:1.1.8.3
+- org.wildfly.openssl:wildfly-openssl:1.0.7.Final
 
 This project bundles the following dependencies under BSD-2 License (https://opensource.org/licenses/BSD-2-Clause).
 See bundled license files for details.
@@ -50,7 +57,6 @@ This project bundles the following dependencies under the MIT (https://opensourc
 This project bundles the following dependencies under the CDDL 1.1 license.
 See bundled license files for details.
 
-- javax.activation:javax.activation-api:1.2.0
 - javax.xml.bind:jaxb-api:2.3.1
 
 This project bundles the following dependencies under the Go License (https://golang.org/LICENSE).
@@ -61,4 +67,16 @@ See bundled license files for details.
 This project bundles the following dependencies under BSD License (https://opensource.org/licenses/bsd-license.php).
 See bundled license files for details.
 
-- org.codehaus.woodstox:stax2-api:3.1.4 (https://github.com/FasterXML/stax2-api/tree/stax2-api-3.1.4)
+- org.codehaus.woodstox:stax2-api:4.2.1 (https://github.com/FasterXML/stax2-api/tree/stax2-api-4.2.1)
+
+The bundled Apache Hadoop Relocated (Shaded) Third-party Miscellaneous Libs
+org.apache.hadoop.thirdparty:hadoop-shaded-guava dependency bundles the following dependencies under
+the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+- com.google.guava:guava:30.1.1-jre
+
+The bundled Apache Hadoop Relocated (Shaded) Third-party Miscellaneous Libs
+org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_7 dependency bundles the following dependencies under
+the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+- com.google.protobuf:protobuf-java:3.7.1

--- a/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
@@ -26,7 +26,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.jackson.core:jackson-core:2.13.2
 - com.fasterxml.jackson.core:jackson-databind:2.13.2.2
 - com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.2
-- com.fasterxml.woodstox:woodstox-core:5.0.3
+- com.fasterxml.woodstox:woodstox-core:5.3.0
 - com.google.guava:guava:26.0-jre
 - com.google.inject:guice:4.2.2
 - com.facebook.airlift:configuration:0.201
@@ -39,16 +39,24 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.commons:commons-configuration2:2.1.1
 - org.apache.commons:commons-lang3:3.3.2
 - org.apache.commons:commons-text:1.4
-- org.apache.hadoop:hadoop-annotations:3.2.2
-- org.apache.hadoop:hadoop-aws:3.2.2
-- org.apache.hadoop:hadoop-auth:3.2.2
-- org.apache.hadoop:hadoop-common:3.2.2
-- org.apache.htrace:htrace-core4:4.1.0-incubating
+- org.apache.commons:commons-compress:1.21
+- org.apache.hadoop:hadoop-annotations:3.3.2
+- org.apache.hadoop:hadoop-aws:3.3.2
+- org.apache.hadoop:hadoop-auth:3.3.2
+- org.apache.hadoop:hadoop-common:3.3.2
 - org.apache.httpcomponents:httpclient:4.5.13
 - org.apache.httpcomponents:httpcore:4.4.14
 - org.apache.hudi:hudi-presto-bundle:0.10.1
 - org.weakref:jmxutils:1.19
 - software.amazon.ion:ion-java:1.0.2
+- org.xerial.snappy:snappy-java:1.1.8.3
+- org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_7:1.1.1
+- org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.1.1
+- org.apache.kerby:kerb-core:1.0.1
+- org.apache.kerby:kerby-pkix:1.0.1
+- org.apache.kerby:kerby-asn1:1.0.1
+- org.apache.kerby:kerby-util:1.0.1
+- org.wildfly.openssl:wildfly-openssl:1.0.7.Final
 
 This project bundles the following dependencies under BSD-2 License (https://opensource.org/licenses/BSD-2-Clause).
 See bundled license files for details.
@@ -63,7 +71,6 @@ See bundled license files for details.
 This project bundles the following dependencies under the CDDL 1.1 license.
 See bundled license files for details.
 
-- javax.activation:javax.activation-api:1.2.0
 - javax.xml.bind:jaxb-api:2.3.1
 
 This project bundles the following dependencies under the Go License (https://golang.org/LICENSE).
@@ -74,9 +81,21 @@ See bundled license files for details.
 This project bundles the following dependencies under BSD License (https://opensource.org/licenses/bsd-license.php).
 See bundled license files for details.
 
-- org.codehaus.woodstox:stax2-api:3.1.4 (https://github.com/FasterXML/stax2-api/tree/stax2-api-3.1.4)
+- org.codehaus.woodstox:stax2-api:4.2.1 (https://github.com/FasterXML/stax2-api/tree/stax2-api-4.2.1)
 
 This project bundles the following dependencies under the Public Domain.
 See bundled license files for details.
 
 - aopalliance:aopalliance:1.0
+
+The bundled Apache Hadoop Relocated (Shaded) Third-party Miscellaneous Libs
+org.apache.hadoop.thirdparty:hadoop-shaded-guava dependency bundles the following dependencies under
+the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+- com.google.guava:guava:30.1.1-jre
+
+The bundled Apache Hadoop Relocated (Shaded) Third-party Miscellaneous Libs
+org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_7 dependency bundles the following dependencies under
+the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+- com.google.protobuf:protobuf-java:3.7.1

--- a/flink-filesystems/pom.xml
+++ b/flink-filesystems/pom.xml
@@ -34,7 +34,7 @@ under the License.
 	<packaging>pom</packaging>
 
 	<properties>
-		<fs.hadoopshaded.version>3.2.2</fs.hadoopshaded.version>
+		<fs.hadoopshaded.version>3.3.2</fs.hadoopshaded.version>
 	</properties>
 
 	<modules>


### PR DESCRIPTION
## What is the purpose of the change

Flink currently uses Hadoop version 3.2.2 for the Flink filesystem implementations. Upgrading this to version 3.3.2 would provide users the features listed in [HADOOP-17566](https://issues.apache.org/jira/browse/HADOOP-17566)

## Brief change log

* Update POM file and NOTICE files

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: yes

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
