### PR TITLE
[hotfix][cep][docs] Corrected version mentioned from Flink-1.3 to Flink-1.13

### DIFF
--- a/docs/content/docs/libs/cep.md
+++ b/docs/content/docs/libs/cep.md
@@ -35,7 +35,7 @@ This page describes the API calls available in Flink CEP. We start by presenting
 which allows you to specify the patterns that you want to detect in your stream, before presenting how you can
 [detect and act upon matching event sequences](#detecting-patterns). We then present the assumptions the CEP
 library makes when [dealing with lateness](#handling-lateness-in-event-time) in event time and how you can
-[migrate your job](#migrating-from-an-older-flink-versionpre-13) from an older Flink version to Flink-1.3.
+[migrate your job](#migrating-from-an-older-flink-versionpre-13) from an older Flink version to Flink-1.13.
 
 ## Getting Started
 


### PR DESCRIPTION

## What is the purpose of the change

* The intro section regarding migration mentions <code>...from an older Flink version to **Flink-1.3**.</code>.  Changed it to <code>...from an older Flink version to **Flink-1.13**.</code>, as referenced in [migration section](https://nightlies.apache.org/flink/flink-docs-release-1.14/docs/libs/cep/#migrating-from-an-older-flink-versionpre-15).

## Brief change log

* Corrected version number in cep docs

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
