### PR TITLE
feat([FLINK-13414]/scala): Add support to last scala version 2.12.15 and remove code deprecated

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="CommitMessageInspectionProfile">
+    <profile version="1.0">
+      <inspection_tool class="CommitFormat" enabled="true" level="WARNING" enabled_by_default="true" />
+      <inspection_tool class="CommitNamingConvention" enabled="true" level="WARNING" enabled_by_default="true" />
+    </profile>
+  </component>
   <component name="IssueNavigationConfiguration">
     <option name="links">
       <list>

--- a/README.md
+++ b/README.md
@@ -83,6 +83,29 @@ Flink is now installed in `build-target`.
 *NOTE: Maven 3.3.x can build Flink, but will not properly shade away certain dependencies. Maven 3.1.1 creates the libraries properly.
 To build unit tests with Java 8, use Java 8u51 or above to prevent failures in unit tests that use the PowerMock runner.*
 
+### Documentation
+
+```
+git submodule init
+git submodule update
+```
+
+### Flink Scala
+
+```
+mvn -am -pl flink-test-utils-parent/flink-test-utils,flink-scala test
+
+mvn -DskipTests -am -P scala-2.13 -pl flink-test-utils-parent/flink-test-utils,flink-scala package
+```
+
+Errores
+```java
+Breaking the build because there is at least one incompatibility: 
+  org.apache.flink.api.scala.CoGroupDataSet.$anonfun$buildGroupSortList$1(org.apache.flink.api.common.typeinfo.TypeInformation,java.util.ArrayList,scala.Tuple2):                         METHOD_REMOVED,
+  org.apache.flink.api.scala.typeutils.CaseClassTypeInfo.$anonfun$getFlatFields$1(int,java.util.List,scala.runtime.IntRef,org.apache.flink.api.common.typeinfo.TypeInformation):          METHOD_REMOVED,
+  org.apache.flink.api.scala.typeutils.CaseClassTypeInfo.$anonfun$getFlatFields$1$adapted(int,java.util.List,scala.runtime.IntRef,org.apache.flink.api.common.typeinfo.TypeInformation):  METHOD_REMOVED
+```
+
 ## Developing Flink
 
 The Flink committers use IntelliJ IDEA to develop the Flink codebase.

--- a/flink-core/src/main/java/org/apache/flink/core/memory/ByteArrayOutputStreamWithPos.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/ByteArrayOutputStreamWithPos.java
@@ -88,7 +88,7 @@ public class ByteArrayOutputStreamWithPos extends OutputStream {
         count = 0;
     }
 
-    public byte toByteArray()[] {
+    public byte[] toByteArray() {
         return Arrays.copyOf(buffer, count);
     }
 

--- a/flink-scala/pom.xml
+++ b/flink-scala/pom.xml
@@ -71,6 +71,11 @@ under the License.
 			<artifactId>scalatest_${scala.binary.version}</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.scalatestplus</groupId>
+			<artifactId>junit-4-13_${scala.binary.version}</artifactId>
+			<scope>test</scope>
+		</dependency>
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
@@ -185,7 +190,7 @@ under the License.
 							<goal>compile</goal>
 						</goals>
 					</execution>
- 
+
 					<!-- Run scala compiler in the process-test-resources phase, so that dependencies on
 						 scala classes can be resolved later in the (Java) test-compile phase -->
 					<execution>
@@ -203,7 +208,7 @@ under the License.
 					</jvmArgs>
 				</configuration>
 			</plugin>
-			
+
 			<!-- Eclipse Integration -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/ClosureCleaner.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/ClosureCleaner.scala
@@ -85,7 +85,7 @@ object ClosureCleaner {
   private def getInnerClosureClasses(obj: AnyRef): List[Class[_]] = {
     val seen = Set[Class[_]](obj.getClass)
     val stack = mutable.Stack[Class[_]](obj.getClass)
-    while (!stack.isEmpty) {
+    while (stack.nonEmpty) {
       val cr = getClassReader(stack.pop())
       if (cr != null) {
         val set = Set.empty[Class[_]]

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/CoGroupDataSet.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/CoGroupDataSet.scala
@@ -71,10 +71,10 @@ class CoGroupDataSet[L, R](
     rightKeys: Keys[R])
   extends DataSet(defaultCoGroup) {
 
-  private val groupSortKeyPositionsFirst = mutable.MutableList[Either[Int, String]]()
-  private val groupSortKeyPositionsSecond = mutable.MutableList[Either[Int, String]]()
-  private val groupSortOrdersFirst = mutable.MutableList[Order]()
-  private val groupSortOrdersSecond = mutable.MutableList[Order]()
+  private val groupSortKeyPositionsFirst = mutable.ListBuffer[Either[Int, String]]()
+  private val groupSortKeyPositionsSecond = mutable.ListBuffer[Either[Int, String]]()
+  private val groupSortOrdersFirst = mutable.ListBuffer[Order]()
+  private val groupSortOrdersSecond = mutable.ListBuffer[Order]()
 
   private var customPartitioner: Partitioner[_] = _
 
@@ -236,8 +236,8 @@ class CoGroupDataSet[L, R](
 
   private def buildGroupSortList[T](
       typeInfo: TypeInformation[T],
-      keys: mutable.MutableList[Either[Int, String]],
-      orders: mutable.MutableList[Order]): java.util.List[Pair[java.lang.Integer, Order]] = {
+      keys: mutable.ListBuffer[Either[Int, String]],
+      orders: mutable.ListBuffer[Order]): java.util.List[Pair[java.lang.Integer, Order]] = {
     if (keys.isEmpty) {
       null
     } else {

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/GroupedDataSet.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/GroupedDataSet.scala
@@ -48,8 +48,8 @@ class GroupedDataSet[T: ClassTag](private val set: DataSet[T], private val keys:
 
   // These are for optional secondary sort. They are only used
   // when using a group-at-a-time reduce function.
-  private val groupSortKeyPositions = mutable.MutableList[Either[Int, String]]()
-  private val groupSortOrders = mutable.MutableList[Order]()
+  private val groupSortKeyPositions = mutable.ListBuffer[Either[Int, String]]()
+  private val groupSortOrders = mutable.ListBuffer[Order]()
 
   private var partitioner: Partitioner[_] = _
 
@@ -138,19 +138,19 @@ class GroupedDataSet[T: ClassTag](private val set: DataSet[T], private val keys:
     groupSortKeySelector match {
       case Some(keySelector) =>
         if (partitioner == null) {
-          new SortedGrouping[T](set.javaSet, keys, keySelector, groupSortOrders(0))
+          new SortedGrouping[T](set.javaSet, keys, keySelector, groupSortOrders.head)
         } else {
-          new SortedGrouping[T](set.javaSet, keys, keySelector, groupSortOrders(0))
+          new SortedGrouping[T](set.javaSet, keys, keySelector, groupSortOrders.head)
             .withPartitioner(partitioner)
         }
       case None =>
         if (groupSortKeyPositions.nonEmpty) {
-          val grouping = groupSortKeyPositions(0) match {
+          val grouping = groupSortKeyPositions.head match {
             case Left(pos) =>
-              new SortedGrouping[T](set.javaSet, keys, pos, groupSortOrders(0))
+              new SortedGrouping[T](set.javaSet, keys, pos, groupSortOrders.head)
 
             case Right(field) =>
-              new SortedGrouping[T](set.javaSet, keys, field, groupSortOrders(0))
+              new SortedGrouping[T](set.javaSet, keys, field, groupSortOrders.head)
 
           }
           // now manually add the rest of the keys

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/codegen/MacroContextHolder.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/codegen/MacroContextHolder.scala
@@ -19,7 +19,7 @@ package org.apache.flink.api.scala.codegen
 
 import org.apache.flink.annotation.Internal
 
-import scala.reflect.macros.Context
+import scala.reflect.macros.whitebox.Context
 
 @Internal
 private[flink] class MacroContextHolder[C <: Context](val c: C)

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/codegen/TypeDescriptors.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/codegen/TypeDescriptors.scala
@@ -21,7 +21,7 @@ import org.apache.flink.annotation.Internal
 
 import scala.collection.Map
 import scala.language.postfixOps
-import scala.reflect.macros.Context
+import scala.reflect.macros.whitebox.Context
 
 // These are only used internally while analyzing Scala types in TypeAnalyzer and TypeInformationGen
 

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/codegen/TypeInformationGen.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/codegen/TypeInformationGen.scala
@@ -30,7 +30,7 @@ import java.lang.reflect.{Field, Modifier}
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.language.postfixOps
-import scala.reflect.macros.Context
+import scala.reflect.macros.whitebox.Context
 
 @Internal
 private[flink] trait TypeInformationGen[C <: Context] {

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/TypeUtils.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/TypeUtils.scala
@@ -21,7 +21,7 @@ import org.apache.flink.annotation.Internal
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.scala.codegen.MacroContextHolder
 
-import scala.reflect.macros.Context
+import scala.reflect.macros.whitebox.Context
 
 @Internal
 private[flink] object TypeUtils {

--- a/flink-scala/src/main/scala/org/apache/flink/runtime/types/FlinkScalaKryoInstantiator.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/runtime/types/FlinkScalaKryoInstantiator.scala
@@ -25,6 +25,7 @@ import com.twitter.chill._
 import scala.collection.JavaConverters._
 import scala.collection.immutable.{BitSet, HashMap, HashSet, ListMap, ListSet, NumericRange, Queue, Range, SortedMap, SortedSet}
 import scala.collection.mutable.{BitSet => MBitSet, Buffer, HashMap => MHashMap, HashSet => MHashSet, ListBuffer, Map => MMap, Queue => MQueue, Set => MSet, WrappedArray}
+import scala.reflect.ClassTag
 import scala.util.matching.Regex
 
 /*
@@ -179,7 +180,7 @@ class AllScalaRegistrar extends IKryoRegistrar {
       def write(k: Kryo, out: Output, obj: Symbol) { out.writeString(obj.name) }
       def read(k: Kryo, in: Input, cls: Class[Symbol]) = Symbol(in.readString)
     }).forSubclass[Regex](new RegexSerializer)
-      .forClass[ClassManifest[Any]](new ClassManifestSerializer[Any])
+      .forClass[ClassTag[Any]](new ClassManifestSerializer[Any])
       .forSubclass[Manifest[Any]](new ManifestSerializer[Any])
       .forSubclass[scala.Enumeration#Value](new EnumerationSerializer)
 

--- a/flink-scala/src/main/scala/org/apache/flink/runtime/types/JavaIterableWrapperSerializer.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/runtime/types/JavaIterableWrapperSerializer.scala
@@ -53,7 +53,7 @@ private class JavaIterableWrapperSerializer extends KSerializer[JIterable[_]] {
   override def read(kryo: Kryo, in: Input, clz: Class[JIterable[_]]): JIterable[_] = {
     kryo.readClassAndObject(in) match {
       case scalaIterable: Iterable[_] =>
-        scala.collection.JavaConversions.asJavaIterable(scalaIterable)
+        scala.collection.JavaConverters.asJavaIterable(scalaIterable)
       case javaIterable: JIterable[_] =>
         javaIterable
     }
@@ -62,7 +62,7 @@ private class JavaIterableWrapperSerializer extends KSerializer[JIterable[_]] {
 
 private object JavaIterableWrapperSerializer {
   // The class returned by asJavaIterable (scala.collection.convert.Wrappers$IterableWrapper).
-  val wrapperClass = scala.collection.JavaConversions.asJavaIterable(Seq(1)).getClass
+  val wrapperClass = scala.collection.JavaConverters.asJavaIterable(Seq(1)).getClass
 
   // Get the underlying method so we can use it to get the Scala collection for serialization.
   private val underlyingMethodOpt = {

--- a/flink-scala/src/test/scala/org/apache/flink/api/scala/extensions/base/AcceptPFTestBase.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/scala/extensions/base/AcceptPFTestBase.scala
@@ -21,7 +21,7 @@ import org.apache.flink.api.scala._
 import org.apache.flink.api.scala.extensions.data.KeyValuePair
 import org.apache.flink.util.TestLogger
 
-import org.scalatest.junit.JUnitSuiteLike
+import org.scalatestplus.junit.JUnitSuiteLike
 
 /** Common facilities to test the `acceptPartialFunctions` extension */
 abstract private[extensions] class AcceptPFTestBase extends TestLogger with JUnitSuiteLike {

--- a/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/EnumValueSerializerCompatibilityTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/EnumValueSerializerCompatibilityTest.scala
@@ -24,7 +24,7 @@ import org.apache.flink.util.TestLogger
 import org.junit.{Rule, Test}
 import org.junit.Assert._
 import org.junit.rules.TemporaryFolder
-import org.scalatest.junit.JUnitSuiteLike
+import org.scalatestplus.junit.JUnitSuiteLike
 
 import java.io._
 import java.net.{URL, URLClassLoader}
@@ -192,6 +192,6 @@ object EnumValueSerializerCompatibilityTest {
 
     run.compile(List(file.getAbsolutePath))
 
-    reporter.printSummary()
+    reporter.finish()
   }
 }

--- a/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/EnumValueSerializerTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/EnumValueSerializerTest.scala
@@ -21,7 +21,7 @@ import org.apache.flink.util.TestLogger
 
 import org.junit.Assert._
 import org.junit.Test
-import org.scalatest.junit.JUnitSuiteLike
+import org.scalatestplus.junit.JUnitSuiteLike
 
 class EnumValueSerializerTest extends TestLogger with JUnitSuiteLike {
 

--- a/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/TypeExtractionTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/TypeExtractionTest.scala
@@ -26,7 +26,7 @@ import org.apache.flink.util.TestLogger
 
 import org.junit.Assert._
 import org.junit.Test
-import org.scalatest.junit.JUnitSuiteLike
+import org.scalatestplus.junit.JUnitSuiteLike
 
 import scala.beans.BeanProperty
 

--- a/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/TypeInfoFactoryTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/TypeInfoFactoryTest.scala
@@ -29,7 +29,7 @@ import org.apache.flink.util.TestLogger
 
 import org.junit.Assert._
 import org.junit.Test
-import org.scalatest.junit.JUnitSuiteLike
+import org.scalatestplus.junit.JUnitSuiteLike
 
 import java.lang.reflect.Type
 import java.util

--- a/flink-streaming-scala/pom.xml
+++ b/flink-streaming-scala/pom.xml
@@ -69,6 +69,11 @@ under the License.
 			<artifactId>scalatest_${scala.binary.version}</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.scalatestplus</groupId>
+			<artifactId>junit-4-13_${scala.binary.version}</artifactId>
+			<scope>test</scope>
+		</dependency>
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
@@ -173,7 +178,7 @@ under the License.
 							<goal>compile</goal>
 						</goals>
 					</execution>
- 
+
 					<!-- Run scala compiler in the process-test-resources phase, so that dependencies on
 						 scala classes can be resolved later in the (Java) test-compile phase -->
 					<execution>

--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/CaseClassFieldAccessorTest.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/CaseClassFieldAccessorTest.scala
@@ -22,7 +22,7 @@ import org.apache.flink.streaming.util.typeutils.{FieldAccessorFactory, FieldAcc
 import org.apache.flink.util.TestLogger
 
 import org.junit.Test
-import org.scalatest.junit.JUnitSuiteLike
+import org.scalatestplus.junit.JUnitSuiteLike
 
 case class Outer(a: Int, i: Inner, b: Boolean)
 case class Inner(x: Long, b: Boolean)

--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/extensions/base/AcceptPFTestBase.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/extensions/base/AcceptPFTestBase.scala
@@ -22,7 +22,7 @@ import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
 import org.apache.flink.streaming.api.scala.extensions.data.KeyValuePair
 import org.apache.flink.util.TestLogger
 
-import org.scalatest.junit.JUnitSuiteLike
+import org.scalatestplus.junit.JUnitSuiteLike
 
 /** Common facilities to test the `acceptPartialFunctions` extension */
 abstract private[extensions] class AcceptPFTestBase extends TestLogger with JUnitSuiteLike {

--- a/pom.xml
+++ b/pom.xml
@@ -118,9 +118,9 @@ under the License.
 		<scala.macros.version>2.1.1</scala.macros.version>
 		<!-- Default scala versions, must be overwritten by build profiles, so we set something
 		invalid here -->
-		<scala.version>2.12.7</scala.version>
+		<scala.version>2.12.15</scala.version>
 		<scala.binary.version>2.12</scala.binary.version>
-		<chill.version>0.7.6</chill.version>
+		<chill.version>0.10.0</chill.version>
 		<!-- keep FlinkContainersBuilder#buildZookeeperContainer() in sync -->
 		<zookeeper.version>3.5.9</zookeeper.version>
 		<curator.version>5.2.0</curator.version>
@@ -569,7 +569,7 @@ under the License.
 				<scope>import</scope>
 				<version>2.13.2.20220328</version>
 			</dependency>
-			
+
 			<dependency>
 				<groupId>com.squareup.okhttp3</groupId>
 				<artifactId>okhttp</artifactId>
@@ -721,7 +721,13 @@ under the License.
 			<dependency>
 				<groupId>org.scalatest</groupId>
 				<artifactId>scalatest_${scala.binary.version}</artifactId>
-				<version>3.0.0</version>
+				<version>3.2.12</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.scalatestplus</groupId>
+				<artifactId>junit-4-13_${scala.binary.version}</artifactId>
+				<version>3.2.12.0</version>
 				<scope>test</scope>
 			</dependency>
 
@@ -863,7 +869,7 @@ under the License.
 		<profile>
 			<id>scala-2.12</id>
 			<properties>
-				<scala.version>2.12.7</scala.version>
+				<scala.version>2.12.15</scala.version>
 				<scala.binary.version>2.12</scala.binary.version>
 			</properties>
 			<activation>
@@ -892,6 +898,44 @@ under the License.
 												<exclude>*:*_2.10</exclude>
 											</excludes>
 											<message>Scala 2.10/2.11 dependencies are not allowed for Scala 2.12 builds. This can be caused by hard-coded scala versions, where the 'scala.binary.version' property should be used instead.</message>
+										</bannedDependencies>
+									</rules>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+
+		<profile>
+			<id>scala-2.13</id>
+			<properties>
+				<scala.version>2.13.8</scala.version>
+				<scala.binary.version>2.13</scala.binary.version>
+			</properties>
+			<build>
+				<plugins>
+					<!-- make sure we don't have any _2.11 or _2.12 dependencies when building
+					for Scala 2.13 -->
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-enforcer-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>enforce-versions</id>
+								<goals>
+									<goal>enforce</goal>
+								</goals>
+								<configuration>
+									<rules>
+										<bannedDependencies>
+											<excludes combine.children="append">
+												<exclude>*:*_2.12</exclude>
+												<exclude>*:*_2.11</exclude>
+												<exclude>*:*_2.10</exclude>
+											</excludes>
+											<message>Scala 2.11/2.12 dependencies are not allowed for Scala 2.13 builds. This can be caused by hard-coded scala versions, where the 'scala.binary.version' property should be used instead.</message>
 										</bannedDependencies>
 									</rules>
 								</configuration>
@@ -932,7 +976,7 @@ under the License.
 						<plugin>
 							<groupId>org.codehaus.mojo</groupId>
 							<artifactId>build-helper-maven-plugin</artifactId>
-							<version>1.7</version>
+							<version>3.3.0</version>
 						</plugin>
 						<plugin>
 							<groupId>org.apache.maven.plugins</groupId>
@@ -1949,7 +1993,7 @@ under the License.
 							<groupId>com.puppycrawl.tools</groupId>
 							<artifactId>checkstyle</artifactId>
 							<!-- Note: match version with docs/flinkDev/ide_setup.md -->
-							<version>8.14</version>
+							<version>8.32</version>
 						</dependency>
 					</dependencies>
 					<executions>
@@ -2017,7 +2061,7 @@ under the License.
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-enforcer-plugin</artifactId>
-					<version>3.0.0-M1</version>
+					<version>3.0.0</version>
 				</plugin>
 
 				<plugin>

--- a/tools/maven/checkstyle.xml
+++ b/tools/maven/checkstyle.xml
@@ -235,14 +235,14 @@ This file is based on the checkstyle file of Apache Beam.
 		<module name="JavadocMethod">
 			<property name="scope" value="protected"/>
 			<property name="severity" value="error"/>
-			<property name="allowMissingJavadoc" value="true"/>
+			<!-- <property name="allowMissingJavadoc" value="true"/> -->
 			<property name="allowMissingParamTags" value="true"/>
 			<property name="allowMissingReturnTag" value="true"/>
-			<property name="allowMissingThrowsTags" value="true"/>
-			<property name="allowThrowsTagsForSubclasses" value="true"/>
-			<property name="allowUndeclaredRTE" value="true"/>
+			<!-- <property name="allowMissingThrowsTags" value="true"/> -->
+			<!-- <property name="allowThrowsTagsForSubclasses" value="true"/> -->
+			<!-- <property name="allowUndeclaredRTE" value="true"/> -->
 			<!-- This check sometimes failed for with "Unable to get class information for @throws tag" for custom exceptions -->
-			<property name="suppressLoadErrors" value="true"/>
+			<!-- <property name="suppressLoadErrors" value="true"/> -->
 		</module>
 
 		<!-- Check that paragraph tags are used correctly in Javadoc. -->


### PR DESCRIPTION
feat([FLINK-13414]/scala): Add support to last scala version 2.12.15 and remove code deprecated

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
