### PR TITLE
[FLINK-25645][table-runtime] UnsupportedOperationException would thrown out when hash shuffle by a field with array type

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CodeGenUtils.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CodeGenUtils.scala
@@ -325,10 +325,11 @@ object CodeGenUtils {
         genHashFunction(ctx, subCtx, genHash, term)
       case MULTISET | MAP =>
         val subCtx = new CodeGeneratorContext(ctx.tableConfig, ctx.classLoader)
-        val (keyType, valueType) = if (t.isInstanceOf[MultisetType]) {
-          (t.asInstanceOf[MultisetType].getElementType, new IntType())
-        } else {
-          (t.asInstanceOf[MapType].getKeyType, t.asInstanceOf[MapType].getValueType)
+        val (keyType, valueType) = t match {
+          case multiset: MultisetType =>
+            (multiset.getElementType, new IntType())
+          case map: MapType =>
+            (map.getKeyType, map.getValueType)
         }
         val genHash =
           HashCodeGenerator.generateMapHash(subCtx, keyType, valueType, "SubHashMap")

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
@@ -633,7 +633,7 @@ object GenerateUtils {
     case TIMESTAMP_WITH_TIME_ZONE | MULTISET | MAP =>
       throw new UnsupportedOperationException(
         s"Type($t) is not an orderable data type, " +
-          s"it is not supported as a field in ORDER_BY and sort-based GROUP_BY/JOIN_EQUAL clause.")
+          s"it is not supported as a ORDER_BY/GROUP_BY/JOIN_EQUAL field.")
     // TODO support MULTISET and MAP?
     case ARRAY =>
       val at = t.asInstanceOf[ArrayType]

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
@@ -631,7 +631,10 @@ object GenerateUtils {
         INTERVAL_YEAR_MONTH | INTERVAL_DAY_TIME =>
       s"($leftTerm > $rightTerm ? 1 : $leftTerm < $rightTerm ? -1 : 0)"
     case TIMESTAMP_WITH_TIME_ZONE | MULTISET | MAP =>
-      throw new UnsupportedOperationException() // TODO support MULTISET and MAP?
+      throw new UnsupportedOperationException(
+        s"Type($t) is not an orderable data type, " +
+          s"it is not supported as a field in ORDER_BY and sort-based GROUP_BY/JOIN_EQUAL clause.")
+    // TODO support MULTISET and MAP?
     case ARRAY =>
       val at = t.asInstanceOf[ArrayType]
       val compareFunc = newName("compareArray")

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/AggregateUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/AggregateUtil.scala
@@ -885,7 +885,7 @@ object AggregateUtil extends Enumeration {
         // ordered by type root definition
         case CHAR | VARCHAR | BOOLEAN | DECIMAL | TINYINT | SMALLINT | INTEGER | BIGINT | FLOAT |
             DOUBLE | DATE | TIME_WITHOUT_TIME_ZONE | TIMESTAMP_WITHOUT_TIME_ZONE |
-            TIMESTAMP_WITH_LOCAL_TIME_ZONE | INTERVAL_YEAR_MONTH | INTERVAL_DAY_TIME =>
+            TIMESTAMP_WITH_LOCAL_TIME_ZONE | INTERVAL_YEAR_MONTH | INTERVAL_DAY_TIME | ARRAY =>
           argTypes(0)
         case t =>
           throw new TableException(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/codegen/HashCodeGeneratorTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/codegen/HashCodeGeneratorTest.scala
@@ -77,10 +77,10 @@ class HashCodeGeneratorTest {
     val row3 = GenericRowData.of(
       ji(5),
       new GenericArrayData(Array(1, 5, 7)),
+      new GenericMapData(Map(1 -> null, 5 -> null, 10 -> null)),
       new GenericMapData(
-        Map(1 -> null, 5 -> null, 10 -> null)),
-      new GenericMapData(
-        Map(1 -> StringData.fromString("ron"), 5 -> StringData.fromString("danny"), 10 -> null)))
+        Map(1 -> StringData.fromString("ron"), 5 -> StringData.fromString("danny"), 10 -> null))
+    )
     Assert.assertEquals(368915957, hashFunc3.hashCode(row3))
 
     // test hash code for ArrayData

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/codegen/HashCodeGeneratorTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/codegen/HashCodeGeneratorTest.scala
@@ -18,18 +18,26 @@
 package org.apache.flink.table.planner.codegen
 
 import org.apache.flink.configuration.Configuration
-import org.apache.flink.table.data.GenericRowData
-import org.apache.flink.table.types.logical.{BigIntType, IntType, RowType, VarBinaryType}
+import org.apache.flink.table.data.{GenericArrayData, GenericMapData, GenericRowData, StringData}
+import org.apache.flink.table.types.logical.{ArrayType, BigIntType, IntType, MapType, MultisetType, RowType, VarBinaryType, VarCharType}
 
-import org.junit.{Assert, Test}
+import org.junit.{Assert, Rule, Test}
+import org.junit.rules.ExpectedException
+
+import scala.collection.JavaConversions.mapAsJavaMap
 
 /** Test for [[HashCodeGenerator]]. */
 class HashCodeGeneratorTest {
 
   private val classLoader = Thread.currentThread().getContextClassLoader
 
+  var expectedException: ExpectedException = ExpectedException.none
+
+  @Rule
+  def thrown: ExpectedException = expectedException
+
   @Test
-  def testHash(): Unit = {
+  def testRowHash(): Unit = {
     val hashFunc1 = HashCodeGenerator
       .generateRowHash(
         new CodeGeneratorContext(new Configuration, Thread.currentThread().getContextClassLoader),
@@ -51,6 +59,145 @@ class HashCodeGeneratorTest {
     val row = GenericRowData.of(ji(5), jl(8), Array[Byte](1, 5, 6))
     Assert.assertEquals(637, hashFunc1.hashCode(row))
     Assert.assertEquals(136516167, hashFunc2.hashCode(row))
+
+    // test row with nested array and map type
+    val hashFunc3 = HashCodeGenerator
+      .generateRowHash(
+        new CodeGeneratorContext(new Configuration),
+        RowType.of(
+          new IntType(),
+          new ArrayType(new IntType()),
+          new MultisetType(new IntType()),
+          new MapType(new IntType(), new VarCharType())),
+        "name",
+        Array(1, 2, 0, 3)
+      )
+      .newInstance(classLoader)
+
+    val row3 = GenericRowData.of(
+      ji(5),
+      new GenericArrayData(Array(1, 5, 7)),
+      new GenericMapData(
+        Map(1 -> null, 5 -> null, 10 -> null)),
+      new GenericMapData(
+        Map(1 -> StringData.fromString("ron"), 5 -> StringData.fromString("danny"), 10 -> null)))
+    Assert.assertEquals(368915957, hashFunc3.hashCode(row3))
+
+    // test hash code for ArrayData
+    thrown.expect(classOf[RuntimeException])
+    thrown.expectMessage(
+      "RowData hash function doesn't support to generate hash code for ArrayData.")
+    hashFunc3.hashCode(new GenericArrayData(Array(1)))
+
+    // test hash code for MapData
+    thrown.expect(classOf[RuntimeException])
+    thrown.expectMessage(
+      "RowData hash function doesn't support to generate hash code for ArrayData.")
+    hashFunc3.hashCode(new GenericMapData(null))
+  }
+
+  @Test
+  def testArrayHash(): Unit = {
+    // test primitive type
+    val hashFunc1 = HashCodeGenerator
+      .generateArrayHash(new CodeGeneratorContext(new Configuration()), new IntType(), "name")
+      .newInstance(classLoader)
+
+    val array1 = new GenericArrayData(Array(1, 5, 7))
+    Assert.assertEquals(13, hashFunc1.hashCode(array1))
+
+    // test complex map type of element
+    val hashFunc2 = HashCodeGenerator
+      .generateArrayHash(
+        new CodeGeneratorContext(new Configuration()),
+        new MapType(new IntType(), new VarCharType()),
+        "name")
+      .newInstance(classLoader)
+
+    val mapData = new GenericMapData(
+      Map(1 -> StringData.fromString("ron"), 5 -> StringData.fromString("danny"), 10 -> null))
+    val array2 = new GenericArrayData(Array[AnyRef](mapData))
+    Assert.assertEquals(357483069, hashFunc2.hashCode(array2))
+
+    // test complex row type of element
+    val hashFunc3 = HashCodeGenerator
+      .generateArrayHash(
+        new CodeGeneratorContext(new Configuration()),
+        RowType.of(new IntType(), new BigIntType()),
+        "name")
+      .newInstance(classLoader)
+
+    val array3 = new GenericArrayData(
+      Array[AnyRef](GenericRowData.of(ji(5), jl(8)), GenericRowData.of(ji(25), jl(52))))
+    Assert.assertEquals(2430, hashFunc3.hashCode(array3))
+
+    // test hash code for RowData
+    thrown.expect(classOf[RuntimeException])
+    thrown.expectMessage(
+      "ArrayData hash function doesn't support to generate hash code for RowData.")
+    hashFunc3.hashCode(GenericRowData.of(null))
+
+    // test hash code for MapData
+    thrown.expect(classOf[RuntimeException])
+    thrown.expectMessage(
+      "ArrayData hash function doesn't support to generate hash code for RowData.")
+    hashFunc3.hashCode(new GenericMapData(null))
+  }
+
+  @Test
+  def testMapHash(): Unit = {
+    // test primitive type
+    val hashFunc1 = HashCodeGenerator
+      .generateMapHash(
+        new CodeGeneratorContext(new Configuration()),
+        new IntType(),
+        new VarCharType(),
+        "name")
+      .newInstance(classLoader)
+
+    val map1 = new GenericMapData(
+      Map(1 -> StringData.fromString("ron"), 5 -> StringData.fromString("danny"), 10 -> null))
+    Assert.assertEquals(357483069, hashFunc1.hashCode(map1))
+
+    // test complex row type of value
+    val hashFunc2 = HashCodeGenerator
+      .generateMapHash(
+        new CodeGeneratorContext(new Configuration()),
+        new IntType(),
+        RowType.of(new IntType(), new BigIntType()),
+        "name")
+      .newInstance(classLoader)
+
+    val map2 = new GenericMapData(
+      Map(1 -> GenericRowData.of(ji(5), jl(8)), 5 -> GenericRowData.of(ji(54), jl(78)), 10 -> null))
+    Assert.assertEquals(4763, hashFunc2.hashCode(map2))
+
+    // test complex array type of value
+    val hashFunc3 = HashCodeGenerator
+      .generateMapHash(
+        new CodeGeneratorContext(new Configuration()),
+        new IntType(),
+        new ArrayType(new IntType()),
+        "name")
+      .newInstance(classLoader)
+
+    val map3 = new GenericMapData(
+      Map(
+        1 -> new GenericArrayData(Array(1, 5, 7)),
+        5 -> new GenericArrayData(Array(2, 4, 8)),
+        10 -> null))
+    Assert.assertEquals(43, hashFunc3.hashCode(map3))
+
+    // test hash code for RowData
+    thrown.expect(classOf[RuntimeException])
+    thrown.expectMessage("MapData hash function doesn't support to generate hash code for RowData.")
+    hashFunc3.hashCode(GenericRowData.of(null))
+
+    // test hash code for ArrayData
+    thrown.expect(classOf[RuntimeException])
+    thrown.expectMessage(
+      "MapData hash function doesn't support to generate hash code for ArrayData.")
+    hashFunc3.hashCode(new GenericArrayData(Array(1)))
   }
 
   def ji(i: Int): Integer = {

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CalcITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CalcITCase.scala
@@ -1035,7 +1035,7 @@ class CalcITCase extends BatchTestBase {
   @Test
   def testMapTypeGroupBy(): Unit = {
     _expectedEx.expectMessage(
-      "Type(MAP<INT NOT NULL, VARCHAR(5) NOT NULL> NOT NULL) is not an orderable data type, it is not supported as a field in ORDER_BY and sort-based GROUP_BY/JOIN_EQUAL clause.")
+      "Type(MAP<INT NOT NULL, VARCHAR(5) NOT NULL> NOT NULL) is not an orderable data type, it is not supported as a ORDER_BY/GROUP_BY/JOIN_EQUAL field.")
     checkResult(
       "SELECT COUNT(*) FROM SmallTable3 GROUP BY MAP[1, 'Hello', 2, 'Hi']",
       Seq()

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CalcITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CalcITCase.scala
@@ -1034,7 +1034,8 @@ class CalcITCase extends BatchTestBase {
 
   @Test
   def testMapTypeGroupBy(): Unit = {
-    _expectedEx.expectMessage("is not supported as a GROUP_BY/PARTITION_BY/JOIN_EQUAL/UNION field")
+    _expectedEx.expectMessage(
+      "Type(MAP<INT NOT NULL, VARCHAR(5) NOT NULL> NOT NULL) is not an orderable data type, it is not supported as a field in ORDER_BY and sort-based GROUP_BY/JOIN_EQUAL clause.")
     checkResult(
       "SELECT COUNT(*) FROM SmallTable3 GROUP BY MAP[1, 'Hello', 2, 'Hi']",
       Seq()

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/AggregateITCaseBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/AggregateITCaseBase.scala
@@ -1108,6 +1108,17 @@ abstract class AggregateITCaseBase(testName: String) extends BatchTestBase {
     )
   }
 
+  @Test
+  def testGroupByArrayType(): Unit = {
+    checkResult(
+      "SELECT sum(a) FROM (VALUES (1, array[1, 2]), (2, array[1, 2]), (5, array[3, 4])) T(a, b) GROUP BY b",
+      Seq(
+        row(3),
+        row(5)
+      )
+    )
+  }
+
   // TODO support csv
 //  @Test
 //  def testMultiGroupBys(): Unit = {

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/AggregateITCaseBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/AggregateITCaseBase.scala
@@ -1111,12 +1111,45 @@ abstract class AggregateITCaseBase(testName: String) extends BatchTestBase {
   @Test
   def testGroupByArrayType(): Unit = {
     checkResult(
-      "SELECT sum(a) FROM (VALUES (1, array[1, 2]), (2, array[1, 2]), (5, array[3, 4])) T(a, b) GROUP BY b",
+      "SELECT sum(a) FROM (" +
+        "VALUES (1, array[1, 2]), (2, array[1, 2]), (5, array[3, 4])) T(a, b) GROUP BY b",
       Seq(
         row(3),
         row(5)
       )
     )
+  }
+
+  @Test
+  def testDistinctArrayType(): Unit = {
+    val sql =
+      s"""
+         |SELECT DISTINCT b FROM (
+         |VALUES (2, array[1, 2]), (2, array[2, 3]), (2, array[1, 2]), (5, array[3, 4])) T(a, b)
+         |""".stripMargin
+    checkResult(
+      sql,
+      Seq(
+        row("[1, 2]"),
+        row("[2, 3]"),
+        row("[3, 4]")
+      ))
+  }
+
+  @Test
+  def testCountDistinctArrayType(): Unit = {
+    val sql =
+      s"""
+         |SELECT a, COUNT(DISTINCT b) FROM (
+         |VALUES (2, array[1, 2]), (2, array[2, 3]), (2, array[1, 2]), (5, array[3, 4])) T(a, b)
+         |GROUP BY a
+         |""".stripMargin
+    checkResult(
+      sql,
+      Seq(
+        row(2, 2),
+        row(5, 1)
+      ))
   }
 
   // TODO support csv

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/AggregateITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/AggregateITCase.scala
@@ -1685,4 +1685,22 @@ class AggregateITCase(aggMode: AggMode, miniBatch: MiniBatchMode, backend: State
     )
     assertEquals(expected.sorted, sink.getRetractResults.sorted)
   }
+
+  @Test
+  def testGroupByArrayType(): Unit = {
+    val sql =
+      s"""
+         |SELECT b, sum(a) FROM (VALUES (1, array[1, 2]), (2, array[1, 2]), (5, array[3, 4])) T(a, b)
+         |GROUP BY b
+         |""".stripMargin
+
+    val sink = new TestingRetractSink
+    tEnv.sqlQuery(sql).toRetractStream[Row].addSink(sink).setParallelism(1)
+    env.execute()
+    val expected = List(
+      "[1, 2],3",
+      "[3, 4],5"
+    )
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/AggregateITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/AggregateITCase.scala
@@ -1703,4 +1703,42 @@ class AggregateITCase(aggMode: AggMode, miniBatch: MiniBatchMode, backend: State
     )
     assertEquals(expected.sorted, sink.getRetractResults.sorted)
   }
+
+  @Test
+  def testDistinctArrayType(): Unit = {
+    val sql =
+      s"""
+         |SELECT DISTINCT b FROM (
+         |VALUES (2, array[1, 2]), (2, array[2, 3]), (2, array[1, 2]), (5, array[3, 4])) T(a, b)
+         |""".stripMargin
+
+    val sink = new TestingRetractSink
+    tEnv.sqlQuery(sql).toRetractStream[Row].addSink(sink).setParallelism(1)
+    env.execute()
+    val expected = List(
+      "[1, 2]",
+      "[2, 3]",
+      "[3, 4]"
+    )
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
+
+  @Test
+  def testCountDistinctArrayType(): Unit = {
+    val sql =
+      s"""
+         |SELECT a, COUNT(DISTINCT b) FROM (
+         |VALUES (2, array[1, 2]), (2, array[2, 3]), (2, array[1, 2]), (5, array[3, 4])) T(a, b)
+         |GROUP BY a
+         |""".stripMargin
+
+    val sink = new TestingRetractSink
+    tEnv.sqlQuery(sql).toRetractStream[Row].addSink(sink).setParallelism(1)
+    env.execute()
+    val expected = List(
+      "2,2",
+      "5,1"
+    )
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/generated/HashFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/generated/HashFunction.java
@@ -23,8 +23,12 @@ import org.apache.flink.table.data.MapData;
 import org.apache.flink.table.data.RowData;
 
 /**
- * Interface for code generated hash code of {@link RowData} or {@link ArrayData} or {@link
- * MapData}, which will select some fields to hash.
+ * Interface for code generated hash code of {@link RowData} which will select some fields to hash
+ * or {@link ArrayData} or {@link MapData}.
+ *
+ * <p>Due to Janino's support for generic type is not very friendly, so here can't introduce generic
+ * type for {@link HashFunction}, please see https://github.com/janino-compiler/janino/issues/109
+ * for details.
  */
 public interface HashFunction {
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/generated/HashFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/generated/HashFunction.java
@@ -25,16 +25,8 @@ import org.apache.flink.table.data.RowData;
 /**
  * Interface for code generated hash code of {@link RowData} which will select some fields to hash
  * or {@link ArrayData} or {@link MapData}.
- *
- * <p>Due to Janino's support for generic type is not very friendly, so here can't introduce generic
- * type for {@link HashFunction}, please see https://github.com/janino-compiler/janino/issues/109
- * for details.
  */
 public interface HashFunction {
 
-    int hashCode(RowData row);
-
-    int hashCode(ArrayData array);
-
-    int hashCode(MapData map);
+    int hashCode(Object data);
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/generated/HashFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/generated/HashFunction.java
@@ -18,12 +18,19 @@
 
 package org.apache.flink.table.runtime.generated;
 
+import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.data.MapData;
 import org.apache.flink.table.data.RowData;
 
 /**
- * Interface for code generated hash code of {@link RowData}, which will select some fields to hash.
+ * Interface for code generated hash code of {@link RowData} or {@link ArrayData} or {@link
+ * MapData}, which will select some fields to hash.
  */
 public interface HashFunction {
 
     int hashCode(RowData row);
+
+    int hashCode(ArrayData array);
+
+    int hashCode(MapData map);
 }


### PR DESCRIPTION
## What is the purpose of the change
Support complex shuffle hash key type

## Brief change log

  - *Support complex shuffle hash key type*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added unit tests in HashCodeGeneratorTest*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? (no)
