### PR TITLE
[FLINK-27381][connector/common] Use Arrays.hashcode for HybridSourceSplit wrappedSplitBytes

### DIFF
--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSourceSplit.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSourceSplit.java
@@ -75,7 +75,7 @@ public class HybridSourceSplit implements SourceSplit {
 
     @Override
     public int hashCode() {
-        return Objects.hash(wrappedSplitBytes, sourceIndex);
+        return Objects.hash(Arrays.hashCode(wrappedSplitBytes), sourceIndex);
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change

HybridSourceSplit's wrappedSplit should use Arrays.hashCode because wrappedSplit has been changed from `SourceSplit` object to serialized wrappedBytes array.

## Brief change log

Correct HybridSourceSplit hashCode method.

## Verifying this change

This change is already covered by existing tests, such as `HybridSourceSplitSerializerTest`, `HybridSourceSplitEnumeratorTest`.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature?  no
- If yes, how is the feature documented? not applicable
