### PR TITLE
[FLINK-27461] Add option to set userAgent for kubeclient

### DIFF
--- a/docs/layouts/shortcodes/generated/kubernetes_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_config_configuration.html
@@ -21,6 +21,12 @@
             <td>The size of the IO executor pool used by the Kubernetes client to execute blocking IO operations (e.g. start/stop TaskManager pods, update leader related ConfigMaps, etc.). Increasing the pool size allows to run more IO operations concurrently.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.client.user-agent</h5></td>
+            <td style="word-wrap: break-word;">"flink"</td>
+            <td>String</td>
+            <td>The user agent to be used for contacting with Kubernetes APIServer.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.cluster-id</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
@@ -498,6 +498,13 @@ public class KubernetesConfigOptions {
                             "Whether to enable HostNetwork mode. "
                                     + "The HostNetwork allows the pod could use the node network namespace instead of the individual pod network namespace. Please note that the JobManager service account should have the permission to update Kubernetes service.");
 
+    public static final ConfigOption<String> KUBERNETES_CLIENT_USER_AGENT =
+            key("kubernetes.client.user-agent")
+                    .stringType()
+                    .defaultValue("flink")
+                    .withDescription(
+                            "The user agent to be used for contacting with Kubernetes APIServer.");
+
     private static String getDefaultFlinkImage() {
         // The default container image that ties to the exact needed versions of both Flink and
         // Scala.

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/FlinkKubeClientFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/FlinkKubeClientFactory.java
@@ -89,8 +89,11 @@ public class FlinkKubeClientFactory {
         }
 
         final String namespace = flinkConfig.getString(KubernetesConfigOptions.NAMESPACE);
-        LOG.debug("Setting namespace of Kubernetes client to {}", namespace);
+        final String userAgent =
+                flinkConfig.getString(KubernetesConfigOptions.KUBERNETES_CLIENT_USER_AGENT);
         config.setNamespace(namespace);
+        config.setUserAgent(userAgent);
+        LOG.debug("Setting Kubernetes client namespace: {}, userAgent: {}", namespace, userAgent);
 
         final NamespacedKubernetesClient client = new DefaultKubernetesClient(config);
         final int poolSize =


### PR DESCRIPTION
## What is the purpose of the change

This Pr is meant to add option to set user agent for kubeclient.

## Verifying this change

This PR is a minor change without test case
