### PR TITLE
[FLINK-25970][core] Add type of original exception to the detailMessage of SerializedThrowable.

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/SerializedThrowable.java
+++ b/flink-core/src/main/java/org/apache/flink/util/SerializedThrowable.java
@@ -63,7 +63,7 @@ public class SerializedThrowable extends Exception implements Serializable {
     }
 
     private SerializedThrowable(Throwable exception, Set<Throwable> alreadySeen) {
-        super(getMessageOrError(exception));
+        super(getClassNameAndMessageOrError(exception));
 
         if (!(exception instanceof SerializedThrowable)) {
             // serialize and memoize the original message
@@ -189,9 +189,14 @@ public class SerializedThrowable extends Exception implements Serializable {
         }
     }
 
-    private static String getMessageOrError(Throwable error) {
+    private static String getClassNameAndMessageOrError(Throwable error) {
         try {
-            return error.getMessage();
+            String className = error.getClass().getName();
+            String message = error.getMessage();
+            if (message != null) {
+                return String.format("%s: %s", className, message);
+            }
+            return className;
         } catch (Throwable t) {
             return "(failed to get message)";
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
@@ -3084,14 +3084,17 @@ public class CheckpointCoordinatorTest extends TestLogger {
                         graph.getJobID(), coordinator, attemptID1, expectedRootCause);
 
         assertTrue(syncSavepoint.isDisposed());
-
+        String expectedRootCauseMessage =
+                String.format(
+                        "%s: %s",
+                        expectedRootCause.getClass().getName(), expectedRootCause.getMessage());
         try {
             savepointFuture.get();
             fail("Expected Exception not found.");
         } catch (ExecutionException e) {
             final Throwable cause = ExceptionUtils.stripExecutionException(e);
             assertTrue(cause instanceof CheckpointException);
-            assertEquals(expectedRootCause.getMessage(), cause.getCause().getCause().getMessage());
+            assertEquals(expectedRootCauseMessage, cause.getCause().getCause().getMessage());
         }
 
         assertEquals(1L, invocationCounterAndException.f0.intValue());
@@ -3102,7 +3105,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
                                 .getCause()
                                 .getCause()
                                 .getMessage()
-                                .equals(expectedRootCause.getMessage()));
+                                .equals(expectedRootCauseMessage));
 
         coordinator.shutdown();
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/messages/checkpoint/DeclineCheckpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/messages/checkpoint/DeclineCheckpointTest.java
@@ -76,6 +76,11 @@ public class DeclineCheckpointTest extends TestLogger {
         Optional<Throwable> throwableWithMessage =
                 ExceptionUtils.findThrowableWithMessage(throwable, userException.getMessage());
         assertTrue(throwableWithMessage.isPresent());
-        assertThat(throwableWithMessage.get().getMessage(), equalTo(userException.getMessage()));
+        assertThat(
+                throwableWithMessage.get().getMessage(),
+                equalTo(
+                        String.format(
+                                "%s: %s",
+                                userException.getClass().getName(), userException.getMessage())));
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/json/SerializedThrowableSerializerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/json/SerializedThrowableSerializerTest.java
@@ -59,14 +59,18 @@ public class SerializedThrowableSerializerTest extends TestLogger {
         final SerializedThrowable deserializedSerializedThrowable =
                 objectMapper.readValue(json, SerializedThrowable.class);
 
-        assertEquals("message", deserializedSerializedThrowable.getMessage());
+        assertEquals("java.lang.Exception: message", deserializedSerializedThrowable.getMessage());
         assertEquals(
                 serializedThrowable.getFullStringifiedStackTrace(),
                 deserializedSerializedThrowable.getFullStringifiedStackTrace());
-        assertEquals("cause", deserializedSerializedThrowable.getCause().getMessage());
+        assertEquals(
+                "java.lang.Exception: cause",
+                deserializedSerializedThrowable.getCause().getMessage());
         assertTrue(deserializedSerializedThrowable.getCause() instanceof SerializedThrowable);
         assertEquals(1, deserializedSerializedThrowable.getSuppressed().length);
-        assertEquals("suppressed", deserializedSerializedThrowable.getSuppressed()[0].getMessage());
+        assertEquals(
+                "java.lang.Exception: suppressed",
+                deserializedSerializedThrowable.getSuppressed()[0].getMessage());
         assertTrue(
                 deserializedSerializedThrowable.getSuppressed()[0] instanceof SerializedThrowable);
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/SerializedThrowableTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/SerializedThrowableTest.java
@@ -41,9 +41,6 @@ public class SerializedThrowableTest {
             IllegalArgumentException original = new IllegalArgumentException("test message");
             SerializedThrowable serialized = new SerializedThrowable(original);
 
-            assertEquals(original.getMessage(), serialized.getMessage());
-            assertEquals(original.toString(), serialized.toString());
-
             assertEquals(
                     ExceptionUtils.stringifyException(original),
                     ExceptionUtils.stringifyException(serialized));
@@ -76,17 +73,23 @@ public class SerializedThrowableTest {
 
             // validate that the SerializedThrowable mimics the original exception
             SerializedThrowable serialized = new SerializedThrowable(userException);
-            assertEquals(userException.getMessage(), serialized.getMessage());
-            assertEquals(userException.toString(), serialized.toString());
             assertEquals(
                     ExceptionUtils.stringifyException(userException),
                     ExceptionUtils.stringifyException(serialized));
             assertArrayEquals(userException.getStackTrace(), serialized.getStackTrace());
 
+            // validate the detailMessage of SerializedThrowable contains the class name of original
+            // exception
+            Exception userException2 = new Exception("error");
+            SerializedThrowable serialized2 = new SerializedThrowable(userException2);
+            String result =
+                    String.format(
+                            "%s: %s",
+                            userException2.getClass().getName(), userException2.getMessage());
+            assertEquals(serialized2.getMessage(), result);
+
             // copy the serialized throwable and make sure everything still works
             SerializedThrowable copy = CommonTestUtils.createCopySerializable(serialized);
-            assertEquals(userException.getMessage(), copy.getMessage());
-            assertEquals(userException.toString(), copy.toString());
             assertEquals(
                     ExceptionUtils.stringifyException(userException),
                     ExceptionUtils.stringifyException(copy));
@@ -115,13 +118,13 @@ public class SerializedThrowableTest {
 
         SerializedThrowable st = new SerializedThrowable(root);
 
-        assertEquals("level0", st.getMessage());
+        assertEquals("java.lang.Exception: level0", st.getMessage());
 
         assertNotNull(st.getCause());
-        assertEquals("level1", st.getCause().getMessage());
+        assertEquals("java.lang.Exception: level1", st.getCause().getMessage());
 
         assertNotNull(st.getCause().getCause());
-        assertEquals("level2", st.getCause().getCause().getMessage());
+        assertEquals("java.lang.Exception: level2", st.getCause().getCause().getMessage());
     }
 
     @Test
@@ -150,9 +153,11 @@ public class SerializedThrowableTest {
         assertNotNull(serialized.getCause());
 
         SerializedThrowable copy = new SerializedThrowable(serialized);
-        assertEquals("parent message", copy.getMessage());
+        assertEquals(
+                "org.apache.flink.util.SerializedThrowable: java.lang.Exception: parent message",
+                copy.getMessage());
         assertNotNull(copy.getCause());
-        assertEquals("original message", copy.getCause().getMessage());
+        assertEquals("java.lang.Exception: original message", copy.getCause().getMessage());
     }
 
     @Test
@@ -166,7 +171,7 @@ public class SerializedThrowableTest {
         assertEquals(1, serializedThrowable.getSuppressed().length);
         Throwable actualSuppressed = serializedThrowable.getSuppressed()[0];
         assertTrue(actualSuppressed instanceof SerializedThrowable);
-        assertEquals("suppressed", actualSuppressed.getMessage());
+        assertEquals("java.lang.Exception: suppressed", actualSuppressed.getMessage());
     }
 
     @Test
@@ -181,6 +186,6 @@ public class SerializedThrowableTest {
         assertEquals(1, copy.getSuppressed().length);
         Throwable actualSuppressed = copy.getSuppressed()[0];
         assertTrue(actualSuppressed instanceof SerializedThrowable);
-        assertEquals("suppressed", actualSuppressed.getMessage());
+        assertEquals("java.lang.Exception: suppressed", actualSuppressed.getMessage());
     }
 }


### PR DESCRIPTION
SerializedThrowable will return itself as a stand in if an exception occurs when calling deserializeError(ClassLoader classloader). When this happens, the call stack printed by logger will not contain the class name of original exception.

Therefore, class name information is added to the detailMessage of SerializedThrowable in this pull request.