### PR TITLE
[FLINK-27229][cassandra][build] Remove test netty dependency

### DIFF
--- a/flink-connectors/flink-connector-cassandra/pom.xml
+++ b/flink-connectors/flink-connector-cassandra/pom.xml
@@ -204,13 +204,6 @@ under the License.
 			<artifactId>cassandra</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<!-- Bump cassandra netty dependency -->
-			<groupId>io.netty</groupId>
-			<artifactId>netty-all</artifactId>
-			<version>4.1.46.Final</version>
-			<scope>test</scope>
-		</dependency>
 
 		<!-- ArchUit test dependencies -->
 


### PR DESCRIPTION
The test-scoped dependency is unnecessary. For production we use the transitive netty dependency, whose version is controlled via the netty-bom in the parent pom.