### PR TITLE
[FLINK-27319] Duplicated '-t' option for savepoint format and deployment target

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
@@ -149,7 +149,7 @@ public class CliFrontendParser {
 
     static final Option SAVEPOINT_FORMAT_OPTION =
             new Option(
-                    "t",
+                    "type",
                     "type",
                     true,
                     "Describes the binary format in which a savepoint should be taken. Supported"

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendSavepointTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendSavepointTest.java
@@ -184,7 +184,7 @@ public class CliFrontendSavepointTest extends CliFrontendTestBase {
 
     @Test
     public void testTriggerSavepointCustomFormatShortOption() throws Exception {
-        testTriggerSavepointCustomFormat("-t", SavepointFormatType.NATIVE);
+        testTriggerSavepointCustomFormat("-type", SavepointFormatType.NATIVE);
     }
 
     @Test

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendStopWithSavepointTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendStopWithSavepointTest.java
@@ -121,7 +121,7 @@ public class CliFrontendStopWithSavepointTest extends CliFrontendTestBase {
 
     @Test
     public void testStopWithExplicitSavepointTypeShortOption() throws Exception {
-        testStopWithExplicitSavepointType("-t", SavepointFormatType.NATIVE);
+        testStopWithExplicitSavepointType("-type", SavepointFormatType.NATIVE);
     }
 
     @Test


### PR DESCRIPTION

## Verifying this change

Run:
```
../flink-1.15.0/bin/flink savepoint --type canonical <job_id> savepoints
```
check it runs correctly

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented) - the short option was undocumented
