### PR TITLE
[FLINK-27368][table-planner] Trim casts from character string to numeric

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/StringToNumericPrimitiveCastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/StringToNumericPrimitiveCastRule.java
@@ -28,6 +28,7 @@ import static org.apache.flink.table.planner.codegen.calls.BuiltInMethods.STRING
 import static org.apache.flink.table.planner.codegen.calls.BuiltInMethods.STRING_DATA_TO_INT;
 import static org.apache.flink.table.planner.codegen.calls.BuiltInMethods.STRING_DATA_TO_LONG;
 import static org.apache.flink.table.planner.codegen.calls.BuiltInMethods.STRING_DATA_TO_SHORT;
+import static org.apache.flink.table.planner.functions.casting.CastRuleUtils.methodCall;
 import static org.apache.flink.table.planner.functions.casting.CastRuleUtils.staticCall;
 
 /**
@@ -54,19 +55,20 @@ class StringToNumericPrimitiveCastRule
             String inputTerm,
             LogicalType inputLogicalType,
             LogicalType targetLogicalType) {
+        final String trimmedInputTerm = methodCall(inputTerm, "trim");
         switch (targetLogicalType.getTypeRoot()) {
             case TINYINT:
-                return staticCall(STRING_DATA_TO_BYTE(), inputTerm);
+                return staticCall(STRING_DATA_TO_BYTE(), trimmedInputTerm);
             case SMALLINT:
-                return staticCall(STRING_DATA_TO_SHORT(), inputTerm);
+                return staticCall(STRING_DATA_TO_SHORT(), trimmedInputTerm);
             case INTEGER:
-                return staticCall(STRING_DATA_TO_INT(), inputTerm);
+                return staticCall(STRING_DATA_TO_INT(), trimmedInputTerm);
             case BIGINT:
-                return staticCall(STRING_DATA_TO_LONG(), inputTerm);
+                return staticCall(STRING_DATA_TO_LONG(), trimmedInputTerm);
             case FLOAT:
-                return staticCall(STRING_DATA_TO_FLOAT(), inputTerm);
+                return staticCall(STRING_DATA_TO_FLOAT(), trimmedInputTerm);
             case DOUBLE:
-                return staticCall(STRING_DATA_TO_DOUBLE(), inputTerm);
+                return staticCall(STRING_DATA_TO_DOUBLE(), trimmedInputTerm);
         }
         throw new IllegalArgumentException("This is a bug. Please file an issue.");
     }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/casting/CastRulesTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/casting/CastRulesTest.java
@@ -386,6 +386,7 @@ class CastRulesTest {
                         .fromCase(STRING(), fromString("1.234"), 1.234d)
                         .fromCase(STRING(), fromString("123"), 123.0d)
                         .fromCase(STRING(), fromString(" 123 "), 123.0d)
+                        .fromCase(STRING(), fromString(" .123 "), 0.123d)
                         .fromCase(STRING(), fromString("-3276913443134"), -3.276913443134E12d)
                         .fromCase(
                                 DECIMAL(4, 3), fromBigDecimal(new BigDecimal("9.87"), 4, 3), 9.87d)
@@ -1261,6 +1262,10 @@ class CastRulesTest {
                                 STRING(),
                                 fromString(" 1.2 "),
                                 fromBigDecimal(new BigDecimal("1.200"), 5, 3))
+                        .fromCase(
+                                STRING(),
+                                fromString(" .2 "),
+                                fromBigDecimal(new BigDecimal("0.200"), 5, 3))
                         .fromCase(
                                 DECIMAL(4, 3),
                                 fromBigDecimal(new BigDecimal("9.87"), 4, 3),

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/casting/CastRulesTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/casting/CastRulesTest.java
@@ -169,6 +169,7 @@ class CastRulesTest {
                         .fail(STRING(), fromString("Apache"), TableException.class)
                         .fromCase(STRING(), fromString("1.234"), (byte) 1)
                         .fromCase(STRING(), fromString("123"), (byte) 123)
+                        .fromCase(STRING(), fromString(" 123 "), (byte) 123)
                         .fail(STRING(), fromString("-130"), TableException.class)
                         .fromCase(
                                 DECIMAL(4, 3),
@@ -203,6 +204,7 @@ class CastRulesTest {
                         .fail(STRING(), fromString("Apache"), TableException.class)
                         .fromCase(STRING(), fromString("1.234"), (short) 1)
                         .fromCase(STRING(), fromString("123"), (short) 123)
+                        .fromCase(STRING(), fromString(" 123 "), (short) 123)
                         .fail(STRING(), fromString("-32769"), TableException.class)
                         .fromCase(
                                 DECIMAL(4, 3),
@@ -247,6 +249,7 @@ class CastRulesTest {
                         .fail(STRING(), fromString("Apache"), TableException.class)
                         .fromCase(STRING(), fromString("1.234"), 1)
                         .fromCase(STRING(), fromString("123"), 123)
+                        .fromCase(STRING(), fromString(" 123 "), 123)
                         .fail(STRING(), fromString("-3276913443134"), TableException.class)
                         .fromCase(DECIMAL(4, 3), fromBigDecimal(new BigDecimal("9.87"), 4, 3), 9)
                         // https://issues.apache.org/jira/browse/FLINK-24420 - Check out of range
@@ -293,6 +296,7 @@ class CastRulesTest {
                         .fail(STRING(), fromString("Apache"), TableException.class)
                         .fromCase(STRING(), fromString("1.234"), 1L)
                         .fromCase(STRING(), fromString("123"), 123L)
+                        .fromCase(STRING(), fromString(" 123 "), 123L)
                         .fromCase(STRING(), fromString("-3276913443134"), -3276913443134L)
                         .fromCase(DECIMAL(4, 3), fromBigDecimal(new BigDecimal("9.87"), 4, 3), 9L)
                         .fromCase(
@@ -334,6 +338,7 @@ class CastRulesTest {
                         .fail(STRING(), fromString("Apache"), TableException.class)
                         .fromCase(STRING(), fromString("1.234"), 1.234f)
                         .fromCase(STRING(), fromString("123"), 123.0f)
+                        .fromCase(STRING(), fromString(" 123 "), 123.0f)
                         .fromCase(STRING(), fromString("-3276913443134"), -3.27691351E12f)
                         .fromCase(
                                 DECIMAL(4, 3), fromBigDecimal(new BigDecimal("9.87"), 4, 3), 9.87f)
@@ -380,6 +385,7 @@ class CastRulesTest {
                         .fail(STRING(), fromString("Apache"), TableException.class)
                         .fromCase(STRING(), fromString("1.234"), 1.234d)
                         .fromCase(STRING(), fromString("123"), 123.0d)
+                        .fromCase(STRING(), fromString(" 123 "), 123.0d)
                         .fromCase(STRING(), fromString("-3276913443134"), -3.276913443134E12d)
                         .fromCase(
                                 DECIMAL(4, 3), fromBigDecimal(new BigDecimal("9.87"), 4, 3), 9.87d)
@@ -1250,6 +1256,10 @@ class CastRulesTest {
                         .fromCase(
                                 STRING(),
                                 fromString("1.2"),
+                                fromBigDecimal(new BigDecimal("1.200"), 5, 3))
+                        .fromCase(
+                                STRING(),
+                                fromString(" 1.2 "),
                                 fromBigDecimal(new BigDecimal("1.200"), 5, 3))
                         .fromCase(
                                 DECIMAL(4, 3),


### PR DESCRIPTION
## What is the purpose of the change

Restores the behavior of trimming a character string before casting it to a numeric.

## Brief change log

- Trim before cast.

## Verifying this change

This change added tests and can be verified as follows: `CastRulesTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
