### PR TITLE
[FLINK-27489] Allow users to run dedicated tests in the CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -68,7 +68,7 @@ stages:
   # CI / PR triggered stage:
   - stage: ci
     displayName: "CI build (custom builders)"
-    condition: not(eq(variables['MODE'], 'release'))
+    condition: not(or(eq(variables['MODE'], 'release'), eq(variables['MODE'], 'single-test')))
     jobs:
       - template: tools/azure-pipelines/jobs-template.yml
         parameters: # see template file for a definition of the parameters.
@@ -89,6 +89,20 @@ stages:
             inputs:
               version: '1.18.1'
           - script: ./tools/ci/docs.sh
+  - stage: ci_single_test
+    displayName: "CI run requested tests"
+    condition: eq(variables['MODE'], 'single-test')
+    jobs:
+      - template: tools/azure-pipelines/single-test-template.yml
+        parameters: # see template file for a definition of the parameters.
+          stage_name: ci_build
+          test_pool_definition:
+            vmImage: 'ubuntu-20.04'
+          e2e_pool_definition:
+            vmImage: 'ubuntu-20.04'
+          environment: PROFILE="-Dhadoop.version=2.8.5 -Dinclude_hadoop_aws -Dscala-2.12"
+          container: flink-build-container
+          jdk: 8
   # CI / Special stage for release, e.g. building PyFlink wheel packages, etc:
   - stage: ci_release
     displayName: "CI build (release)"

--- a/tools/azure-pipelines/e2e-template.yml
+++ b/tools/azure-pipelines/e2e-template.yml
@@ -27,6 +27,7 @@ jobs:
   #condition: or(eq(variables['MODE'], 'e2e'), eq(${{parameters.run_end_to_end}}, 'true'))
   # We are running this in a separate pool
   pool: ${{parameters.e2e_pool_definition}}
+  condition: not(eq(variables['MODE'], 'single-test'))
   timeoutInMinutes: 310
   cancelTimeoutInMinutes: 1
   workspace:

--- a/tools/azure-pipelines/single-test-template.yml
+++ b/tools/azure-pipelines/single-test-template.yml
@@ -1,0 +1,87 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+parameters:
+  test_pool_definition: # defines the hardware pool for compilation and unit test execution.
+  e2e_pool_definion: # defines the hardware pool for end-to-end test execution
+  stage_name: # defines a unique identifier for all jobs in a stage (in case the jobs are added multiple times to a stage)
+  environment: # defines environment variables for downstream scripts
+  container: # the container name for the build
+  jdk: # the jdk version to use
+
+jobs:
+  - job: run_single_test_${{parameters.stage_name}}
+    pool: ${{parameters.test_pool_definition}}
+    container: ${{parameters.container}}
+    timeoutInMinutes: 240
+    cancelTimeoutInMinutes: 1
+    workspace:
+      clean: all
+    steps:
+      # if on Azure, free up disk space
+      - script: ./tools/azure-pipelines/free_disk_space.sh
+        target: host
+        condition: not(eq('${{parameters.test_pool_definition.name}}', 'Default'))
+        displayName: Free up disk space
+
+      - task: Cache@2
+        inputs:
+          key: '"$(module)" | $(DOCKER_IMAGES_CACHE_KEY)'
+          path: $(DOCKER_IMAGES_CACHE_FOLDER)
+          cacheHitVar: DOCKER_IMAGES_CACHE_HIT
+        continueOnError: true
+        condition: not(eq('${{parameters.test_pool_definition.name}}', 'Default'))
+        displayName: Cache docker images
+
+      - script: ./tools/azure-pipelines/cache_docker_images.sh load
+        displayName: Restore docker images
+        condition: and(not(canceled()), eq(variables.DOCKER_IMAGES_CACHE_HIT, 'true'))
+        continueOnError: true
+
+      - script: |
+          echo "##vso[task.setvariable variable=JAVA_HOME]$JAVA_HOME_${{parameters.jdk}}_X64"
+          echo "##vso[task.setvariable variable=PATH]$JAVA_HOME_${{parameters.jdk}}_X64/bin:$PATH"
+        displayName: "Set JDK"
+
+      - script: sudo sysctl -w kernel.core_pattern=core.%p
+        displayName: Set coredump pattern
+
+      # Test
+      - script: ${{parameters.environment}} ./tools/azure-pipelines/uploading_watchdog.sh ./tools/ci/test_controller.sh single-test $(TEST_PATTERN)
+        displayName: Test - single-test
+        env:
+          IT_CASE_S3_BUCKET: $(SECRET_S3_BUCKET)
+          IT_CASE_S3_ACCESS_KEY: $(SECRET_S3_ACCESS_KEY)
+          IT_CASE_S3_SECRET_KEY: $(SECRET_S3_SECRET_KEY)
+          IT_CASE_GLUE_SCHEMA_ACCESS_KEY: $(SECRET_GLUE_SCHEMA_ACCESS_KEY)
+          IT_CASE_GLUE_SCHEMA_SECRET_KEY: $(SECRET_GLUE_SCHEMA_SECRET_KEY)
+
+      - task: PublishTestResults@2
+        condition: succeededOrFailed()
+        inputs:
+          testResultsFormat: 'JUnit'
+
+      # upload debug artifacts
+      - task: PublishPipelineArtifact@1
+        condition: not(eq('$(DEBUG_FILES_OUTPUT_DIR)', ''))
+        displayName: Upload Logs
+        inputs:
+          targetPath: $(DEBUG_FILES_OUTPUT_DIR)
+          artifact: logs-${{parameters.stage_name}}-$(DEBUG_FILES_NAME)
+
+      - script: ./tools/azure-pipelines/cache_docker_images.sh save
+        displayName: Save docker images
+        condition: and(not(canceled()), or(failed(), ne(variables.DOCKER_IMAGES_CACHE_HIT, 'true')))
+        continueOnError: true

--- a/tools/ci/stage.sh
+++ b/tools/ci/stage.sh
@@ -27,6 +27,7 @@ STAGE_TESTS="tests"
 STAGE_MISC="misc"
 STAGE_CLEANUP="cleanup"
 STAGE_FINEGRAINED_RESOURCE_MANAGEMENT="finegrained_resource_management"
+STAGE_SINGLE_TEST="single-test"
 
 MODULES_CORE="\
 flink-annotations,\


### PR DESCRIPTION
## What is the purpose of the change
It adds a way to run a single test in Azure pipelines


## Verifying this change

Run the pipeline in a private Azure setup with variables defined:
MODE=single-test
TEST_PATTERN=<test to run - format as defined by maven surefire>

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
