### PR TITLE
[hot-fix][flink-streaming-java] Delete the udfname not used in the reduce function of AllWindowedStream.

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/AllWindowedStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/AllWindowedStream.java
@@ -201,10 +201,6 @@ public class AllWindowedStream<T, W extends Window> {
 
         // clean the closure
         function = input.getExecutionEnvironment().clean(function);
-
-        String callLocation = Utils.getCallLocationName();
-        String udfName = "AllWindowedStream." + callLocation;
-
         return reduce(function, new PassThroughAllWindowFunction<W, T>());
     }
 


### PR DESCRIPTION
Delete the udfname not used in the reduce function of AllWindowedStream.
