### PR TITLE
[hotfix][docs-zh] Fix two inaccessible links.

### DIFF
--- a/docs/content.zh/docs/dev/dataset/examples.md
+++ b/docs/content.zh/docs/dev/dataset/examples.md
@@ -125,7 +125,7 @@ counts.writeAsCsv(outputPath, "\n", " ")
 
 PageRank算法可以计算互联网中一个网页的重要性，这个重要性通过由一个页面指向其他页面的链接定义。PageRank 算法是一个重复执行相同运算的迭代图算法。在每一次迭代中，每个页面把他当前的 rank 值分发给他所有的邻居节点，并且通过他收到邻居节点的 rank 值更新自身的 rank 值。PageRank 算法因 Google 搜索引擎的使用而流行，它根据网页的重要性来对搜索结果进行排名。
 
-在这个简单的示例中，PageRank 算法由一个[批量迭代](docs/dev/dataset/iterations)和一些固定次数的迭代实现。
+在这个简单的示例中，PageRank 算法由一个[批量迭代]({{< ref "docs/dev/dataset/iterations" >}})和一些固定次数的迭代实现。
 
 {{< tabs "cb5cd992-34f8-4dea-bb6f-c5ec27a97a00" >}}
 {{< tab "Java" >}}
@@ -288,7 +288,7 @@ result.writeAsCsv(outputPath, "\n", " ")
 Connected Components 通过给相连的顶点相同的组件ID来标示出一个较大的图中的连通部分。类似PageRank，Connected Components 也是一个迭代算法。在每一次迭代中，每个顶点把他现在的组件ID传播给所有邻居顶点。当一个顶点接收到的组件ID小于他自身的组件ID时，这个顶点也更新其组件ID为这个新组件ID。
 
 
-这个代码实现使用了[增量迭代](docs/dev/dataset/iterations)： 没有改变其组件 ID 的顶点不会参与下一轮迭代。这种方法会带来更好的性能，因为后面的迭代可以只处理少量的需要计算的顶点。
+这个代码实现使用了[增量迭代]({{< ref "docs/dev/dataset/iterations" >}})： 没有改变其组件 ID 的顶点不会参与下一轮迭代。这种方法会带来更好的性能，因为后面的迭代可以只处理少量的需要计算的顶点。
 
 {{< tabs "33947399-ae91-4965-acd9-44b267d3d53a" >}}
 {{< tab "Java" >}}

--- a/docs/content.zh/docs/dev/dataset/examples.md
+++ b/docs/content.zh/docs/dev/dataset/examples.md
@@ -125,7 +125,7 @@ counts.writeAsCsv(outputPath, "\n", " ")
 
 PageRank算法可以计算互联网中一个网页的重要性，这个重要性通过由一个页面指向其他页面的链接定义。PageRank 算法是一个重复执行相同运算的迭代图算法。在每一次迭代中，每个页面把他当前的 rank 值分发给他所有的邻居节点，并且通过他收到邻居节点的 rank 值更新自身的 rank 值。PageRank 算法因 Google 搜索引擎的使用而流行，它根据网页的重要性来对搜索结果进行排名。
 
-在这个简单的示例中，PageRank 算法由一个[批量迭代](iterations.html)和一些固定次数的迭代实现。
+在这个简单的示例中，PageRank 算法由一个[批量迭代](docs/dev/dataset/iterations)和一些固定次数的迭代实现。
 
 {{< tabs "cb5cd992-34f8-4dea-bb6f-c5ec27a97a00" >}}
 {{< tab "Java" >}}
@@ -288,7 +288,7 @@ result.writeAsCsv(outputPath, "\n", " ")
 Connected Components 通过给相连的顶点相同的组件ID来标示出一个较大的图中的连通部分。类似PageRank，Connected Components 也是一个迭代算法。在每一次迭代中，每个顶点把他现在的组件ID传播给所有邻居顶点。当一个顶点接收到的组件ID小于他自身的组件ID时，这个顶点也更新其组件ID为这个新组件ID。
 
 
-这个代码实现使用了[增量迭代](iterations.html)： 没有改变其组件 ID 的顶点不会参与下一轮迭代。这种方法会带来更好的性能，因为后面的迭代可以只处理少量的需要计算的顶点。
+这个代码实现使用了[增量迭代](docs/dev/dataset/iterations)： 没有改变其组件 ID 的顶点不会参与下一轮迭代。这种方法会带来更好的性能，因为后面的迭代可以只处理少量的需要计算的顶点。
 
 {{< tabs "33947399-ae91-4965-acd9-44b267d3d53a" >}}
 {{< tab "Java" >}}


### PR DESCRIPTION
## What is the purpose of the change

- Fix two inaccessible links in the Chinese documentation.

## Brief change log

- Fix two inaccessible links in the Chinese documentation.



## Verifying this change

- This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**no**)
  - The serializers: (**no**)
  - The runtime per-record code paths (performance sensitive): (**no**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**no**)
  - The S3 file system connector: (**no**)

## Documentation

  - Does this pull request introduce a new feature? (**no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
