### PR TITLE
[FLINK-27384] solve the problem that the latest data cannot be read under the creat…

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HivePartitionFetcherContextBase.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HivePartitionFetcherContextBase.java
@@ -46,7 +46,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.stream.Collectors;
 
 import static org.apache.flink.table.filesystem.DefaultPartTimeExtractor.toMills;
 import static org.apache.flink.table.filesystem.FileSystemConnectorOptions.PARTITION_TIME_EXTRACTOR_CLASS;
@@ -74,8 +73,6 @@ public abstract class HivePartitionFetcherContextBase<P> implements HivePartitio
     protected transient Path tableLocation;
     private transient PartitionTimeExtractor extractor;
     private transient Table table;
-    // remember the map from partition to its create time
-    private transient Map<List<String>, Long> partValuesToCreateTime;
 
     public HivePartitionFetcherContextBase(
             ObjectPath tablePath,
@@ -116,7 +113,6 @@ public abstract class HivePartitionFetcherContextBase<P> implements HivePartitio
                         extractorClass,
                         extractorPattern);
         tableLocation = new Path(table.getSd().getLocation());
-        partValuesToCreateTime = new HashMap<>();
     }
 
     @Override
@@ -134,21 +130,17 @@ public abstract class HivePartitionFetcherContextBase<P> implements HivePartitio
                 }
                 break;
             case CREATE_TIME:
+                Map<List<String>, Long> partValuesToCreateTime = new HashMap<>();
                 partitionNames =
                         metaStoreClient.listPartitionNames(
                                 tablePath.getDatabaseName(),
                                 tablePath.getObjectName(),
                                 Short.MAX_VALUE);
-                List<String> newNames =
-                        partitionNames.stream()
-                                .filter(
-                                        n ->
-                                                !partValuesToCreateTime.containsKey(
-                                                        extractPartitionValues(n)))
-                                .collect(Collectors.toList());
                 List<Partition> newPartitions =
                         metaStoreClient.getPartitionsByNames(
-                                tablePath.getDatabaseName(), tablePath.getObjectName(), newNames);
+                                tablePath.getDatabaseName(),
+                                tablePath.getObjectName(),
+                                partitionNames);
                 for (Partition partition : newPartitions) {
                     partValuesToCreateTime.put(
                             partition.getValues(), getPartitionCreateTime(partition));
@@ -230,9 +222,6 @@ public abstract class HivePartitionFetcherContextBase<P> implements HivePartitio
 
     @Override
     public void close() throws Exception {
-        if (partValuesToCreateTime != null) {
-            partValuesToCreateTime.clear();
-        }
         if (this.metaStoreClient != null) {
             this.metaStoreClient.close();
         }


### PR DESCRIPTION
## What is the purpose of the change
This pull request solve the problem that the latest data cannot be read under the createtime configuration in the hive dimension table.

## Brief change log
solve the problem that the latest data cannot be read under the createtime configuration in the hive dimension table


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

no

This change added tests and can be verified as follows:


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
