### PR TITLE
[FLINK-27454][tests] Remove inheritance from TestBaseUtils 

### DIFF
--- a/flink-connectors/flink-hadoop-compatibility/src/test/java/org/apache/flink/test/hadoopcompatibility/mapred/HadoopIOFormatsITCase.java
+++ b/flink-connectors/flink-hadoop-compatibility/src/test/java/org/apache/flink/test/hadoopcompatibility/mapred/HadoopIOFormatsITCase.java
@@ -46,6 +46,8 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultsByLinesInMemory;
+
 /** Integration tests for Hadoop IO formats. */
 @RunWith(Parameterized.class)
 public class HadoopIOFormatsITCase extends JavaProgramTestBase {

--- a/flink-connectors/flink-hadoop-compatibility/src/test/java/org/apache/flink/test/hadoopcompatibility/mapred/HadoopMapFunctionITCase.java
+++ b/flink-connectors/flink-hadoop-compatibility/src/test/java/org/apache/flink/test/hadoopcompatibility/mapred/HadoopMapFunctionITCase.java
@@ -39,6 +39,8 @@ import org.junit.runners.Parameterized;
 
 import java.io.IOException;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultsByLinesInMemory;
+
 /** IT cases for the {@link HadoopMapFunction}. */
 @RunWith(Parameterized.class)
 public class HadoopMapFunctionITCase extends MultipleProgramsTestBase {

--- a/flink-connectors/flink-hadoop-compatibility/src/test/java/org/apache/flink/test/hadoopcompatibility/mapred/HadoopMapredITCase.java
+++ b/flink-connectors/flink-hadoop-compatibility/src/test/java/org/apache/flink/test/hadoopcompatibility/mapred/HadoopMapredITCase.java
@@ -26,6 +26,8 @@ import org.apache.flink.util.OperatingSystem;
 import org.junit.Assume;
 import org.junit.Before;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultsByLinesInMemory;
+
 /** IT cases for mapred. */
 public class HadoopMapredITCase extends JavaProgramTestBase {
 

--- a/flink-connectors/flink-hadoop-compatibility/src/test/java/org/apache/flink/test/hadoopcompatibility/mapred/HadoopReduceCombineFunctionITCase.java
+++ b/flink-connectors/flink-hadoop-compatibility/src/test/java/org/apache/flink/test/hadoopcompatibility/mapred/HadoopReduceCombineFunctionITCase.java
@@ -42,6 +42,8 @@ import org.junit.runners.Parameterized;
 import java.io.IOException;
 import java.util.Iterator;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultsByLinesInMemory;
+
 /** IT case for the {@link HadoopReduceCombineFunction}. */
 @RunWith(Parameterized.class)
 public class HadoopReduceCombineFunctionITCase extends MultipleProgramsTestBase {

--- a/flink-connectors/flink-hadoop-compatibility/src/test/java/org/apache/flink/test/hadoopcompatibility/mapred/HadoopReduceFunctionITCase.java
+++ b/flink-connectors/flink-hadoop-compatibility/src/test/java/org/apache/flink/test/hadoopcompatibility/mapred/HadoopReduceFunctionITCase.java
@@ -40,6 +40,8 @@ import org.junit.runners.Parameterized;
 import java.io.IOException;
 import java.util.Iterator;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultsByLinesInMemory;
+
 /** IT cases for the {@link HadoopReduceFunction}. */
 @RunWith(Parameterized.class)
 public class HadoopReduceFunctionITCase extends MultipleProgramsTestBase {

--- a/flink-connectors/flink-hadoop-compatibility/src/test/java/org/apache/flink/test/hadoopcompatibility/mapred/WordCountMapredITCase.java
+++ b/flink-connectors/flink-hadoop-compatibility/src/test/java/org/apache/flink/test/hadoopcompatibility/mapred/WordCountMapredITCase.java
@@ -39,6 +39,8 @@ import org.apache.hadoop.mapred.TextOutputFormat;
 import org.junit.Assume;
 import org.junit.Before;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultsByLinesInMemory;
+
 /** Test WordCount with Hadoop input and output "mapred" (legacy) formats. */
 public class WordCountMapredITCase extends JavaProgramTestBase {
 

--- a/flink-connectors/flink-hadoop-compatibility/src/test/java/org/apache/flink/test/hadoopcompatibility/mapreduce/HadoopInputOutputITCase.java
+++ b/flink-connectors/flink-hadoop-compatibility/src/test/java/org/apache/flink/test/hadoopcompatibility/mapreduce/HadoopInputOutputITCase.java
@@ -28,6 +28,8 @@ import org.apache.flink.util.OperatingSystem;
 import org.junit.Assume;
 import org.junit.Before;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultsByLinesInMemory;
+
 /** IT cases for both the {@link HadoopInputFormat} and {@link HadoopOutputFormat}. */
 public class HadoopInputOutputITCase extends JavaProgramTestBase {
 

--- a/flink-connectors/flink-hadoop-compatibility/src/test/java/org/apache/flink/test/hadoopcompatibility/mapreduce/WordCountMapreduceITCase.java
+++ b/flink-connectors/flink-hadoop-compatibility/src/test/java/org/apache/flink/test/hadoopcompatibility/mapreduce/WordCountMapreduceITCase.java
@@ -39,6 +39,8 @@ import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat;
 import org.junit.Assume;
 import org.junit.Before;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultsByLinesInMemory;
+
 /** Test WordCount with Hadoop input and output "mapreduce" (modern) formats. */
 public class WordCountMapreduceITCase extends JavaProgramTestBase {
 

--- a/flink-examples/flink-examples-streaming/src/test/java/org/apache/flink/streaming/test/StreamingExamplesITCase.java
+++ b/flink-examples/flink-examples-streaming/src/test/java/org/apache/flink/streaming/test/StreamingExamplesITCase.java
@@ -39,6 +39,9 @@ import org.junit.Test;
 
 import java.io.File;
 
+import static org.apache.flink.test.util.TestBaseUtils.checkLinesAgainstRegexp;
+import static org.apache.flink.test.util.TestBaseUtils.compareResultsByLinesInMemory;
+
 /** Integration test for streaming programs in Java examples. */
 public class StreamingExamplesITCase extends AbstractTestBase {
 

--- a/flink-examples/flink-examples-streaming/src/test/java/org/apache/flink/streaming/test/scala/examples/windowing/TopSpeedWindowingExampleITCase.java
+++ b/flink-examples/flink-examples-streaming/src/test/java/org/apache/flink/streaming/test/scala/examples/windowing/TopSpeedWindowingExampleITCase.java
@@ -23,6 +23,8 @@ import org.apache.flink.test.util.AbstractTestBase;
 
 import org.junit.Test;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultsByLinesInMemory;
+
 /** Tests for {@link TopSpeedWindowing}. */
 public class TopSpeedWindowingExampleITCase extends AbstractTestBase {
 

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroOutputFormatITCase.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroOutputFormatITCase.java
@@ -45,6 +45,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
+import static org.apache.flink.test.util.TestBaseUtils.asFile;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** IT cases for the {@link AvroOutputFormat}. */

--- a/flink-libraries/flink-gelly-examples/src/test/java/org/apache/flink/graph/library/CommunityDetectionITCase.java
+++ b/flink-libraries/flink-gelly-examples/src/test/java/org/apache/flink/graph/library/CommunityDetectionITCase.java
@@ -31,6 +31,8 @@ import org.junit.runners.Parameterized;
 
 import java.util.List;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultAsTuples;
+
 /** Tests for {@link CommunityDetection}. */
 @RunWith(Parameterized.class)
 public class CommunityDetectionITCase extends MultipleProgramsTestBase {

--- a/flink-libraries/flink-gelly-examples/src/test/java/org/apache/flink/graph/library/LabelPropagationITCase.java
+++ b/flink-libraries/flink-gelly-examples/src/test/java/org/apache/flink/graph/library/LabelPropagationITCase.java
@@ -31,6 +31,8 @@ import org.junit.runners.Parameterized;
 
 import java.util.List;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultAsTuples;
+
 /** Tests for {@link LabelPropagation}. */
 @RunWith(Parameterized.class)
 public class LabelPropagationITCase extends MultipleProgramsTestBase {

--- a/flink-libraries/flink-gelly-examples/src/test/java/org/apache/flink/graph/test/GatherSumApplyITCase.java
+++ b/flink-libraries/flink-gelly-examples/src/test/java/org/apache/flink/graph/test/GatherSumApplyITCase.java
@@ -41,6 +41,8 @@ import org.junit.runners.Parameterized;
 
 import java.util.List;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultAsTuples;
+
 /** Tests for gather-sum-apply. */
 @RunWith(Parameterized.class)
 public class GatherSumApplyITCase extends MultipleProgramsTestBase {

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/ConnectedComponentsWithRandomisedEdgesITCase.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/ConnectedComponentsWithRandomisedEdgesITCase.java
@@ -31,6 +31,8 @@ import org.apache.flink.types.NullValue;
 
 import java.io.BufferedReader;
 
+import static org.apache.flink.test.util.TestBaseUtils.getResultReader;
+
 /** Test {@link ConnectedComponents} with a randomly generated graph. */
 @SuppressWarnings("serial")
 public class ConnectedComponentsWithRandomisedEdgesITCase extends JavaProgramTestBase {

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/GatherSumApplyConfigurationITCase.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/GatherSumApplyConfigurationITCase.java
@@ -43,6 +43,8 @@ import org.junit.runners.Parameterized;
 import java.util.HashSet;
 import java.util.List;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultAsTuples;
+
 /** Tests for {@link GSAConfiguration}. */
 @RunWith(Parameterized.class)
 public class GatherSumApplyConfigurationITCase extends MultipleProgramsTestBase {

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/ScatterGatherConfigurationITCase.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/ScatterGatherConfigurationITCase.java
@@ -44,6 +44,8 @@ import org.junit.runners.Parameterized;
 import java.util.HashSet;
 import java.util.List;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultAsTuples;
+
 /** Tests for {@link ScatterGatherConfiguration}. */
 @RunWith(Parameterized.class)
 public class ScatterGatherConfigurationITCase extends MultipleProgramsTestBase {

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/DegreesITCase.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/DegreesITCase.java
@@ -33,6 +33,8 @@ import org.junit.runners.Parameterized;
 
 import java.util.List;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultAsTuples;
+
 /**
  * Tests for {@link Graph#inDegrees()}, {@link Graph#outDegrees()}, and {@link Graph#getDegrees()}.
  */

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/FromCollectionITCase.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/FromCollectionITCase.java
@@ -34,6 +34,8 @@ import org.junit.runners.Parameterized;
 
 import java.util.List;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultAsTuples;
+
 /** Test creating graphs from collections. */
 @RunWith(Parameterized.class)
 public class FromCollectionITCase extends MultipleProgramsTestBase {

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/GraphCreationITCase.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/GraphCreationITCase.java
@@ -38,6 +38,9 @@ import org.junit.runners.Parameterized;
 import java.util.LinkedList;
 import java.util.List;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultAsText;
+import static org.apache.flink.test.util.TestBaseUtils.compareResultAsTuples;
+
 /** Test graph creation and validation from datasets and tuples. */
 @RunWith(Parameterized.class)
 public class GraphCreationITCase extends MultipleProgramsTestBase {

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/GraphCreationWithCsvITCase.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/GraphCreationWithCsvITCase.java
@@ -38,6 +38,8 @@ import java.io.OutputStreamWriter;
 import java.nio.charset.Charset;
 import java.util.List;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultAsTuples;
+
 /** Test graph creation from CSV. */
 @RunWith(Parameterized.class)
 public class GraphCreationWithCsvITCase extends MultipleProgramsTestBase {

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/GraphCreationWithMapperITCase.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/GraphCreationWithMapperITCase.java
@@ -34,6 +34,8 @@ import org.junit.runners.Parameterized;
 
 import java.util.List;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultAsTuples;
+
 /** Test graph creation with a mapper. */
 @RunWith(Parameterized.class)
 public class GraphCreationWithMapperITCase extends MultipleProgramsTestBase {

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/GraphMutationsITCase.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/GraphMutationsITCase.java
@@ -33,6 +33,8 @@ import org.junit.runners.Parameterized;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultAsTuples;
+
 /** Tests for adding and removing {@link Graph} vertices and edges. */
 @RunWith(Parameterized.class)
 public class GraphMutationsITCase extends MultipleProgramsTestBase {

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/GraphOperationsITCase.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/GraphOperationsITCase.java
@@ -38,6 +38,9 @@ import org.junit.runners.Parameterized;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultAsText;
+import static org.apache.flink.test.util.TestBaseUtils.compareResultAsTuples;
+
 /** Tests for {@link Graph} operations. */
 @RunWith(Parameterized.class)
 public class GraphOperationsITCase extends MultipleProgramsTestBase {

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/JoinWithEdgesITCase.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/JoinWithEdgesITCase.java
@@ -37,6 +37,8 @@ import org.junit.runners.Parameterized;
 
 import java.util.List;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultAsTuples;
+
 /**
  * Tests for {@link Graph#joinWithEdges}, {@link Graph#joinWithEdgesOnSource}, and {@link
  * Graph#joinWithEdgesOnTarget}.

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/JoinWithVerticesITCase.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/JoinWithVerticesITCase.java
@@ -36,6 +36,8 @@ import org.junit.runners.Parameterized;
 
 import java.util.List;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultAsTuples;
+
 /** Tests for {@link Graph#joinWithVertices}. */
 @RunWith(Parameterized.class)
 public class JoinWithVerticesITCase extends MultipleProgramsTestBase {

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/MapEdgesITCase.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/MapEdgesITCase.java
@@ -35,6 +35,8 @@ import org.junit.runners.Parameterized;
 
 import java.util.List;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultAsTuples;
+
 /** Tests for {@link Graph#mapEdges}. */
 @RunWith(Parameterized.class)
 public class MapEdgesITCase extends MultipleProgramsTestBase {

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/MapVerticesITCase.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/MapVerticesITCase.java
@@ -35,6 +35,8 @@ import org.junit.runners.Parameterized;
 
 import java.util.List;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultAsTuples;
+
 /** Tests for {@link Graph#mapVertices}. */
 @RunWith(Parameterized.class)
 public class MapVerticesITCase extends MultipleProgramsTestBase {

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/ReduceOnEdgesMethodsITCase.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/ReduceOnEdgesMethodsITCase.java
@@ -39,6 +39,8 @@ import org.junit.runners.Parameterized;
 import java.util.List;
 import java.util.Objects;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultAsTuples;
+
 /** Tests for {@link Graph#groupReduceOnEdges} and {@link Graph#reduceOnEdges}. */
 @RunWith(Parameterized.class)
 public class ReduceOnEdgesMethodsITCase extends MultipleProgramsTestBase {

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/ReduceOnNeighborMethodsITCase.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/ReduceOnNeighborMethodsITCase.java
@@ -39,6 +39,8 @@ import org.junit.runners.Parameterized;
 
 import java.util.List;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultAsTuples;
+
 /** Tests for {@link Graph#groupReduceOnNeighbors} and {@link Graph#reduceOnNeighbors}. */
 @RunWith(Parameterized.class)
 public class ReduceOnNeighborMethodsITCase extends MultipleProgramsTestBase {

--- a/flink-streaming-scala/src/test/java/org/apache/flink/streaming/scala/api/CsvOutputFormatITCase.java
+++ b/flink-streaming-scala/src/test/java/org/apache/flink/streaming/scala/api/CsvOutputFormatITCase.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 
 import java.io.File;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultsByLinesInMemory;
 import static org.apache.flink.util.ExceptionUtils.findThrowableWithMessage;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;

--- a/flink-streaming-scala/src/test/java/org/apache/flink/streaming/scala/api/TextOutputFormatITCase.java
+++ b/flink-streaming-scala/src/test/java/org/apache/flink/streaming/scala/api/TextOutputFormatITCase.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 
 import java.io.File;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultsByLinesInMemory;
 import static org.apache.flink.util.ExceptionUtils.findThrowableWithMessage;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/AbstractTestBase.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/AbstractTestBase.java
@@ -21,6 +21,7 @@ package org.apache.flink.test.util;
 import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.util.FileUtils;
+import org.apache.flink.util.TestLogger;
 
 import org.junit.After;
 import org.junit.ClassRule;
@@ -56,7 +57,7 @@ import java.io.IOException;
  *
  * </pre>
  */
-public abstract class AbstractTestBase extends TestBaseUtils {
+public abstract class AbstractTestBase extends TestLogger {
 
     private static final Logger LOG = LoggerFactory.getLogger(AbstractTestBase.class);
 

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/TestBaseUtils.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/TestBaseUtils.java
@@ -283,7 +283,7 @@ public class TestBaseUtils extends TestLogger {
         }
     }
 
-    protected static File asFile(String path) {
+    public static File asFile(String path) {
         try {
             URI uri = new URI(path);
             if (uri.getScheme().equals("file")) {

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/TestBaseUtils.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/TestBaseUtils.java
@@ -19,7 +19,6 @@
 package org.apache.flink.test.util;
 
 import org.apache.flink.api.java.tuple.Tuple;
-import org.apache.flink.util.TestLogger;
 
 import org.junit.Assert;
 
@@ -47,26 +46,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /** Utility class containing various methods for testing purposes. */
-public class TestBaseUtils extends TestLogger {
-
-    protected static final int MINIMUM_HEAP_SIZE_MB = 192;
-
-    // ------------------------------------------------------------------------
-
-    protected TestBaseUtils() {
-        verifyJvmOptions();
-    }
-
-    private static void verifyJvmOptions() {
-        long heap = Runtime.getRuntime().maxMemory() >> 20;
-        Assert.assertTrue(
-                "Insufficient java heap space "
-                        + heap
-                        + "mb - set JVM option: -Xmx"
-                        + MINIMUM_HEAP_SIZE_MB
-                        + "m",
-                heap > MINIMUM_HEAP_SIZE_MB - 50);
-    }
+public class TestBaseUtils {
 
     // --------------------------------------------------------------------------------------------
     //  Result Checking

--- a/flink-tests/src/test/java/org/apache/flink/runtime/operators/lifecycle/BoundedSourceITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/operators/lifecycle/BoundedSourceITCase.java
@@ -25,8 +25,8 @@ import org.apache.flink.runtime.operators.lifecycle.validation.DrainingValidator
 import org.apache.flink.runtime.operators.lifecycle.validation.FinishingValidator;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
-import org.apache.flink.test.util.TestBaseUtils;
 import org.apache.flink.testutils.junit.SharedObjects;
+import org.apache.flink.util.TestLogger;
 
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -54,7 +54,7 @@ import static org.apache.flink.runtime.operators.lifecycle.validation.TestOperat
  * same.
  */
 @RunWith(Parameterized.class)
-public class BoundedSourceITCase extends TestBaseUtils {
+public class BoundedSourceITCase extends TestLogger {
 
     @ClassRule public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
 

--- a/flink-tests/src/test/java/org/apache/flink/test/accumulators/AccumulatorITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/accumulators/AccumulatorITCase.java
@@ -42,6 +42,8 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultsByLinesInMemory;
+
 /**
  * Test for the basic functionality of accumulators. We cannot test all different kinds of plans
  * here (iterative, etc.).

--- a/flink-tests/src/test/java/org/apache/flink/test/broadcastvars/BroadcastBranchingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/broadcastvars/BroadcastBranchingITCase.java
@@ -35,6 +35,8 @@ import org.apache.flink.util.Collector;
 import java.util.Collection;
 import java.util.List;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultAsText;
+
 /** Test broadcast input after branching. */
 public class BroadcastBranchingITCase extends JavaProgramTestBase {
     private static final String RESULT = "(2,112)\n";
@@ -90,7 +92,7 @@ public class BroadcastBranchingITCase extends JavaProgramTestBase {
         List<Tuple2<String, Integer>> result =
                 jn2.flatMap(new Mp2()).withBroadcastSet(mp1, "z").collect();
 
-        JavaProgramTestBase.compareResultAsText(result, RESULT);
+        compareResultAsText(result, RESULT);
     }
 
     private static class Jn1

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/utils/SnapshotMigrationTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/utils/SnapshotMigrationTestBase.java
@@ -38,7 +38,7 @@ import org.apache.flink.runtime.state.StateBackendLoader;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
-import org.apache.flink.test.util.TestBaseUtils;
+import org.apache.flink.util.TestLogger;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.ClassRule;
@@ -69,7 +69,7 @@ import static org.junit.Assert.fail;
  * Base for testing snapshot migration. The base test supports snapshots types as defined in {@link
  * SnapshotType}.
  */
-public abstract class SnapshotMigrationTestBase extends TestBaseUtils {
+public abstract class SnapshotMigrationTestBase extends TestLogger {
 
     @ClassRule public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
 

--- a/flink-tests/src/test/java/org/apache/flink/test/example/failing/TaskFailureITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/example/failing/TaskFailureITCase.java
@@ -25,12 +25,12 @@ import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.test.util.JavaProgramTestBase;
-import org.apache.flink.test.util.MultipleProgramsTestBase;
 
 import org.junit.Assert;
 
 import java.util.List;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultAsText;
 import static org.apache.flink.util.ExceptionUtils.findThrowableWithMessage;
 import static org.junit.Assert.assertTrue;
 
@@ -70,7 +70,7 @@ public class TaskFailureITCase extends JavaProgramTestBase {
         env.setParallelism(1);
         env.setRestartStrategy(RestartStrategies.fixedDelayRestart(retries, 0));
         List<Long> result = env.generateSequence(1, 9).map(mapper).collect();
-        MultipleProgramsTestBase.compareResultAsText(result, "1\n2\n3\n4\n5\n6\n7\n8\n9");
+        compareResultAsText(result, "1\n2\n3\n4\n5\n6\n7\n8\n9");
     }
 
     /** Working map function. */

--- a/flink-tests/src/test/java/org/apache/flink/test/example/java/ConnectedComponentsITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/example/java/ConnectedComponentsITCase.java
@@ -25,6 +25,8 @@ import org.apache.flink.test.util.JavaProgramTestBase;
 
 import java.io.BufferedReader;
 
+import static org.apache.flink.test.util.TestBaseUtils.getResultReader;
+
 /** Test for {@link ConnectedComponents}. */
 public class ConnectedComponentsITCase extends JavaProgramTestBase {
 

--- a/flink-tests/src/test/java/org/apache/flink/test/example/java/EnumTriangleBasicITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/example/java/EnumTriangleBasicITCase.java
@@ -23,6 +23,8 @@ import org.apache.flink.examples.java.graph.EnumTriangles;
 import org.apache.flink.test.testdata.EnumTriangleData;
 import org.apache.flink.test.util.JavaProgramTestBase;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultsByLinesInMemory;
+
 /** Test {@link EnumTriangles}. */
 public class EnumTriangleBasicITCase extends JavaProgramTestBase {
 

--- a/flink-tests/src/test/java/org/apache/flink/test/example/java/PageRankITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/example/java/PageRankITCase.java
@@ -35,6 +35,8 @@ import org.junit.runners.Parameterized;
 import java.io.File;
 import java.util.UUID;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareKeyValuePairsWithDelta;
+
 /** Test for {@link PageRank}. */
 @RunWith(Parameterized.class)
 public class PageRankITCase extends MultipleProgramsTestBase {

--- a/flink-tests/src/test/java/org/apache/flink/test/example/java/TransitiveClosureITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/example/java/TransitiveClosureITCase.java
@@ -26,6 +26,8 @@ import org.apache.flink.test.util.JavaProgramTestBase;
 
 import java.io.BufferedReader;
 
+import static org.apache.flink.test.util.TestBaseUtils.getResultReader;
+
 /** Test for {@link TransitiveClosureNaive}. */
 public class TransitiveClosureITCase extends JavaProgramTestBase {
 

--- a/flink-tests/src/test/java/org/apache/flink/test/example/java/WebLogAnalysisITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/example/java/WebLogAnalysisITCase.java
@@ -23,6 +23,8 @@ import org.apache.flink.examples.java.relational.WebLogAnalysis;
 import org.apache.flink.test.testdata.WebLogAnalysisData;
 import org.apache.flink.test.util.JavaProgramTestBase;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultsByLinesInMemory;
+
 /** Test for {@link WebLogAnalysis}. */
 public class WebLogAnalysisITCase extends JavaProgramTestBase {
 

--- a/flink-tests/src/test/java/org/apache/flink/test/example/java/WordCountITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/example/java/WordCountITCase.java
@@ -23,6 +23,8 @@ import org.apache.flink.examples.java.wordcount.WordCount;
 import org.apache.flink.test.testdata.WordCountData;
 import org.apache.flink.test.util.JavaProgramTestBase;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultsByLinesInMemory;
+
 /** Test {@link WordCount}. */
 public class WordCountITCase extends JavaProgramTestBase {
 

--- a/flink-tests/src/test/java/org/apache/flink/test/example/java/WordCountNestedPOJOITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/example/java/WordCountNestedPOJOITCase.java
@@ -31,6 +31,8 @@ import org.apache.flink.util.Collector;
 import java.io.Serializable;
 import java.util.Date;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultsByLinesInMemory;
+
 /** WordCount with nested POJO example. */
 @SuppressWarnings("serial")
 public class WordCountNestedPOJOITCase extends JavaProgramTestBase implements Serializable {

--- a/flink-tests/src/test/java/org/apache/flink/test/example/java/WordCountSimplePOJOITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/example/java/WordCountSimplePOJOITCase.java
@@ -29,6 +29,8 @@ import org.apache.flink.util.Collector;
 
 import java.io.Serializable;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultsByLinesInMemory;
+
 /** WordCount with simple POJO example. */
 public class WordCountSimplePOJOITCase extends JavaProgramTestBase implements Serializable {
     private static final long serialVersionUID = 1L;

--- a/flink-tests/src/test/java/org/apache/flink/test/example/java/WordCountSubclassInterfacePOJOITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/example/java/WordCountSubclassInterfacePOJOITCase.java
@@ -30,6 +30,8 @@ import org.apache.flink.util.Collector;
 
 import java.io.Serializable;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultsByLinesInMemory;
+
 /** WordCount with subclass and interface example. */
 @SuppressWarnings("serial")
 public class WordCountSubclassInterfacePOJOITCase extends JavaProgramTestBase

--- a/flink-tests/src/test/java/org/apache/flink/test/example/java/WordCountSubclassPOJOITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/example/java/WordCountSubclassPOJOITCase.java
@@ -30,6 +30,8 @@ import org.apache.flink.util.Collector;
 
 import java.io.Serializable;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultsByLinesInMemory;
+
 /** WordCount with custom data types example. */
 @SuppressWarnings("serial")
 public class WordCountSubclassPOJOITCase extends JavaProgramTestBase implements Serializable {

--- a/flink-tests/src/test/java/org/apache/flink/test/example/scala/ConnectedComponentsITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/example/scala/ConnectedComponentsITCase.java
@@ -25,6 +25,8 @@ import org.apache.flink.test.util.JavaProgramTestBase;
 
 import java.io.BufferedReader;
 
+import static org.apache.flink.test.util.TestBaseUtils.getResultReader;
+
 /** Test for {@link ConnectedComponents}. */
 public class ConnectedComponentsITCase extends JavaProgramTestBase {
 

--- a/flink-tests/src/test/java/org/apache/flink/test/example/scala/EnumTriangleITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/example/scala/EnumTriangleITCase.java
@@ -23,6 +23,8 @@ import org.apache.flink.examples.scala.graph.EnumTriangles;
 import org.apache.flink.test.testdata.EnumTriangleData;
 import org.apache.flink.test.util.JavaProgramTestBase;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultsByLinesInMemory;
+
 /** Test {@link EnumTriangles}. */
 public class EnumTriangleITCase extends JavaProgramTestBase {
 

--- a/flink-tests/src/test/java/org/apache/flink/test/example/scala/PageRankITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/example/scala/PageRankITCase.java
@@ -34,6 +34,8 @@ import org.junit.runners.Parameterized;
 
 import java.io.File;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareKeyValuePairsWithDelta;
+
 /** Test for {@link PageRankBasic}. */
 @RunWith(Parameterized.class)
 public class PageRankITCase extends MultipleProgramsTestBase {

--- a/flink-tests/src/test/java/org/apache/flink/test/example/scala/TransitiveClosureITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/example/scala/TransitiveClosureITCase.java
@@ -26,6 +26,8 @@ import org.apache.flink.test.util.JavaProgramTestBase;
 
 import java.io.BufferedReader;
 
+import static org.apache.flink.test.util.TestBaseUtils.getResultReader;
+
 /** Test for {@link TransitiveClosureNaive}. */
 public class TransitiveClosureITCase extends JavaProgramTestBase {
 

--- a/flink-tests/src/test/java/org/apache/flink/test/example/scala/WebLogAnalysisITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/example/scala/WebLogAnalysisITCase.java
@@ -23,6 +23,8 @@ import org.apache.flink.examples.scala.relational.WebLogAnalysis;
 import org.apache.flink.test.testdata.WebLogAnalysisData;
 import org.apache.flink.test.util.JavaProgramTestBase;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultsByLinesInMemory;
+
 /** Test for {@link WebLogAnalysis}. */
 public class WebLogAnalysisITCase extends JavaProgramTestBase {
 

--- a/flink-tests/src/test/java/org/apache/flink/test/example/scala/WordCountITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/example/scala/WordCountITCase.java
@@ -23,6 +23,8 @@ import org.apache.flink.examples.scala.wordcount.WordCount;
 import org.apache.flink.test.testdata.WordCountData;
 import org.apache.flink.test.util.JavaProgramTestBase;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultsByLinesInMemory;
+
 /** Test {@link WordCount}. */
 public class WordCountITCase extends JavaProgramTestBase {
 

--- a/flink-tests/src/test/java/org/apache/flink/test/io/CsvReaderITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/io/CsvReaderITCase.java
@@ -42,6 +42,9 @@ import java.io.File;
 import java.util.List;
 import java.util.Locale;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultAsText;
+import static org.apache.flink.test.util.TestBaseUtils.compareResultAsTuples;
+
 /** Tests for {@link ExecutionEnvironment#readCsvFile}. */
 @RunWith(Parameterized.class)
 public class CsvReaderITCase extends MultipleProgramsTestBase {

--- a/flink-tests/src/test/java/org/apache/flink/test/iterative/CoGroupConnectedComponentsITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/iterative/CoGroupConnectedComponentsITCase.java
@@ -37,6 +37,8 @@ import org.apache.flink.util.Collector;
 import java.io.BufferedReader;
 import java.util.Iterator;
 
+import static org.apache.flink.test.util.TestBaseUtils.getResultReader;
+
 /** Delta iteration test implementing the connected components algorithm with a cogroup. */
 public class CoGroupConnectedComponentsITCase extends JavaProgramTestBase {
 

--- a/flink-tests/src/test/java/org/apache/flink/test/iterative/ConnectedComponentsITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/iterative/ConnectedComponentsITCase.java
@@ -31,6 +31,8 @@ import org.apache.flink.test.util.JavaProgramTestBase;
 
 import java.io.BufferedReader;
 
+import static org.apache.flink.test.util.TestBaseUtils.getResultReader;
+
 /** Delta iteration test implementing the connected components algorithm with a join. */
 public class ConnectedComponentsITCase extends JavaProgramTestBase {
 

--- a/flink-tests/src/test/java/org/apache/flink/test/iterative/ConnectedComponentsWithDeferredUpdateITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/iterative/ConnectedComponentsWithDeferredUpdateITCase.java
@@ -39,6 +39,8 @@ import java.io.BufferedReader;
 import java.util.Arrays;
 import java.util.Collection;
 
+import static org.apache.flink.test.util.TestBaseUtils.getResultReader;
+
 /**
  * Delta iteration test implementing the connected components algorithm with a cogroup and join on
  * the solution set.

--- a/flink-tests/src/test/java/org/apache/flink/test/iterative/ConnectedComponentsWithObjectMapITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/iterative/ConnectedComponentsWithObjectMapITCase.java
@@ -32,6 +32,8 @@ import org.apache.flink.test.util.JavaProgramTestBase;
 
 import java.io.BufferedReader;
 
+import static org.apache.flink.test.util.TestBaseUtils.getResultReader;
+
 /** Delta iteration test implementing the connected components algorithm with an object map. */
 @SuppressWarnings("serial")
 public class ConnectedComponentsWithObjectMapITCase extends JavaProgramTestBase {

--- a/flink-tests/src/test/java/org/apache/flink/test/iterative/ConnectedComponentsWithSolutionSetFirstITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/iterative/ConnectedComponentsWithSolutionSetFirstITCase.java
@@ -33,6 +33,8 @@ import org.apache.flink.util.Collector;
 
 import java.io.BufferedReader;
 
+import static org.apache.flink.test.util.TestBaseUtils.getResultReader;
+
 /**
  * Tests a bug that prevented that the solution set can be on both sides of the match/cogroup
  * function.

--- a/flink-tests/src/test/java/org/apache/flink/test/iterative/DependencyConnectedComponentsITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/iterative/DependencyConnectedComponentsITCase.java
@@ -32,6 +32,8 @@ import org.apache.flink.util.Collector;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultsByLinesInMemory;
+
 /**
  * Iterative Connected Components test case which recomputes only the elements of the solution set
  * whose at least one dependency (in-neighbor) has changed since the last iteration. Requires two

--- a/flink-tests/src/test/java/org/apache/flink/test/iterative/IterationTerminationWithTerminationTail.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/iterative/IterationTerminationWithTerminationTail.java
@@ -28,6 +28,8 @@ import org.apache.flink.util.Collector;
 
 import java.util.List;
 
+import static org.apache.flink.test.util.TestBaseUtils.containsResultAsText;
+
 /** Test iteration with termination criterion. */
 public class IterationTerminationWithTerminationTail extends JavaProgramTestBase {
     private static final String EXPECTED = "22\n";

--- a/flink-tests/src/test/java/org/apache/flink/test/iterative/IterationTerminationWithTwoTails.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/iterative/IterationTerminationWithTwoTails.java
@@ -28,6 +28,8 @@ import org.apache.flink.util.Collector;
 
 import java.util.List;
 
+import static org.apache.flink.test.util.TestBaseUtils.containsResultAsText;
+
 /** Test iteration with termination criterion consuming the iteration tail. */
 public class IterationTerminationWithTwoTails extends JavaProgramTestBase {
     private static final String EXPECTED = "22\n";

--- a/flink-tests/src/test/java/org/apache/flink/test/iterative/IterationWithAllReducerITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/iterative/IterationWithAllReducerITCase.java
@@ -26,6 +26,8 @@ import org.apache.flink.test.util.JavaProgramTestBase;
 
 import java.util.List;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultAsText;
+
 /** Test iterator with an all-reduce. */
 public class IterationWithAllReducerITCase extends JavaProgramTestBase {
     private static final String EXPECTED = "1\n";

--- a/flink-tests/src/test/java/org/apache/flink/test/iterative/IterationWithChainingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/iterative/IterationWithChainingITCase.java
@@ -30,6 +30,8 @@ import org.apache.flink.test.util.PointFormatter;
 import org.apache.flink.test.util.PointInFormat;
 import org.apache.flink.util.Collector;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultsByLinesInMemory;
+
 /** Test iteration with operator chaining. */
 public class IterationWithChainingITCase extends JavaProgramTestBase {
 

--- a/flink-tests/src/test/java/org/apache/flink/test/iterative/IterationWithUnionITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/iterative/IterationWithUnionITCase.java
@@ -32,6 +32,8 @@ import org.apache.flink.util.Collector;
 
 import java.io.Serializable;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultsByLinesInMemory;
+
 /** Test iteration with union. */
 public class IterationWithUnionITCase extends JavaProgramTestBase {
 

--- a/flink-tests/src/test/java/org/apache/flink/test/operators/AggregateITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/operators/AggregateITCase.java
@@ -37,6 +37,8 @@ import org.junit.runners.Parameterized;
 
 import java.util.List;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultAsTuples;
+
 /** Integration tests for aggregations. */
 @RunWith(Parameterized.class)
 public class AggregateITCase extends MultipleProgramsTestBase {

--- a/flink-tests/src/test/java/org/apache/flink/test/operators/CoGroupITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/operators/CoGroupITCase.java
@@ -52,6 +52,9 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultAsText;
+import static org.apache.flink.test.util.TestBaseUtils.compareResultAsTuples;
+
 /** Integration tests for {@link CoGroupFunction} and {@link RichCoGroupFunction}. */
 @RunWith(Parameterized.class)
 public class CoGroupITCase extends MultipleProgramsTestBase {

--- a/flink-tests/src/test/java/org/apache/flink/test/operators/CrossITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/operators/CrossITCase.java
@@ -38,6 +38,9 @@ import org.junit.runners.Parameterized;
 import java.util.Collection;
 import java.util.List;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultAsText;
+import static org.apache.flink.test.util.TestBaseUtils.compareResultAsTuples;
+
 /** Integration tests for {@link CrossFunction} and {@link RichCrossFunction}. */
 @RunWith(Parameterized.class)
 public class CrossITCase extends MultipleProgramsTestBase {

--- a/flink-tests/src/test/java/org/apache/flink/test/operators/DataSinkITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/operators/DataSinkITCase.java
@@ -39,6 +39,8 @@ import java.io.File;
 import java.util.Random;
 import java.util.UUID;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultsByLinesInMemoryWithStrictOrder;
+import static org.apache.flink.test.util.TestBaseUtils.getResultReader;
 import static org.junit.Assert.assertTrue;
 
 /** Tests for data sinks. */

--- a/flink-tests/src/test/java/org/apache/flink/test/operators/DataSourceITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/operators/DataSourceITCase.java
@@ -29,6 +29,8 @@ import org.junit.Assert;
 
 import java.util.List;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultAsText;
+
 /** Tests for the DataSource. */
 public class DataSourceITCase extends JavaProgramTestBase {
 

--- a/flink-tests/src/test/java/org/apache/flink/test/operators/DistinctITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/operators/DistinctITCase.java
@@ -38,6 +38,9 @@ import org.junit.runners.Parameterized;
 
 import java.util.List;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultAsText;
+import static org.apache.flink.test.util.TestBaseUtils.compareResultAsTuples;
+
 /** Integration tests for {@link DataSet#distinct}. */
 @SuppressWarnings("serial")
 @RunWith(Parameterized.class)

--- a/flink-tests/src/test/java/org/apache/flink/test/operators/FilterITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/operators/FilterITCase.java
@@ -35,6 +35,9 @@ import org.junit.runners.Parameterized;
 import java.util.Collection;
 import java.util.List;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultAsText;
+import static org.apache.flink.test.util.TestBaseUtils.compareResultAsTuples;
+
 /** Integration tests for {@link FilterFunction} and {@link RichFilterFunction}. */
 @RunWith(Parameterized.class)
 public class FilterITCase extends MultipleProgramsTestBase {

--- a/flink-tests/src/test/java/org/apache/flink/test/operators/FirstNITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/operators/FirstNITCase.java
@@ -36,6 +36,8 @@ import org.junit.runners.Parameterized;
 
 import java.util.List;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultAsText;
+
 /** Integration tests for {@link DataSet#first}. */
 @RunWith(Parameterized.class)
 public class FirstNITCase extends MultipleProgramsTestBase {

--- a/flink-tests/src/test/java/org/apache/flink/test/operators/FlatMapITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/operators/FlatMapITCase.java
@@ -36,6 +36,9 @@ import org.junit.runners.Parameterized;
 import java.util.Collection;
 import java.util.List;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultAsText;
+import static org.apache.flink.test.util.TestBaseUtils.compareResultAsTuples;
+
 /** Integration tests for {@link FlatMapFunction} and {@link RichFlatMapFunction}. */
 @RunWith(Parameterized.class)
 public class FlatMapITCase extends MultipleProgramsTestBase {

--- a/flink-tests/src/test/java/org/apache/flink/test/operators/GroupCombineITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/operators/GroupCombineITCase.java
@@ -41,6 +41,8 @@ import org.junit.runners.Parameterized;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultAsTuples;
+
 /**
  * The GroupCombine operator is not easy to test because it is essentially just a combiner. The
  * result can be the result of a normal groupReduce at any stage its execution. The basic idea is to

--- a/flink-tests/src/test/java/org/apache/flink/test/operators/GroupReduceITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/operators/GroupReduceITCase.java
@@ -55,6 +55,9 @@ import java.util.List;
 
 import scala.math.BigInt;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultAsText;
+import static org.apache.flink.test.util.TestBaseUtils.compareResultAsTuples;
+
 /**
  * Integration tests for {@link GroupReduceFunction}, {@link RichGroupReduceFunction}, and {@link
  * GroupCombineFunction}.

--- a/flink-tests/src/test/java/org/apache/flink/test/operators/JoinITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/operators/JoinITCase.java
@@ -52,6 +52,8 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultAsTuples;
+
 /** Integration tests for {@link JoinFunction} and {@link FlatJoinFunction}. */
 @SuppressWarnings("serial")
 @RunWith(Parameterized.class)

--- a/flink-tests/src/test/java/org/apache/flink/test/operators/MapITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/operators/MapITCase.java
@@ -36,6 +36,9 @@ import org.junit.runners.Parameterized;
 import java.util.Collection;
 import java.util.List;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultAsText;
+import static org.apache.flink.test.util.TestBaseUtils.compareResultAsTuples;
+
 /** Integration tests for {@link MapFunction} and {@link RichMapFunction}. */
 @RunWith(Parameterized.class)
 public class MapITCase extends MultipleProgramsTestBase {

--- a/flink-tests/src/test/java/org/apache/flink/test/operators/MapPartitionITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/operators/MapPartitionITCase.java
@@ -30,6 +30,8 @@ import org.apache.flink.util.Collector;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultCollections;
+
 /** Integration tests for {@link MapPartitionFunction}. */
 @SuppressWarnings("serial")
 public class MapPartitionITCase extends JavaProgramTestBase {

--- a/flink-tests/src/test/java/org/apache/flink/test/operators/ObjectReuseITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/operators/ObjectReuseITCase.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.test.util.MultipleProgramsTestBase;
+import org.apache.flink.test.util.TestBaseUtils.TupleComparator;
 import org.apache.flink.util.Collector;
 
 import org.junit.Test;

--- a/flink-tests/src/test/java/org/apache/flink/test/operators/OuterJoinITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/operators/OuterJoinITCase.java
@@ -45,6 +45,8 @@ import org.junit.runners.Parameterized;
 import java.util.Collection;
 import java.util.List;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultAsTuples;
+
 /**
  * Integration tests for {@link JoinFunction}, {@link FlatJoinFunction}, and {@link
  * RichFlatJoinFunction}.

--- a/flink-tests/src/test/java/org/apache/flink/test/operators/PartitionITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/operators/PartitionITCase.java
@@ -49,6 +49,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultAsText;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 

--- a/flink-tests/src/test/java/org/apache/flink/test/operators/ProjectITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/operators/ProjectITCase.java
@@ -27,6 +27,8 @@ import org.apache.flink.test.util.JavaProgramTestBase;
 
 import java.util.List;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultAsTuples;
+
 /** Integration tests for {@link DataSet#project}. */
 public class ProjectITCase extends JavaProgramTestBase {
 

--- a/flink-tests/src/test/java/org/apache/flink/test/operators/ReduceITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/operators/ReduceITCase.java
@@ -45,6 +45,9 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultAsText;
+import static org.apache.flink.test.util.TestBaseUtils.compareResultAsTuples;
+
 /** Integration tests for {@link ReduceFunction} and {@link RichReduceFunction}. */
 @SuppressWarnings("serial")
 @RunWith(Parameterized.class)

--- a/flink-tests/src/test/java/org/apache/flink/test/operators/ReduceWithCombinerITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/operators/ReduceWithCombinerITCase.java
@@ -37,6 +37,8 @@ import org.junit.runners.Parameterized;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultAsTuples;
+
 /** Integration tests for {@link GroupCombineFunction}. */
 @SuppressWarnings("serial")
 @RunWith(Parameterized.class)

--- a/flink-tests/src/test/java/org/apache/flink/test/operators/ReplicatingDataSourceITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/operators/ReplicatingDataSourceITCase.java
@@ -38,6 +38,8 @@ import org.junit.runners.Parameterized;
 
 import java.util.List;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultAsText;
+
 /** Tests for replicating DataSources. */
 @RunWith(Parameterized.class)
 public class ReplicatingDataSourceITCase extends MultipleProgramsTestBase {

--- a/flink-tests/src/test/java/org/apache/flink/test/operators/SampleITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/operators/SampleITCase.java
@@ -37,6 +37,7 @@ import org.junit.runners.Parameterized;
 import java.util.List;
 import java.util.Random;
 
+import static org.apache.flink.test.util.TestBaseUtils.containsResultAsText;
 import static org.junit.Assert.assertEquals;
 
 /** Integration tests for {@link DataSetUtils#sample}. */

--- a/flink-tests/src/test/java/org/apache/flink/test/operators/SortPartitionITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/operators/SortPartitionITCase.java
@@ -41,6 +41,8 @@ import java.io.Serializable;
 import java.util.Iterator;
 import java.util.List;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultAsText;
+
 /** Tests for {@link DataSet#sortPartition}. */
 @RunWith(Parameterized.class)
 public class SortPartitionITCase extends MultipleProgramsTestBase {

--- a/flink-tests/src/test/java/org/apache/flink/test/operators/SumMinMaxITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/operators/SumMinMaxITCase.java
@@ -32,6 +32,8 @@ import org.junit.runners.Parameterized;
 
 import java.util.List;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultAsTuples;
+
 /**
  * Integration tests for {@link org.apache.flink.api.scala.GroupedDataSet#min} and {@link
  * org.apache.flink.api.scala.GroupedDataSet#max}.

--- a/flink-tests/src/test/java/org/apache/flink/test/operators/TypeHintITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/operators/TypeHintITCase.java
@@ -40,6 +40,8 @@ import org.junit.Test;
 
 import java.util.List;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultAsText;
+
 /** Integration tests for {@link org.apache.flink.api.common.typeinfo.TypeHint}. */
 public class TypeHintITCase extends AbstractTestBase {
 

--- a/flink-tests/src/test/java/org/apache/flink/test/operators/UnionITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/operators/UnionITCase.java
@@ -31,6 +31,8 @@ import org.junit.runners.Parameterized;
 
 import java.util.List;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultAsTuples;
+
 /** Integration tests for {@link DataSet#union}. */
 @RunWith(Parameterized.class)
 public class UnionITCase extends MultipleProgramsTestBase {

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/RegisterTypeWithKryoSerializerITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/RegisterTypeWithKryoSerializerITCase.java
@@ -36,6 +36,8 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultCollections;
+
 /** Test registering types with Kryo. */
 @RunWith(Parameterized.class)
 public class RegisterTypeWithKryoSerializerITCase extends MultipleProgramsTestBase {

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/api/outputformat/CsvOutputFormatITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/api/outputformat/CsvOutputFormatITCase.java
@@ -26,6 +26,8 @@ import org.apache.flink.test.util.AbstractTestBase;
 
 import org.junit.Test;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultsByLinesInMemory;
+
 /** Integration tests for {@link org.apache.flink.api.java.io.CsvOutputFormat}. */
 public class CsvOutputFormatITCase extends AbstractTestBase {
 

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/api/outputformat/TextOutputFormatITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/api/outputformat/TextOutputFormatITCase.java
@@ -26,6 +26,8 @@ import org.apache.flink.test.util.AbstractTestBase;
 
 import org.junit.Test;
 
+import static org.apache.flink.test.util.TestBaseUtils.compareResultsByLinesInMemory;
+
 /** Integration tests for {@link org.apache.flink.api.java.io.TextOutputFormat}. */
 public class TextOutputFormatITCase extends AbstractTestBase {
 


### PR DESCRIPTION
Based on #19612.

Core idea is to get rid of inheritance so we can more easily migrate sub-classes to junit5 (where the TestLogger is currently problematic)