### PR TITLE
[FLINK-25795][python][connector/pulsar] Add pulsar sink DataStream API

### DIFF
--- a/docs/content.zh/docs/connectors/datastream/pulsar.md
+++ b/docs/content.zh/docs/connectors/datastream/pulsar.md
@@ -637,6 +637,51 @@ Pulsar Sink 遵循 [FLIP-191](https://cwiki.apache.org/confluence/display/FLINK/
 
 可以在 Pulsar 集群内指定哪些类型的数据模型的改变是被允许的，详情请参阅 [Pulsar Schema Evolution](https://pulsar.apache.org/docs/zh-CN/schema-evolution-compatibility/)。
 
+### Python API 用例
+
+Python API 支持部分 Java API 功能。
+
+```python
+data_stream = env.from_source( ...
+
+pulsar_sink = PulsarSink.builder() \
+    .set_service_url('pulsar://localhost:6650') \
+    .set_admin_url('http://localhost:8080') \
+    .set_producer_name('fo') \
+    .set_topics(['ada', 'beta']) \
+    .set_serialization_schema(
+        PulsarSerializationSchema.flink_schema(SimpleStringSchema())) \
+    .set_delivery_guarantee(DeliveryGuarantee.AT_LEAST_ONCE) \
+    .set_topic_routing_mode(TopicRoutingMode.ROUND_ROBIN) \
+    .enable_schema_evolution() \
+    .delay_sending_message(MessageDelayer.fixed(Duration.of_seconds(12))) \
+    .set_config('pulsar.producer.chunkingEnabled', True) \
+    .set_properties({'pulsar.producer.batchingMaxMessages': '100'}) \
+    .build()
+
+data_stream.sink_to(pulsar_sink).name('pulsar sink')
+```
+
+#### Producing to topics
+
+可以设置 topic 列表或者单个 topic 。
+
+```python
+PulsarSink.builder().set_topics('ada')
+
+PulsarSink.builder().set_topics(['ada', 'beta'])
+```
+
+#### Serializer
+
+仅支持 Flink 的 SerializationSchema，不支持 Pulsar 的 Schema。
+
+```python
+PulsarSerializationSchema.flink_schema(SimpleStringSchema())
+
+PulsarSerializationSchema.flink_schema(JsonRowSerializationSchema())
+```
+
 ## 升级至最新的连接器
 
 常见的升级步骤，请参阅[升级应用程序和 Flink 版本]({{< ref "docs/ops/upgrading" >}})。Pulsar 连接器没有在 Flink 端存储消费的状态，所有的消费信息都推送到了 Pulsar。所以需要注意下面的事项：

--- a/docs/content/docs/connectors/datastream/pulsar.md
+++ b/docs/content/docs/connectors/datastream/pulsar.md
@@ -768,6 +768,51 @@ you to reuse the same Flink job after certain "allowed" data model changes, like
 a field in a AVRO-based Pojo class. Please note that you can specify Pulsar schema validation rules
 and define an auto schema update. For details, refer to [Pulsar Schema Evolution](https://pulsar.apache.org/docs/en/schema-evolution-compatibility/).
 
+### Python API Usage
+
+Python API supports part of the functionality of Java API.
+
+```python
+data_stream = env.from_source( ...
+
+pulsar_sink = PulsarSink.builder() \
+    .set_service_url('pulsar://localhost:6650') \
+    .set_admin_url('http://localhost:8080') \
+    .set_producer_name('fo') \
+    .set_topics(['ada', 'beta']) \
+    .set_serialization_schema(
+        PulsarSerializationSchema.flink_schema(SimpleStringSchema())) \
+    .set_delivery_guarantee(DeliveryGuarantee.AT_LEAST_ONCE) \
+    .set_topic_routing_mode(TopicRoutingMode.ROUND_ROBIN) \
+    .enable_schema_evolution() \
+    .delay_sending_message(MessageDelayer.fixed(Duration.of_seconds(12))) \
+    .set_config('pulsar.producer.chunkingEnabled', True) \
+    .set_properties({'pulsar.producer.batchingMaxMessages': '100'}) \
+    .build()
+
+data_stream.sink_to(pulsar_sink).name('pulsar sink')
+```
+
+#### Producing to topics
+
+You can provide a list of topics or one topic.
+
+```python
+PulsarSink.builder().set_topics('ada')
+
+PulsarSink.builder().set_topics(['ada', 'beta'])
+```
+
+#### Serializer
+
+Only support Flink’s DeserializationSchema, don't support Pulsar’s Schema.
+
+```python
+PulsarSerializationSchema.flink_schema(SimpleStringSchema())
+
+PulsarSerializationSchema.flink_schema(JsonRowSerializationSchema())
+```
+
 ## Upgrading to the Latest Connector Version
 
 The generic upgrade steps are outlined in [upgrading jobs and Flink versions guide]({{< ref "docs/ops/upgrading" >}}).

--- a/docs/content/docs/connectors/datastream/pulsar.md
+++ b/docs/content/docs/connectors/datastream/pulsar.md
@@ -423,6 +423,9 @@ If you still want to use the legacy `SinkFunction` or on Flink 1.14 or previous 
 The Pulsar Sink uses a builder class to construct the `PulsarSink` instance.
 This example writes a String record to a Pulsar topic with at-least-once delivery guarantee.
 
+{{< tabs "46e225b1-1e34-4ff3-890c-aa06a2b99c0a" >}}
+{{< tab "Java" >}}
+
 ```java
 DataStream<String> stream = ...
 
@@ -433,9 +436,29 @@ PulsarSink<String> sink = PulsarSink.builder()
     .setSerializationSchema(PulsarSerializationSchema.flinkSchema(new SimpleStringSchema()))
     .setDeliverGuarantee(DeliveryGuarantee.AT_LEAST_ONCE)
     .build();
-        
+
 stream.sinkTo(sink);
 ```
+
+{{< /tab >}}
+{{< tab "Python" >}}
+
+```python
+stream = env.from_source( ...
+
+pulsar_sink = PulsarSink.builder() \
+    .set_service_url('pulsar://localhost:6650') \
+    .set_admin_url('http://localhost:8080') \
+    .set_topics("topic1") \
+    .set_serialization_schema(PulsarSerializationSchema.flink_schema(SimpleStringSchema())) \
+    .set_delivery_guarantee(DeliveryGuarantee.AT_LEAST_ONCE) \
+    .build()
+
+stream.sink_to(pulsar_sink)
+```
+
+{{< /tab >}}
+{{< /tabs >}}
 
 The following properties are **required** for building PulsarSink:
 
@@ -454,6 +477,9 @@ Defining the topics for producing is similar to the [topic-partition subscriptio
 in the Pulsar source. We support a mix-in style of topic setting. You can provide a list of topics,
 partitions, or both of them.
 
+{{< tabs "3d452e6b-bffd-42f7-bb91-974b306262ca" >}}
+{{< tab "Java" >}}
+
 ```java
 // Topic "some-topic1" and "some-topic2"
 PulsarSink.builder().setTopics("some-topic1", "some-topic2")
@@ -464,6 +490,23 @@ PulsarSink.builder().setTopics("topic-a-partition-0", "topic-a-partition-2")
 // Partition 0 and 2 of topic "topic-a" and topic "some-topic2"
 PulsarSink.builder().setTopics("topic-a-partition-0", "topic-a-partition-2", "some-topic2")
 ```
+
+{{< /tab >}}
+{{< tab "Python" >}}
+
+```python
+// Topic "some-topic1" and "some-topic2"
+PulsarSink.builder().set_topics(["some-topic1", "some-topic2"])
+
+// Partition 0 and 2 of topic "topic-a"
+PulsarSink.builder().set_topics(["topic-a-partition-0", "topic-a-partition-2"])
+
+// Partition 0 and 2 of topic "topic-a" and topic "some-topic2"
+PulsarSink.builder().set_topics(["topic-a-partition-0", "topic-a-partition-2", "some-topic2"])
+```
+
+{{< /tab >}}
+{{< /tabs >}}
 
 The topics you provide support auto partition discovery. We query the topic metadata from the Pulsar in a fixed interval.
 You can use the `PulsarSinkOptions.PULSAR_TOPIC_METADATA_REFRESH_INTERVAL` option to change the discovery interval option.
@@ -500,9 +543,23 @@ you can use the predefined `PulsarSerializationSchema`. The Pulsar sink provides
   PulsarSerializationSchema.pulsarSchema(Schema, Class, Class)
   ```
 - Encode the message by using Flink's `SerializationSchema`
+
+  {{< tabs "b65b9978-b1d6-4b0d-ade8-78098e0f23d8" >}}
+  {{< tab "Java" >}}
+
   ```java
   PulsarSerializationSchema.flinkSchema(SerializationSchema)
   ```
+
+  {{< /tab >}}
+  {{< tab "Python" >}}
+
+  ```python
+  PulsarSerializationSchema.flink_schema(SimpleStringSchema())
+  ```
+
+  {{< /tab >}}
+  {{< /tabs >}}
 
 [Schema evolution](https://pulsar.apache.org/docs/en/schema-evolution-compatibility/#schema-evolution)
 can be enabled by users using `PulsarSerializationSchema.pulsarSchema()` and
@@ -767,51 +824,6 @@ The Pulsar team is working to optimize the needed resources by unfinished pendin
 you to reuse the same Flink job after certain "allowed" data model changes, like adding or deleting
 a field in a AVRO-based Pojo class. Please note that you can specify Pulsar schema validation rules
 and define an auto schema update. For details, refer to [Pulsar Schema Evolution](https://pulsar.apache.org/docs/en/schema-evolution-compatibility/).
-
-### Python API Usage
-
-Python API supports part of the functionality of Java API.
-
-```python
-data_stream = env.from_source( ...
-
-pulsar_sink = PulsarSink.builder() \
-    .set_service_url('pulsar://localhost:6650') \
-    .set_admin_url('http://localhost:8080') \
-    .set_producer_name('fo') \
-    .set_topics(['ada', 'beta']) \
-    .set_serialization_schema(
-        PulsarSerializationSchema.flink_schema(SimpleStringSchema())) \
-    .set_delivery_guarantee(DeliveryGuarantee.AT_LEAST_ONCE) \
-    .set_topic_routing_mode(TopicRoutingMode.ROUND_ROBIN) \
-    .enable_schema_evolution() \
-    .delay_sending_message(MessageDelayer.fixed(Duration.of_seconds(12))) \
-    .set_config('pulsar.producer.chunkingEnabled', True) \
-    .set_properties({'pulsar.producer.batchingMaxMessages': '100'}) \
-    .build()
-
-data_stream.sink_to(pulsar_sink).name('pulsar sink')
-```
-
-#### Producing to topics
-
-You can provide a list of topics or one topic.
-
-```python
-PulsarSink.builder().set_topics('ada')
-
-PulsarSink.builder().set_topics(['ada', 'beta'])
-```
-
-#### Serializer
-
-Only support Flink’s DeserializationSchema, don't support Pulsar’s Schema.
-
-```python
-PulsarSerializationSchema.flink_schema(SimpleStringSchema())
-
-PulsarSerializationSchema.flink_schema(JsonRowSerializationSchema())
-```
 
 ## Upgrading to the Latest Connector Version
 

--- a/flink-python/pyflink/datastream/connectors/__init__.py
+++ b/flink-python/pyflink/datastream/connectors/__init__.py
@@ -15,7 +15,7 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
-from pyflink.datastream.connectors.base import Sink, Source
+from pyflink.datastream.connectors.base import Sink, Source, DeliveryGuarantee
 from pyflink.datastream.connectors.file_system import (FileEnumeratorProvider, FileSink, FileSource,
                                                        BucketAssigner, FileSourceBuilder,
                                                        FileSplitAssignerProvider, OutputFileConfig,
@@ -25,13 +25,15 @@ from pyflink.datastream.connectors.jdbc import JdbcSink, JdbcConnectionOptions, 
 from pyflink.datastream.connectors.kafka import FlinkKafkaConsumer, FlinkKafkaProducer, Semantic
 from pyflink.datastream.connectors.number_seq import NumberSequenceSource
 from pyflink.datastream.connectors.pulsar import PulsarDeserializationSchema, PulsarSource, \
-    PulsarSourceBuilder, SubscriptionType, StartCursor, StopCursor
+    PulsarSourceBuilder, SubscriptionType, StartCursor, StopCursor, PulsarSerializationSchema, \
+    PulsarSink, PulsarSinkBuilder, MessageDelayer, TopicRoutingMode, SinkConfiguration
 from pyflink.datastream.connectors.rabbitmq import RMQConnectionConfig, RMQSource, RMQSink
 
 
 __all__ = [
     'Sink',
     'Source',
+    'DeliveryGuarantee',
     'FileEnumeratorProvider',
     'FileSink',
     'FileSource',
@@ -50,6 +52,12 @@ __all__ = [
     'PulsarSource',
     'PulsarSourceBuilder',
     'SubscriptionType',
+    'PulsarSerializationSchema',
+    'PulsarSink',
+    'PulsarSinkBuilder',
+    'MessageDelayer',
+    'TopicRoutingMode',
+    'SinkConfiguration',
     'RMQConnectionConfig',
     'RMQSource',
     'RMQSink',

--- a/flink-python/pyflink/datastream/connectors/__init__.py
+++ b/flink-python/pyflink/datastream/connectors/__init__.py
@@ -26,7 +26,7 @@ from pyflink.datastream.connectors.kafka import FlinkKafkaConsumer, FlinkKafkaPr
 from pyflink.datastream.connectors.number_seq import NumberSequenceSource
 from pyflink.datastream.connectors.pulsar import PulsarDeserializationSchema, PulsarSource, \
     PulsarSourceBuilder, SubscriptionType, StartCursor, StopCursor, PulsarSerializationSchema, \
-    PulsarSink, PulsarSinkBuilder, MessageDelayer, TopicRoutingMode, SinkConfiguration
+    PulsarSink, PulsarSinkBuilder, MessageDelayer, TopicRoutingMode
 from pyflink.datastream.connectors.rabbitmq import RMQConnectionConfig, RMQSource, RMQSink
 
 
@@ -57,7 +57,6 @@ __all__ = [
     'PulsarSinkBuilder',
     'MessageDelayer',
     'TopicRoutingMode',
-    'SinkConfiguration',
     'RMQConnectionConfig',
     'RMQSource',
     'RMQSink',

--- a/flink-python/pyflink/datastream/connectors/base.py
+++ b/flink-python/pyflink/datastream/connectors/base.py
@@ -58,15 +58,18 @@ class DeliveryGuarantee(Enum):
     delivery guarantee which is supported by your sources and sinks.
 
     :data: `EXACTLY_ONCE`:
+
     Records are only delivered exactly-once also under failover scenarios. To build a complete
     exactly-once pipeline is required that the source and sink support exactly-once and are
     properly configured.
 
     :data: `AT_LEAST_ONCE`:
+
     Records are ensured to be delivered but it may happen that the same record is delivered
     multiple times. Usually, this guarantee is faster than the exactly-once delivery.
 
     :data: `NONE`:
+
     Records are delivered on a best effort basis. It is often the fastest way to process records
     but it may happen that records are lost or duplicated.
     """

--- a/flink-python/pyflink/datastream/connectors/base.py
+++ b/flink-python/pyflink/datastream/connectors/base.py
@@ -15,11 +15,13 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
+from enum import Enum
 from typing import Union
 
 from py4j.java_gateway import JavaObject
 
 from pyflink.datastream.functions import JavaFunctionWrapper
+from pyflink.java_gateway import get_gateway
 
 
 class Source(JavaFunctionWrapper):
@@ -48,3 +50,32 @@ class Sink(JavaFunctionWrapper):
         :param sink: The java Sink object.
         """
         super(Sink, self).__init__(sink)
+
+
+class DeliveryGuarantee(Enum):
+    """
+    DeliverGuarantees that can be chosen. In general your pipeline can only offer the lowest
+    delivery guarantee which is supported by your sources and sinks.
+
+    :data: `EXACTLY_ONCE`:
+    Records are only delivered exactly-once also under failover scenarios. To build a complete
+    exactly-once pipeline is required that the source and sink support exactly-once and are
+    properly configured.
+
+    :data: `AT_LEAST_ONCE`:
+    Records are ensured to be delivered but it may happen that the same record is delivered
+    multiple times. Usually, this guarantee is faster than the exactly-once delivery.
+
+    :data: `NONE`:
+    Records are delivered on a best effort basis. It is often the fastest way to process records
+    but it may happen that records are lost or duplicated.
+    """
+
+    EXACTLY_ONCE = 0,
+    AT_LEAST_ONCE = 1,
+    NONE = 2
+
+    def _to_j_delivery_guarantee(self):
+        JDeliveryGuarantee = get_gateway().jvm \
+            .org.apache.flink.connector.base.DeliveryGuarantee
+        return getattr(JDeliveryGuarantee, self.name)

--- a/flink-python/pyflink/datastream/connectors/pulsar.py
+++ b/flink-python/pyflink/datastream/connectors/pulsar.py
@@ -18,12 +18,15 @@
 from enum import Enum
 from typing import Dict, Union, List
 
-from pyflink.common import DeserializationSchema, TypeInformation, ExecutionConfig, ConfigOption
-from pyflink.datastream.connectors import Source
+from pyflink.common import DeserializationSchema, TypeInformation, ExecutionConfig, \
+    ConfigOptions, Configuration, Duration, SerializationSchema
+from pyflink.datastream.connectors import Source, Sink, DeliveryGuarantee
 from pyflink.java_gateway import get_gateway
 
 
 # ---- PulsarSource ----
+from pyflink.util.java_utils import load_java_class
+
 
 class PulsarDeserializationSchema(object):
     """
@@ -363,17 +366,18 @@ class PulsarSourceBuilder(object):
             pulsar_deserialization_schema._j_pulsar_deserialization_schema)
         return self
 
-    def set_config(self, key: ConfigOption, value) -> 'PulsarSourceBuilder':
+    def set_config(self, key: str, value) -> 'PulsarSourceBuilder':
         """
         Set arbitrary properties for the PulsarSource and PulsarConsumer. The valid keys can be
         found in PulsarSourceOptions and PulsarOptions.
 
         Make sure the option could be set only once or with same value.
         """
-        self._j_pulsar_source_builder.setConfig(key._j_config_option, value)
+        j_config_option = ConfigOptions.key(key).string_type().no_default_value()._j_config_option
+        self._j_pulsar_source_builder.setConfig(j_config_option, value)
         return self
 
-    def set_config_with_dict(self, config: Dict) -> 'PulsarSourceBuilder':
+    def set_properties(self, config: Dict) -> 'PulsarSourceBuilder':
         """
         Set arbitrary properties for the PulsarSource and PulsarConsumer. The valid keys can be
         found in PulsarSourceOptions and PulsarOptions.
@@ -387,3 +391,313 @@ class PulsarSourceBuilder(object):
         Build the PulsarSource.
         """
         return PulsarSource(self._j_pulsar_source_builder.build())
+
+# ---- PulsarSink ----
+
+
+class PulsarSerializationSchema(object):
+    """
+    The serialization schema for how to serialize records into Pulsar.
+    """
+
+    def __init__(self, _j_pulsar_serialization_schema):
+        self._j_pulsar_serialization_schema = _j_pulsar_serialization_schema
+
+    @staticmethod
+    def flink_schema(serialization_schema: SerializationSchema) \
+            -> 'PulsarSerializationSchema':
+        """
+        Create a PulsarSerializationSchema by using the flink's SerializationSchema. It would
+        serialize the message into byte array and send it to Pulsar with Schema#BYTES.
+        """
+        JPulsarSerializationSchema = get_gateway().jvm.org.apache.flink \
+            .connector.pulsar.sink.writer.serializer.PulsarSerializationSchema
+        _j_pulsar_serialization_schema = JPulsarSerializationSchema.flinkSchema(
+            serialization_schema._j_serialization_schema)
+        return PulsarSerializationSchema(_j_pulsar_serialization_schema)
+
+
+class TopicRoutingMode(Enum):
+    """
+    The routing policy for choosing the desired topic by the given message.
+
+    :data: `ROUND_ROBIN`:
+    The producer will publish messages across all partitions in a round-robin fashion to achieve
+    maximum throughput. Please note that round-robin is not done per individual message but
+    rather it's set to the same boundary of batching delay, to ensure batching is effective.
+
+    :data: `MESSAGE_KEY_HASH`:
+    If no key is provided, The partitioned producer will randomly pick one single topic partition
+    and publish all the messages into that partition. If a key is provided on the message, the
+    partitioned producer will hash the key and assign the message to a particular partition.
+
+    :data: `CUSTOM`:
+    Use custom topic router implementation that will be called to determine the partition for a
+    particular message.
+    """
+
+    ROUND_ROBIN = 0
+    MESSAGE_KEY_HASH = 1
+    CUSTOM = 2
+
+    def _to_j_topic_routing_mode(self):
+        JTopicRoutingMode = get_gateway().jvm \
+            .org.apache.flink.connector.pulsar.sink.writer.router.TopicRoutingMode
+        return getattr(JTopicRoutingMode, self.name)
+
+
+class MessageDelayer(object):
+    """
+    A delayer for Pulsar broker passing the sent message to the downstream consumer. This is only
+    works in {@link SubscriptionType#Shared} subscription.
+
+    Read delayed message delivery
+    https://pulsar.apache.org/docs/en/next/concepts-messaging/#delayed-message-delivery for better
+    understanding this feature.
+    """
+    def __init__(self, _j_message_delayer):
+        self._j_message_delayer = _j_message_delayer
+
+    @staticmethod
+    def never() -> 'MessageDelayer':
+        """
+        All the messages should be consumed immediately.
+        """
+        JMessageDelayer = get_gateway().jvm \
+            .org.apache.flink.connector.pulsar.sink.writer.delayer.MessageDelayer
+        return MessageDelayer(JMessageDelayer.never())
+
+    @staticmethod
+    def fixed(duration: Duration) -> 'MessageDelayer':
+        """
+        All the messages should be consumed in a fixed duration.
+        """
+        JMessageDelayer = get_gateway().jvm \
+            .org.apache.flink.connector.pulsar.sink.writer.delayer.MessageDelayer
+        return MessageDelayer(JMessageDelayer.fixed(duration._j_duration))
+
+
+class PulsarSink(Sink):
+    """
+    The Sink implementation of Pulsar. Please use a PulsarSinkBuilder to construct a
+    PulsarSink. The following example shows how to create a PulsarSink receiving records of
+    String type.
+
+    Example:
+    ::
+
+        >>> sink = PulsarSink() \\
+        ...     .builder() \\
+        ...     .set_service_url(PULSAR_BROKER_URL) \\
+        ...     .set_admin_url(PULSAR_BROKER_HTTP_URL) \\
+        ...     .set_topics(topic) \\
+        ...     .set_serialization_schema(
+        ...         PulsarSerializationSchema.flink_schema(SimpleStringSchema())) \\
+        ...     .build()
+
+    The sink supports all delivery guarantees described by DeliveryGuarantee.
+
+    DeliveryGuarantee#NONE does not provide any guarantees: messages may be lost in
+    case of issues on the Pulsar broker and messages may be duplicated in case of a Flink
+    failure.
+
+    DeliveryGuarantee#AT_LEAST_ONCE the sink will wait for all outstanding records in
+    the Pulsar buffers to be acknowledged by the Pulsar producer on a checkpoint. No messages
+    will be lost in case of any issue with the Pulsar brokers but messages may be duplicated
+    when Flink restarts.
+
+    DeliveryGuarantee#EXACTLY_ONCE: In this mode the PulsarSink will write all messages
+    in a Pulsar transaction that will be committed to Pulsar on a checkpoint. Thus, no
+    duplicates will be seen in case of a Flink restart. However, this delays record writing
+     effectively until a checkpoint is written, so adjust the checkpoint duration accordingly.
+    Additionally, it is highly recommended to tweak Pulsar transaction timeout (link) >>
+    maximum checkpoint duration + maximum restart duration or data loss may happen when Pulsar
+    expires an uncommitted transaction.
+
+    See PulsarSinkBuilder for more details.
+    """
+
+    def __init__(self, j_pulsar_sink):
+        super(PulsarSink, self).__init__(sink=j_pulsar_sink)
+
+    @staticmethod
+    def builder() -> 'PulsarSinkBuilder':
+        """
+        Get a PulsarSinkBuilder to builder a PulsarSink.
+        """
+        return PulsarSinkBuilder()
+
+
+class SinkConfiguration(object):
+    """
+    The configured class for pulsar sink.
+    """
+
+    def __init__(self, configuration: Configuration):
+        JSinkConfiguration = get_gateway().jvm \
+            .org.apache.flink.connector.pulsar.sink.config.SinkConfiguration
+        self._j_sink_configuration = JSinkConfiguration(configuration._j_configuration)
+
+
+class PulsarSinkBuilder(object):
+    """
+    The builder class for PulsarSink to make it easier for the users to construct a PulsarSink.
+
+    The following example shows the minimum setup to create a PulsarSink that reads the String
+    values from a Pulsar topic.
+
+    Example:
+    ::
+
+        >>> sink = PulsarSink() \\
+        ...     .builder() \\
+        ...     .set_service_url(PULSAR_BROKER_URL) \\
+        ...     .set_admin_url(PULSAR_BROKER_HTTP_URL) \\
+        ...     .set_topics([TOPIC1, TOPIC2]) \\
+        ...     .set_serialization_schema(
+        ...         PulsarSerializationSchema.flink_schema(SimpleStringSchema())) \\
+        ...     .build()
+
+    The service url, admin url, and the record serializer are required fields that must be set. If
+    you don't set the topics, make sure you have provided a custom TopicRouter. Otherwise,
+    you must provide the topics to produce.
+
+    To specify the delivery guarantees of PulsarSink, one can call
+    #setDeliveryGuarantee(DeliveryGuarantee). The default value of the delivery guarantee is
+    DeliveryGuarantee#NONE, and it wouldn't promise the consistence when write the message into
+    Pulsar.
+
+    Example:
+    ::
+
+        >>> sink = PulsarSink() \\
+        ...     .builder() \\
+        ...     .set_service_url(PULSAR_BROKER_URL) \\
+        ...     .set_admin_url(PULSAR_BROKER_HTTP_URL) \\
+        ...     .set_topics([TOPIC1, TOPIC2]) \\
+        ...     .set_serialization_schema(
+        ...         PulsarSerializationSchema.flink_schema(SimpleStringSchema())) \\
+        ...     .set_delivery_guarantee(DeliveryGuarantee.EXACTLY_ONCE)
+        ...     .build()
+    """
+
+    def __init__(self):
+        JPulsarSink = get_gateway().jvm.org.apache.flink.connector.pulsar.sink.PulsarSink
+        self._j_pulsar_sink_builder = JPulsarSink.builder()
+
+    def set_admin_url(self, admin_url: str) -> 'PulsarSinkBuilder':
+        """
+        Sets the admin endpoint for the PulsarAdmin of the PulsarSink.
+        """
+        self._j_pulsar_sink_builder.setAdminUrl(admin_url)
+        return self
+
+    def set_service_url(self, service_url: str) -> 'PulsarSinkBuilder':
+        """
+        Sets the server's link for the PulsarProducer of the PulsarSink.
+        """
+        self._j_pulsar_sink_builder.setServiceUrl(service_url)
+        return self
+
+    def set_producer_name(self, producer_name: str) -> 'PulsarSinkBuilder':
+        """
+        The producer name is informative, and it can be used to identify a particular producer
+        instance from the topic stats.
+        """
+        self._j_pulsar_sink_builder.setProducerName(producer_name)
+        return self
+
+    def set_topics(self, topics: Union[str, List[str]]) -> 'PulsarSinkBuilder':
+        """
+        Set a pulsar topic list for flink sink. Some topic may not exist currently, write to this
+        non-existed topic wouldn't throw any exception.
+        """
+        if not isinstance(topics, list):
+            topics = [topics]
+        self._j_pulsar_sink_builder.setTopics(topics)
+        return self
+
+    def set_delivery_guarantee(self, delivery_guarantee: DeliveryGuarantee) -> 'PulsarSinkBuilder':
+        """
+        Sets the wanted the DeliveryGuarantee. The default delivery guarantee is
+        DeliveryGuarantee#NONE.
+        """
+        self._j_pulsar_sink_builder.setDeliveryGuarantee(
+            delivery_guarantee._to_j_delivery_guarantee())
+        return self
+
+    def set_topic_routing_mode(self, topic_routing_mode: TopicRoutingMode) -> 'PulsarSinkBuilder':
+        """
+        Set a routing mode for choosing right topic partition to send messages.
+        """
+        self._j_pulsar_sink_builder.setTopicRoutingMode(
+            topic_routing_mode._to_j_topic_routing_mode())
+        return self
+
+    def set_topic_router(self, class_name: str, sink_configuration: SinkConfiguration) \
+            -> 'PulsarSinkBuilder':
+        """
+        Use a custom topic router instead predefine topic routing.
+        """
+        get_constructor_args = get_gateway().new_array(get_gateway().jvm.java.lang.Class, 1)
+        get_constructor_args[0] = \
+            load_java_class('org.apache.flink.connector.pulsar.sink.config.SinkConfiguration')
+
+        new_instance_args = get_gateway().new_array(get_gateway().jvm.java.lang.Object, 1)
+        new_instance_args[0] = sink_configuration._j_sink_configuration
+
+        j_topic_router = load_java_class(class_name).getConstructor(
+            get_constructor_args).newInstance(new_instance_args)
+        self._j_pulsar_sink_builder.setTopicRouter(j_topic_router)
+        return self
+
+    def set_serialization_schema(self, pulsar_serialization_schema: PulsarSerializationSchema) \
+            -> 'PulsarSinkBuilder':
+        """
+        Sets the PulsarSerializationSchema that transforms incoming records to bytes.
+        """
+        self._j_pulsar_sink_builder.setSerializationSchema(
+            pulsar_serialization_schema._j_pulsar_serialization_schema)
+        return self
+
+    def enable_schema_evolution(self) \
+            -> 'PulsarSinkBuilder':
+        """
+        If you enable this option, we would consume and deserialize the message by using Pulsar
+        Schema.
+        """
+        self._j_pulsar_sink_builder.enableSchemaEvolution()
+        return self
+
+    def delay_sending_message(self, message_delayer: MessageDelayer):
+        """
+        Set a message delayer for enable Pulsar message delay delivery.
+        """
+        self._j_pulsar_sink_builder.delaySendingMessage(message_delayer._j_message_delayer)
+        return self
+
+    def set_config(self, key: str, value) -> 'PulsarSinkBuilder':
+        """
+        Set an arbitrary property for the PulsarSink and Pulsar Producer. The valid keys can be
+        found in PulsarSinkOptions and PulsarOptions.
+
+        Make sure the option could be set only once or with same value.
+        """
+        j_config_option = ConfigOptions.key(key).string_type().no_default_value()._j_config_option
+        self._j_pulsar_sink_builder.setConfig(j_config_option, value)
+        return self
+
+    def set_properties(self, config: Dict) -> 'PulsarSinkBuilder':
+        """
+        Set an arbitrary property for the PulsarSink and Pulsar Producer. The valid keys can be
+        found in PulsarSinkOptions and PulsarOptions.
+        """
+        JConfiguration = get_gateway().jvm.org.apache.flink.configuration.Configuration
+        self._j_pulsar_sink_builder.setConfig(JConfiguration.fromMap(config))
+        return self
+
+    def build(self) -> 'PulsarSink':
+        """
+        Build the PulsarSink.
+        """
+        return PulsarSink(self._j_pulsar_sink_builder.build())

--- a/flink-python/pyflink/datastream/tests/test_connectors.py
+++ b/flink-python/pyflink/datastream/tests/test_connectors.py
@@ -17,7 +17,7 @@
 ################################################################################
 from abc import ABC, abstractmethod
 
-from pyflink.common import typeinfo, Duration, WatermarkStrategy, ConfigOptions
+from pyflink.common import typeinfo, Duration, WatermarkStrategy, ConfigOptions, Configuration
 from pyflink.common.serialization import JsonRowDeserializationSchema, \
     JsonRowSerializationSchema, Encoder, SimpleStringSchema
 from pyflink.common.typeinfo import Types
@@ -27,12 +27,13 @@ from pyflink.datastream.connectors import FlinkKafkaConsumer, FlinkKafkaProducer
     OutputFileConfig, FileSource, StreamFormat, FileEnumeratorProvider, FileSplitAssignerProvider, \
     NumberSequenceSource, RollingPolicy, FileSink, BucketAssigner, RMQSink, RMQSource, \
     RMQConnectionConfig, PulsarSource, StartCursor, PulsarDeserializationSchema, StopCursor, \
-    SubscriptionType
+    SubscriptionType, PulsarSink, PulsarSerializationSchema, DeliveryGuarantee, TopicRoutingMode, \
+    MessageDelayer, SinkConfiguration
 from pyflink.datastream.tests.test_util import DataStreamTestSinkFunction
 from pyflink.java_gateway import get_gateway
 from pyflink.testing.test_case_utils import PyFlinkTestCase, _load_specific_flink_module_jars, \
     invoke_java_object_method
-from pyflink.util.java_utils import load_java_class, get_field_value
+from pyflink.util.java_utils import load_java_class, get_field_value, is_instance_of
 
 
 class ConnectorTestBase(PyFlinkTestCase, ABC):
@@ -171,8 +172,7 @@ class FlinkPulsarTest(ConnectorTestBase):
         return '/flink-connectors/flink-sql-connector-pulsar'
 
     def test_pulsar_source(self):
-        test_option = ConfigOptions.key('pulsar.source.enableAutoAcknowledgeMessage') \
-            .boolean_type().no_default_value()
+        TEST_OPTION_NAME = 'pulsar.source.enableAutoAcknowledgeMessage'
         pulsar_source = PulsarSource.builder() \
             .set_service_url('pulsar://localhost:6650') \
             .set_admin_url('http://localhost:8080') \
@@ -186,8 +186,8 @@ class FlinkPulsarTest(ConnectorTestBase):
                 PulsarDeserializationSchema.flink_type_info(Types.STRING(), None)) \
             .set_deserialization_schema(
                 PulsarDeserializationSchema.flink_schema(SimpleStringSchema())) \
-            .set_config(test_option, True) \
-            .set_config_with_dict({'pulsar.source.autoCommitCursorInterval': '1000'}) \
+            .set_config(TEST_OPTION_NAME, True) \
+            .set_properties({'pulsar.source.autoCommitCursorInterval': '1000'}) \
             .build()
 
         ds = self.env.from_source(source=pulsar_source,
@@ -218,6 +218,7 @@ class FlinkPulsarTest(ConnectorTestBase):
                 ConfigOptions.key('pulsar.consumer.subscriptionType')
                 .string_type()
                 .no_default_value()._j_config_option), SubscriptionType.Exclusive.name)
+        test_option = ConfigOptions.key(TEST_OPTION_NAME).boolean_type().no_default_value()
         self.assertEqual(
             configuration.getBoolean(
                 test_option._j_config_option), True)
@@ -227,7 +228,7 @@ class FlinkPulsarTest(ConnectorTestBase):
                 .long_type()
                 .no_default_value()._j_config_option), 1000)
 
-    def test_set_topics_with_list(self):
+    def test_source_set_topics_with_list(self):
         PulsarSource.builder() \
             .set_service_url('pulsar://localhost:6650') \
             .set_admin_url('http://localhost:8080') \
@@ -237,7 +238,7 @@ class FlinkPulsarTest(ConnectorTestBase):
                 PulsarDeserializationSchema.flink_schema(SimpleStringSchema())) \
             .build()
 
-    def test_set_topics_pattern(self):
+    def test_source_set_topics_pattern(self):
         PulsarSource.builder() \
             .set_service_url('pulsar://localhost:6650') \
             .set_admin_url('http://localhost:8080') \
@@ -246,6 +247,115 @@ class FlinkPulsarTest(ConnectorTestBase):
             .set_deserialization_schema(
                 PulsarDeserializationSchema.flink_schema(SimpleStringSchema())) \
             .build()
+
+    def test_pulsar_sink(self):
+        ds = self.env.from_collection([('ab', 1), ('bdc', 2), ('cfgs', 3), ('deeefg', 4)],
+                                      type_info=Types.ROW([Types.STRING(), Types.INT()]))
+
+        TEST_OPTION_NAME = 'pulsar.producer.chunkingEnabled'
+        pulsar_sink = PulsarSink.builder() \
+            .set_service_url('pulsar://localhost:6650') \
+            .set_admin_url('http://localhost:8080') \
+            .set_producer_name('fo') \
+            .set_topics('ada') \
+            .set_serialization_schema(
+                PulsarSerializationSchema.flink_schema(SimpleStringSchema())) \
+            .set_delivery_guarantee(DeliveryGuarantee.AT_LEAST_ONCE) \
+            .set_topic_routing_mode(TopicRoutingMode.ROUND_ROBIN) \
+            .enable_schema_evolution() \
+            .delay_sending_message(MessageDelayer.fixed(Duration.of_seconds(12))) \
+            .set_config(TEST_OPTION_NAME, True) \
+            .set_properties({'pulsar.producer.batchingMaxMessages': '100'}) \
+            .build()
+
+        ds.sink_to(pulsar_sink).name('pulsar sink')
+
+        plan = eval(self.env.get_execution_plan())
+        self.assertEqual('pulsar sink: Writer', plan['nodes'][1]['type'])
+        configuration = get_field_value(pulsar_sink.get_java_function(), "sinkConfiguration")
+        self.assertEqual(
+            configuration.getString(
+                ConfigOptions.key('pulsar.client.serviceUrl')
+                .string_type()
+                .no_default_value()._j_config_option), 'pulsar://localhost:6650')
+        self.assertEqual(
+            configuration.getString(
+                ConfigOptions.key('pulsar.admin.adminUrl')
+                .string_type()
+                .no_default_value()._j_config_option), 'http://localhost:8080')
+        self.assertEqual(
+            configuration.getString(
+                ConfigOptions.key('pulsar.producer.producerName')
+                .string_type()
+                .no_default_value()._j_config_option), 'fo - %s')
+
+        j_pulsar_serialization_schema = get_field_value(
+            pulsar_sink.get_java_function(), 'serializationSchema')
+        j_serialization_schema = get_field_value(
+            j_pulsar_serialization_schema, 'serializationSchema')
+        self.assertTrue(
+            is_instance_of(
+                j_serialization_schema,
+                'org.apache.flink.api.common.serialization.SimpleStringSchema'))
+
+        self.assertEqual(
+            configuration.getString(
+                ConfigOptions.key('pulsar.sink.deliveryGuarantee')
+                .string_type()
+                .no_default_value()._j_config_option), 'at-least-once')
+
+        j_topic_router = get_field_value(pulsar_sink.get_java_function(), "topicRouter")
+        self.assertTrue(
+            is_instance_of(
+                j_topic_router,
+                'org.apache.flink.connector.pulsar.sink.writer.router.RoundRobinTopicRouter'))
+
+        self.assertEqual(
+            configuration.getBoolean(
+                ConfigOptions.key('pulsar.sink.enableSchemaEvolution')
+                .boolean_type()
+                .no_default_value()._j_config_option), True)
+
+        j_message_delayer = get_field_value(pulsar_sink.get_java_function(), 'messageDelayer')
+        delay_duration = get_field_value(j_message_delayer, 'delayDuration')
+        self.assertEqual(delay_duration, 12000)
+
+        test_option = ConfigOptions.key(TEST_OPTION_NAME).boolean_type().no_default_value()
+        self.assertEqual(
+            configuration.getBoolean(
+                test_option._j_config_option), True)
+        self.assertEqual(
+            configuration.getLong(
+                ConfigOptions.key('pulsar.producer.batchingMaxMessages')
+                .long_type()
+                .no_default_value()._j_config_option), 100)
+
+    def test_sink_set_topics_with_list(self):
+        PulsarSink.builder() \
+            .set_service_url('pulsar://localhost:6650') \
+            .set_admin_url('http://localhost:8080') \
+            .set_topics(['ada', 'beta']) \
+            .set_serialization_schema(
+                PulsarSerializationSchema.flink_schema(SimpleStringSchema())) \
+            .build()
+
+    def test_sink_set_topic_router(self):
+        sink_configuration = SinkConfiguration(Configuration())
+        pulsar_sink = PulsarSink.builder() \
+            .set_service_url('pulsar://localhost:6650') \
+            .set_admin_url('http://localhost:8080') \
+            .set_topics(['ada', 'beta']) \
+            .set_serialization_schema(
+                PulsarSerializationSchema.flink_schema(SimpleStringSchema())) \
+            .set_topic_router(
+            'org.apache.flink.connector.pulsar.sink.writer.router.KeyHashTopicRouter',
+            sink_configuration) \
+            .build()
+        j_topic_router = get_field_value(pulsar_sink.get_java_function(), "topicRouter")
+        self.assertTrue(
+            is_instance_of(
+                j_topic_router,
+                'org.apache.flink.connector.pulsar.sink.writer.router.KeyHashTopicRouter'))
 
 
 class RMQTest(ConnectorTestBase):


### PR DESCRIPTION
## What is the purpose of the change

There is no python pulsar sink API.

## Brief change log

Add python pulsar sink.

## Verifying this change

This change added tests and can be verified as follows:

*(example:)*
  - *Added test that validates sink configuration*


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (n )

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (PyDocs)
