### PR TITLE
[FLINK-24804][FLINK-25505] Upgrade oshi-core to version 6.1.5

### DIFF
--- a/docs/content.zh/docs/ops/metrics.md
+++ b/docs/content.zh/docs/ops/metrics.md
@@ -1707,12 +1707,12 @@ configured interval (`metrics.system-resource-probing-interval`).
 System resources reporting requires an optional dependency to be present on the
 classpath (for example placed in Flink's `lib` directory):
 
-  - `com.github.oshi:oshi-core:3.4.0` (licensed under EPL 1.0 license)
+  - `com.github.oshi:oshi-core:6.1.5` (licensed under MIT license)
 
 Including it's transitive dependencies:
 
-  - `net.java.dev.jna:jna-platform:jar:4.2.2`
-  - `net.java.dev.jna:jna:jar:4.2.2`
+  - `net.java.dev.jna:jna-platform:jar:5.10.0`
+  - `net.java.dev.jna:jna:jar:5.10.0`
 
 Failures in this regard will be reported as warning messages like `NoClassDefFoundError`
 logged by `SystemResourcesMetricsInitializer` during the startup.

--- a/docs/content/docs/ops/metrics.md
+++ b/docs/content/docs/ops/metrics.md
@@ -1691,12 +1691,12 @@ configured interval (`metrics.system-resource-probing-interval`).
 System resources reporting requires an optional dependency to be present on the
 classpath (for example placed in Flink's `lib` directory):
 
-  - `com.github.oshi:oshi-core:3.4.0` (licensed under EPL 1.0 license)
+  - `com.github.oshi:oshi-core:6.1.5` (licensed under MIT license)
 
 Including it's transitive dependencies:
 
-  - `net.java.dev.jna:jna-platform:jar:4.2.2`
-  - `net.java.dev.jna:jna:jar:4.2.2`
+  - `net.java.dev.jna:jna-platform:jar:5.10.0`
+  - `net.java.dev.jna:jna:jar:5.10.0`
 
 Failures in this regard will be reported as warning messages like `NoClassDefFoundError`
 logged by `SystemResourcesMetricsInitializer` during the startup.
@@ -1714,38 +1714,42 @@ logged by `SystemResourcesMetricsInitializer` during the startup.
   </thead>
   <tbody>
     <tr>
-      <th rowspan="12"><strong>Job-/TaskManager</strong></th>
-      <td rowspan="12">System.CPU</td>
+      <th rowspan="13"><strong>Job-/TaskManager</strong></th>
+      <td rowspan="13">System.CPU</td>
       <td>Usage</td>
       <td>Overall % of CPU usage on the machine.</td>
     </tr>
     <tr>
       <td>Idle</td>
-      <td>% of CPU Idle usage on the machine.</td>
+      <td>% of CPU Idle time on the machine.</td>
     </tr>
     <tr>
       <td>Sys</td>
-      <td>% of System CPU usage on the machine.</td>
+      <td>% of System CPU time on the machine.</td>
     </tr>
     <tr>
       <td>User</td>
-      <td>% of User CPU usage on the machine.</td>
+      <td>% of User CPU time on the machine.</td>
     </tr>
     <tr>
       <td>IOWait</td>
-      <td>% of IOWait CPU usage on the machine.</td>
+      <td>% of IOWait CPU time on the machine.</td>
     </tr>
     <tr>
       <td>Irq</td>
-      <td>% of Irq CPU usage on the machine.</td>
+      <td>% of Irq CPU time on the machine.</td>
     </tr>
     <tr>
       <td>SoftIrq</td>
-      <td>% of SoftIrq CPU usage on the machine.</td>
+      <td>% of SoftIrq CPU time on the machine.</td>
     </tr>
     <tr>
       <td>Nice</td>
-      <td>% of Nice Idle usage on the machine.</td>
+      <td>% of Nice CPU time on the machine.</td>
+    </tr>
+    <tr>
+      <td>Steal</td>
+      <td>% of Steal CPU time on the machine.</td>
     </tr>
     <tr>
       <td>Load1min</td>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/util/SystemResourcesMetricsInitializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/util/SystemResourcesMetricsInitializer.java
@@ -63,8 +63,8 @@ public class SystemResourcesMetricsInitializer {
     }
 
     private static void instantiateSwapMetrics(MetricGroup metrics, GlobalMemory memory) {
-        metrics.<Long, Gauge<Long>>gauge("Used", memory::getSwapUsed);
-        metrics.<Long, Gauge<Long>>gauge("Total", memory::getSwapTotal);
+        metrics.<Long, Gauge<Long>>gauge("Used", memory.getVirtualMemory()::getSwapUsed);
+        metrics.<Long, Gauge<Long>>gauge("Total", memory.getVirtualMemory()::getSwapTotal);
     }
 
     private static void instantiateCPUMetrics(
@@ -77,6 +77,7 @@ public class SystemResourcesMetricsInitializer {
         metrics.<Double, Gauge<Double>>gauge("Nice", usageCounter::getCpuNice);
         metrics.<Double, Gauge<Double>>gauge("Irq", usageCounter::getCpuIrq);
         metrics.<Double, Gauge<Double>>gauge("SoftIrq", usageCounter::getCpuSoftIrq);
+        metrics.<Double, Gauge<Double>>gauge("Steal", usageCounter::getCpuSteal);
 
         metrics.<Double, Gauge<Double>>gauge("Load1min", usageCounter::getCpuLoad1);
         metrics.<Double, Gauge<Double>>gauge("Load5min", usageCounter::getCpuLoad5);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/utils/SystemResourcesCounterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/utils/SystemResourcesCounterTest.java
@@ -55,7 +55,8 @@ public class SystemResourcesCounterTest {
                         + systemResources.getCpuSoftIrq()
                         + systemResources.getCpuSys()
                         + systemResources.getCpuUser()
-                        + systemResources.getIOWait();
+                        + systemResources.getIOWait()
+                        + systemResources.getCpuSteal();
 
         assertTrue(
                 "There should be at least one processor", systemResources.getProcessorsCount() > 0);

--- a/flink-tests/src/test/java/org/apache/flink/runtime/metrics/SystemResourcesMetricsITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/metrics/SystemResourcesMetricsITCase.java
@@ -85,6 +85,7 @@ public class SystemResourcesMetricsITCase extends TestLogger {
             "System.CPU.IOWait",
             "System.CPU.Irq",
             "System.CPU.SoftIrq",
+            "System.CPU.Steal",
             "System.CPU.Nice",
             "System.Memory.Available",
             "System.Memory.Total",

--- a/pom.xml
+++ b/pom.xml
@@ -511,7 +511,7 @@ under the License.
 			<dependency>
 				<groupId>com.github.oshi</groupId>
 				<artifactId>oshi-core</artifactId>
-				<version>3.4.0</version>
+				<version>6.1.5</version>
 			</dependency>
 
 			<!-- We no longer align the avro version with the version bundled in Hadoop.


### PR DESCRIPTION
## What is the purpose of the change

* Upgrade oshi-core to version 6.1.5 (according to FLINK-24804) which resolves one issue of building and testing Flink on Apple M1 (see FLINK-25505)

## Brief change log

  - Simply adapted to changed interface
  - Update docs accordingly
  - Fix calculation of CPU load to include steal time according to oshi-core docs: *"To calculate overall Idle time using this method, include both Idle and IOWait ticks. Similarly, IRQ, SoftIRQ and Steal ticks should be added to the System value to get the total. System ticks also include time executing other virtual hosts (steal)."*

## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

* Tests have been in place covering the changes as we simply upgrade oshi-core version.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **yes**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: J**no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**