### PR TITLE
[FLINK-27550] The method of checkYarnQueues is compatible with capacity scheduler

### DIFF
--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNFairSchedulerITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNFairSchedulerITCase.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.yarn;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.yarn.configuration.YarnConfigOptions;
+
+import org.apache.hadoop.yarn.conf.YarnConfiguration;
+import org.apache.hadoop.yarn.server.resourcemanager.scheduler.ResourceScheduler;
+import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.FairScheduler;
+import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.FairSchedulerConfiguration;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.PrintWriter;
+
+/**
+ * This test starts a MiniYARNCluster with a FairScheduler, which has a queue called "default" by
+ * default. The configuration here adds another queue: "queueA".
+ */
+public class YARNFairSchedulerITCase extends YarnTestBase {
+
+    @BeforeAll
+    static void setup() throws Exception {
+        YARN_CONFIGURATION.setClass(
+                YarnConfiguration.RM_SCHEDULER, FairScheduler.class, ResourceScheduler.class);
+        YARN_CONFIGURATION.set(
+                YarnTestBase.TEST_CLUSTER_NAME_KEY, "flink-yarn-tests-fair-scheduler");
+
+        File fairSchedulerFile = File.createTempFile("fair-scheduler", ".xml");
+        YARN_CONFIGURATION.set(
+                FairSchedulerConfiguration.ALLOCATION_FILE, fairSchedulerFile.getAbsolutePath());
+
+        PrintWriter out = new PrintWriter(new FileWriter(fairSchedulerFile));
+        out.println("<?xml version=\"1.0\"?>");
+        out.println("<allocations>");
+        out.println("  <queue name=\"queueA\">");
+        out.println("   <maxContainerAllocation>512 mb 1 vcores</maxContainerAllocation>");
+        out.println("  </queue>");
+        out.println("</allocations>");
+        out.close();
+
+        startYARNWithConfig(YARN_CONFIGURATION);
+    }
+
+    @AfterAll
+    static void tearDown() throws Exception {
+        YarnTestBase.teardown();
+    }
+
+    @Test
+    void testCheckYarnQueues() {
+        Configuration configuration = new Configuration();
+        configuration.setString(YarnConfigOptions.APPLICATION_QUEUE, "root.a");
+        YarnClusterDescriptor yarnClusterDescriptor = createYarnClusterDescriptor(configuration);
+        Assertions.assertFalse(yarnClusterDescriptor.checkYarnQueues());
+
+        configuration.setString(YarnConfigOptions.APPLICATION_QUEUE, "root.queueA");
+        yarnClusterDescriptor = createYarnClusterDescriptor(configuration);
+        Assertions.assertTrue(yarnClusterDescriptor.checkYarnQueues());
+    }
+}

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionCapacitySchedulerITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionCapacitySchedulerITCase.java
@@ -51,7 +51,9 @@ import org.apache.hadoop.yarn.server.resourcemanager.scheduler.ResourceScheduler
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacityScheduler;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -123,6 +125,9 @@ class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
         YARN_CONFIGURATION.set("yarn.scheduler.capacity.root.queues", "default,qa-team");
         YARN_CONFIGURATION.setInt("yarn.scheduler.capacity.root.default.capacity", 40);
         YARN_CONFIGURATION.setInt("yarn.scheduler.capacity.root.qa-team.capacity", 60);
+        YARN_CONFIGURATION.set("yarn.scheduler.capacity.root.qa-team.queues", "p0,p1");
+        YARN_CONFIGURATION.setInt("yarn.scheduler.capacity.root.qa-team.p0.capacity", 50);
+        YARN_CONFIGURATION.setInt("yarn.scheduler.capacity.root.qa-team.p1.capacity", 50);
         YARN_CONFIGURATION.set(
                 YarnTestBase.TEST_CLUSTER_NAME_KEY, "flink-yarn-tests-capacityscheduler");
         startYARNWithConfig(YARN_CONFIGURATION);
@@ -757,5 +762,23 @@ class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
         if (checkForProhibitedLogContents) {
             ensureNoProhibitedStringInLogFiles(PROHIBITED_STRINGS, WHITELISTED_STRINGS);
         }
+    }
+
+    @BeforeEach
+    void beforeEach() {
+        checkForProhibitedLogContents = true;
+    }
+
+    @Test
+    void testCheckYarnQueues() {
+        checkForProhibitedLogContents = false;
+        Configuration configuration = new Configuration();
+        configuration.setString(YarnConfigOptions.APPLICATION_QUEUE, "root.a");
+        YarnClusterDescriptor yarnClusterDescriptor = createYarnClusterDescriptor(configuration);
+        Assertions.assertFalse(yarnClusterDescriptor.checkYarnQueues());
+
+        configuration.setString(YarnConfigOptions.APPLICATION_QUEUE, "root.qa-team.p0");
+        yarnClusterDescriptor = createYarnClusterDescriptor(configuration);
+        Assertions.assertTrue(yarnClusterDescriptor.checkYarnQueues());
     }
 }

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -121,6 +121,7 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -565,7 +566,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 
         // ------------------ Check if the specified queue exists --------------------
 
-        checkYarnQueues(yarnClient);
+        checkYarnQueues();
 
         // ------------------ Check if the YARN ClusterClient has the requested resources
         // --------------
@@ -744,7 +745,8 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
         }
     }
 
-    private void checkYarnQueues(YarnClient yarnClient) {
+    @VisibleForTesting
+    boolean checkYarnQueues() {
         try {
             List<QueueInfo> queues = yarnClient.getAllQueues();
             if (queues.size() > 0
@@ -753,14 +755,31 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
                 // this session.
                 boolean queueFound = false;
                 for (QueueInfo queue : queues) {
-                    if (queue.getQueueName().equals(this.yarnQueue)
-                            || queue.getQueueName().equals("root." + this.yarnQueue)) {
+                    String queueName = queue.getQueueName();
+                    if (queueName.equals(this.yarnQueue)
+                            || queueName.equals("root." + this.yarnQueue)) {
                         queueFound = true;
                         break;
                     }
+
+                    // Distinguish capacity and fair scheduler based on whether queue name contains
+                    // ".". The fair scheduler always returns a full-path queue
+                    // name(e.g.root.parent.q1), while the capacity scheduler returns a leaf queue
+                    // name(e.g. q2).
+                    if (!queueName.contains(".")) {
+                        String[] splitArray = this.yarnQueue.split("\\.");
+                        if (queueName.equals(splitArray[splitArray.length - 1])) {
+                            queueFound = true;
+                            break;
+                        }
+                    }
                 }
                 if (!queueFound) {
-                    String queueNames = StringUtils.toQuotedListString(queues.toArray());
+                    String queueNames =
+                            queues.stream()
+                                    .filter(Objects::nonNull)
+                                    .map(v -> v.getQueueName().toLowerCase())
+                                    .collect(Collectors.joining(", ", "\"", "\""));
                     LOG.warn(
                             "The specified queue '"
                                     + this.yarnQueue
@@ -768,6 +787,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
                                     + "Available queues: "
                                     + queueNames);
                 }
+                return queueFound;
             } else {
                 LOG.debug("The YARN cluster does not have any queues configured");
             }
@@ -777,6 +797,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
                 LOG.debug("Error details", e);
             }
         }
+        return false;
     }
 
     private ApplicationReport startAppMaster(


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*Remove checking yarn queues before submitting job to Yarn*


## Brief change log

When invoking the method of `checkYarnQueues` in `YarnClusterDescriptor`,
it will check the specified yarnQueue whether exists in the queues gotten by the `YarnClient.QueueInfo`.

However when using the capacity-scheduler, the yarn queues path should be retrieved by the api of `QueueInfo.getQueuePath` instead of `getQueueName`.

Due to this, it will always print out the yarn all queues log, but it also can be submitted to Yarn successfully.

The api of `getQueuePath` is introduced in the latest hadoop version(https://issues.apache.org/jira/browse/YARN-10658), so it's hard to
solve this problem in the older hadoop cluster.

According to the above description, the process of checking is unnecessary.


## Verifying this change



## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
