### PR TITLE
[FLINK-24786][state] Introduce and expose RocksDB statistics as metrics

### DIFF
--- a/docs/content.zh/docs/deployment/config.md
+++ b/docs/content.zh/docs/deployment/config.md
@@ -264,7 +264,9 @@ Please refer to the [metrics system documentation]({{< ref "docs/ops/metrics" >}
 ### RocksDB Native Metrics
 
 Flink can report metrics from RocksDB's native code, for applications using the RocksDB state backend.
-The metrics here are scoped to the operators and then further broken down by column family; values are reported as unsigned longs. 
+The metrics here are scoped to the operators with unsigned longs and have two kinds of types：
+1. RocksDB property-based metrics, which is broken down by column family, e.g. number of currently running compactions of one specific column family.
+2. RocksDB statistics-based metrics, which holds at the database level, e.g. total block cache hit count within the DB.
 
 {{< hint warning >}}
 Enabling RocksDB's native metrics may cause degraded performance and should be set carefully. 

--- a/docs/content/docs/deployment/config.md
+++ b/docs/content/docs/deployment/config.md
@@ -266,7 +266,9 @@ Please refer to the [metrics system documentation]({{< ref "docs/ops/metrics" >}
 ### RocksDB Native Metrics
 
 Flink can report metrics from RocksDB's native code, for applications using the RocksDB state backend.
-The metrics here are scoped to the operators and then further broken down by column family; values are reported as unsigned longs. 
+The metrics here are scoped to the operators with unsigned longs and have two kinds of types：
+1. RocksDB property-based metrics, which is broken down by column family, e.g. number of currently running compactions of one specific column family.
+2. RocksDB statistics-based metrics, which holds at the database level, e.g. total block cache hit count within the DB.
 
 {{< hint warning >}}
 Enabling RocksDB's native metrics may cause degraded performance and should be set carefully. 

--- a/docs/layouts/shortcodes/generated/rocksdb_native_metric_configuration.html
+++ b/docs/layouts/shortcodes/generated/rocksdb_native_metric_configuration.html
@@ -27,6 +27,18 @@
             <td>Monitor block cache capacity.</td>
         </tr>
         <tr>
+            <td><h5>state.backend.rocksdb.metrics.block-cache-hit</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Monitor the total count of block cache hit in RocksDB (BLOCK_CACHE_HIT == BLOCK_CACHE_INDEX_HIT + BLOCK_CACHE_FILTER_HIT + BLOCK_CACHE_DATA_HIT).</td>
+        </tr>
+        <tr>
+            <td><h5>state.backend.rocksdb.metrics.block-cache-miss</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Monitor the total count of block cache misses in RocksDB (BLOCK_CACHE_MISS == BLOCK_CACHE_INDEX_MISS + BLOCK_CACHE_FILTER_MISS + BLOCK_CACHE_DATA_MISS).</td>
+        </tr>
+        <tr>
             <td><h5>state.backend.rocksdb.metrics.block-cache-pinned-usage</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
@@ -39,16 +51,40 @@
             <td>Monitor the memory size for the entries residing in block cache.</td>
         </tr>
         <tr>
+            <td><h5>state.backend.rocksdb.metrics.bytes-read</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Monitor the number of uncompressed bytes read (from memtables/cache/sst) from Get() operation in RocksDB.</td>
+        </tr>
+        <tr>
+            <td><h5>state.backend.rocksdb.metrics.bytes-written</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Monitor the number of uncompressed bytes written by DB::{Put(), Delete(), Merge(), Write()} operations, which does not include the compaction written bytes, in RocksDB.</td>
+        </tr>
+        <tr>
             <td><h5>state.backend.rocksdb.metrics.column-family-as-variable</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
-            <td>Whether to expose the column family as a variable.</td>
+            <td>Whether to expose the column family as a variable for RocksDB property based metrics.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.metrics.compaction-pending</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
             <td>Track pending compactions in RocksDB. Returns 1 if a compaction is pending, 0 otherwise.</td>
+        </tr>
+        <tr>
+            <td><h5>state.backend.rocksdb.metrics.compaction-read-bytes</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Monitor the bytes read during compaction in RocksDB.</td>
+        </tr>
+        <tr>
+            <td><h5>state.backend.rocksdb.metrics.compaction-write-bytes</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Monitor the bytes written during compaction in RocksDB.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.metrics.cur-size-active-mem-table</h5></td>
@@ -91,6 +127,12 @@
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
             <td>Track whether write has been stopped in RocksDB. Returns 1 if write has been stopped, 0 otherwise.</td>
+        </tr>
+        <tr>
+            <td><h5>state.backend.rocksdb.metrics.iter-bytes-read</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Monitor the number of uncompressed bytes read (from memtables/cache/sst) from an iterator operation in RocksDB.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.metrics.live-sst-files-size</h5></td>
@@ -163,6 +205,12 @@
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
             <td>Monitor the approximate size of the active, unflushed immutable, and pinned immutable memtables in bytes.</td>
+        </tr>
+        <tr>
+            <td><h5>state.backend.rocksdb.metrics.stall-micros</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Monitor the duration of writer requiring to wait for compaction or flush to finish in RocksDB.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.metrics.total-sst-files-size</h5></td>

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackendBuilder.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackendBuilder.java
@@ -114,7 +114,9 @@ public class RocksDBKeyedStateBackendBuilder<K> extends AbstractKeyedStateBacken
     /** True if incremental checkpointing is enabled. */
     private boolean enableIncrementalCheckpointing;
 
+    /** RocksDB property-based and statistics-based native metrics options. */
     private RocksDBNativeMetricOptions nativeMetricOptions;
+
     private int numberOfTransferingThreads;
     private long writeBatchSize =
             RocksDBConfigurableOptions.WRITE_BATCH_SIZE.defaultValue().getBytes();
@@ -309,7 +311,7 @@ public class RocksDBKeyedStateBackendBuilder<K> extends AbstractKeyedStateBacken
                 nativeMetricMonitor =
                         nativeMetricOptions.isEnabled()
                                 ? new RocksDBNativeMetricMonitor(
-                                        nativeMetricOptions, metricGroup, db)
+                                        nativeMetricOptions, metricGroup, db, null)
                                 : null;
             } else {
                 prepareDirectories();

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBNativeMetricMonitor.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBNativeMetricMonitor.java
@@ -26,10 +26,13 @@ import org.apache.flink.metrics.View;
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.RocksDB;
 import org.rocksdb.RocksDBException;
+import org.rocksdb.Statistics;
+import org.rocksdb.TickerType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 
 import java.io.Closeable;
@@ -54,15 +57,32 @@ public class RocksDBNativeMetricMonitor implements Closeable {
     @GuardedBy("lock")
     private RocksDB rocksDB;
 
+    @Nullable
+    @GuardedBy("lock")
+    private Statistics statistics;
+
     public RocksDBNativeMetricMonitor(
             @Nonnull RocksDBNativeMetricOptions options,
             @Nonnull MetricGroup metricGroup,
-            @Nonnull RocksDB rocksDB) {
+            @Nonnull RocksDB rocksDB,
+            @Nullable Statistics statistics) {
         this.options = options;
         this.metricGroup = metricGroup;
         this.rocksDB = rocksDB;
-
+        this.statistics = statistics;
         this.lock = new Object();
+        registerStatistics();
+    }
+
+    /** Register gauges to pull native metrics for the database. */
+    private void registerStatistics() {
+        if (statistics != null) {
+            for (TickerType tickerType : options.getMonitorTickerTypes()) {
+                metricGroup.gauge(
+                        String.format("rocksdb.%s", tickerType.name().toLowerCase()),
+                        new RocksDBNativeStatisticsMetricView(tickerType));
+            }
+        }
     }
 
     /**
@@ -80,27 +100,38 @@ public class RocksDBNativeMetricMonitor implements Closeable {
                         : metricGroup.addGroup(columnFamilyName);
 
         for (String property : options.getProperties()) {
-            RocksDBNativeMetricView gauge = new RocksDBNativeMetricView(handle, property);
+            RocksDBNativePropertyMetricView gauge =
+                    new RocksDBNativePropertyMetricView(handle, property);
             group.gauge(property, gauge);
         }
     }
 
     /** Updates the value of metricView if the reference is still valid. */
-    private void setProperty(
-            ColumnFamilyHandle handle, String property, RocksDBNativeMetricView metricView) {
+    private void setProperty(RocksDBNativePropertyMetricView metricView) {
         if (metricView.isClosed()) {
             return;
         }
         try {
             synchronized (lock) {
                 if (rocksDB != null) {
-                    long value = rocksDB.getLongProperty(handle, property);
+                    long value = rocksDB.getLongProperty(metricView.handle, metricView.property);
                     metricView.setValue(value);
                 }
             }
         } catch (RocksDBException e) {
             metricView.close();
-            LOG.warn("Failed to read native metric {} from RocksDB.", property, e);
+            LOG.warn("Failed to read native metric {} from RocksDB.", metricView.property, e);
+        }
+    }
+
+    private void setStatistics(RocksDBNativeStatisticsMetricView metricView) {
+        if (metricView.isClosed()) {
+            return;
+        }
+        if (statistics != null) {
+            synchronized (lock) {
+                metricView.setValue(statistics.getTickerCount(metricView.tickerType));
+            }
         }
     }
 
@@ -108,31 +139,46 @@ public class RocksDBNativeMetricMonitor implements Closeable {
     public void close() {
         synchronized (lock) {
             rocksDB = null;
+            statistics = null;
+        }
+    }
+
+    abstract static class RocksDBNativeView implements View {
+        private boolean closed;
+
+        RocksDBNativeView() {
+            this.closed = false;
+        }
+
+        void close() {
+            closed = true;
+        }
+
+        boolean isClosed() {
+            return closed;
         }
     }
 
     /**
-     * A gauge which periodically pulls a RocksDB native metric for the specified column family /
-     * metric pair.
+     * A gauge which periodically pulls a RocksDB property-based native metric for the specified
+     * column family / metric pair.
      *
      * <p><strong>Note</strong>: As the returned property is of type {@code uint64_t} on C++ side
      * the returning value can be negative. Because java does not support unsigned long types, this
      * gauge wraps the result in a {@link BigInteger}.
      */
-    class RocksDBNativeMetricView implements Gauge<BigInteger>, View {
+    class RocksDBNativePropertyMetricView extends RocksDBNativeView implements Gauge<BigInteger> {
         private final String property;
 
         private final ColumnFamilyHandle handle;
 
         private BigInteger bigInteger;
 
-        private boolean closed;
-
-        private RocksDBNativeMetricView(ColumnFamilyHandle handle, @Nonnull String property) {
+        private RocksDBNativePropertyMetricView(
+                ColumnFamilyHandle handle, @Nonnull String property) {
             this.handle = handle;
             this.property = property;
             this.bigInteger = BigInteger.ZERO;
-            this.closed = false;
         }
 
         public void setValue(long value) {
@@ -149,14 +195,6 @@ public class RocksDBNativeMetricMonitor implements Closeable {
             }
         }
 
-        public void close() {
-            closed = true;
-        }
-
-        public boolean isClosed() {
-            return closed;
-        }
-
         @Override
         public BigInteger getValue() {
             return bigInteger;
@@ -164,7 +202,33 @@ public class RocksDBNativeMetricMonitor implements Closeable {
 
         @Override
         public void update() {
-            setProperty(handle, property, this);
+            setProperty(this);
+        }
+    }
+
+    /**
+     * A gauge which periodically pulls a RocksDB statistics-based native metric for the database.
+     */
+    class RocksDBNativeStatisticsMetricView extends RocksDBNativeView implements Gauge<Long> {
+        private final TickerType tickerType;
+        private long value;
+
+        private RocksDBNativeStatisticsMetricView(TickerType tickerType) {
+            this.tickerType = tickerType;
+        }
+
+        @Override
+        public Long getValue() {
+            return value;
+        }
+
+        void setValue(long value) {
+            this.value = value;
+        }
+
+        @Override
+        public void update() {
+            setStatistics(this);
         }
     }
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBResourceContainer.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBResourceContainer.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.contrib.streaming.state;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ReadableConfig;
@@ -34,6 +35,7 @@ import org.rocksdb.Filter;
 import org.rocksdb.IndexType;
 import org.rocksdb.PlainTableConfig;
 import org.rocksdb.ReadOptions;
+import org.rocksdb.Statistics;
 import org.rocksdb.TableFormatConfig;
 import org.rocksdb.WriteOptions;
 import org.slf4j.Logger;
@@ -73,35 +75,42 @@ public final class RocksDBResourceContainer implements AutoCloseable {
      */
     @Nullable private final OpaqueMemoryResource<RocksDBSharedResources> sharedResources;
 
+    private final boolean enableStatistics;
+
     /** The handles to be closed when the container is closed. */
     private final ArrayList<AutoCloseable> handlesToClose;
 
+    @VisibleForTesting
     public RocksDBResourceContainer() {
-        this(new Configuration(), PredefinedOptions.DEFAULT, null, null);
+        this(new Configuration(), PredefinedOptions.DEFAULT, null, null, false);
     }
 
+    @VisibleForTesting
     public RocksDBResourceContainer(
             PredefinedOptions predefinedOptions, @Nullable RocksDBOptionsFactory optionsFactory) {
-        this(new Configuration(), predefinedOptions, optionsFactory, null);
+        this(new Configuration(), predefinedOptions, optionsFactory, null, false);
     }
 
+    @VisibleForTesting
     public RocksDBResourceContainer(
             PredefinedOptions predefinedOptions,
             @Nullable RocksDBOptionsFactory optionsFactory,
             @Nullable OpaqueMemoryResource<RocksDBSharedResources> sharedResources) {
-        this(new Configuration(), predefinedOptions, optionsFactory, sharedResources);
+        this(new Configuration(), predefinedOptions, optionsFactory, sharedResources, false);
     }
 
     public RocksDBResourceContainer(
             ReadableConfig configuration,
             PredefinedOptions predefinedOptions,
             @Nullable RocksDBOptionsFactory optionsFactory,
-            @Nullable OpaqueMemoryResource<RocksDBSharedResources> sharedResources) {
+            @Nullable OpaqueMemoryResource<RocksDBSharedResources> sharedResources,
+            boolean enableStatistics) {
 
         this.configuration = configuration;
         this.predefinedOptions = checkNotNull(predefinedOptions);
         this.optionsFactory = optionsFactory;
         this.sharedResources = sharedResources;
+        this.enableStatistics = enableStatistics;
         this.handlesToClose = new ArrayList<>();
     }
 
@@ -125,6 +134,12 @@ public final class RocksDBResourceContainer implements AutoCloseable {
         // if sharedResources is non-null, use the write buffer manager from it.
         if (sharedResources != null) {
             opt.setWriteBufferManager(sharedResources.getResourceHandle().getWriteBufferManager());
+        }
+
+        if (enableStatistics) {
+            Statistics statistics = new Statistics();
+            opt.setStatistics(statistics);
+            handlesToClose.add(statistics);
         }
 
         return opt;

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBHandle.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBHandle.java
@@ -143,7 +143,8 @@ class RocksDBHandle implements AutoCloseable {
         // init native metrics monitor if configured
         nativeMetricMonitor =
                 nativeMetricOptions.isEnabled()
-                        ? new RocksDBNativeMetricMonitor(nativeMetricOptions, metricGroup, db)
+                        ? new RocksDBNativeMetricMonitor(
+                                nativeMetricOptions, metricGroup, db, dbOptions.statistics())
                         : null;
     }
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBNativeMetricMonitorTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBNativeMetricMonitorTest.java
@@ -31,9 +31,11 @@ import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.RocksDBException;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
+import java.util.List;
 
 /** validate native metric monitor. */
 public class RocksDBNativeMetricMonitorTest {
@@ -42,14 +44,14 @@ public class RocksDBNativeMetricMonitorTest {
 
     private static final String COLUMN_FAMILY_NAME = "column-family";
 
-    @Rule public RocksDBResource rocksDBResource = new RocksDBResource();
+    @Rule public RocksDBResource rocksDBResource = new RocksDBResource(true);
 
     @Test
     public void testMetricMonitorLifecycle() throws Throwable {
         // We use a local variable here to manually control the life-cycle.
         // This allows us to verify that metrics do not try to access
         // RocksDB after the monitor was closed.
-        RocksDBResource localRocksDBResource = new RocksDBResource();
+        RocksDBResource localRocksDBResource = new RocksDBResource(true);
         localRocksDBResource.before();
 
         SimpleMetricRegistry registry = new SimpleMetricRegistry();
@@ -64,24 +66,38 @@ public class RocksDBNativeMetricMonitorTest {
         // value since empty memtables
         // have overhead.
         options.enableSizeAllMemTables();
+        options.enableNativeStatistics(RocksDBNativeMetricOptions.MONITOR_BYTES_WRITTEN);
 
         RocksDBNativeMetricMonitor monitor =
-                new RocksDBNativeMetricMonitor(options, group, localRocksDBResource.getRocksDB());
+                new RocksDBNativeMetricMonitor(
+                        options,
+                        group,
+                        localRocksDBResource.getRocksDB(),
+                        localRocksDBResource.getDbOptions().statistics());
 
         ColumnFamilyHandle handle = localRocksDBResource.createNewColumnFamily(COLUMN_FAMILY_NAME);
         monitor.registerColumnFamily(COLUMN_FAMILY_NAME, handle);
 
         Assert.assertEquals(
-                "Failed to register metrics for column family", 1, registry.metrics.size());
+                "Failed to register metrics for column family", 1, registry.propertyMetrics.size());
 
-        RocksDBNativeMetricMonitor.RocksDBNativeMetricView view = registry.metrics.get(0);
+        // write something to ensure the bytes-written is not zero.
+        localRocksDBResource.getRocksDB().put(new byte[4], new byte[10]);
 
-        view.update();
+        for (RocksDBNativeMetricMonitor.RocksDBNativePropertyMetricView view :
+                registry.propertyMetrics) {
+            view.update();
+            Assert.assertNotEquals(
+                    "Failed to pull metric from RocksDB", BigInteger.ZERO, view.getValue());
+            view.setValue(0L);
+        }
 
-        Assert.assertNotEquals(
-                "Failed to pull metric from RocksDB", BigInteger.ZERO, view.getValue());
-
-        view.setValue(0L);
+        for (RocksDBNativeMetricMonitor.RocksDBNativeStatisticsMetricView view :
+                registry.statisticsMetrics) {
+            view.update();
+            Assert.assertNotEquals(0L, (long) view.getValue());
+            view.setValue(0L);
+        }
 
         // After the monitor is closed no metric should be accessing RocksDB anymore.
         // If they do, then this test will likely fail with a segmentation fault.
@@ -89,10 +105,18 @@ public class RocksDBNativeMetricMonitorTest {
 
         localRocksDBResource.after();
 
-        view.update();
+        for (RocksDBNativeMetricMonitor.RocksDBNativePropertyMetricView view :
+                registry.propertyMetrics) {
+            view.update();
+            Assert.assertEquals(
+                    "Failed to release RocksDB reference", BigInteger.ZERO, view.getValue());
+        }
 
-        Assert.assertEquals(
-                "Failed to release RocksDB reference", BigInteger.ZERO, view.getValue());
+        for (RocksDBNativeMetricMonitor.RocksDBNativeStatisticsMetricView view :
+                registry.statisticsMetrics) {
+            view.update();
+            Assert.assertEquals(0L, (long) view.getValue());
+        }
     }
 
     @Test
@@ -111,11 +135,16 @@ public class RocksDBNativeMetricMonitorTest {
         options.enableSizeAllMemTables();
 
         RocksDBNativeMetricMonitor monitor =
-                new RocksDBNativeMetricMonitor(options, group, localRocksDBResource.getRocksDB());
+                new RocksDBNativeMetricMonitor(
+                        options,
+                        group,
+                        localRocksDBResource.getRocksDB(),
+                        localRocksDBResource.getDbOptions().statistics());
 
         ColumnFamilyHandle handle = rocksDBResource.createNewColumnFamily(COLUMN_FAMILY_NAME);
         monitor.registerColumnFamily(COLUMN_FAMILY_NAME, handle);
-        RocksDBNativeMetricMonitor.RocksDBNativeMetricView view = registry.metrics.get(0);
+        RocksDBNativeMetricMonitor.RocksDBNativePropertyMetricView view =
+                registry.propertyMetrics.get(0);
 
         view.setValue(-1);
         BigInteger result = view.getValue();
@@ -127,7 +156,7 @@ public class RocksDBNativeMetricMonitorTest {
     }
 
     @Test
-    public void testClosedGaugesDontRead() {
+    public void testClosedGaugesDontRead() throws RocksDBException {
         SimpleMetricRegistry registry = new SimpleMetricRegistry();
         GenericMetricGroup group =
                 new GenericMetricGroup(
@@ -137,23 +166,42 @@ public class RocksDBNativeMetricMonitorTest {
 
         RocksDBNativeMetricOptions options = new RocksDBNativeMetricOptions();
         options.enableSizeAllMemTables();
+        options.enableNativeStatistics(RocksDBNativeMetricOptions.MONITOR_BLOCK_CACHE_HIT);
 
         RocksDBNativeMetricMonitor monitor =
-                new RocksDBNativeMetricMonitor(options, group, rocksDBResource.getRocksDB());
+                new RocksDBNativeMetricMonitor(
+                        options,
+                        group,
+                        rocksDBResource.getRocksDB(),
+                        rocksDBResource.getDbOptions().statistics());
 
         ColumnFamilyHandle handle = rocksDBResource.createNewColumnFamily(COLUMN_FAMILY_NAME);
         monitor.registerColumnFamily(COLUMN_FAMILY_NAME, handle);
 
-        RocksDBNativeMetricMonitor.RocksDBNativeMetricView view = registry.metrics.get(0);
+        rocksDBResource.getRocksDB().put(new byte[4], new byte[10]);
 
-        view.close();
-        view.update();
+        for (RocksDBNativeMetricMonitor.RocksDBNativePropertyMetricView view :
+                registry.propertyMetrics) {
+            view.close();
+            view.update();
+            Assert.assertEquals(
+                    "Closed gauge still queried RocksDB", BigInteger.ZERO, view.getValue());
+        }
 
-        Assert.assertEquals("Closed gauge still queried RocksDB", BigInteger.ZERO, view.getValue());
+        for (RocksDBNativeMetricMonitor.RocksDBNativeStatisticsMetricView view :
+                registry.statisticsMetrics) {
+            view.close();
+            view.update();
+            Assert.assertEquals("Closed gauge still queried RocksDB", 0L, (long) view.getValue());
+        }
     }
 
     static class SimpleMetricRegistry implements MetricRegistry {
-        ArrayList<RocksDBNativeMetricMonitor.RocksDBNativeMetricView> metrics = new ArrayList<>();
+        List<RocksDBNativeMetricMonitor.RocksDBNativePropertyMetricView> propertyMetrics =
+                new ArrayList<>();
+
+        List<RocksDBNativeMetricMonitor.RocksDBNativeStatisticsMetricView> statisticsMetrics =
+                new ArrayList<>();
 
         @Override
         public char getDelimiter() {
@@ -167,8 +215,13 @@ public class RocksDBNativeMetricMonitorTest {
 
         @Override
         public void register(Metric metric, String metricName, AbstractMetricGroup group) {
-            if (metric instanceof RocksDBNativeMetricMonitor.RocksDBNativeMetricView) {
-                metrics.add((RocksDBNativeMetricMonitor.RocksDBNativeMetricView) metric);
+            if (metric instanceof RocksDBNativeMetricMonitor.RocksDBNativePropertyMetricView) {
+                propertyMetrics.add(
+                        (RocksDBNativeMetricMonitor.RocksDBNativePropertyMetricView) metric);
+            } else if (metric
+                    instanceof RocksDBNativeMetricMonitor.RocksDBNativeStatisticsMetricView) {
+                statisticsMetrics.add(
+                        (RocksDBNativeMetricMonitor.RocksDBNativeStatisticsMetricView) metric);
             }
         }
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
@@ -531,7 +531,7 @@ public class RocksDBStateBackendConfigTest {
 
             try (RocksDBResourceContainer optionsContainer =
                     new RocksDBResourceContainer(
-                            configuration, PredefinedOptions.DEFAULT, null, null)) {
+                            configuration, PredefinedOptions.DEFAULT, null, null, false)) {
 
                 DBOptions dbOptions = optionsContainer.getDbOptions();
                 assertEquals(-1, dbOptions.maxOpenFiles());
@@ -610,7 +610,11 @@ public class RocksDBStateBackendConfigTest {
         configuration.set(RocksDBConfigurableOptions.COMPACTION_STYLE, CompactionStyle.UNIVERSAL);
         try (final RocksDBResourceContainer optionsContainer =
                 new RocksDBResourceContainer(
-                        configuration, PredefinedOptions.SPINNING_DISK_OPTIMIZED, null, null)) {
+                        configuration,
+                        PredefinedOptions.SPINNING_DISK_OPTIMIZED,
+                        null,
+                        null,
+                        false)) {
 
             final ColumnFamilyOptions columnFamilyOptions = optionsContainer.getColumnOptions();
             assertNotNull(columnFamilyOptions);
@@ -622,7 +626,8 @@ public class RocksDBStateBackendConfigTest {
                         new Configuration(),
                         PredefinedOptions.SPINNING_DISK_OPTIMIZED,
                         null,
-                        null)) {
+                        null,
+                        false)) {
 
             final ColumnFamilyOptions columnFamilyOptions = optionsContainer.getColumnOptions();
             assertNotNull(columnFamilyOptions);


### PR DESCRIPTION
## What is the purpose of the change

Introduce and expose RocksDB statistics as metrics.


## Brief change log

  - Introduce RocksDB statistics based metrics.
  - Expose these native metrics via `RocksDBNativeMetricMonitor`.


## Verifying this change

This change added tests and can be verified as follows: `RocksDBNativeMetricMonitorTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
