### PR TITLE
[FLINK-27437][tests-tpcds] Syntax error when running tpcds test

### DIFF
--- a/flink-end-to-end-tests/flink-tpcds-test/README.md
+++ b/flink-end-to-end-tests/flink-tpcds-test/README.md
@@ -6,7 +6,7 @@ You can run the Flink TPC-DS test in your local environment as following command
 $ cd <your_workspace_dir>/flink                                                                               # go to the Flink project   
 $ mvn compile -DskipTests=true                                                                               # compile Flink source code
 $ export FLINK_DIR=<your_workspace_dir>/flink/flink-dist/target/flink-${flink-version}-bin/flink-${flink-version}  # set Flink distribution directory, the ${flink-version} is the compiled Flink version
-$ sh flink-end-to-end-tests/run-single-test.sh flink-end-to-end-tests/test-scripts/test_tpcds.sh               # run a TPC-DS benchmark
+$ flink-end-to-end-tests/run-single-test.sh flink-end-to-end-tests/test-scripts/test_tpcds.sh               # run a TPC-DS benchmark
 ```
 
 The default scale factor of TPC-DS benchmark in Flink is 1GB, Flink use this scale factor from validation purpose.


### PR DESCRIPTION
## What is the purpose of the change

Fix syntax error when running tpc-ds test. Only bash support process substitution while running bash via sh does not.

## Brief change log

- flink-end-to-end-tests/flink-tpcds-test/README.md

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no

