### PR TITLE
[FLINK-27566][tests] Migrate module flink-connector-aws-kinesis-firehose to JUnit5

### DIFF
--- a/flink-connectors/flink-connector-aws-kinesis-firehose/src/test/java/org/apache/flink/connector/firehose/sink/KinesisFirehoseSinkBuilderTest.java
+++ b/flink-connectors/flink-connector-aws-kinesis-firehose/src/test/java/org/apache/flink/connector/firehose/sink/KinesisFirehoseSinkBuilderTest.java
@@ -22,18 +22,18 @@ import org.apache.flink.api.common.serialization.SimpleStringSchema;
 import org.apache.flink.connector.aws.config.AWSConfigConstants;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Properties;
 
 /** Covers construction, defaults and sanity checking of {@link KinesisFirehoseSinkBuilder}. */
-public class KinesisFirehoseSinkBuilderTest {
+class KinesisFirehoseSinkBuilderTest {
 
     private static final SerializationSchema<String> SERIALIZATION_SCHEMA =
             new SimpleStringSchema();
 
     @Test
-    public void elementConverterOfSinkMustBeSetWhenBuilt() {
+    void elementConverterOfSinkMustBeSetWhenBuilt() {
         Assertions.assertThatExceptionOfType(NullPointerException.class)
                 .isThrownBy(
                         () ->
@@ -45,7 +45,7 @@ public class KinesisFirehoseSinkBuilderTest {
     }
 
     @Test
-    public void streamNameOfSinkMustBeSetWhenBuilt() {
+    void streamNameOfSinkMustBeSetWhenBuilt() {
         Assertions.assertThatExceptionOfType(NullPointerException.class)
                 .isThrownBy(
                         () ->
@@ -57,7 +57,7 @@ public class KinesisFirehoseSinkBuilderTest {
     }
 
     @Test
-    public void streamNameOfSinkMustBeSetToNonEmptyWhenBuilt() {
+    void streamNameOfSinkMustBeSetToNonEmptyWhenBuilt() {
         Assertions.assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(
                         () ->
@@ -70,7 +70,7 @@ public class KinesisFirehoseSinkBuilderTest {
     }
 
     @Test
-    public void defaultProtocolVersionInsertedToConfiguration() {
+    void defaultProtocolVersionInsertedToConfiguration() {
         Properties expectedProps = new Properties();
         expectedProps.setProperty(AWSConfigConstants.HTTP_PROTOCOL_VERSION, "HTTP1_1");
         Properties defaultProperties =

--- a/flink-connectors/flink-connector-aws-kinesis-firehose/src/test/java/org/apache/flink/connector/firehose/sink/KinesisFirehoseSinkElementConverterTest.java
+++ b/flink-connectors/flink-connector-aws-kinesis-firehose/src/test/java/org/apache/flink/connector/firehose/sink/KinesisFirehoseSinkElementConverterTest.java
@@ -21,17 +21,17 @@ import org.apache.flink.api.common.serialization.SimpleStringSchema;
 import org.apache.flink.connector.base.sink.writer.ElementConverter;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.firehose.model.Record;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Covers construction and sanity checking of {@link KinesisFirehoseSinkElementConverter}. */
-public class KinesisFirehoseSinkElementConverterTest {
+class KinesisFirehoseSinkElementConverterTest {
 
     @Test
-    public void elementConverterWillComplainASerializationSchemaIsNotSetIfBuildIsCalledWithoutIt() {
+    void elementConverterWillComplainASerializationSchemaIsNotSetIfBuildIsCalledWithoutIt() {
         Assertions.assertThatExceptionOfType(NullPointerException.class)
                 .isThrownBy(() -> KinesisFirehoseSinkElementConverter.<String>builder().build())
                 .withMessageContaining(
@@ -39,7 +39,7 @@ public class KinesisFirehoseSinkElementConverterTest {
     }
 
     @Test
-    public void elementConverterUsesProvidedSchemaToSerializeRecord() {
+    void elementConverterUsesProvidedSchemaToSerializeRecord() {
         ElementConverter<String, Record> elementConverter =
                 KinesisFirehoseSinkElementConverter.<String>builder()
                         .setSerializationSchema(new SimpleStringSchema())

--- a/flink-connectors/flink-connector-aws-kinesis-firehose/src/test/java/org/apache/flink/connector/firehose/sink/KinesisFirehoseSinkITCase.java
+++ b/flink-connectors/flink-connector-aws-kinesis-firehose/src/test/java/org/apache/flink/connector/firehose/sink/KinesisFirehoseSinkITCase.java
@@ -24,12 +24,13 @@ import org.apache.flink.connector.firehose.sink.testutils.KinesisFirehoseTestUti
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.util.DockerImageVersions;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 import software.amazon.awssdk.core.SdkSystemSetting;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
@@ -52,7 +53,8 @@ import static org.apache.flink.connector.firehose.sink.testutils.KinesisFirehose
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Integration test suite for the {@code KinesisFirehoseSink} using a localstack container. */
-public class KinesisFirehoseSinkITCase {
+@Testcontainers
+class KinesisFirehoseSinkITCase {
 
     private static final Logger LOG = LoggerFactory.getLogger(KinesisFirehoseSinkITCase.class);
     private static final String ROLE_NAME = "super-role";
@@ -67,12 +69,12 @@ public class KinesisFirehoseSinkITCase {
     private FirehoseAsyncClient firehoseAsyncClient;
     private IamAsyncClient iamAsyncClient;
 
-    @ClassRule
-    public static LocalstackContainer mockFirehoseContainer =
+    @Container
+    private static LocalstackContainer mockFirehoseContainer =
             new LocalstackContainer(DockerImageName.parse(DockerImageVersions.LOCALSTACK));
 
-    @Before
-    public void setup() throws Exception {
+    @BeforeEach
+    void setup() throws Exception {
         System.setProperty(SdkSystemSetting.CBOR_ENABLED.property(), "false");
         httpClient = AWSServicesTestUtils.createHttpClient(mockFirehoseContainer.getEndpoint());
         s3AsyncClient = createS3Client(mockFirehoseContainer.getEndpoint(), httpClient);
@@ -81,13 +83,13 @@ public class KinesisFirehoseSinkITCase {
         env = StreamExecutionEnvironment.getExecutionEnvironment();
     }
 
-    @After
-    public void teardown() {
+    @AfterEach
+    void teardown() {
         System.clearProperty(SdkSystemSetting.CBOR_ENABLED.property());
     }
 
     @Test
-    public void firehoseSinkWritesCorrectDataToMockAWSServices() throws Exception {
+    void firehoseSinkWritesCorrectDataToMockAWSServices() throws Exception {
         LOG.info("1 - Creating the bucket for Firehose to deliver into...");
         createBucket(s3AsyncClient, BUCKET_NAME);
         LOG.info("2 - Creating the IAM Role for Firehose to write into the s3 bucket...");

--- a/flink-connectors/flink-connector-aws-kinesis-firehose/src/test/java/org/apache/flink/connector/firehose/sink/KinesisFirehoseSinkTest.java
+++ b/flink-connectors/flink-connector-aws-kinesis-firehose/src/test/java/org/apache/flink/connector/firehose/sink/KinesisFirehoseSinkTest.java
@@ -25,7 +25,7 @@ import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.firehose.model.Record;
 
 import java.util.Properties;
@@ -36,7 +36,7 @@ import static org.apache.flink.connector.aws.config.AWSConfigConstants.TRUST_ALL
 import static org.apache.flink.connector.aws.testutils.AWSServicesTestUtils.createConfig;
 
 /** Covers construction, defaults and sanity checking of {@link KinesisFirehoseSink}. */
-public class KinesisFirehoseSinkTest {
+class KinesisFirehoseSinkTest {
 
     private static final ElementConverter<String, Record> elementConverter =
             KinesisFirehoseSinkElementConverter.<String>builder()
@@ -44,7 +44,7 @@ public class KinesisFirehoseSinkTest {
                     .build();
 
     @Test
-    public void deliveryStreamNameMustNotBeNull() {
+    void deliveryStreamNameMustNotBeNull() {
         Assertions.assertThatExceptionOfType(NullPointerException.class)
                 .isThrownBy(
                         () ->
@@ -64,7 +64,7 @@ public class KinesisFirehoseSinkTest {
     }
 
     @Test
-    public void deliveryStreamNameMustNotBeEmpty() {
+    void deliveryStreamNameMustNotBeEmpty() {
         Assertions.assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(
                         () ->
@@ -84,7 +84,7 @@ public class KinesisFirehoseSinkTest {
     }
 
     @Test
-    public void firehoseSinkFailsWhenAccessKeyIdIsNotProvided() {
+    void firehoseSinkFailsWhenAccessKeyIdIsNotProvided() {
         Properties properties = createConfig("https://non-exisitent-location");
         properties.setProperty(
                 AWS_CREDENTIALS_PROVIDER, AWSConfigConstants.CredentialProvider.BASIC.toString());
@@ -94,7 +94,7 @@ public class KinesisFirehoseSinkTest {
     }
 
     @Test
-    public void firehoseSinkFailsWhenRegionIsNotProvided() {
+    void firehoseSinkFailsWhenRegionIsNotProvided() {
         Properties properties = createConfig("https://non-exisitent-location");
         properties.remove(AWS_REGION);
         firehoseSinkFailsWithAppropriateMessageWhenInitialConditionsAreMisconfigured(
@@ -102,7 +102,7 @@ public class KinesisFirehoseSinkTest {
     }
 
     @Test
-    public void firehoseSinkFailsWhenUnableToConnectToRemoteService() {
+    void firehoseSinkFailsWhenUnableToConnectToRemoteService() {
         Properties properties = createConfig("https://non-exisitent-location");
         properties.remove(TRUST_ALL_CERTIFICATES);
         firehoseSinkFailsWithAppropriateMessageWhenInitialConditionsAreMisconfigured(

--- a/flink-connectors/flink-connector-aws-kinesis-firehose/src/test/java/org/apache/flink/connector/firehose/sink/KinesisFirehoseSinkWriterTest.java
+++ b/flink-connectors/flink-connector-aws-kinesis-firehose/src/test/java/org/apache/flink/connector/firehose/sink/KinesisFirehoseSinkWriterTest.java
@@ -23,8 +23,8 @@ import org.apache.flink.connector.aws.testutils.AWSServicesTestUtils;
 import org.apache.flink.connector.base.sink.writer.ElementConverter;
 import org.apache.flink.connector.base.sink.writer.TestSinkInitContext;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.firehose.model.Record;
@@ -47,8 +47,8 @@ public class KinesisFirehoseSinkWriterTest {
                     .setSerializationSchema(new SimpleStringSchema())
                     .build();
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         TestSinkInitContext sinkInitContext = new TestSinkInitContext();
         Properties sinkProperties = AWSServicesTestUtils.createConfig("https://fake_aws_endpoint");
         sinkWriter =
@@ -67,7 +67,7 @@ public class KinesisFirehoseSinkWriterTest {
     }
 
     @Test
-    public void getSizeInBytesReturnsSizeOfBlobBeforeBase64Encoding() {
+    void getSizeInBytesReturnsSizeOfBlobBeforeBase64Encoding() {
         String testString = "{many hands make light work;";
         Record record = Record.builder().data(SdkBytes.fromUtf8String(testString)).build();
         assertThat(sinkWriter.getSizeInBytes(record))
@@ -75,7 +75,7 @@ public class KinesisFirehoseSinkWriterTest {
     }
 
     @Test
-    public void getNumRecordsOutErrorsCounterRecordsCorrectNumberOfFailures()
+    void getNumRecordsOutErrorsCounterRecordsCorrectNumberOfFailures()
             throws IOException, InterruptedException {
         TestSinkInitContext ctx = new TestSinkInitContext();
         KinesisFirehoseSink<String> kinesisFirehoseSink =

--- a/flink-connectors/flink-connector-aws-kinesis-firehose/src/test/java/org/apache/flink/connector/firehose/sink/KinesisFirehoseStateSerializerTest.java
+++ b/flink-connectors/flink-connector-aws-kinesis-firehose/src/test/java/org/apache/flink/connector/firehose/sink/KinesisFirehoseStateSerializerTest.java
@@ -22,7 +22,7 @@ import org.apache.flink.api.common.serialization.SimpleStringSchema;
 import org.apache.flink.connector.base.sink.writer.BufferedRequestState;
 import org.apache.flink.connector.base.sink.writer.ElementConverter;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.firehose.model.Record;
 
 import java.io.IOException;
@@ -31,7 +31,7 @@ import static org.apache.flink.connector.base.sink.writer.AsyncSinkWriterTestUti
 import static org.apache.flink.connector.base.sink.writer.AsyncSinkWriterTestUtils.getTestState;
 
 /** Test class for {@link KinesisFirehoseStateSerializer}. */
-public class KinesisFirehoseStateSerializerTest {
+class KinesisFirehoseStateSerializerTest {
 
     private static final ElementConverter<String, Record> ELEMENT_CONVERTER =
             KinesisFirehoseSinkElementConverter.<String>builder()
@@ -39,7 +39,7 @@ public class KinesisFirehoseStateSerializerTest {
                     .build();
 
     @Test
-    public void testSerializeAndDeserialize() throws IOException {
+    void testSerializeAndDeserialize() throws IOException {
         BufferedRequestState<Record> expectedState =
                 getTestState(ELEMENT_CONVERTER, this::getRequestSize);
 

--- a/flink-connectors/flink-connector-aws-kinesis-firehose/src/test/java/org/apache/flink/connector/firehose/table/KinesisFirehoseDynamicTableFactoryTest.java
+++ b/flink-connectors/flink-connector-aws-kinesis-firehose/src/test/java/org/apache/flink/connector/firehose/table/KinesisFirehoseDynamicTableFactoryTest.java
@@ -29,10 +29,9 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.factories.TableOptionsBuilder;
 import org.apache.flink.table.factories.TestFormatFactory;
 import org.apache.flink.table.runtime.connector.sink.SinkRuntimeProviderContext;
-import org.apache.flink.util.TestLogger;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 import java.util.Properties;
@@ -43,11 +42,11 @@ import static org.apache.flink.table.factories.utils.FactoryMocks.createTableSin
  * Test for {@link KinesisFirehoseDynamicSink} created by {@link
  * KinesisFirehoseDynamicTableFactory}.
  */
-public class KinesisFirehoseDynamicTableFactoryTest extends TestLogger {
+class KinesisFirehoseDynamicTableFactoryTest {
     private static final String DELIVERY_STREAM_NAME = "myDeliveryStream";
 
     @Test
-    public void testGoodTableSink() {
+    void testGoodTableSink() {
         ResolvedSchema sinkSchema = defaultSinkSchema();
         Map<String, String> sinkOptions = defaultTableOptions().build();
 
@@ -74,7 +73,7 @@ public class KinesisFirehoseDynamicTableFactoryTest extends TestLogger {
     }
 
     @Test
-    public void testGoodTableSinkWithSinkOptions() {
+    void testGoodTableSinkWithSinkOptions() {
         ResolvedSchema sinkSchema = defaultSinkSchema();
         Map<String, String> sinkOptions = defaultTableOptionsWithSinkOptions().build();
 

--- a/flink-connectors/flink-connector-aws-kinesis-firehose/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/flink-connectors/flink-connector-aws-kinesis-firehose/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.util.TestLoggerExtension


### PR DESCRIPTION
## What is the purpose of the change

Update the flink-connector-aws-kinesis-firehose module to AssertJ and JUnit 5 following the [JUnit 5 Migration Guide](https://docs.google.com/document/d/1514Wa_aNB9bJUen4xm5uiuXOooOJTtXqS_Jqk9KJitU/edit)

## Brief change log

Use JUnit5 and AssertJ in tests instead of JUnit4


## Verifying this change
This change is a code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): ( no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no )
  - The S3 file system connector: ( no )

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
