### PR TITLE
[FLINK-27174][connector/kafka] Fix checking of bootstrapServers when already provided in producer Properties

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/KafkaSinkBuilder.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/KafkaSinkBuilder.java
@@ -74,7 +74,6 @@ public class KafkaSinkBuilder<IN> {
 
     private final Properties kafkaProducerConfig;
     private KafkaRecordSerializationSchema<IN> recordSerializer;
-    private String bootstrapServers;
 
     KafkaSinkBuilder() {
         kafkaProducerConfig = new Properties();
@@ -174,8 +173,19 @@ public class KafkaSinkBuilder<IN> {
      * @return {@link KafkaSinkBuilder}
      */
     public KafkaSinkBuilder<IN> setBootstrapServers(String bootstrapServers) {
-        this.bootstrapServers = checkNotNull(bootstrapServers);
-        return this;
+        return setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+    }
+
+    private void sanityCheck() {
+        checkNotNull(
+                kafkaProducerConfig.getProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG),
+                "bootstrapServers");
+        if (deliveryGuarantee == DeliveryGuarantee.EXACTLY_ONCE) {
+            checkState(
+                    transactionalIdPrefix != null,
+                    "EXACTLY_ONCE delivery guarantee requires a transactionIdPrefix to be set to provide unique transaction names across multiple KafkaSinks writing to the same Kafka cluster.");
+        }
+        checkNotNull(recordSerializer, "recordSerializer");
     }
 
     /**
@@ -184,17 +194,8 @@ public class KafkaSinkBuilder<IN> {
      * @return {@link KafkaSink}
      */
     public KafkaSink<IN> build() {
-        checkNotNull(bootstrapServers);
-        if (deliveryGuarantee == DeliveryGuarantee.EXACTLY_ONCE) {
-            checkState(
-                    transactionalIdPrefix != null,
-                    "EXACTLY_ONCE delivery guarantee requires a transactionIdPrefix to be set to provide unique transaction names across multiple KafkaSinks writing to the same Kafka cluster.");
-        }
-        kafkaProducerConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        sanityCheck();
         return new KafkaSink<>(
-                deliveryGuarantee,
-                kafkaProducerConfig,
-                transactionalIdPrefix,
-                checkNotNull(recordSerializer, "recordSerializer"));
+                deliveryGuarantee, kafkaProducerConfig, transactionalIdPrefix, recordSerializer);
     }
 }

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaSinkBuilderTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaSinkBuilderTest.java
@@ -79,6 +79,18 @@ public class KafkaSinkBuilderTest extends TestLogger {
                 });
     }
 
+    @Test
+    public void testBootstrapServerSetting() {
+        Properties testConf1 = new Properties();
+        testConf1.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "testServer");
+
+        validateProducerConfig(
+                getNoServerBuilder().setKafkaProducerConfig(testConf1),
+                p -> {
+                    Arrays.stream(DEFAULT_KEYS).forEach(k -> assertTrue(k, p.containsKey(k)));
+                });
+    }
+
     private void validateProducerConfig(
             KafkaSinkBuilder<?> builder, Consumer<Properties> validator) {
         validator.accept(builder.build().getKafkaProducerConfig());
@@ -87,6 +99,15 @@ public class KafkaSinkBuilderTest extends TestLogger {
     private KafkaSinkBuilder<String> getBasicBuilder() {
         return new KafkaSinkBuilder<String>()
                 .setBootstrapServers("testServer")
+                .setRecordSerializer(
+                        KafkaRecordSerializationSchema.builder()
+                                .setTopic("topic")
+                                .setValueSerializationSchema(new SimpleStringSchema())
+                                .build());
+    }
+
+    private KafkaSinkBuilder<String> getNoServerBuilder() {
+        return new KafkaSinkBuilder<String>()
                 .setRecordSerializer(
                         KafkaRecordSerializationSchema.builder()
                                 .setTopic("topic")


### PR DESCRIPTION
## What is the purpose of the change

Fix checking of bootstrapServers when already provided in producer Properties

## Brief change log

  - *If the user provides bootstrapServers in the producer Properties, even if he does not use the setBootstrapServers method, the relevant check will no longer have a null exception*
  - *The sanityCheck method is provided to put the checked code together*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
