### PR TITLE
[hotfix][docs-zh] Delete redundant English content in Chinese documents.

### DIFF
--- a/docs/content.zh/docs/dev/table/concepts/time_attributes.md
+++ b/docs/content.zh/docs/dev/table/concepts/time_attributes.md
@@ -233,9 +233,6 @@ val windowedTable = tEnv
 
 事件时间属性可以用 WATERMARK 语句在 CREATE TABLE DDL 中进行定义。WATERMARK 语句在一个已有字段上定义一个 watermark 生成表达式，同时标记这个已有字段为时间属性字段。更多信息可以参考：[CREATE TABLE DDL]({{< ref "docs/dev/table/sql/create" >}}#create-table)
 
-Flink supports defining event time attribute on TIMESTAMP column and TIMESTAMP_LTZ column. 
-If the data source contains timestamp literal, it's recommended to defining event time attribute on TIMESTAMP column:
-
 Flink 支持和在 TIMESTAMP 列和 TIMESTAMP_LTZ 列上定义事件时间。如果源数据中的时间戳数据表示为年-月-日-时-分-秒，则通常为不带时区信息的字符串值，例如 `2020-04-15 20:13:40.564`，建议将事件时间属性定义在 `TIMESTAMP` 列上:
 ```sql
 


### PR DESCRIPTION

## What is the purpose of the change

### This is the Chinese document：

![image](https://user-images.githubusercontent.com/95120044/164424061-c50a0caa-6084-4edf-9dd7-9d6bdcbf9dcb.png)


**As can be seen from the above picture, there is an extra part of English content in the Chinese document, so the extra part needs to be deleted.**


## Brief change log

Delete redundant English content in Chinese documents.


## Verifying this change
Delete redundant English content in Chinese documents.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (  no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): ( no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no )
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
