### PR TITLE
[FLINK-27420][runtime] Recreate metric groups for each new RM to avoid metric loss

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerFactory.java
@@ -64,11 +64,6 @@ public abstract class ResourceManagerFactory<T extends ResourceIDRetrievable> {
             Executor ioExecutor)
             throws ConfigurationException {
 
-        final ResourceManagerMetricGroup resourceManagerMetricGroup =
-                ResourceManagerMetricGroup.create(metricRegistry, hostname);
-        final SlotManagerMetricGroup slotManagerMetricGroup =
-                SlotManagerMetricGroup.create(metricRegistry, hostname);
-
         final Configuration runtimeServicesAndRmConfig =
                 getEffectiveConfigurationForResourceManagerAndRuntimeServices(configuration);
 
@@ -89,8 +84,8 @@ public abstract class ResourceManagerFactory<T extends ResourceIDRetrievable> {
                 fatalErrorHandler,
                 clusterInformation,
                 webInterfaceUrl,
-                resourceManagerMetricGroup,
-                slotManagerMetricGroup,
+                metricRegistry,
+                hostname,
                 ioExecutor);
     }
 
@@ -102,7 +97,8 @@ public abstract class ResourceManagerFactory<T extends ResourceIDRetrievable> {
                         context.getRmRuntimeServicesConfig(),
                         context.getRpcService(),
                         context.getHighAvailabilityServices(),
-                        context.getSlotManagerMetricGroup());
+                        SlotManagerMetricGroup.create(
+                                context.getMetricRegistry(), context.getHostname()));
 
         return createResourceManager(
                 context.getRmConfig(),
@@ -114,7 +110,8 @@ public abstract class ResourceManagerFactory<T extends ResourceIDRetrievable> {
                 context.getFatalErrorHandler(),
                 context.getClusterInformation(),
                 context.getWebInterfaceUrl(),
-                context.getResourceManagerMetricGroup(),
+                ResourceManagerMetricGroup.create(
+                        context.getMetricRegistry(), context.getHostname()),
                 resourceManagerRuntimeServices,
                 context.getIoExecutor());
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerProcessContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerProcessContext.java
@@ -23,8 +23,7 @@ import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
-import org.apache.flink.runtime.metrics.groups.ResourceManagerMetricGroup;
-import org.apache.flink.runtime.metrics.groups.SlotManagerMetricGroup;
+import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.security.token.DelegationTokenManager;
@@ -52,8 +51,8 @@ public class ResourceManagerProcessContext {
     private final FatalErrorHandler fatalErrorHandler;
     private final ClusterInformation clusterInformation;
     @Nullable private final String webInterfaceUrl;
-    private final ResourceManagerMetricGroup resourceManagerMetricGroup;
-    private final SlotManagerMetricGroup slotManagerMetricGroup;
+    private final MetricRegistry metricRegistry;
+    private final String hostname;
     private final Executor ioExecutor;
 
     public ResourceManagerProcessContext(
@@ -67,8 +66,8 @@ public class ResourceManagerProcessContext {
             FatalErrorHandler fatalErrorHandler,
             ClusterInformation clusterInformation,
             @Nullable String webInterfaceUrl,
-            ResourceManagerMetricGroup resourceManagerMetricGroup,
-            SlotManagerMetricGroup slotManagerMetricGroup,
+            MetricRegistry metricRegistry,
+            String hostname,
             Executor ioExecutor) {
         this.rmConfig = checkNotNull(rmConfig);
         this.resourceId = checkNotNull(resourceId);
@@ -79,8 +78,8 @@ public class ResourceManagerProcessContext {
         this.delegationTokenManager = checkNotNull(delegationTokenManager);
         this.fatalErrorHandler = checkNotNull(fatalErrorHandler);
         this.clusterInformation = checkNotNull(clusterInformation);
-        this.resourceManagerMetricGroup = checkNotNull(resourceManagerMetricGroup);
-        this.slotManagerMetricGroup = checkNotNull(slotManagerMetricGroup);
+        this.metricRegistry = checkNotNull(metricRegistry);
+        this.hostname = checkNotNull(hostname);
         this.ioExecutor = checkNotNull(ioExecutor);
 
         this.webInterfaceUrl = webInterfaceUrl;
@@ -127,12 +126,12 @@ public class ResourceManagerProcessContext {
         return webInterfaceUrl;
     }
 
-    public ResourceManagerMetricGroup getResourceManagerMetricGroup() {
-        return resourceManagerMetricGroup;
+    public MetricRegistry getMetricRegistry() {
+        return metricRegistry;
     }
 
-    public SlotManagerMetricGroup getSlotManagerMetricGroup() {
-        return slotManagerMetricGroup;
+    public String getHostname() {
+        return hostname;
     }
 
     public Executor getIoExecutor() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerServiceImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerServiceImplTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.heartbeat.TestingHeartbeatServices;
 import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
 import org.apache.flink.runtime.leaderelection.TestingLeaderElectionService;
+import org.apache.flink.runtime.metrics.MetricNames;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.metrics.util.TestingMetricRegistry;
 import org.apache.flink.runtime.rpc.RpcUtils;
@@ -36,14 +37,20 @@ import org.apache.flink.runtime.security.token.NoOpDelegationTokenManager;
 import org.apache.flink.runtime.util.TestingFatalErrorHandler;
 import org.apache.flink.util.TestLogger;
 
+import org.assertj.core.util.Sets;
 import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeoutException;
 
@@ -497,6 +504,62 @@ public class ResourceManagerServiceImplTest extends TestLogger {
         deregisterApplicationFuture.get(TIMEOUT.getSize(), TIMEOUT.getUnit());
     }
 
+    @Test
+    public void grantAndRevokeLeadership_verifyMetrics() throws Exception {
+        final Set<String> registeredMetrics = Collections.newSetFromMap(new ConcurrentHashMap<>());
+        TestingMetricRegistry metricRegistry =
+                TestingMetricRegistry.builder()
+                        .setRegisterConsumer((a, b, c) -> registeredMetrics.add(b))
+                        .setUnregisterConsumer((a, b, c) -> registeredMetrics.remove(b))
+                        .build();
+
+        final TestingResourceManagerFactory rmFactory = rmFactoryBuilder.build();
+        resourceManagerService =
+                ResourceManagerServiceImpl.create(
+                        rmFactory,
+                        new Configuration(),
+                        ResourceID.generate(),
+                        rpcService,
+                        haService,
+                        heartbeatServices,
+                        delegationTokenManager,
+                        fatalErrorHandler,
+                        clusterInformation,
+                        null,
+                        metricRegistry,
+                        "localhost",
+                        ForkJoinPool.commonPool());
+        resourceManagerService.start();
+
+        Assert.assertEquals(0, registeredMetrics.size());
+        // grant leadership
+        leaderElectionService.isLeader(UUID.randomUUID());
+
+        assertRmStarted();
+        Set<String> expectedMetrics =
+                Sets.set(
+                        MetricNames.NUM_REGISTERED_TASK_MANAGERS,
+                        MetricNames.TASK_SLOTS_TOTAL,
+                        MetricNames.TASK_SLOTS_AVAILABLE);
+        Assert.assertTrue(
+                "Expected RM to register leader metrics",
+                registeredMetrics.containsAll(expectedMetrics));
+
+        // revoke leadership, block until old rm is terminated
+        revokeLeadership();
+
+        Set<String> intersection = new HashSet<>(registeredMetrics);
+        intersection.retainAll(expectedMetrics);
+        Assert.assertTrue("Expected RM to unregister leader metrics", intersection.isEmpty());
+
+        leaderElectionService.isLeader(UUID.randomUUID());
+
+        assertRmStarted();
+        Assert.assertTrue(
+                "Expected RM to re-register leader metrics",
+                registeredMetrics.containsAll(expectedMetrics));
+    }
+
     private static void blockOnFuture(CompletableFuture<?> future) {
         try {
             future.get();
@@ -517,5 +580,12 @@ public class ResourceManagerServiceImplTest extends TestLogger {
 
     private void assertRmStarted() throws Exception {
         leaderElectionService.getConfirmationFuture().get(TIMEOUT.getSize(), TIMEOUT.getUnit());
+    }
+
+    private void revokeLeadership() {
+        ResourceManager<?> leaderResourceManager =
+                resourceManagerService.getLeaderResourceManager();
+        leaderElectionService.notLeader();
+        blockOnFuture(leaderResourceManager.getTerminationFuture());
     }
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
Fix bug identified in https://issues.apache.org/jira/browse/FLINK-27420 by recreating the metric groups for slot manager and resource manager when leadership is granted.

## Brief change log
- The MetricRegistry and Hostname are stored in the ResourceManagerProcessContext
- The SlotManagerMetricGroup and ResourceManagerMetricGroup are created in the ResourceManagerFactory

## Verifying this change

- Added tests for granting leadership, revoking leadership, and granting leadership again and verifying the metrics are registered. I verified this test fails before the patch.
- Ran Azure pipelines, which mostly worked, but had some unrelated errors ([link](https://dev.azure.com/baugarten0115/baugarten-flink/_build/results?buildId=57&view=results))

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
