### PR TITLE
[FLINK-27352][tests] [JUnit5 Migration] Module: flink-json

### DIFF
--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonBatchFileSystemITCase.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonBatchFileSystemITCase.java
@@ -18,13 +18,15 @@
 
 package org.apache.flink.formats.json;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.planner.runtime.batch.sql.BatchFileSystemITCaseBase;
 import org.apache.flink.table.utils.LegacyRowExtension;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.FileUtils;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
@@ -34,15 +36,12 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
-import org.junit.jupiter.api.io.TempDir;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** ITCase to test json format for {@link JsonFormatFactory}. */
 class JsonBatchFileSystemITCase extends BatchFileSystemITCaseBase {
 
-    @RegisterExtension
-    LegacyRowExtension usesLegacyRows= LegacyRowExtension.INSTANCE;
+    @RegisterExtension LegacyRowExtension usesLegacyRows = LegacyRowExtension.INSTANCE;
 
     @TempDir private static File temporaryFolder;
 
@@ -67,7 +66,8 @@ class JsonBatchFileSystemITCase extends BatchFileSystemITCaseBase {
                                 + "'connector' = 'filesystem',"
                                 + "'path' = '%s',"
                                 + "%s)",
-                        "file://"+temporaryFolder.toString(), String.join(",\n", formatProperties()));
+                        "file://" + temporaryFolder.toString(),
+                        String.join(",\n", formatProperties()));
         tEnv().executeSql(sql);
 
         String path = new URI(temporaryFolder.toString()).getPath();

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonFormatFactoryTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonFormatFactoryTest.java
@@ -46,10 +46,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for the {@link JsonFormatFactory}. */
-public class JsonFormatFactoryTest {
+class JsonFormatFactoryTest {
 
     @Test
-    public void testSeDeSchema() {
+    void testSeDeSchema() {
         final Map<String, String> tableOptions = getAllOptions();
 
         testSchemaSerializationSchema(tableOptions);
@@ -57,7 +57,7 @@ public class JsonFormatFactoryTest {
     }
 
     @Test
-    public void testFailOnMissingField() {
+    void testFailOnMissingField() {
         final Map<String, String> tableOptions =
                 getModifyOptions(options -> options.put("json.fail-on-missing-field", "true"));
 
@@ -69,7 +69,7 @@ public class JsonFormatFactoryTest {
     }
 
     @Test
-    public void testInvalidOptionForIgnoreParseErrors() {
+    void testInvalidOptionForIgnoreParseErrors() {
         final Map<String, String> tableOptions =
                 getModifyOptions(options -> options.put("json.ignore-parse-errors", "abc"));
 
@@ -81,7 +81,7 @@ public class JsonFormatFactoryTest {
     }
 
     @Test
-    public void testInvalidOptionForTimestampFormat() {
+    void testInvalidOptionForTimestampFormat() {
         final Map<String, String> tableOptions =
                 getModifyOptions(options -> options.put("json.timestamp-format.standard", "test"));
 
@@ -93,7 +93,7 @@ public class JsonFormatFactoryTest {
     }
 
     @Test
-    public void testLowerCaseOptionForTimestampFormat() {
+    void testLowerCaseOptionForTimestampFormat() {
         final Map<String, String> tableOptions =
                 getModifyOptions(
                         options -> options.put("json.timestamp-format.standard", "iso-8601"));
@@ -106,7 +106,7 @@ public class JsonFormatFactoryTest {
     }
 
     @Test
-    public void testInvalidOptionForMapNullKeyMode() {
+    void testInvalidOptionForMapNullKeyMode() {
         final Map<String, String> tableOptions =
                 getModifyOptions(options -> options.put("json.map-null-key.mode", "invalid"));
 
@@ -118,7 +118,7 @@ public class JsonFormatFactoryTest {
     }
 
     @Test
-    public void testLowerCaseOptionForMapNullKeyMode() {
+    void testLowerCaseOptionForMapNullKeyMode() {
         final Map<String, String> tableOptions =
                 getModifyOptions(options -> options.put("json.map-null-key.mode", "fail"));
 

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonNodeDeserializationSchemaTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonNodeDeserializationSchemaTest.java
@@ -17,20 +17,22 @@
 
 package org.apache.flink.formats.json;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.ObjectNode;
 
-import org.junit.Test;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+
 
 /** Tests for the {@link JsonNodeDeserializationSchema}. */
-public class JsonNodeDeserializationSchemaTest {
+class JsonNodeDeserializationSchemaTest {
 
     @Test
-    public void testDeserialize() throws IOException {
+    void testDeserialize() throws IOException {
         ObjectMapper mapper = new ObjectMapper();
         ObjectNode initialValue = mapper.createObjectNode();
         initialValue.put("key", 4).put("value", "world");
@@ -39,7 +41,7 @@ public class JsonNodeDeserializationSchemaTest {
         JsonNodeDeserializationSchema schema = new JsonNodeDeserializationSchema();
         ObjectNode deserializedValue = schema.deserialize(serializedValue);
 
-        assertEquals(4, deserializedValue.get("key").asInt());
-        assertEquals("world", deserializedValue.get("value").asText());
+        assertThat(deserializedValue.get("key").asInt()).isEqualTo(4);
+        assertThat(deserializedValue.get("value").asText()).isEqualTo("world");
     }
 }

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonNodeDeserializationSchemaTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonNodeDeserializationSchemaTest.java
@@ -17,16 +17,14 @@
 
 package org.apache.flink.formats.json;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.ObjectNode;
 
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import org.junit.jupiter.api.Test;
-
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for the {@link JsonNodeDeserializationSchema}. */
 class JsonNodeDeserializationSchemaTest {

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonRowDataSerDeSchemaTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonRowDataSerDeSchemaTest.java
@@ -19,7 +19,7 @@
 package org.apache.flink.formats.json;
 
 import org.apache.flink.api.common.typeinfo.TypeInformation;
-import org.apache.flink.core.testutils.FlinkMatchers;
+import org.apache.flink.core.testutils.FlinkAssertions;
 import org.apache.flink.formats.common.TimestampFormat;
 import org.apache.flink.table.data.GenericMapData;
 import org.apache.flink.table.data.GenericRowData;
@@ -34,9 +34,6 @@ import org.apache.flink.types.Row;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.ArrayNode;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.ObjectNode;
-
-import org.junit.Assert;
-import org.junit.Test;
 
 import java.math.BigDecimal;
 import java.sql.Timestamp;
@@ -53,6 +50,9 @@ import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 
+import org.junit.jupiter.api.Test;
+
+import static org.apache.flink.core.testutils.FlinkAssertions.anyCauseMatches;
 import static org.apache.flink.table.api.DataTypes.ARRAY;
 import static org.apache.flink.table.api.DataTypes.BIGINT;
 import static org.apache.flink.table.api.DataTypes.BOOLEAN;
@@ -73,18 +73,16 @@ import static org.apache.flink.table.api.DataTypes.TIMESTAMP;
 import static org.apache.flink.table.api.DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE;
 import static org.apache.flink.table.api.DataTypes.TINYINT;
 import static org.apache.flink.table.types.utils.TypeConversions.fromLogicalToDataType;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Tests for {@link JsonRowDataDeserializationSchema} and {@link JsonRowDataSerializationSchema}.
  */
-public class JsonRowDataSerDeSchemaTest {
+class JsonRowDataSerDeSchemaTest {
 
     @Test
-    public void testSerDe() throws Exception {
+    void testSerDe() throws Exception {
         byte tinyint = 'c';
         short smallint = 128;
         int intValue = 45536;
@@ -190,7 +188,7 @@ public class JsonRowDataSerDeSchemaTest {
 
         RowData rowData = deserializationSchema.deserialize(serializedJson);
         Row actual = convertToExternal(rowData, dataType);
-        assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
 
         // test serialization
         JsonRowDataSerializationSchema serializationSchema =
@@ -202,7 +200,7 @@ public class JsonRowDataSerDeSchemaTest {
                         true);
 
         byte[] actualBytes = serializationSchema.serialize(rowData);
-        assertEquals(new String(serializedJson), new String(actualBytes));
+        assertThat(new String(actualBytes)).isEqualTo(new String(serializedJson));
     }
 
     /**
@@ -210,7 +208,7 @@ public class JsonRowDataSerDeSchemaTest {
      * Double#parseDouble(String)}.
      */
     @Test
-    public void testSlowDeserialization() throws Exception {
+    void testSlowDeserialization() throws Exception {
         Random random = new Random();
         boolean bool = random.nextBoolean();
         int integer = random.nextInt();
@@ -260,11 +258,11 @@ public class JsonRowDataSerDeSchemaTest {
 
         RowData rowData = deserializationSchema.deserialize(serializedJson);
         Row actual = convertToExternal(rowData, dataType);
-        assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
     }
 
     @Test
-    public void testSerDeMultiRows() throws Exception {
+    void testSerDeMultiRows() throws Exception {
         RowType rowType =
                 (RowType)
                         ROW(
@@ -310,7 +308,7 @@ public class JsonRowDataSerDeSchemaTest {
             byte[] serializedJson = objectMapper.writeValueAsBytes(root);
             RowData rowData = deserializationSchema.deserialize(serializedJson);
             byte[] actual = serializationSchema.serialize(rowData);
-            assertEquals(new String(serializedJson), new String(actual));
+            assertThat(new String(actual)).isEqualTo(new String(serializedJson));
         }
 
         // the second row
@@ -330,12 +328,12 @@ public class JsonRowDataSerDeSchemaTest {
             byte[] serializedJson = objectMapper.writeValueAsBytes(root);
             RowData rowData = deserializationSchema.deserialize(serializedJson);
             byte[] actual = serializationSchema.serialize(rowData);
-            assertEquals(new String(serializedJson), new String(actual));
+            assertThat(new String(actual)).isEqualTo(new String(serializedJson));
         }
     }
 
     @Test
-    public void testSerDeMultiRowsWithNullValues() throws Exception {
+    void testSerDeMultiRowsWithNullValues() throws Exception {
         String[] jsons =
                 new String[] {
                     "{\"svt\":\"2020-02-24T12:58:09.209+0800\",\"metrics\":{\"k1\":10.01,\"k2\":\"invalid\"}}",
@@ -380,12 +378,12 @@ public class JsonRowDataSerDeSchemaTest {
             String json = jsons[i];
             RowData row = deserializationSchema.deserialize(json.getBytes());
             String result = new String(serializationSchema.serialize(row));
-            assertEquals(expected[i], result);
+            assertThat(result).isEqualTo(expected[i]);
         }
     }
 
     @Test
-    public void testDeserializationNullRow() throws Exception {
+    void testDeserializationNullRow() throws Exception {
         DataType dataType = ROW(FIELD("name", STRING()));
         RowType schema = (RowType) dataType.getLogicalType();
 
@@ -393,11 +391,11 @@ public class JsonRowDataSerDeSchemaTest {
                 new JsonRowDataDeserializationSchema(
                         schema, InternalTypeInfo.of(schema), true, false, TimestampFormat.ISO_8601);
 
-        assertNull(deserializationSchema.deserialize(null));
+        assertThat(deserializationSchema.deserialize(null)).isNull();
     }
 
     @Test
-    public void testDeserializationMissingNode() throws Exception {
+    void testDeserializationMissingNode() throws Exception {
         DataType dataType = ROW(FIELD("name", STRING()));
         RowType schema = (RowType) dataType.getLogicalType();
 
@@ -405,11 +403,11 @@ public class JsonRowDataSerDeSchemaTest {
                 new JsonRowDataDeserializationSchema(
                         schema, InternalTypeInfo.of(schema), true, false, TimestampFormat.ISO_8601);
         RowData rowData = deserializationSchema.deserialize("".getBytes());
-        assertEquals(null, rowData);
+        assertThat(rowData).isNull();
     }
 
     @Test
-    public void testDeserializationMissingField() throws Exception {
+    void testDeserializationMissingField() throws Exception {
         ObjectMapper objectMapper = new ObjectMapper();
 
         // Root
@@ -431,7 +429,7 @@ public class JsonRowDataSerDeSchemaTest {
 
         Row expected = new Row(1);
         Row actual = convertToExternal(deserializationSchema.deserialize(serializedJson), dataType);
-        assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
 
         // fail on missing field
         deserializationSchema =
@@ -439,34 +437,27 @@ public class JsonRowDataSerDeSchemaTest {
                         schema, InternalTypeInfo.of(schema), true, false, TimestampFormat.ISO_8601);
 
         String errorMessage = "Failed to deserialize JSON '{\"id\":123123123}'.";
-        try {
-            deserializationSchema.deserialize(serializedJson);
-            fail("expecting exception message: " + errorMessage);
-        } catch (Throwable t) {
-            assertEquals(errorMessage, t.getMessage());
-        }
+
+        JsonRowDataDeserializationSchema finalDeserializationSchema = deserializationSchema;
+        assertThatThrownBy(() -> finalDeserializationSchema.deserialize(serializedJson))
+                .hasMessageContaining(errorMessage);
 
         // ignore on parse error
         deserializationSchema =
                 new JsonRowDataDeserializationSchema(
                         schema, InternalTypeInfo.of(schema), false, true, TimestampFormat.ISO_8601);
         actual = convertToExternal(deserializationSchema.deserialize(serializedJson), dataType);
-        assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
 
         errorMessage =
                 "JSON format doesn't support failOnMissingField and ignoreParseErrors are both enabled.";
-        try {
-            // failOnMissingField and ignoreParseErrors both enabled
-            new JsonRowDataDeserializationSchema(
-                    schema, InternalTypeInfo.of(schema), true, true, TimestampFormat.ISO_8601);
-            Assert.fail("expecting exception message: " + errorMessage);
-        } catch (Throwable t) {
-            assertEquals(errorMessage, t.getMessage());
-        }
+        assertThatThrownBy(() -> new JsonRowDataDeserializationSchema(
+                schema, InternalTypeInfo.of(schema), true, true, TimestampFormat.ISO_8601))
+                .hasMessageContaining(errorMessage);
     }
 
     @Test
-    public void testSerDeSQLTimestampFormat() throws Exception {
+    void testSerDeSQLTimestampFormat() throws Exception {
         RowType rowType =
                 (RowType)
                         ROW(
@@ -501,11 +492,11 @@ public class JsonRowDataSerDeSchemaTest {
         byte[] serializedJson = objectMapper.writeValueAsBytes(root);
         RowData rowData = deserializationSchema.deserialize(serializedJson);
         byte[] actual = serializationSchema.serialize(rowData);
-        assertEquals(new String(serializedJson), new String(actual));
+        assertThat(new String(actual)).isEqualTo(new String(serializedJson));
     }
 
     @Test
-    public void testSerializationMapNullKey() throws Exception {
+    void testSerializationMapNullKey(){
         RowType rowType =
                 (RowType)
                         ROW(FIELD("nestedMap", MAP(STRING(), MAP(STRING(), INT()))))
@@ -559,25 +550,22 @@ public class JsonRowDataSerDeSchemaTest {
         String expectResult3 =
                 "{\"nestedMap\":{\"no-null key\":{\"no-null key\":1,\"nullKey\":2},\"nullKey\":{\"no-null key\":1,\"nullKey\":2}}}";
 
-        try {
-            // throw exception when mapNullKey Mode is fail
-            serializationSchema1.serialize(rowData);
-            Assert.fail("expecting exception message: " + errorMessage1);
-        } catch (Throwable t) {
-            assertThat(t, FlinkMatchers.containsMessage(errorMessage1));
-        }
+        assertThatThrownBy(() -> serializationSchema1.serialize(rowData))
+                .satisfies(
+                        FlinkAssertions.anyCauseMatches(errorMessage1)
+                );
 
         // mapNullKey Mode is drop
         byte[] actual2 = serializationSchema2.serialize(rowData);
-        assertEquals(expectResult2, new String(actual2));
+        assertThat(new String(actual2)).isEqualTo(expectResult2);
 
         // mapNullKey Mode is literal
         byte[] actual3 = serializationSchema3.serialize(rowData);
-        assertEquals(expectResult3, new String(actual3));
+        assertThat(new String(actual3)).isEqualTo(expectResult3);
     }
 
     @Test
-    public void testSerializationDecimalEncode() throws Exception {
+    void testSerializationDecimalEncode() throws Exception {
         RowType schema =
                 (RowType)
                         ROW(
@@ -612,17 +600,17 @@ public class JsonRowDataSerDeSchemaTest {
         RowData rowData = deserializer.deserialize(plainDecimalJson.getBytes());
 
         String plainDecimalResult = new String(plainDecimalSerializer.serialize(rowData));
-        assertEquals(plainDecimalJson, plainDecimalResult);
+        assertThat(plainDecimalResult).isEqualTo(plainDecimalJson);
 
         String scientificDecimalJson =
                 "{\"decimal1\":123.456789,\"decimal2\":4.5462186404924617E+17,\"decimal3\":2.7E-8}";
 
         String scientificDecimalResult = new String(scientificDecimalSerializer.serialize(rowData));
-        assertEquals(scientificDecimalJson, scientificDecimalResult);
+        assertThat(scientificDecimalResult).isEqualTo(scientificDecimalJson);
     }
 
     @Test
-    public void testJsonParse() throws Exception {
+    void testJsonParse() throws Exception {
         for (TestSpec spec : testData) {
             testIgnoreParseErrors(spec);
             if (spec.errorMessage != null) {
@@ -632,7 +620,7 @@ public class JsonRowDataSerDeSchemaTest {
     }
 
     @Test
-    public void testSerializationWithTypesMismatch() {
+    void testSerializationWithTypesMismatch() {
         RowType rowType = (RowType) ROW(FIELD("f0", INT()), FIELD("f1", STRING())).getLogicalType();
         GenericRowData genericRowData = new GenericRowData(2);
         genericRowData.setField(0, 1);
@@ -645,28 +633,28 @@ public class JsonRowDataSerDeSchemaTest {
                         "null",
                         true);
         String errorMessage = "Fail to serialize at field: f1.";
-        try {
-            serializationSchema.serialize(genericRowData);
-            fail("expecting exception message: " + errorMessage);
-        } catch (Throwable t) {
-            assertThat(t, FlinkMatchers.containsMessage(errorMessage));
-        }
+
+        assertThatThrownBy(() -> serializationSchema.serialize(genericRowData))
+                .satisfies(
+                        anyCauseMatches(RuntimeException.class,
+                        errorMessage)
+                );
     }
 
     @Test
-    public void testDeserializationWithTypesMismatch() {
+    void testDeserializationWithTypesMismatch() {
         RowType rowType = (RowType) ROW(FIELD("f0", STRING()), FIELD("f1", INT())).getLogicalType();
         String json = "{\"f0\":\"abc\", \"f1\": \"abc\"}";
         JsonRowDataDeserializationSchema deserializationSchema =
                 new JsonRowDataDeserializationSchema(
                         rowType, InternalTypeInfo.of(rowType), false, false, TimestampFormat.SQL);
         String errorMessage = "Fail to deserialize at field: f1.";
-        try {
-            deserializationSchema.deserialize(json.getBytes());
-            fail("expecting exception message: " + errorMessage);
-        } catch (Throwable t) {
-            assertThat(t, FlinkMatchers.containsMessage(errorMessage));
-        }
+
+        assertThatThrownBy(() -> deserializationSchema.deserialize(json.getBytes()))
+                .satisfies(
+                        anyCauseMatches(RuntimeException.class,
+                                errorMessage)
+                );
     }
 
     private void testIgnoreParseErrors(TestSpec spec) throws Exception {
@@ -686,10 +674,10 @@ public class JsonRowDataSerDeSchemaTest {
         }
         RowData rowData = ignoreErrorsSchema.deserialize(spec.json.getBytes());
         Row actual = convertToExternal(rowData, fromLogicalToDataType(spec.rowType));
-        assertEquals("Test Ignore Parse Error: " + spec.json, expected, actual);
+        assertThat(actual).isEqualTo(expected).withFailMessage("Test Ignore Parse Error: " + spec.json);
     }
 
-    private void testParseErrors(TestSpec spec) throws Exception {
+    private void testParseErrors(TestSpec spec) {
         // expect exception if parse error is not ignored
         JsonRowDataDeserializationSchema failingSchema =
                 new JsonRowDataDeserializationSchema(
@@ -699,12 +687,8 @@ public class JsonRowDataSerDeSchemaTest {
                         false,
                         spec.timestampFormat);
 
-        try {
-            failingSchema.deserialize(spec.json.getBytes());
-            fail("expecting exception " + spec.errorMessage);
-        } catch (Throwable t) {
-            assertEquals(t.getMessage(), spec.errorMessage);
-        }
+        assertThatThrownBy(() -> failingSchema.deserialize(spec.json.getBytes()))
+                .hasMessageContaining(spec.errorMessage);
     }
 
     private static List<TestSpec> testData =

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonRowDataSerDeSchemaTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonRowDataSerDeSchemaTest.java
@@ -35,6 +35,8 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMap
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.ArrayNode;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.ObjectNode;
 
+import org.junit.jupiter.api.Test;
+
 import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.time.Instant;
@@ -49,8 +51,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
-
-import org.junit.jupiter.api.Test;
 
 import static org.apache.flink.core.testutils.FlinkAssertions.anyCauseMatches;
 import static org.apache.flink.table.api.DataTypes.ARRAY;
@@ -451,8 +451,14 @@ class JsonRowDataSerDeSchemaTest {
 
         errorMessage =
                 "JSON format doesn't support failOnMissingField and ignoreParseErrors are both enabled.";
-        assertThatThrownBy(() -> new JsonRowDataDeserializationSchema(
-                schema, InternalTypeInfo.of(schema), true, true, TimestampFormat.ISO_8601))
+        assertThatThrownBy(
+                        () ->
+                                new JsonRowDataDeserializationSchema(
+                                        schema,
+                                        InternalTypeInfo.of(schema),
+                                        true,
+                                        true,
+                                        TimestampFormat.ISO_8601))
                 .hasMessageContaining(errorMessage);
     }
 
@@ -496,7 +502,7 @@ class JsonRowDataSerDeSchemaTest {
     }
 
     @Test
-    void testSerializationMapNullKey(){
+    void testSerializationMapNullKey() {
         RowType rowType =
                 (RowType)
                         ROW(FIELD("nestedMap", MAP(STRING(), MAP(STRING(), INT()))))
@@ -551,9 +557,7 @@ class JsonRowDataSerDeSchemaTest {
                 "{\"nestedMap\":{\"no-null key\":{\"no-null key\":1,\"nullKey\":2},\"nullKey\":{\"no-null key\":1,\"nullKey\":2}}}";
 
         assertThatThrownBy(() -> serializationSchema1.serialize(rowData))
-                .satisfies(
-                        FlinkAssertions.anyCauseMatches(errorMessage1)
-                );
+                .satisfies(FlinkAssertions.anyCauseMatches(errorMessage1));
 
         // mapNullKey Mode is drop
         byte[] actual2 = serializationSchema2.serialize(rowData);
@@ -635,10 +639,7 @@ class JsonRowDataSerDeSchemaTest {
         String errorMessage = "Fail to serialize at field: f1.";
 
         assertThatThrownBy(() -> serializationSchema.serialize(genericRowData))
-                .satisfies(
-                        anyCauseMatches(RuntimeException.class,
-                        errorMessage)
-                );
+                .satisfies(anyCauseMatches(RuntimeException.class, errorMessage));
     }
 
     @Test
@@ -651,10 +652,7 @@ class JsonRowDataSerDeSchemaTest {
         String errorMessage = "Fail to deserialize at field: f1.";
 
         assertThatThrownBy(() -> deserializationSchema.deserialize(json.getBytes()))
-                .satisfies(
-                        anyCauseMatches(RuntimeException.class,
-                                errorMessage)
-                );
+                .satisfies(anyCauseMatches(RuntimeException.class, errorMessage));
     }
 
     private void testIgnoreParseErrors(TestSpec spec) throws Exception {
@@ -674,7 +672,9 @@ class JsonRowDataSerDeSchemaTest {
         }
         RowData rowData = ignoreErrorsSchema.deserialize(spec.json.getBytes());
         Row actual = convertToExternal(rowData, fromLogicalToDataType(spec.rowType));
-        assertThat(actual).isEqualTo(expected).withFailMessage("Test Ignore Parse Error: " + spec.json);
+        assertThat(actual)
+                .isEqualTo(expected)
+                .withFailMessage("Test Ignore Parse Error: " + spec.json);
     }
 
     private void testParseErrors(TestSpec spec) {

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonRowSchemaConverterTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonRowSchemaConverterTest.java
@@ -18,18 +18,18 @@
 
 package org.apache.flink.formats.json;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.util.FileUtils;
+
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.net.URL;
 import java.util.Objects;
 
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link JsonRowSchemaConverter}. */
 class JsonRowSchemaConverterTest {
@@ -120,8 +120,10 @@ class JsonRowSchemaConverterTest {
 
     @Test
     void testArrayWithAdditionalItems() {
-        assertThatThrownBy(() -> JsonRowSchemaConverter.convert(
-                "{ type: 'array', items: [{type: 'integer'}], additionalItems: true }"))
+        assertThatThrownBy(
+                        () ->
+                                JsonRowSchemaConverter.convert(
+                                        "{ type: 'array', items: [{type: 'integer'}], additionalItems: true }"))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonRowSchemaConverterTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonRowSchemaConverterTest.java
@@ -18,23 +18,24 @@
 
 package org.apache.flink.formats.json;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.util.FileUtils;
-
-import org.junit.Test;
 
 import java.io.File;
 import java.net.URL;
 import java.util.Objects;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
 
 /** Tests for {@link JsonRowSchemaConverter}. */
-public class JsonRowSchemaConverterTest {
+class JsonRowSchemaConverterTest {
 
     @Test
-    public void testComplexSchema() throws Exception {
+    void testComplexSchema() throws Exception {
         final URL url = getClass().getClassLoader().getResource("complex-schema.json");
         Objects.requireNonNull(url);
         final String schema = FileUtils.readFileUtf8(new File(url.getFile()));
@@ -66,11 +67,11 @@ public class JsonRowSchemaConverterTest {
                         Types.VOID,
                         Types.ROW_NAMED(new String[] {"organizationUnit"}, Types.ROW()));
 
-        assertEquals(expected, result);
+        assertThat(result).isEqualTo(expected);
     }
 
     @Test
-    public void testReferenceSchema() throws Exception {
+    void testReferenceSchema() throws Exception {
         final URL url = getClass().getClassLoader().getResource("reference-schema.json");
         Objects.requireNonNull(url);
         final String schema = FileUtils.readFileUtf8(new File(url.getFile()));
@@ -95,52 +96,55 @@ public class JsonRowSchemaConverterTest {
                                 Types.STRING,
                                 Types.STRING));
 
-        assertEquals(expected, result);
+        assertThat(result).isEqualTo(expected);
     }
 
     @Test
-    public void testAtomicType() {
+    void testAtomicType() {
         final TypeInformation<?> result = JsonRowSchemaConverter.convert("{ type: 'number' }");
 
-        assertEquals(Types.BIG_DEC, result);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testMissingType() {
-        JsonRowSchemaConverter.convert("{ }");
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testWrongType() {
-        JsonRowSchemaConverter.convert("{ type: 'whatever' }");
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testArrayWithAdditionalItems() {
-        JsonRowSchemaConverter.convert(
-                "{ type: 'array', items: [{type: 'integer'}], additionalItems: true }");
+        assertThat(result).isEqualTo(Types.BIG_DEC);
     }
 
     @Test
-    public void testMissingProperties() {
+    void testMissingType() {
+        assertThatThrownBy(() -> JsonRowSchemaConverter.convert("{ }"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void testWrongType() {
+        assertThatThrownBy(() -> JsonRowSchemaConverter.convert("{ type: 'whatever' }"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void testArrayWithAdditionalItems() {
+        assertThatThrownBy(() -> JsonRowSchemaConverter.convert(
+                "{ type: 'array', items: [{type: 'integer'}], additionalItems: true }"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void testMissingProperties() {
         final TypeInformation<?> result = JsonRowSchemaConverter.convert("{ type: 'object' }");
 
-        assertEquals(Types.ROW(), result);
+        assertThat(result).isEqualTo(Types.ROW());
     }
 
     @Test
-    public void testNullUnionTypes() {
+    void testNullUnionTypes() {
         final TypeInformation<?> result =
                 JsonRowSchemaConverter.convert("{ type: ['string', 'null'] }");
 
-        assertEquals(Types.STRING, result);
+        assertThat(result).isEqualTo(Types.STRING);
     }
 
     @Test
-    public void testTimestamp() {
+    void testTimestamp() {
         final TypeInformation<?> result =
                 JsonRowSchemaConverter.convert("{ type: 'string', format: 'date-time' }");
 
-        assertEquals(Types.SQL_TIMESTAMP, result);
+        assertThat(result).isEqualTo(Types.SQL_TIMESTAMP);
     }
 }

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/canal/CanalJsonSerDeSchemaTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/canal/CanalJsonSerDeSchemaTest.java
@@ -301,7 +301,7 @@ class CanalJsonSerDeSchemaTest {
 
     private static class SimpleCollector implements Collector<RowData> {
 
-        private List<RowData> list = new ArrayList<>();
+        private final List<RowData> list = new ArrayList<>();
 
         @Override
         public void collect(RowData record) {

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/canal/CanalJsonSerDeSchemaTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/canal/CanalJsonSerDeSchemaTest.java
@@ -29,9 +29,7 @@ import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.utils.DataTypeUtils;
 import org.apache.flink.util.Collector;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -51,14 +49,10 @@ import static org.apache.flink.table.api.DataTypes.FLOAT;
 import static org.apache.flink.table.api.DataTypes.INT;
 import static org.apache.flink.table.api.DataTypes.ROW;
 import static org.apache.flink.table.api.DataTypes.STRING;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link CanalJsonSerializationSchema} and {@link CanalJsonDeserializationSchema}. */
-public class CanalJsonSerDeSchemaTest {
-
-    @Rule public ExpectedException thrown = ExpectedException.none();
+class CanalJsonSerDeSchemaTest {
 
     private static final DataType PHYSICAL_DATA_TYPE =
             ROW(
@@ -68,7 +62,7 @@ public class CanalJsonSerDeSchemaTest {
                     FIELD("weight", FLOAT()));
 
     @Test
-    public void testFilteringTables() throws Exception {
+    void testFilteringTables() throws Exception {
         List<String> lines = readLines("canal-data-filter-table.txt");
         CanalJsonDeserializationSchema deserializationSchema =
                 CanalJsonDeserializationSchema.builder(
@@ -82,7 +76,7 @@ public class CanalJsonSerDeSchemaTest {
     }
 
     @Test
-    public void testDeserializeNullRow() throws Exception {
+    void testDeserializeNullRow() throws Exception {
         final List<ReadableMetadata> requestedMetadata = Arrays.asList(ReadableMetadata.values());
         final CanalJsonDeserializationSchema deserializationSchema =
                 createCanalJsonDeserializationSchema(null, null, requestedMetadata);
@@ -90,47 +84,47 @@ public class CanalJsonSerDeSchemaTest {
 
         deserializationSchema.deserialize(null, collector);
         deserializationSchema.deserialize(new byte[0], collector);
-        assertEquals(0, collector.list.size());
+        assertThat(0).isEqualTo(collector.list.size());
     }
 
     @Test
-    public void testDeserializationWithMetadata() throws Exception {
+    void testDeserializationWithMetadata() throws Exception {
         testDeserializationWithMetadata(
                 "canal-data.txt",
                 null,
                 null,
                 row -> {
-                    assertThat(row.getInt(0), equalTo(101));
-                    assertThat(row.getString(1).toString(), equalTo("scooter"));
-                    assertThat(row.getString(2).toString(), equalTo("Small 2-wheel scooter"));
-                    assertThat(row.getFloat(3), equalTo(3.14f));
-                    assertThat(row.getString(4).toString(), equalTo("inventory"));
-                    assertThat(row.getString(5).toString(), equalTo("products2"));
-                    assertThat(row.getMap(6).size(), equalTo(4));
-                    assertThat(row.getArray(7).getString(0).toString(), equalTo("id"));
-                    assertThat(row.getTimestamp(8, 3).getMillisecond(), equalTo(1589373515477L));
-                    assertThat(row.getTimestamp(9, 3).getMillisecond(), equalTo(1589373515000L));
+                    assertThat(row.getInt(0)).isEqualTo(101);
+                    assertThat(row.getString(1).toString()).isEqualTo("scooter");
+                    assertThat(row.getString(2).toString()).isEqualTo("Small 2-wheel scooter");
+                    assertThat(row.getFloat(3)).isEqualTo(3.14f);
+                    assertThat(row.getString(4).toString()).isEqualTo("inventory");
+                    assertThat(row.getString(5).toString()).isEqualTo("products2");
+                    assertThat(row.getMap(6).size()).isEqualTo(4);
+                    assertThat(row.getArray(7).getString(0).toString()).isEqualTo("id");
+                    assertThat(row.getTimestamp(8, 3).getMillisecond()).isEqualTo(1589373515477L);
+                    assertThat(row.getTimestamp(9, 3).getMillisecond()).isEqualTo(1589373515000L);
                 });
         testDeserializationWithMetadata(
                 "canal-data-filter-table.txt",
                 "mydb",
                 "product",
                 row -> {
-                    assertThat(row.getInt(0), equalTo(101));
-                    assertThat(row.getString(1).toString(), equalTo("scooter"));
-                    assertThat(row.getString(2).toString(), equalTo("Small 2-wheel scooter"));
-                    assertThat(row.getFloat(3), equalTo(3.14f));
-                    assertThat(row.getString(4).toString(), equalTo("mydb"));
-                    assertThat(row.getString(5).toString(), equalTo("product"));
-                    assertThat(row.getMap(6).size(), equalTo(4));
-                    assertThat(row.getArray(7).getString(0).toString(), equalTo("id"));
-                    assertThat(row.getTimestamp(8, 3).getMillisecond(), equalTo(1598944146308L));
-                    assertThat(row.getTimestamp(9, 3).getMillisecond(), equalTo(1598944132000L));
+                    assertThat(row.getInt(0)).isEqualTo(101);
+                    assertThat(row.getString(1).toString()).isEqualTo("scooter");
+                    assertThat(row.getString(2).toString()).isEqualTo("Small 2-wheel scooter");
+                    assertThat(row.getFloat(3)).isEqualTo(3.14f);
+                    assertThat(row.getString(4).toString()).isEqualTo("mydb");
+                    assertThat(row.getString(5).toString()).isEqualTo("product");
+                    assertThat(row.getMap(6).size()).isEqualTo(4);
+                    assertThat(row.getArray(7).getString(0).toString()).isEqualTo("id");
+                    assertThat(row.getTimestamp(8, 3).getMillisecond()).isEqualTo(1598944146308L);
+                    assertThat(row.getTimestamp(9, 3).getMillisecond()).isEqualTo(1598944132000L);
                 });
     }
 
     @Test
-    public void testSerializationDeserialization() throws Exception {
+    void testSerializationDeserialization() throws Exception {
         List<String> lines = readLines("canal-data.txt");
         CanalJsonDeserializationSchema deserializationSchema =
                 CanalJsonDeserializationSchema.builder(
@@ -211,7 +205,7 @@ public class CanalJsonSerDeSchemaTest {
                         "-D(103,12-pack drill bits,12-pack of drill bits with sizes ranging from #40 to #3,0.8)");
         List<String> actual =
                 collector.list.stream().map(Object::toString).collect(Collectors.toList());
-        assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
 
         // test Serialization
         CanalJsonSerializationSchema serializationSchema =
@@ -257,7 +251,7 @@ public class CanalJsonSerDeSchemaTest {
                         "{\"data\":[{\"id\":102,\"name\":\"car battery\",\"description\":\"12V car battery\",\"weight\":5.17}],\"type\":\"DELETE\"}",
                         "{\"data\":[{\"id\":103,\"name\":\"12-pack drill bits\",\"description\":\"12-pack of drill bits with sizes ranging from #40 to #3\",\"weight\":0.8}],\"type\":\"DELETE\"}");
 
-        assertEquals(expectedResult, result);
+        assertThat(result).isEqualTo(expectedResult);
     }
 
     private void testDeserializationWithMetadata(
@@ -271,7 +265,7 @@ public class CanalJsonSerDeSchemaTest {
         final SimpleCollector collector = new SimpleCollector();
 
         deserializationSchema.deserialize(firstLine.getBytes(StandardCharsets.UTF_8), collector);
-        assertEquals(9, collector.list.size());
+        assertThat(collector.list.size()).isEqualTo(9);
         testConsumer.accept(collector.list.get(0));
     }
 

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/debezium/DebeziumJsonFileSystemITCase.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/debezium/DebeziumJsonFileSystemITCase.java
@@ -23,8 +23,8 @@ import org.apache.flink.types.Row;
 import org.apache.flink.util.CloseableIterator;
 import org.apache.flink.util.CollectionUtil;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
@@ -36,9 +36,14 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test Filesystem connector with DebeziumJson. */
-public class DebeziumJsonFileSystemITCase extends StreamingTestBase {
+class DebeziumJsonFileSystemITCase extends StreamingTestBase {
+
+    @TempDir private java.nio.file.Path tempSourceDir;
+
+    @TempDir private java.nio.file.Path tempSinkDir;
 
     private static final List<String> EXPECTED =
             Arrays.asList(
@@ -68,7 +73,7 @@ public class DebeziumJsonFileSystemITCase extends StreamingTestBase {
 
     private void prepareTables(boolean isPartition) throws IOException {
         byte[] bytes = readBytes("debezium-data-schema-exclude.txt");
-        source = TEMPORARY_FOLDER.newFolder();
+        source = tempSourceDir.toFile();
         File file;
         if (isPartition) {
             File partition = new File(source, "p=1");
@@ -80,7 +85,7 @@ public class DebeziumJsonFileSystemITCase extends StreamingTestBase {
         file.createNewFile();
         Files.write(file.toPath(), bytes);
 
-        sink = TEMPORARY_FOLDER.newFolder();
+        sink = tempSinkDir.toFile();
 
         env().setParallelism(1);
     }
@@ -100,7 +105,7 @@ public class DebeziumJsonFileSystemITCase extends StreamingTestBase {
     }
 
     @Test
-    public void testNonPartition() throws Exception {
+    void testNonPartition() throws Exception {
         prepareTables(false);
         createTable(false, source.toURI().toString(), false);
         createTable(true, sink.toURI().toString(), false);
@@ -117,11 +122,11 @@ public class DebeziumJsonFileSystemITCase extends StreamingTestBase {
                         .collect(Collectors.toList());
         iter.close();
 
-        Assert.assertEquals(EXPECTED, results);
+        assertThat(results).isEqualTo(EXPECTED);
     }
 
     @Test
-    public void testPartition() throws Exception {
+    void testPartition() throws Exception {
         prepareTables(true);
         createTable(false, source.toURI().toString(), true);
         createTable(true, sink.toURI().toString(), true);
@@ -140,11 +145,11 @@ public class DebeziumJsonFileSystemITCase extends StreamingTestBase {
                         .map(Row::toString)
                         .collect(Collectors.toList());
 
-        Assert.assertEquals(EXPECTED, results);
+        assertThat(results).isEqualTo(EXPECTED);
 
         // check partition value
         for (Row row : list) {
-            Assert.assertEquals(1, row.getField(4));
+            assertThat(row.getField(4)).isEqualTo(1);
         }
     }
 

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/debezium/DebeziumJsonFormatFactoryTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/debezium/DebeziumJsonFormatFactoryTest.java
@@ -31,32 +31,29 @@ import org.apache.flink.table.runtime.connector.sink.SinkRuntimeProviderContext;
 import org.apache.flink.table.runtime.connector.source.ScanRuntimeProviderContext;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.types.logical.RowType;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Consumer;
 
-import static org.apache.flink.core.testutils.FlinkMatchers.containsCause;
+import static org.apache.flink.core.testutils.FlinkAssertions.anyCauseMatches;
 import static org.apache.flink.table.factories.utils.FactoryMocks.PHYSICAL_DATA_TYPE;
 import static org.apache.flink.table.factories.utils.FactoryMocks.PHYSICAL_TYPE;
 import static org.apache.flink.table.factories.utils.FactoryMocks.SCHEMA;
 import static org.apache.flink.table.factories.utils.FactoryMocks.createTableSink;
 import static org.apache.flink.table.factories.utils.FactoryMocks.createTableSource;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /** Tests for {@link DebeziumJsonFormatFactory}. */
-public class DebeziumJsonFormatFactoryTest extends TestLogger {
-    @Rule public ExpectedException thrown = ExpectedException.none();
+class DebeziumJsonFormatFactoryTest {
 
     @Test
-    public void testSeDeSchema() {
+    void testSeDeSchema() {
         final DebeziumJsonDeserializationSchema expectedDeser =
                 new DebeziumJsonDeserializationSchema(
                         PHYSICAL_DATA_TYPE,
@@ -77,7 +74,7 @@ public class DebeziumJsonFormatFactoryTest extends TestLogger {
                 scanSourceMock.valueFormat.createRuntimeDecoder(
                         ScanRuntimeProviderContext.INSTANCE, PHYSICAL_DATA_TYPE);
 
-        assertEquals(expectedDeser, actualDeser);
+        assertThat(actualDeser).isEqualTo(expectedDeser);
 
         final DebeziumJsonSerializationSchema expectedSer =
                 new DebeziumJsonSerializationSchema(
@@ -96,24 +93,39 @@ public class DebeziumJsonFormatFactoryTest extends TestLogger {
                 sinkMock.valueFormat.createRuntimeEncoder(
                         new SinkRuntimeProviderContext(false), PHYSICAL_DATA_TYPE);
 
-        assertEquals(expectedSer, actualSer);
+        assertThat(actualSer).isEqualTo(expectedSer);
     }
 
     @Test
-    public void testInvalidIgnoreParseError() {
-        thrown.expect(
-                containsCause(
-                        new IllegalArgumentException(
-                                "Unrecognized option for boolean: abc. Expected either true or false(case insensitive)")));
-
+    void testInvalidIgnoreParseError() {
         final Map<String, String> options =
                 getModifiedOptions(opts -> opts.put("debezium-json.ignore-parse-errors", "abc"));
 
-        createTableSource(SCHEMA, options);
+        assertThatThrownBy(() -> createTableSource(SCHEMA, options))
+                .satisfies(
+                        anyCauseMatches(
+                                IllegalArgumentException.class,
+                                "Unrecognized option for boolean: abc. "
+                                        + "Expected either true or false(case insensitive)"));
     }
 
     @Test
-    public void testSchemaIncludeOption() {
+    void testInvalidOptionForTimestampFormat() {
+        final Map<String, String> tableOptions =
+                getModifiedOptions(
+                        opts -> opts.put("debezium-json.timestamp-format.standard", "test"));
+
+        assertThatThrownBy(() -> createTableSource(SCHEMA, tableOptions))
+                .isInstanceOf(ValidationException.class)
+                .satisfies(
+                        anyCauseMatches(
+                                ValidationException.class,
+                                "Unsupported value 'test' for timestamp-format.standard. "
+                                        + "Supported values are [SQL, ISO-8601]."));
+    }
+
+    @Test
+    void testSchemaIncludeOption() {
         Map<String, String> options = getAllOptions();
         options.put("debezium-json.schema-include", "true");
 
@@ -131,9 +143,9 @@ public class DebeziumJsonFormatFactoryTest extends TestLogger {
         DeserializationSchema<RowData> actualDeser =
                 scanSourceMock.valueFormat.createRuntimeDecoder(
                         ScanRuntimeProviderContext.INSTANCE, PHYSICAL_DATA_TYPE);
-        assertEquals(expectedDeser, actualDeser);
+        assertThat(actualDeser).isEqualTo(expectedDeser);
 
-        try {
+        assertThatThrownBy(() -> {
             final DynamicTableSink actualSink = createTableSink(SCHEMA, options);
             TestDynamicTableFactory.DynamicTableSinkMock sinkMock =
                     (TestDynamicTableFactory.DynamicTableSinkMock) actualSink;
@@ -141,39 +153,23 @@ public class DebeziumJsonFormatFactoryTest extends TestLogger {
             sinkMock.valueFormat.createRuntimeEncoder(
                     new SinkRuntimeProviderContext(false), PHYSICAL_DATA_TYPE);
             fail();
-        } catch (Exception e) {
-            assertEquals(
-                    e.getCause().getCause().getMessage(),
-                    "Debezium JSON serialization doesn't support "
-                            + "'debezium-json.schema-include' option been set to true.");
-        }
+        }).satisfies(anyCauseMatches(RuntimeException.class,
+                "Debezium JSON serialization doesn't support "
+                        + "'debezium-json.schema-include' option been set to true."));
     }
 
     @Test
-    public void testInvalidOptionForTimestampFormat() {
-        final Map<String, String> tableOptions =
-                getModifiedOptions(
-                        opts -> opts.put("debezium-json.timestamp-format.standard", "test"));
-
-        thrown.expect(ValidationException.class);
-        thrown.expect(
-                containsCause(
-                        new ValidationException(
-                                "Unsupported value 'test' for timestamp-format.standard. Supported values are [SQL, ISO-8601].")));
-        createTableSource(SCHEMA, tableOptions);
-    }
-
-    @Test
-    public void testInvalidOptionForMapNullKeyMode() {
+    void testInvalidOptionForMapNullKeyMode() {
         final Map<String, String> tableOptions =
                 getModifiedOptions(opts -> opts.put("debezium-json.map-null-key.mode", "invalid"));
 
-        thrown.expect(ValidationException.class);
-        thrown.expect(
-                containsCause(
-                        new ValidationException(
-                                "Unsupported value 'invalid' for option map-null-key.mode. Supported values are [LITERAL, FAIL, DROP].")));
-        createTableSink(SCHEMA, tableOptions);
+        assertThatThrownBy(() -> createTableSink(SCHEMA, tableOptions))
+                .isInstanceOf(ValidationException.class)
+                .satisfies(
+                        anyCauseMatches(
+                                ValidationException.class,
+                                "Unsupported value 'invalid' for option map-null-key.mode. "
+                                        + "Supported values are [LITERAL, FAIL, DROP]."));
     }
 
     // ------------------------------------------------------------------------

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/debezium/DebeziumJsonFormatFactoryTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/debezium/DebeziumJsonFormatFactoryTest.java
@@ -145,17 +145,21 @@ class DebeziumJsonFormatFactoryTest {
                         ScanRuntimeProviderContext.INSTANCE, PHYSICAL_DATA_TYPE);
         assertThat(actualDeser).isEqualTo(expectedDeser);
 
-        assertThatThrownBy(() -> {
-            final DynamicTableSink actualSink = createTableSink(SCHEMA, options);
-            TestDynamicTableFactory.DynamicTableSinkMock sinkMock =
-                    (TestDynamicTableFactory.DynamicTableSinkMock) actualSink;
-            // should fail
-            sinkMock.valueFormat.createRuntimeEncoder(
-                    new SinkRuntimeProviderContext(false), PHYSICAL_DATA_TYPE);
-            fail();
-        }).satisfies(anyCauseMatches(RuntimeException.class,
-                "Debezium JSON serialization doesn't support "
-                        + "'debezium-json.schema-include' option been set to true."));
+        assertThatThrownBy(
+                        () -> {
+                            final DynamicTableSink actualSink = createTableSink(SCHEMA, options);
+                            TestDynamicTableFactory.DynamicTableSinkMock sinkMock =
+                                    (TestDynamicTableFactory.DynamicTableSinkMock) actualSink;
+                            // should fail
+                            sinkMock.valueFormat.createRuntimeEncoder(
+                                    new SinkRuntimeProviderContext(false), PHYSICAL_DATA_TYPE);
+                            fail();
+                        })
+                .satisfies(
+                        anyCauseMatches(
+                                RuntimeException.class,
+                                "Debezium JSON serialization doesn't support "
+                                        + "'debezium-json.schema-include' option been set to true."));
     }
 
     @Test

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/debezium/DebeziumJsonSerDeSchemaTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/debezium/DebeziumJsonSerDeSchemaTest.java
@@ -28,11 +28,8 @@ import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.utils.DataTypeUtils;
 import org.apache.flink.util.Collector;
-import org.apache.flink.util.ExceptionUtils;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -52,18 +49,13 @@ import static org.apache.flink.table.api.DataTypes.FLOAT;
 import static org.apache.flink.table.api.DataTypes.INT;
 import static org.apache.flink.table.api.DataTypes.ROW;
 import static org.apache.flink.table.api.DataTypes.STRING;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.startsWith;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Tests for {@link DebeziumJsonSerializationSchema} and {@link DebeziumJsonDeserializationSchema}.
  */
-public class DebeziumJsonSerDeSchemaTest {
-
-    @Rule public ExpectedException thrown = ExpectedException.none();
+class DebeziumJsonSerDeSchemaTest {
 
     private static final DataType PHYSICAL_DATA_TYPE =
             ROW(
@@ -73,41 +65,36 @@ public class DebeziumJsonSerDeSchemaTest {
                     FIELD("weight", FLOAT()));
 
     @Test
-    public void testSerializationAndSchemaIncludeDeserialization() throws Exception {
+    void testSerializationAndSchemaIncludeDeserialization() throws Exception {
         testSerializationDeserialization("debezium-data-schema-include.txt", true);
     }
 
     @Test
-    public void testSerializationAndSchemaExcludeDeserialization() throws Exception {
+    void testSerializationAndSchemaExcludeDeserialization() throws Exception {
         testSerializationDeserialization("debezium-data-schema-exclude.txt", false);
     }
 
     @Test
-    public void testSerializationAndPostgresSchemaIncludeDeserialization() throws Exception {
+    void testSerializationAndPostgresSchemaIncludeDeserialization() throws Exception {
         testSerializationDeserialization("debezium-postgres-data-schema-include.txt", true);
     }
 
     @Test
-    public void testSerializationAndPostgresSchemaExcludeDeserialization() throws Exception {
+    void testSerializationAndPostgresSchemaExcludeDeserialization() throws Exception {
         testSerializationDeserialization("debezium-postgres-data-schema-exclude.txt", false);
     }
 
     @Test
-    public void testPostgresDefaultReplicaIdentify() {
-        try {
-            testSerializationDeserialization("debezium-postgres-data-replica-identity.txt", false);
-        } catch (Exception e) {
-            assertTrue(
-                    ExceptionUtils.findThrowableWithMessage(
-                                    e,
-                                    "The \"before\" field of UPDATE message is null, if you are using Debezium Postgres Connector, "
-                                            + "please check the Postgres table has been set REPLICA IDENTITY to FULL level.")
-                            .isPresent());
-        }
+    void testPostgresDefaultReplicaIdentify() {
+        assertThatThrownBy(() -> testSerializationDeserialization(
+                                        "debezium-postgres-data-replica-identity.txt", false))
+                .as("The \"before\" field of UPDATE message is null, if you are using Debezium Postgres Connector, "
+                                + "please check the Postgres table has been set REPLICA IDENTITY to FULL level.")
+                .isInstanceOf(Exception.class);
     }
 
     @Test
-    public void testTombstoneMessages() throws Exception {
+    void testTombstoneMessages() throws Exception {
         DebeziumJsonDeserializationSchema deserializationSchema =
                 new DebeziumJsonDeserializationSchema(
                         PHYSICAL_DATA_TYPE,
@@ -119,63 +106,62 @@ public class DebeziumJsonSerDeSchemaTest {
         SimpleCollector collector = new SimpleCollector();
         deserializationSchema.deserialize(null, collector);
         deserializationSchema.deserialize(new byte[] {}, collector);
-        assertTrue(collector.list.isEmpty());
+        assertThat(collector.list).isNullOrEmpty();
     }
 
     @Test
-    public void testDeserializationWithMetadata() throws Exception {
+    void testDeserializationWithMetadata() throws Exception {
         testDeserializationWithMetadata(
                 "debezium-data-schema-include.txt",
                 true,
                 row -> {
-                    assertThat(row.getInt(0), equalTo(101));
-                    assertThat(row.getString(1).toString(), equalTo("scooter"));
-                    assertThat(row.getString(2).toString(), equalTo("Small 2-wheel scooter"));
-                    assertThat(row.getFloat(3), equalTo(3.14f));
-                    assertThat(
-                            row.getString(4).toString(),
-                            startsWith(
-                                    "{\"type\":\"struct\",\"fields\":[{\"type\":\"struct\",\"fields\":[{\"type\":\"int32\",\"optional\":false,\"field\":\"id\"},"));
-                    assertThat(row.getTimestamp(5, 3).getMillisecond(), equalTo(1589355606100L));
-                    assertThat(row.getTimestamp(6, 3).getMillisecond(), equalTo(0L));
-                    assertThat(row.getString(7).toString(), equalTo("inventory"));
-                    assertThat(row.isNullAt(8), equalTo(true));
-                    assertThat(row.getString(9).toString(), equalTo("products"));
-                    assertThat(row.getMap(10).size(), equalTo(14));
+                    assertThat(row.getInt(0)).isEqualTo(101);
+                    assertThat(row.getString(1).toString()).isEqualTo("scooter");
+                    assertThat(row.getString(2).toString()).isEqualTo("Small 2-wheel scooter");
+                    assertThat(row.getFloat(3)).isEqualTo(3.14f);
+                    assertThat(row.getString(4).toString())
+                            .startsWith(
+                                    "{\"type\":\"struct\",\"fields\":[{\"type\":\"struct\",\"fields\":[{\"type\":\"int32\",\"optional\":false,\"field\":\"id\"},");
+                    assertThat(row.getTimestamp(5, 3).getMillisecond()).isEqualTo(1589355606100L);
+                    assertThat(row.getTimestamp(6, 3).getMillisecond()).isEqualTo(0L);
+                    assertThat(row.getString(7).toString()).isEqualTo("inventory");
+                    assertThat(row.isNullAt(8)).isEqualTo(true);
+                    assertThat(row.getString(9).toString()).isEqualTo("products");
+                    assertThat(row.getMap(10).size()).isEqualTo(14);
                 });
 
         testDeserializationWithMetadata(
                 "debezium-data-schema-exclude.txt",
                 false,
                 row -> {
-                    assertThat(row.getInt(0), equalTo(101));
-                    assertThat(row.getString(1).toString(), equalTo("scooter"));
-                    assertThat(row.getString(2).toString(), equalTo("Small 2-wheel scooter"));
-                    assertThat(row.getFloat(3), equalTo(3.14f));
-                    assertThat(row.isNullAt(4), equalTo(true));
-                    assertThat(row.getTimestamp(5, 3).getMillisecond(), equalTo(1589355606100L));
-                    assertThat(row.getTimestamp(6, 3).getMillisecond(), equalTo(0L));
-                    assertThat(row.getString(7).toString(), equalTo("inventory"));
-                    assertThat(row.isNullAt(8), equalTo(true));
-                    assertThat(row.getString(9).toString(), equalTo("products"));
-                    assertThat(row.getMap(10).size(), equalTo(14));
+                    assertThat(row.getInt(0)).isEqualTo(101);
+                    assertThat(row.getString(1).toString()).isEqualTo("scooter");
+                    assertThat(row.getString(2).toString()).isEqualTo("Small 2-wheel scooter");
+                    assertThat(row.getFloat(3)).isEqualTo(3.14f);
+                    assertThat(row.isNullAt(4)).isEqualTo(true);
+                    assertThat(row.getTimestamp(5, 3).getMillisecond()).isEqualTo(1589355606100L);
+                    assertThat(row.getTimestamp(6, 3).getMillisecond()).isEqualTo(0L);
+                    assertThat(row.getString(7).toString()).isEqualTo("inventory");
+                    assertThat(row.isNullAt(8)).isEqualTo(true);
+                    assertThat(row.getString(9).toString()).isEqualTo("products");
+                    assertThat(row.getMap(10).size()).isEqualTo(14);
                 });
 
         testDeserializationWithMetadata(
                 "debezium-postgres-data-schema-exclude.txt",
                 false,
                 row -> {
-                    assertThat(row.getInt(0), equalTo(101));
-                    assertThat(row.getString(1).toString(), equalTo("scooter"));
-                    assertThat(row.getString(2).toString(), equalTo("Small 2-wheel scooter"));
-                    assertThat(row.getFloat(3), equalTo(3.14f));
-                    assertThat(row.isNullAt(4), equalTo(true));
-                    assertThat(row.getTimestamp(5, 3).getMillisecond(), equalTo(1596001099434L));
-                    assertThat(row.getTimestamp(6, 3).getMillisecond(), equalTo(1596001099434L));
-                    assertThat(row.getString(7).toString(), equalTo("postgres"));
-                    assertThat(row.getString(8).toString(), equalTo("inventory"));
-                    assertThat(row.getString(9).toString(), equalTo("products"));
-                    assertThat(row.getMap(10).size(), equalTo(11));
+                    assertThat(row.getInt(0)).isEqualTo(101);
+                    assertThat(row.getString(1).toString()).isEqualTo("scooter");
+                    assertThat(row.getString(2).toString()).isEqualTo("Small 2-wheel scooter");
+                    assertThat(row.getFloat(3)).isEqualTo(3.14f);
+                    assertThat(row.isNullAt(4)).isEqualTo(true);
+                    assertThat(row.getTimestamp(5, 3).getMillisecond()).isEqualTo(1596001099434L);
+                    assertThat(row.getTimestamp(6, 3).getMillisecond()).isEqualTo(1596001099434L);
+                    assertThat(row.getString(7).toString()).isEqualTo("postgres");
+                    assertThat(row.getString(8).toString()).isEqualTo("inventory");
+                    assertThat(row.getString(9).toString()).isEqualTo("products");
+                    assertThat(row.getMap(10).size()).isEqualTo(11);
                 });
     }
 
@@ -250,7 +236,7 @@ public class DebeziumJsonSerDeSchemaTest {
                         "-D(111,scooter,Big 2-wheel scooter ,5.17)");
         List<String> actual =
                 collector.list.stream().map(Object::toString).collect(Collectors.toList());
-        assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
 
         DebeziumJsonSerializationSchema serializationSchema =
                 new DebeziumJsonSerializationSchema(
@@ -288,7 +274,7 @@ public class DebeziumJsonSerDeSchemaTest {
                         "{\"before\":{\"id\":111,\"name\":\"scooter\",\"description\":\"Big 2-wheel scooter \",\"weight\":5.18},\"after\":null,\"op\":\"d\"}",
                         "{\"before\":null,\"after\":{\"id\":111,\"name\":\"scooter\",\"description\":\"Big 2-wheel scooter \",\"weight\":5.17},\"op\":\"c\"}",
                         "{\"before\":{\"id\":111,\"name\":\"scooter\",\"description\":\"Big 2-wheel scooter \",\"weight\":5.17},\"after\":null,\"op\":\"d\"}");
-        assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
     }
 
     private void testDeserializationWithMetadata(
@@ -318,7 +304,7 @@ public class DebeziumJsonSerDeSchemaTest {
         final SimpleCollector collector = new SimpleCollector();
         deserializationSchema.deserialize(firstLine.getBytes(StandardCharsets.UTF_8), collector);
 
-        assertEquals(1, collector.list.size());
+        assertThat(collector.list.size()).isEqualTo(1);
         testConsumer.accept(collector.list.get(0));
     }
 

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/debezium/DebeziumJsonSerDeSchemaTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/debezium/DebeziumJsonSerDeSchemaTest.java
@@ -86,9 +86,12 @@ class DebeziumJsonSerDeSchemaTest {
 
     @Test
     void testPostgresDefaultReplicaIdentify() {
-        assertThatThrownBy(() -> testSerializationDeserialization(
+        assertThatThrownBy(
+                        () ->
+                                testSerializationDeserialization(
                                         "debezium-postgres-data-replica-identity.txt", false))
-                .as("The \"before\" field of UPDATE message is null, if you are using Debezium Postgres Connector, "
+                .as(
+                        "The \"before\" field of UPDATE message is null, if you are using Debezium Postgres Connector, "
                                 + "please check the Postgres table has been set REPLICA IDENTITY to FULL level.")
                 .isInstanceOf(Exception.class);
     }

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/maxwell/MaxwellJsonFormatFactoryTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/maxwell/MaxwellJsonFormatFactoryTest.java
@@ -30,34 +30,31 @@ import org.apache.flink.table.factories.TestDynamicTableFactory;
 import org.apache.flink.table.runtime.connector.sink.SinkRuntimeProviderContext;
 import org.apache.flink.table.runtime.connector.source.ScanRuntimeProviderContext;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Consumer;
 
-import static org.apache.flink.core.testutils.FlinkMatchers.containsCause;
+import static org.apache.flink.core.testutils.FlinkAssertions.anyCauseMatches;
 import static org.apache.flink.table.factories.utils.FactoryMocks.PHYSICAL_DATA_TYPE;
 import static org.apache.flink.table.factories.utils.FactoryMocks.PHYSICAL_TYPE;
 import static org.apache.flink.table.factories.utils.FactoryMocks.SCHEMA;
 import static org.apache.flink.table.factories.utils.FactoryMocks.createTableSink;
 import static org.apache.flink.table.factories.utils.FactoryMocks.createTableSource;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link MaxwellJsonFormatFactory}. */
-public class MaxwellJsonFormatFactoryTest extends TestLogger {
-    @Rule public ExpectedException thrown = ExpectedException.none();
+class MaxwellJsonFormatFactoryTest {
 
     private static final InternalTypeInfo<RowData> ROW_TYPE_INFO =
             InternalTypeInfo.of(PHYSICAL_TYPE);
 
     @Test
-    public void testSeDeSchema() {
+    void testSeDeSchema() {
         final MaxwellJsonDeserializationSchema expectedDeser =
                 new MaxwellJsonDeserializationSchema(
                         PHYSICAL_DATA_TYPE,
@@ -85,7 +82,7 @@ public class MaxwellJsonFormatFactoryTest extends TestLogger {
                 scanSourceMock.valueFormat.createRuntimeDecoder(
                         ScanRuntimeProviderContext.INSTANCE, SCHEMA.toPhysicalRowDataType());
 
-        assertEquals(expectedDeser, actualDeser);
+        assertThat(actualDeser).isEqualTo(expectedDeser);
 
         final DynamicTableSink actualSink = createTableSink(SCHEMA, options);
         assert actualSink instanceof TestDynamicTableFactory.DynamicTableSinkMock;
@@ -96,47 +93,49 @@ public class MaxwellJsonFormatFactoryTest extends TestLogger {
                 sinkMock.valueFormat.createRuntimeEncoder(
                         new SinkRuntimeProviderContext(false), SCHEMA.toPhysicalRowDataType());
 
-        assertEquals(expectedSer, actualSer);
+        assertThat(actualSer).isEqualTo(expectedSer);
     }
 
     @Test
-    public void testInvalidIgnoreParseError() {
-        thrown.expect(
-                containsCause(
-                        new IllegalArgumentException(
-                                "Unrecognized option for boolean: abc. Expected either true or false(case insensitive)")));
-
+    void testInvalidIgnoreParseError() {
         final Map<String, String> options =
                 getModifiedOptions(opts -> opts.put("maxwell-json.ignore-parse-errors", "abc"));
 
-        createTableSource(SCHEMA, options);
+        assertThatThrownBy(() -> createTableSource(SCHEMA, options))
+                .satisfies(
+                        anyCauseMatches(
+                                IllegalArgumentException.class,
+                                "Unrecognized option for boolean: abc. "
+                                        + "Expected either true or false(case insensitive)"));
     }
 
     @Test
-    public void testInvalidOptionForTimestampFormat() {
+    void testInvalidOptionForTimestampFormat() {
         final Map<String, String> tableOptions =
                 getModifiedOptions(
                         opts -> opts.put("maxwell-json.timestamp-format.standard", "test"));
 
-        thrown.expect(ValidationException.class);
-        thrown.expect(
-                containsCause(
-                        new ValidationException(
-                                "Unsupported value 'test' for timestamp-format.standard. Supported values are [SQL, ISO-8601].")));
-        createTableSource(SCHEMA, tableOptions);
+        assertThatThrownBy(() -> createTableSource(SCHEMA, tableOptions))
+                .isInstanceOf(ValidationException.class)
+                .satisfies(
+                        anyCauseMatches(
+                                ValidationException.class,
+                                "Unsupported value 'test' for timestamp-format.standard. "
+                                        + "Supported values are [SQL, ISO-8601]."));
     }
 
     @Test
-    public void testInvalidOptionForMapNullKeyMode() {
+    void testInvalidOptionForMapNullKeyMode() {
         final Map<String, String> tableOptions =
                 getModifiedOptions(opts -> opts.put("maxwell-json.map-null-key.mode", "invalid"));
 
-        thrown.expect(ValidationException.class);
-        thrown.expect(
-                containsCause(
-                        new ValidationException(
-                                "Unsupported value 'invalid' for option map-null-key.mode. Supported values are [LITERAL, FAIL, DROP].")));
-        createTableSink(SCHEMA, tableOptions);
+        assertThatThrownBy(() -> createTableSink(SCHEMA, tableOptions))
+                .isInstanceOf(ValidationException.class)
+                .satisfies(
+                        anyCauseMatches(
+                                ValidationException.class,
+                                "Unsupported value 'invalid' for option map-null-key.mode. "
+                                        + "Supported values are [LITERAL, FAIL, DROP]."));
     }
 
     // ------------------------------------------------------------------------

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/maxwell/MaxwellJsonSerDerTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/maxwell/MaxwellJsonSerDerTest.java
@@ -29,7 +29,7 @@ import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.utils.DataTypeUtils;
 import org.apache.flink.util.Collector;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -49,14 +49,12 @@ import static org.apache.flink.table.api.DataTypes.FLOAT;
 import static org.apache.flink.table.api.DataTypes.INT;
 import static org.apache.flink.table.api.DataTypes.ROW;
 import static org.apache.flink.table.api.DataTypes.STRING;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for {@link MaxwellJsonSerializationSchema} and {@link MaxwellJsonDeserializationSchema}.
  */
-public class MaxwellJsonSerDerTest {
+class MaxwellJsonSerDerTest {
 
     private static final DataType PHYSICAL_DATA_TYPE =
             ROW(
@@ -66,7 +64,7 @@ public class MaxwellJsonSerDerTest {
                     FIELD("weight", FLOAT()));
 
     @Test
-    public void testDeserializationWithMetadata() throws Exception {
+    void testDeserializationWithMetadata() throws Exception {
         // we only read the first line for keeping the test simple
         final String firstLine = readLines("maxwell-data.txt").get(0);
         final List<ReadableMetadata> requestedMetadata = Arrays.asList(ReadableMetadata.values());
@@ -85,23 +83,23 @@ public class MaxwellJsonSerDerTest {
                         TimestampFormat.ISO_8601);
         final SimpleCollector collector = new SimpleCollector();
         deserializationSchema.deserialize(firstLine.getBytes(StandardCharsets.UTF_8), collector);
-        assertEquals(1, collector.list.size());
+        assertThat(collector.list.size()).isEqualTo(1);
         Consumer<RowData> consumer =
                 row -> {
-                    assertThat(row.getInt(0), equalTo(101));
-                    assertThat(row.getString(1).toString(), equalTo("scooter"));
-                    assertThat(row.getString(2).toString(), equalTo("Small 2-wheel scooter"));
-                    assertThat(row.getFloat(3), equalTo(3.14f));
-                    assertThat(row.getString(4).toString(), equalTo("test"));
-                    assertThat(row.getString(5).toString(), equalTo("product"));
-                    assertThat(row.getArray(6).getString(0).toString(), equalTo("id"));
-                    assertThat(row.getTimestamp(7, 3).getMillisecond(), equalTo(1596684883000L));
+                    assertThat(row.getInt(0)).isEqualTo(101);
+                    assertThat(row.getString(1).toString()).isEqualTo("scooter");
+                    assertThat(row.getString(2).toString()).isEqualTo("Small 2-wheel scooter");
+                    assertThat(row.getFloat(3)).isEqualTo(3.14f);
+                    assertThat(row.getString(4).toString()).isEqualTo("test");
+                    assertThat(row.getString(5).toString()).isEqualTo("product");
+                    assertThat(row.getArray(6).getString(0).toString()).isEqualTo("id");
+                    assertThat(row.getTimestamp(7, 3).getMillisecond()).isEqualTo(1596684883000L);
                 };
         consumer.accept(collector.list.get(0));
     }
 
     @Test
-    public void testSerializationDeserialization() throws Exception {
+    void testSerializationDeserialization() throws Exception {
         List<String> lines = readLines("maxwell-data.txt");
         MaxwellJsonDeserializationSchema deserializationSchema =
                 new MaxwellJsonDeserializationSchema(
@@ -177,7 +175,7 @@ public class MaxwellJsonSerDerTest {
                         "-D(103,12-pack drill bits,12-pack of drill bits with sizes ranging from #40 to #3,0.8)");
         List<String> actual =
                 collector.list.stream().map(Object::toString).collect(Collectors.toList());
-        assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
 
         MaxwellJsonSerializationSchema serializationSchema =
                 new MaxwellJsonSerializationSchema(
@@ -219,7 +217,7 @@ public class MaxwellJsonSerDerTest {
                         "{\"data\":{\"id\":102,\"name\":\"car battery\",\"description\":\"12V car battery\",\"weight\":5.17},\"type\":\"insert\"}",
                         "{\"data\":{\"id\":102,\"name\":\"car battery\",\"description\":\"12V car battery\",\"weight\":5.17},\"type\":\"delete\"}",
                         "{\"data\":{\"id\":103,\"name\":\"12-pack drill bits\",\"description\":\"12-pack of drill bits with sizes ranging from #40 to #3\",\"weight\":0.8},\"type\":\"delete\"}");
-        assertEquals(expectedResult, result);
+        assertThat(result).isEqualTo(expectedResult);
     }
 
     // --------------------------------------------------------------------------------------------

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/ogg/OggJsonFormatFactoryTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/ogg/OggJsonFormatFactoryTest.java
@@ -27,29 +27,26 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.factories.TestDynamicTableFactory;
 import org.apache.flink.table.runtime.connector.sink.SinkRuntimeProviderContext;
 import org.apache.flink.table.types.logical.RowType;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Consumer;
 
-import static org.apache.flink.core.testutils.FlinkMatchers.containsCause;
+import static org.apache.flink.core.testutils.FlinkAssertions.anyCauseMatches;
 import static org.apache.flink.table.factories.utils.FactoryMocks.PHYSICAL_DATA_TYPE;
 import static org.apache.flink.table.factories.utils.FactoryMocks.SCHEMA;
 import static org.apache.flink.table.factories.utils.FactoryMocks.createTableSink;
 import static org.apache.flink.table.factories.utils.FactoryMocks.createTableSource;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link OggJsonFormatFactory}. */
-public class OggJsonFormatFactoryTest extends TestLogger {
-    @Rule public ExpectedException thrown = ExpectedException.none();
+class OggJsonFormatFactoryTest {
 
     @Test
-    public void testSeDeSchema() {
+    void testSeDeSchema() {
         final Map<String, String> options = getAllOptions();
 
         final OggJsonSerializationSchema expectedSer =
@@ -69,46 +66,48 @@ public class OggJsonFormatFactoryTest extends TestLogger {
                 sinkMock.valueFormat.createRuntimeEncoder(
                         new SinkRuntimeProviderContext(false), PHYSICAL_DATA_TYPE);
 
-        assertEquals(expectedSer, actualSer);
+        assertThat(actualSer).isEqualTo(expectedSer);
     }
 
     @Test
-    public void testInvalidIgnoreParseError() {
-        thrown.expect(
-                containsCause(
-                        new IllegalArgumentException(
-                                "Unrecognized option for boolean: abc. Expected either true or false(case insensitive)")));
-
+    void testInvalidIgnoreParseError() {
         final Map<String, String> options =
                 getModifiedOptions(opts -> opts.put("ogg-json.ignore-parse-errors", "abc"));
 
-        createTableSource(SCHEMA, options);
+        assertThatThrownBy(() -> createTableSource(SCHEMA, options))
+                .satisfies(
+                        anyCauseMatches(
+                                IllegalArgumentException.class,
+                                "Unrecognized option for boolean: abc. "
+                                        + "Expected either true or false(case insensitive)"));
     }
 
     @Test
-    public void testInvalidOptionForTimestampFormat() {
+    void testInvalidOptionForTimestampFormat() {
         final Map<String, String> tableOptions =
                 getModifiedOptions(opts -> opts.put("ogg-json.timestamp-format.standard", "test"));
 
-        thrown.expect(ValidationException.class);
-        thrown.expect(
-                containsCause(
-                        new ValidationException(
-                                "Unsupported value 'test' for timestamp-format.standard. Supported values are [SQL, ISO-8601].")));
-        createTableSource(SCHEMA, tableOptions);
+        assertThatThrownBy(() -> createTableSource(SCHEMA, tableOptions))
+                .isInstanceOf(ValidationException.class)
+                .satisfies(
+                        anyCauseMatches(
+                                ValidationException.class,
+                                "Unsupported value 'test' for timestamp-format.standard. "
+                                        + "Supported values are [SQL, ISO-8601]."));
     }
 
     @Test
-    public void testInvalidOptionForMapNullKeyMode() {
+    void testInvalidOptionForMapNullKeyMode() {
         final Map<String, String> tableOptions =
                 getModifiedOptions(opts -> opts.put("ogg-json.map-null-key.mode", "invalid"));
 
-        thrown.expect(ValidationException.class);
-        thrown.expect(
-                containsCause(
-                        new ValidationException(
-                                "Unsupported value 'invalid' for option map-null-key.mode. Supported values are [LITERAL, FAIL, DROP].")));
-        createTableSink(SCHEMA, tableOptions);
+        assertThatThrownBy(() -> createTableSink(SCHEMA, tableOptions))
+                .isInstanceOf(ValidationException.class)
+                .satisfies(
+                        anyCauseMatches(
+                                ValidationException.class,
+                                "Unsupported value 'invalid' for option map-null-key.mode. "
+                                        + "Supported values are [LITERAL, FAIL, DROP]."));
     }
 
     // ------------------------------------------------------------------------

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/ogg/OggJsonSerDeSchemaTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/ogg/OggJsonSerDeSchemaTest.java
@@ -29,9 +29,8 @@ import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.utils.DataTypeUtils;
 import org.apache.flink.util.Collector;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.assertj.core.data.Percentage;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -51,11 +50,10 @@ import static org.apache.flink.table.api.DataTypes.FLOAT;
 import static org.apache.flink.table.api.DataTypes.INT;
 import static org.apache.flink.table.api.DataTypes.ROW;
 import static org.apache.flink.table.api.DataTypes.STRING;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link OggJsonSerializationSchema} and {@link OggJsonDeserializationSchema}. */
-public class OggJsonSerDeSchemaTest {
+class OggJsonSerDeSchemaTest {
 
     private static final DataType PHYSICAL_DATA_TYPE =
             ROW(
@@ -63,7 +61,6 @@ public class OggJsonSerDeSchemaTest {
                     FIELD("name", STRING()),
                     FIELD("description", STRING()),
                     FIELD("weight", FLOAT()));
-    @Rule public ExpectedException thrown = ExpectedException.none();
 
     private static List<String> readLines(String resource) throws IOException {
         final URL url = OggJsonSerDeSchemaTest.class.getClassLoader().getResource(resource);
@@ -73,17 +70,17 @@ public class OggJsonSerDeSchemaTest {
     }
 
     @Test
-    public void testSerializationAndDeserialization() throws Exception {
+    void testSerializationAndDeserialization() throws Exception {
         testSerializationDeserialization("ogg-data.txt");
     }
 
     @Test
-    public void testDeserializationWithMetadata() throws Exception {
+    void testDeserializationWithMetadata() throws Exception {
         testDeserializationWithMetadata("ogg-data.txt");
     }
 
     @Test
-    public void testTombstoneMessages() throws Exception {
+    void testTombstoneMessages() throws Exception {
         OggJsonDeserializationSchema deserializationSchema =
                 new OggJsonDeserializationSchema(
                         PHYSICAL_DATA_TYPE,
@@ -94,7 +91,7 @@ public class OggJsonSerDeSchemaTest {
         SimpleCollector collector = new SimpleCollector();
         deserializationSchema.deserialize(null, collector);
         deserializationSchema.deserialize(new byte[] {}, collector);
-        assertTrue(collector.list.isEmpty());
+        assertThat(collector.list).isNullOrEmpty();
     }
 
     public void testDeserializationWithMetadata(String resourceFile) throws Exception {
@@ -119,18 +116,19 @@ public class OggJsonSerDeSchemaTest {
 
         final SimpleCollector collector = new SimpleCollector();
         deserializationSchema.deserialize(firstLine.getBytes(StandardCharsets.UTF_8), collector);
-        assertEquals(1, collector.list.size());
+        assertThat(collector.list.size()).isEqualTo(1);
 
         Consumer<RowData> consumer =
                 row -> {
-                    assertEquals(101, row.getInt(0));
-                    assertEquals("scooter", row.getString(1).toString());
-                    assertEquals("Small 2-wheel scooter", row.getString(2).toString());
-                    assertEquals(3.140000104904175, row.getFloat(3), 1e-15);
-                    assertEquals("OGG.TBL_TEST", row.getString(4).toString());
-                    assertEquals("id", row.getArray(5).getString(0).toString());
-                    assertEquals(1589377175766L, row.getTimestamp(6, 6).getMillisecond());
-                    assertEquals(1589384406000L, row.getTimestamp(7, 6).getMillisecond());
+                    assertThat(row.getInt(0)).isEqualTo(101);
+                    assertThat(row.getString(1).toString()).isEqualTo("scooter");
+                    assertThat(row.getString(2).toString()).isEqualTo("Small 2-wheel scooter");
+                    assertThat(row.getFloat(3))
+                            .isCloseTo(3.140000104904175f, Percentage.withPercentage(1e-15));
+                    assertThat(row.getString(4).toString()).isEqualTo("OGG.TBL_TEST");
+                    assertThat(row.getArray(5).getString(0).toString()).isEqualTo("id");
+                    assertThat(row.getTimestamp(6, 6).getMillisecond()).isEqualTo(1589377175766L);
+                    assertThat(row.getTimestamp(7, 6).getMillisecond()).isEqualTo(1589384406000L);
                 };
         consumer.accept(collector.list.get(0));
     }
@@ -204,7 +202,7 @@ public class OggJsonSerDeSchemaTest {
                         "-D(111,scooter,Big 2-wheel scooter ,5.17)");
         List<String> actual =
                 collector.list.stream().map(Object::toString).collect(Collectors.toList());
-        assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
 
         OggJsonSerializationSchema serializationSchema =
                 new OggJsonSerializationSchema(
@@ -242,7 +240,7 @@ public class OggJsonSerDeSchemaTest {
                         "{\"before\":{\"id\":111,\"name\":\"scooter\",\"description\":\"Big 2-wheel scooter \",\"weight\":5.18},\"after\":null,\"op_type\":\"D\"}",
                         "{\"before\":null,\"after\":{\"id\":111,\"name\":\"scooter\",\"description\":\"Big 2-wheel scooter \",\"weight\":5.17},\"op_type\":\"I\"}",
                         "{\"before\":{\"id\":111,\"name\":\"scooter\",\"description\":\"Big 2-wheel scooter \",\"weight\":5.17},\"after\":null,\"op_type\":\"D\"}");
-        assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
     }
 
     private static class SimpleCollector implements Collector<RowData> {

--- a/flink-formats/flink-json/src/test/resources/services/org.junit.jupiter.api.extension.Extension
+++ b/flink-formats/flink-json/src/test/resources/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.util.TestLoggerExtension

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/utils/LegacyRowExtension.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/utils/LegacyRowExtension.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.utils;
+
+import org.apache.flink.types.Row;
+import org.apache.flink.types.RowUtils;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * Enables the old behavior of {@link Row#toString()} for legacy tests.
+ *
+ * <p>It ignores the changes applied in FLINK-16998 and FLINK-19981.
+ */
+public class LegacyRowExtension implements BeforeEachCallback, AfterEachCallback {
+
+    public static final LegacyRowExtension INSTANCE = new LegacyRowExtension();
+
+    private LegacyRowExtension() {
+        // singleton
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) throws Exception {
+        RowUtils.USE_LEGACY_TO_STRING = false;
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext context) throws Exception {
+        RowUtils.USE_LEGACY_TO_STRING = true;
+    }
+}


### PR DESCRIPTION
What is the purpose of the change
Update the flink-table/flink-table-common and flink-formats/flink-json module to AssertJ and JUnit 5 following the [JUnit 5 Migration Guide](https://docs.google.com/document/d/1514Wa_aNB9bJUen4xm5uiuXOooOJTtXqS_Jqk9KJitU/edit)

Brief change log
Use JUnit5 and AssertJ in tests instead of JUnit4 and Hamcrest
Ignore deprecated class test case upgrades(JsonRowSerializationSchemaTest.class,JsonRowDeserializationSchemaTest.class)

Verifying this change
This change is a code cleanup without any test coverage.

Does this pull request potentially affect one of the following parts:
Dependencies (does it add or upgrade a dependency): ( no)
The public API, i.e., is any changed class annotated with @Public(Evolving): ( no)
The serializers: (no)
The runtime per-record code paths (performance sensitive): (no)
Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
The S3 file system connector: ( no)
Documentation
Does this pull request introduce a new feature? ( no)
If yes, how is the feature documented? (not applicable)