### PR TITLE
[FLINK-27440] add ignoreignore-parse-errors in avro format

### DIFF
--- a/docs/content/docs/connectors/table/formats/avro.md
+++ b/docs/content/docs/connectors/table/formats/avro.md
@@ -85,6 +85,13 @@ Format Options
       <td>String</td>
       <td>For <a href="{{< ref "docs/connectors/table/filesystem" >}}">Filesystem</a> only, the compression codec for avro. No compression as default. The valid enumerations are: deflate, snappy, bzip2, xz.</td>
     </tr>
+    <tr>
+      <td><h5>avro.ignore-parse-errors</h5></td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">false</td>
+      <td>Boolean</td>
+      <td>Skip rows with parse errors instead of failing.</td>
+    </tr>
     </tbody>
 </table>
 

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroFormatFactory.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroFormatFactory.java
@@ -38,7 +38,10 @@ import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.RowType;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
+
+import static org.apache.flink.formats.avro.AvroFormatOptions.IGNORE_PARSE_ERRORS;
 
 /**
  * Table format factory for providing configured instances of Avro to RowData {@link
@@ -53,6 +56,7 @@ public class AvroFormatFactory implements DeserializationFormatFactory, Serializ
     public DecodingFormat<DeserializationSchema<RowData>> createDecodingFormat(
             DynamicTableFactory.Context context, ReadableConfig formatOptions) {
         FactoryUtil.validateFactoryOptions(this, formatOptions);
+        final boolean ignoreParseErrors = formatOptions.get(IGNORE_PARSE_ERRORS);
 
         return new DecodingFormat<DeserializationSchema<RowData>>() {
             @Override
@@ -61,7 +65,7 @@ public class AvroFormatFactory implements DeserializationFormatFactory, Serializ
                 final RowType rowType = (RowType) producedDataType.getLogicalType();
                 final TypeInformation<RowData> rowDataTypeInfo =
                         context.createTypeInformation(producedDataType);
-                return new AvroRowDataDeserializationSchema(rowType, rowDataTypeInfo);
+                return new AvroRowDataDeserializationSchema(rowType, rowDataTypeInfo, ignoreParseErrors);
             }
 
             @Override
@@ -103,6 +107,8 @@ public class AvroFormatFactory implements DeserializationFormatFactory, Serializ
 
     @Override
     public Set<ConfigOption<?>> optionalOptions() {
-        return Collections.emptySet();
+        Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(IGNORE_PARSE_ERRORS);
+        return options;
     }
 }

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroFormatOptions.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroFormatOptions.java
@@ -32,5 +32,12 @@ public class AvroFormatOptions {
                     .noDefaultValue()
                     .withDescription("The compression codec for avro");
 
+    public static final ConfigOption<Boolean> IGNORE_PARSE_ERRORS =
+            ConfigOptions.key("ignore-parse-errors")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Optional flag to skip rows with parse errors instead of failing; false by default.");
+
     private AvroFormatOptions() {}
 }


### PR DESCRIPTION
## What is the purpose of the change
This pull request allows users to decide for themselves whether to discard the data that failed to deserialize, instead of failing the task directly.


## Brief change log
add ignoreignore-parse-errors in avro format

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no