### PR TITLE
[FLINK-27401] CEP supports accumulator in IterativeCondition

### DIFF
--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/NFAStateSerializer.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/NFAStateSerializer.java
@@ -43,6 +43,8 @@ public class NFAStateSerializer extends TypeSerializerSingleton<NFAState> {
 
     private static final long serialVersionUID = 2098282423980597010L;
 
+    public static final NFAStateSerializer INSTANCE = new NFAStateSerializer();
+
     /**
      * NOTE: this field should actually be final. The reason that it isn't final is due to backward
      * compatible deserialization paths. See {@link #readObject(ObjectInputStream)}.
@@ -163,7 +165,7 @@ public class NFAStateSerializer extends TypeSerializerSingleton<NFAState> {
     De/serialization methods
     */
 
-    private void serializeComputationStates(Queue<ComputationState> states, DataOutputView target)
+    public void serializeComputationStates(Queue<ComputationState> states, DataOutputView target)
             throws IOException {
         target.writeInt(states.size());
         for (ComputationState computationState : states) {
@@ -171,7 +173,7 @@ public class NFAStateSerializer extends TypeSerializerSingleton<NFAState> {
         }
     }
 
-    private PriorityQueue<ComputationState> deserializeComputationStates(DataInputView source)
+    public PriorityQueue<ComputationState> deserializeComputationStates(DataInputView source)
             throws IOException {
         PriorityQueue<ComputationState> computationStates =
                 new PriorityQueue<>(NFAState.COMPUTATION_STATE_COMPARATOR);
@@ -184,7 +186,7 @@ public class NFAStateSerializer extends TypeSerializerSingleton<NFAState> {
         return computationStates;
     }
 
-    private void serializeSingleComputationState(
+    public void serializeSingleComputationState(
             ComputationState computationState, DataOutputView target) throws IOException {
 
         StringValue.writeString(computationState.getCurrentStateName(), target);
@@ -194,7 +196,7 @@ public class NFAStateSerializer extends TypeSerializerSingleton<NFAState> {
         serializeStartEvent(computationState.getStartEventID(), target);
     }
 
-    private ComputationState deserializeSingleComputationState(DataInputView source)
+    public ComputationState deserializeSingleComputationState(DataInputView source)
             throws IOException {
         String stateName = StringValue.readString(source);
         NodeId prevState = nodeIdSerializer.deserialize(source);

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/sharedbuffer/UserAccumulatorId.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/sharedbuffer/UserAccumulatorId.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cep.nfa.sharedbuffer;
+
+import org.apache.flink.api.common.typeutils.SimpleTypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.base.TypeSerializerSingleton;
+import org.apache.flink.cep.nfa.ComputationState;
+import org.apache.flink.cep.nfa.NFAStateSerializer;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.types.StringValue;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/** Id for user-defined accumulator. */
+public class UserAccumulatorId {
+
+    private static final int VERSION_1 = 1;
+
+    private final int version;
+    private final ComputationState computationState;
+    private final String accmulatorKey;
+
+    public UserAccumulatorId(ComputationState computationState, String accmulatorKey) {
+        this.version = VERSION_1;
+        this.computationState = computationState;
+        this.accmulatorKey = accmulatorKey;
+    }
+
+    public int getVersion() {
+        return version;
+    }
+
+    public ComputationState getComputationState() {
+        return computationState;
+    }
+
+    public String getAccmulatorKey() {
+        return accmulatorKey;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UserAccumulatorId that = (UserAccumulatorId) o;
+        return version == that.version
+                && Objects.equals(computationState, that.computationState)
+                && Objects.equals(accmulatorKey, that.accmulatorKey);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(version, computationState, accmulatorKey);
+    }
+
+    @Override
+    public String toString() {
+        return "UserAccumulatorId{"
+                + "version="
+                + version
+                + ", computationState="
+                + computationState
+                + ", accmulatorKey='"
+                + accmulatorKey
+                + '\''
+                + '}';
+    }
+
+    /** Serializer for {@link UserAccumulatorId}. */
+    public static class UserAccumulatorIdSerializer
+            extends TypeSerializerSingleton<UserAccumulatorId> {
+
+        public static final UserAccumulatorIdSerializer INSTANCE =
+                new UserAccumulatorIdSerializer();
+
+        public UserAccumulatorIdSerializer() {}
+
+        @Override
+        public boolean isImmutableType() {
+            return true;
+        }
+
+        @Override
+        public UserAccumulatorId createInstance() {
+            return null;
+        }
+
+        @Override
+        public UserAccumulatorId copy(UserAccumulatorId from) {
+            return new UserAccumulatorId(from.computationState, from.accmulatorKey);
+        }
+
+        @Override
+        public UserAccumulatorId copy(UserAccumulatorId from, UserAccumulatorId reuse) {
+            return copy(from);
+        }
+
+        @Override
+        public int getLength() {
+            return -1;
+        }
+
+        @Override
+        public void serialize(UserAccumulatorId userAccumulatorId, DataOutputView target)
+                throws IOException {
+            target.writeInt(userAccumulatorId.getVersion());
+            NFAStateSerializer.INSTANCE.serializeSingleComputationState(
+                    userAccumulatorId.getComputationState(), target);
+            StringValue.writeString(userAccumulatorId.getAccmulatorKey(), target);
+        }
+
+        @Override
+        public UserAccumulatorId deserialize(DataInputView source) throws IOException {
+            int version = source.readInt();
+            ComputationState computationState =
+                    NFAStateSerializer.INSTANCE.deserializeSingleComputationState(source);
+            String accumulatorKey = StringValue.readString(source);
+            return new UserAccumulatorId(computationState, accumulatorKey);
+        }
+
+        @Override
+        public UserAccumulatorId deserialize(UserAccumulatorId reuse, DataInputView source)
+                throws IOException {
+            return deserialize(source);
+        }
+
+        @Override
+        public void copy(DataInputView source, DataOutputView target) throws IOException {
+            serialize(deserialize(source), target);
+        }
+
+        @Override
+        public TypeSerializerSnapshot<UserAccumulatorId> snapshotConfiguration() {
+            return new UserAccumulatorIdSerializerSnapshot();
+        }
+
+        /** Serializer configuration snapshot for compatibility and format evolution. */
+        @SuppressWarnings("WeakerAccess")
+        public static class UserAccumulatorIdSerializerSnapshot
+                extends SimpleTypeSerializerSnapshot<UserAccumulatorId> {
+
+            public UserAccumulatorIdSerializerSnapshot() {
+                super(UserAccumulatorIdSerializer::new);
+            }
+        }
+    }
+}

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/AccumulateStateCondition.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/AccumulateStateCondition.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cep.pattern.conditions;
+
+/**
+ * AccmulateStateCondition. Here is the backgroundThe accmulator state belongs to a specific
+ * ComputationState instance, which meansit only needs to be accumulated once per record. And ithas
+ * nothing to do with the conditions either the edges, even thought the interfaceis defined in
+ * IterativeCondition.
+ */
+public interface AccumulateStateCondition<T> {
+    /** Accumulate the state and make sure filter() function is stateless). */
+    void accumulate(T value, IterativeCondition.Context<T> ctx) throws Exception;
+}

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/IterativeCondition.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/IterativeCondition.java
@@ -20,6 +20,7 @@ package org.apache.flink.cep.pattern.conditions;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.functions.Function;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.cep.time.TimeContext;
 
 import java.io.Serializable;
@@ -94,5 +95,10 @@ public abstract class IterativeCondition<T> implements Function, Serializable {
          * @param name The name of the pattern.
          */
         Iterable<T> getEventsForPattern(String name) throws Exception;
+
+        <ACC> ACC getAccumulator(String stateKey, TypeSerializer<ACC> serializer) throws Exception;
+
+        <ACC> void putAccumulator(String stateKey, ACC accumulator, TypeSerializer<ACC> serializer)
+                throws Exception;
     }
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
