### PR TITLE
[FLINK-25567][table] Add support casting of multisets to multisets

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/resolver/ExpressionResolver.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/resolver/ExpressionResolver.java
@@ -409,6 +409,11 @@ public class ExpressionResolver {
                     BuiltInFunctionDefinitions.MAP, Arrays.asList(expression), dataType);
         }
 
+        public CallExpression multiset(DataType dataType, ResolvedExpression... expression) {
+            return createCallExpression(
+                    BuiltInFunctionDefinitions.MULTISET, Arrays.asList(expression), dataType);
+        }
+
         public CallExpression wrappingCall(
                 BuiltInFunctionDefinition definition, ResolvedExpression expression) {
             return createCallExpression(

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -1695,7 +1695,7 @@ public final class BuiltInFunctionDefinitions {
 
     public static final BuiltInFunctionDefinition MULTISET =
             BuiltInFunctionDefinition.newBuilder()
-                    .name("multiset")
+                    .name("MULTISET")
                     .kind(SCALAR)
                     .inputTypeStrategy(SpecificInputTypeStrategies.MULTISET)
                     .outputTypeStrategy(SpecificTypeStrategies.MULTISET)

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -1693,6 +1693,14 @@ public final class BuiltInFunctionDefinitions {
                     .outputTypeStrategy(SpecificTypeStrategies.MAP)
                     .build();
 
+    public static final BuiltInFunctionDefinition MULTISET =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("multiset")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(SpecificInputTypeStrategies.MULTISET)
+                    .outputTypeStrategy(SpecificTypeStrategies.MULTISET)
+                    .build();
+
     public static final BuiltInFunctionDefinition ROW =
             BuiltInFunctionDefinition.newBuilder()
                     .name("row")

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/MultisetTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/MultisetTypeStrategy.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.inference.strategies;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.inference.CallContext;
+import org.apache.flink.table.types.inference.TypeStrategy;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Type strategy that returns a {@link DataTypes#MULTISET(DataType)} with a type equal to type of
+ * the first argument.
+ */
+public class MultisetTypeStrategy implements TypeStrategy {
+
+    @Override
+    public Optional<DataType> inferType(CallContext callContext) {
+        List<DataType> argumentDataTypes = callContext.getArgumentDataTypes();
+        if (argumentDataTypes.size() < 1) {
+            return Optional.empty();
+        }
+
+        return Optional.of(DataTypes.MULTISET(argumentDataTypes.get(0)).notNull());
+    }
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SpecificInputTypeStrategies.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SpecificInputTypeStrategies.java
@@ -106,6 +106,8 @@ public final class SpecificInputTypeStrategies {
     public static final InputTypeStrategy ARRAY =
             new CommonInputTypeStrategy(ConstantArgumentCount.from(1));
 
+    public static final InputTypeStrategy MULTISET =
+            new CommonInputTypeStrategy(ConstantArgumentCount.from(1));
     /**
      * Strategy that checks all types are fully comparable with each other. Requires exactly two
      * arguments.

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SpecificTypeStrategies.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SpecificTypeStrategies.java
@@ -43,6 +43,8 @@ public final class SpecificTypeStrategies {
     /** See {@link MapTypeStrategy}. */
     public static final TypeStrategy MAP = new MapTypeStrategy();
 
+    public static final TypeStrategy MULTISET = new MultisetTypeStrategy();
+
     /** See {@link IfNullTypeStrategy}. */
     public static final TypeStrategy IF_NULL = new IfNullTypeStrategy();
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/expressions/converter/converters/CustomizedConverters.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/expressions/converter/converters/CustomizedConverters.java
@@ -50,6 +50,7 @@ public class CustomizedConverters {
         CONVERTERS.put(BuiltInFunctionDefinitions.TIMESTAMP_DIFF, new TimestampDiffConverter());
         CONVERTERS.put(BuiltInFunctionDefinitions.ARRAY, new ArrayConverter());
         CONVERTERS.put(BuiltInFunctionDefinitions.MAP, new MapConverter());
+        CONVERTERS.put(BuiltInFunctionDefinitions.MULTISET, new MultisetConverter());
         CONVERTERS.put(BuiltInFunctionDefinitions.ROW, new RowConverter());
         CONVERTERS.put(BuiltInFunctionDefinitions.ORDER_ASC, new OrderAscConverter());
         CONVERTERS.put(BuiltInFunctionDefinitions.SQRT, new SqrtConverter());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/expressions/converter/converters/MultisetConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/expressions/converter/converters/MultisetConverter.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.expressions.converter.converters;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.expressions.CallExpression;
+import org.apache.flink.table.expressions.Expression;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.planner.expressions.converter.CallExpressionConvertRule;
+import org.apache.flink.table.planner.functions.sql.FlinkSqlOperatorTable;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexNode;
+
+import java.util.List;
+
+import static org.apache.flink.table.planner.expressions.converter.ExpressionConverter.toRexNodes;
+
+/** Conversion for {@link BuiltInFunctionDefinitions#MULTISET}. */
+@Internal
+class MultisetConverter extends CustomizedConverter {
+    @Override
+    public RexNode convert(CallExpression call, CallExpressionConvertRule.ConvertContext context) {
+        List<Expression> children = call.getChildren();
+        List<RexNode> childrenRexNode = toRexNodes(context, children);
+        RelDataType multisetType =
+                context.getTypeFactory()
+                        .createFieldTypeFromLogicalType(call.getOutputDataType().getLogicalType());
+        return context.getRelBuilder()
+                .getRexBuilder()
+                .makeCall(multisetType, FlinkSqlOperatorTable.MULTISET_VALUE, childrenRexNode);
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/expressions/converter/converters/MultisetConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/expressions/converter/converters/MultisetConverter.java
@@ -44,6 +44,9 @@ class MultisetConverter extends CustomizedConverter {
                         .createFieldTypeFromLogicalType(call.getOutputDataType().getLogicalType());
         return context.getRelBuilder()
                 .getRexBuilder()
-                .makeCall(multisetType, FlinkSqlOperatorTable.MULTISET_VALUE, childrenRexNode);
+                .makeCall(
+                        multisetType,
+                        FlinkSqlOperatorTable.MULTISET_VALUE_CONSTRUCTOR,
+                        childrenRexNode);
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
@@ -1129,7 +1129,7 @@ public class FlinkSqlOperatorTable extends ReflectiveSqlOperatorTable {
     public static final SqlOperator CARDINALITY = SqlStdOperatorTable.CARDINALITY;
 
     // SPECIAL OPERATORS
-    public static final SqlOperator MULTISET_VALUE = SqlStdOperatorTable.MULTISET_VALUE;
+    public static final SqlOperator MULTISET_VALUE_CONSTRUCTOR = SqlStdOperatorTable.MULTISET_VALUE;
     public static final SqlOperator ROW = SqlStdOperatorTable.ROW;
     public static final SqlOperator OVERLAPS = SqlStdOperatorTable.OVERLAPS;
     public static final SqlOperator LITERAL_CHAIN = SqlStdOperatorTable.LITERAL_CHAIN;

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/ExprCodeGenerator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/ExprCodeGenerator.scala
@@ -715,9 +715,9 @@ class ExprCodeGenerator(ctx: CodeGeneratorContext, nullableInput: Boolean)
       case ARRAY_VALUE_CONSTRUCTOR =>
         generateArray(ctx, resultType, operands)
 
-      // maps
-      case MAP_VALUE_CONSTRUCTOR =>
-        generateMap(ctx, resultType, operands)
+      // maps and multisets
+      case MAP_VALUE_CONSTRUCTOR | MULTISET_VALUE =>
+        generateMapOrMultiset(ctx, resultType, operands)
 
       case ITEM =>
         operands.head.resultType.getTypeRoot match {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/ExprCodeGenerator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/ExprCodeGenerator.scala
@@ -716,7 +716,7 @@ class ExprCodeGenerator(ctx: CodeGeneratorContext, nullableInput: Boolean)
         generateArray(ctx, resultType, operands)
 
       // maps and multisets
-      case MAP_VALUE_CONSTRUCTOR | MULTISET_VALUE =>
+      case MAP_VALUE_CONSTRUCTOR | MULTISET_VALUE_CONSTRUCTOR =>
         generateMapOrMultiset(ctx, resultType, operands)
 
       case ITEM =>

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
@@ -1437,7 +1437,7 @@ object ScalarOperatorGens {
       .toSeq
     val valueType = resultType match {
       case mapType1: MapType => mapType1.getValueType
-      case _ => DataTypes.INT().getLogicalType
+      case _ => new IntType()
     }
     val valueExpr = generateArray(ctx, new ArrayType(valueType), valueElements)
     val isValueFixLength = isPrimitive(valueType)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
@@ -17,16 +17,16 @@
  */
 package org.apache.flink.table.planner.codegen.calls
 
-import org.apache.flink.table.api.config.ExecutionConfigOptions
 import org.apache.flink.table.api.{DataTypes, ValidationException}
+import org.apache.flink.table.api.config.ExecutionConfigOptions
 import org.apache.flink.table.data.binary.BinaryArrayData
 import org.apache.flink.table.data.util.MapDataUtil
 import org.apache.flink.table.data.utils.CastExecutor
 import org.apache.flink.table.data.writer.{BinaryArrayWriter, BinaryRowWriter}
+import org.apache.flink.table.planner.codegen.{CodeGeneratorContext, CodeGenException, GeneratedExpression}
 import org.apache.flink.table.planner.codegen.CodeGenUtils._
-import org.apache.flink.table.planner.codegen.GenerateUtils._
 import org.apache.flink.table.planner.codegen.GeneratedExpression.{ALWAYS_NULL, NEVER_NULL, NO_CODE}
-import org.apache.flink.table.planner.codegen.{CodeGenException, CodeGeneratorContext, GeneratedExpression}
+import org.apache.flink.table.planner.codegen.GenerateUtils._
 import org.apache.flink.table.planner.functions.casting.{CastRule, CastRuleProvider, CodeGeneratorCastRule, ExpressionCodeGeneratorCastRule}
 import org.apache.flink.table.planner.utils.JavaScalaConversionUtil.toScala
 import org.apache.flink.table.planner.utils.TableConfigUtils
@@ -34,15 +34,16 @@ import org.apache.flink.table.runtime.functions.SqlFunctionUtils
 import org.apache.flink.table.runtime.types.PlannerTypeUtils
 import org.apache.flink.table.runtime.types.PlannerTypeUtils.{isInteroperable, isPrimitive}
 import org.apache.flink.table.runtime.typeutils.TypeCheckUtils._
+import org.apache.flink.table.types.logical._
 import org.apache.flink.table.types.logical.LogicalTypeFamily.DATETIME
 import org.apache.flink.table.types.logical.LogicalTypeRoot._
-import org.apache.flink.table.types.logical._
 import org.apache.flink.table.types.logical.utils.LogicalTypeChecks.getFieldTypes
 import org.apache.flink.table.types.logical.utils.LogicalTypeMerging.findCommonType
 import org.apache.flink.table.utils.DateTimeUtils.MILLIS_PER_DAY
 import org.apache.flink.util.Preconditions.checkArgument
 
 import java.time.ZoneId
+
 import scala.collection.JavaConversions._
 
 /**

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
@@ -41,10 +41,13 @@ import java.time.Period;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeParseException;
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.apache.flink.table.api.DataTypes.ARRAY;
@@ -63,6 +66,7 @@ import static org.apache.flink.table.api.DataTypes.INT;
 import static org.apache.flink.table.api.DataTypes.INTERVAL;
 import static org.apache.flink.table.api.DataTypes.MAP;
 import static org.apache.flink.table.api.DataTypes.MONTH;
+import static org.apache.flink.table.api.DataTypes.MULTISET;
 import static org.apache.flink.table.api.DataTypes.ROW;
 import static org.apache.flink.table.api.DataTypes.SECOND;
 import static org.apache.flink.table.api.DataTypes.SMALLINT;
@@ -75,8 +79,6 @@ import static org.apache.flink.table.api.DataTypes.VARBINARY;
 import static org.apache.flink.table.api.DataTypes.VARCHAR;
 import static org.apache.flink.table.api.DataTypes.YEAR;
 import static org.apache.flink.table.api.Expressions.$;
-import static org.apache.flink.util.CollectionUtil.entry;
-import static org.apache.flink.util.CollectionUtil.map;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link BuiltInFunctionDefinitions#CAST}. */
@@ -112,6 +114,10 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
     private static final Duration DEFAULT_INTERVAL_DAY = Duration.ofHours(12);
 
     private static final int[] DEFAULT_ARRAY = new int[] {0, 1, 2};
+
+    private static final Map<Integer, Integer> DEFAULT_MAP = map(entry(0, 1), entry(2, 3));
+
+    private static final Map<Integer, Integer> DEFAULT_MULTISET = map(entry(0, 1), entry(2, 3));
 
     @Override
     Configuration getConfiguration() {
@@ -174,8 +180,8 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         .failValidation(INTERVAL(YEAR(), MONTH()), DEFAULT_INTERVAL_YEAR)
                         .failValidation(INTERVAL(DAY(), SECOND()), DEFAULT_INTERVAL_DAY)
                         .failValidation(ARRAY(INT()), DEFAULT_ARRAY)
-                        // MULTISET
-                        // MAP
+                        .failValidation(MAP(INT(), INT()), DEFAULT_MAP)
+                        .failValidation(MULTISET(INT()), DEFAULT_MULTISET)
                         // ROW
                         // RAW
                         .build(),
@@ -211,8 +217,8 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         .failValidation(INTERVAL(YEAR(), MONTH()), DEFAULT_INTERVAL_YEAR)
                         .failValidation(INTERVAL(DAY(), SECOND()), DEFAULT_INTERVAL_DAY)
                         .failValidation(ARRAY(INT()), DEFAULT_ARRAY)
-                        // MULTISET
-                        // MAP
+                        .failValidation(MAP(INT(), INT()), DEFAULT_MAP)
+                        .failValidation(MULTISET(INT()), DEFAULT_MULTISET)
                         // ROW
                         //
                         // RAW supported - check CastFunctionMiscITCase
@@ -245,8 +251,8 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         .failValidation(INTERVAL(YEAR(), MONTH()), DEFAULT_INTERVAL_YEAR)
                         .failValidation(INTERVAL(DAY(), SECOND()), DEFAULT_INTERVAL_DAY)
                         .failValidation(ARRAY(INT()), DEFAULT_ARRAY)
-                        // MULTISET
-                        // MAP
+                        .failValidation(MAP(INT(), INT()), DEFAULT_MAP)
+                        .failValidation(MULTISET(INT()), DEFAULT_MULTISET)
                         // ROW
                         //
                         // RAW supported - check CastFunctionMiscITCase
@@ -281,8 +287,8 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         .failValidation(INTERVAL(YEAR(), MONTH()), DEFAULT_INTERVAL_YEAR)
                         .failValidation(INTERVAL(DAY(), SECOND()), DEFAULT_INTERVAL_DAY)
                         .failValidation(ARRAY(INT()), DEFAULT_ARRAY)
-                        // MULTISET
-                        // MAP
+                        .failValidation(MAP(INT(), INT()), DEFAULT_MAP)
+                        .failValidation(MULTISET(INT()), DEFAULT_MULTISET)
                         // ROW
                         //
                         // RAW supported - check CastFunctionMiscITCase
@@ -317,8 +323,8 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         .failValidation(INTERVAL(YEAR(), MONTH()), DEFAULT_INTERVAL_YEAR)
                         .failValidation(INTERVAL(DAY(), SECOND()), DEFAULT_INTERVAL_DAY)
                         .failValidation(ARRAY(INT()), DEFAULT_ARRAY)
-                        // MULTISET
-                        // MAP
+                        .failValidation(MAP(INT(), INT()), DEFAULT_MAP)
+                        .failValidation(MULTISET(INT()), DEFAULT_MULTISET)
                         // ROW
                         // RAW
                         .build(),
@@ -364,8 +370,8 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         .failValidation(INTERVAL(YEAR(), MONTH()), DEFAULT_INTERVAL_YEAR)
                         .failValidation(INTERVAL(DAY(), SECOND()), DEFAULT_INTERVAL_DAY)
                         .failValidation(ARRAY(INT()), DEFAULT_ARRAY)
-                        // MULTISET
-                        // MAP
+                        .failValidation(MAP(INT(), INT()), DEFAULT_MAP)
+                        .failValidation(MULTISET(INT()), DEFAULT_MULTISET)
                         // ROW
                         // RAW
                         .build(),
@@ -422,8 +428,8 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         .failValidation(INTERVAL(YEAR(), MONTH()), DEFAULT_INTERVAL_YEAR)
                         .failValidation(INTERVAL(DAY(), SECOND()), DEFAULT_INTERVAL_DAY)
                         .failValidation(ARRAY(INT()), DEFAULT_ARRAY)
-                        // MULTISET
-                        // MAP
+                        .failValidation(MAP(INT(), INT()), DEFAULT_MAP)
+                        .failValidation(MULTISET(INT()), DEFAULT_MULTISET)
                         // ROW
                         // RAW
                         .build(),
@@ -482,8 +488,8 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         .failValidation(INTERVAL(YEAR(), MONTH()), DEFAULT_INTERVAL_YEAR)
                         .failValidation(INTERVAL(DAY(), SECOND()), DEFAULT_INTERVAL_DAY)
                         .failValidation(ARRAY(INT()), DEFAULT_ARRAY)
-                        // MULTISET
-                        // MAP
+                        .failValidation(MAP(INT(), INT()), DEFAULT_MAP)
+                        .failValidation(MULTISET(INT()), DEFAULT_MULTISET)
                         // ROW
                         // RAW
                         .build(),
@@ -539,8 +545,8 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         .failValidation(INTERVAL(YEAR(), MONTH()), DEFAULT_INTERVAL_YEAR)
                         .failValidation(INTERVAL(DAY(), SECOND()), DEFAULT_INTERVAL_DAY)
                         .failValidation(ARRAY(INT()), DEFAULT_ARRAY)
-                        // MULTISET
-                        // MAP
+                        .failValidation(MAP(INT(), INT()), DEFAULT_MAP)
+                        .failValidation(MULTISET(INT()), DEFAULT_MULTISET)
                         // ROW
                         // RAW
                         .build(),
@@ -601,8 +607,8 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         .failValidation(INTERVAL(YEAR(), MONTH()), DEFAULT_INTERVAL_YEAR)
                         .failValidation(INTERVAL(DAY(), SECOND()), DEFAULT_INTERVAL_DAY)
                         .failValidation(ARRAY(INT()), DEFAULT_ARRAY)
-                        // MULTISET
-                        // MAP
+                        .failValidation(MAP(INT(), INT()), DEFAULT_MAP)
+                        .failValidation(MULTISET(INT()), DEFAULT_MULTISET)
                         // ROW
                         // RAW
                         .build(),
@@ -664,8 +670,8 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         .failValidation(INTERVAL(YEAR(), MONTH()), DEFAULT_INTERVAL_YEAR)
                         .failValidation(INTERVAL(DAY(), SECOND()), DEFAULT_INTERVAL_DAY)
                         .failValidation(ARRAY(INT()), DEFAULT_ARRAY)
-                        // MULTISET
-                        // MAP
+                        .failValidation(MAP(INT(), INT()), DEFAULT_MAP)
+                        .failValidation(MULTISET(INT()), DEFAULT_MULTISET)
                         // ROW
                         // RAW
                         .build(),
@@ -710,8 +716,8 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         .failValidation(INTERVAL(YEAR(), MONTH()), DEFAULT_INTERVAL_YEAR)
                         .failValidation(INTERVAL(DAY(), SECOND()), DEFAULT_INTERVAL_DAY)
                         .failValidation(ARRAY(INT()), DEFAULT_ARRAY)
-                        // MULTISET
-                        // MAP
+                        .failValidation(MAP(INT(), INT()), DEFAULT_MAP)
+                        .failValidation(MULTISET(INT()), DEFAULT_MULTISET)
                         // ROW
                         // RAW
                         .build(),
@@ -758,8 +764,8 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         .failValidation(INTERVAL(YEAR(), MONTH()), DEFAULT_INTERVAL_YEAR)
                         .failValidation(INTERVAL(DAY(), SECOND()), DEFAULT_INTERVAL_DAY)
                         .failValidation(ARRAY(INT()), DEFAULT_ARRAY)
-                        // MULTISET
-                        // MAP
+                        .failValidation(MAP(INT(), INT()), DEFAULT_MAP)
+                        .failValidation(MULTISET(INT()), DEFAULT_MULTISET)
                         // ROW
                         // RAW
                         .build(),
@@ -824,8 +830,8 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         .failValidation(INTERVAL(YEAR(), MONTH()), DEFAULT_INTERVAL_YEAR)
                         .failValidation(INTERVAL(DAY(), SECOND()), DEFAULT_INTERVAL_DAY)
                         .failValidation(ARRAY(INT()), DEFAULT_ARRAY)
-                        // MULTISET
-                        // MAP
+                        .failValidation(MAP(INT(), INT()), DEFAULT_MAP)
+                        .failValidation(MULTISET(INT()), DEFAULT_MULTISET)
                         // ROW
                         // RAW
                         .build(),
@@ -908,8 +914,8 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         .failValidation(INTERVAL(YEAR(), MONTH()), DEFAULT_INTERVAL_YEAR)
                         .failValidation(INTERVAL(DAY(), SECOND()), DEFAULT_INTERVAL_DAY)
                         .failValidation(ARRAY(INT()), DEFAULT_ARRAY)
-                        // MULTISET
-                        // MAP
+                        .failValidation(MAP(INT(), INT()), DEFAULT_MAP)
+                        .failValidation(MULTISET(INT()), DEFAULT_MULTISET)
                         // ROW
                         // RAW
                         .build(),
@@ -1166,14 +1172,21 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                                 Collections.singletonMap(1, 2),
                                 Collections.singletonMap("1", "2"))
                         .build(),
-                // https://issues.apache.org/jira/browse/FLINK-25567
-                // CastTestSpecBuilder.testCastTo(MULTISET(STRING()))
-                //        .fromCase(MULTISET(TIMESTAMP()), null, null)
-                //        .fromCase(
-                //                MULTISET(INT()),
-                //                map(entry(1, 2), entry(3, 4)),
-                //                map(entry("1", 2), entry("3", 4)))
-                //        .build(),
+                CastTestSpecBuilder.testCastTo(MULTISET(STRING()))
+                        .fromCase(MULTISET(TIMESTAMP()), null, null)
+                        .fromCase(
+                                MULTISET(INT()),
+                                map(entry(1, 2), entry(3, 4)),
+                                map(entry("1", 2), entry("3", 4)))
+                        .fromCase(
+                                MULTISET(DOUBLE()),
+                                map(entry(12.3, 1), entry(0.1, 2)),
+                                map(entry("12.3", 1), entry("0.1", 2)))
+                        .fromCase(
+                                MULTISET(TIMESTAMP(4)),
+                                map(entry(LocalDateTime.parse("2021-09-24T12:34:56.123456"), 2)),
+                                map(entry("2021-09-24 12:34:56.1234", 2)))
+                        .build(),
                 CastTestSpecBuilder.testCastTo(ARRAY(INT()))
                         .fromCase(ARRAY(INT()), null, null)
                         .fromCase(
@@ -1371,5 +1384,21 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
 
     private static boolean isTimestampToNumeric(LogicalType srcType, LogicalType trgType) {
         return srcType.is(LogicalTypeFamily.TIMESTAMP) && trgType.is(LogicalTypeFamily.NUMERIC);
+    }
+
+    private static <K, V> Map.Entry<K, V> entry(K k, V v) {
+        return new AbstractMap.SimpleImmutableEntry<>(k, v);
+    }
+
+    @SafeVarargs
+    private static <K, V> Map<K, V> map(Map.Entry<K, V>... entries) {
+        if (entries == null) {
+            return Collections.emptyMap();
+        }
+        Map<K, V> map = new HashMap<>();
+        for (Map.Entry<K, V> entry : entries) {
+            map.put(entry.getKey(), entry.getValue());
+        }
+        return map;
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR adds support of casting multisets to multisets as in it was decided to do it in https://github.com/apache/flink/pull/18287 a separate PR


## Brief change log

  - Added `MULTISET` as `BuiltInFunctionDefinition` , `MultisetTypeStrategy`, `MultisetConverter`


## Verifying this change
This change added tests and can be verified as follows:
Added tests in `CastFunctionITCase.java`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? (yes )
  - If yes, how is the feature documented? (not applicable)
