### PR TITLE
[FLINK-27426][rpc] Migrate RPC system internals to Duration 

### DIFF
--- a/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaInvocationHandler.java
+++ b/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaInvocationHandler.java
@@ -37,6 +37,7 @@ import org.apache.flink.runtime.rpc.messages.RpcInvocation;
 import org.apache.flink.runtime.rpc.messages.RunAsync;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.TimeUtils;
 
 import akka.actor.ActorRef;
 import akka.pattern.Patterns;
@@ -56,6 +57,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import static org.apache.flink.runtime.concurrent.akka.ClassLoadingUtils.guardCompletionWithContextClassLoader;
@@ -88,7 +90,7 @@ class AkkaInvocationHandler implements InvocationHandler, AkkaBasedEndpoint, Rpc
     protected final boolean forceRpcInvocationSerialization;
 
     // default timeout for asks
-    private final Time timeout;
+    private final Duration timeout;
 
     private final long maximumFramesize;
 
@@ -101,7 +103,7 @@ class AkkaInvocationHandler implements InvocationHandler, AkkaBasedEndpoint, Rpc
             String address,
             String hostname,
             ActorRef rpcEndpoint,
-            Time timeout,
+            Duration timeout,
             long maximumFramesize,
             boolean forceRpcInvocationSerialization,
             @Nullable CompletableFuture<Void> terminationFuture,
@@ -174,7 +176,7 @@ class AkkaInvocationHandler implements InvocationHandler, AkkaBasedEndpoint, Rpc
     }
 
     @Override
-    public <V> CompletableFuture<V> callAsync(Callable<V> callable, Time callTimeout) {
+    public <V> CompletableFuture<V> callAsync(Callable<V> callable, Duration callTimeout) {
         if (isLocal) {
             @SuppressWarnings("unchecked")
             CompletableFuture<V> resultFuture =
@@ -218,7 +220,7 @@ class AkkaInvocationHandler implements InvocationHandler, AkkaBasedEndpoint, Rpc
         Class<?>[] parameterTypes = method.getParameterTypes();
         final boolean isLocalRpcInvocation = method.getAnnotation(Local.class) != null;
         Annotation[][] parameterAnnotations = method.getParameterAnnotations();
-        Time futureTimeout = extractRpcTimeout(parameterAnnotations, args, timeout);
+        Duration futureTimeout = extractRpcTimeout(parameterAnnotations, args, timeout);
 
         final RpcInvocation rpcInvocation =
                 createRpcInvocationMessage(
@@ -271,8 +273,7 @@ class AkkaInvocationHandler implements InvocationHandler, AkkaBasedEndpoint, Rpc
                 result = completableFuture;
             } else {
                 try {
-                    result =
-                            completableFuture.get(futureTimeout.getSize(), futureTimeout.getUnit());
+                    result = completableFuture.get(futureTimeout.toMillis(), TimeUnit.MILLISECONDS);
                 } catch (ExecutionException ee) {
                     throw new RpcException(
                             "Failure while obtaining synchronous RPC result.",
@@ -330,17 +331,17 @@ class AkkaInvocationHandler implements InvocationHandler, AkkaBasedEndpoint, Rpc
      *     has been found
      * @return Timeout extracted from the array of arguments or the default timeout
      */
-    private static Time extractRpcTimeout(
-            Annotation[][] parameterAnnotations, Object[] args, Time defaultTimeout) {
+    private static Duration extractRpcTimeout(
+            Annotation[][] parameterAnnotations, Object[] args, Duration defaultTimeout) {
         if (args != null) {
             Preconditions.checkArgument(parameterAnnotations.length == args.length);
 
             for (int i = 0; i < parameterAnnotations.length; i++) {
                 if (isRpcTimeout(parameterAnnotations[i])) {
                     if (args[i] instanceof Time) {
-                        return (Time) args[i];
+                        return TimeUtils.toDuration((Time) args[i]);
                     } else if (args[i] instanceof Duration) {
-                        return Time.fromDuration((Duration) args[i]);
+                        return (Duration) args[i];
                     } else {
                         throw new RuntimeException(
                                 "The rpc timeout parameter must be of type "
@@ -391,10 +392,9 @@ class AkkaInvocationHandler implements InvocationHandler, AkkaBasedEndpoint, Rpc
      *     TimeoutException}
      * @return Response future
      */
-    protected CompletableFuture<?> ask(Object message, Time timeout) {
+    protected CompletableFuture<?> ask(Object message, Duration timeout) {
         final CompletableFuture<?> response =
-                AkkaFutureUtils.toJava(
-                        Patterns.ask(rpcEndpoint, message, timeout.toMilliseconds()));
+                AkkaFutureUtils.toJava(Patterns.ask(rpcEndpoint, message, timeout.toMillis()));
         return guardCompletionWithContextClassLoader(response, flinkClassLoader);
     }
 

--- a/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcService.java
+++ b/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcService.java
@@ -36,7 +36,6 @@ import org.apache.flink.runtime.rpc.messages.HandshakeSuccessMessage;
 import org.apache.flink.runtime.rpc.messages.RemoteHandshakeMessage;
 import org.apache.flink.util.AutoCloseableAsync;
 import org.apache.flink.util.ExecutorUtils;
-import org.apache.flink.util.TimeUtils;
 import org.apache.flink.util.concurrent.ExecutorThreadFactory;
 import org.apache.flink.util.concurrent.FutureUtils;
 import org.apache.flink.util.concurrent.ScheduledExecutor;
@@ -559,7 +558,7 @@ public class AkkaRpcService implements RpcService {
                                                         actorRef,
                                                         new RemoteHandshakeMessage(
                                                                 clazz, getVersion()),
-                                                        configuration.getTimeout().toMilliseconds())
+                                                        configuration.getTimeout().toMillis())
                                                 .<HandshakeSuccessMessage>mapTo(
                                                         ClassTag$.MODULE$
                                                                 .<HandshakeSuccessMessage>apply(
@@ -598,7 +597,7 @@ public class AkkaRpcService implements RpcService {
     private CompletableFuture<ActorRef> resolveActorAddress(String address) {
         final ActorSelection actorSel = actorSystem.actorSelection(address);
 
-        return actorSel.resolveOne(TimeUtils.toDuration(configuration.getTimeout()))
+        return actorSel.resolveOne(configuration.getTimeout())
                 .toCompletableFuture()
                 .exceptionally(
                         error -> {

--- a/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceConfiguration.java
+++ b/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceConfiguration.java
@@ -17,11 +17,12 @@
 
 package org.apache.flink.runtime.rpc.akka;
 
-import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.AkkaOptions;
 import org.apache.flink.configuration.Configuration;
 
 import javax.annotation.Nonnull;
+
+import java.time.Duration;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 
@@ -30,7 +31,7 @@ public class AkkaRpcServiceConfiguration {
 
     @Nonnull private final Configuration configuration;
 
-    @Nonnull private final Time timeout;
+    @Nonnull private final Duration timeout;
 
     private final long maximumFramesize;
 
@@ -40,7 +41,7 @@ public class AkkaRpcServiceConfiguration {
 
     private AkkaRpcServiceConfiguration(
             @Nonnull Configuration configuration,
-            @Nonnull Time timeout,
+            @Nonnull Duration timeout,
             long maximumFramesize,
             boolean captureAskCallStack,
             boolean forceRpcInvocationSerialization) {
@@ -59,7 +60,7 @@ public class AkkaRpcServiceConfiguration {
     }
 
     @Nonnull
-    public Time getTimeout() {
+    public Duration getTimeout() {
         return timeout;
     }
 
@@ -76,7 +77,7 @@ public class AkkaRpcServiceConfiguration {
     }
 
     public static AkkaRpcServiceConfiguration fromConfiguration(Configuration configuration) {
-        final Time timeout = Time.fromDuration(configuration.get(AkkaOptions.ASK_TIMEOUT_DURATION));
+        final Duration timeout = configuration.get(AkkaOptions.ASK_TIMEOUT_DURATION);
 
         final long maximumFramesize = AkkaRpcServiceUtils.extractMaximumFramesize(configuration);
 

--- a/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/akka/FencedAkkaInvocationHandler.java
+++ b/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/akka/FencedAkkaInvocationHandler.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.rpc.akka;
 
-import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.concurrent.akka.AkkaFutureUtils;
 import org.apache.flink.runtime.rpc.FencedMainThreadExecutable;
 import org.apache.flink.runtime.rpc.FencedRpcEndpoint;
@@ -38,6 +37,7 @@ import javax.annotation.Nullable;
 
 import java.io.Serializable;
 import java.lang.reflect.Method;
+import java.time.Duration;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
@@ -60,7 +60,7 @@ public class FencedAkkaInvocationHandler<F extends Serializable> extends AkkaInv
             String address,
             String hostname,
             ActorRef rpcEndpoint,
-            Time timeout,
+            Duration timeout,
             long maximumFramesize,
             boolean forceRpcInvocationSerialization,
             @Nullable CompletableFuture<Void> terminationFuture,
@@ -109,7 +109,8 @@ public class FencedAkkaInvocationHandler<F extends Serializable> extends AkkaInv
     }
 
     @Override
-    public <V> CompletableFuture<V> callAsyncWithoutFencing(Callable<V> callable, Time timeout) {
+    public <V> CompletableFuture<V> callAsyncWithoutFencing(
+            Callable<V> callable, Duration timeout) {
         checkNotNull(callable, "callable");
         checkNotNull(timeout, "timeout");
 
@@ -121,7 +122,7 @@ public class FencedAkkaInvocationHandler<F extends Serializable> extends AkkaInv
                                     Patterns.ask(
                                             getActorRef(),
                                             new UnfencedMessage<>(new CallAsync(callable)),
-                                            timeout.toMilliseconds()));
+                                            timeout.toMillis()));
 
             return resultFuture;
         } else {
@@ -138,7 +139,7 @@ public class FencedAkkaInvocationHandler<F extends Serializable> extends AkkaInv
     }
 
     @Override
-    public CompletableFuture<?> ask(Object message, Time timeout) {
+    public CompletableFuture<?> ask(Object message, Duration timeout) {
         return super.ask(fenceMessage(message), timeout);
     }
 

--- a/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActorHandshakeTest.java
+++ b/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActorHandshakeTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.rpc.akka;
 
-import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.rpc.RpcGateway;
 import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.rpc.exceptions.HandshakeException;
@@ -33,15 +32,12 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for the handshake between rpc endpoints. */
 class AkkaRpcActorHandshakeTest {
-
-    private static final Time timeout = Time.seconds(10L);
 
     private static AkkaRpcService akkaRpcService1;
     private static AkkaRpcService akkaRpcService2;
@@ -71,8 +67,7 @@ class AkkaRpcActorHandshakeTest {
         terminationFutures.add(akkaRpcService2.stopService());
         terminationFutures.add(wrongVersionAkkaRpcService.stopService());
 
-        FutureUtils.waitForAll(terminationFutures)
-                .get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+        FutureUtils.waitForAll(terminationFutures).get();
     }
 
     @Test
@@ -135,7 +130,7 @@ class AkkaRpcActorHandshakeTest {
                 akkaRpcService2.connect(rpcEndpoint.getAddress(), WrongRpcGateway.class);
 
         try {
-            assertThatThrownBy(() -> futureGateway.get(timeout.getSize(), timeout.getUnit()))
+            assertThatThrownBy(() -> futureGateway.get())
                     .extracting(ExceptionUtils::stripExecutionException)
                     .isInstanceOf(HandshakeException.class);
 

--- a/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActorTest.java
+++ b/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActorTest.java
@@ -39,7 +39,6 @@ import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.SerializedValue;
-import org.apache.flink.util.TimeUtils;
 import org.apache.flink.util.concurrent.FutureUtils;
 
 import akka.actor.ActorRef;
@@ -76,7 +75,7 @@ class AkkaRpcActorTest {
     //  shared test members
     // ------------------------------------------------------------------------
 
-    private static Time timeout = Time.milliseconds(10000L);
+    private static Duration timeout = Duration.ofSeconds(10L);
 
     private static AkkaRpcService akkaRpcService;
 
@@ -373,9 +372,9 @@ class AkkaRpcActorTest {
             assertThat(terminationFuture).isNotDone();
 
             final CompletableFuture<Integer> firstAsyncOperationFuture =
-                    asyncOperationGateway.asyncOperation(timeout);
+                    asyncOperationGateway.asyncOperation(Time.fromDuration(timeout));
             final CompletableFuture<Integer> secondAsyncOperationFuture =
-                    asyncOperationGateway.asyncOperation(timeout);
+                    asyncOperationGateway.asyncOperation(Time.fromDuration(timeout));
 
             endpoint.awaitEnterAsyncOperation();
 
@@ -395,7 +394,7 @@ class AkkaRpcActorTest {
 
             assertThat(endpoint.getNumberAsyncOperationCalls()).isEqualTo(1);
             assertThat(secondAsyncOperationFuture)
-                    .failsWithin(TimeUtils.toDuration(timeout))
+                    .failsWithin(timeout)
                     .withThrowableOfType(ExecutionException.class)
                     .withCauseInstanceOf(RecipientUnreachableException.class);
         } finally {

--- a/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActorTest.java
+++ b/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActorTest.java
@@ -105,7 +105,7 @@ class AkkaRpcActorTest {
         CompletableFuture<DummyRpcGateway> futureRpcGateway =
                 akkaRpcService.connect(rpcEndpoint.getAddress(), DummyRpcGateway.class);
 
-        DummyRpcGateway rpcGateway = futureRpcGateway.get(timeout.getSize(), timeout.getUnit());
+        DummyRpcGateway rpcGateway = futureRpcGateway.get();
 
         assertThat(rpcGateway.getAddress()).isEqualTo(rpcEndpoint.getAddress());
     }
@@ -119,7 +119,7 @@ class AkkaRpcActorTest {
         CompletableFuture<DummyRpcGateway> futureRpcGateway =
                 akkaRpcService.connect("foobar", DummyRpcGateway.class);
 
-        assertThatThrownBy(() -> futureRpcGateway.get(timeout.getSize(), timeout.getUnit()))
+        assertThatThrownBy(() -> futureRpcGateway.get())
                 .hasCauseInstanceOf(RpcConnectionException.class);
     }
 
@@ -136,7 +136,7 @@ class AkkaRpcActorTest {
         DummyRpcGateway rpcGateway = rpcEndpoint.getSelfGateway(DummyRpcGateway.class);
 
         // this message should be discarded and complete with an exception
-        assertThatThrownBy(() -> rpcGateway.foobar().get(timeout.getSize(), timeout.getUnit()))
+        assertThatThrownBy(() -> rpcGateway.foobar().get())
                 .hasCauseInstanceOf(EndpointNotStartedException.class);
 
         // set a new value which we expect to be returned
@@ -150,7 +150,7 @@ class AkkaRpcActorTest {
             CompletableFuture<Integer> result = rpcGateway.foobar();
 
             // now we should receive a result :-)
-            Integer actualValue = result.get(timeout.getSize(), timeout.getUnit());
+            Integer actualValue = result.get();
 
             assertThat(actualValue).isEqualTo(expectedValue);
         } finally {
@@ -187,7 +187,7 @@ class AkkaRpcActorTest {
         ExceptionalGateway rpcGateway = rpcEndpoint.getSelfGateway(ExceptionalGateway.class);
         CompletableFuture<Integer> result = rpcGateway.doStuff();
 
-        assertThatThrownBy(() -> result.get(timeout.getSize(), timeout.getUnit()))
+        assertThatThrownBy(() -> result.get())
                 .extracting(e -> e.getCause())
                 .satisfies(
                         e ->
@@ -204,7 +204,7 @@ class AkkaRpcActorTest {
         ExceptionalGateway rpcGateway = rpcEndpoint.getSelfGateway(ExceptionalGateway.class);
         CompletableFuture<Integer> result = rpcGateway.doStuff();
 
-        assertThatThrownBy(() -> result.get(timeout.getSize(), timeout.getUnit()))
+        assertThatThrownBy(() -> result.get())
                 .extracting(e -> e.getCause())
                 .satisfies(
                         e -> assertThat(e).isInstanceOf(Exception.class).hasMessage("some test"));
@@ -302,11 +302,10 @@ class AkkaRpcActorTest {
 
             rpcService.stopService();
 
-            terminationFuture.get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+            terminationFuture.get();
         } finally {
             rpcActorSystem.terminate();
-            AkkaFutureUtils.toJava(rpcActorSystem.whenTerminated())
-                    .get(timeout.getSize(), timeout.getUnit());
+            AkkaFutureUtils.toJava(rpcActorSystem.whenTerminated()).get();
         }
     }
 

--- a/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceTest.java
+++ b/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.rpc.akka;
 
-import org.apache.flink.api.common.time.Time;
 import org.apache.flink.core.testutils.FlinkAssertions;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.concurrent.akka.AkkaFutureUtils;
@@ -55,8 +54,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /** Tests for the {@link AkkaRpcService}. */
 class AkkaRpcServiceTest {
 
-    private static final Time TIMEOUT = Time.milliseconds(10000L);
-
     // ------------------------------------------------------------------------
     //  shared test members
     // ------------------------------------------------------------------------
@@ -79,7 +76,7 @@ class AkkaRpcServiceTest {
                 AkkaFutureUtils.toJava(actorSystem.terminate());
 
         FutureUtils.waitForAll(Arrays.asList(rpcTerminationFuture, actorSystemTerminationFuture))
-                .get(TIMEOUT.toMilliseconds(), TimeUnit.MILLISECONDS);
+                .get();
 
         actorSystem = null;
         akkaRpcService = null;

--- a/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/ContextClassLoadingSettingTest.java
+++ b/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/ContextClassLoadingSettingTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.flink.runtime.rpc.akka;
 
-import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.concurrent.akka.AkkaFutureUtils;
 import org.apache.flink.runtime.rpc.RpcEndpoint;
@@ -39,6 +38,7 @@ import java.io.ObjectInputStream;
 import java.io.Serializable;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
@@ -417,8 +417,7 @@ class ContextClassLoadingSettingTest {
         @Override
         public CompletableFuture<ClassLoader> doCallAsync() {
             return callAsync(
-                    () -> Thread.currentThread().getContextClassLoader(),
-                    Time.of(10, TimeUnit.SECONDS));
+                    () -> Thread.currentThread().getContextClassLoader(), Duration.ofSeconds(10));
         }
 
         @Override

--- a/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/ContextClassLoadingSettingTest.java
+++ b/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/ContextClassLoadingSettingTest.java
@@ -60,8 +60,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class ContextClassLoadingSettingTest {
 
-    private static final Time TIMEOUT = Time.milliseconds(10000L);
-
     // Many of the contained tests assert that a future is completed with a specific context class
     // loader by applying a synchronous operation.
     // If the initial future is completed by the time we apply the synchronous operation the test
@@ -98,7 +96,7 @@ class ContextClassLoadingSettingTest {
                 AkkaFutureUtils.toJava(actorSystem.terminate());
 
         FutureUtils.waitForAll(Arrays.asList(rpcTerminationFuture, actorSystemTerminationFuture))
-                .get(TIMEOUT.toMilliseconds(), TimeUnit.MILLISECONDS);
+                .get();
 
         actorSystem = null;
         akkaRpcService = null;

--- a/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/FencedMainThreadExecutable.java
+++ b/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/FencedMainThreadExecutable.java
@@ -18,8 +18,7 @@
 
 package org.apache.flink.runtime.rpc;
 
-import org.apache.flink.api.common.time.Time;
-
+import java.time.Duration;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 
@@ -44,5 +43,5 @@ public interface FencedMainThreadExecutable extends MainThreadExecutable {
      * @param <V> type of the callable result
      * @return Future containing the callable result
      */
-    <V> CompletableFuture<V> callAsyncWithoutFencing(Callable<V> callable, Time timeout);
+    <V> CompletableFuture<V> callAsyncWithoutFencing(Callable<V> callable, Duration timeout);
 }

--- a/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/FencedRpcEndpoint.java
+++ b/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/FencedRpcEndpoint.java
@@ -19,13 +19,13 @@
 package org.apache.flink.runtime.rpc;
 
 import org.apache.flink.annotation.VisibleForTesting;
-import org.apache.flink.api.common.time.Time;
 import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.io.Serializable;
+import java.time.Duration;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
@@ -149,7 +149,8 @@ public abstract class FencedRpcEndpoint<F extends Serializable> extends RpcEndpo
      * @param timeout for the operation.
      * @return Future containing the callable result.
      */
-    protected <V> CompletableFuture<V> callAsyncWithoutFencing(Callable<V> callable, Time timeout) {
+    protected <V> CompletableFuture<V> callAsyncWithoutFencing(
+            Callable<V> callable, Duration timeout) {
         if (rpcServer instanceof FencedMainThreadExecutable) {
             return ((FencedMainThreadExecutable) rpcServer)
                     .callAsyncWithoutFencing(callable, timeout);

--- a/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/MainThreadExecutable.java
+++ b/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/MainThreadExecutable.java
@@ -18,8 +18,7 @@
 
 package org.apache.flink.runtime.rpc;
 
-import org.apache.flink.api.common.time.Time;
-
+import java.time.Duration;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
@@ -51,7 +50,7 @@ public interface MainThreadExecutable {
      * @param <V> Return value of the callable
      * @return Future of the callable result
      */
-    <V> CompletableFuture<V> callAsync(Callable<V> callable, Time callTimeout);
+    <V> CompletableFuture<V> callAsync(Callable<V> callable, Duration callTimeout);
 
     /**
      * Execute the runnable in the main thread of the underlying RPC endpoint, with a delay of the

--- a/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/RpcEndpoint.java
+++ b/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/RpcEndpoint.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.rpc;
 
-import org.apache.flink.api.common.time.Time;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.concurrent.ScheduledFutureAdapter;
@@ -33,6 +32,7 @@ import javax.annotation.Nonnull;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
@@ -62,8 +62,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * thread, we don't have to reason about concurrent accesses, in the same way in the Actor Model of
  * Erlang or Akka.
  *
- * <p>The RPC endpoint provides {@link #runAsync(Runnable)}, {@link #callAsync(Callable, Time)} and
- * the {@link #getMainThreadExecutor()} to execute code in the RPC endpoint's main thread.
+ * <p>The RPC endpoint provides {@link #runAsync(Runnable)}, {@link #callAsync(Callable, Duration)}
+ * and the {@link #getMainThreadExecutor()} to execute code in the RPC endpoint's main thread.
  *
  * <h1>Lifecycle</h1>
  *
@@ -390,8 +390,8 @@ public abstract class RpcEndpoint implements RpcGateway, AutoCloseableAsync {
      * @param runnable Runnable to be executed
      * @param delay The delay after which the runnable will be executed
      */
-    protected void scheduleRunAsync(Runnable runnable, Time delay) {
-        scheduleRunAsync(runnable, delay.getSize(), delay.getUnit());
+    protected void scheduleRunAsync(Runnable runnable, Duration delay) {
+        scheduleRunAsync(runnable, delay.toMillis(), TimeUnit.MILLISECONDS);
     }
 
     /**
@@ -415,7 +415,7 @@ public abstract class RpcEndpoint implements RpcGateway, AutoCloseableAsync {
      * @param <V> Return type of the callable
      * @return Future for the result of the callable.
      */
-    protected <V> CompletableFuture<V> callAsync(Callable<V> callable, Time timeout) {
+    protected <V> CompletableFuture<V> callAsync(Callable<V> callable, Duration timeout) {
         return rpcServer.callAsync(callable, timeout);
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/dump/MetricQueryService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/dump/MetricQueryService.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.metrics.groups.AbstractMetricGroup;
 import org.apache.flink.runtime.rpc.RpcEndpoint;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.webmonitor.retriever.MetricQueryServiceGateway;
+import org.apache.flink.util.TimeUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -129,7 +130,7 @@ public class MetricQueryService extends RpcEndpoint implements MetricQueryServic
             Time timeout) {
         return callAsync(
                 () -> enforceSizeLimit(serializer.serialize(counters, gauges, histograms, meters)),
-                timeout);
+                TimeUtils.toDuration(timeout));
     }
 
     private MetricDumpSerialization.MetricSerializationResult enforceSizeLimit(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManager.java
@@ -42,6 +42,7 @@ import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.security.token.DelegationTokenManager;
 import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.TimeUtils;
 import org.apache.flink.util.concurrent.FutureUtils;
 import org.apache.flink.util.concurrent.ScheduledExecutor;
 
@@ -74,7 +75,7 @@ public class ActiveResourceManager<WorkerType extends ResourceIDRetrievable>
 
     protected final Configuration flinkConfig;
 
-    private final Time startWorkerRetryInterval;
+    private final Duration startWorkerRetryInterval;
 
     private final ResourceManagerDriver<WorkerType> resourceManagerDriver;
 
@@ -92,7 +93,7 @@ public class ActiveResourceManager<WorkerType extends ResourceIDRetrievable>
 
     private final ThresholdMeter startWorkerFailureRater;
 
-    private final Time workerRegistrationTimeout;
+    private final Duration workerRegistrationTimeout;
 
     /**
      * Incompletion of this future indicates that the max failure rate of start worker is reached
@@ -143,9 +144,8 @@ public class ActiveResourceManager<WorkerType extends ResourceIDRetrievable>
         this.currentAttemptUnregisteredWorkers = new HashMap<>();
         this.previousAttemptUnregisteredWorkers = new HashSet<>();
         this.startWorkerFailureRater = checkNotNull(startWorkerFailureRater);
-        this.startWorkerRetryInterval = Time.of(retryInterval.toMillis(), TimeUnit.MILLISECONDS);
-        this.workerRegistrationTimeout =
-                Time.of(workerRegistrationTimeout.toMillis(), TimeUnit.MILLISECONDS);
+        this.startWorkerRetryInterval = retryInterval;
+        this.workerRegistrationTimeout = workerRegistrationTimeout;
         this.startWorkerCoolDown = FutureUtils.completedVoidFuture();
     }
 
@@ -456,6 +456,6 @@ public class ActiveResourceManager<WorkerType extends ResourceIDRetrievable>
 
     @VisibleForTesting
     <T> CompletableFuture<T> runInMainThread(Callable<T> callable, Time timeout) {
-        return callAsync(callable, timeout);
+        return callAsync(callable, TimeUtils.toDuration(timeout));
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -151,6 +151,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetSocketAddress;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -1452,7 +1453,8 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
     }
 
     private void startRegistrationTimeout() {
-        final Time maxRegistrationDuration = taskManagerConfiguration.getMaxRegistrationDuration();
+        final Duration maxRegistrationDuration =
+                taskManagerConfiguration.getMaxRegistrationDuration();
 
         if (maxRegistrationDuration != null) {
             final UUID newRegistrationTimeoutId = UUID.randomUUID();
@@ -1468,7 +1470,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 
     private void registrationTimeout(@Nonnull UUID registrationTimeoutId) {
         if (registrationTimeoutId.equals(currentRegistrationTimeoutId)) {
-            final Time maxRegistrationDuration =
+            final Duration maxRegistrationDuration =
                     taskManagerConfiguration.getMaxRegistrationDuration();
 
             onFatalError(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerConfiguration.java
@@ -56,7 +56,7 @@ public class TaskManagerConfiguration implements TaskManagerRuntimeInfo {
     private final Time slotTimeout;
 
     // null indicates an infinite duration
-    @Nullable private final Time maxRegistrationDuration;
+    @Nullable private final Duration maxRegistrationDuration;
 
     private final UnmodifiableConfiguration configuration;
 
@@ -81,7 +81,7 @@ public class TaskManagerConfiguration implements TaskManagerRuntimeInfo {
             String[] tmpDirectories,
             Time rpcTimeout,
             Time slotTimeout,
-            @Nullable Time maxRegistrationDuration,
+            @Nullable Duration maxRegistrationDuration,
             Configuration configuration,
             boolean exitJvmOnOutOfMemory,
             @Nullable String taskManagerLogPath,
@@ -130,7 +130,7 @@ public class TaskManagerConfiguration implements TaskManagerRuntimeInfo {
     }
 
     @Nullable
-    public Time getMaxRegistrationDuration() {
+    public Duration getMaxRegistrationDuration() {
         return maxRegistrationDuration;
     }
 
@@ -203,11 +203,9 @@ public class TaskManagerConfiguration implements TaskManagerRuntimeInfo {
         final Time slotTimeout =
                 Time.milliseconds(configuration.get(TaskManagerOptions.SLOT_TIMEOUT).toMillis());
 
-        Time finiteRegistrationDuration;
+        Duration finiteRegistrationDuration;
         try {
-            Duration maxRegistrationDuration =
-                    configuration.get(TaskManagerOptions.REGISTRATION_TIMEOUT);
-            finiteRegistrationDuration = Time.milliseconds(maxRegistrationDuration.toMillis());
+            finiteRegistrationDuration = configuration.get(TaskManagerOptions.REGISTRATION_TIMEOUT);
         } catch (IllegalArgumentException e) {
             LOG.warn(
                     "Invalid format for parameter {}. Set the timeout to be infinite.",

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/TestingDispatcher.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/TestingDispatcher.java
@@ -45,6 +45,7 @@ import org.apache.flink.runtime.scheduler.ExecutionGraphInfo;
 import org.apache.flink.runtime.util.TestingFatalErrorHandler;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
 import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.TimeUtils;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -159,12 +160,14 @@ class TestingDispatcher extends Dispatcher {
     }
 
     CompletableFuture<Void> getJobTerminationFuture(@Nonnull JobID jobId, @Nonnull Time timeout) {
-        return callAsyncWithoutFencing(() -> getJobTerminationFuture(jobId), timeout)
+        return callAsyncWithoutFencing(
+                        () -> getJobTerminationFuture(jobId), TimeUtils.toDuration(timeout))
                 .thenCompose(Function.identity());
     }
 
     CompletableFuture<Integer> getNumberJobs(Time timeout) {
-        return callAsyncWithoutFencing(() -> listJobs(timeout).get().size(), timeout);
+        return callAsyncWithoutFencing(
+                () -> listJobs(timeout).get().size(), TimeUtils.toDuration(timeout));
     }
 
     void waitUntilStarted() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/AsyncCallsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/AsyncCallsTest.java
@@ -30,6 +30,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.time.Duration;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -52,7 +53,7 @@ public class AsyncCallsTest extends TestLogger {
     //  shared test members
     // ------------------------------------------------------------------------
 
-    private static final Time timeout = Time.seconds(10L);
+    private static final Duration timeout = Duration.ofSeconds(10L);
 
     private static RpcService rpcService;
 
@@ -121,7 +122,7 @@ public class AsyncCallsTest extends TestLogger {
                                 }
                                 return "test";
                             },
-                            Time.seconds(30L));
+                            Duration.ofSeconds(30L));
 
             String str = result.get(30, TimeUnit.SECONDS);
             assertEquals("test", str);
@@ -202,7 +203,7 @@ public class AsyncCallsTest extends TestLogger {
     /** Tests that async code is not executed if the fencing token changes. */
     @Test
     public void testRunAsyncWithFencing() throws Exception {
-        final Time shortTimeout = Time.milliseconds(100L);
+        final Duration shortTimeout = Duration.ofMillis(100L);
         final UUID newFencingToken = UUID.randomUUID();
         final CompletableFuture<UUID> resultFuture = new CompletableFuture<>();
 
@@ -215,7 +216,7 @@ public class AsyncCallsTest extends TestLogger {
                 newFencingToken);
 
         try {
-            resultFuture.get(shortTimeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+            resultFuture.get(shortTimeout.toMillis(), TimeUnit.MILLISECONDS);
 
             fail(
                     "The async run operation should not complete since it is filtered out due to the changed fencing token.");
@@ -237,8 +238,7 @@ public class AsyncCallsTest extends TestLogger {
                 },
                 newFencingToken);
 
-        assertEquals(
-                newFencingToken, resultFuture.get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS));
+        assertEquals(newFencingToken, resultFuture.get());
     }
 
     /** Tests that async callables are not executed if the fencing token changes. */
@@ -308,7 +308,8 @@ public class AsyncCallsTest extends TestLogger {
             fencedTestEndpoint.start();
 
             CompletableFuture<Acknowledge> newFencingTokenFuture =
-                    fencedTestGateway.setNewFencingToken(newFencingToken, timeout);
+                    fencedTestGateway.setNewFencingToken(
+                            newFencingToken, Time.fromDuration(timeout));
 
             assertFalse(newFencingTokenFuture.isDone());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/AsyncCallsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/AsyncCallsTest.java
@@ -250,7 +250,7 @@ public class AsyncCallsTest extends TestLogger {
                 testRunAsync(endpoint -> endpoint.callAsync(() -> true, timeout), newFencingToken);
 
         try {
-            resultFuture.get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+            resultFuture.get();
 
             fail("The async call operation should fail due to the changed fencing token.");
         } catch (ExecutionException e) {
@@ -271,7 +271,7 @@ public class AsyncCallsTest extends TestLogger {
                         endpoint -> endpoint.callAsyncWithoutFencing(() -> true, timeout),
                         newFencingToken);
 
-        assertTrue(resultFuture.get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS));
+        assertTrue(resultFuture.get());
     }
 
     @Test
@@ -320,7 +320,7 @@ public class AsyncCallsTest extends TestLogger {
 
             triggerSetNewFencingToken.trigger();
 
-            newFencingTokenFuture.get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+            newFencingTokenFuture.get();
 
             return result;
         } finally {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/FencedRpcEndpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/FencedRpcEndpointTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.rpc.exceptions.RpcRuntimeException;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TestLoggerExtension;
+import org.apache.flink.util.TimeUtils;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -409,7 +410,7 @@ public class FencedRpcEndpointTest {
 
                         return Acknowledge.get();
                     },
-                    timeout);
+                    TimeUtils.toDuration(timeout));
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/RpcEndpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/RpcEndpointTest.java
@@ -51,7 +51,6 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 @ExtendWith(TestLoggerExtension.class)
 public class RpcEndpointTest {
 
-    private static final Time TIMEOUT = Time.seconds(10L);
     private static RpcService rpcService = null;
 
     @BeforeAll
@@ -181,7 +180,7 @@ public class RpcEndpointTest {
         assertFalse(gateway.queryIsRunningFlag().get());
 
         stopFuture.complete(null);
-        terminationFuture.get(TIMEOUT.toMilliseconds(), TimeUnit.MILLISECONDS);
+        terminationFuture.get();
         endpoint.validateResourceClosed();
     }
 
@@ -289,7 +288,7 @@ public class RpcEndpointTest {
                                 endpoint.validateRunsInMainThread();
                                 asyncExecutionFuture.complete(null);
                             });
-            asyncExecutionFuture.get(TIMEOUT.getSize(), TIMEOUT.getUnit());
+            asyncExecutionFuture.get();
         } finally {
             RpcUtils.terminateRpcEndpoint(endpoint);
             endpoint.validateResourceClosed();
@@ -451,8 +450,8 @@ public class RpcEndpointTest {
                                 endpoint.validateRunsInMainThread();
                                 return expectedInteger;
                             },
-                            TIMEOUT);
-            assertEquals(expectedInteger, integerFuture.get(TIMEOUT.getSize(), TIMEOUT.getUnit()));
+                            Time.seconds(10L));
+            assertEquals(expectedInteger, integerFuture.get());
         } finally {
             RpcUtils.terminateRpcEndpoint(endpoint);
             endpoint.validateResourceClosed();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/RpcEndpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/RpcEndpointTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.rpc;
 
-import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.TestLoggerExtension;
 
@@ -450,7 +449,7 @@ public class RpcEndpointTest {
                                 endpoint.validateRunsInMainThread();
                                 return expectedInteger;
                             },
-                            Time.seconds(10L));
+                            Duration.ofSeconds(10L));
             assertEquals(expectedInteger, integerFuture.get());
         } finally {
             RpcUtils.terminateRpcEndpoint(endpoint);
@@ -466,7 +465,7 @@ public class RpcEndpointTest {
     public void testCallAsyncTimeout()
             throws InterruptedException, ExecutionException, TimeoutException {
         final RpcEndpoint endpoint = new BaseEndpoint(rpcService);
-        final Time timeout = Time.milliseconds(100);
+        final Duration timeout = Duration.ofMillis(100);
         CountDownLatch latch = new CountDownLatch(1);
         try {
             endpoint.start();
@@ -504,7 +503,7 @@ public class RpcEndpointTest {
         }
 
         @Override
-        public <V> CompletableFuture<V> callAsync(Callable<V> callable, Time callTimeout) {
+        public <V> CompletableFuture<V> callAsync(Callable<V> callable, Duration callTimeout) {
             throw new UnsupportedOperationException();
         }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -131,6 +131,7 @@ import javax.annotation.Nonnull;
 import java.io.File;
 import java.io.IOException;
 import java.net.InetAddress;
+import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -3005,7 +3006,7 @@ public class TaskExecutorTest extends TestLogger {
             throws InterruptedException, ExecutionException {
         return ctx.taskExecutor
                 .getMainThreadExecutableForTesting()
-                .callAsync(booleanCallable, Time.seconds(5))
+                .callAsync(booleanCallable, Duration.ofSeconds(5))
                 .get();
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/ThreadSafeTaskSlotTable.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/ThreadSafeTaskSlotTable.java
@@ -32,6 +32,7 @@ import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nullable;
 
+import java.time.Duration;
 import java.util.Iterator;
 import java.util.Set;
 import java.util.UUID;
@@ -62,7 +63,7 @@ public class ThreadSafeTaskSlotTable<T extends TaskSlotPayload> implements TaskS
         try {
             return mainThreadExecutable
                     .callAsync(
-                            callable, Time.days(1) // practically infinite timeout
+                            callable, Duration.ofDays(1) // practically infinite timeout
                             )
                     .get();
         } catch (InterruptedException | ExecutionException e) {


### PR DESCRIPTION
Based on #19592.

Migrates the RPC system internals to use Duration instead of Time. The only exception is the special timeout handling for the RPC interfaces, which will be done later (as that requires touching all the runtime components).