### PR TITLE
[hotfix][table] avoid NPE and add more UTs. 

### DIFF
--- a/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/JavaCodeSplitter.java
+++ b/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/JavaCodeSplitter.java
@@ -32,12 +32,8 @@ public class JavaCodeSplitter {
 
     public static String split(String code, int maxMethodLength, int maxClassMemberCount) {
         try {
-            if (code.length() <= maxMethodLength) {
-                return code;
-            }
             return splitImpl(code, maxMethodLength, maxClassMemberCount);
         } catch (Throwable t) {
-            System.out.println(code);
             throw new RuntimeException(
                     "JavaCodeSplitter failed. This is a bug. Please file an issue.", t);
         }
@@ -45,8 +41,12 @@ public class JavaCodeSplitter {
 
     private static String splitImpl(String code, int maxMethodLength, int maxClassMemberCount) {
         checkArgument(code != null && !code.isEmpty(), "code cannot be empty");
-        checkArgument(maxMethodLength > 0);
-        checkArgument(maxClassMemberCount > 0);
+        checkArgument(maxMethodLength > 0, "maxMethodLength must be greater than 0");
+        checkArgument(maxClassMemberCount > 0, "maxClassMemberCount must be greater than 0");
+
+        if (code.length() <= maxMethodLength) {
+            return code;
+        }
 
         String returnValueRewrittenCode = new ReturnValueRewriter(code, maxMethodLength).rewrite();
         return Optional.ofNullable(

--- a/flink-table/flink-table-code-splitter/src/test/java/org/apache/flink/table/codesplit/JavaCodeSplitterTest.java
+++ b/flink-table/flink-table-code-splitter/src/test/java/org/apache/flink/table/codesplit/JavaCodeSplitterTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import java.io.File;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.HamcrestCondition.matching;
 
 /** Tests for {@link JavaCodeSplitter}. */
@@ -51,6 +52,38 @@ public class JavaCodeSplitterTest {
                                     FlinkMatchers.containsMessage(
                                             "JavaCodeSplitter failed. This is a bug. Please file an issue.")));
         }
+    }
+
+    @Test
+    public void testNullCode() {
+        assertThatThrownBy(() -> JavaCodeSplitter.split(null, 4000, 10000))
+                .getCause()
+                .hasMessage("code cannot be empty");
+    }
+
+    @Test
+    public void testEmptyCode() {
+        assertThatThrownBy(() -> JavaCodeSplitter.split("", 4000, 10000))
+                .getCause()
+                .hasMessage("code cannot be empty");
+    }
+
+    @Test
+    public void testWrongMaxMethodLength() {
+        assertThatThrownBy(
+                        () ->
+                                JavaCodeSplitter.split(
+                                        "public interface DummyInterface {}", 0, 10000))
+                .getCause()
+                .hasMessage("maxMethodLength must be greater than 0");
+    }
+
+    @Test
+    public void testWrongMaxClassMemberCount() {
+        assertThatThrownBy(
+                        () -> JavaCodeSplitter.split("public interface DummyInterface {}", 10, 0))
+                .getCause()
+                .hasMessage("maxClassMemberCount must be greater than 0");
     }
 
     private void runTest(String filename, int maxLength, int maxMembers) {


### PR DESCRIPTION
## What is the purpose of the change

improve the code quality while reading and understanding how code gen works.


## Brief change log

  -  move code length check into splitImpl(...) method to avoid NPE. 
  -  add more UTs to test argument check logics.
  - remove System.out.println() call.

## Verifying this change

This change is already covered by existing tests, such as JavaCodeSplitterTest.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)