### PR TITLE
[FLINK-27167][test] fix javadoc issue

### DIFF
--- a/flink-architecture-tests/flink-architecture-tests-production/pom.xml
+++ b/flink-architecture-tests/flink-architecture-tests-production/pom.xml
@@ -60,6 +60,13 @@ under the License.
 			<scope>compile</scope>
 		</dependency>
 
+		<!-- test dependencies required for javadoc-plugin, reference: FLINK-27167-->
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<scope>compile</scope>
+		</dependency>
+
 		<!-- Tested Flink modules -->
 
 		<dependency>


### PR DESCRIPTION
## What is the purpose of the change

got "javadoc: error - class file for org.junit.platform.commons.annotation.Testable not found" error while performing javadoc-plugin.


## Brief change log

  - change the junit-jupiter dependency scope to compile

## Verifying this change

mvn javadoc:javadoc works without error.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
