### PR TITLE
[FLINK-27287][tests] Use random ports 

### DIFF
--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/FileSinkCompactionSwitchITCase.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/FileSinkCompactionSwitchITCase.java
@@ -24,7 +24,6 @@ import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ExecutionOptions;
-import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.configuration.StateChangelogOptions;
 import org.apache.flink.connector.file.sink.FileSink.DefaultRowFormatBuilder;
 import org.apache.flink.connector.file.sink.compactor.DecoderBasedReader;
@@ -178,13 +177,11 @@ public class FileSinkCompactionSwitchITCase extends TestLogger {
         JobGraph jobGraph = createJobGraph(cpPath, originFileSink, false, sendCountMap);
         JobGraph restoringJobGraph = createJobGraph(cpPath, restoredFileSink, true, sendCountMap);
 
-        final Configuration config = new Configuration();
-        config.setString(RestOptions.BIND_PORT, "18081-19000");
         final MiniClusterConfiguration cfg =
                 new MiniClusterConfiguration.Builder()
+                        .withRandomPorts()
                         .setNumTaskManagers(1)
                         .setNumSlotsPerTaskManager(4)
-                        .setConfiguration(config)
                         .build();
 
         try (MiniCluster miniCluster = new MiniCluster(cfg)) {

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/FileSinkITBase.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/FileSinkITBase.java
@@ -18,8 +18,6 @@
 
 package org.apache.flink.connector.file.sink;
 
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.connector.file.sink.utils.IntegerFileSinkTestDataUtils;
 import org.apache.flink.connector.file.sink.utils.PartSizeAndCheckpointRollingPolicy;
 import org.apache.flink.core.fs.Path;
@@ -64,13 +62,11 @@ public abstract class FileSinkITBase extends TestLogger {
 
         JobGraph jobGraph = createJobGraph(path);
 
-        final Configuration config = new Configuration();
-        config.setString(RestOptions.BIND_PORT, "18081-19000");
         final MiniClusterConfiguration cfg =
                 new MiniClusterConfiguration.Builder()
+                        .withRandomPorts()
                         .setNumTaskManagers(1)
                         .setNumSlotsPerTaskManager(4)
-                        .setConfiguration(config)
                         .build();
 
         try (MiniCluster miniCluster = new MiniCluster(cfg)) {

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/writer/FileSinkMigrationITCase.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/writer/FileSinkMigrationITCase.java
@@ -23,8 +23,6 @@ import org.apache.flink.api.common.JobSubmissionResult;
 import org.apache.flink.api.common.state.CheckpointListener;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.connector.file.sink.FileSink;
 import org.apache.flink.connector.file.sink.utils.IntegerFileSinkTestDataUtils;
 import org.apache.flink.core.execution.SavepointFormatType;
@@ -115,13 +113,11 @@ public class FileSinkMigrationITCase extends TestLogger {
         String outputPath = TEMPORARY_FOLDER.newFolder().getAbsolutePath();
         String savepointBasePath = TEMPORARY_FOLDER.newFolder().getAbsolutePath();
 
-        final Configuration config = new Configuration();
-        config.setString(RestOptions.BIND_PORT, "18081-19000");
         final MiniClusterConfiguration cfg =
                 new MiniClusterConfiguration.Builder()
+                        .withRandomPorts()
                         .setNumTaskManagers(1)
                         .setNumSlotsPerTaskManager(4)
-                        .setConfiguration(config)
                         .build();
 
         JobGraph streamingFileSinkJobGraph = createStreamingFileSinkJobGraph(outputPath);

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/JobManagerWatermarkTrackerTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/JobManagerWatermarkTrackerTest.java
@@ -18,57 +18,30 @@
 package org.apache.flink.streaming.connectors.kinesis.util;
 
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.RestOptions;
-import org.apache.flink.runtime.minicluster.MiniCluster;
-import org.apache.flink.runtime.minicluster.MiniClusterConfiguration;
+import org.apache.flink.runtime.testutils.MiniClusterResource;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.streaming.api.functions.source.RichSourceFunction;
 
-import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 /** Test for {@link JobManagerWatermarkTracker}. */
 public class JobManagerWatermarkTrackerTest {
 
-    private static MiniCluster flink;
-
-    @BeforeClass
-    public static void setUp() throws Exception {
-        final Configuration config = new Configuration();
-        config.setInteger(RestOptions.PORT, 0);
-
-        final MiniClusterConfiguration miniClusterConfiguration =
-                new MiniClusterConfiguration.Builder()
-                        .setConfiguration(config)
-                        .setNumTaskManagers(1)
-                        .setNumSlotsPerTaskManager(1)
-                        .build();
-
-        flink = new MiniCluster(miniClusterConfiguration);
-
-        flink.start();
-    }
-
-    @AfterClass
-    public static void tearDown() throws Exception {
-        if (flink != null) {
-            flink.close();
-        }
-    }
+    @ClassRule
+    public static final MiniClusterResource FLINK =
+            new MiniClusterResource(
+                    new MiniClusterResourceConfiguration.Builder()
+                            .setNumberTaskManagers(1)
+                            .setNumberSlotsPerTaskManager(1)
+                            .build());
 
     @Test
     public void testUpateWatermark() throws Exception {
-        final Configuration clientConfiguration = new Configuration();
-        clientConfiguration.setInteger(RestOptions.RETRY_MAX_ATTEMPTS, 0);
-
-        final StreamExecutionEnvironment env =
-                StreamExecutionEnvironment.createRemoteEnvironment(
-                        flink.getRestAddress().get().getHost(),
-                        flink.getRestAddress().get().getPort(),
-                        clientConfiguration);
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         env.addSource(new TestSourceFunction(new JobManagerWatermarkTracker("fakeId")))
                 .addSink(new SinkFunction<Integer>() {});

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroExternalJarProgramITCase.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroExternalJarProgramITCase.java
@@ -46,6 +46,7 @@ class AvroExternalJarProgramITCase {
     private static final MiniCluster MINI_CLUSTER =
             new MiniCluster(
                     new MiniClusterConfiguration.Builder()
+                            .withRandomPorts()
                             .setNumTaskManagers(1)
                             .setNumSlotsPerTaskManager(PARALLELISM)
                             .build());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniClusterConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniClusterConfiguration.java
@@ -175,6 +175,7 @@ public class MiniClusterConfiguration {
         private RpcServiceSharing rpcServiceSharing = SHARED;
         @Nullable private String commonBindAddress = null;
         private MiniCluster.HaServices haServices = MiniCluster.HaServices.CONFIGURED;
+        private boolean useRandomPorts = false;
 
         public Builder setConfiguration(Configuration configuration1) {
             this.configuration = Preconditions.checkNotNull(configuration1);
@@ -206,6 +207,11 @@ public class MiniClusterConfiguration {
             return this;
         }
 
+        public Builder withRandomPorts() {
+            this.useRandomPorts = true;
+            return this;
+        }
+
         public MiniClusterConfiguration build() {
             final Configuration modifiedConfiguration = new Configuration(configuration);
             modifiedConfiguration.setInteger(
@@ -213,6 +219,15 @@ public class MiniClusterConfiguration {
             modifiedConfiguration.setString(
                     RestOptions.ADDRESS,
                     modifiedConfiguration.getString(RestOptions.ADDRESS, "localhost"));
+
+            if (useRandomPorts) {
+                if (!configuration.contains(JobManagerOptions.PORT)) {
+                    modifiedConfiguration.set(JobManagerOptions.PORT, 0);
+                }
+                if (!configuration.contains(RestOptions.BIND_PORT)) {
+                    modifiedConfiguration.setString(RestOptions.BIND_PORT, "0");
+                }
+            }
 
             return new MiniClusterConfiguration(
                     modifiedConfiguration,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/FileExecutionGraphInfoStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/FileExecutionGraphInfoStoreTest.java
@@ -340,7 +340,7 @@ public class FileExecutionGraphInfoStoreTest extends TestLogger {
         File rootDir = temporaryFolder.newFolder();
         try (final MiniCluster miniCluster =
                 new ExecutionGraphInfoStoreTestUtils.PersistingMiniCluster(
-                        new MiniClusterConfiguration.Builder().build(),
+                        new MiniClusterConfiguration.Builder().withRandomPorts().build(),
                         rootDir,
                         new ScheduledExecutorServiceAdapter(EXECUTOR_RESOURCE.getExecutor()))) {
             miniCluster.start();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/MemoryExecutionGraphInfoStoreITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/MemoryExecutionGraphInfoStoreITCase.java
@@ -50,6 +50,7 @@ public class MemoryExecutionGraphInfoStoreITCase extends TestLogger {
         try (final MiniCluster miniCluster =
                 new ExecutionGraphInfoStoreTestUtils.PersistingMiniCluster(
                         new MiniClusterConfiguration.Builder()
+                                .withRandomPorts()
                                 .setConfiguration(configuration)
                                 .build(),
                         new ScheduledExecutorServiceAdapter(EXECUTOR_RESOURCE.getExecutor()))) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/FileBufferReaderITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/FileBufferReaderITCase.java
@@ -21,7 +21,6 @@ package org.apache.flink.runtime.io.network.partition;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.NettyShuffleEnvironmentOptions;
-import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.execution.Environment;
@@ -111,7 +110,6 @@ public class FileBufferReaderITCase extends TestLogger {
         // if the netty server thread could not response in time, like when it is
         // busy reading the files.
         configuration.setInteger(SecurityOptions.SSL_INTERNAL_HANDSHAKE_TIMEOUT, 100000);
-        configuration.setString(RestOptions.BIND_PORT, "0");
         configuration.setString(
                 NettyShuffleEnvironmentOptions.NETWORK_BLOCKING_SHUFFLE_TYPE, "file");
         configuration.set(TaskManagerOptions.TOTAL_FLINK_MEMORY, MemorySize.parse("1g"));
@@ -120,6 +118,7 @@ public class FileBufferReaderITCase extends TestLogger {
 
         final MiniClusterConfiguration miniClusterConfiguration =
                 new MiniClusterConfiguration.Builder()
+                        .withRandomPorts()
                         .setConfiguration(configuration)
                         .setNumTaskManagers(parallelism)
                         .setNumSlotsPerTaskManager(1)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/minicluster/MiniClusterITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/minicluster/MiniClusterITCase.java
@@ -23,7 +23,6 @@ import org.apache.flink.api.common.JobSubmissionResult;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
-import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.core.testutils.FlinkMatchers;
 import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
@@ -73,10 +72,10 @@ public class MiniClusterITCase extends TestLogger {
 
         final MiniClusterConfiguration cfg =
                 new MiniClusterConfiguration.Builder()
+                        .withRandomPorts()
                         .setNumTaskManagers(numOfTMs)
                         .setNumSlotsPerTaskManager(slotsPerTM)
                         .setRpcServiceSharing(RpcServiceSharing.SHARED)
-                        .setConfiguration(getDefaultConfiguration())
                         .build();
 
         try (final MiniCluster miniCluster = new MiniCluster(cfg)) {
@@ -93,10 +92,10 @@ public class MiniClusterITCase extends TestLogger {
 
         final MiniClusterConfiguration cfg =
                 new MiniClusterConfiguration.Builder()
+                        .withRandomPorts()
                         .setNumTaskManagers(numOfTMs)
                         .setNumSlotsPerTaskManager(slotsPerTM)
                         .setRpcServiceSharing(RpcServiceSharing.DEDICATED)
-                        .setConfiguration(getDefaultConfiguration())
                         .build();
 
         try (final MiniCluster miniCluster = new MiniCluster(cfg)) {
@@ -134,7 +133,7 @@ public class MiniClusterITCase extends TestLogger {
     }
 
     private void runHandleJobsWhenNotEnoughSlots(final JobGraph jobGraph) throws Exception {
-        final Configuration configuration = getDefaultConfiguration();
+        final Configuration configuration = new Configuration();
         // this triggers the failure for the default scheduler
         configuration.setLong(JobManagerOptions.SLOT_REQUEST_TIMEOUT, 100L);
         // this triggers the failure for the adaptive scheduler
@@ -142,6 +141,7 @@ public class MiniClusterITCase extends TestLogger {
 
         final MiniClusterConfiguration cfg =
                 new MiniClusterConfiguration.Builder()
+                        .withRandomPorts()
                         .setNumTaskManagers(1)
                         .setNumSlotsPerTaskManager(1)
                         .setConfiguration(configuration)
@@ -160,9 +160,9 @@ public class MiniClusterITCase extends TestLogger {
 
         final MiniClusterConfiguration cfg =
                 new MiniClusterConfiguration.Builder()
+                        .withRandomPorts()
                         .setNumTaskManagers(1)
                         .setNumSlotsPerTaskManager(2 * parallelism)
-                        .setConfiguration(getDefaultConfiguration())
                         .build();
 
         try (final MiniCluster miniCluster = new MiniCluster(cfg)) {
@@ -191,9 +191,9 @@ public class MiniClusterITCase extends TestLogger {
 
         final MiniClusterConfiguration cfg =
                 new MiniClusterConfiguration.Builder()
+                        .withRandomPorts()
                         .setNumTaskManagers(1)
                         .setNumSlotsPerTaskManager(2 * parallelism)
-                        .setConfiguration(getDefaultConfiguration())
                         .build();
 
         try (final MiniCluster miniCluster = new MiniCluster(cfg)) {
@@ -222,9 +222,9 @@ public class MiniClusterITCase extends TestLogger {
 
         final MiniClusterConfiguration cfg =
                 new MiniClusterConfiguration.Builder()
+                        .withRandomPorts()
                         .setNumTaskManagers(1)
                         .setNumSlotsPerTaskManager(6 * parallelism)
-                        .setConfiguration(getDefaultConfiguration())
                         .build();
 
         try (final MiniCluster miniCluster = new MiniCluster(cfg)) {
@@ -267,9 +267,9 @@ public class MiniClusterITCase extends TestLogger {
 
         final MiniClusterConfiguration cfg =
                 new MiniClusterConfiguration.Builder()
+                        .withRandomPorts()
                         .setNumTaskManagers(1)
                         .setNumSlotsPerTaskManager(6 * parallelism)
-                        .setConfiguration(getDefaultConfiguration())
                         .build();
 
         try (final MiniCluster miniCluster = new MiniCluster(cfg)) {
@@ -305,9 +305,9 @@ public class MiniClusterITCase extends TestLogger {
 
         final MiniClusterConfiguration cfg =
                 new MiniClusterConfiguration.Builder()
+                        .withRandomPorts()
                         .setNumTaskManagers(1)
                         .setNumSlotsPerTaskManager(parallelism)
-                        .setConfiguration(getDefaultConfiguration())
                         .build();
 
         try (final MiniCluster miniCluster = new MiniCluster(cfg)) {
@@ -348,9 +348,9 @@ public class MiniClusterITCase extends TestLogger {
 
         final MiniClusterConfiguration cfg =
                 new MiniClusterConfiguration.Builder()
+                        .withRandomPorts()
                         .setNumTaskManagers(1)
                         .setNumSlotsPerTaskManager(2 * parallelism)
-                        .setConfiguration(getDefaultConfiguration())
                         .build();
 
         try (final MiniCluster miniCluster = new MiniCluster(cfg)) {
@@ -386,9 +386,9 @@ public class MiniClusterITCase extends TestLogger {
 
         final MiniClusterConfiguration cfg =
                 new MiniClusterConfiguration.Builder()
+                        .withRandomPorts()
                         .setNumTaskManagers(1)
                         .setNumSlotsPerTaskManager(parallelism)
-                        .setConfiguration(getDefaultConfiguration())
                         .build();
 
         try (final MiniCluster miniCluster = new MiniCluster(cfg)) {
@@ -434,9 +434,9 @@ public class MiniClusterITCase extends TestLogger {
 
         final MiniClusterConfiguration cfg =
                 new MiniClusterConfiguration.Builder()
+                        .withRandomPorts()
                         .setNumTaskManagers(1)
                         .setNumSlotsPerTaskManager(2 * parallelism)
-                        .setConfiguration(getDefaultConfiguration())
                         .build();
 
         try (final MiniCluster miniCluster = new MiniCluster(cfg)) {
@@ -472,9 +472,9 @@ public class MiniClusterITCase extends TestLogger {
 
         final MiniClusterConfiguration cfg =
                 new MiniClusterConfiguration.Builder()
+                        .withRandomPorts()
                         .setNumTaskManagers(1)
                         .setNumSlotsPerTaskManager(2 * parallelism)
-                        .setConfiguration(getDefaultConfiguration())
                         .build();
 
         try (final MiniCluster miniCluster = new MiniCluster(cfg)) {
@@ -511,9 +511,9 @@ public class MiniClusterITCase extends TestLogger {
 
         final MiniClusterConfiguration cfg =
                 new MiniClusterConfiguration.Builder()
+                        .withRandomPorts()
                         .setNumTaskManagers(1)
                         .setNumSlotsPerTaskManager(parallelism)
-                        .setConfiguration(getDefaultConfiguration())
                         .build();
 
         try (final MiniCluster miniCluster = new MiniCluster(cfg)) {
@@ -560,9 +560,9 @@ public class MiniClusterITCase extends TestLogger {
 
         final MiniClusterConfiguration cfg =
                 new MiniClusterConfiguration.Builder()
+                        .withRandomPorts()
                         .setNumTaskManagers(1)
                         .setNumSlotsPerTaskManager(2 * parallelism)
-                        .setConfiguration(getDefaultConfiguration())
                         .build();
 
         try (final MiniCluster miniCluster = new MiniCluster(cfg)) {
@@ -603,9 +603,9 @@ public class MiniClusterITCase extends TestLogger {
 
         final MiniClusterConfiguration cfg =
                 new MiniClusterConfiguration.Builder()
+                        .withRandomPorts()
                         .setNumTaskManagers(1)
                         .setNumSlotsPerTaskManager(parallelism)
-                        .setConfiguration(getDefaultConfiguration())
                         .build();
 
         try (final MiniCluster miniCluster = new MiniCluster(cfg)) {
@@ -645,9 +645,9 @@ public class MiniClusterITCase extends TestLogger {
 
         final MiniClusterConfiguration cfg =
                 new MiniClusterConfiguration.Builder()
+                        .withRandomPorts()
                         .setNumTaskManagers(1)
                         .setNumSlotsPerTaskManager(parallelism)
-                        .setConfiguration(getDefaultConfiguration())
                         .build();
 
         try (final MiniCluster miniCluster = new MiniCluster(cfg)) {
@@ -682,13 +682,6 @@ public class MiniClusterITCase extends TestLogger {
     // ------------------------------------------------------------------------
     //  Utilities
     // ------------------------------------------------------------------------
-
-    private Configuration getDefaultConfiguration() {
-        final Configuration configuration = new Configuration();
-        configuration.setString(RestOptions.BIND_PORT, "0");
-
-        return configuration;
-    }
 
     private static JobGraph getSimpleJob(int parallelism) throws IOException {
         final JobVertex task = new JobVertex("Test task");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/shuffle/ShuffleMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/shuffle/ShuffleMasterTest.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.runtime.io.network.NettyShuffleServiceFactory;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
@@ -108,9 +107,9 @@ public class ShuffleMasterTest extends TestLogger {
         configuration.setString(
                 ShuffleServiceOptions.SHUFFLE_SERVICE_FACTORY_CLASS,
                 TestShuffleServiceFactory.class.getName());
-        configuration.setString(RestOptions.BIND_PORT, "0");
         configuration.setBoolean(STOP_TRACKING_PARTITION_KEY, stopTrackingPartition);
         return new MiniClusterConfiguration.Builder()
+                .withRandomPorts()
                 .setNumTaskManagers(1)
                 .setNumSlotsPerTaskManager(1)
                 .setConfiguration(configuration)

--- a/flink-tests/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorEventSendingCheckpointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorEventSendingCheckpointITCase.java
@@ -555,6 +555,7 @@ public class OperatorEventSendingCheckpointITCase extends TestLogger {
                 final int numSlots, final Configuration configuration) {
             super(
                     new MiniClusterConfiguration.Builder()
+                            .withRandomPorts()
                             .setRpcServiceSharing(RpcServiceSharing.SHARED)
                             .setNumTaskManagers(1)
                             .setConfiguration(configuration)

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/CheckpointRestoreWithUidHashITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/CheckpointRestoreWithUidHashITCase.java
@@ -23,17 +23,15 @@ import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.common.state.CheckpointListener;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.runtime.OperatorIDPair;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
-import org.apache.flink.runtime.minicluster.MiniCluster;
-import org.apache.flink.runtime.minicluster.MiniClusterConfiguration;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
+import org.apache.flink.runtime.testutils.MiniClusterResource;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.streaming.api.CheckpointingMode;
 import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
@@ -72,6 +70,14 @@ public class CheckpointRestoreWithUidHashITCase {
 
     @Rule public final SharedObjects sharedObjects = SharedObjects.create();
 
+    @Rule
+    public final MiniClusterResource miniClusterResource =
+            new MiniClusterResource(
+                    new MiniClusterResourceConfiguration.Builder()
+                            .setNumberTaskManagers(1)
+                            .setNumberSlotsPerTaskManager(1)
+                            .build());
+
     private SharedReference<CountDownLatch> startWaitingForCheckpointLatch;
 
     private SharedReference<List<Integer>> result;
@@ -86,49 +92,46 @@ public class CheckpointRestoreWithUidHashITCase {
     public void testRestoreFromSavepointBySetUidHash() throws Exception {
         final int maxNumber = 100;
 
-        try (MiniCluster miniCluster = new MiniCluster(createMiniClusterConfig())) {
-            miniCluster.start();
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        JobGraph firstJob =
+                createJobGraph(
+                        env,
+                        StatefulSourceBehavior.HOLD_AFTER_CHECKPOINT_ON_FIRST_RUN,
+                        maxNumber,
+                        "test-uid",
+                        null,
+                        null);
+        JobID jobId = miniClusterResource.getMiniCluster().submitJob(firstJob).get().getJobID();
+        waitForAllTaskRunning(miniClusterResource.getMiniCluster(), jobId, false);
 
-            StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-            JobGraph firstJob =
-                    createJobGraph(
-                            env,
-                            StatefulSourceBehavior.HOLD_AFTER_CHECKPOINT_ON_FIRST_RUN,
-                            maxNumber,
-                            "test-uid",
-                            null,
-                            null);
-            JobID jobId = miniCluster.submitJob(firstJob).get().getJobID();
-            waitForAllTaskRunning(miniCluster, jobId, false);
+        // The source would emit some records and start waiting for the checkpoint to happen.
+        // With this latch we ensures the savepoint happens in a fixed position and no following
+        // records are emitted after savepoint is triggered.
+        startWaitingForCheckpointLatch.get().await();
+        String savepointPath =
+                miniClusterResource
+                        .getMiniCluster()
+                        .triggerSavepoint(
+                                jobId,
+                                TMP_FOLDER.newFolder().getAbsolutePath(),
+                                true,
+                                SavepointFormatType.CANONICAL)
+                        .get();
 
-            // The source would emit some records and start waiting for the checkpoint to happen.
-            // With this latch we ensures the savepoint happens in a fixed position and no following
-            // records are emitted after savepoint is triggered.
-            startWaitingForCheckpointLatch.get().await();
-            String savepointPath =
-                    miniCluster
-                            .triggerSavepoint(
-                                    jobId,
-                                    TMP_FOLDER.newFolder().getAbsolutePath(),
-                                    true,
-                                    SavepointFormatType.CANONICAL)
-                            .get();
+        // Get the operator id
+        List<OperatorIDPair> operatorIds =
+                firstJob.getVerticesSortedTopologicallyFromSources().get(0).getOperatorIDs();
+        OperatorIDPair sourceOperatorIds = operatorIds.get(operatorIds.size() - 1);
 
-            // Get the operator id
-            List<OperatorIDPair> operatorIds =
-                    firstJob.getVerticesSortedTopologicallyFromSources().get(0).getOperatorIDs();
-            OperatorIDPair sourceOperatorIds = operatorIds.get(operatorIds.size() - 1);
-
-            JobGraph secondJob =
-                    createJobGraph(
-                            env,
-                            StatefulSourceBehavior.PROCESS_ONLY,
-                            maxNumber,
-                            null,
-                            sourceOperatorIds.getGeneratedOperatorID().toHexString(),
-                            savepointPath);
-            miniCluster.executeJobBlocking(secondJob);
-        }
+        JobGraph secondJob =
+                createJobGraph(
+                        env,
+                        StatefulSourceBehavior.PROCESS_ONLY,
+                        maxNumber,
+                        null,
+                        sourceOperatorIds.getGeneratedOperatorID().toHexString(),
+                        savepointPath);
+        miniClusterResource.getMiniCluster().executeJobBlocking(secondJob);
         assertThat(result.get(), contains(IntStream.range(0, maxNumber).boxed().toArray()));
     }
 
@@ -149,21 +152,8 @@ public class CheckpointRestoreWithUidHashITCase {
                         new OperatorID().toHexString(),
                         null);
 
-        try (MiniCluster miniCluster = new MiniCluster(createMiniClusterConfig())) {
-            miniCluster.start();
-            miniCluster.executeJobBlocking(jobGraph);
-        }
+        miniClusterResource.getMiniCluster().executeJobBlocking(jobGraph);
         assertThat(result.get(), contains(IntStream.range(0, maxNumber).boxed().toArray()));
-    }
-
-    private MiniClusterConfiguration createMiniClusterConfig() {
-        final Configuration config = new Configuration();
-        config.setString(RestOptions.BIND_PORT, "18081-19000");
-        return new MiniClusterConfiguration.Builder()
-                .setNumTaskManagers(1)
-                .setNumSlotsPerTaskManager(1)
-                .setConfiguration(config)
-                .build();
     }
 
     private JobGraph createJobGraph(

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/DefaultSchedulerLocalRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/DefaultSchedulerLocalRecoveryITCase.java
@@ -26,7 +26,6 @@ import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.MemorySize;
-import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
@@ -107,8 +106,6 @@ public class DefaultSchedulerLocalRecoveryITCase extends TestLogger {
 
     private ArchivedExecutionGraph executeSchedulingTest(
             Configuration configuration, int parallelism) throws Exception {
-        configuration.setString(RestOptions.BIND_PORT, "0");
-
         final long slotIdleTimeout = TIMEOUT;
         configuration.setLong(JobManagerOptions.SLOT_IDLE_TIMEOUT, slotIdleTimeout);
 
@@ -118,6 +115,7 @@ public class DefaultSchedulerLocalRecoveryITCase extends TestLogger {
 
         final MiniClusterConfiguration miniClusterConfiguration =
                 new MiniClusterConfiguration.Builder()
+                        .withRandomPorts()
                         .setConfiguration(configuration)
                         .setNumTaskManagers(parallelism)
                         .setNumSlotsPerTaskManager(1)

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/JobGraphRunningUtil.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/JobGraphRunningUtil.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.client.program.MiniClusterClient;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MemorySize;
-import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmaster.JobResult;
@@ -39,10 +38,10 @@ public class JobGraphRunningUtil {
             int numSlotsPerTaskManager)
             throws Exception {
         configuration.set(TaskManagerOptions.TOTAL_FLINK_MEMORY, MemorySize.parse("1g"));
-        configuration.setString(RestOptions.BIND_PORT, "0");
 
         final MiniClusterConfiguration miniClusterConfiguration =
                 new MiniClusterConfiguration.Builder()
+                        .withRandomPorts()
                         .setConfiguration(configuration)
                         .setNumTaskManagers(numTaskManagers)
                         .setNumSlotsPerTaskManager(numSlotsPerTaskManager)

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/SchedulingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/SchedulingITCase.java
@@ -26,7 +26,6 @@ import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.MemorySize;
-import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
@@ -95,8 +94,6 @@ public class SchedulingITCase extends TestLogger {
     }
 
     private void executeSchedulingTest(Configuration configuration) throws Exception {
-        configuration.setString(RestOptions.BIND_PORT, "0");
-
         final long slotIdleTimeout = 50L;
         configuration.setLong(JobManagerOptions.SLOT_IDLE_TIMEOUT, slotIdleTimeout);
 
@@ -105,6 +102,7 @@ public class SchedulingITCase extends TestLogger {
         final int parallelism = 4;
         final MiniClusterConfiguration miniClusterConfiguration =
                 new MiniClusterConfiguration.Builder()
+                        .withRandomPorts()
                         .setConfiguration(configuration)
                         .setNumTaskManagers(parallelism)
                         .setNumSlotsPerTaskManager(1)

--- a/flink-tests/src/test/java/org/apache/flink/test/scheduling/PipelinedRegionSchedulingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/scheduling/PipelinedRegionSchedulingITCase.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.client.program.MiniClusterClient;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
-import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.configuration.RestartStrategyOptions;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.io.network.api.reader.RecordReader;
@@ -105,11 +104,11 @@ public class PipelinedRegionSchedulingITCase extends TestLogger {
 
     private JobResult executeSchedulingTest(
             JobGraph jobGraph, int numSlots, Configuration configuration) throws Exception {
-        configuration.setString(RestOptions.BIND_PORT, "0");
         configuration.setLong(JobManagerOptions.SLOT_REQUEST_TIMEOUT, 5000L);
 
         final MiniClusterConfiguration miniClusterConfiguration =
                 new MiniClusterConfiguration.Builder()
+                        .withRandomPorts()
                         .setConfiguration(configuration)
                         .setNumTaskManagers(1)
                         .setNumSlotsPerTaskManager(numSlots)


### PR DESCRIPTION
- migrates some tests to MiniClusterResources (where it was easy to do so)
- introduces MiniClusterConfiguration#withRandomPorts
  - this gives us a single point where we can configure ports in the future