### PR TITLE
[FLINK-26909][Client/Job Submission] Support AdaptiveBatch when parallelism is -1 from Cli

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/cli/ProgramOptions.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/ProgramOptions.java
@@ -57,6 +57,8 @@ public class ProgramOptions extends CommandLineOptions {
 
     private final String[] programArgs;
 
+    private final boolean hasParallelismOpt;
+
     private final int parallelism;
 
     private final boolean detachedMode;
@@ -93,10 +95,11 @@ public class ProgramOptions extends CommandLineOptions {
         this.classpaths = classpaths;
 
         if (line.hasOption(PARALLELISM_OPTION.getOpt())) {
+            hasParallelismOpt = true;
             String parString = line.getOptionValue(PARALLELISM_OPTION.getOpt());
             try {
                 parallelism = Integer.parseInt(parString);
-                if (parallelism <= 0) {
+                if (parallelism <= 0 && parallelism != ExecutionConfig.PARALLELISM_DEFAULT) {
                     throw new NumberFormatException();
                 }
             } catch (NumberFormatException e) {
@@ -104,6 +107,7 @@ public class ProgramOptions extends CommandLineOptions {
                         "The parallelism must be a positive number: " + parString);
             }
         } else {
+            hasParallelismOpt = false;
             parallelism = ExecutionConfig.PARALLELISM_DEFAULT;
         }
 
@@ -169,7 +173,7 @@ public class ProgramOptions extends CommandLineOptions {
     }
 
     public void applyToConfiguration(Configuration configuration) {
-        if (getParallelism() != ExecutionConfig.PARALLELISM_DEFAULT) {
+        if (hasParallelismOpt) {
             configuration.setInteger(CoreOptions.DEFAULT_PARALLELISM, getParallelism());
         }
 

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendRunTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendRunTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.client.cli;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.client.deployment.ClusterClientServiceLoader;
 import org.apache.flink.client.deployment.DefaultClusterClientServiceLoader;
 import org.apache.flink.client.program.PackagedProgram;
@@ -210,8 +211,8 @@ public class CliFrontendRunTest extends CliFrontendTestBase {
     }
 
     @Test(expected = CliArgsException.class)
-    public void testParallelismWithInvalidValue() throws Exception {
-        String[] parameters = {"-v", "-p", "-2", getTestJarPath()};
+    public void testInvalidNegativeParallelismOption() throws Exception {
+        String[] parameters = {"-p", "-2", getTestJarPath()};
         Configuration configuration = new Configuration();
         CliFrontend testFrontend =
                 new CliFrontend(configuration, Collections.singletonList(getCli()));
@@ -219,19 +220,25 @@ public class CliFrontendRunTest extends CliFrontendTestBase {
     }
 
     @Test
-    public void testParallelismWithNegativeOne() throws Exception {
+    public void testDefaultParallelismOption() throws Exception {
         final Configuration configuration = getConfiguration();
-        String[] parameters = {"-v", "-p", "-1", getTestJarPath()};
-        verifyCliFrontend(configuration, getCli(), parameters, -1, false);
+        String[] parameters = {
+            "-p", String.valueOf(ExecutionConfig.PARALLELISM_DEFAULT), getTestJarPath()
+        };
+        verifyCliFrontend(
+                configuration, getCli(), parameters, ExecutionConfig.PARALLELISM_DEFAULT, false);
     }
 
     @Test
-    public void testParallelismWithNegativeOneAndConfig() throws Exception {
+    public void testDefaultParallelismOptionOverridesConfiguration() throws Exception {
         // The parallelism should be the same with Cli param -1 instead of config 1.
         final Configuration configuration = getConfiguration();
         configuration.set(CoreOptions.DEFAULT_PARALLELISM, 1);
-        String[] parameters = {"-v", "-p", "-1", getTestJarPath()};
-        verifyCliFrontend(configuration, getCli(), parameters, -1, false);
+        String[] parameters = {
+            "-p", String.valueOf(ExecutionConfig.PARALLELISM_DEFAULT), getTestJarPath()
+        };
+        verifyCliFrontend(
+                configuration, getCli(), parameters, ExecutionConfig.PARALLELISM_DEFAULT, false);
     }
 
     // --------------------------------------------------------------------------------------------

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendRunTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendRunTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.client.deployment.ClusterClientServiceLoader;
 import org.apache.flink.client.deployment.DefaultClusterClientServiceLoader;
 import org.apache.flink.client.program.PackagedProgram;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.runtime.jobgraph.RestoreMode;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 
@@ -206,6 +207,31 @@ public class CliFrontendRunTest extends CliFrontendTestBase {
         CliFrontend testFrontend =
                 new CliFrontend(configuration, Collections.singletonList(getCli()));
         testFrontend.run(parameters);
+    }
+
+    @Test(expected = CliArgsException.class)
+    public void testParallelismWithInvalidValue() throws Exception {
+        String[] parameters = {"-v", "-p", "-2", getTestJarPath()};
+        Configuration configuration = new Configuration();
+        CliFrontend testFrontend =
+                new CliFrontend(configuration, Collections.singletonList(getCli()));
+        testFrontend.run(parameters);
+    }
+
+    @Test
+    public void testParallelismWithNegativeOne() throws Exception {
+        final Configuration configuration = getConfiguration();
+        String[] parameters = {"-v", "-p", "-1", getTestJarPath()};
+        verifyCliFrontend(configuration, getCli(), parameters, -1, false);
+    }
+
+    @Test
+    public void testParallelismWithNegativeOneAndConfig() throws Exception {
+        // The parallelism should be the same with Cli param -1 instead of config 1.
+        final Configuration configuration = getConfiguration();
+        configuration.set(CoreOptions.DEFAULT_PARALLELISM, 1);
+        String[] parameters = {"-v", "-p", "-1", getTestJarPath()};
+        verifyCliFrontend(configuration, getCli(), parameters, -1, false);
     }
 
     // --------------------------------------------------------------------------------------------


### PR DESCRIPTION
## What is the purpose of the change

*When we start the job by command with args "-p $parallelism", the error is thrown with "The parallelism must be a positive number: -1". Since we can use AdaptiveBatch with config parallelism.default: -1, we should support it from Cli.*


## Brief change log
  - *Remove the limit when the Cli parallelism is -1 in class ProgramOptions.*
  - *Apply to the configuration when Cli parallelism is set.*


## Verifying this change
This change added tests and can be verified as follows:

  - *Add unittest for this feature in CliFrontendRunTest*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
