### PR TITLE
[FLINK-27490][table][tests] Migrate test to JUnit5 for flink-table-co…

### DIFF
--- a/flink-table/flink-table-code-splitter/src/test/java/org/apache/flink/table/codesplit/AddBooleanBeforeReturnRewriterTest.java
+++ b/flink-table/flink-table-code-splitter/src/test/java/org/apache/flink/table/codesplit/AddBooleanBeforeReturnRewriterTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.flink.table.codesplit;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;
@@ -25,15 +25,14 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link AddBoolBeforeReturnRewriter}. */
-public class AddBooleanBeforeReturnRewriterTest
-        extends CodeRewriterTestBase<AddBoolBeforeReturnRewriter> {
+class AddBooleanBeforeReturnRewriterTest extends CodeRewriterTestBase<AddBoolBeforeReturnRewriter> {
 
     public AddBooleanBeforeReturnRewriterTest() {
         super("add-boolean", code -> new AddBoolBeforeReturnRewriter(code, 50));
     }
 
     @Test
-    public void testAddBooleanBeforeReturn() {
+    void testAddBooleanBeforeReturn() {
         AddBoolBeforeReturnRewriter rewriter = runTest("TestAddBooleanBeforeReturn");
         List<Map<String, String>> result = rewriter.getBoolVarNames();
         assertThat(result).hasSize(1);
@@ -43,7 +42,7 @@ public class AddBooleanBeforeReturnRewriterTest
     }
 
     @Test
-    public void testRewriteInnerClass() {
+    void testRewriteInnerClass() {
         AddBoolBeforeReturnRewriter rewriter = runTest("TestRewriteInnerClass");
         List<Map<String, String>> result = rewriter.getBoolVarNames();
         assertThat(result).hasSize(3);
@@ -56,7 +55,7 @@ public class AddBooleanBeforeReturnRewriterTest
     }
 
     @Test
-    public void testNotRewrite() {
+    void testNotRewrite() {
         AddBoolBeforeReturnRewriter rewriter = runTest("TestNotRewrite");
         List<Map<String, String>> result = rewriter.getBoolVarNames();
         assertThat(result).hasSize(1);
@@ -64,7 +63,7 @@ public class AddBooleanBeforeReturnRewriterTest
     }
 
     @Test
-    public void testSkipAnonymousClassAndLambda() {
+    void testSkipAnonymousClassAndLambda() {
         AddBoolBeforeReturnRewriter rewriter = runTest("TestSkipAnonymousClassAndLambda");
         List<Map<String, String>> result = rewriter.getBoolVarNames();
         assertThat(result).hasSize(2);

--- a/flink-table/flink-table-code-splitter/src/test/java/org/apache/flink/table/codesplit/CodeRewriterTestBase.java
+++ b/flink-table/flink-table-code-splitter/src/test/java/org/apache/flink/table/codesplit/CodeRewriterTestBase.java
@@ -25,7 +25,7 @@ import java.util.function.Function;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Base test class for {@link CodeRewriter}. */
-public abstract class CodeRewriterTestBase<R extends CodeRewriter> {
+abstract class CodeRewriterTestBase<R extends CodeRewriter> {
 
     private final String resourceDir;
     private final Function<String, R> rewriterProvider;

--- a/flink-table/flink-table-code-splitter/src/test/java/org/apache/flink/table/codesplit/DeclarationRewriterTest.java
+++ b/flink-table/flink-table-code-splitter/src/test/java/org/apache/flink/table/codesplit/DeclarationRewriterTest.java
@@ -17,43 +17,43 @@
 
 package org.apache.flink.table.codesplit;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Tests for {@link DeclarationRewriter}. */
-public class DeclarationRewriterTest extends CodeRewriterTestBase<DeclarationRewriter> {
+class DeclarationRewriterTest extends CodeRewriterTestBase<DeclarationRewriter> {
 
     public DeclarationRewriterTest() {
         super("declaration", code -> new DeclarationRewriter(code, 20));
     }
 
     @Test
-    public void testRewriteLocalVariable() {
+    void testRewriteLocalVariable() {
         runTest("TestRewriteLocalVariable");
     }
 
     @Test
-    public void testNotRewriteLocalVariableInFunctionWithReturnValue() {
+    void testNotRewriteLocalVariableInFunctionWithReturnValue() {
         runTest("TestNotRewriteLocalVariableInFunctionWithReturnValue");
     }
 
     @Test
-    public void testRewriteLocalVariableInForLoop() {
+    void testRewriteLocalVariableInForLoop() {
         runTest("TestRewriteLocalVariableInForLoop1");
         runTest("TestRewriteLocalVariableInForLoop2");
     }
 
     @Test
-    public void testLocalVariableWithSameName() {
+    void testLocalVariableWithSameName() {
         runTest("TestLocalVariableWithSameName");
     }
 
     @Test
-    public void testRewriteInnerClass() {
+    void testRewriteInnerClass() {
         runTest("TestRewriteInnerClass");
     }
 
     @Test
-    public void testLocalVariableAndMemberVariableWithSameName() {
+    void testLocalVariableAndMemberVariableWithSameName() {
         runTest("TestLocalVariableAndMemberVariableWithSameName");
     }
 }

--- a/flink-table/flink-table-code-splitter/src/test/java/org/apache/flink/table/codesplit/FunctionSplitterTest.java
+++ b/flink-table/flink-table-code-splitter/src/test/java/org/apache/flink/table/codesplit/FunctionSplitterTest.java
@@ -17,32 +17,32 @@
 
 package org.apache.flink.table.codesplit;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Tests for {@link FunctionSplitter}. */
-public class FunctionSplitterTest extends CodeRewriterTestBase<FunctionSplitter> {
+class FunctionSplitterTest extends CodeRewriterTestBase<FunctionSplitter> {
 
     public FunctionSplitterTest() {
         super("function", code -> new FunctionSplitter(code, 40));
     }
 
     @Test
-    public void testSplitFunction() {
+    void testSplitFunction() {
         runTest("TestSplitFunction");
     }
 
     @Test
-    public void testNotSplitFunctionWithReturnValue() {
+    void testNotSplitFunctionWithReturnValue() {
         runTest("TestNotSplitFunctionWithReturnValue");
     }
 
     @Test
-    public void testNotSplitFunctionWithOnlyOneStatement() {
+    void testNotSplitFunctionWithOnlyOneStatement() {
         runTest("TestNotSplitFunctionWithOnlyOneStatement");
     }
 
     @Test
-    public void testRewriteInnerClass() {
+    void testRewriteInnerClass() {
         runTest("TestRewriteInnerClass");
     }
 }

--- a/flink-table/flink-table-code-splitter/src/test/java/org/apache/flink/table/codesplit/IfStatementRewriterTest.java
+++ b/flink-table/flink-table-code-splitter/src/test/java/org/apache/flink/table/codesplit/IfStatementRewriterTest.java
@@ -17,27 +17,27 @@
 
 package org.apache.flink.table.codesplit;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Tests for {@link IfStatementRewriter}. */
-public class IfStatementRewriterTest extends CodeRewriterTestBase<IfStatementRewriter> {
+class IfStatementRewriterTest extends CodeRewriterTestBase<IfStatementRewriter> {
 
     public IfStatementRewriterTest() {
         super("if", code -> new IfStatementRewriter(code, 20));
     }
 
     @Test
-    public void testIfStatementRewrite() {
+    void testIfStatementRewrite() {
         runTest("TestIfStatementRewrite");
     }
 
     @Test
-    public void testNotRewriteIfStatementInFunctionWithReturnValue() {
+    void testNotRewriteIfStatementInFunctionWithReturnValue() {
         runTest("TestNotRewriteIfStatementInFunctionWithReturnValue");
     }
 
     @Test
-    public void testRewriteInnerClass() {
+    void testRewriteInnerClass() {
         runTest("TestRewriteInnerClass");
     }
 }

--- a/flink-table/flink-table-code-splitter/src/test/java/org/apache/flink/table/codesplit/JavaCodeSplitterTest.java
+++ b/flink-table/flink-table-code-splitter/src/test/java/org/apache/flink/table/codesplit/JavaCodeSplitterTest.java
@@ -20,7 +20,8 @@ package org.apache.flink.table.codesplit;
 import org.apache.flink.core.testutils.FlinkMatchers;
 import org.apache.flink.util.FileUtils;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
@@ -29,20 +30,21 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.HamcrestCondition.matching;
 
 /** Tests for {@link JavaCodeSplitter}. */
-public class JavaCodeSplitterTest {
+class JavaCodeSplitterTest {
 
     @Test
-    public void testSplitJavaCode() {
+    void testSplitJavaCode() {
         runTest("TestSplitJavaCode", 100, 3);
     }
 
     @Test
-    public void testNotSplitJavaCode() {
+    void testNotSplitJavaCode() {
         runTest("TestNotSplitJavaCode", 4000, 10000);
     }
 
     @Test
-    public void testInvalidJavaCode() {
+    @Disabled("Disabled in because of https://issues.apache.org/jira/browse/FLINK-27702")
+    void testInvalidJavaCode() {
         try {
             JavaCodeSplitter.split("public class InvalidClass { return 1; }", 4000, 10000);
         } catch (Exception e) {

--- a/flink-table/flink-table-code-splitter/src/test/java/org/apache/flink/table/codesplit/JavaParserTest.java
+++ b/flink-table/flink-table-code-splitter/src/test/java/org/apache/flink/table/codesplit/JavaParserTest.java
@@ -19,15 +19,15 @@ package org.apache.flink.table.codesplit;
 
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link JavaParser}. */
-public class JavaParserTest {
+class JavaParserTest {
 
     @Test
-    public void testConstructorCall() {
+    void testConstructorCall() {
         String code =
                 "public class A extends B {\n"
                         + "  private final int a, b;\n"

--- a/flink-table/flink-table-code-splitter/src/test/java/org/apache/flink/table/codesplit/MemberFieldRewriterTest.java
+++ b/flink-table/flink-table-code-splitter/src/test/java/org/apache/flink/table/codesplit/MemberFieldRewriterTest.java
@@ -17,42 +17,42 @@
 
 package org.apache.flink.table.codesplit;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Tests for {@link MemberFieldRewriter}. */
-public class MemberFieldRewriterTest extends CodeRewriterTestBase<MemberFieldRewriter> {
+class MemberFieldRewriterTest extends CodeRewriterTestBase<MemberFieldRewriter> {
 
     public MemberFieldRewriterTest() {
         super("member", code -> new MemberFieldRewriter(code, 3));
     }
 
     @Test
-    public void testRewriteMemberField() {
+    void testRewriteMemberField() {
         runTest("TestRewriteMemberField");
     }
 
     @Test
-    public void testRewriteGenericType() {
+    void testRewriteGenericType() {
         runTest("TestRewriteGenericType");
     }
 
     @Test
-    public void testNotRewriteFunctionParameter() {
+    void testNotRewriteFunctionParameter() {
         runTest("TestNotRewriteFunctionParameter");
     }
 
     @Test
-    public void testNotRewriteLocalVariable() {
+    void testNotRewriteLocalVariable() {
         runTest("TestNotRewriteLocalVariable");
     }
 
     @Test
-    public void testNotRewriteMember() {
+    void testNotRewriteMember() {
         runTest("TestNotRewriteMember");
     }
 
     @Test
-    public void testRewriteInnerClass() {
+    void testRewriteInnerClass() {
         runTest("TestRewriteInnerClass");
     }
 }

--- a/flink-table/flink-table-code-splitter/src/test/java/org/apache/flink/table/codesplit/ReturnValueRewriterTest.java
+++ b/flink-table/flink-table-code-splitter/src/test/java/org/apache/flink/table/codesplit/ReturnValueRewriterTest.java
@@ -17,32 +17,32 @@
 
 package org.apache.flink.table.codesplit;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Tests for {@link ReturnValueRewriter}. */
-public class ReturnValueRewriterTest extends CodeRewriterTestBase<ReturnValueRewriter> {
+class ReturnValueRewriterTest extends CodeRewriterTestBase<ReturnValueRewriter> {
 
     public ReturnValueRewriterTest() {
         super("return", code -> new ReturnValueRewriter(code, 50));
     }
 
     @Test
-    public void testRewriteReturnValue() {
+    void testRewriteReturnValue() {
         runTest("TestRewriteReturnValue");
     }
 
     @Test
-    public void testRewriteInnerClass() {
+    void testRewriteInnerClass() {
         runTest("TestRewriteInnerClass");
     }
 
     @Test
-    public void testNotRewrite() {
+    void testNotRewrite() {
         runTest("TestNotRewrite");
     }
 
     @Test
-    public void testSkipAnonymousClassAndLambda() {
+    void testSkipAnonymousClassAndLambda() {
         runTest("TestSkipAnonymousClassAndLambda");
     }
 }

--- a/flink-table/flink-table-code-splitter/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/flink-table/flink-table-code-splitter/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.util.TestLoggerExtension


### PR DESCRIPTION
## What is the purpose of the change

[JUnit5 Migration] Module: flink-table-code-splitter


## Brief change log

[JUnit5 Migration] Module: flink-table-code-splitter

## Verifying this change

This change is already covered by existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable )
