### PR TITLE
[FLINK-27421][python] Bundle test utility classes

### DIFF
--- a/flink-python/setup.py
+++ b/flink-python/setup.py
@@ -280,7 +280,8 @@ try:
                 'pyflink.conf',
                 'pyflink.log',
                 'pyflink.examples',
-                'pyflink.bin']
+                'pyflink.bin',
+                'pyflink.testing']
 
     PACKAGE_DIR = {
         'pyflink.conf': TEMP_PATH + '/conf',


### PR DESCRIPTION
## What is the purpose of the change

Bundle test utility classes into the PyFlink package to make users write test cases easily.

## Brief change log

  - *set `pyflink.testing` package `into setup.py` *

## Verifying this change

Change build script, no test case.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (xno)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
