### PR TITLE
[FLINK-27382][runtime] Moves cluster shutdown to when the job cleanup is done in job mode

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -652,6 +652,8 @@ public abstract class Dispatcher extends PermanentlyFencedRpcEndpoint<Dispatcher
             JobManagerRunnerResult jobManagerRunnerResult, ExecutionType executionType) {
         if (jobManagerRunnerResult.isInitializationFailure()
                 && executionType == ExecutionType.RECOVERY) {
+            // fail fatally to make the Dispatcher fail-over and recover all jobs once more (which
+            // can only happen in HA mode)
             return CompletableFuture.completedFuture(
                     jobManagerRunnerFailed(
                             jobManagerRunnerResult.getExecutionGraphInfo().getJobId(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/MiniDispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/MiniDispatcher.java
@@ -18,24 +18,23 @@
 
 package org.apache.flink.runtime.dispatcher;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
+import org.apache.flink.runtime.dispatcher.cleanup.ResourceCleanerFactory;
 import org.apache.flink.runtime.entrypoint.ClusterEntrypoint;
 import org.apache.flink.runtime.entrypoint.JobClusterEntrypoint;
-import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.rpc.RpcService;
-import org.apache.flink.runtime.scheduler.ExecutionGraphInfo;
 import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.FlinkException;
 
 import javax.annotation.Nullable;
 
-import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -71,6 +70,31 @@ public class MiniDispatcher extends Dispatcher {
                 CollectionUtil.ofNullable(recoveredDirtyJob),
                 dispatcherBootstrapFactory,
                 dispatcherServices);
+
+        this.executionMode = checkNotNull(executionMode);
+    }
+
+    @VisibleForTesting
+    public MiniDispatcher(
+            RpcService rpcService,
+            DispatcherId fencingToken,
+            DispatcherServices dispatcherServices,
+            @Nullable JobGraph jobGraph,
+            @Nullable JobResult recoveredDirtyJob,
+            DispatcherBootstrapFactory dispatcherBootstrapFactory,
+            JobManagerRunnerRegistry jobManagerRunnerRegistry,
+            ResourceCleanerFactory resourceCleanerFactory,
+            JobClusterEntrypoint.ExecutionMode executionMode)
+            throws Exception {
+        super(
+                rpcService,
+                fencingToken,
+                CollectionUtil.ofNullable(jobGraph),
+                CollectionUtil.ofNullable(recoveredDirtyJob),
+                dispatcherBootstrapFactory,
+                dispatcherServices,
+                jobManagerRunnerRegistry,
+                resourceCleanerFactory);
 
         this.executionMode = checkNotNull(executionMode);
     }
@@ -129,33 +153,18 @@ public class MiniDispatcher extends Dispatcher {
     }
 
     @Override
-    protected CompletableFuture<CleanupJobState> jobReachedTerminalState(
-            ExecutionGraphInfo executionGraphInfo) {
-        final ArchivedExecutionGraph archivedExecutionGraph =
-                executionGraphInfo.getArchivedExecutionGraph();
-        final CompletableFuture<CleanupJobState> cleanupHAState =
-                super.jobReachedTerminalState(executionGraphInfo);
+    protected void runPostJobGloballyTerminated(JobID jobId, JobStatus jobStatus) {
+        super.runPostJobGloballyTerminated(jobId, jobStatus);
 
-        return cleanupHAState.thenApply(
-                cleanupJobState -> {
-                    JobStatus jobStatus =
-                            Objects.requireNonNull(
-                                    archivedExecutionGraph.getState(),
-                                    "JobStatus should not be null here.");
-                    if (jobStatus.isGloballyTerminalState()
-                            && (jobCancelled
-                                    || executionMode == ClusterEntrypoint.ExecutionMode.DETACHED)) {
-                        // shut down if job is cancelled or we don't have to wait for the execution
-                        // result retrieval
-                        log.info(
-                                "Shutting down cluster with state {}, jobCancelled: {}, executionMode: {}",
-                                jobStatus,
-                                jobCancelled,
-                                executionMode);
-                        shutDownFuture.complete(ApplicationStatus.fromJobStatus(jobStatus));
-                    }
-
-                    return cleanupJobState;
-                });
+        if (jobCancelled || executionMode == ClusterEntrypoint.ExecutionMode.DETACHED) {
+            // shut down if job is cancelled or we don't have to wait for the execution
+            // result retrieval
+            log.info(
+                    "Shutting down cluster after job with state {}, jobCancelled: {}, executionMode: {}",
+                    jobStatus,
+                    jobCancelled,
+                    executionMode);
+            shutDownFuture.complete(ApplicationStatus.fromJobStatus(jobStatus));
+        }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/MiniDispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/MiniDispatcherTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.blob.BlobServer;
 import org.apache.flink.runtime.blob.VoidBlobStore;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.dispatcher.cleanup.TestingCleanupRunnerFactory;
+import org.apache.flink.runtime.dispatcher.cleanup.TestingResourceCleanerFactory;
 import org.apache.flink.runtime.entrypoint.ClusterEntrypoint;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
@@ -40,9 +41,11 @@ import org.apache.flink.runtime.rest.handler.legacy.utils.ArchivedExecutionGraph
 import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.scheduler.ExecutionGraphInfo;
+import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.runtime.testutils.TestingJobResultStore;
 import org.apache.flink.runtime.util.TestingFatalErrorHandlerResource;
 import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.concurrent.FutureUtils;
 
 import org.assertj.core.api.Assertions;
 import org.junit.AfterClass;
@@ -99,6 +102,9 @@ public class MiniDispatcherTest extends TestLogger {
     private TestingJobMasterServiceLeadershipRunnerFactory testingJobManagerRunnerFactory;
     private TestingCleanupRunnerFactory testingCleanupRunnerFactory;
 
+    private CompletableFuture<Void> localCleanupResultFuture;
+    private CompletableFuture<Void> globalCleanupResultFuture;
+
     @BeforeClass
     public static void setupClass() throws IOException {
         jobGraph = JobGraphTestUtils.singleNoOpJobGraph();
@@ -123,6 +129,10 @@ public class MiniDispatcherTest extends TestLogger {
 
         testingJobManagerRunnerFactory = new TestingJobMasterServiceLeadershipRunnerFactory();
         testingCleanupRunnerFactory = new TestingCleanupRunnerFactory();
+
+        // the default setting shouldn't block the cleanup
+        localCleanupResultFuture = FutureUtils.completedVoidFuture();
+        globalCleanupResultFuture = FutureUtils.completedVoidFuture();
     }
 
     @AfterClass
@@ -182,6 +192,7 @@ public class MiniDispatcherTest extends TestLogger {
      */
     @Test
     public void testTerminationAfterJobCompletion() throws Exception {
+        globalCleanupResultFuture = new CompletableFuture<>();
         final MiniDispatcher miniDispatcher =
                 createMiniDispatcher(ClusterEntrypoint.ExecutionMode.DETACHED);
 
@@ -194,9 +205,24 @@ public class MiniDispatcherTest extends TestLogger {
 
             testingJobManagerRunner.completeResultFuture(executionGraphInfo);
 
-            // wait until we terminate
+            CommonTestUtils.waitUntilCondition(
+                    () ->
+                            !highAvailabilityServices
+                                    .getJobResultStore()
+                                    .getDirtyResults()
+                                    .isEmpty());
+
+            assertFalse(
+                    "The shutdownFuture should not be completed before the cleanup is triggered.",
+                    miniDispatcher.getShutDownFuture().isDone());
+
+            globalCleanupResultFuture.complete(null);
+
             miniDispatcher.getShutDownFuture().get();
         } finally {
+            // we have to complete the future to make the job and, as a consequence, the
+            // MiniDispatcher terminate
+            globalCleanupResultFuture.complete(null);
             RpcUtils.terminateRpcEndpoint(miniDispatcher);
         }
     }
@@ -310,6 +336,8 @@ public class MiniDispatcherTest extends TestLogger {
             @Nullable JobGraph recoveredJobGraph,
             @Nullable JobResult recoveredDirtyJob)
             throws Exception {
+        final JobManagerRunnerRegistry jobManagerRunnerRegistry =
+                new DefaultJobManagerRunnerRegistry(2);
         return new MiniDispatcher(
                 rpcService,
                 DispatcherId.generate(),
@@ -333,6 +361,17 @@ public class MiniDispatcherTest extends TestLogger {
                 recoveredJobGraph,
                 recoveredDirtyJob,
                 (dispatcher, scheduledExecutor, errorHandler) -> new NoOpDispatcherBootstrap(),
+                jobManagerRunnerRegistry,
+                TestingResourceCleanerFactory.builder()
+                        // JobManagerRunnerRegistry needs to be added explicitly
+                        // because cleaning it will trigger the closeAsync latch
+                        // provided by TestingJobManagerRunner
+                        .withLocallyCleanableResource(jobManagerRunnerRegistry)
+                        .withGloballyCleanableResource(
+                                (jobId, ignoredExecutor) -> globalCleanupResultFuture)
+                        .withLocallyCleanableResource(
+                                (jobId, ignoredExecutor) -> localCleanupResultFuture)
+                        .build(),
                 executionMode);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

In job mode, we triggered the shutdown as soon as the job reached a globally terminal state. This was fine in 1.14- because we didn't do any promises on the cleanup anyway. With 1.15, we introduced retries for cleanup which results in the final termination taking longer. During cluster shutdown the ResourceManager is informed about deregistering the cluster which results in the workers being shutdown in case of active RMs (i.e. k8s and YARN). See further details in FLINK-26772 (parent issue of this issue).

## Brief change log

* removed overwriting of `Dispatcher#jobReachedTerminalState` in `MiniDispatcher`
* Introduced new method that is called when the job reached a globally terminal state which then gets implemented by `MiniDispatcher`

## Verifying this change

* I extended existing tests to verify that the shutdown happens after the cleanup

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
