### PR TITLE
[FLINK-27529][connector/common] Replace HybridSourceSplitEnumerator readerSourceIndex Integer == check to equals check

### DIFF
--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSourceSplitEnumerator.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSourceSplitEnumerator.java
@@ -351,7 +351,7 @@ public class HybridSourceSplitEnumerator
             }
             Integer lastIndex = null;
             for (Integer sourceIndex : readerSourceIndex.values()) {
-                if (lastIndex != null && lastIndex != sourceIndex) {
+                if (lastIndex != null && !lastIndex.equals(sourceIndex)) {
                     return filterRegisteredReaders(readers);
                 }
                 lastIndex = sourceIndex;
@@ -362,7 +362,7 @@ public class HybridSourceSplitEnumerator
         private Map<Integer, ReaderInfo> filterRegisteredReaders(Map<Integer, ReaderInfo> readers) {
             Map<Integer, ReaderInfo> readersForSource = new HashMap<>(readers.size());
             for (Map.Entry<Integer, ReaderInfo> e : readers.entrySet()) {
-                if (readerSourceIndex.get(e.getKey()) == (Integer) sourceIndex) {
+                if (((Integer) sourceIndex).equals(readerSourceIndex.get(e.getKey()))) {
                     readersForSource.put(e.getKey(), e.getValue());
                 }
             }


### PR DESCRIPTION
## What is the purpose of the change

Currently HybridSourceSplitEnumerator check readerSourceIndex using Integer type but == operator. In some case, it will cause severe error(Integer == only works fine in [-128,127]) we can use Integer.equals instead. 

## Brief change log

Correct HybridSourceSplitEnumerator readerSourceIndex check logic.

## Verifying this change

This change is already covered by existing tests, such as `HybridSourceSplitSerializerTest`, `HybridSourceSplitEnumeratorTest`.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature?  no
- If yes, how is the feature documented? not applicable
