### PR TITLE
[FLINK-27427][rpc] Remove timeouts from RpcUtils#terminate*

### DIFF
--- a/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActorHandshakeTest.java
+++ b/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActorHandshakeTest.java
@@ -94,7 +94,7 @@ class AkkaRpcActorHandshakeTest {
 
             assertThat(dummyRpcGateway.foobar().get()).isEqualTo(value);
         } finally {
-            RpcUtils.terminateRpcEndpoint(rpcEndpoint, timeout);
+            RpcUtils.terminateRpcEndpoint(rpcEndpoint);
         }
     }
 
@@ -116,7 +116,7 @@ class AkkaRpcActorHandshakeTest {
                     .extracting(ExceptionUtils::stripExecutionException)
                     .isInstanceOf(HandshakeException.class);
         } finally {
-            RpcUtils.terminateRpcEndpoint(rpcEndpoint, timeout);
+            RpcUtils.terminateRpcEndpoint(rpcEndpoint);
         }
     }
 
@@ -140,7 +140,7 @@ class AkkaRpcActorHandshakeTest {
                     .isInstanceOf(HandshakeException.class);
 
         } finally {
-            RpcUtils.terminateRpcEndpoint(rpcEndpoint, timeout);
+            RpcUtils.terminateRpcEndpoint(rpcEndpoint);
         }
     }
 

--- a/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActorOversizedResponseMessageTest.java
+++ b/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActorOversizedResponseMessageTest.java
@@ -69,7 +69,7 @@ class AkkaRpcActorOversizedResponseMessageTest {
 
     @AfterAll
     static void teardownClass() throws Exception {
-        RpcUtils.terminateRpcServices(rpcService1, rpcService2);
+        RpcUtils.terminateRpcService(rpcService1, rpcService2);
     }
 
     @Test

--- a/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActorOversizedResponseMessageTest.java
+++ b/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActorOversizedResponseMessageTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.rpc.akka;
 
-import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.AkkaOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.testutils.FlinkAssertions;
@@ -45,8 +44,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /** Tests for the over sized response message handling of the {@link AkkaRpcActor}. */
 class AkkaRpcActorOversizedResponseMessageTest {
 
-    private static final Time TIMEOUT = Time.seconds(10L);
-
     private static final int FRAMESIZE = 32000;
 
     private static final String OVERSIZED_PAYLOAD = new String(new byte[FRAMESIZE]);
@@ -72,7 +69,7 @@ class AkkaRpcActorOversizedResponseMessageTest {
 
     @AfterAll
     static void teardownClass() throws Exception {
-        RpcUtils.terminateRpcServices(TIMEOUT, rpcService1, rpcService2);
+        RpcUtils.terminateRpcServices(rpcService1, rpcService2);
     }
 
     @Test
@@ -152,7 +149,7 @@ class AkkaRpcActorOversizedResponseMessageTest {
 
             return rpcCall.apply(rpcGateway);
         } finally {
-            RpcUtils.terminateRpcEndpoint(rpcEndpoint, TIMEOUT);
+            RpcUtils.terminateRpcEndpoint(rpcEndpoint);
         }
     }
 
@@ -169,7 +166,7 @@ class AkkaRpcActorOversizedResponseMessageTest {
 
             return rpcCall.apply(rpcGateway);
         } finally {
-            RpcUtils.terminateRpcEndpoint(rpcEndpoint, TIMEOUT);
+            RpcUtils.terminateRpcEndpoint(rpcEndpoint);
         }
     }
 

--- a/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActorTest.java
+++ b/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActorTest.java
@@ -90,7 +90,7 @@ class AkkaRpcActorTest {
 
     @AfterAll
     static void shutdown() throws InterruptedException, ExecutionException, TimeoutException {
-        RpcUtils.terminateRpcService(akkaRpcService, timeout);
+        RpcUtils.terminateRpcService(akkaRpcService);
     }
 
     /**
@@ -154,7 +154,7 @@ class AkkaRpcActorTest {
 
             assertThat(actualValue).isEqualTo(expectedValue);
         } finally {
-            RpcUtils.terminateRpcEndpoint(rpcEndpoint, timeout);
+            RpcUtils.terminateRpcEndpoint(rpcEndpoint);
         }
     }
 
@@ -252,8 +252,8 @@ class AkkaRpcActorTest {
                     .withThrowableOfType(ExecutionException.class)
                     .withCauseInstanceOf(RpcException.class);
         } finally {
-            RpcUtils.terminateRpcService(clientAkkaRpcService, timeout);
-            RpcUtils.terminateRpcService(serverAkkaRpcService, timeout);
+            RpcUtils.terminateRpcService(clientAkkaRpcService);
+            RpcUtils.terminateRpcService(serverAkkaRpcService);
         }
     }
 
@@ -332,7 +332,7 @@ class AkkaRpcActorTest {
             // the onStopFuture completion should allow the endpoint to terminate
             terminationFuture.get();
         } finally {
-            RpcUtils.terminateRpcEndpoint(endpoint, timeout);
+            RpcUtils.terminateRpcEndpoint(endpoint);
         }
     }
 
@@ -352,7 +352,7 @@ class AkkaRpcActorTest {
 
             terminationFuture.get();
         } finally {
-            RpcUtils.terminateRpcEndpoint(endpoint, timeout);
+            RpcUtils.terminateRpcEndpoint(endpoint);
         }
     }
 
@@ -400,7 +400,7 @@ class AkkaRpcActorTest {
                     .withThrowableOfType(ExecutionException.class)
                     .withCauseInstanceOf(RecipientUnreachableException.class);
         } finally {
-            RpcUtils.terminateRpcEndpoint(endpoint, timeout);
+            RpcUtils.terminateRpcEndpoint(endpoint);
         }
     }
 
@@ -416,7 +416,7 @@ class AkkaRpcActorTest {
             onStartEndpoint.start();
             onStartEndpoint.awaitUntilOnStartCalled();
         } finally {
-            RpcUtils.terminateRpcEndpoint(onStartEndpoint, timeout);
+            RpcUtils.terminateRpcEndpoint(onStartEndpoint);
         }
     }
 
@@ -464,7 +464,7 @@ class AkkaRpcActorTest {
             assertThat(endpoint.getNumOnStopCalls()).isEqualTo(1);
         } finally {
             onStopFuture.complete(null);
-            RpcUtils.terminateRpcEndpoint(endpoint, timeout);
+            RpcUtils.terminateRpcEndpoint(endpoint);
         }
     }
 

--- a/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceTest.java
+++ b/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceTest.java
@@ -315,7 +315,7 @@ class AkkaRpcServiceTest {
             terminationFuture.get();
             assertThat(akkaRpcService.getActorSystem().whenTerminated().isCompleted()).isTrue();
         } finally {
-            RpcUtils.terminateRpcService(akkaRpcService, TIMEOUT);
+            RpcUtils.terminateRpcService(akkaRpcService);
         }
     }
 

--- a/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/ContextClassLoadingSettingTest.java
+++ b/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/ContextClassLoadingSettingTest.java
@@ -323,8 +323,8 @@ class ContextClassLoadingSettingTest {
             // exception
             connect.getPickyObject().get();
         } finally {
-            RpcUtils.terminateRpcService(clientAkkaRpcService, TIMEOUT);
-            RpcUtils.terminateRpcService(serverAkkaRpcService, TIMEOUT);
+            RpcUtils.terminateRpcService(clientAkkaRpcService);
+            RpcUtils.terminateRpcService(serverAkkaRpcService);
         }
     }
 

--- a/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/RemoteAkkaRpcActorTest.java
+++ b/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/RemoteAkkaRpcActorTest.java
@@ -57,7 +57,7 @@ class RemoteAkkaRpcActorTest {
 
     @AfterAll
     static void teardownClass() throws InterruptedException, ExecutionException, TimeoutException {
-        RpcUtils.terminateRpcServices(rpcService, otherRpcService);
+        RpcUtils.terminateRpcService(rpcService, otherRpcService);
     }
 
     @Test

--- a/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/RemoteAkkaRpcActorTest.java
+++ b/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/RemoteAkkaRpcActorTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.rpc.akka;
 
-import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.testutils.FlinkAssertions;
 import org.apache.flink.runtime.rpc.RpcUtils;
@@ -58,7 +57,7 @@ class RemoteAkkaRpcActorTest {
 
     @AfterAll
     static void teardownClass() throws InterruptedException, ExecutionException, TimeoutException {
-        RpcUtils.terminateRpcServices(Time.seconds(10), rpcService, otherRpcService);
+        RpcUtils.terminateRpcServices(rpcService, otherRpcService);
     }
 
     @Test
@@ -168,7 +167,7 @@ class RemoteAkkaRpcActorTest {
                     .satisfies(
                             FlinkAssertions.anyCauseMatches(RecipientUnreachableException.class));
         } finally {
-            RpcUtils.terminateRpcService(toBeClosedRpcService, Time.seconds(10L));
+            RpcUtils.terminateRpcService(toBeClosedRpcService);
         }
     }
 }

--- a/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/RpcUtils.java
+++ b/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/RpcUtils.java
@@ -35,7 +35,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 /** Utility functions for Flink's RPC implementation. */
@@ -73,45 +72,16 @@ public class RpcUtils {
     }
 
     /**
-     * Shuts the given {@link RpcEndpoint} down and awaits its termination.
+     * Shuts the given {@link RpcEndpoint}s down and awaits their termination.
      *
-     * @param rpcEndpoint to terminate
+     * @param rpcEndpoints to terminate
      * @throws ExecutionException if a problem occurred
      * @throws InterruptedException if the operation has been interrupted
-     * @throws TimeoutException if a timeout occurred
      */
     @VisibleForTesting
-    public static void terminateRpcEndpoint(RpcEndpoint rpcEndpoint)
-            throws ExecutionException, InterruptedException, TimeoutException {
-        rpcEndpoint.closeAsync().get();
-    }
-
-    /**
-     * Shuts the given {@link RpcEndpoint RpcEndpoints} down and waits for their termination.
-     *
-     * @param rpcEndpoints to shut down
-     * @throws InterruptedException if the operation has been interrupted
-     * @throws ExecutionException if a problem occurred
-     * @throws TimeoutException if a timeout occurred
-     */
-    @VisibleForTesting
-    public static void terminateRpcEndpoints(RpcEndpoint... rpcEndpoints)
-            throws InterruptedException, ExecutionException, TimeoutException {
+    public static void terminateRpcEndpoint(RpcEndpoint... rpcEndpoints)
+            throws ExecutionException, InterruptedException {
         terminateAsyncCloseables(Arrays.asList(rpcEndpoints));
-    }
-
-    /**
-     * Shuts the given rpc service down and waits for its termination.
-     *
-     * @param rpcService to shut down
-     * @throws InterruptedException if the operation has been interrupted
-     * @throws ExecutionException if a problem occurred
-     * @throws TimeoutException if a timeout occurred
-     */
-    @VisibleForTesting
-    public static void terminateRpcService(RpcService rpcService)
-            throws InterruptedException, ExecutionException, TimeoutException {
-        rpcService.stopService().get();
     }
 
     /**
@@ -120,11 +90,10 @@ public class RpcUtils {
      * @param rpcServices to shut down
      * @throws InterruptedException if the operation has been interrupted
      * @throws ExecutionException if a problem occurred
-     * @throws TimeoutException if a timeout occurred
      */
     @VisibleForTesting
-    public static void terminateRpcServices(RpcService... rpcServices)
-            throws InterruptedException, ExecutionException, TimeoutException {
+    public static void terminateRpcService(RpcService... rpcServices)
+            throws InterruptedException, ExecutionException {
         terminateAsyncCloseables(
                 Arrays.stream(rpcServices)
                         .map(rpcService -> (AutoCloseableAsync) rpcService::stopService)
@@ -133,7 +102,7 @@ public class RpcUtils {
 
     private static void terminateAsyncCloseables(
             Collection<? extends AutoCloseableAsync> closeables)
-            throws InterruptedException, ExecutionException, TimeoutException {
+            throws InterruptedException, ExecutionException {
         final Collection<CompletableFuture<?>> terminationFutures =
                 new ArrayList<>(closeables.size());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/AbstractDispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/AbstractDispatcherTest.java
@@ -59,7 +59,7 @@ public class AbstractDispatcherTest extends TestLogger {
     @AfterClass
     public static void teardownClass() throws Exception {
         if (rpcService != null) {
-            RpcUtils.terminateRpcService(rpcService, TIMEOUT);
+            RpcUtils.terminateRpcService(rpcService);
             rpcService = null;
         }
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherCleanupITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherCleanupITCase.java
@@ -119,7 +119,7 @@ public class DispatcherCleanupITCase extends AbstractDispatcherTest {
         while (!toTerminate.isEmpty()) {
             final RpcEndpoint endpoint = toTerminate.poll();
             try {
-                RpcUtils.terminateRpcEndpoint(endpoint, TIMEOUT);
+                RpcUtils.terminateRpcEndpoint(endpoint);
             } catch (Exception e) {
                 // Ignore.
             }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -177,7 +177,7 @@ public class DispatcherTest extends AbstractDispatcherTest {
     @After
     public void tearDown() throws Exception {
         if (dispatcher != null) {
-            RpcUtils.terminateRpcEndpoint(dispatcher, TIMEOUT);
+            RpcUtils.terminateRpcEndpoint(dispatcher);
         }
         super.tearDown();
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/MiniDispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/MiniDispatcherTest.java
@@ -133,7 +133,7 @@ public class MiniDispatcherTest extends TestLogger {
         }
 
         if (rpcService != null) {
-            RpcUtils.terminateRpcService(rpcService, timeout);
+            RpcUtils.terminateRpcService(rpcService);
         }
     }
 
@@ -151,7 +151,7 @@ public class MiniDispatcherTest extends TestLogger {
 
             assertThat(testingJobManagerRunner.getJobID(), is(jobGraph.getJobID()));
         } finally {
-            RpcUtils.terminateRpcEndpoint(miniDispatcher, timeout);
+            RpcUtils.terminateRpcEndpoint(miniDispatcher);
         }
     }
 
@@ -172,7 +172,7 @@ public class MiniDispatcherTest extends TestLogger {
                     testingCleanupRunnerFactory.takeCreatedJobManagerRunner();
             assertThat(testingCleanupRunner.getJobID(), is(jobId));
         } finally {
-            RpcUtils.terminateRpcEndpoint(miniDispatcher, timeout);
+            RpcUtils.terminateRpcEndpoint(miniDispatcher);
         }
     }
 
@@ -197,7 +197,7 @@ public class MiniDispatcherTest extends TestLogger {
             // wait until we terminate
             miniDispatcher.getShutDownFuture().get();
         } finally {
-            RpcUtils.terminateRpcEndpoint(miniDispatcher, timeout);
+            RpcUtils.terminateRpcEndpoint(miniDispatcher);
         }
     }
 
@@ -226,7 +226,7 @@ public class MiniDispatcherTest extends TestLogger {
             testingJobManagerRunner.getTerminationFuture().get();
             Assertions.assertThat(miniDispatcher.getShutDownFuture()).isNotDone();
         } finally {
-            RpcUtils.terminateRpcEndpoint(miniDispatcher, timeout);
+            RpcUtils.terminateRpcEndpoint(miniDispatcher);
         }
     }
 
@@ -261,7 +261,7 @@ public class MiniDispatcherTest extends TestLogger {
 
             assertThat(jobResult.getJobId(), is(jobGraph.getJobID()));
         } finally {
-            RpcUtils.terminateRpcEndpoint(miniDispatcher, timeout);
+            RpcUtils.terminateRpcEndpoint(miniDispatcher);
         }
     }
 
@@ -292,7 +292,7 @@ public class MiniDispatcherTest extends TestLogger {
             ApplicationStatus applicationStatus = miniDispatcher.getShutDownFuture().get();
             assertThat(applicationStatus, is(ApplicationStatus.CANCELED));
         } finally {
-            RpcUtils.terminateRpcEndpoint(miniDispatcher, timeout);
+            RpcUtils.terminateRpcEndpoint(miniDispatcher);
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterPartitionReleaseTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterPartitionReleaseTest.java
@@ -319,7 +319,7 @@ public class JobMasterPartitionReleaseTest extends TestLogger {
         public void close() throws Exception {
             try {
                 if (jobMaster != null) {
-                    RpcUtils.terminateRpcEndpoint(jobMaster, testingTimeout);
+                    RpcUtils.terminateRpcEndpoint(jobMaster);
                 }
             } finally {
                 temporaryFolder.delete();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerJobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerJobMasterTest.java
@@ -133,7 +133,7 @@ public class ResourceManagerJobMasterTest extends TestLogger {
         }
 
         if (rpcService != null) {
-            RpcUtils.terminateRpcService(rpcService, TIMEOUT);
+            RpcUtils.terminateRpcService(rpcService);
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerPartitionLifecycleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerPartitionLifecycleTest.java
@@ -82,7 +82,7 @@ public class ResourceManagerPartitionLifecycleTest extends TestLogger {
     @AfterClass
     public static void tearDownClass() throws Exception {
         if (rpcService != null) {
-            RpcUtils.terminateRpcServices(TIMEOUT, rpcService);
+            RpcUtils.terminateRpcServices(rpcService);
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerPartitionLifecycleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerPartitionLifecycleTest.java
@@ -82,7 +82,7 @@ public class ResourceManagerPartitionLifecycleTest extends TestLogger {
     @AfterClass
     public static void tearDownClass() throws Exception {
         if (rpcService != null) {
-            RpcUtils.terminateRpcServices(rpcService);
+            RpcUtils.terminateRpcService(rpcService);
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerServiceImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerServiceImplTest.java
@@ -110,7 +110,7 @@ public class ResourceManagerServiceImplTest extends TestLogger {
     @AfterClass
     public static void teardownClass() throws Exception {
         if (rpcService != null) {
-            RpcUtils.terminateRpcService(rpcService, TIMEOUT);
+            RpcUtils.terminateRpcService(rpcService);
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTaskExecutorTest.java
@@ -166,7 +166,7 @@ public class ResourceManagerTaskExecutorTest extends TestLogger {
     @AfterClass
     public static void teardownClass() throws Exception {
         if (rpcService != null) {
-            RpcUtils.terminateRpcService(rpcService, TIMEOUT);
+            RpcUtils.terminateRpcService(rpcService);
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTest.java
@@ -148,7 +148,7 @@ public class ResourceManagerTest extends TestLogger {
     @AfterClass
     public static void tearDownClass() throws Exception {
         if (rpcService != null) {
-            RpcUtils.terminateRpcServices(rpcService);
+            RpcUtils.terminateRpcService(rpcService);
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTest.java
@@ -129,7 +129,7 @@ public class ResourceManagerTest extends TestLogger {
     @After
     public void after() throws Exception {
         if (resourceManager != null) {
-            RpcUtils.terminateRpcEndpoint(resourceManager, TIMEOUT);
+            RpcUtils.terminateRpcEndpoint(resourceManager);
         }
 
         if (highAvailabilityServices != null) {
@@ -148,7 +148,7 @@ public class ResourceManagerTest extends TestLogger {
     @AfterClass
     public static void tearDownClass() throws Exception {
         if (rpcService != null) {
-            RpcUtils.terminateRpcServices(TIMEOUT, rpcService);
+            RpcUtils.terminateRpcServices(rpcService);
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/AsyncCallsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/AsyncCallsTest.java
@@ -129,7 +129,7 @@ public class AsyncCallsTest extends TestLogger {
             // validate that no concurrent access happened
             assertFalse("Rpc Endpoint had concurrent access", concurrentAccess.get());
         } finally {
-            RpcUtils.terminateRpcEndpoint(rpcEndpoint, timeout);
+            RpcUtils.terminateRpcEndpoint(rpcEndpoint);
         }
     }
 
@@ -189,7 +189,7 @@ public class AsyncCallsTest extends TestLogger {
 
             assertTrue("call was not properly delayed", ((stop - start) / 1_000_000) >= delay);
         } finally {
-            RpcUtils.terminateRpcEndpoint(rpcEndpoint, timeout);
+            RpcUtils.terminateRpcEndpoint(rpcEndpoint);
         }
     }
 
@@ -324,7 +324,7 @@ public class AsyncCallsTest extends TestLogger {
 
             return result;
         } finally {
-            RpcUtils.terminateRpcEndpoint(fencedTestEndpoint, timeout);
+            RpcUtils.terminateRpcEndpoint(fencedTestEndpoint);
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/FencedRpcEndpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/FencedRpcEndpointTest.java
@@ -62,7 +62,7 @@ public class FencedRpcEndpointTest {
     public static void teardown()
             throws ExecutionException, InterruptedException, TimeoutException {
         if (rpcService != null) {
-            RpcUtils.terminateRpcService(rpcService, timeout);
+            RpcUtils.terminateRpcService(rpcService);
         }
     }
 
@@ -109,7 +109,7 @@ public class FencedRpcEndpointTest {
             assertEquals(newFencingToken, fencedGateway.getFencingToken());
             assertEquals(newFencingToken, fencedTestingEndpoint.getFencingToken());
         } finally {
-            RpcUtils.terminateRpcEndpoint(fencedTestingEndpoint, timeout);
+            RpcUtils.terminateRpcEndpoint(fencedTestingEndpoint);
             fencedTestingEndpoint.validateResourceClosed();
         }
     }
@@ -178,7 +178,7 @@ public class FencedRpcEndpointTest {
             }
 
         } finally {
-            RpcUtils.terminateRpcEndpoint(fencedTestingEndpoint, timeout);
+            RpcUtils.terminateRpcEndpoint(fencedTestingEndpoint);
             fencedTestingEndpoint.validateResourceClosed();
         }
     }
@@ -246,7 +246,7 @@ public class FencedRpcEndpointTest {
                         ExceptionUtils.stripExecutionException(e) instanceof FencingTokenException);
             }
         } finally {
-            RpcUtils.terminateRpcEndpoint(fencedTestingEndpoint, timeout);
+            RpcUtils.terminateRpcEndpoint(fencedTestingEndpoint);
             fencedTestingEndpoint.validateResourceClosed();
         }
     }
@@ -296,7 +296,7 @@ public class FencedRpcEndpointTest {
             }
 
         } finally {
-            RpcUtils.terminateRpcEndpoint(fencedTestingEndpoint, timeout);
+            RpcUtils.terminateRpcEndpoint(fencedTestingEndpoint);
             fencedTestingEndpoint.validateResourceClosed();
         }
     }
@@ -338,7 +338,7 @@ public class FencedRpcEndpointTest {
                 // we should not be able to call getFencingToken on an unfenced gateway
             }
         } finally {
-            RpcUtils.terminateRpcEndpoint(fencedTestingEndpoint, timeout);
+            RpcUtils.terminateRpcEndpoint(fencedTestingEndpoint);
             fencedTestingEndpoint.validateResourceClosed();
         }
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/RpcEndpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/RpcEndpointTest.java
@@ -82,7 +82,7 @@ public class RpcEndpointTest {
 
             assertEquals(Integer.valueOf(expectedValue), foobar.get());
         } finally {
-            RpcUtils.terminateRpcEndpoint(baseEndpoint, TIMEOUT);
+            RpcUtils.terminateRpcEndpoint(baseEndpoint);
 
             baseEndpoint.validateResourceClosed();
         }
@@ -109,7 +109,7 @@ public class RpcEndpointTest {
                         fail(
                                 "Expected to fail with a RuntimeException since we requested the wrong gateway type.");
                     } finally {
-                        RpcUtils.terminateRpcEndpoint(baseEndpoint, TIMEOUT);
+                        RpcUtils.terminateRpcEndpoint(baseEndpoint);
 
                         baseEndpoint.validateResourceClosed();
                     }
@@ -141,7 +141,7 @@ public class RpcEndpointTest {
             assertEquals(Integer.valueOf(barfoo), extendedGateway.barfoo().get());
             assertEquals(foo, differentGateway.foo().get());
         } finally {
-            RpcUtils.terminateRpcEndpoint(endpoint, TIMEOUT);
+            RpcUtils.terminateRpcEndpoint(endpoint);
             endpoint.validateResourceClosed();
         }
     }
@@ -160,7 +160,7 @@ public class RpcEndpointTest {
             endpoint.start();
             assertTrue(gateway.queryIsRunningFlag().get());
         } finally {
-            RpcUtils.terminateRpcEndpoint(endpoint, TIMEOUT);
+            RpcUtils.terminateRpcEndpoint(endpoint);
             endpoint.validateResourceClosed();
         }
     }
@@ -291,7 +291,7 @@ public class RpcEndpointTest {
                             });
             asyncExecutionFuture.get(TIMEOUT.getSize(), TIMEOUT.getUnit());
         } finally {
-            RpcUtils.terminateRpcEndpoint(endpoint, TIMEOUT);
+            RpcUtils.terminateRpcEndpoint(endpoint);
             endpoint.validateResourceClosed();
         }
     }
@@ -454,7 +454,7 @@ public class RpcEndpointTest {
                             TIMEOUT);
             assertEquals(expectedInteger, integerFuture.get(TIMEOUT.getSize(), TIMEOUT.getUnit()));
         } finally {
-            RpcUtils.terminateRpcEndpoint(endpoint, TIMEOUT);
+            RpcUtils.terminateRpcEndpoint(endpoint);
             endpoint.validateResourceClosed();
         }
     }
@@ -486,7 +486,7 @@ public class RpcEndpointTest {
             assertTrue(throwable instanceof TimeoutException);
         } finally {
             latch.countDown();
-            RpcUtils.terminateRpcEndpoint(endpoint, TIMEOUT);
+            RpcUtils.terminateRpcEndpoint(endpoint);
             endpoint.validateResourceClosed();
         }
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorExecutionDeploymentReconciliationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorExecutionDeploymentReconciliationTest.java
@@ -201,7 +201,7 @@ public class TaskExecutorExecutionDeploymentReconciliationTest extends TestLogge
             taskExecutorGateway.heartbeatFromJobManager(jobManagerResourceId, slotAllocationReport);
             assertThat(deployedExecutionsQueue.take(), hasSize(0));
         } finally {
-            RpcUtils.terminateRpcEndpoint(taskExecutor, timeout);
+            RpcUtils.terminateRpcEndpoint(taskExecutor);
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorPartitionLifecycleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorPartitionLifecycleTest.java
@@ -246,7 +246,7 @@ public class TaskExecutorPartitionLifecycleTest extends TestLogger {
 
             disconnectFuture.get();
         } finally {
-            RpcUtils.terminateRpcEndpoint(taskExecutor, timeout);
+            RpcUtils.terminateRpcEndpoint(taskExecutor);
         }
     }
 
@@ -567,7 +567,7 @@ public class TaskExecutorPartitionLifecycleTest extends TestLogger {
             testAction.accept(
                     jobId, taskResultPartitionDescriptor, taskExecutor, taskExecutorGateway);
         } finally {
-            RpcUtils.terminateRpcEndpoint(taskExecutor, timeout);
+            RpcUtils.terminateRpcEndpoint(taskExecutor);
         }
 
         // the shutdown of the backing shuffle environment releases all partitions

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -249,7 +249,7 @@ public class TaskExecutorTest extends TestLogger {
     @After
     public void teardown() throws Exception {
         if (rpc != null) {
-            RpcUtils.terminateRpcService(rpc, timeout);
+            RpcUtils.terminateRpcService(rpc);
             rpc = null;
         }
 
@@ -299,7 +299,7 @@ public class TaskExecutorTest extends TestLogger {
         try {
             taskManager.start();
         } finally {
-            RpcUtils.terminateRpcEndpoint(taskManager, timeout);
+            RpcUtils.terminateRpcEndpoint(taskManager);
         }
 
         assertThat(taskSlotTable.isClosed(), is(true));
@@ -467,7 +467,7 @@ public class TaskExecutorTest extends TestLogger {
                     "The TaskExecutor should try to reconnect to the JM",
                     registrationAttempts.await(timeout.toMilliseconds(), TimeUnit.SECONDS));
         } finally {
-            RpcUtils.terminateRpcEndpoint(taskManager, timeout);
+            RpcUtils.terminateRpcEndpoint(taskManager);
         }
     }
 
@@ -582,7 +582,7 @@ public class TaskExecutorTest extends TestLogger {
                     "The TaskExecutor should try to reconnect to the RM",
                     registrationAttempts.await(timeout.toMilliseconds(), TimeUnit.SECONDS));
         } finally {
-            RpcUtils.terminateRpcEndpoint(taskManager, timeout);
+            RpcUtils.terminateRpcEndpoint(taskManager);
         }
     }
 
@@ -689,7 +689,7 @@ public class TaskExecutorTest extends TestLogger {
             assertEquals(
                     partitionTracker.createClusterPartitionReport(), actualClusterPartitionReport);
         } finally {
-            RpcUtils.terminateRpcEndpoint(taskManager, timeout);
+            RpcUtils.terminateRpcEndpoint(taskManager);
         }
     }
 
@@ -752,7 +752,7 @@ public class TaskExecutorTest extends TestLogger {
                     taskManagerRegisteredLatch.await(
                             timeout.toMilliseconds(), TimeUnit.MILLISECONDS));
         } finally {
-            RpcUtils.terminateRpcEndpoint(taskManager, timeout);
+            RpcUtils.terminateRpcEndpoint(taskManager);
         }
     }
 
@@ -832,7 +832,7 @@ public class TaskExecutorTest extends TestLogger {
                     is(unresolvedTaskManagerLocation.getResourceID()));
             assertNotNull(taskManager.getResourceManagerConnection());
         } finally {
-            RpcUtils.terminateRpcEndpoint(taskManager, timeout);
+            RpcUtils.terminateRpcEndpoint(taskManager);
         }
     }
 
@@ -971,7 +971,7 @@ public class TaskExecutorTest extends TestLogger {
                             .collect(Collectors.toList());
             assertThat(allocationIds, containsInAnyOrder(allocationId));
         } finally {
-            RpcUtils.terminateRpcEndpoint(taskManager, timeout);
+            RpcUtils.terminateRpcEndpoint(taskManager);
         }
     }
 
@@ -1071,7 +1071,7 @@ public class TaskExecutorTest extends TestLogger {
                     jobMasterGateway.getAddress(),
                     resourceManagerGateway.getFencingToken());
         } finally {
-            RpcUtils.terminateRpcEndpoint(taskManager, timeout);
+            RpcUtils.terminateRpcEndpoint(taskManager);
         }
     }
 
@@ -1208,7 +1208,7 @@ public class TaskExecutorTest extends TestLogger {
                     return;
             }
         } finally {
-            RpcUtils.terminateRpcEndpoint(taskExecutor, timeout);
+            RpcUtils.terminateRpcEndpoint(taskExecutor);
         }
     }
 
@@ -1317,7 +1317,7 @@ public class TaskExecutorTest extends TestLogger {
                     threadSafeTaskSlotTable.getActiveTaskSlotAllocationIdsPerJob(jobId2),
                     contains(slotOffer2.getAllocationId()));
         } finally {
-            RpcUtils.terminateRpcEndpoint(taskExecutor, timeout);
+            RpcUtils.terminateRpcEndpoint(taskExecutor);
         }
     }
 
@@ -1394,7 +1394,7 @@ public class TaskExecutorTest extends TestLogger {
             assertThat(availableSlotFuture.get().f2, is(allocationId));
             assertThat(threadSafeTaskSlotTable.getAllocationIdsPerJob(jobId), empty());
         } finally {
-            RpcUtils.terminateRpcEndpoint(taskExecutor, timeout);
+            RpcUtils.terminateRpcEndpoint(taskExecutor);
         }
     }
 
@@ -1474,7 +1474,7 @@ public class TaskExecutorTest extends TestLogger {
             // wait for the task completion
             taskInTerminalState.await();
         } finally {
-            RpcUtils.terminateRpcEndpoint(taskManager, timeout);
+            RpcUtils.terminateRpcEndpoint(taskManager);
         }
     }
 
@@ -1616,7 +1616,7 @@ public class TaskExecutorTest extends TestLogger {
                     unmonitoredTargets.poll(pollTimeout, TimeUnit.MILLISECONDS),
                     equalTo(rmResourceID));
         } finally {
-            RpcUtils.terminateRpcEndpoint(taskExecutor, timeout);
+            RpcUtils.terminateRpcEndpoint(taskExecutor);
         }
     }
 
@@ -1704,7 +1704,7 @@ public class TaskExecutorTest extends TestLogger {
             stopFuture.get();
             assertThat(jobLeaderService.containsJob(jobId), is(false));
         } finally {
-            RpcUtils.terminateRpcEndpoint(taskExecutor, timeout);
+            RpcUtils.terminateRpcEndpoint(taskExecutor);
         }
     }
 
@@ -1727,7 +1727,7 @@ public class TaskExecutorTest extends TestLogger {
 
             testingFatalErrorHandler.clearError();
         } finally {
-            RpcUtils.terminateRpcEndpoint(taskExecutor, timeout);
+            RpcUtils.terminateRpcEndpoint(taskExecutor);
         }
     }
 
@@ -1787,7 +1787,7 @@ public class TaskExecutorTest extends TestLogger {
 
             testingFatalErrorHandler.clearError();
         } finally {
-            RpcUtils.terminateRpcEndpoint(taskExecutor, timeout);
+            RpcUtils.terminateRpcEndpoint(taskExecutor);
         }
     }
 
@@ -1848,7 +1848,7 @@ public class TaskExecutorTest extends TestLogger {
                         instanceOf(TaskManagerException.class));
             }
         } finally {
-            RpcUtils.terminateRpcEndpoint(taskExecutor, timeout);
+            RpcUtils.terminateRpcEndpoint(taskExecutor);
         }
     }
 
@@ -1913,7 +1913,7 @@ public class TaskExecutorTest extends TestLogger {
                     equalTo(unresolvedTaskManagerLocation.getResourceID()));
 
         } finally {
-            RpcUtils.terminateRpcEndpoint(taskExecutor, timeout);
+            RpcUtils.terminateRpcEndpoint(taskExecutor);
         }
     }
 
@@ -1946,7 +1946,7 @@ public class TaskExecutorTest extends TestLogger {
 
             assertThat(initialSlotReportFuture.get(), equalTo(taskExecutor.getResourceID()));
         } finally {
-            RpcUtils.terminateRpcEndpoint(taskExecutor, timeout);
+            RpcUtils.terminateRpcEndpoint(taskExecutor);
         }
     }
 
@@ -1987,7 +1987,7 @@ public class TaskExecutorTest extends TestLogger {
                             TaskExecutorResourceUtils.generateDefaultSlotResourceProfile(
                                     TM_RESOURCE_SPEC, numberOfSlots)));
         } finally {
-            RpcUtils.terminateRpcEndpoint(taskExecutor, timeout);
+            RpcUtils.terminateRpcEndpoint(taskExecutor);
         }
     }
 
@@ -2050,7 +2050,7 @@ public class TaskExecutorTest extends TestLogger {
             // wait for the second registration attempt
             numberRegistrations.await();
         } finally {
-            RpcUtils.terminateRpcEndpoint(taskExecutor, timeout);
+            RpcUtils.terminateRpcEndpoint(taskExecutor);
         }
     }
 
@@ -2127,7 +2127,7 @@ public class TaskExecutorTest extends TestLogger {
             assertThat(offeredSlotFuture.get(), is(allocationId));
             assertTrue(taskSlotTable.isSlotFree(1));
         } finally {
-            RpcUtils.terminateRpcEndpoint(taskExecutor, timeout);
+            RpcUtils.terminateRpcEndpoint(taskExecutor);
         }
     }
 
@@ -2203,7 +2203,7 @@ public class TaskExecutorTest extends TestLogger {
 
             assertThat(disconnectFuture.get(), is(resourceID));
         } finally {
-            RpcUtils.terminateRpcEndpoint(taskExecutor, timeout);
+            RpcUtils.terminateRpcEndpoint(taskExecutor);
         }
     }
 
@@ -2356,7 +2356,7 @@ public class TaskExecutorTest extends TestLogger {
             assertThat(failedSlotFutures.poll(5L, TimeUnit.MILLISECONDS), nullValue());
             assertThat(allocationsNotifiedFree.poll(5L, TimeUnit.MILLISECONDS), nullValue());
         } finally {
-            RpcUtils.terminateRpcEndpoint(taskExecutor, timeout);
+            RpcUtils.terminateRpcEndpoint(taskExecutor);
         }
     }
 
@@ -2466,7 +2466,7 @@ public class TaskExecutorTest extends TestLogger {
         } finally {
             ExecutorUtils.gracefulShutdown(
                     timeout.toMilliseconds(), TimeUnit.MILLISECONDS, heartbeatExecutor);
-            RpcUtils.terminateRpcEndpoint(taskExecutor, timeout);
+            RpcUtils.terminateRpcEndpoint(taskExecutor);
         }
     }
 
@@ -2668,7 +2668,7 @@ public class TaskExecutorTest extends TestLogger {
             // all job partitions should be released
             assertThat(jobPartitionsReleaseFuture.get(), is(jobId));
         } finally {
-            RpcUtils.terminateRpcEndpoint(taskExecutor, timeout);
+            RpcUtils.terminateRpcEndpoint(taskExecutor);
         }
     }
 
@@ -2733,7 +2733,7 @@ public class TaskExecutorTest extends TestLogger {
             assertThat(availableSlotFuture.get().f1, is(slotId));
             assertThat(availableSlotFuture.get().f2, is(allocationId));
         } finally {
-            RpcUtils.terminateRpcEndpoint(taskExecutor, timeout);
+            RpcUtils.terminateRpcEndpoint(taskExecutor);
         }
     }
 
@@ -2914,7 +2914,7 @@ public class TaskExecutorTest extends TestLogger {
 
         @Override
         public void close() throws ExecutionException, InterruptedException, TimeoutException {
-            RpcUtils.terminateRpcEndpoint(taskExecutor, timeout);
+            RpcUtils.terminateRpcEndpoint(taskExecutor);
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/retriever/impl/RpcGatewayRetrieverTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/retriever/impl/RpcGatewayRetrieverTest.java
@@ -59,7 +59,7 @@ public class RpcGatewayRetrieverTest extends TestLogger {
     public static void teardown()
             throws InterruptedException, ExecutionException, TimeoutException {
         if (rpcService != null) {
-            RpcUtils.terminateRpcService(rpcService, TIMEOUT);
+            RpcUtils.terminateRpcService(rpcService);
             rpcService = null;
         }
     }
@@ -130,7 +130,7 @@ public class RpcGatewayRetrieverTest extends TestLogger {
                             .foobar(TIMEOUT)
                             .get(TIMEOUT.toMilliseconds(), TimeUnit.MILLISECONDS));
         } finally {
-            RpcUtils.terminateRpcEndpoints(TIMEOUT, dummyRpcEndpoint, dummyRpcEndpoint2);
+            RpcUtils.terminateRpcEndpoints(dummyRpcEndpoint, dummyRpcEndpoint2);
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/retriever/impl/RpcGatewayRetrieverTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/retriever/impl/RpcGatewayRetrieverTest.java
@@ -130,7 +130,7 @@ public class RpcGatewayRetrieverTest extends TestLogger {
                             .foobar(TIMEOUT)
                             .get(TIMEOUT.toMilliseconds(), TimeUnit.MILLISECONDS));
         } finally {
-            RpcUtils.terminateRpcEndpoints(dummyRpcEndpoint, dummyRpcEndpoint2);
+            RpcUtils.terminateRpcEndpoint(dummyRpcEndpoint, dummyRpcEndpoint2);
         }
     }
 

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/JobManagerHAProcessFailureRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/JobManagerHAProcessFailureRecoveryITCase.java
@@ -430,7 +430,7 @@ public class JobManagerHAProcessFailureRecoveryITCase extends TestLogger {
                 highAvailabilityServices.closeAndCleanupAllData();
             }
 
-            RpcUtils.terminateRpcService(rpcService, timeout);
+            RpcUtils.terminateRpcService(rpcService);
 
             // Delete coordination directory
             if (coordinateTempDir != null) {

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
@@ -20,7 +20,6 @@ package org.apache.flink.test.recovery;
 
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
-import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.io.DiscardingOutputFormat;
 import org.apache.flink.client.program.ProgramInvocationException;
@@ -239,7 +238,7 @@ public class ProcessFailureCancelingITCase extends TestLogger {
 
             fatalErrorHandler.rethrowError();
 
-            RpcUtils.terminateRpcService(rpcService, Time.seconds(100L));
+            RpcUtils.terminateRpcService(rpcService);
 
             haServices.closeAndCleanupAllData();
         }


### PR DESCRIPTION
These methods are only used in tests. We could remove the timeouts (easing [FLINK-27426](https://issues.apache.org/jira/browse/FLINK-27426)), and should annotate them with @VisibleForTesting.