### PR TITLE
[FLINK-27242][table] Support RENAME PARTITION statement for partitioned table

### DIFF
--- a/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
+++ b/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
@@ -29,6 +29,7 @@
     "org.apache.flink.sql.parser.ddl.SqlAddJar"
     "org.apache.flink.sql.parser.ddl.SqlAlterDatabase"
     "org.apache.flink.sql.parser.ddl.SqlAlterFunction"
+    "org.apache.flink.sql.parser.ddl.SqlAlterPartitionRename"
     "org.apache.flink.sql.parser.ddl.SqlAlterTable"
     "org.apache.flink.sql.parser.ddl.SqlAlterTableAddConstraint"
     "org.apache.flink.sql.parser.ddl.SqlAlterTableCompact"

--- a/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
@@ -588,10 +588,24 @@ SqlAlterTable SqlAlterTable() :
                 PartitionSpecCommaList(partitionSpec);
             }
         ]
-        <COMPACT>
-        {
-            return new SqlAlterTableCompact(startPos.plus(getPos()), tableIdentifier, partitionSpec);
-        }
+        (
+            <RENAME> <TO> <PARTITION> {
+                SqlNodeList newPartSpec = new SqlNodeList(getPos());
+                PartitionSpecCommaList(newPartSpec);
+                return new SqlAlterPartitionRename(
+                            startPos.plus(getPos()),
+                            tableIdentifier,
+                            partitionSpec,
+                            newPartSpec);
+            }
+        |
+            <COMPACT> {
+                return new SqlAlterTableCompact(
+                            startPos.plus(getPos()),
+                            tableIdentifier,
+                            partitionSpec);
+            }
+        )
     )
 }
 

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlAlterPartitionRename.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlAlterPartitionRename.java
@@ -1,0 +1,79 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.flink.sql.parser.ddl;
+
+import org.apache.flink.sql.parser.SqlPartitionUtils;
+
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.util.ImmutableNullableList;
+
+import javax.annotation.Nonnull;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+/** ALTER TABLE DDL to change the specifications of a partition. */
+public class SqlAlterPartitionRename extends SqlAlterTable {
+
+    private final SqlNodeList newPartSpec;
+
+    public SqlAlterPartitionRename(
+            SqlParserPos pos,
+            SqlIdentifier tableName,
+            SqlNodeList partSpec,
+            SqlNodeList newPartSpec) {
+        super(
+                pos,
+                tableName,
+                requireNonNull(
+                        partSpec, "Old partition spec have to be specified when rename partition"));
+        this.newPartSpec = newPartSpec;
+    }
+
+    @Nonnull
+    @Override
+    public List<SqlNode> getOperandList() {
+        return ImmutableNullableList.of(tableIdentifier, getPartitionSpec(), newPartSpec);
+    }
+
+    @Override
+    public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+        super.unparse(writer, leftPrec, rightPrec);
+        writer.newlineAndIndent();
+        writer.keyword("RENAME TO");
+        writer.newlineAndIndent();
+        writer.keyword("PARTITION");
+        newPartSpec.unparse(writer, getOperator().getLeftPrec(), getOperator().getRightPrec());
+    }
+
+    public SqlNodeList getNewPartSpec() {
+        return newPartSpec;
+    }
+
+    /** Get partition spec as key-value strings. */
+    public LinkedHashMap<String, String> getNewPartitionKVs() {
+        return SqlPartitionUtils.getPartitionKVs(getNewPartSpec());
+    }
+}

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -339,6 +339,21 @@ class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
+    public void testAlterPartitionRename() {
+        sql("alter table tbl partition (p=1) rename to partition (p=2)")
+                .ok(
+                        "ALTER TABLE `TBL` PARTITION (`P` = 1)\n"
+                                + "RENAME TO\n"
+                                + "PARTITION (`P` = 2)");
+
+        sql("alter table tbl rename to partition (p=2)")
+                .ok(
+                        "ALTER TABLE `TBL` PARTITION (`P` = 1)\n"
+                                + "RENAME TO\n"
+                                + "PARTITION (`P` = 2)");
+    }
+
+    @Test
     void testCreateTable() {
         final String sql =
                 "CREATE TABLE tbl1 (\n"

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/PartitionRenameOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/PartitionRenameOperation.java
@@ -1,0 +1,64 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.flink.table.operations.ddl;
+
+import org.apache.flink.table.catalog.CatalogPartition;
+import org.apache.flink.table.catalog.CatalogPartitionSpec;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.operations.OperationUtils;
+
+/** Operation to describe a ALTER TABLE .. PARTITION .. RENAME TO PARTITION .. statement. */
+public class PartitionRenameOperation extends AlterPartitionOperation {
+
+    private final CatalogPartitionSpec newPartSpec;
+    private final CatalogPartition newPartition;
+
+    public PartitionRenameOperation(
+            ObjectIdentifier tableIdentifier,
+            CatalogPartitionSpec partSpec,
+            CatalogPartitionSpec newPartSpec,
+            CatalogPartition newPartition) {
+        super(tableIdentifier, partSpec);
+        this.newPartSpec = newPartSpec;
+        this.newPartition = newPartition;
+    }
+
+    public CatalogPartitionSpec getNewPartSpec() {
+        return newPartSpec;
+    }
+
+    public CatalogPartition getNewPartition() {
+        return newPartition;
+    }
+
+    @Override
+    public String asSummaryString() {
+        StringBuilder builder =
+                new StringBuilder(
+                        String.format("ALTER TABLE %s", tableIdentifier.asSummaryString()));
+        builder.append(
+                String.format(
+                        " PARTITION (%s)", OperationUtils.formatPartitionSpec(getPartitionSpec())));
+        builder.append(" RENAME TO");
+        builder.append(
+                String.format(" PARTITION (%s)", OperationUtils.formatPartitionSpec(newPartSpec)));
+
+        return builder.toString();
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

*Support RENAME PARTITION statement for partitioned table*


## Brief change log

  - *Support RENAME PARTITION statement for partitioned table*


## Verifying this change
This change added tests and can be verified as follows:

  - *Added unit tests in SqlToOperationConverterTest*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
