### PR TITLE
[BP-1.14][hotfix][docs] Misprint in types.md

### DIFF
--- a/docs/content.zh/docs/dev/table/types.md
+++ b/docs/content.zh/docs/dev/table/types.md
@@ -47,7 +47,7 @@ A list of all pre-defined data types can be found [below](#list-of-data-types).
 
 ### Data Types in the Table API
 
-{{< tabs "dataytes" >}}
+{{< tabs "datatypes" >}}
 {{< tab "Java/Scala" >}}
 Users of the JVM-based API work with instances of `org.apache.flink.table.types.DataType` within the Table API or when
 defining connectors, catalogs, or user-defined functions. 

--- a/docs/content/docs/dev/table/types.md
+++ b/docs/content/docs/dev/table/types.md
@@ -47,7 +47,7 @@ A list of all pre-defined data types can be found [below](#list-of-data-types).
 
 ### Data Types in the Table API
 
-{{< tabs "dataytes" >}}
+{{< tabs "datatypes" >}}
 {{< tab "Java/Scala" >}}
 Users of the JVM-based API work with instances of `org.apache.flink.table.types.DataType` within the Table API or when
 defining connectors, catalogs, or user-defined functions. 


### PR DESCRIPTION
1.14 backport PR of parent PR https://github.com/apache/flink/pull/17505. Cherry-picking worked without conflicts.