### PR TITLE
[FLINK-22984][python] Disable PushWatermarkIntoTableSourceScanAcrossCalcRule when having Python UDF

### DIFF
--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/utils/JavaUserDefinedScalarFunctions.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/utils/JavaUserDefinedScalarFunctions.java
@@ -295,11 +295,12 @@ public class JavaUserDefinedScalarFunctions {
         }
     }
 
+    /** A Python UDF that returns current timestamp with any input. */
     public static class PythonTimestampScalarFunction extends ScalarFunction
             implements PythonFunction {
 
         @DataTypeHint("TIMESTAMP(3)")
-        public LocalDateTime eval(Integer i) {
+        public LocalDateTime eval(@DataTypeHint(inputGroup = InputGroup.ANY) Object... o) {
             return LocalDateTime.now();
         }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/utils/JavaUserDefinedScalarFunctions.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/utils/JavaUserDefinedScalarFunctions.java
@@ -29,6 +29,7 @@ import org.apache.flink.table.functions.python.PythonFunctionKind;
 import org.apache.flink.types.Row;
 
 import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.util.Random;
 import java.util.TimeZone;
 
@@ -291,6 +292,25 @@ public class JavaUserDefinedScalarFunctions {
         @Override
         public PythonFunctionKind getPythonFunctionKind() {
             return PythonFunctionKind.PANDAS;
+        }
+    }
+
+    public static class PythonTimestampScalarFunction extends ScalarFunction
+            implements PythonFunction {
+
+        @DataTypeHint("TIMESTAMP(3)")
+        public LocalDateTime eval(Integer i) {
+            return LocalDateTime.now();
+        }
+
+        @Override
+        public byte[] getSerializedPythonFunction() {
+            return new byte[0];
+        }
+
+        @Override
+        public PythonEnv getPythonEnv() {
+            return null;
         }
     }
 }

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushWatermarkIntoTableSourceScanRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushWatermarkIntoTableSourceScanRuleTest.xml
@@ -194,4 +194,25 @@ FlinkLogicalCalc(select=[a, b, c, d])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testWatermarkWithPythonFunctionInComputedColumn">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1])
++- LogicalWatermarkAssigner(rowtime=[b], watermark=[$1])
+   +- LogicalProject(a=[$0], b=[parse_ts($0)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+FlinkLogicalCalc(select=[a, b])
++- FlinkLogicalWatermarkAssigner(rowtime=[b], watermark=[$1])
+   +- FlinkLogicalCalc(select=[a, parse_ts(a) AS b])
+      +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a])
+]]>
+    </Resource>
+  </TestCase>
 </Root>


### PR DESCRIPTION
## What is the purpose of the change

This pr fixes [FLINK-22984](https://issues.apache.org/jira/browse/FLINK-22984), which is caused by `PushWatermarkIntoTableSourceScanAcrossCalcRule` pushing Python UDF in computed column into the table source, so that Python UDF cannot be converted to PythonCalc node and later `PythonScalarFunctionOperator`.


## Brief change log

- add `containsPythonCall` condition in `PushWatermarkIntoTableSourceScanAcrossCalcRule`


## Verifying this change


This change added tests and can be verified as follows:

- Added rule test `testWatermarkWithPythonFunctionInComputedColumn`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
