### PR TITLE
[FLINK-27567][tests] Migrate module flink-connector-aws-kinesis-streams to JUnit5

### DIFF
--- a/flink-connectors/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/sink/KinesisStreamsSinkBuilderTest.java
+++ b/flink-connectors/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/sink/KinesisStreamsSinkBuilderTest.java
@@ -21,17 +21,17 @@ import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.api.common.serialization.SimpleStringSchema;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Covers construction, defaults and sanity checking of KinesisStreamsSinkBuilder. */
-public class KinesisStreamsSinkBuilderTest {
+class KinesisStreamsSinkBuilderTest {
     private static final SerializationSchema<String> SERIALIZATION_SCHEMA =
             new SimpleStringSchema();
     private static final PartitionKeyGenerator<String> PARTITION_KEY_GENERATOR =
             element -> String.valueOf(element.hashCode());
 
     @Test
-    public void elementConverterOfSinkMustBeSetWhenBuilt() {
+    void elementConverterOfSinkMustBeSetWhenBuilt() {
         Assertions.assertThatExceptionOfType(NullPointerException.class)
                 .isThrownBy(() -> KinesisStreamsSink.builder().setStreamName("stream").build())
                 .withMessageContaining(
@@ -39,7 +39,7 @@ public class KinesisStreamsSinkBuilderTest {
     }
 
     @Test
-    public void streamNameOfSinkMustBeSetWhenBuilt() {
+    void streamNameOfSinkMustBeSetWhenBuilt() {
         Assertions.assertThatExceptionOfType(NullPointerException.class)
                 .isThrownBy(
                         () ->
@@ -52,7 +52,7 @@ public class KinesisStreamsSinkBuilderTest {
     }
 
     @Test
-    public void streamNameOfSinkMustBeSetToNonEmptyWhenBuilt() {
+    void streamNameOfSinkMustBeSetToNonEmptyWhenBuilt() {
         Assertions.assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(
                         () ->
@@ -66,7 +66,7 @@ public class KinesisStreamsSinkBuilderTest {
     }
 
     @Test
-    public void serializationSchemaMustBeSetWhenSinkIsBuilt() {
+    void serializationSchemaMustBeSetWhenSinkIsBuilt() {
         Assertions.assertThatExceptionOfType(NullPointerException.class)
                 .isThrownBy(
                         () ->
@@ -79,7 +79,7 @@ public class KinesisStreamsSinkBuilderTest {
     }
 
     @Test
-    public void partitionKeyGeneratorMustBeSetWhenSinkIsBuilt() {
+    void partitionKeyGeneratorMustBeSetWhenSinkIsBuilt() {
         Assertions.assertThatExceptionOfType(NullPointerException.class)
                 .isThrownBy(
                         () ->

--- a/flink-connectors/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/sink/KinesisStreamsStateSerializerTest.java
+++ b/flink-connectors/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/sink/KinesisStreamsStateSerializerTest.java
@@ -22,7 +22,7 @@ import org.apache.flink.api.common.serialization.SimpleStringSchema;
 import org.apache.flink.connector.base.sink.writer.BufferedRequestState;
 import org.apache.flink.connector.base.sink.writer.ElementConverter;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.kinesis.model.PutRecordsRequestEntry;
 
 import java.io.IOException;
@@ -31,7 +31,7 @@ import static org.apache.flink.connector.base.sink.writer.AsyncSinkWriterTestUti
 import static org.apache.flink.connector.base.sink.writer.AsyncSinkWriterTestUtils.getTestState;
 
 /** Test class for {@link KinesisStreamsStateSerializer}. */
-public class KinesisStreamsStateSerializerTest {
+class KinesisStreamsStateSerializerTest {
 
     private static final ElementConverter<String, PutRecordsRequestEntry> ELEMENT_CONVERTER =
             KinesisStreamsSinkElementConverter.<String>builder()
@@ -40,7 +40,7 @@ public class KinesisStreamsStateSerializerTest {
                     .build();
 
     @Test
-    public void testSerializeAndDeserialize() throws IOException {
+    void testSerializeAndDeserialize() throws IOException {
         BufferedRequestState<PutRecordsRequestEntry> expectedState =
                 getTestState(ELEMENT_CONVERTER, this::getRequestSize);
 

--- a/flink-connectors/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/table/KinesisDynamicTableSinkFactoryTest.java
+++ b/flink-connectors/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/table/KinesisDynamicTableSinkFactoryTest.java
@@ -32,10 +32,9 @@ import org.apache.flink.table.factories.TestFormatFactory;
 import org.apache.flink.table.runtime.connector.sink.SinkRuntimeProviderContext;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.RowType;
-import org.apache.flink.util.TestLogger;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
@@ -51,11 +50,11 @@ import static org.apache.flink.connector.kinesis.table.KinesisConnectorOptions.S
 import static org.apache.flink.table.factories.utils.FactoryMocks.createTableSink;
 
 /** Test for {@link KinesisDynamicSink} created by {@link KinesisDynamicTableSinkFactory}. */
-public class KinesisDynamicTableSinkFactoryTest extends TestLogger {
+class KinesisDynamicTableSinkFactoryTest {
     private static final String STREAM_NAME = "myStream";
 
     @Test
-    public void testGoodTableSinkForPartitionedTable() {
+    void testGoodTableSinkForPartitionedTable() {
         ResolvedSchema sinkSchema = defaultSinkSchema();
         DataType physicalDataType = sinkSchema.toPhysicalRowDataType();
         Map<String, String> sinkOptions = defaultTableOptions().build();
@@ -89,7 +88,7 @@ public class KinesisDynamicTableSinkFactoryTest extends TestLogger {
     }
 
     @Test
-    public void testGoodTableSinkCopyForPartitionedTable() {
+    void testGoodTableSinkCopyForPartitionedTable() {
         ResolvedSchema sinkSchema = defaultSinkSchema();
         DataType physicalDataType = sinkSchema.toPhysicalRowDataType();
         Map<String, String> sinkOptions = defaultTableOptions().build();
@@ -117,7 +116,7 @@ public class KinesisDynamicTableSinkFactoryTest extends TestLogger {
     }
 
     @Test
-    public void testGoodTableSinkForNonPartitionedTable() {
+    void testGoodTableSinkForNonPartitionedTable() {
         ResolvedSchema sinkSchema = defaultSinkSchema();
         Map<String, String> sinkOptions = defaultTableOptions().build();
 
@@ -146,7 +145,7 @@ public class KinesisDynamicTableSinkFactoryTest extends TestLogger {
     }
 
     @Test
-    public void testGoodTableSinkForNonPartitionedTableWithSinkOptions() {
+    void testGoodTableSinkForNonPartitionedTableWithSinkOptions() {
         ResolvedSchema sinkSchema = defaultSinkSchema();
         Map<String, String> sinkOptions = defaultTableOptionsWithSinkOptions().build();
 
@@ -175,7 +174,7 @@ public class KinesisDynamicTableSinkFactoryTest extends TestLogger {
     }
 
     @Test
-    public void testGoodTableSinkForNonPartitionedTableWithProducerOptions() {
+    void testGoodTableSinkForNonPartitionedTableWithProducerOptions() {
         ResolvedSchema sinkSchema = defaultSinkSchema();
         Map<String, String> sinkOptions = defaultTableOptionsWithDeprecatedOptions().build();
 
@@ -209,7 +208,7 @@ public class KinesisDynamicTableSinkFactoryTest extends TestLogger {
     }
 
     @Test
-    public void testBadTableSinkForCustomPartitionerForPartitionedTable() {
+    void testBadTableSinkForCustomPartitionerForPartitionedTable() {
         ResolvedSchema sinkSchema = defaultSinkSchema();
         Map<String, String> sinkOptions =
                 defaultTableOptions()
@@ -229,7 +228,7 @@ public class KinesisDynamicTableSinkFactoryTest extends TestLogger {
     }
 
     @Test
-    public void testBadTableSinkForNonExistingPartitionerClass() {
+    void testBadTableSinkForNonExistingPartitionerClass() {
         ResolvedSchema sinkSchema = defaultSinkSchema();
         Map<String, String> sinkOptions =
                 defaultTableOptions()

--- a/flink-connectors/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/table/util/KinesisProducerOptionsMapperTest.java
+++ b/flink-connectors/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/table/util/KinesisProducerOptionsMapperTest.java
@@ -20,19 +20,18 @@ package org.apache.flink.connector.kinesis.table.util;
 
 import org.apache.flink.connector.aws.config.AWSConfigConstants;
 import org.apache.flink.connector.kinesis.table.util.KinesisStreamsConnectorOptionsUtils.KinesisProducerOptionsMapper;
-import org.apache.flink.util.TestLogger;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
 /** Unit tests for {@link KinesisProducerOptionsMapper}. */
-public class KinesisProducerOptionsMapperTest extends TestLogger {
+class KinesisProducerOptionsMapperTest {
 
     @Test
-    public void testProducerVerifyCertificateOptionsMapping() {
+    void testProducerVerifyCertificateOptionsMapping() {
         Map<String, String> deprecatedOptions = new HashMap<>();
         deprecatedOptions.put("sink.producer.verify-certificate", "false");
         Map<String, String> expectedOptions = new HashMap<>();
@@ -48,7 +47,7 @@ public class KinesisProducerOptionsMapperTest extends TestLogger {
     }
 
     @Test
-    public void testProducerEndpointExtraction() {
+    void testProducerEndpointExtraction() {
         Map<String, String> deprecatedOptions = new HashMap<>();
         Map<String, String> expectedOptions = new HashMap<>();
         deprecatedOptions.put("sink.producer.kinesis-endpoint", "some-end-point.kinesis");
@@ -63,7 +62,7 @@ public class KinesisProducerOptionsMapperTest extends TestLogger {
     }
 
     @Test
-    public void testProducerEndpointAndPortExtraction() {
+    void testProducerEndpointAndPortExtraction() {
         Map<String, String> deprecatedOptions = new HashMap<>();
         Map<String, String> expectedOptions = new HashMap<>();
         deprecatedOptions.put("sink.producer.kinesis-endpoint", "some-end-point.kinesis");

--- a/flink-connectors/flink-connector-aws-kinesis-streams/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/flink-connectors/flink-connector-aws-kinesis-streams/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.util.TestLoggerExtension


### PR DESCRIPTION
## What is the purpose of the change

Update the flink-connector-aws-kinesis-streams module to AssertJ and JUnit 5 following the [JUnit 5 Migration Guide](https://docs.google.com/document/d/1514Wa_aNB9bJUen4xm5uiuXOooOJTtXqS_Jqk9KJitU/edit)


## Brief change log

Use JUnit5 and AssertJ in tests instead of JUnit4 and Hamcrest


## Verifying this change

This change is a code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
