### PR TITLE
[FLINK-27255] [flink-avro] flink-avro does not support ser/de of larg…

### DIFF
--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/typeutils/GenericRecordAvroTypeInfo.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/typeutils/GenericRecordAvroTypeInfo.java
@@ -28,6 +28,7 @@ import org.apache.avro.generic.GenericRecord;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -104,10 +105,15 @@ public class GenericRecordAvroTypeInfo extends TypeInformation<GenericRecord> {
     }
 
     private void writeObject(ObjectOutputStream oos) throws IOException {
-        oos.writeUTF(schema.toString());
+        byte[] schemaStrInBytes = schema.toString(false).getBytes(StandardCharsets.UTF_8);
+        oos.writeInt(schemaStrInBytes.length);
+        oos.write(schemaStrInBytes);
     }
 
     private void readObject(ObjectInputStream ois) throws ClassNotFoundException, IOException {
-        this.schema = new Schema.Parser().parse(ois.readUTF());
+        int len = ois.readInt();
+        byte[] content = new byte[len];
+        ois.readFully(content);
+        this.schema = new Schema.Parser().parse(new String(content, StandardCharsets.UTF_8));
     }
 }

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroGenericRecordTypeInfoTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroGenericRecordTypeInfoTest.java
@@ -18,38 +18,33 @@
 
 package org.apache.flink.formats.avro.typeutils;
 
-import org.apache.flink.api.common.typeutils.SerializerTestBase;
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeutils.TypeInformationTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.formats.avro.utils.AvroTestUtils;
 
-import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
-import org.apache.avro.generic.GenericRecordBuilder;
+import org.junit.jupiter.api.Test;
 
-/** Test for {@link AvroSerializer} that tests GenericRecord. */
-public class AvroSerializerGenericRecordTest extends SerializerTestBase<GenericRecord> {
+import static org.assertj.core.api.Assertions.assertThat;
 
-    private static final Schema SCHEMA = AvroTestUtils.getSmallSchema();
-
-    @Override
-    protected TypeSerializer<GenericRecord> createSerializer() {
-        return new AvroSerializer<>(GenericRecord.class, SCHEMA);
-    }
+/** Test for {@link GenericRecordAvroTypeInfo}. */
+public class AvroGenericRecordTypeInfoTest
+        extends TypeInformationTestBase<GenericRecordAvroTypeInfo> {
 
     @Override
-    protected int getLength() {
-        return -1;
-    }
-
-    @Override
-    protected Class<GenericRecord> getTypeClass() {
-        return GenericRecord.class;
-    }
-
-    @Override
-    protected GenericRecord[] getTestData() {
-        return new GenericRecord[] {
-            new GenericRecordBuilder(SCHEMA).set("afield", "foo bar").build()
+    protected GenericRecordAvroTypeInfo[] getTestData() {
+        return new GenericRecordAvroTypeInfo[] {
+            new GenericRecordAvroTypeInfo(AvroTestUtils.getSmallSchema()),
+            new GenericRecordAvroTypeInfo(AvroTestUtils.getLargeSchema())
         };
+    }
+
+    @Test
+    void testAvroByDefault() {
+        final TypeSerializer<GenericRecord> serializer =
+                new GenericRecordAvroTypeInfo(AvroTestUtils.getLargeSchema())
+                        .createSerializer(new ExecutionConfig());
+        assertThat(serializer).isInstanceOf(AvroSerializer.class);
     }
 }

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroGenericRecordTypeInfoTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroGenericRecordTypeInfoTest.java
@@ -26,7 +26,7 @@ import org.apache.flink.formats.avro.utils.AvroTestUtils;
 import org.apache.avro.generic.GenericRecord;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertTrue;
 
 /** Test for {@link GenericRecordAvroTypeInfo}. */
 public class AvroGenericRecordTypeInfoTest
@@ -45,6 +45,6 @@ public class AvroGenericRecordTypeInfoTest
         final TypeSerializer<GenericRecord> serializer =
                 new GenericRecordAvroTypeInfo(AvroTestUtils.getLargeSchema())
                         .createSerializer(new ExecutionConfig());
-        assertThat(serializer).isInstanceOf(AvroSerializer.class);
+        assertTrue(serializer instanceof AvroSerializer);
     }
 }

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroSerializerLargeGenericRecordTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroSerializerLargeGenericRecordTest.java
@@ -27,9 +27,9 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.GenericRecordBuilder;
 
 /** Test for {@link AvroSerializer} that tests GenericRecord. */
-public class AvroSerializerGenericRecordTest extends SerializerTestBase<GenericRecord> {
+public class AvroSerializerLargeGenericRecordTest extends SerializerTestBase<GenericRecord> {
 
-    private static final Schema SCHEMA = AvroTestUtils.getSmallSchema();
+    private static final Schema SCHEMA = AvroTestUtils.getLargeSchema();
 
     @Override
     protected TypeSerializer<GenericRecord> createSerializer() {
@@ -49,7 +49,7 @@ public class AvroSerializerGenericRecordTest extends SerializerTestBase<GenericR
     @Override
     protected GenericRecord[] getTestData() {
         return new GenericRecord[] {
-            new GenericRecordBuilder(SCHEMA).set("afield", "foo bar").build()
+            new GenericRecordBuilder(SCHEMA).set("field1", "foo bar").build()
         };
     }
 }


### PR DESCRIPTION
…e avro schema (https://github.com/apache/flink/pull/19645)

Backporting fix to release branch 1.14, with minor changes to fit the change into 1.14. Original PR: https://github.com/apache/flink/pull/19645