### PR TITLE
[hotfix][docs] Mention changes of "RuntimeContext#getMetricGroup" in 1.14 release notes.

### DIFF
--- a/docs/content.zh/release-notes/flink-1.14.md
+++ b/docs/content.zh/release-notes/flink-1.14.md
@@ -261,7 +261,8 @@ chaining by explicitly setting `python.operator-chaining.enabled` as `false`.
 ##### [FLINK-23652](https://issues.apache.org/jira/browse/FLINK-23652)
 
 Connectors using the unified Source and Sink interface will expose certain standardized metrics
-automatically.
+automatically. Applications that use `RuntimeContext#getMetricGroup` need to be rebuild against
+1.14 before being submitted to a 1.14 cluster.
 
 #### Port KafkaSink to new Unified Sink API (FLIP-143)
 

--- a/docs/content/release-notes/flink-1.14.md
+++ b/docs/content/release-notes/flink-1.14.md
@@ -268,7 +268,8 @@ chaining by explicitly setting `python.operator-chaining.enabled` as `false`.
 ##### [FLINK-23652](https://issues.apache.org/jira/browse/FLINK-23652)
 
 Connectors using the unified Source and Sink interface will expose certain standardized metrics
-automatically.
+automatically. Applications that use `RuntimeContext#getMetricGroup` need to be rebuild against
+1.14 before being submitted to a 1.14 cluster.
 
 #### Port KafkaSink to new Unified Sink API (FLIP-143)
 


### PR DESCRIPTION
## What is the purpose of the change
Mention changes of "RuntimeContext#getMetricGroup" in 1.14 release notes.

## Verifying this change
This change is a doc fix without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**no**)
  - The serializers: (**no**)
  - The runtime per-record code paths (performance sensitive): (**no**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**no**)
  - The S3 file system connector: (**no**)

## Documentation

  - Does this pull request introduce a new feature? (**no**)
  - If yes, how is the feature documented? (**not applicable*)
