### PR TITLE
[FLINK-23589][flink-avro] Support microsecond precision for timestamp

### DIFF
--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroRowDeserializationSchema.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroRowDeserializationSchema.java
@@ -365,7 +365,11 @@ public class AvroRowDeserializationSchema extends AbstractDeserializationSchema<
             timestamp.setNanos(nanos);
             return timestamp;
         } else if (jodaConverter != null) {
-            millis = jodaConverter.convertTimestamp(object);
+            if (isMicros) {
+                millis = jodaConverter.convertTimestampMicros(object);
+            } else {
+                millis = jodaConverter.convertTimestampMillis(object);
+            }
         } else {
             throw new IllegalArgumentException(
                     "Unexpected object type for DATE logical type. Received: " + object);

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/JodaConverter.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/JodaConverter.java
@@ -61,9 +61,12 @@ class JodaConverter {
         return value.get(DateTimeFieldType.millisOfDay());
     }
 
-    public long convertTimestamp(Object object) {
-        final DateTime value = (DateTime) object;
-        return value.toDate().getTime();
+    public long convertTimestampMillis(Object object) {
+        return ((DateTime) object).getMillis();
+    }
+
+    public long convertTimestampMicros(Object object) {
+        return ((DateTime) object).getMillis() * 1_000;
     }
 
     private JodaConverter() {}

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/typeutils/AvroSchemaConverter.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/typeutils/AvroSchemaConverter.java
@@ -354,12 +354,14 @@ public class AvroSchemaConverter {
                 org.apache.avro.LogicalType avroLogicalType;
                 if (precision <= 3) {
                     avroLogicalType = LogicalTypes.timestampMillis();
+                } else if (precision <= 6) {
+                    avroLogicalType = LogicalTypes.timestampMicros();
                 } else {
                     throw new IllegalArgumentException(
                             "Avro does not support TIMESTAMP type "
                                     + "with precision: "
                                     + precision
-                                    + ", it only supports precision less than 3.");
+                                    + ", it only supports precision less than or equal to 6.");
                 }
                 Schema timestamp = avroLogicalType.addToSchema(SchemaBuilder.builder().longType());
                 return nullable ? nullableSchema(timestamp) : timestamp;

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroOutputFormatITCase.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroOutputFormatITCase.java
@@ -39,7 +39,6 @@ import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -109,16 +108,17 @@ public class AvroOutputFormatITCase extends JavaProgramTestBase {
         DatumReader<User> userDatumReader1 = new SpecificDatumReader<>(User.class);
         for (File avroOutput : output1) {
 
-            DataFileReader<User> dataFileReader1 =
-                    new DataFileReader<>(avroOutput, userDatumReader1);
-            while (dataFileReader1.hasNext()) {
-                User user = dataFileReader1.next();
-                result1.add(
-                        user.getName()
-                                + "|"
-                                + user.getFavoriteNumber()
-                                + "|"
-                                + user.getFavoriteColor());
+            try (DataFileReader<User> dataFileReader1 =
+                    new DataFileReader<>(avroOutput, userDatumReader1)) {
+                while (dataFileReader1.hasNext()) {
+                    User user = dataFileReader1.next();
+                    result1.add(
+                            user.getName()
+                                    + "|"
+                                    + user.getFavoriteNumber()
+                                    + "|"
+                                    + user.getFavoriteColor());
+                }
             }
         }
         assertThat(result1).contains(userData.split("\n"));
@@ -135,16 +135,17 @@ public class AvroOutputFormatITCase extends JavaProgramTestBase {
         DatumReader<ReflectiveUser> userDatumReader2 =
                 new ReflectDatumReader<>(ReflectiveUser.class);
         for (File avroOutput : Objects.requireNonNull(output2)) {
-            DataFileReader<ReflectiveUser> dataFileReader2 =
-                    new DataFileReader<>(avroOutput, userDatumReader2);
-            while (dataFileReader2.hasNext()) {
-                ReflectiveUser user = dataFileReader2.next();
-                result2.add(
-                        user.getName()
-                                + "|"
-                                + user.getFavoriteNumber()
-                                + "|"
-                                + user.getFavoriteColor());
+            try (DataFileReader<ReflectiveUser> dataFileReader2 =
+                    new DataFileReader<>(avroOutput, userDatumReader2)) {
+                while (dataFileReader2.hasNext()) {
+                    ReflectiveUser user = dataFileReader2.next();
+                    result2.add(
+                            user.getName()
+                                    + "|"
+                                    + user.getFavoriteNumber()
+                                    + "|"
+                                    + user.getFavoriteColor());
+                }
             }
         }
         assertThat(result2).contains(userData.split("\n"));
@@ -166,10 +167,10 @@ public class AvroOutputFormatITCase extends JavaProgramTestBase {
             user.setTypeMap(Collections.emptyMap());
             user.setTypeBytes(ByteBuffer.allocate(10));
             user.setTypeDate(LocalDate.parse("2014-03-01"));
-            user.setTypeTimeMillis(LocalTime.parse("12:12:12"));
-            user.setTypeTimeMicros(LocalTime.ofSecondOfDay(0).plus(123456L, ChronoUnit.MICROS));
-            user.setTypeTimestampMillis(Instant.parse("2014-03-01T12:12:12.321Z"));
-            user.setTypeTimestampMicros(Instant.ofEpochSecond(0).plus(123456L, ChronoUnit.MICROS));
+            user.setTypeTimeMillis(LocalTime.parse("12:34:56.123"));
+            user.setTypeTimeMicros(LocalTime.parse("12:34:56.123456"));
+            user.setTypeTimestampMillis(Instant.parse("2014-03-01T12:34:56.123Z"));
+            user.setTypeTimestampMicros(Instant.parse("2014-03-01T12:34:56.123456Z"));
             // 20.00
             user.setTypeDecimalBytes(
                     ByteBuffer.wrap(BigDecimal.valueOf(2000, 2).unscaledValue().toByteArray()));

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroRecordInputFormatTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroRecordInputFormatTest.java
@@ -61,7 +61,6 @@ import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -135,10 +134,10 @@ public class AvroRecordInputFormatTest {
         user1.setTypeNested(addr);
         user1.setTypeBytes(ByteBuffer.allocate(10));
         user1.setTypeDate(LocalDate.parse("2014-03-01"));
-        user1.setTypeTimeMillis(LocalTime.parse("12:12:12"));
-        user1.setTypeTimeMicros(LocalTime.ofSecondOfDay(0).plus(123456L, ChronoUnit.MICROS));
-        user1.setTypeTimestampMillis(Instant.parse("2014-03-01T12:12:12.321Z"));
-        user1.setTypeTimestampMicros(Instant.ofEpochSecond(0).plus(123456L, ChronoUnit.MICROS));
+        user1.setTypeTimeMillis(LocalTime.parse("12:34:56.123"));
+        user1.setTypeTimeMicros(LocalTime.parse("12:34:56.123456"));
+        user1.setTypeTimestampMillis(Instant.parse("2014-03-01T12:34:56.123Z"));
+        user1.setTypeTimestampMicros(Instant.parse("2014-03-01T12:34:56.123456Z"));
         // 20.00
         user1.setTypeDecimalBytes(
                 ByteBuffer.wrap(BigDecimal.valueOf(2000, 2).unscaledValue().toByteArray()));
@@ -173,12 +172,10 @@ public class AvroRecordInputFormatTest {
                                         .build())
                         .setTypeBytes(ByteBuffer.allocate(10))
                         .setTypeDate(LocalDate.parse("2014-03-01"))
-                        .setTypeTimeMillis(LocalTime.parse("12:12:12"))
-                        .setTypeTimeMicros(
-                                LocalTime.ofSecondOfDay(0).plus(123456L, ChronoUnit.MICROS))
-                        .setTypeTimestampMillis(Instant.parse("2014-03-01T12:12:12.321Z"))
-                        .setTypeTimestampMicros(
-                                Instant.ofEpochSecond(0).plus(123456L, ChronoUnit.MICROS))
+                        .setTypeTimeMillis(LocalTime.parse("12:34:56.123"))
+                        .setTypeTimeMicros(LocalTime.parse("12:34:56.123456"))
+                        .setTypeTimestampMillis(Instant.parse("2014-03-01T12:34:56.123Z"))
+                        .setTypeTimestampMicros(Instant.parse("2014-03-01T12:34:56.123456Z"))
                         // 20.00
                         .setTypeDecimalBytes(
                                 ByteBuffer.wrap(

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroSplittableInputFormatTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroSplittableInputFormatTest.java
@@ -42,7 +42,6 @@ import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Random;
@@ -115,10 +114,10 @@ class AvroSplittableInputFormatTest {
         user1.setTypeNested(addr);
         user1.setTypeBytes(ByteBuffer.allocate(10));
         user1.setTypeDate(LocalDate.parse("2014-03-01"));
-        user1.setTypeTimeMillis(LocalTime.parse("12:12:12"));
-        user1.setTypeTimeMicros(LocalTime.ofSecondOfDay(0).plus(123456L, ChronoUnit.MICROS));
-        user1.setTypeTimestampMillis(Instant.parse("2014-03-01T12:12:12.321Z"));
-        user1.setTypeTimestampMicros(Instant.ofEpochSecond(0).plus(123456L, ChronoUnit.MICROS));
+        user1.setTypeTimeMillis(LocalTime.parse("12:34:56.123"));
+        user1.setTypeTimeMicros(LocalTime.parse("12:34:56.123456"));
+        user1.setTypeTimestampMillis(Instant.parse("2014-03-01T12:34:56.123Z"));
+        user1.setTypeTimestampMicros(Instant.parse("2014-03-01T12:34:56.123456Z"));
         // 20.00
         user1.setTypeDecimalBytes(
                 ByteBuffer.wrap(BigDecimal.valueOf(2000, 2).unscaledValue().toByteArray()));
@@ -153,12 +152,10 @@ class AvroSplittableInputFormatTest {
                                         .build())
                         .setTypeBytes(ByteBuffer.allocate(10))
                         .setTypeDate(LocalDate.parse("2014-03-01"))
-                        .setTypeTimeMillis(LocalTime.parse("12:12:12"))
-                        .setTypeTimeMicros(
-                                LocalTime.ofSecondOfDay(0).plus(123456L, ChronoUnit.MICROS))
-                        .setTypeTimestampMillis(Instant.parse("2014-03-01T12:12:12.321Z"))
-                        .setTypeTimestampMicros(
-                                Instant.ofEpochSecond(0).plus(123456L, ChronoUnit.MICROS))
+                        .setTypeTimeMillis(LocalTime.parse("12:34:56.123"))
+                        .setTypeTimeMicros(LocalTime.parse("12:34:56.123456"))
+                        .setTypeTimestampMillis(Instant.parse("2014-03-01T12:34:56.123Z"))
+                        .setTypeTimestampMicros(Instant.parse("2014-03-01T12:34:56.123456Z"))
                         // 20.00
                         .setTypeDecimalBytes(
                                 ByteBuffer.wrap(
@@ -194,10 +191,10 @@ class AvroSplittableInputFormatTest {
             user.setTypeNested(address);
             user.setTypeBytes(ByteBuffer.allocate(10));
             user.setTypeDate(LocalDate.parse("2014-03-01"));
-            user.setTypeTimeMillis(LocalTime.parse("12:12:12"));
-            user.setTypeTimeMicros(LocalTime.ofSecondOfDay(0).plus(123456L, ChronoUnit.MICROS));
-            user.setTypeTimestampMillis(Instant.parse("2014-03-01T12:12:12.321Z"));
-            user.setTypeTimestampMicros(Instant.ofEpochSecond(0).plus(123456L, ChronoUnit.MICROS));
+            user.setTypeTimeMillis(LocalTime.parse("12:34:56.123"));
+            user.setTypeTimeMicros(LocalTime.parse("12:34:56.123456"));
+            user.setTypeTimestampMillis(Instant.parse("2014-03-01T12:34:56.123Z"));
+            user.setTypeTimestampMicros(Instant.parse("2014-03-01T12:34:56.123456Z"));
             // 20.00
             user.setTypeDecimalBytes(
                     ByteBuffer.wrap(BigDecimal.valueOf(2000, 2).unscaledValue().toByteArray()));
@@ -234,7 +231,7 @@ class AvroSplittableInputFormatTest {
             format.close();
         }
 
-        assertThat(elementsPerSplit).containsExactly(1604, 1203, 1203, 990);
+        assertThat(elementsPerSplit).containsExactly(1528, 1146, 1146, 1180);
         assertThat(elements).isEqualTo(NUM_RECORDS);
         format.close();
     }
@@ -280,7 +277,7 @@ class AvroSplittableInputFormatTest {
             format.close();
         }
 
-        assertThat(elementsPerSplit).containsExactly(1604, 1203, 1203, 990);
+        assertThat(elementsPerSplit).containsExactly(1528, 1146, 1146, 1180);
         assertThat(elements).isEqualTo(NUM_RECORDS);
         format.close();
     }
@@ -326,7 +323,7 @@ class AvroSplittableInputFormatTest {
             format.close();
         }
 
-        assertThat(elementsPerSplit).containsExactly(1604, 1203, 1203, 990);
+        assertThat(elementsPerSplit).containsExactly(1528, 1146, 1146, 1180);
         assertThat(elements).isEqualTo(NUM_RECORDS);
         format.close();
     }

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/EncoderDecoderTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/EncoderDecoderTest.java
@@ -40,7 +40,6 @@ import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -168,7 +167,7 @@ class EncoderDecoderTest {
                         -1L,
                         (byte) -65,
                         "Serve me the sky with a big slice of lemon",
-                        (short) Byte.MIN_VALUE,
+                        Byte.MIN_VALUE,
                         0.0000001));
     }
 
@@ -295,10 +294,10 @@ class EncoderDecoderTest {
                         addr,
                         ByteBuffer.wrap(b),
                         LocalDate.parse("2014-03-01"),
-                        LocalTime.parse("12:12:12"),
-                        LocalTime.ofSecondOfDay(0).plus(123456L, ChronoUnit.MICROS),
-                        Instant.parse("2014-03-01T12:12:12.321Z"),
-                        Instant.ofEpochSecond(0).plus(123456L, ChronoUnit.MICROS),
+                        LocalTime.parse("12:34:56.123"),
+                        LocalTime.parse("12:34:56.123456"),
+                        Instant.parse("2014-03-01T12:34:56.123Z"),
+                        Instant.parse("2014-03-01T12:34:56.123456Z"),
                         ByteBuffer.wrap(
                                 BigDecimal.valueOf(2000, 2).unscaledValue().toByteArray()), // 20.00
                         new Fixed2(

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroTypeExtractionTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroTypeExtractionTest.java
@@ -109,9 +109,9 @@ class AvroTypeExtractionTest {
                         + "\"type_nested\": {\"num\": 239, \"street\": \"Baker Street\", \"city\": \"London\", "
                         + "\"state\": \"London\", \"zip\": \"NW1 6XE\"}, "
                         + "\"type_bytes\": \"\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\", "
-                        + "\"type_date\": 2014-03-01, \"type_time_millis\": 12:12:12, \"type_time_micros\": 00:00:00.123456, "
-                        + "\"type_timestamp_millis\": 2014-03-01T12:12:12.321Z, "
-                        + "\"type_timestamp_micros\": 1970-01-01T00:00:00.123456Z, \"type_decimal_bytes\": \"\\u0007Ð\", "
+                        + "\"type_date\": 2014-03-01, \"type_time_millis\": 12:34:56.123, \"type_time_micros\": 12:34:56.123456, "
+                        + "\"type_timestamp_millis\": 2014-03-01T12:34:56.123Z, "
+                        + "\"type_timestamp_micros\": 2014-03-01T12:34:56.123456Z, \"type_decimal_bytes\": \"\\u0007Ð\", "
                         + "\"type_decimal_fixed\": [7, -48]}\n"
                         + "{\"name\": \"Charlie\", \"favorite_number\": null, "
                         + "\"favorite_color\": \"blue\", \"type_long_test\": 1337, \"type_double_test\": 1.337, "
@@ -121,9 +121,9 @@ class AvroTypeExtractionTest {
                         + "\"type_nested\": {\"num\": 239, \"street\": \"Baker Street\", \"city\": \"London\", \"state\": \"London\", "
                         + "\"zip\": \"NW1 6XE\"}, "
                         + "\"type_bytes\": \"\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\", "
-                        + "\"type_date\": 2014-03-01, \"type_time_millis\": 12:12:12, \"type_time_micros\": 00:00:00.123456, "
-                        + "\"type_timestamp_millis\": 2014-03-01T12:12:12.321Z, "
-                        + "\"type_timestamp_micros\": 1970-01-01T00:00:00.123456Z, \"type_decimal_bytes\": \"\\u0007Ð\", "
+                        + "\"type_date\": 2014-03-01, \"type_time_millis\": 12:34:56.123, \"type_time_micros\": 12:34:56.123456, "
+                        + "\"type_timestamp_millis\": 2014-03-01T12:34:56.123Z, "
+                        + "\"type_timestamp_micros\": 2014-03-01T12:34:56.123456Z, \"type_decimal_bytes\": \"\\u0007Ð\", "
                         + "\"type_decimal_fixed\": [7, -48]}\n";
     }
 
@@ -160,9 +160,9 @@ class AvroTypeExtractionTest {
                         + " \"type_nested\": {\"num\": 239, \"street\": \"Baker Street\", \"city\": \"London\","
                         + " \"state\": \"London\", \"zip\": \"NW1 6XE\"},"
                         + " \"type_bytes\": \"\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\", "
-                        + "\"type_date\": 2014-03-01, \"type_time_millis\": 12:12:12, \"type_time_micros\": 00:00:00.123456, "
-                        + "\"type_timestamp_millis\": 2014-03-01T12:12:12.321Z, "
-                        + "\"type_timestamp_micros\": 1970-01-01T00:00:00.123456Z, \"type_decimal_bytes\": \"\\u0007Ð\", "
+                        + "\"type_date\": 2014-03-01, \"type_time_millis\": 12:34:56.123, \"type_time_micros\": 12:34:56.123456, "
+                        + "\"type_timestamp_millis\": 2014-03-01T12:34:56.123Z, "
+                        + "\"type_timestamp_micros\": 2014-03-01T12:34:56.123456Z, \"type_decimal_bytes\": \"\\u0007Ð\", "
                         + "\"type_decimal_fixed\": [7, -48]}\n"
                         + "{\"name\": \"Charlie\", \"favorite_number\": null, "
                         + "\"favorite_color\": \"blue\", \"type_long_test\": 1337, \"type_double_test\": 1.337, "
@@ -172,9 +172,9 @@ class AvroTypeExtractionTest {
                         + "\"type_nested\": {\"num\": 239, \"street\": \"Baker Street\", \"city\": \"London\", \"state\": \"London\", "
                         + "\"zip\": \"NW1 6XE\"}, "
                         + "\"type_bytes\": \"\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\", "
-                        + "\"type_date\": 2014-03-01, \"type_time_millis\": 12:12:12, \"type_time_micros\": 00:00:00.123456, "
-                        + "\"type_timestamp_millis\": 2014-03-01T12:12:12.321Z, "
-                        + "\"type_timestamp_micros\": 1970-01-01T00:00:00.123456Z, \"type_decimal_bytes\": \"\\u0007Ð\", "
+                        + "\"type_date\": 2014-03-01, \"type_time_millis\": 12:34:56.123, \"type_time_micros\": 12:34:56.123456, "
+                        + "\"type_timestamp_millis\": 2014-03-01T12:34:56.123Z, "
+                        + "\"type_timestamp_micros\": 2014-03-01T12:34:56.123456Z, \"type_decimal_bytes\": \"\\u0007Ð\", "
                         + "\"type_decimal_fixed\": [7, -48]}\n";
     }
 

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/utils/AvroTestUtils.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/utils/AvroTestUtils.java
@@ -45,7 +45,6 @@ import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
-import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Collections;
 
@@ -94,12 +93,10 @@ public final class AvroTestUtils {
                         .setTypeNested(addr)
                         .setTypeBytes(ByteBuffer.allocate(10))
                         .setTypeDate(LocalDate.parse("2014-03-01"))
-                        .setTypeTimeMillis(LocalTime.parse("12:12:12"))
-                        .setTypeTimeMicros(
-                                LocalTime.ofSecondOfDay(0).plus(123456L, ChronoUnit.MICROS))
-                        .setTypeTimestampMillis(Instant.parse("2014-03-01T12:12:12.321Z"))
-                        .setTypeTimestampMicros(
-                                Instant.ofEpochSecond(0).plus(123456L, ChronoUnit.MICROS))
+                        .setTypeTimeMillis(LocalTime.parse("12:34:56.123"))
+                        .setTypeTimeMicros(LocalTime.parse("12:34:56.123456"))
+                        .setTypeTimestampMillis(Instant.parse("2014-03-01T12:34:56.123Z"))
+                        .setTypeTimestampMicros(Instant.parse("2014-03-01T12:34:56.123456Z"))
                         // byte array must contain the two's-complement representation of the
                         // unscaled integer value in big-endian byte order
                         .setTypeDecimalBytes(
@@ -131,12 +128,10 @@ public final class AvroTestUtils {
         rowUser.setField(14, rowAddr);
         rowUser.setField(15, new byte[10]);
         rowUser.setField(16, Date.valueOf("2014-03-01"));
-        rowUser.setField(17, Time.valueOf("12:12:12"));
-        rowUser.setField(
-                18, Time.valueOf(LocalTime.ofSecondOfDay(0).plus(123456L, ChronoUnit.MICROS)));
-        rowUser.setField(19, Timestamp.valueOf("2014-03-01 12:12:12.321"));
-        rowUser.setField(
-                20, Timestamp.from(Instant.ofEpochSecond(0).plus(123456L, ChronoUnit.MICROS)));
+        rowUser.setField(17, Time.valueOf(LocalTime.parse("12:34:56.123")));
+        rowUser.setField(18, Time.valueOf(LocalTime.parse("12:34:56.123456")));
+        rowUser.setField(19, Timestamp.valueOf("2014-03-01 12:34:56.123"));
+        rowUser.setField(20, Timestamp.valueOf("2014-03-01 12:34:56.123456"));
         rowUser.setField(21, BigDecimal.valueOf(2000, 2));
         rowUser.setField(22, BigDecimal.valueOf(2000, 2));
 
@@ -210,11 +205,10 @@ public final class AvroTestUtils {
         user.put("type_nested", addr);
         user.put("type_bytes", ByteBuffer.allocate(10));
         user.put("type_date", LocalDate.parse("2014-03-01"));
-        user.put("type_time_millis", LocalTime.parse("12:12:12"));
-        user.put("type_time_micros", LocalTime.ofSecondOfDay(0).plus(123456L, ChronoUnit.MICROS));
-        user.put("type_timestamp_millis", Instant.parse("2014-03-01T12:12:12.321Z"));
-        user.put(
-                "type_timestamp_micros", Instant.ofEpochSecond(0).plus(123456L, ChronoUnit.MICROS));
+        user.put("type_time_millis", LocalTime.parse("12:34:56.123"));
+        user.put("type_time_micros", LocalTime.parse("12:34:56.123456"));
+        user.put("type_timestamp_millis", Instant.parse("2014-03-01T12:34:56.123Z"));
+        user.put("type_timestamp_micros", Instant.parse("2014-03-01T12:34:56.123456Z"));
         user.put(
                 "type_decimal_bytes",
                 ByteBuffer.wrap(BigDecimal.valueOf(2000, 2).unscaledValue().toByteArray()));
@@ -242,12 +236,10 @@ public final class AvroTestUtils {
         rowUser.setField(14, rowAddr);
         rowUser.setField(15, new byte[10]);
         rowUser.setField(16, Date.valueOf("2014-03-01"));
-        rowUser.setField(17, Time.valueOf("12:12:12"));
-        rowUser.setField(
-                18, Time.valueOf(LocalTime.ofSecondOfDay(0).plus(123456L, ChronoUnit.MICROS)));
-        rowUser.setField(19, Timestamp.valueOf("2014-03-01 12:12:12.321"));
-        rowUser.setField(
-                20, Timestamp.from(Instant.ofEpochSecond(0).plus(123456L, ChronoUnit.MICROS)));
+        rowUser.setField(17, Time.valueOf(LocalTime.parse("12:34:56.123")));
+        rowUser.setField(18, Time.valueOf(LocalTime.parse("12:34:56.123456")));
+        rowUser.setField(19, Timestamp.valueOf("2014-03-01 12:34:56.123"));
+        rowUser.setField(20, Timestamp.valueOf("2014-03-01 12:34:56.123456"));
         rowUser.setField(21, BigDecimal.valueOf(2000, 2));
         rowUser.setField(22, BigDecimal.valueOf(2000, 2));
 

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/utils/TestDataGenerator.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/utils/TestDataGenerator.java
@@ -30,7 +30,6 @@ import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -58,10 +57,10 @@ public class TestDataGenerator {
                 generateRandomAddress(rnd),
                 generateRandomBytes(rnd),
                 LocalDate.parse("2014-03-01"),
-                LocalTime.parse("12:12:12"),
-                LocalTime.ofSecondOfDay(0).plus(123456L, ChronoUnit.MICROS),
-                Instant.parse("2014-03-01T12:12:12.321Z"),
-                Instant.ofEpochSecond(0).plus(123456L, ChronoUnit.MICROS),
+                LocalTime.parse("12:34:56.123"),
+                LocalTime.parse("12:34:56.123456"),
+                Instant.parse("2014-03-01T12:34:56.123Z"),
+                Instant.parse("2014-03-01T12:34:56.123456Z"),
                 ByteBuffer.wrap(BigDecimal.valueOf(2000, 2).unscaledValue().toByteArray()),
                 new Fixed2(BigDecimal.valueOf(2000, 2).unscaledValue().toByteArray()));
     }

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/table/runtime/batch/AvroTypesITCase.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/table/runtime/batch/AvroTypesITCase.java
@@ -44,7 +44,6 @@ import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -84,11 +83,10 @@ public class AvroTypesITCase extends AbstractTestBase {
                                     .build())
                     .setTypeBytes(ByteBuffer.allocate(10))
                     .setTypeDate(LocalDate.parse("2014-03-01"))
-                    .setTypeTimeMillis(LocalTime.parse("12:12:12"))
-                    .setTypeTimeMicros(LocalTime.ofSecondOfDay(0).plus(123456L, ChronoUnit.MICROS))
-                    .setTypeTimestampMillis(Instant.parse("2014-03-01T12:12:12.321Z"))
-                    .setTypeTimestampMicros(
-                            Instant.ofEpochSecond(0).plus(123456L, ChronoUnit.MICROS))
+                    .setTypeTimeMillis(LocalTime.parse("12:34:56.123"))
+                    .setTypeTimeMicros(LocalTime.parse("12:34:56.123456"))
+                    .setTypeTimestampMillis(Instant.parse("2014-03-01T12:34:56.123Z"))
+                    .setTypeTimestampMicros(Instant.parse("2014-03-01T12:34:56.123456Z"))
                     .setTypeDecimalBytes(
                             ByteBuffer.wrap(
                                     BigDecimal.valueOf(2000, 2).unscaledValue().toByteArray()))
@@ -114,11 +112,10 @@ public class AvroTypesITCase extends AbstractTestBase {
                     .setTypeNested(null)
                     .setTypeDate(LocalDate.parse("2014-03-01"))
                     .setTypeBytes(ByteBuffer.allocate(10))
-                    .setTypeTimeMillis(LocalTime.parse("12:12:12"))
-                    .setTypeTimeMicros(LocalTime.ofSecondOfDay(0).plus(123456L, ChronoUnit.MICROS))
-                    .setTypeTimestampMillis(Instant.parse("2014-03-01T12:12:12.321Z"))
-                    .setTypeTimestampMicros(
-                            Instant.ofEpochSecond(0).plus(123456L, ChronoUnit.MICROS))
+                    .setTypeTimeMillis(LocalTime.parse("12:34:56.123"))
+                    .setTypeTimeMicros(LocalTime.parse("12:34:56.123456"))
+                    .setTypeTimestampMillis(Instant.parse("2014-03-01T12:34:56.123Z"))
+                    .setTypeTimestampMicros(Instant.parse("2014-03-01T12:34:56.123456Z"))
                     .setTypeDecimalBytes(
                             ByteBuffer.wrap(
                                     BigDecimal.valueOf(2000, 2).unscaledValue().toByteArray()))
@@ -144,11 +141,10 @@ public class AvroTypesITCase extends AbstractTestBase {
                     .setTypeNested(null)
                     .setTypeBytes(ByteBuffer.allocate(10))
                     .setTypeDate(LocalDate.parse("2014-03-01"))
-                    .setTypeTimeMillis(LocalTime.parse("12:12:12"))
-                    .setTypeTimeMicros(LocalTime.ofSecondOfDay(0).plus(123456L, ChronoUnit.MICROS))
-                    .setTypeTimestampMillis(Instant.parse("2014-03-01T12:12:12.321Z"))
-                    .setTypeTimestampMicros(
-                            Instant.ofEpochSecond(0).plus(123456L, ChronoUnit.MICROS))
+                    .setTypeTimeMillis(LocalTime.parse("12:34:56.123"))
+                    .setTypeTimeMicros(LocalTime.parse("12:34:56.123456"))
+                    .setTypeTimestampMillis(Instant.parse("2014-03-01T12:34:56.123Z"))
+                    .setTypeTimestampMicros(Instant.parse("2014-03-01T12:34:56.123456Z"))
                     .setTypeDecimalBytes(
                             ByteBuffer.wrap(
                                     BigDecimal.valueOf(2000, 2).unscaledValue().toByteArray()))
@@ -173,17 +169,17 @@ public class AvroTypesITCase extends AbstractTestBase {
         String expected =
                 "+I[black, null, Whatever, [true], [hello], true, java.nio.HeapByteBuffer[pos=0 lim=10 cap=10], "
                         + "2014-03-01, java.nio.HeapByteBuffer[pos=0 lim=2 cap=2], [7, -48], 0.0, GREEN, "
-                        + "[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], 42, {}, null, null, null, 00:00:00.123456, "
-                        + "12:12:12, 1970-01-01T00:00:00.123456Z, 2014-03-01T12:12:12.321Z, null]\n"
+                        + "[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], 42, {}, null, null, null, 12:34:56.123456, "
+                        + "12:34:56.123, 2014-03-01T12:34:56.123456Z, 2014-03-01T12:34:56.123Z, null]\n"
                         + "+I[blue, null, Charlie, [], [], false, java.nio.HeapByteBuffer[pos=0 lim=10 cap=10], 2014-03-01, "
                         + "java.nio.HeapByteBuffer[pos=0 lim=2 cap=2], [7, -48], 1.337, RED, null, 1337, {}, "
-                        + "+I[Berlin, 42, Berlin, Bakerstreet, 12049], null, null, 00:00:00.123456, 12:12:12, 1970-01-01T00:00:00.123456Z, "
-                        + "2014-03-01T12:12:12.321Z, null]\n"
+                        + "+I[Berlin, 42, Berlin, Bakerstreet, 12049], null, null, 12:34:56.123456, 12:34:56.123, 2014-03-01T12:34:56.123456Z, "
+                        + "2014-03-01T12:34:56.123Z, null]\n"
                         + "+I[yellow, null, Terminator, [false], [world], false, "
                         + "java.nio.HeapByteBuffer[pos=0 lim=10 cap=10], 2014-03-01, "
                         + "java.nio.HeapByteBuffer[pos=0 lim=2 cap=2], [7, -48], 0.0, GREEN, "
-                        + "[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], 1, {}, null, null, null, 00:00:00.123456, "
-                        + "12:12:12, 1970-01-01T00:00:00.123456Z, 2014-03-01T12:12:12.321Z, null]";
+                        + "[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], 1, {}, null, null, null, 12:34:56.123456, "
+                        + "12:34:56.123, 2014-03-01T12:34:56.123456Z, 2014-03-01T12:34:56.123Z, null]";
         TestBaseUtils.compareResultAsText(results, expected);
     }
 

--- a/flink-formats/flink-avro/src/test/resources/avro/user.avsc
+++ b/flink-formats/flink-avro/src/test/resources/avro/user.avsc
@@ -112,6 +112,7 @@
    "name": "LogicalTimeRecord",
    "fields": [
        {"name": "type_timestamp_millis", "type": {"type": "long", "logicalType": "timestamp-millis"}},
+       {"name": "type_timestamp_micros", "type": {"type": "long", "logicalType": "timestamp-micros"}},
        {"name": "type_date", "type": {"type": "int", "logicalType": "date"}},
        {"name": "type_time_millis", "type": {"type": "int", "logicalType": "time-millis"}}
    ]


### PR DESCRIPTION
## What is the purpose of the change

Add support for microsecond precision for timestamp in Avro.


## Brief change log

  - Add support for microsecond precision for timestamp in `AvroRowDataDeserializationSchema`.
  - Adjust tests to use different digits for `hours:mins:seconds`
  - Adjust tests to use complete timestamp and time when testing micros


## Verifying this change

This change added tests and can be verified as follows:

  - `AvroRowDataDeSerializationSchemaTest#testSpecificType`
  - Adjusted all other tests to use full data/time when testing timestamp/time with micros
  
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
