### PR TITLE
[FLINK-27485][Documentation][Build] Fix the documentation build pipeline

### DIFF
--- a/.github/workflows/docs.sh
+++ b/.github/workflows/docs.sh
@@ -23,23 +23,23 @@ java -version
 javadoc -J-version
 
 # setup hugo
-HUGO_REPO=https://github.com/gohugoio/hugo/releases/download/v0.80.0/hugo_extended_0.80.0_Linux-64bit.tar.gz
-HUGO_ARTIFACT=hugo_extended_0.80.0_Linux-64bit.tar.gz
+HUGO_REPO=https://github.com/gohugoio/hugo/releases/download/v0.98.0/hugo_extended_0.98.0_Linux-64bit.tar.gz
+HUGO_ARTIFACT=hugo_extended_0.98.0_Linux-64bit.tar.gz
 if ! curl --fail -OL $HUGO_REPO ; then
 	echo "Failed to download Hugo binary"
 	exit 1
 fi
-tar -zxvf $HUGO_ARTIFACT
+tar -zxvf $HUGO_ARTIFACT -C /usr/local/bin
 git submodule update --init --recursive
 # Setup the external documentation modules
 cd docs
 source setup_docs.sh
 cd ..
 # Build the docs
-./hugo --source docs
+hugo --source docs
 
 # generate docs into docs/target
-./hugo -v --source docs --destination target
+hugo -v --source docs --destination target
 if [ $? -ne 0 ]; then
 	echo "Error building the docs"
 	exit 1

--- a/docs/setup_docs.sh
+++ b/docs/setup_docs.sh
@@ -33,7 +33,7 @@ EOF
 echo "Created temporary file" $goModFileLocation/go.mod
 
 # Make Hugo retrieve modules which are used for externally hosted documentation
-currentBranch=$(git branch --show-current)
+currentBranch=$(git rev-parse --abbrev-ref HEAD)
 
 if [[ ! "$currentBranch" =~ ^release- ]] || [[ -z "$currentBranch" ]]; then
   # If the current branch is master or not provided, get the documentation from the main branch


### PR DESCRIPTION
## What is the purpose of the change

* Fix the currently broken documentation build pipeline

## Brief change log

* Use different Git command (which is supported by the installed Git version on the Docker image)
* Upgrading Hugo and making sure that this is added to the PATH by extracting it to `/usr/local/bin`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
