### PR TITLE
[hotfix] Ignore Hugo Module files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ tools/flink
 tools/flink-*
 tools/releasing/release
 tools/japicmp-output
+/docs/go.mod
+/docs/go.sum
+/docs/.hugo_build.lock


### PR DESCRIPTION
## What is the purpose of the change

* Make sure that Hugo Modules files (which can be created while working on the current `master` branch) will be ignored when working with the currently support `release-1.15` and `release-1.14` branches

## Brief change log

* Updated .gitignore

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
