### PR TITLE
[FLINK-27441][webfrontend] fix "nzScroll" calculations

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/pages/job/overview/accumulators/job-overview-drawer-accumulators.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/overview/accumulators/job-overview-drawer-accumulators.component.html
@@ -22,7 +22,7 @@
       [nzSize]="'small'"
       [nzLoading]="isLoading"
       [nzData]="listOfAccumulator"
-      [nzScroll]="{ y: 'calc( 100% - 72px )' }"
+      [nzScroll]="{ y: 'calc( 100vh - 72px )' }"
       [nzFrontPagination]="false"
       [nzShowPagination]="false"
     >
@@ -47,7 +47,7 @@
       [nzSize]="'small'"
       [nzLoading]="isLoading"
       [nzData]="listOfSubTaskAccumulator"
-      [nzScroll]="{ y: 'calc( 100% - 72px )' }"
+      [nzScroll]="{ y: 'calc( 100vh - 72px )' }"
       [nzFrontPagination]="false"
       [nzShowPagination]="false"
     >

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/overview/backpressure/job-overview-drawer-backpressure.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/overview/backpressure/job-overview-drawer-backpressure.component.html
@@ -21,7 +21,7 @@
   [nzSize]="'small'"
   [nzLoading]="isLoading"
   [nzData]="listOfSubTaskBackpressure"
-  [nzScroll]="{ y: 'calc( 100% - 72px )' }"
+  [nzScroll]="{ y: 'calc( 100vh - 72px )' }"
   [nzWidthConfig]="['33.33%', '33.33%', '33.33%']"
   [nzFrontPagination]="false"
   [nzShowPagination]="false"

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/overview/subtasks/job-overview-drawer-subtasks.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/overview/subtasks/job-overview-drawer-subtasks.component.html
@@ -22,7 +22,7 @@
   [nzSize]="'small'"
   [nzLoading]="isLoading"
   [nzData]="listOfTask"
-  [nzScroll]="{ x: '1480px', y: 'calc( 100% - 35px )' }"
+  [nzScroll]="{ x: '1480px', y: 'calc( 100vh - 35px )' }"
   [nzFrontPagination]="false"
   [nzShowPagination]="false"
 >

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/overview/taskmanagers/job-overview-drawer-taskmanagers.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/overview/taskmanagers/job-overview-drawer-taskmanagers.component.html
@@ -22,7 +22,7 @@
   [nzSize]="'small'"
   [nzLoading]="isLoading"
   [nzData]="listOfTaskManager"
-  [nzScroll]="{ x: '1500px', y: 'calc( 100% - 35px )' }"
+  [nzScroll]="{ x: '1500px', y: 'calc( 100vh - 35px )' }"
   [nzFrontPagination]="false"
   [nzShowPagination]="false"
 >

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/overview/watermarks/job-overview-drawer-watermarks.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/overview/watermarks/job-overview-drawer-watermarks.component.html
@@ -21,7 +21,7 @@
   [nzSize]="'small'"
   [nzLoading]="isLoading"
   [nzData]="listOfWaterMark"
-  [nzScroll]="{ y: 'calc( 100% - 35px )' }"
+  [nzScroll]="{ y: 'calc( 100vh - 35px )' }"
   [nzFrontPagination]="false"
   [nzShowPagination]="false"
 >


### PR DESCRIPTION
## What is the purpose of the change

Fixes hidden scrollbar for some UI elements, where CSS calculate was based on a percentage. The current Angular version has a bug, so in those cases the scrollbar is hidden and scrolling is not possible.

Relevant Angular issue: https://github.com/NG-ZORRO/ng-zorro-antd/issues/3090

## Brief change log

Changed `calc ( X% ...)` to `calc( Xvh ...)`, which solves this problem.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## How to test

Prepare a Flink job with a number of Accumulators that cannot fit to the tab, so scrolling is required. After running the job, the "Accumulators" tab has no scrollbar. The CSS can be changed in the browser, so it can be modified on the fly to try out the fix.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
