### PR TITLE
[FLINK-27369][table-planner] Fix the type mismatch error in RemoveUnreachableCoalesceArgumentsRule

### DIFF
--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/rules/logical/RemoveUnreachableCoalesceArgumentsRuleTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/rules/logical/RemoveUnreachableCoalesceArgumentsRuleTest.java
@@ -83,4 +83,27 @@ public class RemoveUnreachableCoalesceArgumentsRuleTest extends TableTestBase {
         util.verifyRelPlan(
                 "SELECT * FROM T t1 LEFT JOIN T t2 ON COALESCE(t1.f0, '-', t1.f2) = t2.f0");
     }
+
+    @Test
+    public void testMultipleCoalesces() {
+        util.verifyRelPlan(
+                "SELECT COALESCE(1),\n"
+                        + "COALESCE(1, 2),\n"
+                        + "COALESCE(cast(NULL as int), 2),\n"
+                        + "COALESCE(1, cast(NULL as int)),\n"
+                        + "COALESCE(cast(NULL as int), cast(NULL as int), 3),\n"
+                        + "COALESCE(4, cast(NULL as int), cast(NULL as int), cast(NULL as int)),\n"
+                        + "COALESCE('1'),\n"
+                        + "COALESCE('1', '23'),\n"
+                        + "COALESCE(cast(NULL as varchar), '2'),\n"
+                        + "COALESCE('1', cast(NULL as varchar)),\n"
+                        + "COALESCE(cast(NULL as varchar), cast(NULL as varchar), '3'),\n"
+                        + "COALESCE('4', cast(NULL as varchar), cast(NULL as varchar), cast(NULL as varchar)),\n"
+                        + "COALESCE(1.0),\n"
+                        + "COALESCE(1.0, 2),\n"
+                        + "COALESCE(cast(NULL as double), 2.0),\n"
+                        + "COALESCE(cast(NULL as double), 2.0, 3.0),\n"
+                        + "COALESCE(2.0, cast(NULL as double), 3.0),\n"
+                        + "COALESCE(cast(NULL as double), cast(NULL as double))");
+    }
 }

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/RemoveUnreachableCoalesceArgumentsRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/RemoveUnreachableCoalesceArgumentsRuleTest.xml
@@ -84,6 +84,24 @@ Calc(select=[COALESCE(f0, f1) AS EXPR$0])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testFilterCoalesce">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM T WHERE COALESCE(f0, f1, '-') = 'abc']]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(f0=[$0], f1=[$1], f2=[$2])
++- LogicalFilter(condition=[=(COALESCE($0, $1, _UTF-16LE'-'), _UTF-16LE'abc')])
+   +- LogicalTableScan(table=[[default_catalog, default_database, T]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[f0, f1, f2], where=[=(COALESCE(f0, f1), 'abc')])
++- TableSourceScan(table=[[default_catalog, default_database, T]], fields=[f0, f1, f2])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testJoinCoalesce">
     <Resource name="sql">
       <![CDATA[SELECT * FROM T t1 LEFT JOIN T t2 ON COALESCE(t1.f0, '-', t1.f2) = t2.f0]]>
@@ -109,21 +127,37 @@ Calc(select=[f0, f1, f2, f00, f10, f20])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testFilterCoalesce">
+  <TestCase name="testMultipleCoalesces">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM T WHERE COALESCE(f0, f1, '-') = 'abc']]>
+      <![CDATA[SELECT COALESCE(1),
+COALESCE(1, 2),
+COALESCE(cast(NULL as int), 2),
+COALESCE(1, cast(NULL as int)),
+COALESCE(cast(NULL as int), cast(NULL as int), 3),
+COALESCE(4, cast(NULL as int), cast(NULL as int), cast(NULL as int)),
+COALESCE('1'),
+COALESCE('1', '23'),
+COALESCE(cast(NULL as varchar), '2'),
+COALESCE('1', cast(NULL as varchar)),
+COALESCE(cast(NULL as varchar), cast(NULL as varchar), '3'),
+COALESCE('4', cast(NULL as varchar), cast(NULL as varchar), cast(NULL as varchar)),
+COALESCE(1.0),
+COALESCE(1.0, 2),
+COALESCE(cast(NULL as double), 2.0),
+COALESCE(cast(NULL as double), 2.0, 3.0),
+COALESCE(2.0, cast(NULL as double), 3.0),
+COALESCE(cast(NULL as double), cast(NULL as double))]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalProject(f0=[$0], f1=[$1], f2=[$2])
-+- LogicalFilter(condition=[=(COALESCE($0, $1, _UTF-16LE'-'), _UTF-16LE'abc')])
-   +- LogicalTableScan(table=[[default_catalog, default_database, T]])
+LogicalProject(EXPR$0=[COALESCE(1)], EXPR$1=[COALESCE(1, 2)], EXPR$2=[COALESCE(null:INTEGER, 2)], EXPR$3=[COALESCE(1, null:INTEGER)], EXPR$4=[COALESCE(null:INTEGER, null:INTEGER, 3)], EXPR$5=[COALESCE(4, null:INTEGER, null:INTEGER, null:INTEGER)], EXPR$6=[COALESCE(_UTF-16LE'1')], EXPR$7=[COALESCE(_UTF-16LE'1', _UTF-16LE'23')], EXPR$8=[COALESCE(null:VARCHAR(2147483647) CHARACTER SET "UTF-16LE", _UTF-16LE'2')], EXPR$9=[COALESCE(_UTF-16LE'1', null:VARCHAR(2147483647) CHARACTER SET "UTF-16LE")], EXPR$10=[COALESCE(null:VARCHAR(2147483647) CHARACTER SET "UTF-16LE", null:VARCHAR(2147483647) CHARACTER SET "UTF-16LE", _UTF-16LE'3')], EXPR$11=[COALESCE(_UTF-16LE'4', null:VARCHAR(2147483647) CHARACTER SET "UTF-16LE", null:VARCHAR(2147483647) CHARACTER SET "UTF-16LE", null:VARCHAR(2147483647) CHARACTER SET "UTF-16LE")], EXPR$12=[COALESCE(1.0:DECIMAL(2, 1))], EXPR$13=[COALESCE(1.0:DECIMAL(11, 1), 2:DECIMAL(11, 1))], EXPR$14=[COALESCE(null:DOUBLE, 2.0:DOUBLE)], EXPR$15=[COALESCE(null:DOUBLE, 2.0:DOUBLE, 3.0:DOUBLE)], EXPR$16=[COALESCE(2.0:DOUBLE, null:DOUBLE, 3.0:DOUBLE)], EXPR$17=[COALESCE(null:DOUBLE, null:DOUBLE)])
++- LogicalValues(tuples=[[{ 0 }]])
 ]]>
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-Calc(select=[f0, f1, f2], where=[=(COALESCE(f0, f1), 'abc')])
-+- TableSourceScan(table=[[default_catalog, default_database, T]], fields=[f0, f1, f2])
+Calc(select=[1 AS EXPR$0, 1 AS EXPR$1, 2 AS EXPR$2, 1 AS EXPR$3, 3 AS EXPR$4, 4 AS EXPR$5, '1' AS EXPR$6, '1' AS EXPR$7, '2' AS EXPR$8, '1' AS EXPR$9, '3' AS EXPR$10, '4' AS EXPR$11, 1.0 AS EXPR$12, 1.0 AS EXPR$13, 2E0 AS EXPR$14, 2E0 AS EXPR$15, 2.0 AS EXPR$16, null:DOUBLE AS EXPR$17])
++- Values(tuples=[[{ 0 }]])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CalcITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CalcITCase.scala
@@ -2063,4 +2063,29 @@ class CalcITCase extends BatchTestBase {
     checkResult("SELECT TRY_CAST('invalid' AS INT)", Seq(row(null)))
     checkResult("SELECT TRY_CAST(g AS DOUBLE) FROM testTable", Seq(row(null), row(null), row(null)))
   }
+
+  @Test
+  def testMultipleCoalesces(): Unit = {
+    checkResult(
+      "SELECT COALESCE(1),\n" +
+        "COALESCE(1, 2),\n" +
+        "COALESCE(cast(NULL as int), 2),\n" +
+        "COALESCE(1, cast(NULL as int)),\n" +
+        "COALESCE(cast(NULL as int), cast(NULL as int), 3),\n" +
+        "COALESCE(4, cast(NULL as int), cast(NULL as int), cast(NULL as int)),\n" +
+        "COALESCE('1'),\n" +
+        "COALESCE('1', '23'),\n" +
+        "COALESCE(cast(NULL as varchar), '2'),\n" +
+        "COALESCE('1', cast(NULL as varchar)),\n" +
+        "COALESCE(cast(NULL as varchar), cast(NULL as varchar), '3'),\n" +
+        "COALESCE('4', cast(NULL as varchar), cast(NULL as varchar), cast(NULL as varchar)),\n" +
+        "COALESCE(1.0),\n" +
+        "COALESCE(1.0, 2),\n" +
+        "COALESCE(cast(NULL as double), 2.0),\n" +
+        "COALESCE(cast(NULL as double), 2.0, 3.0),\n" +
+        "COALESCE(2.0, cast(NULL as double), 3.0),\n" +
+        "COALESCE(cast(NULL as double), cast(NULL as double))",
+      Seq(row(1, 1, 2, 1, 3, 4, 1, 1, 2, 1, 3, 4, 1.0, 1.0, 2.0, 2.0, 2.0, null))
+    )
+  }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/CalcITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/CalcITCase.scala
@@ -649,4 +649,33 @@ class CalcITCase extends StreamingTestBase {
       List("HC809", "H389N     ")
     assertEquals(expected.sorted, sink.getAppendResults.sorted)
   }
+
+  @Test
+  def testMultipleCoalesces(): Unit = {
+    val result = tEnv
+      .sqlQuery(
+        "SELECT COALESCE(1),\n" +
+          "COALESCE(1, 2),\n" +
+          "COALESCE(cast(NULL as int), 2),\n" +
+          "COALESCE(1, cast(NULL as int)),\n" +
+          "COALESCE(cast(NULL as int), cast(NULL as int), 3),\n" +
+          "COALESCE(4, cast(NULL as int), cast(NULL as int), cast(NULL as int)),\n" +
+          "COALESCE('1'),\n" +
+          "COALESCE('1', '23'),\n" +
+          "COALESCE(cast(NULL as varchar), '2'),\n" +
+          "COALESCE('1', cast(NULL as varchar)),\n" +
+          "COALESCE(cast(NULL as varchar), cast(NULL as varchar), '3'),\n" +
+          "COALESCE('4', cast(NULL as varchar), cast(NULL as varchar), cast(NULL as varchar)),\n" +
+          "COALESCE(1.0),\n" +
+          "COALESCE(1.0, 2),\n" +
+          "COALESCE(cast(NULL as double), 2.0),\n" +
+          "COALESCE(cast(NULL as double), 2.0, 3.0),\n" +
+          "COALESCE(2.0, cast(NULL as double), 3.0),\n" +
+          "COALESCE(cast(NULL as double), cast(NULL as double))")
+      .execute()
+      .collect()
+      .toList
+    TestBaseUtils.compareResultAsText(result, "1,1,2,1,3,4,1,1,2,1,3,4,1.0,1.0,2.0,2.0,2.0,null")
+  }
+
 }


### PR DESCRIPTION


## What is the purpose of the change

*SELECT COALESCE('1', cast(NULL as varchar)), COALESCE('4', cast(NULL as varchar), cast(NULL as varchar), cast(NULL as varchar)); is failed with "Caused by: java.lang.AssertionError: Cannot add expression of different type to set: ....". This pr aims to fix it*


## Brief change log

  - *Fix the type mismatch error in RemoveUnreachableCoalesceArgumentsRule*


## Verifying this change



This change added tests and can be verified as follows:

  - *Extended RemoveUnreachableCoalesceArgumentsRuleTest to verify the bug*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
