### PR TITLE
[FLINK-27333] Flink filesystems hadoop version upgrade to 3.3.2

### DIFF
--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/java/org/apache/flink/fs/s3hadoop/HadoopS3AccessHelper.java
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/java/org/apache/flink/fs/s3hadoop/HadoopS3AccessHelper.java
@@ -54,19 +54,15 @@ public class HadoopS3AccessHelper implements S3AccessHelper {
 
     private final InternalWriteOperationHelper s3accessHelper;
 
-    public HadoopS3AccessHelper(
-            S3AFileSystem s3a,
-            Configuration conf,
-            S3AStatisticsContext statisticsContext,
-            AuditSpanSource auditSpanSource,
-            AuditSpan auditSpan) {
+    public HadoopS3AccessHelper(S3AFileSystem s3a, Configuration conf) {
+        checkNotNull(s3a);
         this.s3accessHelper =
                 new InternalWriteOperationHelper(
-                        checkNotNull(s3a),
+                        s3a,
                         checkNotNull(conf),
-                        statisticsContext,
-                        auditSpanSource,
-                        auditSpan);
+                        s3a.createStoreContext().getInstrumentation(),
+                        s3a.getAuditSpanSource(),
+                        s3a.getActiveAuditSpan());
         this.s3a = s3a;
     }
 

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/java/org/apache/flink/fs/s3hadoop/HadoopS3AccessHelper.java
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/java/org/apache/flink/fs/s3hadoop/HadoopS3AccessHelper.java
@@ -34,6 +34,9 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.s3a.S3AFileSystem;
 import org.apache.hadoop.fs.s3a.S3AUtils;
 import org.apache.hadoop.fs.s3a.WriteOperationHelper;
+import org.apache.hadoop.fs.s3a.statistics.S3AStatisticsContext;
+import org.apache.hadoop.fs.store.audit.AuditSpan;
+import org.apache.hadoop.fs.store.audit.AuditSpanSource;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -51,9 +54,19 @@ public class HadoopS3AccessHelper implements S3AccessHelper {
 
     private final InternalWriteOperationHelper s3accessHelper;
 
-    public HadoopS3AccessHelper(S3AFileSystem s3a, Configuration conf) {
+    public HadoopS3AccessHelper(
+            S3AFileSystem s3a,
+            Configuration conf,
+            S3AStatisticsContext statisticsContext,
+            AuditSpanSource auditSpanSource,
+            AuditSpan auditSpan) {
         this.s3accessHelper =
-                new InternalWriteOperationHelper(checkNotNull(s3a), checkNotNull(conf));
+                new InternalWriteOperationHelper(
+                        checkNotNull(s3a),
+                        checkNotNull(conf),
+                        statisticsContext,
+                        auditSpanSource,
+                        auditSpan);
         this.s3a = s3a;
     }
 
@@ -144,8 +157,13 @@ public class HadoopS3AccessHelper implements S3AccessHelper {
      */
     private static final class InternalWriteOperationHelper extends WriteOperationHelper {
 
-        InternalWriteOperationHelper(S3AFileSystem owner, Configuration conf) {
-            super(owner, conf);
+        InternalWriteOperationHelper(
+                S3AFileSystem owner,
+                Configuration conf,
+                S3AStatisticsContext statisticsContext,
+                AuditSpanSource auditSpanSource,
+                AuditSpan auditSpan) {
+            super(owner, conf, statisticsContext, auditSpanSource, auditSpan);
         }
     }
 }

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/java/org/apache/flink/fs/s3hadoop/S3FileSystemFactory.java
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/java/org/apache/flink/fs/s3hadoop/S3FileSystemFactory.java
@@ -94,11 +94,6 @@ public class S3FileSystemFactory extends AbstractS3FileSystemFactory {
     @Override
     protected S3AccessHelper getS3AccessHelper(FileSystem fs) {
         final S3AFileSystem s3Afs = (S3AFileSystem) fs;
-        return new HadoopS3AccessHelper(
-                s3Afs,
-                s3Afs.getConf(),
-                s3Afs.createStoreContext().getInstrumentation(),
-                s3Afs.getAuditSpanSource(),
-                s3Afs.getActiveAuditSpan());
+        return new HadoopS3AccessHelper(s3Afs, s3Afs.getConf());
     }
 }

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/java/org/apache/flink/fs/s3hadoop/S3FileSystemFactory.java
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/java/org/apache/flink/fs/s3hadoop/S3FileSystemFactory.java
@@ -94,6 +94,11 @@ public class S3FileSystemFactory extends AbstractS3FileSystemFactory {
     @Override
     protected S3AccessHelper getS3AccessHelper(FileSystem fs) {
         final S3AFileSystem s3Afs = (S3AFileSystem) fs;
-        return new HadoopS3AccessHelper(s3Afs, s3Afs.getConf());
+        return new HadoopS3AccessHelper(
+                s3Afs,
+                s3Afs.getConf(),
+                s3Afs.createStoreContext().getInstrumentation(),
+                s3Afs.getAuditSpanSource(),
+                s3Afs.getActiveAuditSpan());
     }
 }

--- a/flink-filesystems/pom.xml
+++ b/flink-filesystems/pom.xml
@@ -35,7 +35,7 @@ under the License.
 	<packaging>pom</packaging>
 
 	<properties>
-		<fs.hadoopshaded.version>3.2.2</fs.hadoopshaded.version>
+		<fs.hadoopshaded.version>3.3.2</fs.hadoopshaded.version>
 	</properties>
 
 	<modules>


### PR DESCRIPTION
## What is the purpose of the change

This PR upgrades flink-filesystems hadoop version to 3.3.2 and makes the necessary code changes as part of changes to constructors in hadoop 3.3.2 code. 

Context: We have a security requirement to client side encrypt flink state for certain flink applications that process sensitive data.
One way to do it is to use flink-s3-fs-hadoop compiled against hadoop 3.3.2 for checkpoints as hadoop 3.3.2 provides out of the box AWS client side encryption using AWS KMS keys before writing the data to S3.  (https://issues.apache.org/jira/browse/HADOOP-13887) 


## Brief change log

Change shaded hadoop version to 3.3.2 in flink-filesystems pom.xml
Update arguments for methods connected to `WriteOperationHelper` since hadoop 3.3.2 introduces 3 new arguments to its constructor. 


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

Tested on flink jobs with jar flink-s3-fs-hadoop in checkpoint plugin path at Apple Flink Infrastructure for Flink version 1.14.3

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (yes)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
