### PR TITLE
[hotfix][docs] Fix the formatting errors of some Chinese documents.

### DIFF
--- a/docs/content.zh/docs/dev/datastream/fault-tolerance/broadcast_state.md
+++ b/docs/content.zh/docs/dev/datastream/fault-tolerance/broadcast_state.md
@@ -220,16 +220,16 @@ new KeyedBroadcastProcessFunction<Color, Item, Rule, String>() {
 
 这里有一些 broadcast state 的重要注意事项，在使用它时需要时刻清楚：
 
-  - **没有跨 task 通讯：**如上所述，这就是为什么**只有**在 `(Keyed)-BroadcastProcessFunction` 中处理广播流元素的方法里可以更改 broadcast state 的内容。
+  - **没有跨 task 通讯**：如上所述，这就是为什么只有在 `(Keyed)-BroadcastProcessFunction` 中处理广播流元素的方法里可以更改 broadcast state 的内容。
   同时，用户需要保证所有 task 对于 broadcast state 的处理方式是一致的，否则会造成不同 task 读取 broadcast state 时内容不一致的情况，最终导致结果不一致。
 
-  - **broadcast state 在不同的 task 的事件顺序可能是不同的：**虽然广播流中元素的过程能够保证所有的下游 task 全部能够收到，但在不同 task 中元素的到达顺序可能不同。
+  - **broadcast state 在不同的 task 的事件顺序可能是不同的**：虽然广播流中元素的过程能够保证所有的下游 task 全部能够收到，但在不同 task 中元素的到达顺序可能不同。
   所以 broadcast state 的更新*不能依赖于流中元素到达的顺序*。
 
-  - **所有的 task 均会对 broadcast state 进行 checkpoint：**虽然所有 task 中的 broadcast state 是一致的，但当 checkpoint 来临时所有 task 均会对 broadcast state 做 checkpoint。
+  - **所有的 task 均会对 broadcast state 进行 checkpoint**：虽然所有 task 中的 broadcast state 是一致的，但当 checkpoint 来临时所有 task 均会对 broadcast state 做 checkpoint。
   这个设计是为了防止在作业恢复后读文件造成的文件热点。当然这种方式会造成 checkpoint 一定程度的写放大，放大倍数为 p（=并行度）。Flink 会保证在恢复状态/改变并发的时候数据**没有重复**且**没有缺失**。
   在作业恢复时，如果与之前具有相同或更小的并发度，所有的 task 读取之前已经 checkpoint 过的 state。在增大并发的情况下，task 会读取本身的 state，多出来的并发（`p_new` - `p_old`）会使用轮询调度算法读取之前 task 的 state。
 
-  - **不使用 RocksDB state backend：** broadcast state 在运行时保存在内存中，需要保证内存充足。这一特性同样适用于所有其他 Operator State。
+  - **不使用 RocksDB state backend:** broadcast state 在运行时保存在内存中，需要保证内存充足。这一特性同样适用于所有其他 Operator State。
 
 {{< top >}}


### PR DESCRIPTION
## What is the purpose of the change

- **This is the English document：**
 
![image](https://user-images.githubusercontent.com/95120044/167246953-e18dbf1e-39d1-47dd-8939-8bff24d8466e.png)

- **This is the Chinese document：**

![image](https://user-images.githubusercontent.com/95120044/167246866-5aa800f8-23ad-47b5-8098-96cb10253ae1.png)

- **According to the 2 pictures above, we can clearly find that the Chinese document is not formatted correctly.**

## Brief change log

- Fix the formatting errors of some Chinese documents.


## Verifying this change

- This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

 - Dependencies (does it add or upgrade a dependency): (**no**)
- The public API, i.e., is any changed class annotated with @Public(Evolving): (**no**)
- The serializers: (**no**)
- The runtime per-record code paths (performance sensitive): (**no**)
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**no**)
- The S3 file system connector: (**no**)

## Documentation

  - Does this pull request introduce a new feature? (**no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
