### PR TITLE
[FLINK-27212][table-planner] Revert binary<->string cast behaviour (backport)

### DIFF
--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/catalog/PostgresCatalogITCase.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/catalog/PostgresCatalogITCase.java
@@ -126,7 +126,7 @@ public class PostgresCatalogITCase extends PostgresCatalogTestBase {
                                 .execute()
                                 .collect());
         assertEquals(
-                "[+I[1, [65], 3, 4, 5.5, 6.6, 7.70000, 8.8, true, a, B, C  , d, 2016-06-22T19:10:25, 2015-01-01, 00:51:03, 500.000000000000000000]]",
+                "[+I[1, [52, 49], 3, 4, 5.5, 6.6, 7.70000, 8.8, true, a, B, C  , d, 2016-06-22T19:10:25, 2015-01-01, 00:51:03, 500.000000000000000000]]",
                 results.toString());
     }
 

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliTableauResultViewTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliTableauResultViewTest.java
@@ -80,7 +80,8 @@ public class CliTableauResultViewTest {
                         Column.physical("varchar", DataTypes.STRING()),
                         Column.physical("decimal(10, 5)", DataTypes.DECIMAL(10, 5)),
                         Column.physical(
-                                "timestamp", DataTypes.TIMESTAMP(6).bridgedTo(Timestamp.class)));
+                                "timestamp", DataTypes.TIMESTAMP(6).bridgedTo(Timestamp.class)),
+                        Column.physical("binary", DataTypes.BYTES()));
         rowDataToStringConverter = new RowDataToStringConverterImpl(schema.toPhysicalRowDataType());
 
         List<Row> rows =
@@ -92,7 +93,8 @@ public class CliTableauResultViewTest {
                                 2L,
                                 "abc",
                                 BigDecimal.valueOf(1.23),
-                                Timestamp.valueOf("2020-03-01 18:39:14")),
+                                Timestamp.valueOf("2020-03-01 18:39:14"),
+                                new byte[] {50, 51, 52, -123, 54, 93, 115, 126}),
                         Row.ofKind(
                                 RowKind.UPDATE_BEFORE,
                                 false,
@@ -100,7 +102,8 @@ public class CliTableauResultViewTest {
                                 0L,
                                 "",
                                 BigDecimal.valueOf(1),
-                                Timestamp.valueOf("2020-03-01 18:39:14.1")),
+                                Timestamp.valueOf("2020-03-01 18:39:14.1"),
+                                new byte[] {100, -98, 32, 121, -125}),
                         Row.ofKind(
                                 RowKind.UPDATE_AFTER,
                                 true,
@@ -108,7 +111,8 @@ public class CliTableauResultViewTest {
                                 null,
                                 "abcdefg",
                                 BigDecimal.valueOf(12345),
-                                Timestamp.valueOf("2020-03-01 18:39:14.12")),
+                                Timestamp.valueOf("2020-03-01 18:39:14.12"),
+                                new byte[] {-110, -23, 1, 2}),
                         Row.ofKind(
                                 RowKind.DELETE,
                                 false,
@@ -116,7 +120,8 @@ public class CliTableauResultViewTest {
                                 Long.MAX_VALUE,
                                 null,
                                 BigDecimal.valueOf(12345.06789),
-                                Timestamp.valueOf("2020-03-01 18:39:14.123")),
+                                Timestamp.valueOf("2020-03-01 18:39:14.123"),
+                                new byte[] {50, 51, 52, -123, 54, 93, 115, 126}),
                         Row.ofKind(
                                 RowKind.INSERT,
                                 true,
@@ -124,7 +129,8 @@ public class CliTableauResultViewTest {
                                 Long.MIN_VALUE,
                                 "abcdefg111",
                                 null,
-                                Timestamp.valueOf("2020-03-01 18:39:14.123456")),
+                                Timestamp.valueOf("2020-03-01 18:39:14.123456"),
+                                new byte[] {110, 23, -1, -2}),
                         Row.ofKind(
                                 RowKind.DELETE,
                                 null,
@@ -132,6 +138,7 @@ public class CliTableauResultViewTest {
                                 -1L,
                                 "abcdefghijklmnopqrstuvwxyz",
                                 BigDecimal.valueOf(-12345.06789),
+                                null,
                                 null),
                         Row.ofKind(
                                 RowKind.INSERT,
@@ -140,7 +147,8 @@ public class CliTableauResultViewTest {
                                 -1L,
                                 "这是一段中文",
                                 BigDecimal.valueOf(-12345.06789),
-                                Timestamp.valueOf("2020-03-04 18:39:14")),
+                                Timestamp.valueOf("2020-03-04 18:39:14"),
+                                new byte[] {-3, -2, -1, 0, 1, 2, 3}),
                         Row.ofKind(
                                 RowKind.DELETE,
                                 null,
@@ -148,7 +156,8 @@ public class CliTableauResultViewTest {
                                 -1L,
                                 "これは日本語をテストするための文です",
                                 BigDecimal.valueOf(-12345.06789),
-                                Timestamp.valueOf("2020-03-04 18:39:14")));
+                                Timestamp.valueOf("2020-03-04 18:39:14"),
+                                new byte[] {-3, -2, -1, 0, 1, 2, 3}));
 
         final DataStructureConverter<Object, Object> dataStructureConverter =
                 DataStructureConverters.getConverter(schema.toPhysicalRowDataType());
@@ -187,29 +196,29 @@ public class CliTableauResultViewTest {
         view.displayResults();
         view.close();
         Assert.assertEquals(
-                "+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+"
+                "+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+---------------------+"
                         + System.lineSeparator()
-                        + "| boolean |         int |               bigint |                        varchar | decimal(10, 5) |                  timestamp |"
+                        + "| boolean |         int |               bigint |                        varchar | decimal(10, 5) |                  timestamp |              binary |"
                         + System.lineSeparator()
-                        + "+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+"
+                        + "+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+---------------------+"
                         + System.lineSeparator()
-                        + "|  <NULL> |           1 |                    2 |                            abc |        1.23000 | 2020-03-01 18:39:14.000000 |"
+                        + "|  <NULL> |           1 |                    2 |                            abc |        1.23000 | 2020-03-01 18:39:14.000000 | x'32333485365d737e' |"
                         + System.lineSeparator()
-                        + "|   FALSE |      <NULL> |                    0 |                                |        1.00000 | 2020-03-01 18:39:14.100000 |"
+                        + "|   FALSE |      <NULL> |                    0 |                                |        1.00000 | 2020-03-01 18:39:14.100000 |       x'649e207983' |"
                         + System.lineSeparator()
-                        + "|    TRUE |  2147483647 |               <NULL> |                        abcdefg |    12345.00000 | 2020-03-01 18:39:14.120000 |"
+                        + "|    TRUE |  2147483647 |               <NULL> |                        abcdefg |    12345.00000 | 2020-03-01 18:39:14.120000 |         x'92e90102' |"
                         + System.lineSeparator()
-                        + "|   FALSE | -2147483648 |  9223372036854775807 |                         <NULL> |    12345.06789 | 2020-03-01 18:39:14.123000 |"
+                        + "|   FALSE | -2147483648 |  9223372036854775807 |                         <NULL> |    12345.06789 | 2020-03-01 18:39:14.123000 | x'32333485365d737e' |"
                         + System.lineSeparator()
-                        + "|    TRUE |         100 | -9223372036854775808 |                     abcdefg111 |         <NULL> | 2020-03-01 18:39:14.123456 |"
+                        + "|    TRUE |         100 | -9223372036854775808 |                     abcdefg111 |         <NULL> | 2020-03-01 18:39:14.123456 |         x'6e17fffe' |"
                         + System.lineSeparator()
-                        + "|  <NULL> |          -1 |                   -1 |     abcdefghijklmnopqrstuvwxyz |   -12345.06789 |                     <NULL> |"
+                        + "|  <NULL> |          -1 |                   -1 |     abcdefghijklmnopqrstuvwxyz |   -12345.06789 |                     <NULL> |              <NULL> |"
                         + System.lineSeparator()
-                        + "|  <NULL> |          -1 |                   -1 |                   这是一段中文 |   -12345.06789 | 2020-03-04 18:39:14.000000 |"
+                        + "|  <NULL> |          -1 |                   -1 |                   这是一段中文 |   -12345.06789 | 2020-03-04 18:39:14.000000 |   x'fdfeff00010203' |"
                         + System.lineSeparator()
-                        + "|  <NULL> |          -1 |                   -1 |  これは日本語をテストするた... |   -12345.06789 | 2020-03-04 18:39:14.000000 |"
+                        + "|  <NULL> |          -1 |                   -1 |  これは日本語をテストするた... |   -12345.06789 | 2020-03-04 18:39:14.000000 |   x'fdfeff00010203' |"
                         + System.lineSeparator()
-                        + "+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+"
+                        + "+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+---------------------+"
                         + System.lineSeparator()
                         + "8 rows in set"
                         + System.lineSeparator(),
@@ -350,29 +359,29 @@ public class CliTableauResultViewTest {
         // source file
         // by vim or just cat the file to check the regular result.
         Assert.assertEquals(
-                "+----+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+"
+                "+----+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+--------------------------------+"
                         + System.lineSeparator()
-                        + "| op | boolean |         int |               bigint |                        varchar | decimal(10, 5) |                  timestamp |"
+                        + "| op | boolean |         int |               bigint |                        varchar | decimal(10, 5) |                  timestamp |                         binary |"
                         + System.lineSeparator()
-                        + "+----+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+"
+                        + "+----+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+--------------------------------+"
                         + System.lineSeparator()
-                        + "| +I |  <NULL> |           1 |                    2 |                            abc |        1.23000 | 2020-03-01 18:39:14.000000 |"
+                        + "| +I |  <NULL> |           1 |                    2 |                            abc |        1.23000 | 2020-03-01 18:39:14.000000 |            x'32333485365d737e' |"
                         + System.lineSeparator()
-                        + "| -U |   FALSE |      <NULL> |                    0 |                                |        1.00000 | 2020-03-01 18:39:14.100000 |"
+                        + "| -U |   FALSE |      <NULL> |                    0 |                                |        1.00000 | 2020-03-01 18:39:14.100000 |                  x'649e207983' |"
                         + System.lineSeparator()
-                        + "| +U |    TRUE |  2147483647 |               <NULL> |                        abcdefg |    12345.00000 | 2020-03-01 18:39:14.120000 |"
+                        + "| +U |    TRUE |  2147483647 |               <NULL> |                        abcdefg |    12345.00000 | 2020-03-01 18:39:14.120000 |                    x'92e90102' |"
                         + System.lineSeparator()
-                        + "| -D |   FALSE | -2147483648 |  9223372036854775807 |                         <NULL> |    12345.06789 | 2020-03-01 18:39:14.123000 |"
+                        + "| -D |   FALSE | -2147483648 |  9223372036854775807 |                         <NULL> |    12345.06789 | 2020-03-01 18:39:14.123000 |            x'32333485365d737e' |"
                         + System.lineSeparator()
-                        + "| +I |    TRUE |         100 | -9223372036854775808 |                     abcdefg111 |         <NULL> | 2020-03-01 18:39:14.123456 |"
+                        + "| +I |    TRUE |         100 | -9223372036854775808 |                     abcdefg111 |         <NULL> | 2020-03-01 18:39:14.123456 |                    x'6e17fffe' |"
                         + System.lineSeparator()
-                        + "| -D |  <NULL> |          -1 |                   -1 |     abcdefghijklmnopqrstuvwxyz |   -12345.06789 |                     <NULL> |"
+                        + "| -D |  <NULL> |          -1 |                   -1 |     abcdefghijklmnopqrstuvwxyz |   -12345.06789 |                     <NULL> |                         <NULL> |"
                         + System.lineSeparator()
-                        + "| +I |  <NULL> |          -1 |                   -1 |                   这是一段中文 |   -12345.06789 | 2020-03-04 18:39:14.000000 |"
+                        + "| +I |  <NULL> |          -1 |                   -1 |                   这是一段中文 |   -12345.06789 | 2020-03-04 18:39:14.000000 |              x'fdfeff00010203' |"
                         + System.lineSeparator()
-                        + "| -D |  <NULL> |          -1 |                   -1 |  これは日本語をテストするた... |   -12345.06789 | 2020-03-04 18:39:14.000000 |"
+                        + "| -D |  <NULL> |          -1 |                   -1 |  これは日本語をテストするた... |   -12345.06789 | 2020-03-04 18:39:14.000000 |              x'fdfeff00010203' |"
                         + System.lineSeparator()
-                        + "+----+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+"
+                        + "+----+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+--------------------------------+"
                         + System.lineSeparator()
                         + "Received a total of 8 rows"
                         + System.lineSeparator(),
@@ -400,11 +409,11 @@ public class CliTableauResultViewTest {
         view.close();
 
         Assert.assertEquals(
-                "+----+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+"
+                "+----+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+--------------------------------+"
                         + System.lineSeparator()
-                        + "| op | boolean |         int |               bigint |                        varchar | decimal(10, 5) |                  timestamp |"
+                        + "| op | boolean |         int |               bigint |                        varchar | decimal(10, 5) |                  timestamp |                         binary |"
                         + System.lineSeparator()
-                        + "+----+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+"
+                        + "+----+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+--------------------------------+"
                         + System.lineSeparator()
                         + "Received a total of 0 row"
                         + System.lineSeparator(),
@@ -446,19 +455,19 @@ public class CliTableauResultViewTest {
         view.close();
 
         Assert.assertEquals(
-                "+----+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+"
+                "+----+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+--------------------------------+"
                         + System.lineSeparator()
-                        + "| op | boolean |         int |               bigint |                        varchar | decimal(10, 5) |                  timestamp |"
+                        + "| op | boolean |         int |               bigint |                        varchar | decimal(10, 5) |                  timestamp |                         binary |"
                         + System.lineSeparator()
-                        + "+----+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+"
+                        + "+----+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+--------------------------------+"
                         + System.lineSeparator()
-                        + "| +I |  <NULL> |           1 |                    2 |                            abc |        1.23000 | 2020-03-01 18:39:14.000000 |"
+                        + "| +I |  <NULL> |           1 |                    2 |                            abc |        1.23000 | 2020-03-01 18:39:14.000000 |            x'32333485365d737e' |"
                         + System.lineSeparator()
-                        + "| -U |   FALSE |      <NULL> |                    0 |                                |        1.00000 | 2020-03-01 18:39:14.100000 |"
+                        + "| -U |   FALSE |      <NULL> |                    0 |                                |        1.00000 | 2020-03-01 18:39:14.100000 |                  x'649e207983' |"
                         + System.lineSeparator()
-                        + "| +U |    TRUE |  2147483647 |               <NULL> |                        abcdefg |    12345.00000 | 2020-03-01 18:39:14.120000 |"
+                        + "| +U |    TRUE |  2147483647 |               <NULL> |                        abcdefg |    12345.00000 | 2020-03-01 18:39:14.120000 |                    x'92e90102' |"
                         + System.lineSeparator()
-                        + "| -D |   FALSE | -2147483648 |  9223372036854775807 |                         <NULL> |    12345.06789 | 2020-03-01 18:39:14.123000 |"
+                        + "| -D |   FALSE | -2147483648 |  9223372036854775807 |                         <NULL> |    12345.06789 | 2020-03-01 18:39:14.123000 |            x'32333485365d737e' |"
                         + System.lineSeparator()
                         + "Query terminated, received a total of 4 rows"
                         + System.lineSeparator(),
@@ -498,19 +507,19 @@ public class CliTableauResultViewTest {
         view.close();
 
         Assert.assertEquals(
-                "+----+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+"
+                "+----+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+--------------------------------+"
                         + System.lineSeparator()
-                        + "| op | boolean |         int |               bigint |                        varchar | decimal(10, 5) |                  timestamp |"
+                        + "| op | boolean |         int |               bigint |                        varchar | decimal(10, 5) |                  timestamp |                         binary |"
                         + System.lineSeparator()
-                        + "+----+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+"
+                        + "+----+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+--------------------------------+"
                         + System.lineSeparator()
-                        + "| +I |  <NULL> |           1 |                    2 |                            abc |        1.23000 | 2020-03-01 18:39:14.000000 |"
+                        + "| +I |  <NULL> |           1 |                    2 |                            abc |        1.23000 | 2020-03-01 18:39:14.000000 |            x'32333485365d737e' |"
                         + System.lineSeparator()
-                        + "| -U |   FALSE |      <NULL> |                    0 |                                |        1.00000 | 2020-03-01 18:39:14.100000 |"
+                        + "| -U |   FALSE |      <NULL> |                    0 |                                |        1.00000 | 2020-03-01 18:39:14.100000 |                  x'649e207983' |"
                         + System.lineSeparator()
-                        + "| +U |    TRUE |  2147483647 |               <NULL> |                        abcdefg |    12345.00000 | 2020-03-01 18:39:14.120000 |"
+                        + "| +U |    TRUE |  2147483647 |               <NULL> |                        abcdefg |    12345.00000 | 2020-03-01 18:39:14.120000 |                    x'92e90102' |"
                         + System.lineSeparator()
-                        + "| -D |   FALSE | -2147483648 |  9223372036854775807 |                         <NULL> |    12345.06789 | 2020-03-01 18:39:14.123000 |"
+                        + "| -D |   FALSE | -2147483648 |  9223372036854775807 |                         <NULL> |    12345.06789 | 2020-03-01 18:39:14.123000 |            x'32333485365d737e' |"
                         + System.lineSeparator(),
                 terminalOutput.toString());
         assertThat(mockExecutor.getNumCancelCalls(), is(1));

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/AbstractCodeGeneratorCastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/AbstractCodeGeneratorCastRule.java
@@ -187,6 +187,11 @@ abstract class AbstractCodeGeneratorCastRule<IN, OUT> extends AbstractCastRule<I
         }
 
         @Override
+        public boolean isPrinting() {
+            return castRuleCtx.isPrinting();
+        }
+
+        @Override
         public boolean legacyBehaviour() {
             return castRuleCtx.legacyBehaviour();
         }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/AbstractExpressionCodeGeneratorCastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/AbstractExpressionCodeGeneratorCastRule.java
@@ -104,6 +104,11 @@ abstract class AbstractExpressionCodeGeneratorCastRule<IN, OUT>
             CastRule.Context ctx) {
         return new CodeGeneratorCastRule.Context() {
             @Override
+            public boolean isPrinting() {
+                return ctx.isPrinting();
+            }
+
+            @Override
             public boolean legacyBehaviour() {
                 return ctx.legacyBehaviour();
             }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/BinaryToStringCastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/BinaryToStringCastRule.java
@@ -21,7 +21,6 @@ package org.apache.flink.table.planner.functions.casting;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.LogicalTypeFamily;
 import org.apache.flink.table.types.logical.utils.LogicalTypeChecks;
-import org.apache.flink.table.utils.EncodingUtils;
 
 import java.nio.charset.StandardCharsets;
 
@@ -29,7 +28,6 @@ import static org.apache.flink.table.planner.codegen.CodeGenUtils.newName;
 import static org.apache.flink.table.planner.codegen.calls.BuiltInMethods.BINARY_STRING_DATA_FROM_STRING;
 import static org.apache.flink.table.planner.functions.casting.CastRuleUtils.accessStaticField;
 import static org.apache.flink.table.planner.functions.casting.CastRuleUtils.constructorCall;
-import static org.apache.flink.table.planner.functions.casting.CastRuleUtils.staticCall;
 
 /**
  * {@link LogicalTypeFamily#BINARY_STRING} to {@link LogicalTypeFamily#CHARACTER_STRING} cast rule.
@@ -50,25 +48,26 @@ class BinaryToStringCastRule extends AbstractNullAwareCodeGeneratorCastRule<byte
 
     isNull$0 = _myInputIsNull;
     if (!isNull$0) {
-        java.lang.String hexString$0;
-        hexString$0 = org.apache.flink.table.utils.EncodingUtils.hex(_myInput);
-        java.lang.String resultString$152;
-        resultString$152 = hexString$0.toString();
-        if (hexString$0.length() > 3) {
-            resultString$152 = hexString$0.substring(0, java.lang.Math.min(hexString$0.length(), 3));
+        java.lang.String resultString$435;
+        resultString$435 = new java.lang.String(_myInput, java.nio.charset.StandardCharsets.UTF_8);
+        java.lang.String resultPadOrTrim$538;
+        resultPadOrTrim$538 = resultString$435.toString();
+        if (resultString$435.length() > 12) {
+            resultPadOrTrim$538 = resultString$435.substring(0, java.lang.Math.min(resultString$435.length(), 12));
         } else {
-            if (resultString$1.length() < 12) {
-                int padLength$3;
-                padLength$3 = 12 - resultString$152.length();
-                java.lang.StringBuilder sbPadding$4;
-                sbPadding$4 = new java.lang.StringBuilder();
-                for (int i$5 = 0; i$5 < padLength$3; i$5++) {
-                    sbPadding$4.append(" ");
+            if (resultPadOrTrim$538.length() < 12) {
+                int padLength$539;
+                padLength$539 = 12 - resultPadOrTrim$538.length();
+                java.lang.StringBuilder sbPadding$540;
+                sbPadding$540 = new java.lang.StringBuilder();
+                for (int i$541 = 0; i$541 < padLength$539; i$541++) {
+                    sbPadding$540.append(" ");
                 }
-                resultString$152 = resultString$152 + sbPadding$4.toString();
+                resultPadOrTrim$538 = resultPadOrTrim$538 + sbPadding$540.toString();
             }
         }
-        result$1 = org.apache.flink.table.data.binary.BinaryStringData.fromString(resultString$152);
+        resultString$435 = resultPadOrTrim$538;
+        result$1 = org.apache.flink.table.data.binary.BinaryStringData.fromString(resultString$435);
         isNull$0 = result$1 == null;
     } else {
         result$1 = org.apache.flink.table.data.binary.BinaryStringData.EMPTY_UTF8;
@@ -84,28 +83,27 @@ class BinaryToStringCastRule extends AbstractNullAwareCodeGeneratorCastRule<byte
             LogicalType inputLogicalType,
             LogicalType targetLogicalType) {
         final String resultStringTerm = newName("resultString");
-        CastRuleUtils.CodeWriter writer = new CastRuleUtils.CodeWriter();
-        if (context.legacyBehaviour()) {
-            writer.declStmt(String.class, resultStringTerm)
-                    .assignStmt(
-                            resultStringTerm,
-                            constructorCall(
-                                    String.class,
-                                    inputTerm,
-                                    accessStaticField(StandardCharsets.class, "UTF_8")));
-        } else {
-            final int length = LogicalTypeChecks.getLength(targetLogicalType);
+        final CastRuleUtils.CodeWriter writer = new CastRuleUtils.CodeWriter();
 
-            final String hexStringTerm = newName("hexString");
-            writer.declStmt(String.class, hexStringTerm)
-                    .assignStmt(hexStringTerm, staticCall(EncodingUtils.class, "hex", inputTerm));
+        writer.declStmt(String.class, resultStringTerm)
+                .assignStmt(
+                        resultStringTerm,
+                        constructorCall(
+                                String.class,
+                                inputTerm,
+                                accessStaticField(StandardCharsets.class, "UTF_8")));
+
+        if (!context.legacyBehaviour()) {
+            final String resultPadOrTrim = newName("resultPadOrTrim");
+            final int length = LogicalTypeChecks.getLength(targetLogicalType);
             CharVarCharTrimPadCastRule.padAndTrimStringIfNeeded(
                     writer,
                     targetLogicalType,
                     context.legacyBehaviour(),
                     length,
-                    resultStringTerm,
-                    hexStringTerm);
+                    resultPadOrTrim,
+                    resultStringTerm);
+            writer.assignStmt(resultStringTerm, resultPadOrTrim);
         }
         return writer
                 // Assign the result value

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/CastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/CastRule.java
@@ -34,7 +34,7 @@ import java.time.ZoneId;
 @Internal
 public interface CastRule<IN, OUT> {
 
-    /** @see CastRulePredicate for more details about a cast rule predicate definition */
+    /** @see CastRulePredicate for more details about a cast rule predicate definition. */
     CastRulePredicate getPredicateDefinition();
 
     /**
@@ -50,6 +50,9 @@ public interface CastRule<IN, OUT> {
 
     /** Casting context. */
     interface Context {
+
+        boolean isPrinting();
+
         @Deprecated
         boolean legacyBehaviour();
 
@@ -58,8 +61,17 @@ public interface CastRule<IN, OUT> {
         ClassLoader getClassLoader();
 
         /** Create a casting context. */
-        static Context create(boolean legacyBehaviour, ZoneId zoneId, ClassLoader classLoader) {
+        static Context create(
+                boolean isPrinting,
+                boolean legacyBehaviour,
+                ZoneId zoneId,
+                ClassLoader classLoader) {
             return new Context() {
+                @Override
+                public boolean isPrinting() {
+                    return isPrinting;
+                }
+
                 @Override
                 public boolean legacyBehaviour() {
                     return legacyBehaviour;

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/CastRuleUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/CastRuleUtils.java
@@ -212,6 +212,10 @@ final class CastRuleUtils {
             return stmt(varName + " = " + value);
         }
 
+        public CodeWriter assignPlusStmt(String varName, String value) {
+            return stmt(varName + " += " + value);
+        }
+
         public CodeWriter assignArrayStmt(String varName, String index, String value) {
             return stmt(varName + "[" + index + "] = " + value);
         }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/CodeGeneratorCastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/CodeGeneratorCastRule.java
@@ -44,6 +44,12 @@ public interface CodeGeneratorCastRule<IN, OUT> extends CastRule<IN, OUT> {
 
     /** Context for code generation. */
     interface Context {
+        /**
+         * @return whether it's in printing mode or not. Printing is used by {@link
+         *     RowDataToStringConverterImpl} when printing table row results.
+         */
+        boolean isPrinting();
+
         /** @return where the legacy behaviour should be followed or not. */
         @Deprecated
         boolean legacyBehaviour();

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/RowDataToStringConverterImpl.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/RowDataToStringConverterImpl.java
@@ -55,7 +55,7 @@ public final class RowDataToStringConverterImpl implements RowDataToStringConver
     public RowDataToStringConverterImpl(
             DataType dataType, ZoneId zoneId, ClassLoader classLoader, boolean legacyBehaviour) {
         this.dataType = dataType;
-        this.castRuleContext = CastRule.Context.create(legacyBehaviour, zoneId, classLoader);
+        this.castRuleContext = CastRule.Context.create(true, legacyBehaviour, zoneId, classLoader);
     }
 
     @SuppressWarnings("unchecked")

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/StringToBinaryCastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/StringToBinaryCastRule.java
@@ -22,14 +22,12 @@ import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.LogicalTypeFamily;
 import org.apache.flink.table.types.logical.utils.LogicalTypeChecks;
-import org.apache.flink.table.utils.EncodingUtils;
 
 import static org.apache.flink.table.codesplit.CodeSplitUtil.newName;
 import static org.apache.flink.table.planner.functions.casting.BinaryToBinaryCastRule.couldPad;
 import static org.apache.flink.table.planner.functions.casting.BinaryToBinaryCastRule.trimOrPadByteArray;
 import static org.apache.flink.table.planner.functions.casting.CastRuleUtils.arrayLength;
 import static org.apache.flink.table.planner.functions.casting.CastRuleUtils.methodCall;
-import static org.apache.flink.table.planner.functions.casting.CastRuleUtils.staticCall;
 
 /**
  * {@link LogicalTypeFamily#CHARACTER_STRING} to {@link LogicalTypeFamily#BINARY_STRING} cast rule.
@@ -60,8 +58,7 @@ class StringToBinaryCastRule extends AbstractNullAwareCodeGeneratorCastRule<Stri
     // new behavior
     isNull$0 = _myInputIsNull;
     if (!isNull$0) {
-        java.lang.String hexStringTerm$10 = _myInput.toString();
-        byte[] byteArrayTerm$0 = org.apache.flink.table.utils.EncodingUtils.decodeHex(hexStringTerm$10);
+        byte[] byteArrayTerm$0 = _myInput.toBytes();
         if (byteArrayTerm$0.length <= 2) {
             // If could pad
             result$1 = java.util.Arrays.copyOf(byteArrayTerm$0, 2);
@@ -90,14 +87,9 @@ class StringToBinaryCastRule extends AbstractNullAwareCodeGeneratorCastRule<Stri
         } else {
             final int targetLength = LogicalTypeChecks.getLength(targetLogicalType);
             final String byteArrayTerm = newName("byteArrayTerm");
-            final String hexStringTerm = newName("hexStringTerm");
 
             return new CastRuleUtils.CodeWriter()
-                    .declStmt(String.class, hexStringTerm, methodCall(inputTerm, "toString"))
-                    .declStmt(
-                            byte[].class,
-                            byteArrayTerm,
-                            staticCall(EncodingUtils.class, "decodeHex", hexStringTerm))
+                    .declStmt(byte[].class, byteArrayTerm, methodCall(inputTerm, "toBytes"))
                     .ifStmt(
                             arrayLength(byteArrayTerm) + " <= " + targetLength,
                             thenWriter -> {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
@@ -1829,6 +1829,7 @@ object ScalarOperatorGens {
 
   def toCodegenCastContext(ctx: CodeGeneratorContext): CodeGeneratorCastRule.Context = {
     new CodeGeneratorCastRule.Context {
+      override def isPrinting(): Boolean = false
       override def legacyBehaviour(): Boolean = isLegacyCastBehaviourEnabled(ctx)
       override def getSessionTimeZoneTerm: String = ctx.addReusableSessionTimeZone()
       override def declareVariable(ty: String, variablePrefix: String): String =
@@ -1844,6 +1845,8 @@ object ScalarOperatorGens {
 
   def toCastContext(ctx: CodeGeneratorContext): CastRule.Context = {
     new CastRule.Context {
+      override def isPrinting(): Boolean = false
+
       override def legacyBehaviour(): Boolean = isLegacyCastBehaviourEnabled(ctx)
 
       override def getSessionZoneId: ZoneId = ctx.tableConfig.getLocalTimeZone

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
@@ -188,11 +188,11 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         .build(),
                 CastTestSpecBuilder.testCastTo(BINARY(2))
                         .fromCase(BINARY(5), null, null)
-                        .fromCase(CHAR(4), "666F", new byte[] {102, 111})
-                        .fromCase(VARCHAR(8), "666f", new byte[] {102, 111})
-                        .fromCase(STRING(), "AAbbcCdD", new byte[] {-86, -69})
-                        .fromCase(VARCHAR(4), "FC", new byte[] {-4, 0})
-                        .fromCase(STRING(), "df", new byte[] {-33, 0})
+                        .fromCase(CHAR(4), "666F", new byte[] {54, 54})
+                        .fromCase(VARCHAR(8), "666f", new byte[] {54, 54})
+                        .fromCase(STRING(), "a", new byte[] {97, 0})
+                        .fromCase(VARCHAR(4), "FC", new byte[] {70, 67})
+                        .fromCase(STRING(), "foobar", new byte[] {102, 111})
                         // Not supported - no fix
                         .failValidation(BOOLEAN(), true)
                         //
@@ -226,9 +226,9 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         .build(),
                 CastTestSpecBuilder.testCastTo(VARBINARY(4))
                         .fromCase(VARBINARY(5), null, null)
-                        .fromCase(CHAR(4), "666F", new byte[] {102, 111})
-                        .fromCase(VARCHAR(8), "666f", new byte[] {102, 111})
-                        .fromCase(STRING(), "AAbbCcDdEe", new byte[] {-86, -69, -52, -35})
+                        .fromCase(CHAR(4), "foo", new byte[] {102, 111, 111, 32})
+                        .fromCase(VARCHAR(8), "foobar", new byte[] {102, 111, 111, 98})
+                        .fromCase(STRING(), "AAbbCcDdEe", new byte[] {65, 65, 98, 98})
                         // Not supported - no fix
                         .failValidation(BOOLEAN(), true)
                         //
@@ -260,9 +260,12 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         .build(),
                 CastTestSpecBuilder.testCastTo(BYTES())
                         .fromCase(BYTES(), null, null)
-                        .fromCase(CHAR(4), "666f", new byte[] {102, 111})
-                        .fromCase(VARCHAR(8), "666F", new byte[] {102, 111})
-                        .fromCase(STRING(), "aaBBCcDdEe", new byte[] {-86, -69, -52, -35, -18})
+                        .fromCase(CHAR(4), "foo", new byte[] {102, 111, 111, 32})
+                        .fromCase(VARCHAR(8), "foobar", new byte[] {102, 111, 111, 98, 97, 114})
+                        .fromCase(
+                                STRING(),
+                                "Apache Flink",
+                                new byte[] {65, 112, 97, 99, 104, 101, 32, 70, 108, 105, 110, 107})
                         // Not supported - no fix
                         .failValidation(BOOLEAN(), true)
                         //
@@ -992,11 +995,11 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         .fromCase(STRING(), "Apache Flink", "Apache Flink")
                         .fromCase(STRING(), null, null)
                         .fromCase(BOOLEAN(), true, "TRUE")
-                        .fromCase(BINARY(2), DEFAULT_BINARY, "0001")
-                        .fromCase(BINARY(3), DEFAULT_BINARY, "000100")
-                        .fromCase(VARBINARY(3), DEFAULT_VARBINARY, "000102")
-                        .fromCase(VARBINARY(5), DEFAULT_VARBINARY, "000102")
-                        .fromCase(BYTES(), DEFAULT_BYTES, "0001020304")
+                        .fromCase(BINARY(2), DEFAULT_BINARY, "\u0000\u0001")
+                        .fromCase(BINARY(3), DEFAULT_BINARY, "\u0000\u0001\u0000")
+                        .fromCase(VARBINARY(3), DEFAULT_VARBINARY, "\u0000\u0001\u0002")
+                        .fromCase(VARBINARY(5), DEFAULT_VARBINARY, "\u0000\u0001\u0002")
+                        .fromCase(BYTES(), DEFAULT_BYTES, "\u0000\u0001\u0002\u0003\u0004")
                         .fromCase(DECIMAL(4, 3), 9.87, "9.870")
                         .fromCase(DECIMAL(10, 5), 1, "1.00000")
                         .fromCase(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionMiscITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionMiscITCase.java
@@ -206,14 +206,14 @@ public class CastFunctionMiscITCase extends BuiltInFunctionTestBase {
                         .onFieldsWithData("foo")
                         .testSqlResult(
                                 "CAST(CAST(x'68656C6C6F20636F6465' AS BINARY(10)) AS VARCHAR)",
-                                "68656c6c6f20636f6465",
+                                "hello code",
                                 STRING().notNull()),
                 TestSpec.forFunction(
                                 BuiltInFunctionDefinitions.CAST, "test the x'....' binary syntax")
                         .onFieldsWithData("foo")
                         .testSqlResult(
-                                "CAST(CAST(x'68656C6C6F2063617374' AS BINARY(10)) AS VARCHAR)",
-                                "68656c6c6f2063617374",
+                                "CAST(CAST(x'68656C6C6F20636F6465' AS BINARY(5)) AS VARCHAR)",
+                                "hello",
                                 STRING().notNull()),
                 TestSpec.forFunction(BuiltInFunctionDefinitions.CAST, "cast STRUCTURED to STRING")
                         .onFieldsWithData(123456, "Flink")

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/casting/CastRulesTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/casting/CastRulesTest.java
@@ -651,19 +651,20 @@ class CastRulesTest {
                         .fromCase(BOOLEAN(), false, fromString("FALSE"))
                         .fromCaseLegacy(BOOLEAN(), true, fromString("true"))
                         .fromCaseLegacy(BOOLEAN(), false, fromString("false"))
-                        .fromCase(BINARY(2), new byte[] {0, 1}, fromString("0001"))
+                        .fromCase(BINARY(2), new byte[] {0, 1}, fromString("\u0000\u0001"))
                         .fromCaseLegacy(BINARY(2), new byte[] {0, 1}, fromString("\u0000\u0001"))
-                        .fromCase(VARBINARY(3), new byte[] {0, 1, 2}, fromString("000102"))
+                        .fromCase(
+                                VARBINARY(3),
+                                new byte[] {0, 1, 2},
+                                fromString("\u0000\u0001\u0002"))
                         .fromCaseLegacy(
                                 VARBINARY(3),
                                 new byte[] {0, 1, 2},
                                 fromString("\u0000\u0001\u0002"))
-                        .fromCase(VARBINARY(5), new byte[] {0, -1, -2}, fromString("00fffe"))
                         .fromCaseLegacy(VARBINARY(5), new byte[] {102, 111, 111}, fromString("foo"))
-                        .fromCase(
-                                BYTES(),
-                                new byte[] {-123, 43, -4, 125, 5},
-                                fromString("852bfc7d05"))
+                        .fromCaseLegacy(VARBINARY(5), new byte[] {102, 111, 111}, fromString("foo"))
+                        .fromCaseLegacy(
+                                BYTES(), new byte[] {70, 108, 105, 110, 107}, fromString("Flink"))
                         .fromCaseLegacy(
                                 BYTES(), new byte[] {70, 108, 105, 110, 107}, fromString("Flink"))
                         .fromCase(BOOLEAN(), true, StringData.fromString("TRUE"))
@@ -838,11 +839,11 @@ class CastRulesTest {
                         .fromCaseLegacy(BOOLEAN(), true, fromString("true"))
                         .fromCase(BOOLEAN(), false, fromString("FALSE "))
                         .fromCaseLegacy(BOOLEAN(), false, fromString("false"))
-                        .fromCase(BINARY(1), new byte[] {-12}, fromString("f4    "))
+                        .fromCase(BINARY(1), new byte[] {102}, fromString("f     "))
                         .fromCaseLegacy(BINARY(1), new byte[] {102}, fromString("f"))
-                        .fromCase(VARBINARY(1), new byte[] {23}, fromString("17    "))
+                        .fromCase(VARBINARY(1), new byte[] {33}, fromString("\u0021     "))
                         .fromCaseLegacy(VARBINARY(1), new byte[] {33}, fromString("\u0021"))
-                        .fromCase(BYTES(), new byte[] {32}, fromString("20    "))
+                        .fromCase(BYTES(), new byte[] {32}, fromString("      "))
                         .fromCaseLegacy(BYTES(), new byte[] {32}, fromString(" "))
                         .fromCase(TINYINT(), (byte) -125, fromString("-125  "))
                         .fromCaseLegacy(TINYINT(), (byte) -125, fromString("-125"))
@@ -863,20 +864,20 @@ class CastRulesTest {
                 CastTestSpecBuilder.testCastTo(CHAR(12))
                         .fromCase(
                                 BINARY(4),
-                                new byte[] {-12, 32, 46, -72},
-                                fromString("f4202eb8    "))
+                                new byte[] {1, 11, 111, 2},
+                                fromString("\u0001\u000B\u006F\u0002        "))
                         .fromCaseLegacy(
                                 BINARY(4),
                                 new byte[] {1, 11, 111, 2},
                                 fromString("\u0001\u000B\u006F\u0002"))
-                        .fromCase(VARBINARY(4), new byte[] {1, 11, 22}, fromString("010b16      "))
+                        .fromCase(
+                                VARBINARY(4),
+                                new byte[] {1, 11, 22},
+                                fromString("\u0001\u000B\u0016         "))
                         .fromCaseLegacy(
                                 VARBINARY(4),
                                 new byte[] {1, 11, 22},
                                 fromString("\u0001\u000B\u0016"))
-                        .fromCase(BYTES(), new byte[] {1, 11}, fromString("010b        "))
-                        .fromCaseLegacy(
-                                BYTES(), new byte[] {1, 11, 111}, fromString("\u0001\u000B\u006F"))
                         .fromCase(
                                 ARRAY(INT()),
                                 new GenericArrayData(new int[] {-1, 2, 3}),
@@ -963,17 +964,28 @@ class CastRulesTest {
                         .fromCaseLegacy(BOOLEAN(), true, fromString("true"))
                         .fromCase(BOOLEAN(), false, fromString("FAL"))
                         .fromCaseLegacy(BOOLEAN(), false, fromString("false"))
-                        .fromCase(BINARY(5), new byte[] {0, 1, 2, 3, 4}, fromString("000"))
+                        .fromCase(BINARY(2), new byte[] {0, 1}, fromString("\u0000\u0001"))
+                        .fromCaseLegacy(BINARY(1), new byte[] {0, 1}, fromString("\u0000\u0001"))
+                        .fromCase(
+                                BINARY(5),
+                                new byte[] {0, 1, 2, 3, 4},
+                                fromString("\u0000\u0001\u0002"))
                         .fromCaseLegacy(
                                 BINARY(5),
                                 new byte[] {0, 1, 2, 3, 4},
                                 fromString("\u0000\u0001\u0002\u0003\u0004"))
-                        .fromCase(VARBINARY(5), new byte[] {0, 1, 2, 3, 4}, fromString("000"))
+                        .fromCase(
+                                VARBINARY(5),
+                                new byte[] {0, 1, 2, 3, 4},
+                                fromString("\u0000\u0001\u0002"))
                         .fromCaseLegacy(
                                 VARBINARY(5),
                                 new byte[] {0, 1, 2, 3, 4},
                                 fromString("\u0000\u0001\u0002\u0003\u0004"))
-                        .fromCase(BYTES(), new byte[] {0, 1, 2, 3, 4}, fromString("000"))
+                        .fromCase(
+                                BYTES(),
+                                new byte[] {0, 1, 2, 3, 4},
+                                fromString("\u0000\u0001\u0002"))
                         .fromCaseLegacy(
                                 BYTES(),
                                 new byte[] {0, 1, 2, 3, 4},
@@ -1127,30 +1139,27 @@ class CastRulesTest {
                         .fromCase(DOUBLE(), 0.0d, false)
                         .fromCase(DOUBLE(), -0.12345678d, true),
                 CastTestSpecBuilder.testCastTo(BINARY(4))
-                        .fromCase(CHAR(4), fromString("66"), new byte[] {102, 0, 0, 0})
+                        .fromCase(CHAR(4), fromString("66"), new byte[] {54, 54, 0, 0})
+                        .fromCaseLegacy(CHAR(4), fromString("66"), new byte[] {54, 54})
+                        .fromCase(CHAR(3), fromString("foo"), new byte[] {102, 111, 111, 0})
                         .fromCaseLegacy(CHAR(3), fromString("foo"), new byte[] {102, 111, 111})
-                        .fromCase(CHAR(10), fromString("66A2"), new byte[] {102, -94, 0, 0})
+                        .fromCase(CHAR(10), fromString("66A2"), new byte[] {54, 54, 65, 50})
+                        .fromCaseLegacy(CHAR(10), fromString("66A2"), new byte[] {54, 54, 65, 50})
+                        .fromCase(CHAR(1), fromString("f"), new byte[] {102, 0, 0, 0})
                         .fromCaseLegacy(CHAR(1), fromString("f"), new byte[] {102})
-                        .fromCase(CHAR(16), fromString("12f4aBc7"), new byte[] {18, -12, -85, -57})
-                        .fromCaseLegacy(CHAR(3), fromString("f"), new byte[] {102})
-                        .fromCase(VARCHAR(8), fromString("bACd"), new byte[] {-70, -51, 0, 0})
+                        .fromCase(CHAR(16), fromString("12f4aBc7"), new byte[] {49, 50, 102, 52})
+                        .fromCase(CHAR(3), fromString("A f "), new byte[] {65, 32, 102, 32})
+                        .fromCase(VARCHAR(8), fromString("bAC"), new byte[] {98, 65, 67, 0})
+                        .fromCase(VARCHAR(5), fromString("Flink"), new byte[] {70, 108, 105, 110})
                         .fromCaseLegacy(
                                 VARCHAR(5),
                                 fromString("Flink"),
                                 new byte[] {70, 108, 105, 110, 107})
-                        .fromCase(
-                                STRING(),
-                                fromString("12f4ABc71232"),
-                                new byte[] {18, -12, -85, -57})
+                        .fromCase(STRING(), fromString("Apache"), new byte[] {65, 112, 97, 99})
                         .fromCaseLegacy(
                                 STRING(),
                                 fromString("Apache"),
                                 new byte[] {65, 112, 97, 99, 104, 101})
-                        .fromCase(STRING(), fromString("12F4ab"), new byte[] {18, -12, -85, 0})
-                        .fromCaseLegacy(STRING(), fromString("bar"), new byte[] {98, 97, 114})
-                        .fail(STRING(), fromString("123"), TableException.class)
-                        .fail(STRING(), fromString("12P9"), TableException.class)
-                        .fail(STRING(), fromString("12  A9"), TableException.class)
                         .fromCase(BINARY(2), new byte[] {1, 2}, new byte[] {1, 2, 0, 0})
                         .fromCaseLegacy(BINARY(2), new byte[] {1, 2}, new byte[] {1, 2})
                         .fromCase(VARBINARY(3), new byte[] {1, 2, 3}, new byte[] {1, 2, 3, 0})
@@ -1158,24 +1167,27 @@ class CastRulesTest {
                         .fromCase(BYTES(), new byte[] {1, 2, 3}, new byte[] {1, 2, 3, 0})
                         .fromCaseLegacy(BYTES(), new byte[] {1, 2, 3}, new byte[] {1, 2, 3}),
                 CastTestSpecBuilder.testCastTo(VARBINARY(4))
-                        .fromCase(CHAR(4), fromString("c9"), new byte[] {-55})
+                        .fromCase(CHAR(4), fromString("c9"), new byte[] {99, 57})
+                        .fromCaseLegacy(CHAR(4), fromString("c9"), new byte[] {99, 57})
+                        .fromCase(CHAR(3), fromString("foo"), new byte[] {102, 111, 111})
                         .fromCaseLegacy(CHAR(3), fromString("foo"), new byte[] {102, 111, 111})
-                        .fromCase(VARCHAR(8), fromString("7de2"), new byte[] {125, -30})
+                        .fromCase(VARCHAR(8), fromString("7de2"), new byte[] {55, 100, 101, 50})
+                        .fromCaseLegacy(
+                                VARCHAR(8), fromString("7de2"), new byte[] {55, 100, 101, 50})
+                        .fromCase(VARCHAR(5), fromString("Flink"), new byte[] {70, 108, 105, 110})
                         .fromCaseLegacy(
                                 VARCHAR(5),
                                 fromString("Flink"),
                                 new byte[] {70, 108, 105, 110, 107})
-                        .fromCase(
+                        .fromCase(STRING(), fromString("12F4a bC7"), new byte[] {49, 50, 70, 52})
+                        .fromCaseLegacy(
                                 STRING(),
-                                fromString("12F4abC71232"),
-                                new byte[] {18, -12, -85, -57})
+                                fromString("12F4a bC7"),
+                                new byte[] {49, 50, 70, 52, 97, 32, 98, 67, 55})
                         .fromCaseLegacy(
                                 STRING(),
                                 fromString("Apache"),
                                 new byte[] {65, 112, 97, 99, 104, 101})
-                        .fail(STRING(), fromString("123"), TableException.class)
-                        .fail(STRING(), fromString("12P9"), TableException.class)
-                        .fail(STRING(), fromString("12  A9"), TableException.class)
                         // We assume that the input length is respected, therefore, no trimming is
                         // applied
                         .fromCase(BINARY(2), new byte[] {1, 2, 3, 4, 5}, new byte[] {1, 2, 3, 4, 5})
@@ -1190,24 +1202,37 @@ class CastRulesTest {
                                 new byte[] {1, 2, 3, 4, 5},
                                 new byte[] {1, 2, 3, 4, 5}),
                 CastTestSpecBuilder.testCastTo(BYTES())
-                        .fromCase(CHAR(4), fromString("9C"), new byte[] {-100})
+                        .fromCase(CHAR(4), fromString("9C"), new byte[] {57, 67})
+                        .fromCaseLegacy(CHAR(4), fromString("9C"), new byte[] {57, 67})
+                        .fromCase(CHAR(3), fromString("foo"), new byte[] {102, 111, 111})
                         .fromCaseLegacy(CHAR(3), fromString("foo"), new byte[] {102, 111, 111})
-                        .fromCase(VARCHAR(8), fromString("3ee3"), new byte[] {62, -29})
+                        .fromCase(VARCHAR(8), fromString("3ee3"), new byte[] {51, 101, 101, 51})
+                        .fromCaseLegacy(
+                                VARCHAR(8), fromString("3ee3"), new byte[] {51, 101, 101, 51})
+                        .fromCase(
+                                VARCHAR(5),
+                                fromString("Flink"),
+                                new byte[] {70, 108, 105, 110, 107})
                         .fromCaseLegacy(
                                 VARCHAR(5),
                                 fromString("Flink"),
                                 new byte[] {70, 108, 105, 110, 107})
                         .fromCase(
                                 STRING(),
-                                fromString("AAbbCcDdff"),
-                                new byte[] {-86, -69, -52, -35, -1})
+                                fromString("AAbb Cc Dd"),
+                                new byte[] {65, 65, 98, 98, 32, 67, 99, 32, 68, 100})
                         .fromCaseLegacy(
+                                STRING(),
+                                fromString("AAbb Cc Dd"),
+                                new byte[] {65, 65, 98, 98, 32, 67, 99, 32, 68, 100})
+                        .fromCase(
                                 STRING(),
                                 fromString("Apache"),
                                 new byte[] {65, 112, 97, 99, 104, 101})
-                        .fail(STRING(), fromString("123"), TableException.class)
-                        .fail(STRING(), fromString("12P9"), TableException.class)
-                        .fail(STRING(), fromString("12  A9"), TableException.class),
+                        .fromCaseLegacy(
+                                STRING(),
+                                fromString("Apache"),
+                                new byte[] {65, 112, 97, 99, 104, 101}),
                 CastTestSpecBuilder.testCastTo(DECIMAL(5, 3))
                         .fail(CHAR(3), fromString("foo"), TableException.class)
                         .fail(VARCHAR(5), fromString("Flink"), TableException.class)

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/casting/CastRulesTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/casting/CastRulesTest.java
@@ -107,9 +107,11 @@ class CastRulesTest {
     private static final ZoneId CET = ZoneId.of("CET");
 
     private static final CastRule.Context CET_CONTEXT =
-            CastRule.Context.create(false, CET, Thread.currentThread().getContextClassLoader());
+            CastRule.Context.create(
+                    false, false, CET, Thread.currentThread().getContextClassLoader());
     private static final CastRule.Context CET_CONTEXT_LEGACY =
-            CastRule.Context.create(true, CET, Thread.currentThread().getContextClassLoader());
+            CastRule.Context.create(
+                    false, true, CET, Thread.currentThread().getContextClassLoader());
 
     private static final byte DEFAULT_POSITIVE_TINY_INT = (byte) 5;
     private static final byte DEFAULT_NEGATIVE_TINY_INT = (byte) -5;
@@ -667,6 +669,10 @@ class CastRulesTest {
                                 BYTES(), new byte[] {70, 108, 105, 110, 107}, fromString("Flink"))
                         .fromCaseLegacy(
                                 BYTES(), new byte[] {70, 108, 105, 110, 107}, fromString("Flink"))
+                        .fromCasePrinting(
+                                BYTES(),
+                                new byte[] {70, 108, 105, 110, 107},
+                                fromString("x'466c696e6b'"))
                         .fromCase(BOOLEAN(), true, StringData.fromString("TRUE"))
                         .fromCase(BOOLEAN(), false, StringData.fromString("FALSE"))
                         .fromCase(
@@ -1574,6 +1580,20 @@ class CastRulesTest {
                     srcDataType,
                     CastRule.Context.create(
                             false,
+                            false,
+                            DateTimeUtils.UTC_ZONE.toZoneId(),
+                            Thread.currentThread().getContextClassLoader()),
+                    src,
+                    target);
+        }
+
+        private CastTestSpecBuilder fromCasePrinting(
+                DataType srcDataType, Object src, Object target) {
+            return fromCase(
+                    srcDataType,
+                    CastRule.Context.create(
+                            true,
+                            false,
                             DateTimeUtils.UTC_ZONE.toZoneId(),
                             Thread.currentThread().getContextClassLoader()),
                     src,
@@ -1585,6 +1605,7 @@ class CastRulesTest {
             return fromCase(
                     srcDataType,
                     CastRule.Context.create(
+                            false,
                             true,
                             DateTimeUtils.UTC_ZONE.toZoneId(),
                             Thread.currentThread().getContextClassLoader()),
@@ -1614,6 +1635,7 @@ class CastRulesTest {
             return fail(
                     dataType,
                     CastRule.Context.create(
+                            false,
                             false,
                             DateTimeUtils.UTC_ZONE.toZoneId(),
                             Thread.currentThread().getContextClassLoader()),

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
@@ -4190,7 +4190,7 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
     // the answer BINARY will cast to STRING in ExpressionTestBase.scala
     testSqlApi(
       "IF(f7 < 5, f53, f54)",
-      "68656c6c6f20776f726c64") // hello world
+      "hello world") // hello world
 
     // test DATE, DATE
     testSqlApi(
@@ -4398,6 +4398,6 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
     testSqlApi(s"IFNULL(CAST(INTERVAL '2' DAY AS VARCHAR(20)), $str2)", "+2 00:00:00.000")
     testSqlApi(
       s"IFNULL(CAST(f53 AS VARCHAR(100)), $str2)",
-      "68656c6c6f20776f726c64")
+      "hello world")
   }
 }


### PR DESCRIPTION
## What is the purpose of the change

Revert behaviour of binary to string casts and vice versa, to not use
hex enconding/decoding, but simple UTF-8 bytes transformation from a
byte[] to a string and vice versa.

Add a `isPrinting()` method to the `CastRule.Context` set to true used by `RowDataToStringConverterImpl`
which defines a different casting behaviour for `BinaryToStringCastRule` when printing binary columns, so
that we output columns of binary type as (for example): `x'ab03f98e'`, which can easily be copy pasted as
a binary literal to another SQL query.

## Verifying this change

Adjusted the tests accordingly in

  - `CastFunctionITCase`
  - `CastRulesTest`
  - `ScalarFunctionsTest`
  - `CastFunctionMiscITCase`
  - Added binary column to `CliTableauResultViewTest` to test the printing.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
