### PR TITLE
[FLINK-27457] Implement flush() logic in Cassandra output formats

### DIFF
--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/batch/connectors/cassandra/CassandraColumnarOutputFormatBase.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/batch/connectors/cassandra/CassandraColumnarOutputFormatBase.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.batch.connectors.cassandra;
+
+import org.apache.flink.streaming.connectors.cassandra.ClusterBuilder;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.flink.shaded.guava30.com.google.common.base.Strings;
+
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.ResultSet;
+import com.google.common.util.concurrent.ListenableFuture;
+
+import java.time.Duration;
+
+/**
+ * CassandraColumnarOutputFormatBase is the common abstract class for writing into Apache Cassandra
+ * using column based output formats.
+ *
+ * @param <OUT> Type of the elements to write.
+ */
+abstract class CassandraColumnarOutputFormatBase<OUT>
+        extends CassandraOutputFormatBase<OUT, ResultSet> {
+    private final String insertQuery;
+    private transient PreparedStatement prepared;
+
+    public CassandraColumnarOutputFormatBase(
+            String insertQuery,
+            ClusterBuilder builder,
+            int maxConcurrentRequests,
+            Duration maxConcurrentRequestsTimeout) {
+        super(builder, maxConcurrentRequests, maxConcurrentRequestsTimeout);
+        Preconditions.checkArgument(
+                !Strings.isNullOrEmpty(insertQuery), "Query cannot be null or empty");
+        this.insertQuery = insertQuery;
+    }
+
+    @Override
+    public void open(int taskNumber, int numTasks) {
+        super.open(taskNumber, numTasks);
+        this.prepared = session.prepare(insertQuery);
+    }
+
+    @Override
+    protected ListenableFuture<ResultSet> send(OUT record) {
+        Object[] fields = extractFields(record);
+        return session.executeAsync(prepared.bind(fields));
+    }
+
+    protected abstract Object[] extractFields(OUT record);
+}

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/batch/connectors/cassandra/CassandraOutputFormatBase.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/batch/connectors/cassandra/CassandraOutputFormatBase.java
@@ -17,130 +17,73 @@
 
 package org.apache.flink.batch.connectors.cassandra;
 
-import org.apache.flink.api.common.io.RichOutputFormat;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.connectors.cassandra.ClusterBuilder;
 import org.apache.flink.util.Preconditions;
 
 import com.datastax.driver.core.Cluster;
-import com.datastax.driver.core.PreparedStatement;
-import com.datastax.driver.core.ResultSet;
-import com.datastax.driver.core.ResultSetFuture;
 import com.datastax.driver.core.Session;
-import com.google.common.base.Strings;
-import com.google.common.util.concurrent.FutureCallback;
-import com.google.common.util.concurrent.Futures;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.time.Duration;
 
 /**
- * CassandraOutputFormatBase is the common abstract class for writing into Apache Cassandra.
+ * CassandraOutputFormatBase is the common abstract class for writing into Apache Cassandra using
+ * output formats.
  *
  * @param <OUT> Type of the elements to write.
  */
-public abstract class CassandraOutputFormatBase<OUT> extends RichOutputFormat<OUT> {
+abstract class CassandraOutputFormatBase<OUT, V> extends OutputFormatBase<OUT, V> {
     private static final Logger LOG = LoggerFactory.getLogger(CassandraOutputFormatBase.class);
 
-    private final String insertQuery;
     private final ClusterBuilder builder;
-
     private transient Cluster cluster;
-    private transient Session session;
-    private transient PreparedStatement prepared;
-    private transient FutureCallback<ResultSet> callback;
-    private transient Throwable exception = null;
+    protected transient Session session;
 
-    public CassandraOutputFormatBase(String insertQuery, ClusterBuilder builder) {
-        Preconditions.checkArgument(
-                !Strings.isNullOrEmpty(insertQuery), "Query cannot be null or empty");
+    public CassandraOutputFormatBase(
+            ClusterBuilder builder,
+            int maxConcurrentRequests,
+            Duration maxConcurrentRequestsTimeout) {
+        super(maxConcurrentRequests, maxConcurrentRequestsTimeout);
         Preconditions.checkNotNull(builder, "Builder cannot be null");
-
-        this.insertQuery = insertQuery;
         this.builder = builder;
     }
 
+    /** Configure the connection to Cassandra. */
     @Override
     public void configure(Configuration parameters) {
         this.cluster = builder.getCluster();
     }
 
-    /**
-     * Opens a Session to Cassandra and initializes the prepared statement.
-     *
-     * @param taskNumber The number of the parallel instance.
-     * @throws IOException Thrown, if the output could not be opened due to an I/O problem.
-     */
+    /** Opens a Session to Cassandra . */
     @Override
-    public void open(int taskNumber, int numTasks) throws IOException {
+    public void open(int taskNumber, int numTasks) {
         this.session = cluster.connect();
-        this.prepared = session.prepare(insertQuery);
-        this.callback =
-                new FutureCallback<ResultSet>() {
-                    @Override
-                    public void onSuccess(ResultSet ignored) {
-                        onWriteSuccess(ignored);
-                    }
-
-                    @Override
-                    public void onFailure(Throwable t) {
-                        onWriteFailure(t);
-                    }
-                };
+        super.open(taskNumber, numTasks);
     }
 
-    @Override
-    public void writeRecord(OUT record) throws IOException {
-        if (exception != null) {
-            throw new IOException("write record failed", exception);
-        }
-
-        Object[] fields = extractFields(record);
-        ResultSetFuture result = session.executeAsync(prepared.bind(fields));
-        Futures.addCallback(result, callback);
-    }
-
-    protected abstract Object[] extractFields(OUT record);
-
-    /**
-     * Callback that is invoked after a record is written to Cassandra successfully.
-     *
-     * <p>Subclass can override to provide its own logic.
-     *
-     * @param ignored the result.
-     */
-    protected void onWriteSuccess(ResultSet ignored) {}
-
-    /**
-     * Callback that is invoked when failing to write to Cassandra. Current implementation will
-     * record the exception and fail the job upon next record.
-     *
-     * <p>Subclass can override to provide its own failure handling logic.
-     *
-     * @param t the exception
-     */
-    protected void onWriteFailure(Throwable t) {
-        exception = t;
-    }
-
-    /** Closes all resources used. */
+    /** Closes all resources used by Cassandra connection. */
     @Override
     public void close() throws IOException {
         try {
-            if (session != null) {
-                session.close();
+            super.close();
+        } finally {
+            try {
+                if (session != null) {
+                    session.close();
+                }
+            } catch (Exception e) {
+                LOG.error("Error while closing session.", e);
             }
-        } catch (Exception e) {
-            LOG.error("Error while closing session.", e);
-        }
-
-        try {
-            if (cluster != null) {
-                cluster.close();
+            try {
+                if (cluster != null) {
+                    cluster.close();
+                }
+            } catch (Exception e) {
+                LOG.error("Error while closing cluster.", e);
             }
-        } catch (Exception e) {
-            LOG.error("Error while closing cluster.", e);
         }
     }
 }

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/batch/connectors/cassandra/CassandraPojoOutputFormat.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/batch/connectors/cassandra/CassandraPojoOutputFormat.java
@@ -17,44 +17,29 @@
 
 package org.apache.flink.batch.connectors.cassandra;
 
-import org.apache.flink.api.common.io.RichOutputFormat;
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.connectors.cassandra.ClusterBuilder;
 import org.apache.flink.streaming.connectors.cassandra.MapperOptions;
 import org.apache.flink.util.Preconditions;
 
-import com.datastax.driver.core.Cluster;
-import com.datastax.driver.core.Session;
 import com.datastax.driver.mapping.Mapper;
 import com.datastax.driver.mapping.MappingManager;
-import com.google.common.util.concurrent.FutureCallback;
-import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.time.Duration;
 
 /**
  * OutputFormat to write data to Apache Cassandra and from a custom Cassandra annotated object.
  *
  * @param <OUT> type of outputClass
  */
-public class CassandraPojoOutputFormat<OUT> extends RichOutputFormat<OUT> {
+public class CassandraPojoOutputFormat<OUT> extends CassandraOutputFormatBase<OUT, Void> {
 
-    private static final Logger LOG = LoggerFactory.getLogger(CassandraPojoOutputFormat.class);
     private static final long serialVersionUID = -1701885135103942460L;
-
-    private final ClusterBuilder builder;
 
     private final MapperOptions mapperOptions;
     private final Class<OUT> outputClass;
-
-    private transient Cluster cluster;
-    private transient Session session;
     private transient Mapper<OUT> mapper;
-    private transient FutureCallback<Void> callback;
-    private transient Throwable exception = null;
 
     public CassandraPojoOutputFormat(ClusterBuilder builder, Class<OUT> outputClass) {
         this(builder, outputClass, null);
@@ -62,16 +47,24 @@ public class CassandraPojoOutputFormat<OUT> extends RichOutputFormat<OUT> {
 
     public CassandraPojoOutputFormat(
             ClusterBuilder builder, Class<OUT> outputClass, MapperOptions mapperOptions) {
-        Preconditions.checkNotNull(outputClass, "OutputClass cannot be null");
-        Preconditions.checkNotNull(builder, "Builder cannot be null");
-        this.builder = builder;
-        this.mapperOptions = mapperOptions;
-        this.outputClass = outputClass;
+        this(
+                builder,
+                outputClass,
+                mapperOptions,
+                Integer.MAX_VALUE,
+                Duration.ofMillis(Long.MAX_VALUE));
     }
 
-    @Override
-    public void configure(Configuration parameters) {
-        this.cluster = builder.getCluster();
+    public CassandraPojoOutputFormat(
+            ClusterBuilder builder,
+            Class<OUT> outputClass,
+            MapperOptions mapperOptions,
+            int maxConcurrentRequests,
+            Duration maxConcurrentRequestsTimeout) {
+        super(builder, maxConcurrentRequests, maxConcurrentRequestsTimeout);
+        Preconditions.checkNotNull(outputClass, "OutputClass cannot be null");
+        this.mapperOptions = mapperOptions;
+        this.outputClass = outputClass;
     }
 
     /**
@@ -81,7 +74,7 @@ public class CassandraPojoOutputFormat<OUT> extends RichOutputFormat<OUT> {
      */
     @Override
     public void open(int taskNumber, int numTasks) {
-        this.session = cluster.connect();
+        super.open(taskNumber, numTasks);
         MappingManager mappingManager = new MappingManager(session);
         this.mapper = mappingManager.mapper(outputClass);
         if (mapperOptions != null) {
@@ -90,67 +83,20 @@ public class CassandraPojoOutputFormat<OUT> extends RichOutputFormat<OUT> {
                 mapper.setDefaultSaveOptions(optionsArray);
             }
         }
-        this.callback =
-                new FutureCallback<Void>() {
-                    @Override
-                    public void onSuccess(Void ignored) {
-                        onWriteSuccess();
-                    }
-
-                    @Override
-                    public void onFailure(Throwable t) {
-                        onWriteFailure(t);
-                    }
-                };
     }
 
     @Override
-    public void writeRecord(OUT record) throws IOException {
-        if (exception != null) {
-            throw new IOException("write record failed", exception);
-        }
-
-        ListenableFuture<Void> result = mapper.saveAsync(record);
-        Futures.addCallback(result, callback);
-    }
-
-    /**
-     * Callback that is invoked after a record is written to Cassandra successfully.
-     *
-     * <p>Subclass can override to provide its own logic.
-     */
-    protected void onWriteSuccess() {}
-
-    /**
-     * Callback that is invoked when failing to write to Cassandra. Current implementation will
-     * record the exception and fail the job upon next record.
-     *
-     * <p>Subclass can override to provide its own failure handling logic.
-     *
-     * @param t the exception
-     */
-    protected void onWriteFailure(Throwable t) {
-        exception = t;
+    protected ListenableFuture<Void> send(OUT record) {
+        return mapper.saveAsync(record);
     }
 
     /** Closes all resources used. */
     @Override
-    public void close() {
-        mapper = null;
+    public void close() throws IOException {
         try {
-            if (session != null) {
-                session.close();
-            }
-        } catch (Exception e) {
-            LOG.error("Error while closing session.", e);
-        }
-
-        try {
-            if (cluster != null) {
-                cluster.close();
-            }
-        } catch (Exception e) {
-            LOG.error("Error while closing cluster.", e);
+            super.close();
+        } finally {
+            mapper = null;
         }
     }
 }

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/batch/connectors/cassandra/CassandraRowOutputFormat.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/batch/connectors/cassandra/CassandraRowOutputFormat.java
@@ -20,11 +20,21 @@ package org.apache.flink.batch.connectors.cassandra;
 import org.apache.flink.streaming.connectors.cassandra.ClusterBuilder;
 import org.apache.flink.types.Row;
 
+import java.time.Duration;
+
 /** OutputFormat to write Flink {@link Row}s into a Cassandra cluster. */
-public class CassandraRowOutputFormat extends CassandraOutputFormatBase<Row> {
+public class CassandraRowOutputFormat extends CassandraColumnarOutputFormatBase<Row> {
 
     public CassandraRowOutputFormat(String insertQuery, ClusterBuilder builder) {
-        super(insertQuery, builder);
+        this(insertQuery, builder, Integer.MAX_VALUE, Duration.ofMillis(Long.MAX_VALUE));
+    }
+
+    public CassandraRowOutputFormat(
+            String insertQuery,
+            ClusterBuilder builder,
+            int maxConcurrentRequests,
+            Duration maxConcurrentRequestsTimeout) {
+        super(insertQuery, builder, maxConcurrentRequests, maxConcurrentRequestsTimeout);
     }
 
     @Override

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/batch/connectors/cassandra/CassandraTupleOutputFormat.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/batch/connectors/cassandra/CassandraTupleOutputFormat.java
@@ -20,15 +20,26 @@ package org.apache.flink.batch.connectors.cassandra;
 import org.apache.flink.api.java.tuple.Tuple;
 import org.apache.flink.streaming.connectors.cassandra.ClusterBuilder;
 
+import java.time.Duration;
+
 /**
  * OutputFormat to write Flink {@link Tuple}s into a Cassandra cluster.
  *
  * @param <OUT> Type of {@link Tuple} to write to Cassandra.
  */
-public class CassandraTupleOutputFormat<OUT extends Tuple> extends CassandraOutputFormatBase<OUT> {
+public class CassandraTupleOutputFormat<OUT extends Tuple>
+        extends CassandraColumnarOutputFormatBase<OUT> {
 
     public CassandraTupleOutputFormat(String insertQuery, ClusterBuilder builder) {
-        super(insertQuery, builder);
+        this(insertQuery, builder, Integer.MAX_VALUE, Duration.ofMillis(Long.MAX_VALUE));
+    }
+
+    public CassandraTupleOutputFormat(
+            String insertQuery,
+            ClusterBuilder builder,
+            int maxConcurrentRequests,
+            Duration maxConcurrentRequestsTimeout) {
+        super(insertQuery, builder, maxConcurrentRequests, maxConcurrentRequestsTimeout);
     }
 
     @Override

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/batch/connectors/cassandra/OutputFormatBase.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/batch/connectors/cassandra/OutputFormatBase.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.batch.connectors.cassandra;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.io.RichOutputFormat;
+import org.apache.flink.connectors.cassandra.utils.SinkUtils;
+import org.apache.flink.util.Preconditions;
+
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * OutputFormatBase is the common abstract class for output formats. It implements a flush mechanism
+ * and has a maximum number of concurrent requests.
+ *
+ * @param <OUT> Type of the elements to write.
+ */
+public abstract class OutputFormatBase<OUT, V> extends RichOutputFormat<OUT> {
+    private static final Logger LOG = LoggerFactory.getLogger(OutputFormatBase.class);
+
+    private Semaphore semaphore;
+    private Duration maxConcurrentRequestsTimeout = Duration.ofMillis(Long.MAX_VALUE);
+    private int maxConcurrentRequests = Integer.MAX_VALUE;
+
+    private transient FutureCallback<V> callback;
+    private AtomicReference<Throwable> throwable;
+
+    protected OutputFormatBase(int maxConcurrentRequests, Duration maxConcurrentRequestsTimeout) {
+        Preconditions.checkArgument(
+                maxConcurrentRequests > 0, "Max concurrent requests is expected to be positive");
+        this.maxConcurrentRequests = maxConcurrentRequests;
+        Preconditions.checkNotNull(
+                maxConcurrentRequestsTimeout, "Max concurrent requests timeout cannot be null");
+        Preconditions.checkArgument(
+                !maxConcurrentRequestsTimeout.isNegative(),
+                "Max concurrent requests timeout is expected to be positive");
+        this.maxConcurrentRequestsTimeout = maxConcurrentRequestsTimeout;
+    }
+
+    /** Opens the format and initializes the flush system. */
+    @Override
+    public void open(int taskNumber, int numTasks) {
+        throwable = new AtomicReference<>();
+        this.semaphore = new Semaphore(maxConcurrentRequests);
+        this.callback =
+                new FutureCallback<V>() {
+                    @Override
+                    public void onSuccess(V ignored) {
+                        semaphore.release();
+                    }
+
+                    @Override
+                    public void onFailure(Throwable t) {
+                        throwable.compareAndSet(null, t);
+                        LOG.error("Error while writing value.", t);
+                        semaphore.release();
+                    }
+                };
+    }
+
+    private void flush() throws IOException {
+        tryAcquire(maxConcurrentRequests);
+        semaphore.release(maxConcurrentRequests);
+    }
+
+    private void tryAcquire(int permits) throws IOException {
+        try {
+            SinkUtils.tryAcquire(
+                    permits, maxConcurrentRequests, maxConcurrentRequestsTimeout, semaphore);
+        } catch (Exception e) {
+            throw new IOException(e);
+        }
+    }
+
+    @Override
+    public void writeRecord(OUT record) throws IOException {
+        checkAsyncErrors();
+        tryAcquire(1);
+        final ListenableFuture<V> result;
+        try {
+            result = send(record);
+        } catch (Throwable e) {
+            semaphore.release();
+            throw e;
+        }
+        Futures.addCallback(result, callback);
+    }
+
+    protected abstract ListenableFuture<V> send(OUT value);
+
+    private void checkAsyncErrors() throws IOException {
+        final Throwable currentError = throwable.getAndSet(null);
+        if (currentError != null) {
+            throw new IOException("Write record failed", currentError);
+        }
+    }
+
+    /** Closes the format waiting for pending writes and reports errors. */
+    @Override
+    public void close() throws IOException {
+        checkAsyncErrors();
+        flush();
+        checkAsyncErrors();
+    }
+
+    @VisibleForTesting
+    int getAvailablePermits() {
+        return semaphore.availablePermits();
+    }
+
+    @VisibleForTesting
+    int getAcquiredPermits() {
+        return maxConcurrentRequests - semaphore.availablePermits();
+    }
+}

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/connectors/cassandra/utils/SinkUtils.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/connectors/cassandra/utils/SinkUtils.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connectors.cassandra.utils;
+
+import java.io.Serializable;
+import java.time.Duration;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/** Utility class for sinks. */
+public class SinkUtils implements Serializable {
+
+    /**
+     * Acquire permits on the given semaphore within a given allowed timeout and deal with errors.
+     *
+     * @param permits the mumber of permits to acquire.
+     * @param maxConcurrentRequests the maximum number of permits the semaphore was initialized
+     *     with.
+     * @param maxConcurrentRequestsTimeout the timeout to acquire the permits.
+     * @param semaphore the semaphore to acquire permits to.
+     * @throws InterruptedException if the current thread was interrupted.
+     * @throws TimeoutException if the waiting time elapsed before all permits were acquired.
+     */
+    public static void tryAcquire(
+            int permits,
+            int maxConcurrentRequests,
+            Duration maxConcurrentRequestsTimeout,
+            Semaphore semaphore)
+            throws InterruptedException, TimeoutException {
+        if (!semaphore.tryAcquire(
+                permits, maxConcurrentRequestsTimeout.toMillis(), TimeUnit.MILLISECONDS)) {
+            throw new TimeoutException(
+                    String.format(
+                            "Failed to acquire %d out of %d permits to send value in %s.",
+                            permits, maxConcurrentRequests, maxConcurrentRequestsTimeout));
+        }
+    }
+}

--- a/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/batch/connectors/cassandra/OutputFormatBaseTest.java
+++ b/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/batch/connectors/cassandra/OutputFormatBaseTest.java
@@ -1,0 +1,319 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.batch.connectors.cassandra;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.testutils.CheckedThread;
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.concurrent.FutureUtils;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for the {@link OutputFormatBase}. */
+class OutputFormatBaseTest {
+
+    private static final Duration DEFAULT_MAX_CONCURRENT_REQUESTS_TIMEOUT =
+            Duration.ofMillis(Long.MAX_VALUE);
+
+    @Test
+    void testSuccessfulWrite() throws Exception {
+        try (TestOutputFormat testOutputFormat = createOpenedTestOutputFormat()) {
+
+            testOutputFormat.enqueueCompletableFuture(CompletableFuture.completedFuture(null));
+
+            final int originalPermits = testOutputFormat.getAvailablePermits();
+            assertThat(originalPermits).isGreaterThan(0);
+            assertThat(testOutputFormat.getAcquiredPermits()).isEqualTo(0);
+
+            testOutputFormat.writeRecord("hello");
+
+            assertThat(testOutputFormat.getAvailablePermits()).isEqualTo(originalPermits);
+            assertThat(testOutputFormat.getAcquiredPermits()).isEqualTo(0);
+        }
+    }
+
+    @Test
+    void testThrowErrorOnClose() throws Exception {
+        TestOutputFormat testOutputFormat = createTestOutputFormat();
+        testOutputFormat.open(1, 1);
+
+        Exception cause = new RuntimeException();
+        testOutputFormat.enqueueCompletableFuture(FutureUtils.completedExceptionally(cause));
+        testOutputFormat.writeRecord("none");
+
+        assertThatThrownBy(() -> testOutputFormat.close())
+                .isInstanceOf(IOException.class)
+                .hasCauseReference(cause);
+    }
+
+    @Test
+    void testThrowErrorOnWrite() throws Exception {
+        try (TestOutputFormat testOutputFormat = createOpenedTestOutputFormat()) {
+            Exception cause = new RuntimeException();
+            testOutputFormat.enqueueCompletableFuture(FutureUtils.completedExceptionally(cause));
+
+            testOutputFormat.writeRecord("none");
+
+            // should fail because the first write failed and the second will check for asynchronous
+            // errors (throwable set by the async callback)
+            assertThatThrownBy(
+                            () -> testOutputFormat.writeRecord("none"),
+                            "Sending of second value should have failed.")
+                    .isInstanceOf(IOException.class)
+                    .hasCauseReference(cause);
+            assertThat(testOutputFormat.getAcquiredPermits()).isEqualTo(0);
+        }
+    }
+
+    @Test
+    void testWaitForPendingUpdatesOnClose() throws Exception {
+        try (TestOutputFormat testOutputFormat = createOpenedTestOutputFormat()) {
+
+            CompletableFuture<Void> completableFuture = new CompletableFuture<>();
+            testOutputFormat.enqueueCompletableFuture(completableFuture);
+
+            testOutputFormat.writeRecord("hello");
+            assertThat(testOutputFormat.getAcquiredPermits()).isEqualTo(1);
+
+            CheckedThread checkedThread =
+                    new CheckedThread("Flink-OutputFormatBaseTest") {
+                        @Override
+                        public void go() throws Exception {
+                            testOutputFormat.close();
+                        }
+                    };
+            checkedThread.start();
+            while (checkedThread.getState() != Thread.State.TIMED_WAITING) {
+                Thread.sleep(5);
+            }
+
+            assertThat(testOutputFormat.getAcquiredPermits()).isEqualTo(1);
+            // start writing
+            completableFuture.complete(null);
+            // wait for the close
+            checkedThread.sync();
+            assertThat(testOutputFormat.getAcquiredPermits()).isEqualTo(0);
+        }
+    }
+
+    @Test
+    void testReleaseOnSuccess() throws Exception {
+        try (TestOutputFormat openedTestOutputFormat = createOpenedTestOutputFormat()) {
+
+            assertThat(openedTestOutputFormat.getAvailablePermits()).isEqualTo(1);
+            assertThat(openedTestOutputFormat.getAcquiredPermits()).isEqualTo(0);
+
+            CompletableFuture<Void> completableFuture = new CompletableFuture<>();
+            openedTestOutputFormat.enqueueCompletableFuture(completableFuture);
+            openedTestOutputFormat.writeRecord("hello");
+
+            assertThat(openedTestOutputFormat.getAvailablePermits()).isEqualTo(0);
+            assertThat(openedTestOutputFormat.getAcquiredPermits()).isEqualTo(1);
+
+            // start writing
+            completableFuture.complete(null);
+
+            assertThat(openedTestOutputFormat.getAvailablePermits()).isEqualTo(1);
+            assertThat(openedTestOutputFormat.getAcquiredPermits()).isEqualTo(0);
+        }
+    }
+
+    @Test
+    void testReleaseOnFailure() throws Exception {
+        TestOutputFormat testOutputFormat = createOpenedTestOutputFormat();
+
+        assertThat(testOutputFormat.getAvailablePermits()).isEqualTo(1);
+        assertThat(testOutputFormat.getAcquiredPermits()).isEqualTo(0);
+
+        CompletableFuture<Void> completableFuture = new CompletableFuture<>();
+        testOutputFormat.enqueueCompletableFuture(completableFuture);
+        testOutputFormat.writeRecord("none");
+
+        assertThat(testOutputFormat.getAvailablePermits()).isEqualTo(0);
+        assertThat(testOutputFormat.getAcquiredPermits()).isEqualTo(1);
+
+        completableFuture.completeExceptionally(new RuntimeException());
+
+        assertThat(testOutputFormat.getAvailablePermits()).isEqualTo(1);
+        assertThat(testOutputFormat.getAcquiredPermits()).isEqualTo(0);
+        assertThatThrownBy(() -> testOutputFormat.close());
+    }
+
+    @Test
+    void testReleaseOnThrowingSend() throws Exception {
+        Function<String, ListenableFuture<Void>> failingSendFunction =
+                ignoredRecord -> {
+                    throw new RuntimeException("expected");
+                };
+
+        try (TestOutputFormat testOutputFormat =
+                createOpenedTestOutputFormat(failingSendFunction)) {
+
+            assertThat(testOutputFormat.getAvailablePermits()).isEqualTo(1);
+            assertThat(testOutputFormat.getAcquiredPermits()).isEqualTo(0);
+
+            try {
+                testOutputFormat.writeRecord("none");
+            } catch (RuntimeException ignored) {
+                /// there is no point asserting on the exception that we have set,
+                // just avoid the test failure
+            }
+            // writeRecord acquires a permit that is then released when send fails
+            assertThat(testOutputFormat.getAvailablePermits()).isEqualTo(1);
+            assertThat(testOutputFormat.getAcquiredPermits()).isEqualTo(0);
+        }
+    }
+
+    @Test
+    void testMaxConcurrentRequestsReached() throws Exception {
+        try (TestOutputFormat testOutputFormat =
+                createOpenedTestOutputFormat(Duration.ofMillis(1))) {
+            CompletableFuture<Void> completableFuture = new CompletableFuture<>();
+            testOutputFormat.enqueueCompletableFuture(completableFuture);
+            testOutputFormat.enqueueCompletableFuture(completableFuture);
+            testOutputFormat.writeRecord("writeRecord #1");
+
+            // writing a second time while the first request is still not completed and the
+            // outputFormat is set for maxConcurrentRequests=1 will fail
+            assertThatThrownBy(
+                            () -> testOutputFormat.writeRecord("writeRecord #2"),
+                            "Sending value should have experienced a TimeoutException.")
+                    .hasCauseInstanceOf(TimeoutException.class);
+            completableFuture.complete(null);
+        }
+    }
+
+    private static TestOutputFormat createTestOutputFormat() {
+        final TestOutputFormat testOutputFormat =
+                new TestOutputFormat(1, DEFAULT_MAX_CONCURRENT_REQUESTS_TIMEOUT);
+        testOutputFormat.configure(new Configuration());
+        return testOutputFormat;
+    }
+
+    private static TestOutputFormat createOpenedTestOutputFormat() {
+        return createOpenedTestOutputFormat(DEFAULT_MAX_CONCURRENT_REQUESTS_TIMEOUT);
+    }
+
+    private static TestOutputFormat createOpenedTestOutputFormat(
+            Duration maxConcurrentRequestsTimeout) {
+        final TestOutputFormat testOutputFormat =
+                new TestOutputFormat(1, maxConcurrentRequestsTimeout);
+        testOutputFormat.configure(new Configuration());
+        testOutputFormat.open(1, 1);
+        return testOutputFormat;
+    }
+
+    private static TestOutputFormat createOpenedTestOutputFormat(
+            Function<String, ListenableFuture<Void>> sendFunction) {
+        final TestOutputFormat testOutputFormat =
+                new TestOutputFormat(1, DEFAULT_MAX_CONCURRENT_REQUESTS_TIMEOUT, sendFunction);
+        testOutputFormat.configure(new Configuration());
+        testOutputFormat.open(1, 1);
+        return testOutputFormat;
+    }
+
+    private static class TestOutputFormat extends OutputFormatBase<String, Void>
+            implements AutoCloseable {
+        private static final long serialVersionUID = 6646648756749403023L;
+
+        private final Queue<ListenableFuture<Void>> tasksQueue = new LinkedList<>();
+        @Nullable private final Function<String, ListenableFuture<Void>> sendFunction;
+
+        private TestOutputFormat(int maxConcurrentRequests, Duration maxConcurrentRequestsTimeout) {
+            super(maxConcurrentRequests, maxConcurrentRequestsTimeout);
+            sendFunction = null;
+        }
+
+        private TestOutputFormat(
+                int maxConcurrentRequests,
+                Duration maxConcurrentRequestsTimeout,
+                Function<String, ListenableFuture<Void>> sendFunction) {
+            super(maxConcurrentRequests, maxConcurrentRequestsTimeout);
+            this.sendFunction = sendFunction;
+        }
+
+        @Override
+        protected ListenableFuture<Void> send(String value) {
+            return sendFunction == null ? tasksQueue.poll() : sendFunction.apply(value);
+        }
+
+        void enqueueCompletableFuture(CompletableFuture<Void> completableFuture) {
+            Preconditions.checkNotNull(completableFuture);
+            tasksQueue.offer(new ListenableCompletableFuture(completableFuture));
+        }
+
+        @Override
+        public void configure(Configuration parameters) {}
+    }
+
+    private static class ListenableCompletableFuture implements ListenableFuture<Void> {
+        private final CompletableFuture<Void> completableFuture;
+
+        public ListenableCompletableFuture(CompletableFuture<Void> completableFuture) {
+            this.completableFuture = completableFuture;
+        }
+
+        @Override
+        public boolean cancel(boolean b) {
+            return completableFuture.cancel(b);
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return completableFuture.isCancelled();
+        }
+
+        @Override
+        public boolean isDone() {
+            return completableFuture.isDone();
+        }
+
+        @Override
+        public Void get() throws InterruptedException, ExecutionException {
+            return completableFuture.get();
+        }
+
+        @Override
+        public Void get(long timeout, TimeUnit unit)
+                throws InterruptedException, ExecutionException, TimeoutException {
+            return completableFuture.get(timeout, unit);
+        }
+
+        @Override
+        public void addListener(Runnable listener, Executor executor) {
+            completableFuture.whenComplete((result, error) -> listener.run());
+        }
+    }
+}

--- a/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/connectors/cassandra/utils/ResultSetFutures.java
+++ b/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/connectors/cassandra/utils/ResultSetFutures.java
@@ -1,12 +1,13 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.streaming.connectors.cassandra;
+package org.apache.flink.connectors.cassandra.utils;
 
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.ResultSetFuture;
@@ -29,11 +30,11 @@ import java.util.concurrent.TimeoutException;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** Utility class to create {@link com.datastax.driver.core.ResultSetFuture}s. */
-class ResultSetFutures {
+public class ResultSetFutures {
 
     private ResultSetFutures() {}
 
-    static ResultSetFuture fromCompletableFuture(CompletableFuture<ResultSet> future) {
+    public static ResultSetFuture fromCompletableFuture(CompletableFuture<ResultSet> future) {
         checkNotNull(future);
         return new CompletableResultSetFuture(future);
     }

--- a/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraSinkBaseTest.java
+++ b/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraSinkBaseTest.java
@@ -18,6 +18,7 @@
 package org.apache.flink.streaming.connectors.cassandra;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connectors.cassandra.utils.ResultSetFutures;
 import org.apache.flink.core.testutils.CheckedThread;
 import org.apache.flink.streaming.api.operators.StreamSink;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/OutputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/OutputFormat.java
@@ -71,7 +71,7 @@ public interface OutputFormat<IT> extends Serializable {
      * <p>When this method is called, the output format it guaranteed to be opened.
      *
      * @param record The records to add to the output.
-     * @throws IOException Thrown, if the records could not be added to to an I/O problem.
+     * @throws IOException Thrown, if the records could not be added due to an I/O problem.
      */
     void writeRecord(IT record) throws IOException;
 

--- a/tools/maven/suppressions.xml
+++ b/tools/maven/suppressions.xml
@@ -51,7 +51,7 @@ under the License.
 			checks="IllegalImport"/>
 		<!-- Cassandra connectors have to use guava directly -->
 		<suppress
-			files="AbstractCassandraTupleSink.java|CassandraInputFormat.java|CassandraOutputFormatBase.java|CassandraSinkBase.java|CassandraSinkBaseTest.java|CassandraPojoSink.java|CassandraRowSink.java|CassandraTupleWriteAheadSink.java|CassandraRowWriteAheadSink.java|CassandraPojoOutputFormat.java"
+			files="AbstractCassandraTupleSink.java|CassandraInputFormat.java|CassandraOutputFormatBase.java|OutputFormatBase.java|OutputFormatBaseTest.java|CassandraColumnarOutputFormatBase.java|CassandraSinkBase.java|CassandraSinkBaseTest.java|CassandraPojoSink.java|CassandraRowSink.java|CassandraTupleWriteAheadSink.java|CassandraRowWriteAheadSink.java|CassandraPojoOutputFormat.java"
 			checks="IllegalImport"/>
 		<!-- Kinesis producer has to use guava directly -->
 		<suppress


### PR DESCRIPTION


## What is the purpose of the change

When migrating to Cassandra 4.x in [this PR](https://github.com/apache/flink/pull/19586) a race condition in the tests between the asynchronous writes and the junit assertions was uncovered. So it was decided to introduce the flush mechanism to asynchronous writes in the Cassandra output formats similarly to what was done in Cassandra sinks.


## Brief change log

The existing class `CassandraOutputFormatBase` that was previously used as a base class only for Tuple and Row outputFormats is now used as a base class for the 3 output formats including Pojo. the base class for column based output formats (tuple and row) is now a new class called CassandraColumnarOutputFormatBase.
Regarding configuration of the flush I preferred using simple setters to a configuration object as there was no builders for the output formats.
Regarding other modules: I extracted a utility method for semaphore management (SinkUtils) because it is used by both sinks and output formats now. And I also had to change the exceptions thrown in OutputFormat as some methods can now throw TimeoutException and InterruptedException because of the flush mechanism. I think it is ok as this interface is not user facing.


## Verifying this change



This change is already covered by existing ITCAse tests 
This change added UTests for the flush mechanism and can be verified as follows: CassandraOutputFormatBaseTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): adding semaphore permit management + flush on close
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes 
  - If yes, how is the feature documented? javadocs
