### PR TITLE
[FLINK-27465] Handle conversion of negative long to timestamp in AvroRowDeserializationSchema

### DIFF
--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroRowDeserializationSchema.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroRowDeserializationSchema.java
@@ -349,6 +349,11 @@ public class AvroRowDeserializationSchema extends AbstractDeserializationSchema<
                 long seconds = micros / MICROS_PER_SECOND - offsetMillis / 1000;
                 int nanos =
                         ((int) (micros % MICROS_PER_SECOND)) * 1000 - offsetMillis % 1000 * 1000;
+                if (nanos < 0) {
+                    // can't set negative nanos on timestamp
+                    seconds--;
+                    nanos = (int) (MICROS_PER_SECOND * 1000 + nanos);
+                }
                 Timestamp timestamp = new Timestamp(seconds * 1000L);
                 timestamp.setNanos(nanos);
                 return timestamp;


### PR DESCRIPTION
A small change to (deprecated) AvroRowDeserializationSchema to handle the conversion of a negative micros long value to `java.sql.Timestamp`

This was exposed in `AvroRowDeSerializationSchemaTest.testSpecificDeserializeFromSchemaSeveralTimes` when the test is run with local time zone with negative offset. 

micros: `-28799876544`
ts: `1969-12-31 16:00:00.123456`