### PR TITLE
[FLINK-27228][ci] Redistributed modules across CI profiles 

### DIFF
--- a/tools/azure-pipelines/jobs-template.yml
+++ b/tools/azure-pipelines/jobs-template.yml
@@ -92,10 +92,10 @@ jobs:
         module: python
       table:
         module: table
-      connectors:
-        module: connectors
-      kafka_gelly:
-        module: kafka/gelly
+      connect_1:
+        module: connect_1
+      connect_2:
+        module: connect_2
       tests:
         module: tests
       misc:

--- a/tools/ci/stage.sh
+++ b/tools/ci/stage.sh
@@ -127,7 +127,10 @@ MODULES_TESTS="\
 flink-tests,\
 flink-architecture-tests"
 
-MODULES_FINEGRAINED_RESOURCE_MANAGEMENT=${MODULES_CORE},${MODULES_TESTS}
+MODULES_FINEGRAINED_RESOURCE_MANAGEMENT="\
+flink-runtime,\
+flink-tests,\
+"
 
 function get_compile_modules_for_stage() {
     local stage=$1

--- a/tools/ci/stage.sh
+++ b/tools/ci/stage.sh
@@ -21,8 +21,8 @@ STAGE_COMPILE="compile"
 STAGE_CORE="core"
 STAGE_PYTHON="python"
 STAGE_TABLE="table"
-STAGE_CONNECTORS="connectors"
-STAGE_KAFKA_GELLY="kafka/gelly"
+STAGE_CONNECTORS_1="connect_1"
+STAGE_CONNECTORS_2="connect_2"
 STAGE_TESTS="tests"
 STAGE_MISC="misc"
 STAGE_CLEANUP="cleanup"
@@ -31,6 +31,9 @@ STAGE_FINEGRAINED_RESOURCE_MANAGEMENT="finegrained_resource_management"
 MODULES_CORE="\
 flink-annotations,\
 flink-test-utils-parent/flink-test-utils,\
+flink-state-backends,\
+flink-state-backends/flink-statebackend-changelog,\
+flink-state-backends/flink-statebackend-heap-spillable,\
 flink-state-backends/flink-statebackend-rocksdb,\
 flink-clients,\
 flink-core,\
@@ -39,6 +42,7 @@ flink-optimizer,\
 flink-rpc,\
 flink-rpc/flink-rpc-core,\
 flink-rpc/flink-rpc-akka,\
+flink-rpc/flink-rpc-akka-loader,\
 flink-runtime,\
 flink-runtime-web,\
 flink-scala,\
@@ -48,11 +52,23 @@ flink-metrics,\
 flink-metrics/flink-metrics-core,\
 flink-external-resources,\
 flink-external-resources/flink-external-resource-gpu,\
+flink-libraries,\
 flink-libraries/flink-cep,\
 flink-libraries/flink-cep-scala,\
-flink-libraries/flink-state-processing-api"
+flink-libraries/flink-state-processing-api,\
+flink-libraries/flink-gelly,\
+flink-libraries/flink-gelly-scala,\
+flink-libraries/flink-gelly-examples,\
+flink-queryable-state,\
+flink-queryable-state/flink-queryable-state-runtime,\
+flink-queryable-state/flink-queryable-state-client-java,\
+flink-container,\
+flink-dstl,\
+flink-dstl/flink-dstl-dfs,\
+"
 
 MODULES_TABLE="\
+flink-table,\
 flink-table/flink-sql-parser,\
 flink-table/flink-sql-parser-hive,\
 flink-table/flink-table-common,\
@@ -61,17 +77,22 @@ flink-table/flink-table-api-scala,\
 flink-table/flink-table-api-bridge-base,\
 flink-table/flink-table-api-java-bridge,\
 flink-table/flink-table-api-scala-bridge,\
+flink-table/flink-table-api-java-uber,\
 flink-table/flink-sql-client,\
 flink-table/flink-table-planner,\
 flink-table/flink-table-planner-loader,\
+flink-table/flink-table-planner-loader-bundle,\
 flink-table/flink-table-runtime,\
 flink-table/flink-table-code-splitter,\
-flink-table/flink-table-test-utils"
+flink-table/flink-table-test-utils,\
+"
 
-MODULES_CONNECTORS="\
+MODULES_CONNECTORS_1="\
 flink-contrib/flink-connector-wikiedits,\
 flink-filesystems,\
+flink-filesystems/flink-azure-fs-hadoop,\
 flink-filesystems/flink-fs-hadoop-shaded,\
+flink-filesystems/flink-gs-fs-hadoop,\
 flink-filesystems/flink-hadoop-fs,\
 flink-filesystems/flink-oss-fs-hadoop,\
 flink-filesystems/flink-s3-fs-base,\
@@ -79,17 +100,29 @@ flink-filesystems/flink-s3-fs-hadoop,\
 flink-filesystems/flink-s3-fs-presto,\
 flink-fs-tests,\
 flink-formats,\
+flink-formats/flink-format-common,\
 flink-formats/flink-avro-confluent-registry,\
+flink-formats/flink-sql-avro-confluent-registry,\
+flink-formats/flink-avro-glue-schema-registry,\
+flink-formats/flink-json-glue-schema-registry,\
 flink-formats/flink-avro,\
+flink-formats/flink-sql-avro,\
+flink-formats/flink-compress,\
+flink-formats/flink-hadoop-bulk,\
 flink-formats/flink-parquet,\
+flink-formats/flink-sql-parquet,\
 flink-formats/flink-sequence-file,\
 flink-formats/flink-json,\
 flink-formats/flink-csv,\
 flink-formats/flink-orc,\
+flink-formats/flink-sql-orc,\
 flink-formats/flink-orc-nohive,\
+flink-connectors/flink-file-sink-common,\
 flink-connectors/flink-connector-hbase-base,\
 flink-connectors/flink-connector-hbase-1.4,\
+flink-connectors/flink-sql-connector-hbase-1.4,\
 flink-connectors/flink-connector-hbase-2.2,\
+flink-connectors/flink-sql-connector-hbase-2.2,\
 flink-connectors/flink-hcatalog,\
 flink-connectors/flink-hadoop-compatibility,\
 flink-connectors,\
@@ -101,10 +134,6 @@ flink-connectors/flink-connector-elasticsearch7,\
 flink-connectors/flink-sql-connector-elasticsearch6,\
 flink-connectors/flink-sql-connector-elasticsearch7,\
 flink-connectors/flink-connector-elasticsearch-base,\
-flink-connectors/flink-connector-rabbitmq,\
-flink-connectors/flink-connector-kinesis,\
-flink-connectors/flink-connector-aws-kinesis-streams,\
-flink-connectors/flink-connector-aws-kinesis-firehose,\
 flink-metrics/flink-metrics-dropwizard,\
 flink-metrics/flink-metrics-graphite,\
 flink-metrics/flink-metrics-jmx,\
@@ -113,19 +142,29 @@ flink-metrics/flink-metrics-prometheus,\
 flink-metrics/flink-metrics-statsd,\
 flink-metrics/flink-metrics-datadog,\
 flink-metrics/flink-metrics-slf4j,\
-flink-queryable-state/flink-queryable-state-runtime,\
-flink-queryable-state/flink-queryable-state-client-java"
+"
 
-MODULES_KAFKA_GELLY="\
-flink-libraries/flink-gelly,\
-flink-libraries/flink-gelly-scala,\
-flink-libraries/flink-gelly-examples,\
+MODULES_CONNECTORS_2="\
+flink-connectors/flink-connector-base,\
 flink-connectors/flink-connector-kafka,\
-flink-connectors/flink-sql-connector-kafka,"
+flink-connectors/flink-sql-connector-kafka,\
+flink-connectors/flink-connector-gcp-pubsub,\
+flink-connectors/flink-connector-pulsar,\
+flink-connectors/flink-sql-connector-pulsar,\
+flink-connectors/flink-connector-rabbitmq,\
+flink-connectors/flink-sql-connector-rabbitmq,\
+flink-connectors/flink-connector-aws-base,\
+flink-connectors/flink-connector-kinesis,\
+flink-connectors/flink-sql-connector-kinesis,\
+flink-connectors/flink-connector-aws-kinesis-streams,\
+flink-connectors/flink-sql-connector-aws-kinesis-streams,\
+flink-connectors/flink-connector-aws-kinesis-firehose,\
+flink-connectors/flink-sql-connector-aws-kinesis-firehose,\
+"
 
 MODULES_TESTS="\
 flink-tests,\
-flink-architecture-tests"
+"
 
 MODULES_FINEGRAINED_RESOURCE_MANAGEMENT="\
 flink-runtime,\
@@ -142,11 +181,11 @@ function get_compile_modules_for_stage() {
         (${STAGE_TABLE})
             echo "-pl $MODULES_TABLE -am"
         ;;
-        (${STAGE_CONNECTORS})
-            echo "-pl $MODULES_CONNECTORS -am"
+        (${STAGE_CONNECTORS_1})
+            echo "-pl $MODULES_CONNECTORS_1 -am"
         ;;
-        (${STAGE_KAFKA_GELLY})
-            echo "-pl $MODULES_KAFKA_GELLY -am"
+        (${STAGE_CONNECTORS_2})
+            echo "-pl $MODULES_CONNECTORS_2 -am"
         ;;
         (${STAGE_TESTS})
             echo "-pl $MODULES_TESTS -am"
@@ -171,15 +210,15 @@ function get_test_modules_for_stage() {
 
     local modules_core=$MODULES_CORE
     local modules_table=$MODULES_TABLE
-    local modules_kafka_gelly=$MODULES_KAFKA_GELLY
-    local modules_connectors=$MODULES_CONNECTORS
+    local modules_connectors_2=$MODULES_CONNECTORS_2
+    local modules_connectors_1=$MODULES_CONNECTORS_1
     local modules_tests=$MODULES_TESTS
     local negated_core=\!${MODULES_CORE//,/,\!}
     local negated_table=\!${MODULES_TABLE//,/,\!}
-    local negated_kafka_gelly=\!${MODULES_KAFKA_GELLY//,/,\!}
-    local negated_connectors=\!${MODULES_CONNECTORS//,/,\!}
+    local negated_connectors_2=\!${MODULES_CONNECTORS_2//,/,\!}
+    local negated_connectors_1=\!${MODULES_CONNECTORS_1//,/,\!}
     local negated_tests=\!${MODULES_TESTS//,/,\!}
-    local modules_misc="$negated_core,$negated_table,$negated_connectors,$negated_kafka_gelly,$negated_tests"
+    local modules_misc="$negated_core,$negated_table,$negated_connectors_1,$negated_connectors_2,$negated_tests"
     local modules_finegrained_resource_management=$MODULES_FINEGRAINED_RESOURCE_MANAGEMENT
 
     case ${stage} in
@@ -189,11 +228,11 @@ function get_test_modules_for_stage() {
         (${STAGE_TABLE})
             echo "-pl $modules_table"
         ;;
-        (${STAGE_CONNECTORS})
-            echo "-pl $modules_connectors"
+        (${STAGE_CONNECTORS_1})
+            echo "-pl $modules_connectors_1"
         ;;
-        (${STAGE_KAFKA_GELLY})
-            echo "-pl $modules_kafka_gelly"
+        (${STAGE_CONNECTORS_2})
+            echo "-pl $modules_connectors_2"
         ;;
         (${STAGE_TESTS})
             echo "-pl $modules_tests"


### PR DESCRIPTION
Move as much out of misc as possible, and balance the 2 connectors profiles.

-> runtime
* gelly
* statebackends
* dstl
* queryable-state

-> connectors -> connectors_1
* remaining filesystems/formats
* hbase

-> kafka/gelly -> connectors_2
* pubsub
* pulsar
* rabitmq
* aws

-> misc
* architecture-tests