### PR TITLE
[FLINK-27607][tests] Migrate module flink-connector-files to JUnit5

### DIFF
--- a/flink-connectors/flink-connector-files/pom.xml
+++ b/flink-connectors/flink-connector-files/pom.xml
@@ -132,6 +132,12 @@ under the License.
 						<goals>
 							<goal>test-jar</goal>
 						</goals>
+						<configuration>
+							<excludes>
+								<!-- test-jar is still used by JUnit4 modules -->
+								<exclude>META-INF/services/org.junit.jupiter.api.extension.Extension</exclude>
+							</excludes>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/BatchCompactingFileSinkITCase.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/BatchCompactingFileSinkITCase.java
@@ -29,21 +29,18 @@ import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.minicluster.RpcServiceSharing;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
-import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.apache.flink.test.junit5.MiniClusterExtension;
 
-import org.junit.Rule;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /** Tests the compaction of the {@link FileSink} in BATCH mode. */
-@RunWith(Parameterized.class)
-public class BatchCompactingFileSinkITCase extends BatchExecutionFileSinkITCase {
+class BatchCompactingFileSinkITCase extends BatchExecutionFileSinkITCase {
 
     private static final int PARALLELISM = 4;
 
-    @Rule
-    public final MiniClusterWithClientResource miniClusterResource =
-            new MiniClusterWithClientResource(
+    @RegisterExtension
+    private static final MiniClusterExtension MINI_CLUSTER_RESOURCE =
+            new MiniClusterExtension(
                     new MiniClusterResourceConfiguration.Builder()
                             .setNumberTaskManagers(1)
                             .setNumberSlotsPerTaskManager(PARALLELISM)

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/BatchExecutionFileSinkITCase.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/BatchExecutionFileSinkITCase.java
@@ -34,19 +34,15 @@ import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunctio
 import org.apache.flink.streaming.api.graph.StreamGraph;
 import org.apache.flink.streaming.api.operators.StreamSource;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-
 /** Tests the functionality of the {@link FileSink} in BATCH mode. */
-@RunWith(Parameterized.class)
-public class BatchExecutionFileSinkITCase extends FileSinkITBase {
+class BatchExecutionFileSinkITCase extends FileSinkITBase {
 
     /**
      * Creating the testing job graph in batch mode. The graph created is [Source] -> [Failover Map
      * -> File Sink]. The Failover Map is introduced to ensure the failover would always restart the
      * file writer so the data would be re-written.
      */
-    protected JobGraph createJobGraph(String path) {
+    protected JobGraph createJobGraph(boolean triggerFailover, String path) {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         Configuration config = new Configuration();
         config.set(ExecutionOptions.RUNTIME_MODE, RuntimeExecutionMode.BATCH);

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/FileCommittableSerializerTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/FileCommittableSerializerTest.java
@@ -21,59 +21,52 @@ package org.apache.flink.connector.file.sink;
 import org.apache.flink.connector.file.sink.utils.FileSinkTestUtils;
 import org.apache.flink.core.fs.Path;
 
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests the serialization and deserialization for {@link FileSinkCommittable}. */
-public class FileCommittableSerializerTest {
-
-    @ClassRule public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+class FileCommittableSerializerTest {
 
     @Test
-    public void testCommittableWithPendingFile() throws IOException {
+    void testCommittableWithPendingFile() throws IOException {
         FileSinkCommittable committable =
                 new FileSinkCommittable("0", new FileSinkTestUtils.TestPendingFileRecoverable());
         FileSinkCommittable deserialized = serializeAndDeserialize(committable);
-        assertEquals(committable.getBucketId(), deserialized.getBucketId());
-        assertEquals(committable.getPendingFile(), deserialized.getPendingFile());
-        assertEquals(
-                committable.getInProgressFileToCleanup(),
-                deserialized.getInProgressFileToCleanup());
-        assertEquals(
-                committable.getCompactedFileToCleanup(), deserialized.getCompactedFileToCleanup());
+        assertThat(committable.getBucketId()).isEqualTo(deserialized.getBucketId());
+        assertThat(committable.getPendingFile()).isEqualTo(deserialized.getPendingFile());
+        assertThat(committable.getInProgressFileToCleanup())
+                .isEqualTo(deserialized.getInProgressFileToCleanup());
+        assertThat(committable.getCompactedFileToCleanup())
+                .isEqualTo(deserialized.getCompactedFileToCleanup());
     }
 
     @Test
-    public void testCommittableWithInProgressFileToCleanup() throws IOException {
+    void testCommittableWithInProgressFileToCleanup() throws IOException {
         FileSinkCommittable committable =
                 new FileSinkCommittable("0", new FileSinkTestUtils.TestInProgressFileRecoverable());
         FileSinkCommittable deserialized = serializeAndDeserialize(committable);
-        assertEquals(committable.getBucketId(), deserialized.getBucketId());
-        assertEquals(committable.getPendingFile(), deserialized.getPendingFile());
-        assertEquals(
-                committable.getInProgressFileToCleanup(),
-                deserialized.getInProgressFileToCleanup());
-        assertEquals(
-                committable.getCompactedFileToCleanup(), deserialized.getCompactedFileToCleanup());
+        assertThat(committable.getBucketId()).isEqualTo(deserialized.getBucketId());
+        assertThat(committable.getPendingFile()).isEqualTo(deserialized.getPendingFile());
+        assertThat(committable.getInProgressFileToCleanup())
+                .isEqualTo(deserialized.getInProgressFileToCleanup());
+        assertThat(committable.getCompactedFileToCleanup())
+                .isEqualTo(deserialized.getCompactedFileToCleanup());
     }
 
     @Test
-    public void testCommittableWithCompactedFileToCleanup() throws IOException {
+    void testCommittableWithCompactedFileToCleanup() throws IOException {
         FileSinkCommittable committable =
                 new FileSinkCommittable("0", new Path("/tmp/mock_path_to_cleanup"));
         FileSinkCommittable deserialized = serializeAndDeserialize(committable);
-        assertEquals(committable.getBucketId(), deserialized.getBucketId());
-        assertEquals(committable.getPendingFile(), deserialized.getPendingFile());
-        assertEquals(
-                committable.getInProgressFileToCleanup(),
-                deserialized.getInProgressFileToCleanup());
-        assertEquals(
-                committable.getCompactedFileToCleanup(), deserialized.getCompactedFileToCleanup());
+        assertThat(committable.getBucketId()).isEqualTo(deserialized.getBucketId());
+        assertThat(committable.getPendingFile()).isEqualTo(deserialized.getPendingFile());
+        assertThat(committable.getInProgressFileToCleanup())
+                .isEqualTo(deserialized.getInProgressFileToCleanup());
+        assertThat(committable.getCompactedFileToCleanup())
+                .isEqualTo(deserialized.getCompactedFileToCleanup());
     }
 
     private FileSinkCommittable serializeAndDeserialize(FileSinkCommittable committable)

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/FileSinkCompactionSwitchITCase.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/FileSinkCompactionSwitchITCase.java
@@ -106,7 +106,8 @@ public class FileSinkCompactionSwitchITCase {
 
     @TempDir private static java.nio.file.Path tmpDir;
 
-    @RegisterExtension private final SharedObjectsExtension sharedObjects = SharedObjectsExtension.create();
+    @RegisterExtension
+    private final SharedObjectsExtension sharedObjects = SharedObjectsExtension.create();
 
     private static final Map<String, CountDownLatch> LATCH_MAP = new ConcurrentHashMap<>();
 

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/FileSinkCompactionSwitchITCase.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/FileSinkCompactionSwitchITCase.java
@@ -53,17 +53,15 @@ import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
 import org.apache.flink.streaming.api.graph.StreamGraph;
-import org.apache.flink.test.util.MiniClusterWithClientResource;
-import org.apache.flink.testutils.junit.SharedObjects;
+import org.apache.flink.test.junit5.MiniClusterExtension;
+import org.apache.flink.testutils.junit.SharedObjectsExtension;
 import org.apache.flink.testutils.junit.SharedReference;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.DataInputStream;
 import java.io.EOFException;
@@ -80,19 +78,17 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 /** Tests of switching on or off compaction for the {@link FileSink}. */
-public class FileSinkCompactionSwitchITCase extends TestLogger {
+public class FileSinkCompactionSwitchITCase {
 
     private static final int PARALLELISM = 4;
 
-    @Rule
-    public final MiniClusterWithClientResource miniClusterResource =
-            new MiniClusterWithClientResource(
+    @RegisterExtension
+    private static final MiniClusterExtension MINI_CLUSTER_RESOURCE =
+            new MiniClusterExtension(
                     new MiniClusterResourceConfiguration.Builder()
                             .setNumberTaskManagers(1)
                             .setNumberSlotsPerTaskManager(PARALLELISM)
@@ -108,29 +104,29 @@ public class FileSinkCompactionSwitchITCase extends TestLogger {
 
     protected static final int NUM_BUCKETS = 4;
 
-    @ClassRule public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+    @TempDir private static java.nio.file.Path tmpDir;
 
-    @Rule public final SharedObjects sharedObjects = SharedObjects.create();
+    @RegisterExtension final SharedObjectsExtension sharedObjects = SharedObjectsExtension.create();
 
     private static final Map<String, CountDownLatch> LATCH_MAP = new ConcurrentHashMap<>();
 
     private String latchId;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         this.latchId = UUID.randomUUID().toString();
         // Wait for 3 checkpoints to ensure that the coordinator and all compactors have state
         LATCH_MAP.put(latchId, new CountDownLatch(NUM_SOURCES * 3));
     }
 
-    @After
-    public void teardown() {
+    @AfterEach
+    void teardown() {
         LATCH_MAP.remove(latchId);
     }
 
     @Test
-    public void testSwitchNeverEnabledToEnabled() throws Exception {
-        String path = TEMPORARY_FOLDER.newFolder().getAbsolutePath();
+    void testSwitchNeverEnabledToEnabled(@TempDir java.nio.file.Path tmpPath) throws Exception {
+        String path = tmpPath.toFile().getAbsolutePath();
         FileSink<Integer> originFileSink = createFileSink(path, null, false);
         FileSink<Integer> restoredFileSink =
                 createFileSink(path, createFileCompactStrategy(), false);
@@ -138,8 +134,8 @@ public class FileSinkCompactionSwitchITCase extends TestLogger {
     }
 
     @Test
-    public void testSwitchDisabledToEnabled() throws Exception {
-        String path = TEMPORARY_FOLDER.newFolder().getAbsolutePath();
+    void testSwitchDisabledToEnabled(@TempDir java.nio.file.Path tmpPath) throws Exception {
+        String path = tmpPath.toFile().getAbsolutePath();
         FileSink<Integer> originFileSink = createFileSink(path, null, true);
         FileSink<Integer> restoredFileSink =
                 createFileSink(path, createFileCompactStrategy(), false);
@@ -147,16 +143,17 @@ public class FileSinkCompactionSwitchITCase extends TestLogger {
     }
 
     @Test
-    public void testSwitchEnabledToDisabled() throws Exception {
-        String path = TEMPORARY_FOLDER.newFolder().getAbsolutePath();
+    void testSwitchEnabledToDisabled(@TempDir java.nio.file.Path tmpPath) throws Exception {
+        String path = tmpPath.toFile().getAbsolutePath();
         FileSink<Integer> originFileSink = createFileSink(path, createFileCompactStrategy(), false);
         FileSink<Integer> restoredFileSink = createFileSink(path, null, true);
         testSwitchingCompaction(path, originFileSink, restoredFileSink);
     }
 
     @Test
-    public void testSwitchEnabledToDisabledImproperly() throws Exception {
-        String path = TEMPORARY_FOLDER.newFolder().getAbsolutePath();
+    void testSwitchEnabledToDisabledImproperly(@TempDir java.nio.file.Path tmpPath)
+            throws Exception {
+        String path = tmpPath.toFile().getAbsolutePath();
         FileSink<Integer> originFileSink = createFileSink(path, createFileCompactStrategy(), false);
         FileSink<Integer> restoredFileSink = createFileSink(path, null, false);
         try {
@@ -170,7 +167,7 @@ public class FileSinkCompactionSwitchITCase extends TestLogger {
     private void testSwitchingCompaction(
             String path, FileSink<Integer> originFileSink, FileSink<Integer> restoredFileSink)
             throws Exception {
-        String cpPath = "file://" + TEMPORARY_FOLDER.newFolder().getAbsolutePath();
+        String cpPath = "file://" + tmpDir.toFile().getAbsolutePath();
 
         SharedReference<ConcurrentHashMap<Integer, Integer>> sendCountMap =
                 sharedObjects.add(new ConcurrentHashMap<>());
@@ -194,7 +191,7 @@ public class FileSinkCompactionSwitchITCase extends TestLogger {
                     miniCluster
                             .triggerSavepoint(
                                     jobGraph.getJobID(),
-                                    TEMPORARY_FOLDER.newFolder().getAbsolutePath(),
+                                    tmpDir.toFile().getAbsolutePath(),
                                     true,
                                     SavepointFormatType.CANONICAL)
                             .get();
@@ -265,29 +262,29 @@ public class FileSinkCompactionSwitchITCase extends TestLogger {
     private static void checkIntegerSequenceSinkOutput(
             String path, Map<Integer, Integer> countMap, int numBuckets, int numSources)
             throws Exception {
-        assertEquals(numSources, countMap.size());
+        assertThat(countMap).hasSize(numSources);
 
         File dir = new File(path);
         String[] subDirNames = dir.list();
-        assertNotNull(subDirNames);
+        assertThat(subDirNames).isNotNull();
 
         Arrays.sort(subDirNames, Comparator.comparingInt(Integer::parseInt));
-        assertEquals(numBuckets, subDirNames.length);
+        assertThat(subDirNames).hasSize(numBuckets);
         for (int i = 0; i < numBuckets; ++i) {
-            assertEquals(Integer.toString(i), subDirNames[i]);
+            assertThat(subDirNames[i]).isEqualTo(Integer.toString(i));
 
             // now check its content
             File bucketDir = new File(path, subDirNames[i]);
-            assertTrue(
-                    bucketDir.getAbsolutePath() + " Should be a existing directory",
-                    bucketDir.isDirectory());
+            assertThat(bucketDir)
+                    .isDirectory()
+                    .as(bucketDir.getAbsolutePath() + " Should be a existing directory");
 
             Map<Integer, Integer> counts = new HashMap<>();
             File[] files = bucketDir.listFiles(f -> !f.getName().startsWith("."));
-            assertNotNull(files);
+            assertThat(files).isNotNull();
 
             for (File file : files) {
-                assertTrue(file.isFile());
+                assertThat(file).isFile();
 
                 try (DataInputStream dataInputStream =
                         new DataInputStream(new FileInputStream(file))) {
@@ -310,7 +307,7 @@ public class FileSinkCompactionSwitchITCase extends TestLogger {
                             .mapToInt(num -> num)
                             .max()
                             .getAsInt();
-            assertEquals(expectedCount, counts.size());
+            assertThat(counts).hasSize(expectedCount);
 
             List<Integer> countList = new ArrayList<>(countMap.values());
             Collections.sort(countList);
@@ -323,17 +320,17 @@ public class FileSinkCompactionSwitchITCase extends TestLogger {
                                         : (rangeFrom + numBuckets - rangeFrom % numBuckets));
                 int rangeTo = countList.get(j);
                 for (int k = rangeFrom; k < rangeTo; k += numBuckets) {
-                    assertEquals(
-                            "The record "
-                                    + k
-                                    + " should occur "
-                                    + (numBuckets - j)
-                                    + " times, "
-                                    + " but only occurs "
-                                    + counts.getOrDefault(k, 0)
-                                    + "time",
-                            numBuckets - j,
-                            counts.getOrDefault(k, 0).intValue());
+                    assertThat(counts.getOrDefault(k, 0).intValue())
+                            .as(
+                                    "The record "
+                                            + k
+                                            + " should occur "
+                                            + (numBuckets - j)
+                                            + " times, "
+                                            + " but only occurs "
+                                            + counts.getOrDefault(k, 0)
+                                            + "time")
+                            .isEqualTo(numBuckets - j);
                 }
             }
         }

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/FileSinkCompactionSwitchITCase.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/FileSinkCompactionSwitchITCase.java
@@ -106,7 +106,7 @@ public class FileSinkCompactionSwitchITCase {
 
     @TempDir private static java.nio.file.Path tmpDir;
 
-    @RegisterExtension final SharedObjectsExtension sharedObjects = SharedObjectsExtension.create();
+    @RegisterExtension private final SharedObjectsExtension sharedObjects = SharedObjectsExtension.create();
 
     private static final Map<String, CountDownLatch> LATCH_MAP = new ConcurrentHashMap<>();
 

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/FileSinkITBase.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/FileSinkITBase.java
@@ -24,18 +24,15 @@ import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.minicluster.MiniCluster;
 import org.apache.flink.runtime.minicluster.MiniClusterConfiguration;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.Arrays;
-import java.util.Collection;
+import java.util.stream.Stream;
 
 /** The base class for the File Sink IT Case in different execution mode. */
-public abstract class FileSinkITBase extends TestLogger {
+abstract class FileSinkITBase {
 
     protected static final int NUM_SOURCES = 4;
 
@@ -47,20 +44,17 @@ public abstract class FileSinkITBase extends TestLogger {
 
     protected static final double FAILOVER_RATIO = 0.4;
 
-    @ClassRule public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
-
-    @Parameterized.Parameter public boolean triggerFailover;
-
-    @Parameterized.Parameters(name = "triggerFailover = {0}")
-    public static Collection<Object[]> params() {
-        return Arrays.asList(new Object[] {false}, new Object[] {true});
+    public static Stream<Boolean> params() {
+        return Stream.of(false, true);
     }
 
-    @Test
-    public void testFileSink() throws Exception {
-        String path = TEMPORARY_FOLDER.newFolder().getAbsolutePath();
+    @ParameterizedTest(name = "triggerFailover = {0}")
+    @MethodSource("params")
+    void testFileSink(boolean triggerFailover, @TempDir java.nio.file.Path tmpDir)
+            throws Exception {
+        String path = tmpDir.toString();
 
-        JobGraph jobGraph = createJobGraph(path);
+        JobGraph jobGraph = createJobGraph(triggerFailover, path);
 
         final MiniClusterConfiguration cfg =
                 new MiniClusterConfiguration.Builder()
@@ -78,7 +72,7 @@ public abstract class FileSinkITBase extends TestLogger {
                 path, NUM_RECORDS, NUM_BUCKETS, NUM_SOURCES);
     }
 
-    protected abstract JobGraph createJobGraph(String path);
+    protected abstract JobGraph createJobGraph(boolean triggerFailover, String path);
 
     protected FileSink<Integer> createFileSink(String path) {
         return FileSink.forRowFormat(new Path(path), new IntegerFileSinkTestDataUtils.IntEncoder())

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/FileSinkITBase.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/FileSinkITBase.java
@@ -44,7 +44,7 @@ abstract class FileSinkITBase {
 
     protected static final double FAILOVER_RATIO = 0.4;
 
-    public static Stream<Boolean> params() {
+    private static Stream<Boolean> params() {
         return Stream.of(false, true);
     }
 

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/StreamingCompactingFileSinkITCase.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/StreamingCompactingFileSinkITCase.java
@@ -29,21 +29,18 @@ import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.minicluster.RpcServiceSharing;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
-import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.apache.flink.test.junit5.MiniClusterExtension;
 
-import org.junit.Rule;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /** Tests the compaction of the {@link FileSink} in STREAMING mode. */
-@RunWith(Parameterized.class)
-public class StreamingCompactingFileSinkITCase extends StreamingExecutionFileSinkITCase {
+class StreamingCompactingFileSinkITCase extends StreamingExecutionFileSinkITCase {
 
     private static final int PARALLELISM = 4;
 
-    @Rule
-    public final MiniClusterWithClientResource miniClusterResource =
-            new MiniClusterWithClientResource(
+    @RegisterExtension
+    private static final MiniClusterExtension MINI_CLUSTER_RESOURCE =
+            new MiniClusterExtension(
                     new MiniClusterResourceConfiguration.Builder()
                             .setNumberTaskManagers(1)
                             .setNumberSlotsPerTaskManager(PARALLELISM)

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/StreamingExecutionFileSinkITCase.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/StreamingExecutionFileSinkITCase.java
@@ -36,10 +36,8 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
 import org.apache.flink.streaming.api.graph.StreamGraph;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.util.Collections;
 import java.util.Map;
@@ -48,15 +46,14 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 
 /** Tests the functionality of the {@link FileSink} in STREAMING mode. */
-@RunWith(Parameterized.class)
-public class StreamingExecutionFileSinkITCase extends FileSinkITBase {
+class StreamingExecutionFileSinkITCase extends FileSinkITBase {
 
     private static final Map<String, CountDownLatch> LATCH_MAP = new ConcurrentHashMap<>();
 
     private String latchId;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         this.latchId = UUID.randomUUID().toString();
         // We wait for two successful checkpoints in sources before shutting down. This ensures that
         // the sink can commit its data.
@@ -66,8 +63,8 @@ public class StreamingExecutionFileSinkITCase extends FileSinkITBase {
         LATCH_MAP.put(latchId, new CountDownLatch(NUM_SOURCES * 2));
     }
 
-    @After
-    public void teardown() {
+    @AfterEach
+    void teardown() {
         LATCH_MAP.remove(latchId);
     }
 
@@ -76,7 +73,7 @@ public class StreamingExecutionFileSinkITCase extends FileSinkITBase {
      * Sink]. The source would trigger failover if required.
      */
     @Override
-    protected JobGraph createJobGraph(String path) {
+    protected JobGraph createJobGraph(boolean triggerFailover, String path) {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         Configuration config = new Configuration();
         config.set(ExecutionOptions.RUNTIME_MODE, RuntimeExecutionMode.STREAMING);

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/committer/FileCommitterTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/committer/FileCommitterTest.java
@@ -26,7 +26,7 @@ import org.apache.flink.connector.file.sink.utils.NoOpBucketWriter;
 import org.apache.flink.streaming.api.functions.sink.filesystem.BucketWriter;
 import org.apache.flink.streaming.api.functions.sink.filesystem.InProgressFileWriter;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -36,14 +36,13 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link FileCommitter}. */
-public class FileCommitterTest {
+class FileCommitterTest {
 
     @Test
-    public void testCommitPendingFile() throws Exception {
+    void testCommitPendingFile() throws Exception {
         StubBucketWriter stubBucketWriter = new StubBucketWriter();
         FileCommitter fileCommitter = new FileCommitter(stubBucketWriter);
 
@@ -53,14 +52,14 @@ public class FileCommitterTest {
                                 "0", new FileSinkTestUtils.TestPendingFileRecoverable()));
         fileCommitter.commit(Collections.singletonList(fileSinkCommittable));
 
-        assertEquals(1, stubBucketWriter.getRecoveredPendingFiles().size());
-        assertEquals(0, stubBucketWriter.getNumCleanUp());
-        assertTrue(stubBucketWriter.getRecoveredPendingFiles().get(0).isCommitted());
-        assertEquals(0, fileSinkCommittable.getNumberOfRetries());
+        assertThat(stubBucketWriter.getRecoveredPendingFiles()).hasSize(1);
+        assertThat(stubBucketWriter.getNumCleanUp()).isEqualTo(0);
+        assertThat(stubBucketWriter.getRecoveredPendingFiles().get(0).isCommitted()).isTrue();
+        assertThat(fileSinkCommittable.getNumberOfRetries()).isEqualTo(0);
     }
 
     @Test
-    public void testCleanupInProgressFiles() throws Exception {
+    void testCleanupInProgressFiles() throws Exception {
         StubBucketWriter stubBucketWriter = new StubBucketWriter();
         FileCommitter fileCommitter = new FileCommitter(stubBucketWriter);
 
@@ -70,13 +69,13 @@ public class FileCommitterTest {
                                 "0", new FileSinkTestUtils.TestInProgressFileRecoverable()));
         fileCommitter.commit(Collections.singletonList(fileSinkCommittable));
 
-        assertEquals(0, stubBucketWriter.getRecoveredPendingFiles().size());
-        assertEquals(1, stubBucketWriter.getNumCleanUp());
-        assertEquals(0, fileSinkCommittable.getNumberOfRetries());
+        assertThat(stubBucketWriter.getRecoveredPendingFiles()).isEmpty();
+        assertThat(stubBucketWriter.getNumCleanUp()).isEqualTo(1);
+        assertThat(fileSinkCommittable.getNumberOfRetries()).isEqualTo(0);
     }
 
     @Test
-    public void testCommitMultiple() throws Exception {
+    void testCommitMultiple() throws Exception {
         StubBucketWriter stubBucketWriter = new StubBucketWriter();
         FileCommitter fileCommitter = new FileCommitter(stubBucketWriter);
 
@@ -96,12 +95,12 @@ public class FileCommitterTest {
                         .collect(Collectors.toList());
         fileCommitter.commit(committables);
 
-        assertEquals(3, stubBucketWriter.getRecoveredPendingFiles().size());
-        assertEquals(2, stubBucketWriter.getNumCleanUp());
+        assertThat(stubBucketWriter.getRecoveredPendingFiles()).hasSize(3);
+        assertThat(stubBucketWriter.getNumCleanUp()).isEqualTo(2);
         stubBucketWriter
                 .getRecoveredPendingFiles()
-                .forEach(pendingFile -> assertTrue(pendingFile.isCommitted()));
-        assertTrue(committables.stream().allMatch(c -> c.getNumberOfRetries() == 0));
+                .forEach(pendingFile -> assertThat(pendingFile.isCommitted()).isTrue());
+        assertThat(committables).allMatch(c -> c.getNumberOfRetries() == 0);
     }
 
     // ------------------------------- Mock Classes --------------------------------

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/compactor/AbstractCompactTestBase.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/compactor/AbstractCompactTestBase.java
@@ -19,28 +19,24 @@
 package org.apache.flink.connector.file.sink.compactor;
 
 import org.apache.flink.core.fs.Path;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 
 /** Test base for compact operators. */
-public abstract class AbstractCompactTestBase extends TestLogger {
-
-    @ClassRule public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
+abstract class AbstractCompactTestBase {
 
     public static final int TARGET_SIZE = 9;
 
     Path folder;
 
-    @Before
-    public void before() throws IOException {
-        folder = new Path(TEMP_FOLDER.newFolder().getPath());
+    @BeforeEach
+    void before(@TempDir java.nio.file.Path tmpDir) {
+        folder = new Path(tmpDir.toString());
     }
 
     Path newFile(String name, int len) throws IOException {

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/compactor/CompactCoordinatorTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/compactor/CompactCoordinatorTest.java
@@ -40,17 +40,18 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.types.Either;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /** Test for {@link CompactCoordinator}. */
-public class CompactCoordinatorTest extends AbstractCompactTestBase {
+class CompactCoordinatorTest extends AbstractCompactTestBase {
 
     @Test
-    public void testSizeThreshold() throws Exception {
+    void testSizeThreshold() throws Exception {
         FileCompactStrategy strategy = Builder.newBuilder().setSizeThreshold(10).build();
         CompactCoordinator coordinator =
                 new CompactCoordinator(strategy, getTestCommittableSerializer());
@@ -64,23 +65,23 @@ public class CompactCoordinatorTest extends AbstractCompactTestBase {
             FileSinkCommittable committable0 = committable("0", ".0", 5);
             FileSinkCommittable committable1 = committable("0", ".1", 6);
             harness.processElement(message(committable0));
-            Assert.assertEquals(0, harness.extractOutputValues().size());
+            assertThat(harness.extractOutputValues()).isEmpty();
 
             harness.processElement(message(committable1));
 
             List<CompactorRequest> results = harness.extractOutputValues();
-            Assert.assertEquals(1, results.size());
+            assertThat(results).hasSize(1);
             assertToCompact(results.get(0), committable0, committable1);
 
             harness.processElement(message(committable("0", ".2", 5)));
             harness.processElement(message(committable("1", ".0", 5)));
 
-            Assert.assertEquals(1, harness.extractOutputValues().size());
+            assertThat(harness.extractOutputValues()).hasSize(1);
         }
     }
 
     @Test
-    public void testCompactOnCheckpoint() throws Exception {
+    void testCompactOnCheckpoint() throws Exception {
         FileCompactStrategy strategy = Builder.newBuilder().enableCompactionOnCheckpoint(1).build();
         CompactCoordinator coordinator =
                 new CompactCoordinator(strategy, getTestCommittableSerializer());
@@ -101,23 +102,23 @@ public class CompactCoordinatorTest extends AbstractCompactTestBase {
             harness.processElement(message(committable0));
             harness.processElement(message(committable1));
 
-            Assert.assertEquals(0, harness.extractOutputValues().size());
+            assertThat(harness.extractOutputValues()).isEmpty();
 
             harness.prepareSnapshotPreBarrier(1);
             harness.snapshot(1, 1);
 
-            Assert.assertEquals(1, harness.extractOutputValues().size());
+            assertThat(harness.extractOutputValues()).hasSize(1);
 
             harness.processElement(message(committable2));
             harness.processElement(message(committable3));
 
-            Assert.assertEquals(1, harness.extractOutputValues().size());
+            assertThat(harness.extractOutputValues()).hasSize(1);
 
             harness.prepareSnapshotPreBarrier(2);
             harness.snapshot(2, 2);
 
             List<CompactorRequest> results = harness.extractOutputValues();
-            Assert.assertEquals(3, results.size());
+            assertThat(results).hasSize(3);
             assertToCompact(results.get(0), committable0, committable1);
             assertToPassthrough(results.get(0), passThroughCommittable);
             assertToCompact(results.get(1), committable2);
@@ -126,7 +127,7 @@ public class CompactCoordinatorTest extends AbstractCompactTestBase {
     }
 
     @Test
-    public void testCompactOverMultipleCheckpoints() throws Exception {
+    void testCompactOverMultipleCheckpoints() throws Exception {
         FileCompactStrategy strategy = Builder.newBuilder().enableCompactionOnCheckpoint(3).build();
         CompactCoordinator coordinator =
                 new CompactCoordinator(strategy, getTestCommittableSerializer());
@@ -143,26 +144,26 @@ public class CompactCoordinatorTest extends AbstractCompactTestBase {
             harness.processElement(message(committable0));
             harness.processElement(message(committable1));
 
-            Assert.assertEquals(0, harness.extractOutputValues().size());
+            assertThat(harness.extractOutputValues()).isEmpty();
 
             harness.prepareSnapshotPreBarrier(1);
             harness.snapshot(1, 1);
             harness.prepareSnapshotPreBarrier(2);
             harness.snapshot(2, 2);
 
-            Assert.assertEquals(0, harness.extractOutputValues().size());
+            assertThat(harness.extractOutputValues()).isEmpty();
 
             harness.prepareSnapshotPreBarrier(3);
             harness.snapshot(3, 3);
 
             List<CompactorRequest> results = harness.extractOutputValues();
-            Assert.assertEquals(1, results.size());
+            assertThat(results).hasSize(1);
             assertToCompact(results.get(0), committable0, committable1);
         }
     }
 
     @Test
-    public void testCompactOnEndOfInput() throws Exception {
+    void testCompactOnEndOfInput() throws Exception {
         FileCompactStrategy strategy = Builder.newBuilder().setSizeThreshold(10).build();
         CompactCoordinator coordinator =
                 new CompactCoordinator(strategy, getTestCommittableSerializer());
@@ -177,23 +178,23 @@ public class CompactCoordinatorTest extends AbstractCompactTestBase {
 
             harness.processElement(message(committable0));
 
-            Assert.assertEquals(0, harness.extractOutputValues().size());
+            assertThat(harness.extractOutputValues()).isEmpty();
 
             harness.prepareSnapshotPreBarrier(1);
             harness.snapshot(1, 1);
 
-            Assert.assertEquals(0, harness.extractOutputValues().size());
+            assertThat(harness.extractOutputValues()).isEmpty();
 
             harness.endInput();
 
             List<CompactorRequest> results = harness.extractOutputValues();
-            Assert.assertEquals(1, results.size());
+            assertThat(results).hasSize(1);
             assertToCompact(results.get(0), committable0);
         }
     }
 
     @Test
-    public void testPassthrough() throws Exception {
+    void testPassthrough() throws Exception {
         FileCompactStrategy strategy = Builder.newBuilder().setSizeThreshold(10).build();
         CompactCoordinator coordinator =
                 new CompactCoordinator(strategy, getTestCommittableSerializer());
@@ -215,7 +216,7 @@ public class CompactCoordinatorTest extends AbstractCompactTestBase {
             harness.processElement(message(normalCommittable));
 
             List<CompactorRequest> results = harness.extractOutputValues();
-            Assert.assertEquals(1, results.size());
+            assertThat(results).hasSize(1);
             assertToCompact(results.get(0), normalCommittable);
             assertToPassthrough(
                     results.get(0),
@@ -226,7 +227,7 @@ public class CompactCoordinatorTest extends AbstractCompactTestBase {
     }
 
     @Test
-    public void testRestore() throws Exception {
+    void testRestore() throws Exception {
         FileCompactStrategy strategy = Builder.newBuilder().setSizeThreshold(10).build();
         CompactCoordinator coordinator =
                 new CompactCoordinator(strategy, getTestCommittableSerializer());
@@ -244,7 +245,7 @@ public class CompactCoordinatorTest extends AbstractCompactTestBase {
             harness.open();
 
             harness.processElement(message(committable0));
-            Assert.assertEquals(0, harness.extractOutputValues().size());
+            assertThat(harness.extractOutputValues()).isEmpty();
 
             harness.prepareSnapshotPreBarrier(1);
             state = harness.snapshot(1, 1);
@@ -260,17 +261,17 @@ public class CompactCoordinatorTest extends AbstractCompactTestBase {
 
             harness.processElement(message(committable1));
 
-            Assert.assertEquals(1, harness.extractOutputValues().size());
+            assertThat(harness.extractOutputValues()).hasSize(1);
 
             harness.processElement(message(committable2));
             harness.processElement(message(committable3));
 
-            Assert.assertEquals(1, harness.extractOutputValues().size());
+            assertThat(harness.extractOutputValues()).hasSize(1);
 
             harness.endInput();
 
             List<CompactorRequest> results = harness.extractOutputValues();
-            Assert.assertEquals(3, results.size());
+            assertThat(results).hasSize(3);
             assertToCompact(results.get(0), committable0, committable1);
             assertToCompact(results.get(1), committable2);
             assertToCompact(results.get(2), committable3);
@@ -278,7 +279,7 @@ public class CompactCoordinatorTest extends AbstractCompactTestBase {
     }
 
     @Test
-    public void testRestoreWithChangedStrategy() throws Exception {
+    void testRestoreWithChangedStrategy() throws Exception {
         FileCompactStrategy strategy = Builder.newBuilder().setSizeThreshold(100).build();
         CompactCoordinator coordinator =
                 new CompactCoordinator(strategy, getTestCommittableSerializer());
@@ -306,7 +307,7 @@ public class CompactCoordinatorTest extends AbstractCompactTestBase {
             harness.prepareSnapshotPreBarrier(1);
             state = harness.snapshot(1, 1);
 
-            Assert.assertEquals(0, harness.extractOutputValues().size());
+            assertThat(harness.extractOutputValues()).isEmpty();
         }
 
         FileCompactStrategy changedStrategy = Builder.newBuilder().setSizeThreshold(10).build();
@@ -319,12 +320,12 @@ public class CompactCoordinatorTest extends AbstractCompactTestBase {
             harness.initializeState(state);
             harness.open();
 
-            Assert.assertEquals(2, harness.extractOutputValues().size());
+            assertThat(harness.extractOutputValues()).hasSize(2);
 
             harness.processElement(message(committable5));
 
             List<CompactorRequest> results = harness.extractOutputValues();
-            Assert.assertEquals(3, results.size());
+            assertThat(results).hasSize(3);
             assertToCompact(results.get(0), committable0, committable1);
             assertToCompact(results.get(1), committable2, committable3);
             assertToCompact(results.get(2), committable4, committable5);
@@ -332,7 +333,7 @@ public class CompactCoordinatorTest extends AbstractCompactTestBase {
     }
 
     @Test
-    public void testStateHandler() throws Exception {
+    void testStateHandler() throws Exception {
         FileCompactStrategy strategy = Builder.newBuilder().setSizeThreshold(10).build();
         CompactCoordinator coordinator =
                 new CompactCoordinator(strategy, getTestCommittableSerializer());
@@ -354,10 +355,10 @@ public class CompactCoordinatorTest extends AbstractCompactTestBase {
             harness.open();
 
             harness.processElement(message(committable0));
-            Assert.assertEquals(0, harness.extractOutputValues().size());
+            assertThat(harness.extractOutputValues()).isEmpty();
 
             harness.processElement(message(cleanup3));
-            Assert.assertEquals(0, harness.extractOutputValues().size());
+            assertThat(harness.extractOutputValues()).isEmpty();
 
             harness.prepareSnapshotPreBarrier(1);
             state = harness.snapshot(1, 1);
@@ -382,38 +383,40 @@ public class CompactCoordinatorTest extends AbstractCompactTestBase {
             harness.initializeState(state);
             harness.open();
 
-            Assert.assertEquals(2, harness.extractOutputValues().size());
+            assertThat(harness.extractOutputValues()).hasSize(2);
 
             harness.processElement(message(committable1));
             harness.processElement(message(committable2));
 
             List<Either<CommittableMessage<FileSinkCommittable>, CompactorRequest>> results =
                     harness.extractOutputValues();
-            Assert.assertEquals(4, results.size());
+            assertThat(results).hasSize(4);
 
             // restored request
-            Assert.assertTrue(results.get(0).isRight());
+            assertThat(results.get(0).isRight()).isTrue();
             assertToCompact(results.get(0).right(), committable0);
 
             assertToPassthrough(results.get(1).right(), cleanup3);
 
             // committable with . prefix should also be passed through
-            Assert.assertTrue(
-                    results.get(2).isLeft()
-                            && results.get(2).left() instanceof CommittableWithLineage);
-            Assert.assertEquals(
-                    ((CommittableWithLineage<FileSinkCommittable>) results.get(2).left())
-                            .getCommittable(),
-                    committable1);
+            assertThat(
+                            results.get(2).isLeft()
+                                    && results.get(2).left() instanceof CommittableWithLineage)
+                    .isTrue();
+            assertThat(
+                            ((CommittableWithLineage<FileSinkCommittable>) results.get(2).left())
+                                    .getCommittable())
+                    .isEqualTo(committable1);
 
             // committable without . prefix should be passed through normally
-            Assert.assertTrue(
-                    results.get(3).isLeft()
-                            && results.get(3).left() instanceof CommittableWithLineage);
-            Assert.assertEquals(
-                    ((CommittableWithLineage<FileSinkCommittable>) results.get(3).left())
-                            .getCommittable(),
-                    committable2);
+            assertThat(
+                            results.get(3).isLeft()
+                                    && results.get(3).left() instanceof CommittableWithLineage)
+                    .isTrue();
+            assertThat(
+                            ((CommittableWithLineage<FileSinkCommittable>) results.get(3).left())
+                                    .getCommittable())
+                    .isEqualTo(committable2);
         }
     }
 
@@ -448,12 +451,12 @@ public class CompactCoordinatorTest extends AbstractCompactTestBase {
 
     private void assertToCompact(CompactorRequest request, FileSinkCommittable... committables) {
         List<FileSinkCommittable> committableToCompact = request.getCommittableToCompact();
-        Assert.assertArrayEquals(committables, committableToCompact.toArray());
+        assertThat(committableToCompact.toArray()).isEqualTo(committables);
     }
 
     private void assertToPassthrough(
             CompactorRequest request, FileSinkCommittable... committables) {
         List<FileSinkCommittable> committableToCompact = request.getCommittableToPassthrough();
-        Assert.assertArrayEquals(committables, committableToCompact.toArray());
+        assertThat(committableToCompact.toArray()).isEqualTo(committables);
     }
 }

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/compactor/CompactorOperatorTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/compactor/CompactorOperatorTest.java
@@ -45,8 +45,7 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.types.Either;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.BufferedWriter;
 import java.io.FileOutputStream;
@@ -58,11 +57,13 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /** Test for {@link CompactorOperator}. */
-public class CompactorOperatorTest extends AbstractCompactTestBase {
+class CompactorOperatorTest extends AbstractCompactTestBase {
 
     @Test
-    public void testCompact() throws Exception {
+    void testCompact() throws Exception {
         FileCompactor fileCompactor =
                 new RecordWiseFileCompactor<>(new DecoderBasedReader.Factory<>(IntDecoder::new));
         CompactorOperator compactor = createTestOperator(fileCompactor);
@@ -79,7 +80,7 @@ public class CompactorOperatorTest extends AbstractCompactTestBase {
                             Arrays.asList(committable("0", ".0", 5), committable("0", ".1", 5)),
                             null));
 
-            Assert.assertEquals(0, harness.extractOutputValues().size());
+            assertThat(harness.extractOutputValues()).isEmpty();
 
             harness.prepareSnapshotPreBarrier(1);
             harness.snapshot(1, 1L);
@@ -87,13 +88,13 @@ public class CompactorOperatorTest extends AbstractCompactTestBase {
 
             compactor.getAllTasksFuture().join();
 
-            Assert.assertEquals(0, harness.extractOutputValues().size());
+            assertThat(harness.extractOutputValues()).isEmpty();
 
             harness.prepareSnapshotPreBarrier(2);
 
             // 1summary+1compacted+2cleanup
             List<CommittableMessage<FileSinkCommittable>> results = harness.extractOutputValues();
-            Assert.assertEquals(4, results.size());
+            assertThat(results).hasSize(4);
             SinkV2Assertions.assertThat((CommittableSummary<?>) results.get(0))
                     .hasPendingCommittables(3);
             SinkV2Assertions.assertThat((CommittableWithLineage<?>) results.get(1))
@@ -106,7 +107,7 @@ public class CompactorOperatorTest extends AbstractCompactTestBase {
     }
 
     @Test
-    public void testPassthrough() throws Exception {
+    void testPassthrough() throws Exception {
         FileCompactor fileCompactor =
                 new RecordWiseFileCompactor<>(new DecoderBasedReader.Factory<>(IntDecoder::new));
         CompactorOperator compactor = createTestOperator(fileCompactor);
@@ -125,7 +126,7 @@ public class CompactorOperatorTest extends AbstractCompactTestBase {
             harness.processElement(
                     request("0", null, Collections.singletonList(cleanupPathRequest)));
 
-            Assert.assertEquals(0, harness.extractOutputValues().size());
+            assertThat(harness.extractOutputValues()).isEmpty();
 
             harness.prepareSnapshotPreBarrier(1);
             harness.snapshot(1, 1L);
@@ -133,12 +134,12 @@ public class CompactorOperatorTest extends AbstractCompactTestBase {
 
             compactor.getAllTasksFuture().join();
 
-            Assert.assertEquals(0, harness.extractOutputValues().size());
+            assertThat(harness.extractOutputValues()).isEmpty();
 
             harness.prepareSnapshotPreBarrier(2);
 
             List<CommittableMessage<FileSinkCommittable>> results = harness.extractOutputValues();
-            Assert.assertEquals(3, results.size());
+            assertThat(results).hasSize(3);
             SinkV2Assertions.assertThat((CommittableSummary<?>) results.get(0))
                     .hasPendingCommittables(2);
             SinkV2Assertions.assertThat((CommittableWithLineage<?>) results.get(1))
@@ -149,7 +150,7 @@ public class CompactorOperatorTest extends AbstractCompactTestBase {
     }
 
     @Test
-    public void testRestore() throws Exception {
+    void testRestore() throws Exception {
         FileCompactor fileCompactor =
                 new RecordWiseFileCompactor<>(new DecoderBasedReader.Factory<>(IntDecoder::new));
         CompactorOperator compactor = createTestOperator(fileCompactor);
@@ -193,7 +194,7 @@ public class CompactorOperatorTest extends AbstractCompactTestBase {
             harness.prepareSnapshotPreBarrier(3);
 
             // the result of request 1 should be emitted
-            Assert.assertEquals(4, harness.extractOutputValues().size());
+            assertThat(harness.extractOutputValues()).hasSize(4);
 
             harness.snapshot(3, 3L);
             harness.notifyOfCompletedCheckpoint(3L);
@@ -203,11 +204,11 @@ public class CompactorOperatorTest extends AbstractCompactTestBase {
             harness.prepareSnapshotPreBarrier(4);
 
             // the result of request 2 should be emitted
-            Assert.assertEquals(8, harness.extractOutputValues().size());
+            assertThat(harness.extractOutputValues()).hasSize(8);
 
             // 1summary+1compacted+2cleanup * 2
             List<CommittableMessage<FileSinkCommittable>> results = harness.extractOutputValues();
-            Assert.assertEquals(8, results.size());
+            assertThat(results).hasSize(8);
             SinkV2Assertions.assertThat((CommittableSummary<?>) results.get(0))
                     .hasPendingCommittables(3);
             SinkV2Assertions.assertThat((CommittableWithLineage<?>) results.get(1))
@@ -229,7 +230,7 @@ public class CompactorOperatorTest extends AbstractCompactTestBase {
     }
 
     @Test
-    public void testStateHandler() throws Exception {
+    void testStateHandler() throws Exception {
         FileCompactor fileCompactor =
                 new RecordWiseFileCompactor<>(new DecoderBasedReader.Factory<>(IntDecoder::new));
         CompactorOperator compactor = createTestOperator(fileCompactor);
@@ -317,7 +318,7 @@ public class CompactorOperatorTest extends AbstractCompactTestBase {
             // 1 summary + (1 compacted committable + 1 compacted cleanup) * 6 + 1 hidden + 1 normal
             // + 1 summary + 1 cleanup + 1 summary
             List<CommittableMessage<FileSinkCommittable>> results = harness.extractOutputValues();
-            Assert.assertEquals(18, results.size());
+            assertThat(results).hasSize(18);
             SinkV2Assertions.assertThat((CommittableSummary<?>) results.get(0))
                     .hasPendingCommittables(14);
 
@@ -354,7 +355,7 @@ public class CompactorOperatorTest extends AbstractCompactTestBase {
     }
 
     @Test
-    public void testStateHandlerRestore() throws Exception {
+    void testStateHandlerRestore() throws Exception {
         OperatorSubtaskState state;
         try (OneInputStreamOperatorTestHarness<
                         Either<CommittableMessage<FileSinkCommittable>, CompactorRequest>,
@@ -386,7 +387,7 @@ public class CompactorOperatorTest extends AbstractCompactTestBase {
             state = harness.snapshot(1, 1L);
 
             List<CommittableMessage<FileSinkCommittable>> results = harness.extractOutputValues();
-            Assert.assertEquals(3, results.size());
+            assertThat(results).hasSize(3);
             SinkV2Assertions.assertThat((CommittableSummary<?>) results.get(0))
                     .hasPendingCommittables(4);
             SinkV2Assertions.assertThat((CommittableWithLineage<?>) results.get(1))
@@ -422,7 +423,7 @@ public class CompactorOperatorTest extends AbstractCompactTestBase {
             state = harness.snapshot(2, 2L);
 
             List<CommittableMessage<FileSinkCommittable>> results = harness.extractOutputValues();
-            Assert.assertEquals(2, results.size());
+            assertThat(results).hasSize(2);
             SinkV2Assertions.assertThat((CommittableWithLineage<?>) results.get(0))
                     .hasCommittable(committable("0", "2", 2));
             SinkV2Assertions.assertThat((CommittableWithLineage<?>) results.get(1))
@@ -445,7 +446,7 @@ public class CompactorOperatorTest extends AbstractCompactTestBase {
                     new StreamRecord<>(Either.Left(new CommittableSummary<>(0, 1, 2L, 0, 0, 0))));
 
             List<CommittableMessage<FileSinkCommittable>> results = harness.extractOutputValues();
-            Assert.assertEquals(2, results.size());
+            assertThat(results).hasSize(2);
             SinkV2Assertions.assertThat((CommittableSummary<?>) results.get(0))
                     .hasPendingCommittables(1);
             SinkV2Assertions.assertThat((CommittableWithLineage<?>) results.get(1))

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/utils/IntegerFileSinkTestDataUtils.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/utils/IntegerFileSinkTestDataUtils.java
@@ -37,9 +37,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Utilities for file sinks that writes a sequence of continues integers into files starting from 0.
@@ -117,25 +115,25 @@ public class IntegerFileSinkTestDataUtils {
             String path, int numRecords, int numBuckets, int numSources) throws Exception {
         File dir = new File(path);
         String[] subDirNames = dir.list();
-        assertNotNull(subDirNames);
+        assertThat(subDirNames).isNotNull();
 
         Arrays.sort(subDirNames, Comparator.comparingInt(Integer::parseInt));
-        assertEquals(numBuckets, subDirNames.length);
+        assertThat(subDirNames).hasSize(numBuckets);
         for (int i = 0; i < numBuckets; ++i) {
-            assertEquals(Integer.toString(i), subDirNames[i]);
+            assertThat(subDirNames[i]).isEqualTo(Integer.toString(i));
 
             // now check its content
             File bucketDir = new File(path, subDirNames[i]);
-            assertTrue(
-                    bucketDir.getAbsolutePath() + " Should be a existing directory",
-                    bucketDir.isDirectory());
+            assertThat(bucketDir.isDirectory())
+                    .as(bucketDir.getAbsolutePath() + " Should be a existing directory")
+                    .isTrue();
 
             Map<Integer, Integer> counts = new HashMap<>();
             File[] files = bucketDir.listFiles(f -> !f.getName().startsWith("."));
-            assertNotNull(files);
+            assertThat(files).isNotNull();
 
             for (File file : files) {
-                assertTrue(file.isFile());
+                assertThat(file).isFile();
 
                 try (DataInputStream dataInputStream =
                         new DataInputStream(new FileInputStream(file))) {
@@ -149,20 +147,20 @@ public class IntegerFileSinkTestDataUtils {
             }
 
             int expectedCount = numRecords / numBuckets + (i < numRecords % numBuckets ? 1 : 0);
-            assertEquals(expectedCount, counts.size());
+            assertThat(counts).hasSize(expectedCount);
 
             for (int j = i; j < numRecords; j += numBuckets) {
-                assertEquals(
-                        "The record "
-                                + j
-                                + " should occur "
-                                + numSources
-                                + " times, "
-                                + " but only occurs "
-                                + counts.getOrDefault(j, 0)
-                                + "time",
-                        numSources,
-                        counts.getOrDefault(j, 0).intValue());
+                assertThat(counts.getOrDefault(j, 0).intValue())
+                        .as(
+                                "The record "
+                                        + j
+                                        + " should occur "
+                                        + numSources
+                                        + " times, "
+                                        + " but only occurs "
+                                        + counts.getOrDefault(j, 0)
+                                        + "time")
+                        .isEqualTo(numSources);
             }
         }
     }

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/utils/IntegerFileSinkTestDataUtils.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/utils/IntegerFileSinkTestDataUtils.java
@@ -124,9 +124,9 @@ public class IntegerFileSinkTestDataUtils {
 
             // now check its content
             File bucketDir = new File(path, subDirNames[i]);
-            assertThat(bucketDir.isDirectory())
+            assertThat(bucketDir)
                     .as(bucketDir.getAbsolutePath() + " Should be a existing directory")
-                    .isTrue();
+                    .isDirectory();
 
             Map<Integer, Integer> counts = new HashMap<>();
             File[] files = bucketDir.listFiles(f -> !f.getName().startsWith("."));

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/writer/FileSinkMigrationITCase.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/writer/FileSinkMigrationITCase.java
@@ -64,7 +64,8 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class FileSinkMigrationITCase {
 
-    @RegisterExtension final SharedObjectsExtension sharedObjects = SharedObjectsExtension.create();
+    @RegisterExtension
+    private final SharedObjectsExtension sharedObjects = SharedObjectsExtension.create();
 
     private static final String SOURCE_UID = "source";
 

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/writer/FileSinkMigrationITCase.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/writer/FileSinkMigrationITCase.java
@@ -39,15 +39,13 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink;
 import org.apache.flink.streaming.api.functions.sink.filesystem.rollingpolicies.OnCheckpointRollingPolicy;
 import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
-import org.apache.flink.testutils.junit.SharedObjects;
+import org.apache.flink.testutils.junit.SharedObjectsExtension;
 import org.apache.flink.testutils.junit.SharedReference;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -58,17 +56,15 @@ import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 
 import static org.apache.flink.runtime.testutils.CommonTestUtils.waitForAllTaskRunning;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests migrating from {@link StreamingFileSink} to {@link FileSink}. It trigger a savepoint for
  * the {@link StreamingFileSink} job and restore the {@link FileSink} job from the savepoint taken.
  */
-public class FileSinkMigrationITCase extends TestLogger {
+class FileSinkMigrationITCase {
 
-    @ClassRule public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
-
-    @Rule public final SharedObjects sharedObjects = SharedObjects.create();
+    @RegisterExtension final SharedObjectsExtension sharedObjects = SharedObjectsExtension.create();
 
     private static final String SOURCE_UID = "source";
 
@@ -84,8 +80,8 @@ public class FileSinkMigrationITCase extends TestLogger {
 
     private SharedReference<CountDownLatch> finalCheckpointLatch;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         // We wait for two successful checkpoints in sources before shutting down. This ensures that
         // the sink can commit its data.
         // We need to keep a "static" latch here because all sources need to be kept running
@@ -95,23 +91,24 @@ public class FileSinkMigrationITCase extends TestLogger {
     }
 
     @Test
-    public void test() throws Exception {
+    void test() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         SharedReference<Collection<Long>> list = sharedObjects.add(new ArrayList<>());
         int n = 10000;
         env.setParallelism(100);
         env.fromSequence(0, n).map(i -> list.applySync(l -> l.add(i)));
         env.execute();
-        assertEquals(n + 1, list.get().size());
-        assertEquals(
-                LongStream.rangeClosed(0, n).boxed().collect(Collectors.toList()),
-                list.get().stream().sorted().collect(Collectors.toList()));
+        assertThat(list.get()).hasSize(n + 1);
+        assertThat(LongStream.rangeClosed(0, n).boxed().collect(Collectors.toList()))
+                .isEqualTo(list.get().stream().sorted().collect(Collectors.toList()));
     }
 
     @Test
-    public void testMigration() throws Exception {
-        String outputPath = TEMPORARY_FOLDER.newFolder().getAbsolutePath();
-        String savepointBasePath = TEMPORARY_FOLDER.newFolder().getAbsolutePath();
+    void testMigration(
+            @TempDir java.nio.file.Path tmpOutputDir, @TempDir java.nio.file.Path tmpSavepointDir)
+            throws Exception {
+        String outputPath = tmpOutputDir.toString();
+        String savepointBasePath = tmpSavepointDir.toString();
 
         final MiniClusterConfiguration cfg =
                 new MiniClusterConfiguration.Builder()

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/writer/FileWriterBucketStateSerializerMigrationTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/writer/FileWriterBucketStateSerializerMigrationTest.java
@@ -37,30 +37,22 @@ import org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSin
 import org.apache.flink.streaming.api.functions.sink.filesystem.rollingpolicies.DefaultRollingPolicy;
 import org.apache.flink.util.FileUtils;
 
-import org.junit.Assert;
-import org.junit.ClassRule;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.startsWith;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.iterableWithSize;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for the {@link FileWriterBucketStateSerializer} that verify we can still read snapshots
@@ -74,17 +66,13 @@ import static org.junit.Assert.assertThat;
  * test. The generated test data from {@code BucketStateSerializerTest} has been copied to be reused
  * in this test to ensure we can restore the same bytes.
  */
-@RunWith(Parameterized.class)
-public class FileWriterBucketStateSerializerMigrationTest {
+class FileWriterBucketStateSerializerMigrationTest {
 
     private static final int CURRENT_VERSION = 2;
 
-    @Parameterized.Parameters(name = "Previous Version = {0}")
-    public static Collection<Integer> previousVersions() {
-        return Arrays.asList(1, 2);
+    static Stream<Integer> previousVersions() {
+        return Stream.of(1, 2);
     }
-
-    @Parameterized.Parameter public Integer previousVersion;
 
     private static final String IN_PROGRESS_CONTENT = "writing";
     private static final String PENDING_CONTENT = "wrote";
@@ -94,20 +82,19 @@ public class FileWriterBucketStateSerializerMigrationTest {
     private static final java.nio.file.Path BASE_PATH =
             Paths.get("src/test/resources/").resolve("bucket-state-migration-test");
 
-    @ClassRule public static TemporaryFolder tempFolder = new TemporaryFolder();
-
     private final BucketStateGenerator generator =
             new BucketStateGenerator(
                     BUCKET_ID, IN_PROGRESS_CONTENT, PENDING_CONTENT, BASE_PATH, CURRENT_VERSION);
 
     @Test
-    @Ignore
-    public void prepareDeserializationEmpty() throws IOException {
+    @Disabled
+    void prepareDeserializationEmpty() throws IOException {
         generator.prepareDeserializationEmpty();
     }
 
-    @Test
-    public void testSerializationEmpty() throws IOException {
+    @ParameterizedTest(name = "Previous Version = {0}")
+    @MethodSource("previousVersions")
+    void testSerializationEmpty(int previousVersion) throws IOException {
 
         final String scenarioName = "empty";
         final BucketStatePathResolver pathResolver =
@@ -119,19 +106,20 @@ public class FileWriterBucketStateSerializerMigrationTest {
 
         final FileWriterBucket<String> bucket = restoreBucket(recoveredState);
 
-        Assert.assertEquals(testBucketPath, bucket.getBucketPath());
-        Assert.assertNull(bucket.getInProgressPart());
-        Assert.assertTrue(bucket.getPendingFiles().isEmpty());
+        assertThat(bucket.getBucketPath()).isEqualTo(testBucketPath);
+        assertThat(bucket.getInProgressPart()).isNull();
+        assertThat(bucket.getPendingFiles()).isEmpty();
     }
 
     @Test
-    @Ignore
-    public void prepareDeserializationOnlyInProgress() throws IOException {
+    @Disabled
+    void prepareDeserializationOnlyInProgress() throws IOException {
         generator.prepareDeserializationOnlyInProgress();
     }
 
-    @Test
-    public void testSerializationOnlyInProgress() throws IOException {
+    @ParameterizedTest(name = "Previous Version = {0}")
+    @MethodSource("previousVersions")
+    void testSerializationOnlyInProgress(int previousVersion) throws IOException {
 
         final String scenarioName = "only-in-progress";
         final BucketStatePathResolver pathResolver =
@@ -145,48 +133,51 @@ public class FileWriterBucketStateSerializerMigrationTest {
 
         final FileWriterBucket<String> bucket = restoreBucket(recoveredState);
 
-        Assert.assertEquals(testBucketPath, bucket.getBucketPath());
+        assertThat(bucket.getBucketPath()).isEqualTo(testBucketPath);
 
         // check restore the correct in progress file writer
-        Assert.assertEquals(8, bucket.getInProgressPart().getSize());
+        assertThat(bucket.getInProgressPart().getSize()).isEqualTo(8);
 
         long numFiles =
                 Files.list(Paths.get(testBucketPath.toString()))
                         .map(
                                 file -> {
-                                    assertThat(
-                                            file.getFileName().toString(),
-                                            startsWith(".part-0-0.inprogress"));
+                                    assertThat(file.getFileName().toString())
+                                            .startsWith(".part-0-0.inprogress");
                                     return 1;
                                 })
                         .count();
 
-        assertThat(numFiles, is(1L));
+        assertThat(numFiles).isEqualTo(1L);
     }
 
     @Test
-    @Ignore
-    public void prepareDeserializationFull() throws IOException {
+    @Disabled
+    void prepareDeserializationFull() throws IOException {
         generator.prepareDeserializationFull();
     }
 
-    @Test
-    public void testSerializationFull() throws IOException, InterruptedException {
-        testDeserializationFull(true, "full");
+    @ParameterizedTest(name = "Previous Version = {0}")
+    @MethodSource("previousVersions")
+    void testSerializationFull(int previousVersion) throws IOException, InterruptedException {
+        testDeserializationFull(previousVersion, true, "full");
     }
 
     @Test
-    @Ignore
-    public void prepareDeserializationNullInProgress() throws IOException {
+    @Disabled
+    void prepareDeserializationNullInProgress() throws IOException {
         generator.prepareDeserializationNullInProgress();
     }
 
-    @Test
-    public void testSerializationNullInProgress() throws IOException, InterruptedException {
-        testDeserializationFull(false, "full-no-in-progress");
+    @ParameterizedTest(name = "Previous Version = {0}")
+    @MethodSource("previousVersions")
+    void testSerializationNullInProgress(int previousVersion)
+            throws IOException, InterruptedException {
+        testDeserializationFull(previousVersion, false, "full-no-in-progress");
     }
 
-    private void testDeserializationFull(final boolean withInProgress, final String scenarioName)
+    private void testDeserializationFull(
+            int previousVersion, final boolean withInProgress, final String scenarioName)
             throws IOException, InterruptedException {
 
         final BucketStatePathResolver pathResolver =
@@ -204,7 +195,7 @@ public class FileWriterBucketStateSerializerMigrationTest {
             final Map<Long, List<InProgressFileWriter.PendingFileRecoverable>>
                     pendingFileRecoverables =
                             recoveredState.getPendingFileRecoverablesPerCheckpoint();
-            Assert.assertEquals(5L, pendingFileRecoverables.size());
+            assertThat(pendingFileRecoverables).hasSize(5);
 
             final Set<String> beforeRestorePaths =
                     Files.list(outputPath.resolve(BUCKET_ID))
@@ -214,12 +205,12 @@ public class FileWriterBucketStateSerializerMigrationTest {
             // before retsoring all file has "inprogress"
             for (int i = 0; i < noOfPendingCheckpoints; i++) {
                 final String part = ".part-0-" + i + ".inprogress";
-                assertThat(beforeRestorePaths, hasItem(startsWith(part)));
+                assertThat(beforeRestorePaths).anyMatch(s -> s.startsWith(part));
             }
 
             final FileWriterBucket<String> bucket = restoreBucket(recoveredState);
-            Assert.assertEquals(testBucketPath, bucket.getBucketPath());
-            Assert.assertEquals(noOfPendingCheckpoints, bucket.getPendingFiles().size());
+            assertThat(bucket.getBucketPath()).isEqualTo(testBucketPath);
+            assertThat(bucket.getPendingFiles()).hasSize(noOfPendingCheckpoints);
 
             // simulates we commit the recovered pending files on the first checkpoint
             bucket.snapshotState();
@@ -239,20 +230,24 @@ public class FileWriterBucketStateSerializerMigrationTest {
             // there is no "inporgress" in file name for the committed files.
             for (int i = 0; i < noOfPendingCheckpoints; i++) {
                 final String part = "part-0-" + i;
-                assertThat(afterRestorePaths, hasItem(part));
+                assertThat(afterRestorePaths).contains(part);
                 afterRestorePaths.remove(part);
             }
 
             if (withInProgress) {
                 // only the in-progress must be left
-                assertThat(afterRestorePaths, iterableWithSize(1));
+                assertThat(afterRestorePaths).hasSize(1);
 
                 // verify that the in-progress file is still there
-                assertThat(
-                        afterRestorePaths,
-                        hasItem(startsWith(".part-0-" + noOfPendingCheckpoints + ".inprogress")));
+                assertThat(afterRestorePaths)
+                        .anyMatch(
+                                s ->
+                                        s.startsWith(
+                                                ".part-0-"
+                                                        + noOfPendingCheckpoints
+                                                        + ".inprogress"));
             } else {
-                assertThat(afterRestorePaths, empty());
+                assertThat(afterRestorePaths).isEmpty();
             }
         } finally {
             FileUtils.deleteDirectory(pathResolver.getResourcePath(scenarioName).toFile());

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/writer/FileWriterBucketStateSerializerTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/writer/FileWriterBucketStateSerializerTest.java
@@ -21,17 +21,17 @@ package org.apache.flink.connector.file.sink.writer;
 import org.apache.flink.connector.file.sink.utils.FileSinkTestUtils;
 import org.apache.flink.core.fs.Path;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests the serialization and deserialization for {@link FileWriterBucketState}. */
-public class FileWriterBucketStateSerializerTest {
+class FileWriterBucketStateSerializerTest {
 
     @Test
-    public void testWithoutInProgressFile() throws IOException {
+    void testWithoutInProgressFile() throws IOException {
         FileWriterBucketState bucketState =
                 new FileWriterBucketState(
                         "bucketId", new Path("file:///tmp/bucketId"), 1429537268, null);
@@ -40,7 +40,7 @@ public class FileWriterBucketStateSerializerTest {
     }
 
     @Test
-    public void testWithInProgressFile() throws IOException {
+    void testWithInProgressFile() throws IOException {
         FileWriterBucketState bucketState =
                 new FileWriterBucketState(
                         "bucketId",
@@ -53,14 +53,12 @@ public class FileWriterBucketStateSerializerTest {
 
     private void assertBucketStateEquals(
             FileWriterBucketState bucketState, FileWriterBucketState deserialized) {
-        assertEquals(bucketState.getBucketId(), deserialized.getBucketId());
-        assertEquals(bucketState.getBucketPath(), deserialized.getBucketPath());
-        assertEquals(
-                bucketState.getInProgressFileCreationTime(),
-                deserialized.getInProgressFileCreationTime());
-        assertEquals(
-                bucketState.getInProgressFileRecoverable(),
-                deserialized.getInProgressFileRecoverable());
+        assertThat(bucketState.getBucketId()).isEqualTo(deserialized.getBucketId());
+        assertThat(bucketState.getBucketPath()).isEqualTo(deserialized.getBucketPath());
+        assertThat(bucketState.getInProgressFileCreationTime())
+                .isEqualTo(deserialized.getInProgressFileCreationTime());
+        assertThat(bucketState.getInProgressFileRecoverable())
+                .isEqualTo(deserialized.getInProgressFileRecoverable());
     }
 
     private FileWriterBucketState serializeAndDeserialize(FileWriterBucketState bucketState)

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/writer/FileWriterTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/writer/FileWriterTest.java
@@ -62,17 +62,17 @@ import java.util.concurrent.ScheduledFuture;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link FileWriter}. */
-public class FileWriterTest {
+class FileWriterTest {
 
     private MetricListener metricListener;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         metricListener = new MetricListener();
     }
 
     @Test
-    public void testPreCommit(@TempDir java.nio.file.Path tempDir) throws Exception {
+    void testPreCommit(@TempDir java.nio.file.Path tempDir) throws Exception {
         Path path = new Path(tempDir.toUri());
 
         FileWriter<String> fileWriter =
@@ -91,7 +91,7 @@ public class FileWriterTest {
     }
 
     @Test
-    public void testSnapshotAndRestore(@TempDir java.nio.file.Path tempDir) throws Exception {
+    void testSnapshotAndRestore(@TempDir java.nio.file.Path tempDir) throws Exception {
         Path path = new Path(tempDir.toUri());
 
         FileWriter<String> fileWriter =
@@ -128,7 +128,7 @@ public class FileWriterTest {
     }
 
     @Test
-    public void testMergingForRescaling(@TempDir java.nio.file.Path tempDir) throws Exception {
+    void testMergingForRescaling(@TempDir java.nio.file.Path tempDir) throws Exception {
         Path path = new Path(tempDir.toUri());
 
         FileWriter<String> firstFileWriter =
@@ -191,8 +191,7 @@ public class FileWriterTest {
     }
 
     @Test
-    public void testBucketIsRemovedWhenNotActive(@TempDir java.nio.file.Path tempDir)
-            throws Exception {
+    void testBucketIsRemovedWhenNotActive(@TempDir java.nio.file.Path tempDir) throws Exception {
         Path path = new Path(tempDir.toUri());
 
         FileWriter<String> fileWriter =
@@ -210,7 +209,7 @@ public class FileWriterTest {
     }
 
     @Test
-    public void testOnProcessingTime(@TempDir java.nio.file.Path tempDir) throws Exception {
+    void testOnProcessingTime(@TempDir java.nio.file.Path tempDir) throws Exception {
         Path path = new Path(tempDir.toUri());
 
         // Create the processing timer service starts from 10.
@@ -276,19 +275,17 @@ public class FileWriterTest {
     }
 
     @Test
-    public void testContextPassingNormalExecution(@TempDir java.nio.file.Path tempDir)
-            throws Exception {
+    void testContextPassingNormalExecution(@TempDir java.nio.file.Path tempDir) throws Exception {
         testCorrectTimestampPassingInContext(1L, 2L, 3L, tempDir);
     }
 
     @Test
-    public void testContextPassingNullTimestamp(@TempDir java.nio.file.Path tempDir)
-            throws Exception {
+    void testContextPassingNullTimestamp(@TempDir java.nio.file.Path tempDir) throws Exception {
         testCorrectTimestampPassingInContext(null, 4L, 5L, tempDir);
     }
 
     @Test
-    public void testNumberRecordsOutCounter(@TempDir java.nio.file.Path tempDir)
+    void testNumberRecordsOutCounter(@TempDir java.nio.file.Path tempDir)
             throws IOException, InterruptedException {
         Path path = new Path(tempDir.toUri());
 

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/FileSourceHeavyThroughputTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/FileSourceHeavyThroughputTest.java
@@ -38,8 +38,8 @@ import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.util.SimpleUserCodeClassLoader;
 import org.apache.flink.util.UserCodeClassLoader;
 
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
 
@@ -53,7 +53,7 @@ import static org.apache.flink.util.Preconditions.checkArgument;
  * This test simulates readers that just produce byte arrays very fast. The test is meant to check
  * that this does not break the system in terms of object allocations, etc.
  */
-public class FileSourceHeavyThroughputTest {
+class FileSourceHeavyThroughputTest {
 
     /**
      * Testing file system reference, to be cleaned up in an @After method. That way it also gets
@@ -61,8 +61,8 @@ public class FileSourceHeavyThroughputTest {
      */
     private TestingFileSystem testFs;
 
-    @After
-    public void unregisterTestFs() throws Exception {
+    @AfterEach
+    void unregisterTestFs() throws Exception {
         if (testFs != null) {
             testFs.unregister();
         }
@@ -71,7 +71,7 @@ public class FileSourceHeavyThroughputTest {
     // ------------------------------------------------------------------------
 
     @Test
-    public void testHeavyThroughput() throws Exception {
+    void testHeavyThroughput() throws Exception {
         final Path path = new Path("testfs:///testpath");
         final long fileSize = 20L << 30; // 20 GB
         final FileSourceSplit split =

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/FileSourceSplitSerializerTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/FileSourceSplitSerializerTest.java
@@ -22,19 +22,17 @@ import org.apache.flink.connector.file.src.util.CheckpointedPosition;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.io.SimpleVersionedSerialization;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Unit tests for the {@link FileSourceSplitSerializer}. */
-public class FileSourceSplitSerializerTest {
+class FileSourceSplitSerializerTest {
 
     @Test
-    public void serializeSplitWithHosts() throws Exception {
+    void serializeSplitWithHosts() throws Exception {
         final FileSourceSplit split =
                 new FileSourceSplit(
                         "random-id",
@@ -53,7 +51,7 @@ public class FileSourceSplitSerializerTest {
     }
 
     @Test
-    public void serializeSplitWithoutHosts() throws Exception {
+    void serializeSplitWithoutHosts() throws Exception {
         final FileSourceSplit split =
                 new FileSourceSplit(
                         "some-id",
@@ -69,7 +67,7 @@ public class FileSourceSplitSerializerTest {
     }
 
     @Test
-    public void serializeSplitWithReaderPosition() throws Exception {
+    void serializeSplitWithReaderPosition() throws Exception {
         final FileSourceSplit split =
                 new FileSourceSplit(
                         "random-id",
@@ -87,7 +85,7 @@ public class FileSourceSplitSerializerTest {
     }
 
     @Test
-    public void repeatedSerialization() throws Exception {
+    void repeatedSerialization() throws Exception {
         final FileSourceSplit split =
                 new FileSourceSplit(
                         "an-id",
@@ -105,7 +103,7 @@ public class FileSourceSplitSerializerTest {
     }
 
     @Test
-    public void repeatedSerializationCaches() throws Exception {
+    void repeatedSerializationCaches() throws Exception {
         final FileSourceSplit split =
                 new FileSourceSplit(
                         "random-id",
@@ -121,7 +119,7 @@ public class FileSourceSplitSerializerTest {
         final byte[] ser1 = FileSourceSplitSerializer.INSTANCE.serialize(split);
         final byte[] ser2 = FileSourceSplitSerializer.INSTANCE.serialize(split);
 
-        assertSame(ser1, ser2);
+        assertThat(ser1).isSameAs(ser2);
     }
 
     // ------------------------------------------------------------------------
@@ -137,11 +135,11 @@ public class FileSourceSplitSerializerTest {
     }
 
     static void assertSplitsEqual(FileSourceSplit expected, FileSourceSplit actual) {
-        assertEquals(expected.splitId(), actual.splitId());
-        assertEquals(expected.path(), actual.path());
-        assertEquals(expected.offset(), actual.offset());
-        assertEquals(expected.length(), actual.length());
-        assertArrayEquals(expected.hostnames(), actual.hostnames());
-        assertEquals(expected.getReaderPosition(), actual.getReaderPosition());
+        assertThat(actual.splitId()).isEqualTo(expected.splitId());
+        assertThat(actual.path()).isEqualTo(expected.path());
+        assertThat(actual.offset()).isEqualTo(expected.offset());
+        assertThat(actual.length()).isEqualTo(expected.length());
+        assertThat(actual.hostnames()).isEqualTo(expected.hostnames());
+        assertThat(actual.getReaderPosition()).isEqualTo(expected.getReaderPosition());
     }
 }

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/FileSourceSplitStateTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/FileSourceSplitStateTest.java
@@ -21,37 +21,36 @@ package org.apache.flink.connector.file.src;
 import org.apache.flink.connector.file.src.util.CheckpointedPosition;
 import org.apache.flink.core.fs.Path;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Unit tests for the {@link FileSourceSplitState}. */
-public class FileSourceSplitStateTest {
+class FileSourceSplitStateTest {
 
     @Test
-    public void testRoundTripWithoutModification() {
+    void testRoundTripWithoutModification() {
         final FileSourceSplit split = getTestSplit();
         final FileSourceSplitState state = new FileSourceSplitState(split);
 
         final FileSourceSplit resultSplit = state.toFileSourceSplit();
 
-        assertEquals(split.getReaderPosition(), resultSplit.getReaderPosition());
+        assertThat(resultSplit.getReaderPosition()).isEqualTo(split.getReaderPosition());
     }
 
     @Test
-    public void testStateStartsWithSplitValues() {
+    void testStateStartsWithSplitValues() {
         final FileSourceSplit split = getTestSplit(new CheckpointedPosition(123L, 456L));
         final FileSourceSplitState state = new FileSourceSplitState(split);
 
-        assertEquals(123L, state.getOffset());
-        assertEquals(456L, state.getRecordsToSkipAfterOffset());
+        assertThat(state.getOffset()).isEqualTo(123L);
+        assertThat(state.getRecordsToSkipAfterOffset()).isEqualTo(456L);
     }
 
     @Test
-    public void testNewSplitTakesModifiedOffsetAndCount() {
+    void testNewSplitTakesModifiedOffsetAndCount() {
         final FileSourceSplit split = getTestSplit();
         final FileSourceSplitState state = new FileSourceSplitState(split);
 
@@ -59,8 +58,8 @@ public class FileSourceSplitStateTest {
         final Optional<CheckpointedPosition> position =
                 state.toFileSourceSplit().getReaderPosition();
 
-        assertTrue(position.isPresent());
-        assertEquals(new CheckpointedPosition(1234L, 7566L), position.get());
+        assertThat(position).isPresent();
+        assertThat(position.get()).isEqualTo(new CheckpointedPosition(1234L, 7566L));
     }
 
     // ------------------------------------------------------------------------

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/FileSourceSplitTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/FileSourceSplitTest.java
@@ -20,14 +20,27 @@ package org.apache.flink.connector.file.src;
 
 import org.apache.flink.core.fs.Path;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Unit tests for the {@link FileSourceSplit}. */
-public class FileSourceSplitTest {
+class FileSourceSplitTest {
 
-    @Test(expected = IllegalArgumentException.class)
-    public void noNullHostsAllowed() {
-        new FileSourceSplit(
-                "id", new Path("file:/some/random/path"), 0, 10, 0, 10, "host1", null, "host2");
+    @Test
+    void noNullHostsAllowed() {
+        assertThatThrownBy(
+                        () ->
+                                new FileSourceSplit(
+                                        "id",
+                                        new Path("file:/some/random/path"),
+                                        0,
+                                        10,
+                                        0,
+                                        10,
+                                        "host1",
+                                        null,
+                                        "host2"))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/FileSourceTextLinesITCase.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/FileSourceTextLinesITCase.java
@@ -31,16 +31,14 @@ import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamUtils;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.operators.collect.ClientAndIterator;
-import org.apache.flink.test.util.MiniClusterWithClientResource;
-import org.apache.flink.testutils.junit.FailsWithAdaptiveScheduler;
-import org.apache.flink.util.TestLogger;
+import org.apache.flink.test.junit5.InjectMiniCluster;
+import org.apache.flink.test.junit5.MiniClusterExtension;
 import org.apache.flink.util.function.FunctionWithException;
 
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -59,20 +57,18 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.zip.GZIPOutputStream;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** MiniCluster-based integration test for the {@link FileSource}. */
-public class FileSourceTextLinesITCase extends TestLogger {
+class FileSourceTextLinesITCase {
 
     private static final int PARALLELISM = 4;
 
-    @ClassRule public static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();
+    @TempDir private static java.nio.file.Path tmpDir;
 
-    @Rule
-    public final MiniClusterWithClientResource miniClusterResource =
-            new MiniClusterWithClientResource(
+    @RegisterExtension
+    private static final MiniClusterExtension MINI_CLUSTER_RESOURCE =
+            new MiniClusterExtension(
                     new MiniClusterResourceConfiguration.Builder()
                             .setNumberTaskManagers(1)
                             .setNumberSlotsPerTaskManager(PARALLELISM)
@@ -86,8 +82,10 @@ public class FileSourceTextLinesITCase extends TestLogger {
 
     /** This test runs a job reading bounded input with a stream record format (text lines). */
     @Test
-    public void testBoundedTextFileSource() throws Exception {
-        testBoundedTextFileSource(FailoverType.NONE);
+    void testBoundedTextFileSource(
+            @TempDir java.nio.file.Path tmpTestDir, @InjectMiniCluster MiniCluster miniCluster)
+            throws Exception {
+        testBoundedTextFileSource(tmpTestDir, FailoverType.NONE, miniCluster);
     }
 
     /**
@@ -95,8 +93,10 @@ public class FileSourceTextLinesITCase extends TestLogger {
      * restarts TaskManager.
      */
     @Test
-    public void testBoundedTextFileSourceWithTaskManagerFailover() throws Exception {
-        testBoundedTextFileSource(FailoverType.TM);
+    void testBoundedTextFileSourceWithTaskManagerFailover(
+            @TempDir java.nio.file.Path tmpTestDir, @InjectMiniCluster MiniCluster miniCluster)
+            throws Exception {
+        testBoundedTextFileSource(tmpTestDir, FailoverType.TM, miniCluster);
     }
 
     /**
@@ -104,12 +104,16 @@ public class FileSourceTextLinesITCase extends TestLogger {
      * triggers JobManager failover.
      */
     @Test
-    public void testBoundedTextFileSourceWithJobManagerFailover() throws Exception {
-        testBoundedTextFileSource(FailoverType.JM);
+    void testBoundedTextFileSourceWithJobManagerFailover(
+            @TempDir java.nio.file.Path tmpTestDir, @InjectMiniCluster MiniCluster miniCluster)
+            throws Exception {
+        testBoundedTextFileSource(tmpTestDir, FailoverType.JM, miniCluster);
     }
 
-    private void testBoundedTextFileSource(FailoverType failoverType) throws Exception {
-        final File testDir = TMP_FOLDER.newFolder();
+    private void testBoundedTextFileSource(
+            java.nio.file.Path tmpTestDir, FailoverType failoverType, MiniCluster miniCluster)
+            throws Exception {
+        final File testDir = tmpTestDir.toFile();
 
         // our main test data
         writeAllFiles(testDir);
@@ -139,11 +143,7 @@ public class FileSourceTextLinesITCase extends TestLogger {
         final JobID jobId = client.client.getJobID();
 
         RecordCounterToFail.waitToFail();
-        triggerFailover(
-                failoverType,
-                jobId,
-                RecordCounterToFail::continueProcessing,
-                miniClusterResource.getMiniCluster());
+        triggerFailover(failoverType, jobId, RecordCounterToFail::continueProcessing, miniCluster);
 
         final List<String> result = new ArrayList<>();
         while (client.iterator.hasNext()) {
@@ -158,8 +158,10 @@ public class FileSourceTextLinesITCase extends TestLogger {
      * record format (text lines).
      */
     @Test
-    public void testContinuousTextFileSource() throws Exception {
-        testContinuousTextFileSource(FailoverType.NONE);
+    void testContinuousTextFileSource(
+            @TempDir java.nio.file.Path tmpTestDir, @InjectMiniCluster MiniCluster miniCluster)
+            throws Exception {
+        testContinuousTextFileSource(tmpTestDir, FailoverType.NONE, miniCluster);
     }
 
     /**
@@ -167,9 +169,11 @@ public class FileSourceTextLinesITCase extends TestLogger {
      * record format (text lines) and restarts TaskManager.
      */
     @Test
-    @Category(FailsWithAdaptiveScheduler.class) // FLINK-21450
-    public void testContinuousTextFileSourceWithTaskManagerFailover() throws Exception {
-        testContinuousTextFileSource(FailoverType.TM);
+    @Tag("FailsWithAdaptiveScheduler.class") // FLINK-21450
+    void testContinuousTextFileSourceWithTaskManagerFailover(
+            @TempDir java.nio.file.Path tmpTestDir, @InjectMiniCluster MiniCluster miniCluster)
+            throws Exception {
+        testContinuousTextFileSource(tmpTestDir, FailoverType.TM, miniCluster);
     }
 
     /**
@@ -177,12 +181,16 @@ public class FileSourceTextLinesITCase extends TestLogger {
      * record format (text lines) and triggers JobManager failover.
      */
     @Test
-    public void testContinuousTextFileSourceWithJobManagerFailover() throws Exception {
-        testContinuousTextFileSource(FailoverType.JM);
+    void testContinuousTextFileSourceWithJobManagerFailover(
+            @TempDir java.nio.file.Path tmpTestDir, @InjectMiniCluster MiniCluster miniCluster)
+            throws Exception {
+        testContinuousTextFileSource(tmpTestDir, FailoverType.JM, miniCluster);
     }
 
-    private void testContinuousTextFileSource(FailoverType type) throws Exception {
-        final File testDir = TMP_FOLDER.newFolder();
+    private void testContinuousTextFileSource(
+            java.nio.file.Path tmpTestDir, FailoverType type, MiniCluster miniCluster)
+            throws Exception {
+        final File testDir = tmpTestDir.toFile();
 
         final FileSource<String> source =
                 FileSource.forRecordStreamFormat(
@@ -218,7 +226,7 @@ public class FileSourceTextLinesITCase extends TestLogger {
             writeFile(testDir, i);
             final boolean failAfterHalfOfInput = i == LINES_PER_FILE.length / 2;
             if (failAfterHalfOfInput) {
-                triggerFailover(type, jobId, () -> {}, miniClusterResource.getMiniCluster());
+                triggerFailover(type, jobId, () -> {}, miniCluster);
             }
         }
 
@@ -284,7 +292,7 @@ public class FileSourceTextLinesITCase extends TestLogger {
         Arrays.sort(expected);
         Arrays.sort(actual);
 
-        assertThat(actual, equalTo(expected));
+        assertThat(actual).isEqualTo(expected);
     }
 
     // ------------------------------------------------------------------------
@@ -423,7 +431,7 @@ public class FileSourceTextLinesITCase extends TestLogger {
         // file,
         // but just construct the file path
         final File stagingFile =
-                new File(TMP_FOLDER.getRoot(), ".tmp-" + UUID.randomUUID().toString());
+                new File(tmpDir.getParent().toFile(), ".tmp-" + UUID.randomUUID().toString());
 
         try (final FileOutputStream fileOut = new FileOutputStream(stagingFile);
                 final OutputStream out = streamEncoderFactory.apply(fileOut);
@@ -437,9 +445,9 @@ public class FileSourceTextLinesITCase extends TestLogger {
         }
 
         final File parent = file.getParentFile();
-        assertTrue(parent.mkdirs() || parent.exists());
+        assertThat(parent.mkdirs() || parent.exists()).isTrue();
 
-        assertTrue(stagingFile.renameTo(file));
+        assertThat(stagingFile.renameTo(file)).isTrue();
     }
 
     // ------------------------------------------------------------------------

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/PendingSplitsCheckpointSerializerTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/PendingSplitsCheckpointSerializerTest.java
@@ -21,8 +21,7 @@ package org.apache.flink.connector.file.src;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.io.SimpleVersionedSerialization;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -31,14 +30,13 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.function.BiConsumer;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Unit tests for the {@link FileSourceSplitSerializer}. */
-public class PendingSplitsCheckpointSerializerTest {
+class PendingSplitsCheckpointSerializerTest {
 
     @Test
-    public void serializeEmptyCheckpoint() throws Exception {
+    void serializeEmptyCheckpoint() throws Exception {
         final PendingSplitsCheckpoint<FileSourceSplit> checkpoint =
                 PendingSplitsCheckpoint.fromCollectionSnapshot(Collections.emptyList());
 
@@ -49,7 +47,7 @@ public class PendingSplitsCheckpointSerializerTest {
     }
 
     @Test
-    public void serializeSomeSplits() throws Exception {
+    void serializeSomeSplits() throws Exception {
         final PendingSplitsCheckpoint<FileSourceSplit> checkpoint =
                 PendingSplitsCheckpoint.fromCollectionSnapshot(
                         Arrays.asList(testSplit1(), testSplit2(), testSplit3()));
@@ -61,7 +59,7 @@ public class PendingSplitsCheckpointSerializerTest {
     }
 
     @Test
-    public void serializeSplitsAndProcessedPaths() throws Exception {
+    void serializeSplitsAndProcessedPaths() throws Exception {
         final PendingSplitsCheckpoint<FileSourceSplit> checkpoint =
                 PendingSplitsCheckpoint.fromCollectionSnapshot(
                         Arrays.asList(testSplit1(), testSplit2(), testSplit3()),
@@ -77,7 +75,7 @@ public class PendingSplitsCheckpointSerializerTest {
     }
 
     @Test
-    public void repeatedSerialization() throws Exception {
+    void repeatedSerialization() throws Exception {
         final PendingSplitsCheckpoint<FileSourceSplit> checkpoint =
                 PendingSplitsCheckpoint.fromCollectionSnapshot(
                         Arrays.asList(testSplit3(), testSplit1()));
@@ -91,7 +89,7 @@ public class PendingSplitsCheckpointSerializerTest {
     }
 
     @Test
-    public void repeatedSerializationCaches() throws Exception {
+    void repeatedSerializationCaches() throws Exception {
         final PendingSplitsCheckpoint<FileSourceSplit> checkpoint =
                 PendingSplitsCheckpoint.fromCollectionSnapshot(
                         Collections.singletonList(testSplit2()));
@@ -103,7 +101,7 @@ public class PendingSplitsCheckpointSerializerTest {
                 new PendingSplitsCheckpointSerializer<>(FileSourceSplitSerializer.INSTANCE)
                         .serialize(checkpoint);
 
-        assertSame(ser1, ser2);
+        assertThat(ser1).isSameAs(ser2);
     }
 
     // ------------------------------------------------------------------------
@@ -150,16 +148,14 @@ public class PendingSplitsCheckpointSerializerTest {
                 actual.getSplits(),
                 FileSourceSplitSerializerTest::assertSplitsEqual);
 
-        assertOrderedCollectionEquals(
-                expected.getAlreadyProcessedPaths(),
-                actual.getAlreadyProcessedPaths(),
-                Assert::assertEquals);
+        assertThat(actual.getAlreadyProcessedPaths())
+                .containsExactlyElementsOf(expected.getAlreadyProcessedPaths());
     }
 
     private static <E> void assertOrderedCollectionEquals(
             Collection<E> expected, Collection<E> actual, BiConsumer<E, E> equalityAsserter) {
 
-        assertEquals(expected.size(), actual.size());
+        assertThat(actual).hasSize(expected.size());
         final Iterator<E> expectedIter = expected.iterator();
         final Iterator<E> actualIter = actual.iterator();
         while (expectedIter.hasNext()) {

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/assigners/LocalityAwareSplitAssignerTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/assigners/LocalityAwareSplitAssignerTest.java
@@ -21,7 +21,7 @@ package org.apache.flink.connector.file.src.assigners;
 import org.apache.flink.connector.file.src.FileSourceSplit;
 import org.apache.flink.core.fs.Path;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.Calendar;
@@ -30,13 +30,10 @@ import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Unit tests for the {@link LocalityAwareSplitAssigner}. */
-public class LocalityAwareSplitAssignerTest {
+class LocalityAwareSplitAssignerTest {
 
     private static final Path TEST_PATH =
             Path.fromLocalFile(new File(System.getProperty("java.io.tmpdir")));
@@ -44,7 +41,7 @@ public class LocalityAwareSplitAssignerTest {
     // ------------------------------------------------------------------------
 
     @Test
-    public void testAssignmentWithNullHost() {
+    void testAssignmentWithNullHost() {
         final int numSplits = 50;
         final String[][] hosts = new String[][] {new String[] {"localhost"}, new String[0]};
 
@@ -58,18 +55,18 @@ public class LocalityAwareSplitAssignerTest {
         final LocalityAwareSplitAssigner ia = new LocalityAwareSplitAssigner(splits);
         Optional<FileSourceSplit> is;
         while ((is = ia.getNext(null)).isPresent()) {
-            assertTrue(splits.remove(is.get()));
+            assertThat(splits.remove(is.get())).isTrue();
         }
 
         // check we had all
-        assertTrue(splits.isEmpty());
-        assertFalse(ia.getNext("").isPresent());
-        assertEquals(numSplits, ia.getNumberOfRemoteAssignments());
-        assertEquals(0, ia.getNumberOfLocalAssignments());
+        assertThat(splits).isEmpty();
+        assertThat(ia.getNext("")).isNotPresent();
+        assertThat(ia.getNumberOfRemoteAssignments()).isEqualTo(numSplits);
+        assertThat(ia.getNumberOfLocalAssignments()).isEqualTo(0);
     }
 
     @Test
-    public void testAssignmentAllForSameHost() {
+    void testAssignmentAllForSameHost() {
         final int numSplits = 50;
 
         // load some splits
@@ -82,19 +79,19 @@ public class LocalityAwareSplitAssignerTest {
         LocalityAwareSplitAssigner ia = new LocalityAwareSplitAssigner(splits);
         Optional<FileSourceSplit> is;
         while ((is = ia.getNext("testhost")).isPresent()) {
-            assertTrue(splits.remove(is.get()));
+            assertThat(splits.remove(is.get())).isTrue();
         }
 
         // check we had all
-        assertTrue(splits.isEmpty());
-        assertFalse(ia.getNext("").isPresent());
+        assertThat(splits).isEmpty();
+        assertThat(ia.getNext("")).isNotPresent();
 
-        assertEquals(0, ia.getNumberOfRemoteAssignments());
-        assertEquals(numSplits, ia.getNumberOfLocalAssignments());
+        assertThat(ia.getNumberOfRemoteAssignments()).isEqualTo(0);
+        assertThat(ia.getNumberOfLocalAssignments()).isEqualTo(numSplits);
     }
 
     @Test
-    public void testAssignmentAllForRemoteHost() {
+    void testAssignmentAllForRemoteHost() {
         final String[] hosts = {"host1", "host1", "host1", "host2", "host2", "host3"};
         final int numSplits = 10 * hosts.length;
 
@@ -108,19 +105,19 @@ public class LocalityAwareSplitAssignerTest {
         final LocalityAwareSplitAssigner ia = new LocalityAwareSplitAssigner(splits);
         Optional<FileSourceSplit> is;
         while ((is = ia.getNext("testhost")).isPresent()) {
-            assertTrue(splits.remove(is.get()));
+            assertThat(splits.remove(is.get())).isTrue();
         }
 
         // check we had all
-        assertTrue(splits.isEmpty());
-        assertFalse(ia.getNext("anotherHost").isPresent());
+        assertThat(splits).isEmpty();
+        assertThat(ia.getNext("anotherHost")).isNotPresent();
 
-        assertEquals(numSplits, ia.getNumberOfRemoteAssignments());
-        assertEquals(0, ia.getNumberOfLocalAssignments());
+        assertThat(ia.getNumberOfRemoteAssignments()).isEqualTo(numSplits);
+        assertThat(ia.getNumberOfLocalAssignments()).isEqualTo(0);
     }
 
     @Test
-    public void testAssignmentSomeForRemoteHost() {
+    void testAssignmentSomeForRemoteHost() {
         // host1 reads all local
         // host2 reads 10 local and 10 remote
         // host3 reads all remote
@@ -151,20 +148,20 @@ public class LocalityAwareSplitAssignerTest {
         Optional<FileSourceSplit> is;
         int i = 0;
         while ((is = ia.getNext(hosts[i++ % hosts.length])).isPresent()) {
-            assertTrue(splits.remove(is.get()));
+            assertThat(splits.remove(is.get())).isTrue();
         }
 
         // check we had all
-        assertTrue(splits.isEmpty());
-        assertFalse(ia.getNext("anotherHost").isPresent());
+        assertThat(splits).isEmpty();
+        assertThat(ia.getNext("anotherHost")).isNotPresent();
 
-        assertEquals(numRemoteSplits, ia.getNumberOfRemoteAssignments());
-        assertEquals(numLocalSplits, ia.getNumberOfLocalAssignments());
+        assertThat(ia.getNumberOfRemoteAssignments()).isEqualTo(numRemoteSplits);
+        assertThat(ia.getNumberOfLocalAssignments()).isEqualTo(numLocalSplits);
     }
 
     @SuppressWarnings("UnnecessaryLocalVariable")
     @Test
-    public void testAssignmentMultiLocalHost() {
+    void testAssignmentMultiLocalHost() {
         final String[] localHosts = {"local1", "local2", "local3"};
         final String[] remoteHosts = {"remote1", "remote2", "remote3"};
         final String[] requestingHosts = {"local3", "local2", "local1", "other"};
@@ -206,31 +203,31 @@ public class LocalityAwareSplitAssignerTest {
             final String host = requestingHosts[i % requestingHosts.length];
 
             final Optional<FileSourceSplit> ois = ia.getNext(host);
-            assertTrue(ois.isPresent());
+            assertThat(ois).isPresent();
 
             final FileSourceSplit is = ois.get();
-            assertTrue(splits.remove(is));
+            assertThat(splits.remove(is)).isTrue();
             // check priority of split
             if (host.equals(localHosts[0])) {
-                assertArrayEquals(is.hostnames(), oneLocalHost);
+                assertThat(is.hostnames()).isEqualTo(oneLocalHost);
             } else if (host.equals(localHosts[1])) {
-                assertArrayEquals(is.hostnames(), twoLocalHosts);
+                assertThat(is.hostnames()).isEqualTo(twoLocalHosts);
             } else if (host.equals(localHosts[2])) {
-                assertArrayEquals(is.hostnames(), threeLocalHosts);
+                assertThat(is.hostnames()).isEqualTo(threeLocalHosts);
             } else {
-                assertArrayEquals(is.hostnames(), noLocalHost);
+                assertThat(is.hostnames()).isEqualTo(noLocalHost);
             }
         }
         // check we had all
-        assertTrue(splits.isEmpty());
-        assertFalse(ia.getNext("anotherHost").isPresent());
+        assertThat(splits).isEmpty();
+        assertThat(ia.getNext("anotherHost")).isNotPresent();
 
-        assertEquals(numRemoteSplits, ia.getNumberOfRemoteAssignments());
-        assertEquals(numLocalSplits, ia.getNumberOfLocalAssignments());
+        assertThat(ia.getNumberOfRemoteAssignments()).isEqualTo(numRemoteSplits);
+        assertThat(ia.getNumberOfLocalAssignments()).isEqualTo(numLocalSplits);
     }
 
     @Test
-    public void testAssignmentMixedLocalHost() {
+    void testAssignmentMixedLocalHost() {
         final String[] hosts = {"host1", "host1", "host1", "host2", "host2", "host3"};
         final int numSplits = 10 * hosts.length;
 
@@ -245,19 +242,19 @@ public class LocalityAwareSplitAssignerTest {
         Optional<FileSourceSplit> is;
         int i = 0;
         while ((is = ia.getNext(hosts[i++ % hosts.length])).isPresent()) {
-            assertTrue(splits.remove(is.get()));
+            assertThat(splits.remove(is.get())).isTrue();
         }
 
         // check we had all
-        assertTrue(splits.isEmpty());
-        assertFalse(ia.getNext("anotherHost").isPresent());
+        assertThat(splits).isEmpty();
+        assertThat(ia.getNext("anotherHost")).isNotPresent();
 
-        assertEquals(0, ia.getNumberOfRemoteAssignments());
-        assertEquals(numSplits, ia.getNumberOfLocalAssignments());
+        assertThat(ia.getNumberOfRemoteAssignments()).isEqualTo(0);
+        assertThat(ia.getNumberOfLocalAssignments()).isEqualTo(numSplits);
     }
 
     @Test
-    public void testAssignmentOfManySplitsRandomly() {
+    void testAssignmentOfManySplitsRandomly() {
         final long seed = Calendar.getInstance().getTimeInMillis();
 
         final int numSplits = 1000;
@@ -292,12 +289,12 @@ public class LocalityAwareSplitAssignerTest {
         for (int i = 0; i < numSplits; i++) {
             final Optional<FileSourceSplit> split =
                     ia.getNext(requestingHosts[rand.nextInt(requestingHosts.length)]);
-            assertTrue(split.isPresent());
-            assertTrue(splits.remove(split.get()));
+            assertThat(split).isPresent();
+            assertThat(splits.remove(split.get())).isTrue();
         }
 
-        assertTrue(splits.isEmpty());
-        assertFalse(ia.getNext("testHost").isPresent());
+        assertThat(splits).isEmpty();
+        assertThat(ia.getNext("testHost")).isNotPresent();
     }
 
     // ------------------------------------------------------------------------

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/enumerate/BlockSplittingRecursiveEnumeratorTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/enumerate/BlockSplittingRecursiveEnumeratorTest.java
@@ -22,17 +22,17 @@ import org.apache.flink.connector.file.src.FileSourceSplit;
 import org.apache.flink.connector.file.src.testutils.TestingFileSystem;
 import org.apache.flink.core.fs.Path;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collection;
 
 /** Unit tests for the {@link BlockSplittingRecursiveEnumerator}. */
-public class BlockSplittingRecursiveEnumeratorTest extends NonSplittingRecursiveEnumeratorTest {
+class BlockSplittingRecursiveEnumeratorTest extends NonSplittingRecursiveEnumeratorTest {
 
     @Test
     @Override
-    public void testFileWithMultipleBlocks() throws Exception {
+    void testFileWithMultipleBlocks() throws Exception {
         final Path testPath = new Path("testfs:///dir/file");
         testFs =
                 TestingFileSystem.createForFileStatus(

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/enumerate/NonSplittingRecursiveEnumeratorTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/enumerate/NonSplittingRecursiveEnumeratorTest.java
@@ -22,21 +22,18 @@ import org.apache.flink.connector.file.src.FileSourceSplit;
 import org.apache.flink.connector.file.src.testutils.TestingFileSystem;
 import org.apache.flink.core.fs.Path;
 
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.stream.Collectors;
 
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Unit tests for the {@link NonSplittingRecursiveEnumerator}. */
-public class NonSplittingRecursiveEnumeratorTest {
+class NonSplittingRecursiveEnumeratorTest {
 
     /**
      * Testing file system reference, to be cleaned up in an @After method. That way it also gets
@@ -44,8 +41,8 @@ public class NonSplittingRecursiveEnumeratorTest {
      */
     protected TestingFileSystem testFs;
 
-    @After
-    public void unregisterTestFs() throws Exception {
+    @AfterEach
+    void unregisterTestFs() throws Exception {
         if (testFs != null) {
             testFs.unregister();
         }
@@ -54,7 +51,7 @@ public class NonSplittingRecursiveEnumeratorTest {
     // ------------------------------------------------------------------------
 
     @Test
-    public void testIncludeFilesFromNestedDirectories() throws Exception {
+    void testIncludeFilesFromNestedDirectories() throws Exception {
         final Path[] testPaths =
                 new Path[] {
                     new Path("testfs:///dir/file1"),
@@ -68,11 +65,11 @@ public class NonSplittingRecursiveEnumeratorTest {
         final Collection<FileSourceSplit> splits =
                 enumerator.enumerateSplits(new Path[] {new Path("testfs:///dir")}, 1);
 
-        assertThat(toPaths(splits), containsInAnyOrder(testPaths));
+        assertThat(toPaths(splits)).containsExactlyInAnyOrder(testPaths);
     }
 
     @Test
-    public void testDefaultHiddenFilesFilter() throws Exception {
+    void testDefaultHiddenFilesFilter() throws Exception {
         final Path[] testPaths =
                 new Path[] {
                     new Path("testfs:///visiblefile"),
@@ -86,11 +83,12 @@ public class NonSplittingRecursiveEnumeratorTest {
         final Collection<FileSourceSplit> splits =
                 enumerator.enumerateSplits(new Path[] {new Path("testfs:///")}, 1);
 
-        assertEquals(Collections.singletonList(new Path("testfs:///visiblefile")), toPaths(splits));
+        assertThat(toPaths(splits))
+                .isEqualTo(Collections.singletonList(new Path("testfs:///visiblefile")));
     }
 
     @Test
-    public void testHiddenDirectories() throws Exception {
+    void testHiddenDirectories() throws Exception {
         final Path[] testPaths =
                 new Path[] {
                     new Path("testfs:///dir/visiblefile"),
@@ -104,12 +102,12 @@ public class NonSplittingRecursiveEnumeratorTest {
         final Collection<FileSourceSplit> splits =
                 enumerator.enumerateSplits(new Path[] {new Path("testfs:///")}, 1);
 
-        assertEquals(
-                Collections.singletonList(new Path("testfs:///dir/visiblefile")), toPaths(splits));
+        assertThat(toPaths(splits))
+                .isEqualTo(Collections.singletonList(new Path("testfs:///dir/visiblefile")));
     }
 
     @Test
-    public void testFilesWithNoBlockInfo() throws Exception {
+    void testFilesWithNoBlockInfo() throws Exception {
         final Path testPath = new Path("testfs:///dir/file1");
         testFs =
                 TestingFileSystem.createForFileStatus(
@@ -121,14 +119,14 @@ public class NonSplittingRecursiveEnumeratorTest {
         final Collection<FileSourceSplit> splits =
                 enumerator.enumerateSplits(new Path[] {new Path("testfs:///dir")}, 0);
 
-        assertEquals(1, splits.size());
+        assertThat(splits).hasSize(1);
         assertSplitsEqual(
                 new FileSourceSplit("ignoredId", testPath, 0L, 12345L, 0, 12345L),
                 splits.iterator().next());
     }
 
     @Test
-    public void testFileWithIncorrectBlocks() throws Exception {
+    void testFileWithIncorrectBlocks() throws Exception {
         final Path testPath = new Path("testfs:///testdir/testfile");
 
         testFs =
@@ -145,14 +143,14 @@ public class NonSplittingRecursiveEnumeratorTest {
         final Collection<FileSourceSplit> splits =
                 enumerator.enumerateSplits(new Path[] {new Path("testfs:///testdir")}, 0);
 
-        assertEquals(1, splits.size());
+        assertThat(splits).hasSize(1);
         assertSplitsEqual(
                 new FileSourceSplit("ignoredId", testPath, 0L, 10000L, 0, 12345L),
                 splits.iterator().next());
     }
 
     @Test
-    public void testFileWithMultipleBlocks() throws Exception {
+    void testFileWithMultipleBlocks() throws Exception {
         final Path testPath = new Path("testfs:///dir/file");
         testFs =
                 TestingFileSystem.createForFileStatus(
@@ -200,16 +198,16 @@ public class NonSplittingRecursiveEnumeratorTest {
 
     protected static void assertSplitsEqual(
             final FileSourceSplit expected, final FileSourceSplit actual) {
-        assertEquals(expected.path(), actual.path());
-        assertEquals(expected.offset(), actual.offset());
-        assertEquals(expected.length(), actual.length());
-        assertArrayEquals(expected.hostnames(), actual.hostnames());
+        assertThat(actual.path()).isEqualTo(expected.path());
+        assertThat(actual.offset()).isEqualTo(expected.offset());
+        assertThat(actual.length()).isEqualTo(expected.length());
+        assertThat(actual.hostnames()).isEqualTo(expected.hostnames());
     }
 
     protected static void assertSplitsEqual(
             final Collection<FileSourceSplit> expected, final Collection<FileSourceSplit> actual) {
 
-        assertEquals(expected.size(), actual.size());
+        assertThat(actual).hasSize(expected.size());
 
         final ArrayList<FileSourceSplit> expectedCopy = new ArrayList<>(expected);
         final ArrayList<FileSourceSplit> actualCopy = new ArrayList<>(expected);

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/impl/AdapterTestBase.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/impl/AdapterTestBase.java
@@ -29,10 +29,9 @@ import org.apache.flink.connector.file.src.util.RecordAndPosition;
 import org.apache.flink.core.fs.FSDataInputStream;
 import org.apache.flink.core.fs.Path;
 
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.DataOutputStream;
 import java.io.File;
@@ -44,27 +43,25 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Queue;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Fail.fail;
 
 /**
  * Base class for adapters, as used by {@link StreamFormatAdapterTest} and {@link
  * FileRecordFormatAdapterTest}.
  */
-public abstract class AdapterTestBase<FormatT> {
+abstract class AdapterTestBase<FormatT> {
 
-    @ClassRule public static final TemporaryFolder TMP_DIR = new TemporaryFolder();
+    @TempDir public static java.nio.file.Path tmpDir;
 
     protected static final int NUM_NUMBERS = 100;
     protected static final long FILE_LEN = 4 * NUM_NUMBERS;
 
     protected static Path testPath;
 
-    @BeforeClass
-    public static void writeTestFile() throws IOException {
-        final File testFile = new File(TMP_DIR.getRoot(), "testFile");
+    @BeforeAll
+    static void writeTestFile() throws IOException {
+        final File testFile = new File(tmpDir.toFile(), "testFile");
         testPath = Path.fromLocalFile(testFile);
 
         try (DataOutputStream out = new DataOutputStream(new FileOutputStream(testFile))) {
@@ -91,17 +88,17 @@ public abstract class AdapterTestBase<FormatT> {
     // ------------------------------------------------------------------------
 
     @Test
-    public void testRecoverCheckpointedFormatOneSplit() throws IOException {
+    void testRecoverCheckpointedFormatOneSplit() throws IOException {
         testReading(createCheckpointedFormat(), 1, 5, 44);
     }
 
     @Test
-    public void testRecoverCheckpointedFormatMultipleSplits() throws IOException {
+    void testRecoverCheckpointedFormatMultipleSplits() throws IOException {
         testReading(createCheckpointedFormat(), 3, 11, 33, 56);
     }
 
     @Test
-    public void testRecoverNonCheckpointedFormatOneSplit() throws IOException {
+    void testRecoverNonCheckpointedFormatOneSplit() throws IOException {
         testReading(createNonCheckpointedFormat(), 1, 5, 44);
     }
 
@@ -144,7 +141,7 @@ public abstract class AdapterTestBase<FormatT> {
     // ------------------------------------------------------------------------
 
     @Test
-    public void testClosesStreamIfReaderCreationFails() throws Exception {
+    void testClosesStreamIfReaderCreationFails() throws Exception {
         // setup
         final Path testPath = new Path("testFs:///testpath-1");
         final CloseTestingInputStream in = new CloseTestingInputStream();
@@ -164,14 +161,14 @@ public abstract class AdapterTestBase<FormatT> {
         }
 
         // assertions
-        assertTrue(in.closed);
+        assertThat(in.closed).isTrue();
 
         // cleanup
         testFs.unregister();
     }
 
     @Test
-    public void testClosesStreamIfReaderRestoreFails() throws Exception {
+    void testClosesStreamIfReaderRestoreFails() throws Exception {
         // setup
         final Path testPath = new Path("testFs:///testpath-1");
         final CloseTestingInputStream in = new CloseTestingInputStream();
@@ -201,7 +198,7 @@ public abstract class AdapterTestBase<FormatT> {
         }
 
         // assertions
-        assertTrue(in.closed);
+        assertThat(in.closed).isTrue();
 
         // cleanup
         testFs.unregister();
@@ -212,7 +209,7 @@ public abstract class AdapterTestBase<FormatT> {
     // ------------------------------------------------------------------------
 
     protected static void verifyIntListResult(List<Integer> result) {
-        assertEquals("wrong result size", NUM_NUMBERS, result.size());
+        assertThat(result).as("wrong result size").hasSize(NUM_NUMBERS);
         int nextExpected = 0;
         for (int next : result) {
             if (next != nextExpected++) {
@@ -243,7 +240,7 @@ public abstract class AdapterTestBase<FormatT> {
         while (num > 0) {
             if (currentReader == null) {
                 currentSplit = moreSplits.poll();
-                assertNotNull(currentSplit);
+                assertThat(currentSplit).isNotNull();
                 currentReader = format.createReader(config, currentSplit);
             }
 

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/impl/ContinuousFileSplitEnumeratorTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/impl/ContinuousFileSplitEnumeratorTest.java
@@ -26,18 +26,15 @@ import org.apache.flink.connector.file.src.testutils.TestingFileEnumerator;
 import org.apache.flink.connector.testutils.source.reader.TestingSplitEnumeratorContext;
 import org.apache.flink.core.fs.Path;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.Collections;
 
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.empty;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Unit tests for the {@link ContinuousFileSplitEnumerator}. */
-public class ContinuousFileSplitEnumeratorTest {
+class ContinuousFileSplitEnumeratorTest {
 
     // this is no JUnit temporary folder, because we don't create actual files, we just
     // need some random file path.
@@ -46,7 +43,7 @@ public class ContinuousFileSplitEnumeratorTest {
     private static long splitId = 1L;
 
     @Test
-    public void testDiscoverSplitWhenNoReaderRegistered() throws Exception {
+    void testDiscoverSplitWhenNoReaderRegistered() throws Exception {
         final TestingFileEnumerator fileEnumerator = new TestingFileEnumerator();
         final TestingSplitEnumeratorContext<FileSourceSplit> context =
                 new TestingSplitEnumeratorContext<>(4);
@@ -57,11 +54,11 @@ public class ContinuousFileSplitEnumeratorTest {
         fileEnumerator.addSplits(split);
         context.triggerAllActions();
 
-        assertThat(enumerator.snapshotState(1L).getSplits(), contains(split));
+        assertThat(enumerator.snapshotState(1L).getSplits()).contains(split);
     }
 
     @Test
-    public void testDiscoverWhenReaderRegistered() throws Exception {
+    void testDiscoverWhenReaderRegistered() throws Exception {
         final TestingFileEnumerator fileEnumerator = new TestingFileEnumerator();
         final TestingSplitEnumeratorContext<FileSourceSplit> context =
                 new TestingSplitEnumeratorContext<>(4);
@@ -77,12 +74,12 @@ public class ContinuousFileSplitEnumeratorTest {
         fileEnumerator.addSplits(split);
         context.triggerAllActions();
 
-        assertThat(enumerator.snapshotState(1L).getSplits(), empty());
-        assertThat(context.getSplitAssignments().get(2).getAssignedSplits(), contains(split));
+        assertThat(enumerator.snapshotState(1L).getSplits()).isEmpty();
+        assertThat(context.getSplitAssignments().get(2).getAssignedSplits()).contains(split);
     }
 
     @Test
-    public void testRequestingReaderUnavailableWhenSplitDiscovered() throws Exception {
+    void testRequestingReaderUnavailableWhenSplitDiscovered() throws Exception {
         final TestingFileEnumerator fileEnumerator = new TestingFileEnumerator();
         final TestingSplitEnumeratorContext<FileSourceSplit> context =
                 new TestingSplitEnumeratorContext<>(4);
@@ -101,8 +98,8 @@ public class ContinuousFileSplitEnumeratorTest {
         fileEnumerator.addSplits(split);
         context.triggerAllActions();
 
-        assertFalse(context.getSplitAssignments().containsKey(2));
-        assertThat(enumerator.snapshotState(1L).getSplits(), contains(split));
+        assertThat(context.getSplitAssignments()).doesNotContainKey(2);
+        assertThat(enumerator.snapshotState(1L).getSplits()).contains(split);
     }
 
     // ------------------------------------------------------------------------

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/impl/FileRecordFormatAdapterTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/impl/FileRecordFormatAdapterTest.java
@@ -33,11 +33,11 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Unit and behavior tests for the {@link FileRecordFormatAdapter}. */
 @SuppressWarnings("serial")
-public class FileRecordFormatAdapterTest extends AdapterTestBase<FileRecordFormat<Integer>> {
+class FileRecordFormatAdapterTest extends AdapterTestBase<FileRecordFormat<Integer>> {
 
     @Override
     protected FileRecordFormat<Integer> createCheckpointedFormat() {
@@ -93,7 +93,7 @@ public class FileRecordFormatAdapterTest extends AdapterTestBase<FileRecordForma
             final long fileLen = status.getLen();
             final long splitEnd = splitOffset + splitLength;
 
-            assertEquals("invalid file length", 0, fileLen % 4);
+            assertThat(fileLen % 4).as("invalid file length").isEqualTo(0);
 
             // round all positions to the next integer boundary
             // to simulate common split behavior, we round up to the next int boundary even when we
@@ -121,7 +121,7 @@ public class FileRecordFormatAdapterTest extends AdapterTestBase<FileRecordForma
             final long fileLen = status.getLen();
             final long splitEnd = splitOffset + splitLength;
 
-            assertEquals("invalid file length", 0, fileLen % 4);
+            assertThat(fileLen % 4).as("invalid file length").isEqualTo(0);
 
             // round end position to the next integer boundary
             final long end = splitEnd == fileLen ? fileLen : splitEnd + 4 - splitEnd % 4;

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/impl/FileSourceReaderTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/impl/FileSourceReaderTest.java
@@ -24,33 +24,32 @@ import org.apache.flink.connector.file.src.reader.TextLineInputFormat;
 import org.apache.flink.connector.testutils.source.reader.TestingReaderContext;
 import org.apache.flink.core.fs.Path;
 
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
 import java.util.Collections;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Unit tests for the {@link FileSourceReader}. */
-public class FileSourceReaderTest {
+class FileSourceReaderTest {
 
-    @ClassRule public static final TemporaryFolder TMP_DIR = new TemporaryFolder();
+    @TempDir private static java.nio.file.Path tmpDir;
 
     @Test
-    public void testRequestSplitWhenNoSplitRestored() throws Exception {
+    void testRequestSplitWhenNoSplitRestored() throws Exception {
         final TestingReaderContext context = new TestingReaderContext();
         final FileSourceReader<String, FileSourceSplit> reader = createReader(context);
 
         reader.start();
         reader.close();
 
-        assertEquals(1, context.getNumSplitRequests());
+        assertThat(context.getNumSplitRequests()).isEqualTo(1);
     }
 
     @Test
-    public void testNoSplitRequestWhenSplitRestored() throws Exception {
+    void testNoSplitRequestWhenSplitRestored() throws Exception {
         final TestingReaderContext context = new TestingReaderContext();
         final FileSourceReader<String, FileSourceSplit> reader = createReader(context);
 
@@ -58,7 +57,7 @@ public class FileSourceReaderTest {
         reader.start();
         reader.close();
 
-        assertEquals(0, context.getNumSplitRequests());
+        assertThat(context.getNumSplitRequests()).isEqualTo(0);
     }
 
     private static FileSourceReader<String, FileSourceSplit> createReader(
@@ -68,7 +67,6 @@ public class FileSourceReaderTest {
     }
 
     private static FileSourceSplit createTestFileSplit() throws IOException {
-        return new FileSourceSplit(
-                "test-id", Path.fromLocalFile(TMP_DIR.newFile()), 0L, 0L, 0L, 0L);
+        return new FileSourceSplit("test-id", Path.fromLocalFile(tmpDir.toFile()), 0L, 0L, 0L, 0L);
     }
 }

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/impl/StaticFileSplitEnumeratorTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/impl/StaticFileSplitEnumeratorTest.java
@@ -25,19 +25,15 @@ import org.apache.flink.connector.file.src.assigners.SimpleSplitAssigner;
 import org.apache.flink.connector.testutils.source.reader.TestingSplitEnumeratorContext;
 import org.apache.flink.core.fs.Path;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.Arrays;
 
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.empty;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Unit tests for the {@link ContinuousFileSplitEnumerator}. */
-public class StaticFileSplitEnumeratorTest {
+class StaticFileSplitEnumeratorTest {
 
     // this is no JUnit temporary folder, because we don't create actual files, we just
     // need some random file path.
@@ -46,7 +42,7 @@ public class StaticFileSplitEnumeratorTest {
     private static long splitId = 1L;
 
     @Test
-    public void testCheckpointNoSplitRequested() throws Exception {
+    void testCheckpointNoSplitRequested() throws Exception {
         final TestingSplitEnumeratorContext<FileSourceSplit> context =
                 new TestingSplitEnumeratorContext<>(4);
         final FileSourceSplit split = createRandomSplit();
@@ -54,11 +50,11 @@ public class StaticFileSplitEnumeratorTest {
 
         final PendingSplitsCheckpoint<FileSourceSplit> checkpoint = enumerator.snapshotState(1L);
 
-        assertThat(checkpoint.getSplits(), contains(split));
+        assertThat(checkpoint.getSplits()).contains(split);
     }
 
     @Test
-    public void testSplitRequestForRegisteredReader() throws Exception {
+    void testSplitRequestForRegisteredReader() throws Exception {
         final TestingSplitEnumeratorContext<FileSourceSplit> context =
                 new TestingSplitEnumeratorContext<>(4);
         final FileSourceSplit split = createRandomSplit();
@@ -68,12 +64,12 @@ public class StaticFileSplitEnumeratorTest {
         enumerator.addReader(3);
         enumerator.handleSplitRequest(3, "somehost");
 
-        assertThat(enumerator.snapshotState(1L).getSplits(), empty());
-        assertThat(context.getSplitAssignments().get(3).getAssignedSplits(), contains(split));
+        assertThat(enumerator.snapshotState(1L).getSplits()).isEmpty();
+        assertThat(context.getSplitAssignments().get(3).getAssignedSplits()).contains(split);
     }
 
     @Test
-    public void testSplitRequestForNonRegisteredReader() throws Exception {
+    void testSplitRequestForNonRegisteredReader() throws Exception {
         final TestingSplitEnumeratorContext<FileSourceSplit> context =
                 new TestingSplitEnumeratorContext<>(4);
         final FileSourceSplit split = createRandomSplit();
@@ -81,12 +77,12 @@ public class StaticFileSplitEnumeratorTest {
 
         enumerator.handleSplitRequest(3, "somehost");
 
-        assertFalse(context.getSplitAssignments().containsKey(3));
-        assertThat(enumerator.snapshotState(1L).getSplits(), contains(split));
+        assertThat(context.getSplitAssignments()).doesNotContainKey(3);
+        assertThat(enumerator.snapshotState(1L).getSplits()).contains(split);
     }
 
     @Test
-    public void testNoMoreSplits() throws Exception {
+    void testNoMoreSplits() throws Exception {
         final TestingSplitEnumeratorContext<FileSourceSplit> context =
                 new TestingSplitEnumeratorContext<>(4);
         final FileSourceSplit split = createRandomSplit();
@@ -100,8 +96,8 @@ public class StaticFileSplitEnumeratorTest {
         // second request has no more split
         enumerator.handleSplitRequest(1, "somehost");
 
-        assertThat(context.getSplitAssignments().get(1).getAssignedSplits(), contains(split));
-        assertTrue(context.getSplitAssignments().get(1).hasReceivedNoMoreSplitsSignal());
+        assertThat(context.getSplitAssignments().get(1).getAssignedSplits()).contains(split);
+        assertThat(context.getSplitAssignments().get(1).hasReceivedNoMoreSplitsSignal()).isTrue();
     }
 
     // ------------------------------------------------------------------------

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/impl/StreamFormatAdapterTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/impl/StreamFormatAdapterTest.java
@@ -28,17 +28,17 @@ import org.apache.flink.connector.file.src.reader.SimpleStreamFormat;
 import org.apache.flink.connector.file.src.reader.StreamFormat;
 import org.apache.flink.core.fs.FSDataInputStream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Unit and behavior tests for the {@link StreamFormatAdapter}. */
 @SuppressWarnings("serial")
-public class StreamFormatAdapterTest extends AdapterTestBase<StreamFormat<Integer>> {
+class StreamFormatAdapterTest extends AdapterTestBase<StreamFormat<Integer>> {
 
     // ------------------------------------------------------------------------
     //  Factories for Shared Tests
@@ -69,17 +69,17 @@ public class StreamFormatAdapterTest extends AdapterTestBase<StreamFormat<Intege
     // ------------------------------------------------------------------------
 
     @Test
-    public void testReadSmallBatchSize() throws IOException {
+    void testReadSmallBatchSize() throws IOException {
         simpleReadTest(1);
     }
 
     @Test
-    public void testBatchSizeMatchesOneRecord() throws IOException {
+    void testBatchSizeMatchesOneRecord() throws IOException {
         simpleReadTest(4);
     }
 
     @Test
-    public void testBatchSizeIsRecordMultiple() throws IOException {
+    void testBatchSizeIsRecordMultiple() throws IOException {
         simpleReadTest(20);
     }
 
@@ -110,7 +110,7 @@ public class StreamFormatAdapterTest extends AdapterTestBase<StreamFormat<Intege
                 Configuration config, FSDataInputStream stream, long fileLen, long splitEnd)
                 throws IOException {
 
-            assertEquals("invalid file length", 0, fileLen % 4);
+            assertThat(fileLen % 4).as("invalid file length").isEqualTo(0);
 
             // round all positions to the next integer boundary
             // to simulate common split behavior, we round up to the next int boundary even when we
@@ -132,7 +132,7 @@ public class StreamFormatAdapterTest extends AdapterTestBase<StreamFormat<Intege
                 long splitEnd)
                 throws IOException {
 
-            assertEquals("invalid file length", 0, fileLen % 4);
+            assertThat(fileLen % 4).as("invalid file length").isEqualTo(0);
 
             // round end position to the next integer boundary
             final long end = splitEnd == fileLen ? fileLen : splitEnd + 4 - splitEnd % 4;

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/util/ArrayResultIteratorTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/util/ArrayResultIteratorTest.java
@@ -18,26 +18,23 @@
 
 package org.apache.flink.connector.file.src.util;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Unit tests for the {@link ArrayResultIterator}. */
-public class ArrayResultIteratorTest {
+class ArrayResultIteratorTest {
 
     @Test
-    public void testEmptyConstruction() {
+    void testEmptyConstruction() {
         final ArrayResultIterator<Object> iter = new ArrayResultIterator<>();
-        assertNull(iter.next());
+        assertThat(iter.next()).isNull();
     }
 
     @Test
-    public void testGetElements() {
+    void testGetElements() {
         final String[] elements = new String[] {"1", "2", "3", "4"};
         final long initialPos = 1422;
         final long initialSkipCount = 17;
@@ -47,47 +44,47 @@ public class ArrayResultIteratorTest {
 
         for (int i = 0; i < elements.length; i++) {
             final RecordAndPosition<String> recAndPos = iter.next();
-            assertEquals(elements[i], recAndPos.getRecord());
-            assertEquals(initialPos, recAndPos.getOffset());
-            assertEquals(initialSkipCount + i + 1, recAndPos.getRecordSkipCount());
+            assertThat(recAndPos.getRecord()).isEqualTo(elements[i]);
+            assertThat(recAndPos.getOffset()).isEqualTo(initialPos);
+            assertThat(recAndPos.getRecordSkipCount()).isEqualTo(initialSkipCount + i + 1);
         }
     }
 
     @Test
-    public void testExhausted() {
+    void testExhausted() {
         final ArrayResultIterator<String> iter = new ArrayResultIterator<>();
         iter.set(new String[] {"1", "2"}, 2, 0L, 0L);
 
         iter.next();
         iter.next();
 
-        assertNull(iter.next());
+        assertThat(iter.next()).isNull();
     }
 
     @Test
-    public void testArraySubRange() {
+    void testArraySubRange() {
         final ArrayResultIterator<String> iter = new ArrayResultIterator<>();
         iter.set(new String[] {"1", "2", "3"}, 2, 0L, 0L);
 
-        assertNotNull(iter.next());
-        assertNotNull(iter.next());
-        assertNull(iter.next());
+        assertThat(iter.next()).isNotNull();
+        assertThat(iter.next()).isNotNull();
+        assertThat(iter.next()).isNull();
     }
 
     @Test
-    public void testNoRecycler() {
+    void testNoRecycler() {
         final ArrayResultIterator<Object> iter = new ArrayResultIterator<>();
         iter.releaseBatch();
     }
 
     @Test
-    public void testRecycler() {
+    void testRecycler() {
         final AtomicBoolean recycled = new AtomicBoolean();
         final ArrayResultIterator<Object> iter =
                 new ArrayResultIterator<>(() -> recycled.set(true));
 
         iter.releaseBatch();
 
-        assertTrue(recycled.get());
+        assertThat(recycled.get()).isTrue();
     }
 }

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/util/IteratorResultIteratorTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/util/IteratorResultIteratorTest.java
@@ -18,18 +18,17 @@
 
 package org.apache.flink.connector.file.src.util;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Unit tests for the {@link IteratorResultIterator}. */
-public class IteratorResultIteratorTest {
+class IteratorResultIteratorTest {
 
     @Test
-    public void testGetElements() {
+    void testGetElements() {
         final String[] elements = new String[] {"1", "2", "3", "4"};
         final long initialPos = 1422;
         final long initialSkipCount = 17;
@@ -40,20 +39,20 @@ public class IteratorResultIteratorTest {
 
         for (int i = 0; i < elements.length; i++) {
             final RecordAndPosition<String> recAndPos = iter.next();
-            assertEquals(elements[i], recAndPos.getRecord());
-            assertEquals(initialPos, recAndPos.getOffset());
-            assertEquals(initialSkipCount + i + 1, recAndPos.getRecordSkipCount());
+            assertThat(recAndPos.getRecord()).isEqualTo(elements[i]);
+            assertThat(recAndPos.getOffset()).isEqualTo(initialPos);
+            assertThat(recAndPos.getRecordSkipCount()).isEqualTo(initialSkipCount + i + 1);
         }
     }
 
     @Test
-    public void testExhausted() {
+    void testExhausted() {
         final IteratorResultIterator<String> iter =
                 new IteratorResultIterator<>(Arrays.asList("1", "2").iterator(), 0L, 0L);
 
         iter.next();
         iter.next();
 
-        assertNull(iter.next());
+        assertThat(iter.next()).isNull();
     }
 }

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/util/SingletonResultIteratorTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/util/SingletonResultIteratorTest.java
@@ -18,26 +18,23 @@
 
 package org.apache.flink.connector.file.src.util;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Unit tests for the {@link SingletonResultIterator}. */
-public class SingletonResultIteratorTest {
+class SingletonResultIteratorTest {
 
     @Test
-    public void testEmptyConstruction() {
+    void testEmptyConstruction() {
         final SingletonResultIterator<Object> iter = new SingletonResultIterator<>();
-        assertNull(iter.next());
+        assertThat(iter.next()).isNull();
     }
 
     @Test
-    public void testGetElement() {
+    void testGetElement() {
         final Object element = new Object();
         final long pos = 1422;
         final long skipCount = 17;
@@ -46,35 +43,35 @@ public class SingletonResultIteratorTest {
         iter.set(element, pos, skipCount);
 
         final RecordAndPosition<Object> record = iter.next();
-        assertNotNull(record);
-        assertEquals(element, record.getRecord());
-        assertEquals(pos, record.getOffset());
-        assertEquals(skipCount, record.getRecordSkipCount());
+        assertThat(record).isNotNull();
+        assertThat(record.getRecord()).isNotNull();
+        assertThat(record.getOffset()).isEqualTo(pos);
+        assertThat(record.getRecordSkipCount()).isEqualTo(skipCount);
     }
 
     @Test
-    public void testExhausted() {
+    void testExhausted() {
         final SingletonResultIterator<Object> iter = new SingletonResultIterator<>();
         iter.set(new Object(), 1, 2);
         iter.next();
 
-        assertNull(iter.next());
+        assertThat(iter.next()).isNull();
     }
 
     @Test
-    public void testNoRecycler() {
+    void testNoRecycler() {
         final SingletonResultIterator<Object> iter = new SingletonResultIterator<>();
         iter.releaseBatch();
     }
 
     @Test
-    public void testRecycler() {
+    void testRecycler() {
         final AtomicBoolean recycled = new AtomicBoolean();
         final SingletonResultIterator<Object> iter =
                 new SingletonResultIterator<>(() -> recycled.set(true));
 
         iter.releaseBatch();
 
-        assertTrue(recycled.get());
+        assertThat(recycled.get()).isTrue();
     }
 }

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/BinPackingTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/BinPackingTest.java
@@ -18,58 +18,50 @@
 
 package org.apache.flink.connector.file.table;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link BinPacking}. */
-public class BinPackingTest {
+class BinPackingTest {
 
     @Test
-    public void testBinPacking() {
-        Assert.assertEquals(
-                "Should pack the first 2 values",
-                asList(asList(1, 2), singletonList(3), singletonList(4), singletonList(5)),
-                pack(asList(1, 2, 3, 4, 5), 3));
+    void testBinPacking() {
+        assertThat(asList(asList(1, 2), singletonList(3), singletonList(4), singletonList(5)))
+                .as("Should pack the first 2 values")
+                .isEqualTo(pack(asList(1, 2, 3, 4, 5), 3));
 
-        Assert.assertEquals(
-                "Should pack the first 2 values",
-                asList(asList(1, 2), singletonList(3), singletonList(4), singletonList(5)),
-                pack(asList(1, 2, 3, 4, 5), 5));
+        assertThat(asList(asList(1, 2), singletonList(3), singletonList(4), singletonList(5)))
+                .as("Should pack the first 2 values")
+                .isEqualTo(pack(asList(1, 2, 3, 4, 5), 5));
 
-        Assert.assertEquals(
-                "Should pack the first 3 values",
-                asList(asList(1, 2, 3), singletonList(4), singletonList(5)),
-                pack(asList(1, 2, 3, 4, 5), 6));
+        assertThat(asList(asList(1, 2, 3), singletonList(4), singletonList(5)))
+                .as("Should pack the first 3 values")
+                .isEqualTo(pack(asList(1, 2, 3, 4, 5), 6));
 
-        Assert.assertEquals(
-                "Should pack the first 3 values",
-                asList(asList(1, 2, 3), singletonList(4), singletonList(5)),
-                pack(asList(1, 2, 3, 4, 5), 8));
+        assertThat(asList(asList(1, 2, 3), singletonList(4), singletonList(5)))
+                .as("Should pack the first 3 values")
+                .isEqualTo(pack(asList(1, 2, 3, 4, 5), 8));
 
-        Assert.assertEquals(
-                "Should pack the first 3 values, last 2 values",
-                asList(asList(1, 2, 3), asList(4, 5)),
-                pack(asList(1, 2, 3, 4, 5), 9));
+        assertThat(asList(asList(1, 2, 3), asList(4, 5)))
+                .as("Should pack the first 3 values, last 2 values")
+                .isEqualTo(pack(asList(1, 2, 3, 4, 5), 9));
 
-        Assert.assertEquals(
-                "Should pack the first 4 values",
-                asList(asList(1, 2, 3, 4), singletonList(5)),
-                pack(asList(1, 2, 3, 4, 5), 10));
+        assertThat(asList(asList(1, 2, 3, 4), singletonList(5)))
+                .as("Should pack the first 4 values")
+                .isEqualTo(pack(asList(1, 2, 3, 4, 5), 10));
 
-        Assert.assertEquals(
-                "Should pack the first 4 values",
-                asList(asList(1, 2, 3, 4), singletonList(5)),
-                pack(asList(1, 2, 3, 4, 5), 14));
+        assertThat(asList(asList(1, 2, 3, 4), singletonList(5)))
+                .as("Should pack the first 4 values")
+                .isEqualTo(pack(asList(1, 2, 3, 4, 5), 14));
 
-        Assert.assertEquals(
-                "Should pack the first 5 values",
-                singletonList(asList(1, 2, 3, 4, 5)),
-                pack(asList(1, 2, 3, 4, 5), 15));
+        assertThat(singletonList(asList(1, 2, 3, 4, 5)))
+                .as("Should pack the first 5 values")
+                .isEqualTo(pack(asList(1, 2, 3, 4, 5), 15));
     }
 
     private List<List<Integer>> pack(List<Integer> items, long targetWeight) {

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/EnrichedRowDataTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/EnrichedRowDataTest.java
@@ -31,10 +31,10 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /** Tests for {@link JoinedRowData}. */
-public class EnrichedRowDataTest {
+class EnrichedRowDataTest {
 
     @Test
-    public void testEnrichedRow() {
+    void testEnrichedRow() {
         final List<String> completeRowFields =
                 Arrays.asList(
                         "fixedRow1",

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/FileSystemCommitterTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/FileSystemCommitterTest.java
@@ -21,99 +21,97 @@ package org.apache.flink.connector.file.table;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.LinkedHashMap;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /** Test for {@link FileSystemCommitter}. */
-public class FileSystemCommitterTest {
-
-    @ClassRule public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
-
-    private File tmpFile;
-    private File outputFile;
-
-    private Path tmpPath;
+class FileSystemCommitterTest {
 
     private FileSystemFactory fileSystemFactory = FileSystem::get;
 
     private TableMetaStoreFactory metaStoreFactory;
+    @TempDir private java.nio.file.Path outputPath;
+    @TempDir private java.nio.file.Path path;
 
-    @Before
+    @BeforeEach
     public void before() throws IOException {
-        tmpFile = TEMP_FOLDER.newFolder();
-        outputFile = TEMP_FOLDER.newFolder();
-
-        tmpPath = new Path(tmpFile.getPath());
-        Path outputPath = new Path(outputFile.getPath());
-        metaStoreFactory = new TestMetaStoreFactory(outputPath);
+        metaStoreFactory = new TestMetaStoreFactory(new Path(outputPath.toString()));
     }
 
     @SuppressWarnings("ResultOfMethodCallIgnored")
-    private void createFile(String path, String... files) throws IOException {
-        File p1 = new File(tmpFile, path);
-        p1.mkdirs();
+    private void createFile(java.nio.file.Path parent, String path, String... files)
+            throws IOException {
+        java.nio.file.Path dir = Files.createDirectories(Paths.get(parent.toString(), path));
         for (String file : files) {
-            new File(p1, file).createNewFile();
+            Files.createFile(Paths.get(dir.toString(), file));
         }
     }
 
     @Test
-    public void testPartition() throws Exception {
+    void testPartition() throws Exception {
         FileSystemCommitter committer =
-                new FileSystemCommitter(fileSystemFactory, metaStoreFactory, true, tmpPath, 2);
+                new FileSystemCommitter(
+                        fileSystemFactory, metaStoreFactory, true, new Path(path.toString()), 2);
 
-        createFile("task-1/p1=0/p2=0/", "f1", "f2");
-        createFile("task-2/p1=0/p2=0/", "f3");
-        createFile("task-2/p1=0/p2=1/", "f4");
+        createFile(path, "task-1/p1=0/p2=0/", "f1", "f2");
+        createFile(path, "task-2/p1=0/p2=0/", "f3");
+        createFile(path, "task-2/p1=0/p2=1/", "f4");
         committer.commitPartitions();
-        Assert.assertTrue(new File(outputFile, "p1=0/p2=0/f1").exists());
-        Assert.assertTrue(new File(outputFile, "p1=0/p2=0/f2").exists());
-        Assert.assertTrue(new File(outputFile, "p1=0/p2=0/f3").exists());
-        Assert.assertTrue(new File(outputFile, "p1=0/p2=1/f4").exists());
+        assertThat(new File(outputPath.toFile(), "p1=0/p2=0/f1")).exists();
+        assertThat(new File(outputPath.toFile(), "p1=0/p2=0/f2")).exists();
+        assertThat(new File(outputPath.toFile(), "p1=0/p2=0/f3")).exists();
+        assertThat(new File(outputPath.toFile(), "p1=0/p2=1/f4")).exists();
 
-        createFile("task-2/p1=0/p2=1/", "f5");
+        createFile(path, "task-2/p1=0/p2=1/", "f5");
         committer.commitPartitions();
-        Assert.assertTrue(new File(outputFile, "p1=0/p2=0/f1").exists());
-        Assert.assertTrue(new File(outputFile, "p1=0/p2=0/f2").exists());
-        Assert.assertTrue(new File(outputFile, "p1=0/p2=0/f3").exists());
-        Assert.assertTrue(new File(outputFile, "p1=0/p2=1/f5").exists());
+        assertThat(new File(outputPath.toFile(), "p1=0/p2=0/f1")).exists();
+        assertThat(new File(outputPath.toFile(), "p1=0/p2=0/f2")).exists();
+        assertThat(new File(outputPath.toFile(), "p1=0/p2=0/f3")).exists();
+        assertThat(new File(outputPath.toFile(), "p1=0/p2=1/f5")).exists();
 
-        committer = new FileSystemCommitter(fileSystemFactory, metaStoreFactory, false, tmpPath, 2);
-        createFile("task-2/p1=0/p2=1/", "f6");
+        committer =
+                new FileSystemCommitter(
+                        fileSystemFactory, metaStoreFactory, false, new Path(path.toString()), 2);
+        createFile(path, "task-2/p1=0/p2=1/", "f6");
         committer.commitPartitions();
-        Assert.assertTrue(new File(outputFile, "p1=0/p2=1/f5").exists());
-        Assert.assertTrue(new File(outputFile, "p1=0/p2=1/f6").exists());
+        assertThat(new File(outputPath.toFile(), "p1=0/p2=1/f5")).exists();
+        assertThat(new File(outputPath.toFile(), "p1=0/p2=1/f6")).exists();
     }
 
     @Test
-    public void testNotPartition() throws Exception {
+    void testNotPartition() throws Exception {
         FileSystemCommitter committer =
-                new FileSystemCommitter(fileSystemFactory, metaStoreFactory, true, tmpPath, 0);
+                new FileSystemCommitter(
+                        fileSystemFactory, metaStoreFactory, true, new Path(path.toString()), 0);
 
-        createFile("task-1/", "f1", "f2");
-        createFile("task-2/", "f3");
+        createFile(path, "task-1/", "f1", "f2");
+        createFile(path, "task-2/", "f3");
         committer.commitPartitions();
-        Assert.assertTrue(new File(outputFile, "f1").exists());
-        Assert.assertTrue(new File(outputFile, "f2").exists());
-        Assert.assertTrue(new File(outputFile, "f3").exists());
+        assertThat(new File(outputPath.toFile(), "f1")).exists();
+        assertThat(new File(outputPath.toFile(), "f2")).exists();
+        assertThat(new File(outputPath.toFile(), "f3")).exists();
 
-        createFile("task-2/", "f4");
+        createFile(path, "task-2/", "f4");
         committer.commitPartitions();
-        Assert.assertTrue(new File(outputFile, "f4").exists());
+        assertThat(new File(outputPath.toFile(), "f4")).exists();
 
-        committer = new FileSystemCommitter(fileSystemFactory, metaStoreFactory, false, tmpPath, 0);
-        createFile("task-2/", "f5");
+        committer =
+                new FileSystemCommitter(
+                        fileSystemFactory, metaStoreFactory, false, new Path(path.toString()), 0);
+        createFile(path, "task-2/", "f5");
         committer.commitPartitions();
-        Assert.assertTrue(new File(outputFile, "f4").exists());
-        Assert.assertTrue(new File(outputFile, "f5").exists());
+        assertThat(new File(outputPath.toFile(), "f4")).exists();
+        assertThat(new File(outputPath.toFile(), "f5")).exists();
     }
 
     static class TestMetaStoreFactory implements TableMetaStoreFactory {

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/FileSystemCommitterTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/FileSystemCommitterTest.java
@@ -53,7 +53,7 @@ class FileSystemCommitterTest {
             throws IOException {
         java.nio.file.Path dir = Files.createDirectories(Paths.get(parent.toString(), path));
         for (String file : files) {
-            Files.createFile(Paths.get(dir.toString(), file));
+            Files.createFile(dir.resolve(file));
         }
     }
 

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/FileSystemOutputFormatTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/FileSystemOutputFormatTest.java
@@ -96,9 +96,7 @@ class FileSystemOutputFormatTest {
 
         ref.get().finalizeGlobal(1);
         Map<File, String> content = getFileContentByPath(outputPath);
-        assertThat(content).hasSize(1);
-        assertThat(content.values().iterator().next())
-                .isEqualTo("a1,1,p1\n" + "a2,2,p1\n" + "a2,2,p2\n" + "a3,3,p1\n");
+        assertThat(content.values()).containsExactly("a1,1,p1\n" + "a2,2,p1\n" + "a2,2,p2\n" + "a3,3,p1\n");
     }
 
     private void writeUnorderedRecords(OneInputStreamOperatorTestHarness<Row, Object> testHarness)

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/FileSystemOutputFormatTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/FileSystemOutputFormatTest.java
@@ -24,18 +24,18 @@ import org.apache.flink.streaming.api.functions.sink.OutputFormatSinkFunction;
 import org.apache.flink.streaming.api.operators.StreamSink;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
-import org.apache.flink.table.utils.LegacyRowResource;
 import org.apache.flink.types.Row;
+import org.apache.flink.types.RowUtils;
 
 import org.apache.commons.io.FileUtils;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -43,41 +43,41 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link FileSystemOutputFormat}. */
-public class FileSystemOutputFormatTest {
+class FileSystemOutputFormatTest {
 
-    @ClassRule public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
+    @TempDir private java.nio.file.Path tmpPath;
+    @TempDir private java.nio.file.Path outputPath;
 
-    private File tmpFile;
-    private File outputFile;
-
-    private static Map<File, String> getFileContentByPath(File directory) throws IOException {
+    private static Map<File, String> getFileContentByPath(java.nio.file.Path directory)
+            throws IOException {
         Map<File, String> contents = new HashMap<>(4);
 
-        if (!directory.exists() || !directory.isDirectory()) {
+        if (Files.notExists(directory) || !Files.isDirectory(directory)) {
             return contents;
         }
 
-        final Collection<File> filesInBucket = FileUtils.listFiles(directory, null, true);
+        final Collection<File> filesInBucket = FileUtils.listFiles(directory.toFile(), null, true);
         for (File file : filesInBucket) {
             contents.put(file, FileUtils.readFileToString(file));
         }
         return contents;
     }
 
-    @Rule public final LegacyRowResource usesLegacyRows = LegacyRowResource.INSTANCE;
+    @BeforeEach
+    void before() {
+        RowUtils.USE_LEGACY_TO_STRING = true;
+    }
 
-    @Before
-    public void before() throws IOException {
-        tmpFile = TEMP_FOLDER.newFolder();
-        outputFile = TEMP_FOLDER.newFolder();
+    @AfterEach
+    void after() {
+        RowUtils.USE_LEGACY_TO_STRING = false;
     }
 
     @Test
-    public void testClosingWithoutInput() throws Exception {
+    void testClosingWithoutInput() throws Exception {
         try (OneInputStreamOperatorTestHarness<Row, Object> testHarness =
                 createSink(false, false, false, new LinkedHashMap<>(), new AtomicReference<>())) {
             testHarness.setup();
@@ -86,20 +86,19 @@ public class FileSystemOutputFormatTest {
     }
 
     @Test
-    public void testNonPartition() throws Exception {
+    void testNonPartition() throws Exception {
         AtomicReference<FileSystemOutputFormat<Row>> ref = new AtomicReference<>();
         try (OneInputStreamOperatorTestHarness<Row, Object> testHarness =
                 createSink(false, false, false, new LinkedHashMap<>(), ref)) {
             writeUnorderedRecords(testHarness);
-            assertEquals(1, getFileContentByPath(tmpFile).size());
+            assertThat(getFileContentByPath(tmpPath)).hasSize(1);
         }
 
         ref.get().finalizeGlobal(1);
-        Map<File, String> content = getFileContentByPath(outputFile);
-        assertEquals(1, content.size());
-        assertEquals(
-                "a1,1,p1\n" + "a2,2,p1\n" + "a2,2,p2\n" + "a3,3,p1\n",
-                content.values().iterator().next());
+        Map<File, String> content = getFileContentByPath(outputPath);
+        assertThat(content).hasSize(1);
+        assertThat(content.values().iterator().next())
+                .isEqualTo("a1,1,p1\n" + "a2,2,p1\n" + "a2,2,p2\n" + "a3,3,p1\n");
     }
 
     private void writeUnorderedRecords(OneInputStreamOperatorTestHarness<Row, Object> testHarness)
@@ -114,27 +113,26 @@ public class FileSystemOutputFormatTest {
     }
 
     @Test
-    public void testOverrideNonPartition() throws Exception {
+    void testOverrideNonPartition() throws Exception {
         testNonPartition();
 
         AtomicReference<FileSystemOutputFormat<Row>> ref = new AtomicReference<>();
         try (OneInputStreamOperatorTestHarness<Row, Object> testHarness =
                 createSink(true, false, false, new LinkedHashMap<>(), ref)) {
             writeUnorderedRecords(testHarness);
-            assertEquals(1, getFileContentByPath(tmpFile).size());
+            assertThat(getFileContentByPath(tmpPath)).hasSize(1);
         }
 
         ref.get().finalizeGlobal(1);
-        Map<File, String> content = getFileContentByPath(outputFile);
-        assertEquals(1, content.size());
-        assertEquals(
-                "a1,1,p1\n" + "a2,2,p1\n" + "a2,2,p2\n" + "a3,3,p1\n",
-                content.values().iterator().next());
-        assertFalse(new File(tmpFile.toURI()).exists());
+        Map<File, String> content = getFileContentByPath(outputPath);
+        assertThat(content).hasSize(1);
+        assertThat(content.values().iterator().next())
+                .isEqualTo("a1,1,p1\n" + "a2,2,p1\n" + "a2,2,p2\n" + "a3,3,p1\n");
+        assertThat(new File(tmpPath.toUri())).doesNotExist();
     }
 
     @Test
-    public void testStaticPartition() throws Exception {
+    void testStaticPartition() throws Exception {
         AtomicReference<FileSystemOutputFormat<Row>> ref = new AtomicReference<>();
         LinkedHashMap<String, String> staticParts = new LinkedHashMap<>();
         staticParts.put("c", "p1");
@@ -147,39 +145,40 @@ public class FileSystemOutputFormatTest {
             testHarness.processElement(new StreamRecord<>(Row.of("a2", 2), 1L));
             testHarness.processElement(new StreamRecord<>(Row.of("a2", 2), 1L));
             testHarness.processElement(new StreamRecord<>(Row.of("a3", 3), 1L));
-            assertEquals(1, getFileContentByPath(tmpFile).size());
+            assertThat(getFileContentByPath(tmpPath)).hasSize(1);
         }
 
         ref.get().finalizeGlobal(1);
-        Map<File, String> content = getFileContentByPath(outputFile);
-        assertEquals(1, content.size());
-        assertEquals("c=p1", content.keySet().iterator().next().getParentFile().getName());
-        assertEquals("a1,1\n" + "a2,2\n" + "a2,2\n" + "a3,3\n", content.values().iterator().next());
-        assertFalse(new File(tmpFile.toURI()).exists());
+        Map<File, String> content = getFileContentByPath(outputPath);
+        assertThat(content).hasSize(1);
+        assertThat(content.keySet().iterator().next().getParentFile().getName()).isEqualTo("c=p1");
+        assertThat(content.values().iterator().next())
+                .isEqualTo("a1,1\n" + "a2,2\n" + "a2,2\n" + "a3,3\n");
+        assertThat(new File(tmpPath.toUri())).doesNotExist();
     }
 
     @Test
-    public void testDynamicPartition() throws Exception {
+    void testDynamicPartition() throws Exception {
         AtomicReference<FileSystemOutputFormat<Row>> ref = new AtomicReference<>();
         try (OneInputStreamOperatorTestHarness<Row, Object> testHarness =
                 createSink(false, true, false, new LinkedHashMap<>(), ref)) {
             writeUnorderedRecords(testHarness);
-            assertEquals(2, getFileContentByPath(tmpFile).size());
+            assertThat(getFileContentByPath(tmpPath)).hasSize(2);
         }
 
         ref.get().finalizeGlobal(1);
-        Map<File, String> content = getFileContentByPath(outputFile);
+        Map<File, String> content = getFileContentByPath(outputPath);
         Map<String, String> sortedContent = new TreeMap<>();
         content.forEach((file, s) -> sortedContent.put(file.getParentFile().getName(), s));
 
-        assertEquals(2, sortedContent.size());
-        assertEquals("a1,1\n" + "a2,2\n" + "a3,3\n", sortedContent.get("c=p1"));
-        assertEquals("a2,2\n", sortedContent.get("c=p2"));
-        assertFalse(new File(tmpFile.toURI()).exists());
+        assertThat(sortedContent).hasSize(2);
+        assertThat(sortedContent.get("c=p1")).isEqualTo("a1,1\n" + "a2,2\n" + "a3,3\n");
+        assertThat(sortedContent.get("c=p2")).isEqualTo("a2,2\n");
+        assertThat(new File(tmpPath.toUri())).doesNotExist();
     }
 
     @Test
-    public void testGroupedDynamicPartition() throws Exception {
+    void testGroupedDynamicPartition() throws Exception {
         AtomicReference<FileSystemOutputFormat<Row>> ref = new AtomicReference<>();
         try (OneInputStreamOperatorTestHarness<Row, Object> testHarness =
                 createSink(false, true, true, new LinkedHashMap<>(), ref)) {
@@ -190,18 +189,18 @@ public class FileSystemOutputFormatTest {
             testHarness.processElement(new StreamRecord<>(Row.of("a2", 2, "p1"), 1L));
             testHarness.processElement(new StreamRecord<>(Row.of("a3", 3, "p1"), 1L));
             testHarness.processElement(new StreamRecord<>(Row.of("a2", 2, "p2"), 1L));
-            assertEquals(2, getFileContentByPath(tmpFile).size());
+            assertThat(getFileContentByPath(tmpPath)).hasSize(2);
         }
 
         ref.get().finalizeGlobal(1);
-        Map<File, String> content = getFileContentByPath(outputFile);
+        Map<File, String> content = getFileContentByPath(outputPath);
         Map<String, String> sortedContent = new TreeMap<>();
         content.forEach((file, s) -> sortedContent.put(file.getParentFile().getName(), s));
 
-        assertEquals(2, sortedContent.size());
-        assertEquals("a1,1\n" + "a2,2\n" + "a3,3\n", sortedContent.get("c=p1"));
-        assertEquals("a2,2\n", sortedContent.get("c=p2"));
-        assertFalse(new File(tmpFile.toURI()).exists());
+        assertThat(sortedContent).hasSize(2);
+        assertThat(sortedContent.get("c=p1")).isEqualTo("a1,1\n" + "a2,2\n" + "a3,3\n");
+        assertThat(sortedContent.get("c=p2")).isEqualTo("a2,2\n");
+        assertThat(new File(tmpPath.toUri())).doesNotExist();
     }
 
     private OneInputStreamOperatorTestHarness<Row, Object> createSink(
@@ -215,11 +214,11 @@ public class FileSystemOutputFormatTest {
         String[] partitionColumns = partition ? new String[] {"c"} : new String[0];
 
         TableMetaStoreFactory msFactory =
-                new FileSystemCommitterTest.TestMetaStoreFactory(new Path(outputFile.getPath()));
+                new FileSystemCommitterTest.TestMetaStoreFactory(new Path(outputPath.toString()));
         FileSystemOutputFormat<Row> sink =
                 new FileSystemOutputFormat.Builder<Row>()
                         .setMetaStoreFactory(msFactory)
-                        .setTempPath(new Path(tmpFile.getPath()))
+                        .setTempPath(new Path(tmpPath.toString()))
                         .setOverwrite(override)
                         .setPartitionColumns(partitionColumns)
                         .setPartitionComputer(

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/FileSystemOutputFormatTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/FileSystemOutputFormatTest.java
@@ -44,6 +44,7 @@ import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 
 /** Test for {@link FileSystemOutputFormat}. */
 class FileSystemOutputFormatTest {
@@ -96,7 +97,8 @@ class FileSystemOutputFormatTest {
 
         ref.get().finalizeGlobal(1);
         Map<File, String> content = getFileContentByPath(outputPath);
-        assertThat(content.values()).containsExactly("a1,1,p1\n" + "a2,2,p1\n" + "a2,2,p2\n" + "a3,3,p1\n");
+        assertThat(content.values())
+                .containsExactly("a1,1,p1\n" + "a2,2,p1\n" + "a2,2,p2\n" + "a3,3,p1\n");
     }
 
     private void writeUnorderedRecords(OneInputStreamOperatorTestHarness<Row, Object> testHarness)
@@ -124,8 +126,8 @@ class FileSystemOutputFormatTest {
         ref.get().finalizeGlobal(1);
         Map<File, String> content = getFileContentByPath(outputPath);
         assertThat(content).hasSize(1);
-        assertThat(content.values().iterator().next())
-                .isEqualTo("a1,1,p1\n" + "a2,2,p1\n" + "a2,2,p2\n" + "a3,3,p1\n");
+        assertThat(content.values())
+                .containsExactly("a1,1,p1\n" + "a2,2,p1\n" + "a2,2,p2\n" + "a3,3,p1\n");
         assertThat(new File(tmpPath.toUri())).doesNotExist();
     }
 
@@ -150,8 +152,7 @@ class FileSystemOutputFormatTest {
         Map<File, String> content = getFileContentByPath(outputPath);
         assertThat(content).hasSize(1);
         assertThat(content.keySet().iterator().next().getParentFile().getName()).isEqualTo("c=p1");
-        assertThat(content.values().iterator().next())
-                .isEqualTo("a1,1\n" + "a2,2\n" + "a2,2\n" + "a3,3\n");
+        assertThat(content.values()).containsExactly("a1,1\n" + "a2,2\n" + "a2,2\n" + "a3,3\n");
         assertThat(new File(tmpPath.toUri())).doesNotExist();
     }
 
@@ -170,8 +171,8 @@ class FileSystemOutputFormatTest {
         content.forEach((file, s) -> sortedContent.put(file.getParentFile().getName(), s));
 
         assertThat(sortedContent).hasSize(2);
-        assertThat(sortedContent.get("c=p1")).isEqualTo("a1,1\n" + "a2,2\n" + "a3,3\n");
-        assertThat(sortedContent.get("c=p2")).isEqualTo("a2,2\n");
+        assertThat(sortedContent)
+                .contains(entry("c=p1", "a1,1\n" + "a2,2\n" + "a3,3\n"), entry("c=p2", "a2,2\n"));
         assertThat(new File(tmpPath.toUri())).doesNotExist();
     }
 

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/PartitionWriterTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/PartitionWriterTest.java
@@ -23,8 +23,8 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.file.table.PartitionWriter.Context;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.table.utils.LegacyRowResource;
 import org.apache.flink.types.Row;
-import org.apache.flink.types.RowUtils;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -42,6 +42,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 /** Test for {@link PartitionWriter}s. */
 class PartitionWriterTest {
 
+    private final LegacyRowResource usesLegacyRows = LegacyRowResource.INSTANCE;
+
     @TempDir private java.nio.file.Path tmpDir;
 
     private PartitionTempFileManager manager;
@@ -49,12 +51,12 @@ class PartitionWriterTest {
     @BeforeEach
     void before() throws IOException {
         manager = new PartitionTempFileManager(fsFactory, new Path(tmpDir.toUri()), 0);
-        RowUtils.USE_LEGACY_TO_STRING = true;
+        usesLegacyRows.before();
     }
 
     @AfterEach
     void after() {
-        RowUtils.USE_LEGACY_TO_STRING = false;
+        usesLegacyRows.after();
     }
 
     private final Map<String, List<Row>> records = new LinkedHashMap<>();

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/PartitionWriterTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/PartitionWriterTest.java
@@ -23,26 +23,39 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.file.table.PartitionWriter.Context;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
-import org.apache.flink.table.utils.LegacyRowResource;
 import org.apache.flink.types.Row;
+import org.apache.flink.types.RowUtils;
 
-import org.junit.Assert;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /** Test for {@link PartitionWriter}s. */
-public class PartitionWriterTest {
+class PartitionWriterTest {
 
-    @Rule public final LegacyRowResource usesLegacyRows = LegacyRowResource.INSTANCE;
+    @TempDir private java.nio.file.Path tmpDir;
 
-    @ClassRule public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
+    private PartitionTempFileManager manager;
+
+    @BeforeEach
+    void before() throws IOException {
+        manager = new PartitionTempFileManager(fsFactory, new Path(tmpDir.toUri()), 0);
+        RowUtils.USE_LEGACY_TO_STRING = true;
+    }
+
+    @AfterEach
+    void after() {
+        RowUtils.USE_LEGACY_TO_STRING = false;
+    }
 
     private final Map<String, List<Row>> records = new LinkedHashMap<>();
 
@@ -77,16 +90,10 @@ public class PartitionWriterTest {
                         public void close() {}
                     };
 
-    private final String basePath = TEMP_FOLDER.newFolder().getPath();
-
     private final Context<Row> context =
             new Context<>(null, path -> factory.createOutputFormat(path));
 
     private FileSystemFactory fsFactory = FileSystem::get;
-
-    private Path tmpPath = new Path(basePath);
-
-    private PartitionTempFileManager manager = new PartitionTempFileManager(fsFactory, tmpPath, 0);
 
     private PartitionComputer<Row> computer =
             new PartitionComputer<Row>() {
@@ -107,15 +114,15 @@ public class PartitionWriterTest {
     public PartitionWriterTest() throws Exception {}
 
     @Test
-    public void testEmptySingleDirectoryWriter() throws Exception {
+    void testEmptySingleDirectoryWriter() throws Exception {
         SingleDirectoryWriter<Row> writer =
                 new SingleDirectoryWriter<>(context, manager, computer, new LinkedHashMap<>());
         writer.close();
-        Assert.assertTrue(records.isEmpty());
+        assertThat(records).isEmpty();
     }
 
     @Test
-    public void testSingleDirectoryWriter() throws Exception {
+    void testSingleDirectoryWriter() throws Exception {
         SingleDirectoryWriter<Row> writer =
                 new SingleDirectoryWriter<>(context, manager, computer, new LinkedHashMap<>());
 
@@ -123,20 +130,20 @@ public class PartitionWriterTest {
         writer.write(Row.of("p1", 2));
         writer.write(Row.of("p2", 2));
         writer.close();
-        Assert.assertEquals("{task-0=[p1,1, p1,2, p2,2]}", records.toString());
+        assertThat(records.toString()).isEqualTo("{task-0=[p1,1, p1,2, p2,2]}");
 
-        manager = new PartitionTempFileManager(fsFactory, tmpPath, 1);
+        manager = new PartitionTempFileManager(fsFactory, new Path(tmpDir.toUri()), 1);
         writer = new SingleDirectoryWriter<>(context, manager, computer, new LinkedHashMap<>());
         writer.write(Row.of("p3", 3));
         writer.write(Row.of("p5", 5));
         writer.write(Row.of("p2", 2));
         writer.close();
-        Assert.assertEquals(
-                "{task-0=[p1,1, p1,2, p2,2], task-1=[p3,3, p5,5, p2,2]}", records.toString());
+        assertThat(records.toString())
+                .isEqualTo("{task-0=[p1,1, p1,2, p2,2], task-1=[p3,3, p5,5, p2,2]}");
     }
 
     @Test
-    public void testGroupedPartitionWriter() throws Exception {
+    void testGroupedPartitionWriter() throws Exception {
         GroupedPartitionWriter<Row> writer =
                 new GroupedPartitionWriter<>(context, manager, computer);
 
@@ -144,21 +151,21 @@ public class PartitionWriterTest {
         writer.write(Row.of("p1", 2));
         writer.write(Row.of("p2", 2));
         writer.close();
-        Assert.assertEquals("{task-0/p=p1=[p1,1, p1,2], task-0/p=p2=[p2,2]}", records.toString());
+        assertThat(records.toString()).isEqualTo("{task-0/p=p1=[p1,1, p1,2], task-0/p=p2=[p2,2]}");
 
-        manager = new PartitionTempFileManager(fsFactory, tmpPath, 1);
+        manager = new PartitionTempFileManager(fsFactory, new Path(tmpDir.toUri()), 1);
         writer = new GroupedPartitionWriter<>(context, manager, computer);
         writer.write(Row.of("p3", 3));
         writer.write(Row.of("p4", 5));
         writer.write(Row.of("p5", 2));
         writer.close();
-        Assert.assertEquals(
-                "{task-0/p=p1=[p1,1, p1,2], task-0/p=p2=[p2,2], task-1/p=p3=[p3,3], task-1/p=p4=[p4,5], task-1/p=p5=[p5,2]}",
-                records.toString());
+        assertThat(records.toString())
+                .isEqualTo(
+                        "{task-0/p=p1=[p1,1, p1,2], task-0/p=p2=[p2,2], task-1/p=p3=[p3,3], task-1/p=p4=[p4,5], task-1/p=p5=[p5,2]}");
     }
 
     @Test
-    public void testDynamicPartitionWriter() throws Exception {
+    void testDynamicPartitionWriter() throws Exception {
         DynamicPartitionWriter<Row> writer =
                 new DynamicPartitionWriter<>(context, manager, computer);
 
@@ -166,16 +173,16 @@ public class PartitionWriterTest {
         writer.write(Row.of("p2", 2));
         writer.write(Row.of("p1", 2));
         writer.close();
-        Assert.assertEquals("{task-0/p=p1=[p1,1, p1,2], task-0/p=p2=[p2,2]}", records.toString());
+        assertThat(records.toString()).isEqualTo("{task-0/p=p1=[p1,1, p1,2], task-0/p=p2=[p2,2]}");
 
-        manager = new PartitionTempFileManager(fsFactory, tmpPath, 1);
+        manager = new PartitionTempFileManager(fsFactory, new Path(tmpDir.toUri()), 1);
         writer = new DynamicPartitionWriter<>(context, manager, computer);
         writer.write(Row.of("p4", 5));
         writer.write(Row.of("p3", 3));
         writer.write(Row.of("p5", 2));
         writer.close();
-        Assert.assertEquals(
-                "{task-0/p=p1=[p1,1, p1,2], task-0/p=p2=[p2,2], task-1/p=p4=[p4,5], task-1/p=p3=[p3,3], task-1/p=p5=[p5,2]}",
-                records.toString());
+        assertThat(records.toString())
+                .isEqualTo(
+                        "{task-0/p=p1=[p1,1, p1,2], task-0/p=p2=[p2,2], task-1/p=p4=[p4,5], task-1/p=p3=[p3,3], task-1/p=p5=[p5,2]}");
     }
 }

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/RowPartitionComputerTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/RowPartitionComputerTest.java
@@ -20,23 +20,23 @@ package org.apache.flink.connector.file.table;
 
 import org.apache.flink.types.Row;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.flink.table.utils.PartitionPathUtils.generatePartitionPath;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link RowPartitionComputer}. */
-public class RowPartitionComputerTest {
+class RowPartitionComputerTest {
 
     @Test
-    public void testProjectColumnsToWrite() throws Exception {
+    void testProjectColumnsToWrite() {
         Row projected1 =
                 new RowPartitionComputer(
                                 "",
                                 new String[] {"f1", "p1", "p2", "f2"},
                                 new String[] {"p1", "p2"})
                         .projectColumnsToWrite(Row.of(1, 2, 3, 4));
-        Assert.assertEquals(Row.of(1, 4), projected1);
+        assertThat(projected1).isEqualTo(Row.of(1, 4));
 
         Row projected2 =
                 new RowPartitionComputer(
@@ -44,7 +44,7 @@ public class RowPartitionComputerTest {
                                 new String[] {"f1", "f2", "p1", "p2"},
                                 new String[] {"p1", "p2"})
                         .projectColumnsToWrite(Row.of(1, 2, 3, 4));
-        Assert.assertEquals(Row.of(1, 2), projected2);
+        assertThat(projected2).isEqualTo(Row.of(1, 2));
 
         Row projected3 =
                 new RowPartitionComputer(
@@ -52,21 +52,19 @@ public class RowPartitionComputerTest {
                                 new String[] {"f1", "p1", "f2", "p2"},
                                 new String[] {"p1", "p2"})
                         .projectColumnsToWrite(Row.of(1, 2, 3, 4));
-        Assert.assertEquals(Row.of(1, 3), projected3);
+        assertThat(projected3).isEqualTo(Row.of(1, 3));
     }
 
     @Test
-    public void testComputePartition() throws Exception {
+    void testComputePartition() throws Exception {
         RowPartitionComputer computer =
                 new RowPartitionComputer(
                         "myDefaultname",
                         new String[] {"f1", "p1", "p2", "f2"},
                         new String[] {"p1", "p2"});
-        Assert.assertEquals(
-                "p1=2/p2=3/",
-                generatePartitionPath(computer.generatePartValues(Row.of(1, 2, 3, 4))));
-        Assert.assertEquals(
-                "p1=myDefaultname/p2=3/",
-                generatePartitionPath(computer.generatePartValues(Row.of(1, null, 3, 4))));
+        assertThat(generatePartitionPath(computer.generatePartValues(Row.of(1, 2, 3, 4))))
+                .isEqualTo("p1=2/p2=3/");
+        assertThat(generatePartitionPath(computer.generatePartValues(Row.of(1, null, 3, 4))))
+                .isEqualTo("p1=myDefaultname/p2=3/");
     }
 }

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/stream/StreamingFileWriterTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/stream/StreamingFileWriterTest.java
@@ -160,7 +160,7 @@ class StreamingFileWriterTest {
 
             harness.notifyOfCompletedCheckpoint(1);
             List<String> partitions = collect(harness);
-            assertThat(partitions).isEqualTo(Arrays.asList("1", "2"));
+            assertThat(partitions).containsExactly("1", "2");
         }
     }
 

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/stream/StreamingFileWriterTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/stream/StreamingFileWriterTest.java
@@ -36,11 +36,9 @@ import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
@@ -60,25 +58,26 @@ import static org.apache.flink.connector.file.table.FileSystemConnectorOptions.S
 import static org.apache.flink.connector.file.table.FileSystemConnectorOptions.SINK_PARTITION_COMMIT_POLICY_KIND;
 import static org.apache.flink.connector.file.table.FileSystemConnectorOptions.SINK_PARTITION_COMMIT_TRIGGER;
 import static org.apache.flink.connector.file.table.FileSystemConnectorOptions.SINK_PARTITION_COMMIT_WATERMARK_TIME_ZONE;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link StreamingFileWriter}. */
-public class StreamingFileWriterTest {
+class StreamingFileWriterTest {
 
-    @ClassRule public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
     private final OutputFileConfig outputFileConfig = OutputFileConfig.builder().build();
     private final DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
 
+    @TempDir private java.nio.file.Path tmpDir;
     private Path path;
 
-    @Before
-    public void before() throws IOException {
-        File file = TEMPORARY_FOLDER.newFile();
+    @BeforeEach
+    void before() throws IOException {
+        File file = tmpDir.toFile();
         file.delete();
         path = new Path(file.toURI());
     }
 
     @Test
-    public void testFailover() throws Exception {
+    void testFailover() throws Exception {
         OperatorSubtaskState state;
         try (OneInputStreamOperatorTestHarness<RowData, PartitionCommitInfo> harness = create()) {
             harness.setup();
@@ -92,7 +91,7 @@ public class StreamingFileWriterTest {
             harness.processElement(row("4"), 0);
             harness.notifyOfCompletedCheckpoint(1);
             List<String> partitions = collect(harness);
-            Assert.assertEquals(Arrays.asList("1", "2"), partitions);
+            assertThat(partitions).isEqualTo(Arrays.asList("1", "2"));
         }
 
         // first retry, no partition {1, 2} records
@@ -105,7 +104,7 @@ public class StreamingFileWriterTest {
             state = harness.snapshot(2, 2);
             harness.notifyOfCompletedCheckpoint(2);
             List<String> partitions = collect(harness);
-            Assert.assertEquals(Arrays.asList("1", "2", "3", "4"), partitions);
+            assertThat(partitions).isEqualTo(Arrays.asList("1", "2", "3", "4"));
         }
 
         // second retry, partition {4} repeat
@@ -118,7 +117,7 @@ public class StreamingFileWriterTest {
             state = harness.snapshot(3, 3);
             harness.notifyOfCompletedCheckpoint(3);
             List<String> partitions = collect(harness);
-            Assert.assertEquals(Arrays.asList("3", "4", "5"), partitions);
+            assertThat(partitions).isEqualTo(Arrays.asList("3", "4", "5"));
         }
 
         // third retry, multiple snapshots
@@ -136,12 +135,12 @@ public class StreamingFileWriterTest {
             harness.notifyOfCompletedCheckpoint(5);
             List<String> partitions = collect(harness);
             // should not contains partition {9}
-            Assert.assertEquals(Arrays.asList("4", "5", "6", "7", "8"), partitions);
+            assertThat(partitions).isEqualTo(Arrays.asList("4", "5", "6", "7", "8"));
         }
     }
 
     @Test
-    public void testCommitImmediately() throws Exception {
+    void testCommitImmediately() throws Exception {
         try (OneInputStreamOperatorTestHarness<RowData, PartitionCommitInfo> harness = create()) {
             harness.setup();
             harness.initializeEmptyState();
@@ -161,12 +160,12 @@ public class StreamingFileWriterTest {
 
             harness.notifyOfCompletedCheckpoint(1);
             List<String> partitions = collect(harness);
-            Assert.assertEquals(Arrays.asList("1", "2"), partitions);
+            assertThat(partitions).isEqualTo(Arrays.asList("1", "2"));
         }
     }
 
     @Test
-    public void testCommitFileWhenPartitionIsCommittableByProcessTime() throws Exception {
+    void testCommitFileWhenPartitionIsCommittableByProcessTime() throws Exception {
         // the rolling policy is not to roll file by filesize and roll file after one day,
         // it can ensure the file can be closed only when the partition is committable in this test.
         FileSystemTableSink.TableRollingPolicy tableRollingPolicy =
@@ -192,8 +191,8 @@ public class StreamingFileWriterTest {
             harness.processElement(row("3"), 0);
             harness.notifyOfCompletedCheckpoint(1);
             // assert files aren't committed in {1, 2} partitions
-            Assert.assertFalse(isPartitionFileCommitted("1", 0, 0));
-            Assert.assertFalse(isPartitionFileCommitted("2", 0, 1));
+            assertThat(isPartitionFileCommitted("1", 0, 0)).isFalse();
+            assertThat(isPartitionFileCommitted("2", 0, 1)).isFalse();
         }
 
         // first retry
@@ -212,15 +211,15 @@ public class StreamingFileWriterTest {
             harness.notifyOfCompletedCheckpoint(2);
             // only file in partition {3} should be committed
             // assert files are committed
-            Assert.assertTrue(isPartitionFileCommitted("3", 0, 2));
-            Assert.assertFalse(isPartitionFileCommitted("4", 0, 3));
+            assertThat(isPartitionFileCommitted("3", 0, 2)).isTrue();
+            assertThat(isPartitionFileCommitted("4", 0, 3)).isFalse();
 
             // simulate waiting for 2 seconds again, now partition {1} is committable
             currentTimeMillis += Duration.ofSeconds(2).toMillis();
             harness.setProcessingTime(currentTimeMillis);
             state = harness.snapshot(3, 3);
             harness.notifyOfCompletedCheckpoint(3);
-            Assert.assertTrue(isPartitionFileCommitted("4", 0, 3));
+            assertThat(isPartitionFileCommitted("4", 0, 3)).isTrue();
         }
 
         // second retry
@@ -236,13 +235,13 @@ public class StreamingFileWriterTest {
             harness.processElement(row("5"), 5);
             harness.endInput();
             // assert files in all partition have been committed
-            Assert.assertTrue(isPartitionFileCommitted("4", 0, 4));
-            Assert.assertTrue(isPartitionFileCommitted("5", 0, 5));
+            assertThat(isPartitionFileCommitted("4", 0, 4)).isTrue();
+            assertThat(isPartitionFileCommitted("5", 0, 5)).isTrue();
         }
     }
 
     @Test
-    public void testCommitFileWhenPartitionIsCommittableByPartitionTime() throws Exception {
+    void testCommitFileWhenPartitionIsCommittableByPartitionTime() throws Exception {
         // the rolling policy is not to roll file by filesize and roll file after one day,
         // it can ensure the file can be closed only when the partition is committable in this test.
         FileSystemTableSink.TableRollingPolicy tableRollingPolicy =
@@ -277,7 +276,7 @@ public class StreamingFileWriterTest {
             state = harness.snapshot(1, 1);
             harness.notifyOfCompletedCheckpoint(1);
             // assert yesterday partition file is committed
-            Assert.assertTrue(isPartitionFileCommitted(yesterdayPartition, 0, 0));
+            assertThat(isPartitionFileCommitted(yesterdayPartition, 0, 0)).isTrue();
         }
 
         // first retry
@@ -295,16 +294,16 @@ public class StreamingFileWriterTest {
             harness.snapshot(2, 2);
             harness.notifyOfCompletedCheckpoint(2);
             // assert today partition file is committed
-            Assert.assertTrue(isPartitionFileCommitted(todayPartition, 0, 2));
+            assertThat(isPartitionFileCommitted(todayPartition, 0, 2)).isTrue();
             // assert tomorrow partition file isn't committed
-            Assert.assertFalse(isPartitionFileCommitted(tomorrowPartition, 0, 1));
+            assertThat(isPartitionFileCommitted(tomorrowPartition, 0, 1)).isFalse();
 
             // simulate waiting for 1 day again, now tomorrow partition is committable
             currentTimeMillis += Duration.ofDays(1).toMillis();
             harness.processWatermark(currentTimeMillis);
             state = harness.snapshot(3, 3);
             harness.notifyOfCompletedCheckpoint(3);
-            Assert.assertTrue(isPartitionFileCommitted(tomorrowPartition, 0, 1));
+            assertThat(isPartitionFileCommitted(tomorrowPartition, 0, 1)).isTrue();
 
             harness.processElement(row(nextYearPartition), 0);
         }
@@ -320,8 +319,8 @@ public class StreamingFileWriterTest {
             harness.processElement(row(tomorrowPartition), 0);
             harness.endInput();
             // assert files in all partition have been committed
-            Assert.assertTrue(isPartitionFileCommitted(tomorrowPartition, 0, 4));
-            Assert.assertTrue(isPartitionFileCommitted(nextYearPartition, 0, 3));
+            assertThat(isPartitionFileCommitted(tomorrowPartition, 0, 4)).isTrue();
+            assertThat(isPartitionFileCommitted(nextYearPartition, 0, 3)).isTrue();
         }
     }
 

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/stream/StreamingFileWriterTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/stream/StreamingFileWriterTest.java
@@ -40,7 +40,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
@@ -48,7 +47,6 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -89,7 +87,7 @@ class StreamingFileWriterTest {
             harness.processElement(row("4"), 0);
             harness.notifyOfCompletedCheckpoint(1);
             List<String> partitions = collect(harness);
-            assertThat(partitions).isEqualTo(Arrays.asList("1", "2"));
+            assertThat(partitions).containsExactly("1", "2");
         }
 
         // first retry, no partition {1, 2} records
@@ -102,7 +100,7 @@ class StreamingFileWriterTest {
             state = harness.snapshot(2, 2);
             harness.notifyOfCompletedCheckpoint(2);
             List<String> partitions = collect(harness);
-            assertThat(partitions).isEqualTo(Arrays.asList("1", "2", "3", "4"));
+            assertThat(partitions).containsExactly("1", "2", "3", "4");
         }
 
         // second retry, partition {4} repeat
@@ -115,7 +113,7 @@ class StreamingFileWriterTest {
             state = harness.snapshot(3, 3);
             harness.notifyOfCompletedCheckpoint(3);
             List<String> partitions = collect(harness);
-            assertThat(partitions).isEqualTo(Arrays.asList("3", "4", "5"));
+            assertThat(partitions).containsExactly("3", "4", "5");
         }
 
         // third retry, multiple snapshots
@@ -133,7 +131,7 @@ class StreamingFileWriterTest {
             harness.notifyOfCompletedCheckpoint(5);
             List<String> partitions = collect(harness);
             // should not contains partition {9}
-            assertThat(partitions).isEqualTo(Arrays.asList("4", "5", "6", "7", "8"));
+            assertThat(partitions).containsExactly("4", "5", "6", "7", "8");
         }
     }
 

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/stream/StreamingFileWriterTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/stream/StreamingFileWriterTest.java
@@ -71,9 +71,7 @@ class StreamingFileWriterTest {
 
     @BeforeEach
     void before() throws IOException {
-        File file = tmpDir.toFile();
-        file.delete();
-        path = new Path(file.toURI());
+        path = new Path(tmpDir.resolve("tmp").toUri());
     }
 
     @Test

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/stream/compact/AbstractCompactTestBase.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/stream/compact/AbstractCompactTestBase.java
@@ -20,9 +20,8 @@ package org.apache.flink.connector.file.table.stream.compact;
 
 import org.apache.flink.core.fs.Path;
 
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -31,15 +30,15 @@ import java.io.IOException;
 /** Test base for compact operators. */
 public abstract class AbstractCompactTestBase {
 
-    @ClassRule public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
-
     public static final int TARGET_SIZE = 9;
+
+    @TempDir private java.nio.file.Path path;
 
     Path folder;
 
-    @Before
-    public void before() throws IOException {
-        folder = new Path(TEMP_FOLDER.newFolder().getPath());
+    @BeforeEach
+    void before() {
+        folder = new Path(path.toString());
     }
 
     Path newFile(String name, int len) throws IOException {

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/stream/compact/CompactCoordinatorTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/stream/compact/CompactCoordinatorTest.java
@@ -29,8 +29,7 @@ import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.util.function.ThrowingConsumer;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -40,11 +39,13 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /** Test for {@link CompactCoordinator}. */
-public class CompactCoordinatorTest extends AbstractCompactTestBase {
+class CompactCoordinatorTest extends AbstractCompactTestBase {
 
     @Test
-    public void testCoordinatorCrossCheckpoints() throws Exception {
+    void testCoordinatorCrossCheckpoints() throws Exception {
         AtomicReference<OperatorSubtaskState> state = new AtomicReference<>();
         runCoordinator(
                 harness -> {
@@ -87,12 +88,12 @@ public class CompactCoordinatorTest extends AbstractCompactTestBase {
 
                     List<CoordinatorOutput> outputs = harness.extractOutputValues();
 
-                    Assert.assertEquals(7, outputs.size());
+                    assertThat(outputs).hasSize(7);
 
                     List<CompactionUnit> cp1Units = new ArrayList<>();
                     for (int i = 0; i < 4; i++) {
                         CoordinatorOutput output = outputs.get(i);
-                        Assert.assertTrue(output instanceof CompactionUnit);
+                        assertThat(output).isInstanceOf(CompactionUnit.class);
                         cp1Units.add((CompactionUnit) output);
                     }
                     cp1Units.sort(
@@ -127,21 +128,20 @@ public class CompactCoordinatorTest extends AbstractCompactTestBase {
     }
 
     private void assertEndCompaction(CoordinatorOutput output, long checkpointId) {
-        Assert.assertTrue(output instanceof EndCompaction);
+        assertThat(output).isInstanceOf(EndCompaction.class);
         EndCompaction end = (EndCompaction) output;
 
-        Assert.assertEquals(checkpointId, end.getCheckpointId());
+        assertThat(end.getCheckpointId()).isEqualTo(checkpointId);
     }
 
     private void assertUnit(
             CoordinatorOutput output, int unitId, String partition, List<String> fileNames) {
-        Assert.assertTrue(output instanceof CompactionUnit);
+        assertThat(output).isInstanceOf(CompactionUnit.class);
         CompactionUnit unit = (CompactionUnit) output;
 
-        Assert.assertEquals(unitId, unit.getUnitId());
-        Assert.assertEquals(partition, unit.getPartition());
-        Assert.assertEquals(
-                fileNames,
-                unit.getPaths().stream().map(Path::getName).collect(Collectors.toList()));
+        assertThat(unit.getUnitId()).isEqualTo(unitId);
+        assertThat(unit.getPartition()).isEqualTo(partition);
+        assertThat(unit.getPaths().stream().map(Path::getName).collect(Collectors.toList()))
+                .isEqualTo(fileNames);
     }
 }

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/stream/compact/CompactCoordinatorTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/stream/compact/CompactCoordinatorTest.java
@@ -141,7 +141,6 @@ class CompactCoordinatorTest extends AbstractCompactTestBase {
 
         assertThat(unit.getUnitId()).isEqualTo(unitId);
         assertThat(unit.getPartition()).isEqualTo(partition);
-        assertThat(unit.getPaths().stream().map(Path::getName).collect(Collectors.toList()))
-                .isEqualTo(fileNames);
+        assertThat(unit.getPaths().stream().map(Path::getName)).containsExactlyElementsOf(fileNames);
     }
 }

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/stream/compact/CompactCoordinatorTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/stream/compact/CompactCoordinatorTest.java
@@ -37,7 +37,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -141,6 +140,7 @@ class CompactCoordinatorTest extends AbstractCompactTestBase {
 
         assertThat(unit.getUnitId()).isEqualTo(unitId);
         assertThat(unit.getPartition()).isEqualTo(partition);
-        assertThat(unit.getPaths().stream().map(Path::getName)).containsExactlyElementsOf(fileNames);
+        assertThat(unit.getPaths().stream().map(Path::getName))
+                .containsExactlyElementsOf(fileNames);
     }
 }

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/stream/compact/CompactFileWriterTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/stream/compact/CompactFileWriterTest.java
@@ -26,19 +26,19 @@ import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
 import static org.apache.flink.connector.file.table.stream.compact.CompactMessages.CoordinatorInput;
 import static org.apache.flink.connector.file.table.stream.compact.CompactMessages.InputFile;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link CompactFileWriter}. */
-public class CompactFileWriterTest extends AbstractCompactTestBase {
+class CompactFileWriterTest extends AbstractCompactTestBase {
 
     @Test
-    public void testEmitEndCheckpointAfterEndInput() throws Exception {
+    void testEmitEndCheckpointAfterEndInput() throws Exception {
         CompactFileWriter<RowData> compactFileWriter =
                 new CompactFileWriter<>(
                         1000, StreamingFileSink.forRowFormat(folder, new SimpleStringEncoder<>()));
@@ -53,11 +53,11 @@ public class CompactFileWriterTest extends AbstractCompactTestBase {
 
             List<CoordinatorInput> coordinatorInputs = harness.extractOutputValues();
 
-            Assert.assertEquals(2, coordinatorInputs.size());
+            assertThat(coordinatorInputs).hasSize(2);
             // assert emit InputFile
-            Assert.assertTrue(coordinatorInputs.get(0) instanceof InputFile);
+            assertThat(coordinatorInputs.get(0)).isInstanceOf(InputFile.class);
             // assert emit EndCheckpoint
-            Assert.assertEquals(1, ((EndCheckpoint) coordinatorInputs.get(1)).getCheckpointId());
+            assertThat(((EndCheckpoint) coordinatorInputs.get(1)).getCheckpointId()).isEqualTo(1);
 
             harness.processElement(row("test1"), 0);
             harness.processElement(row("test2"), 0);
@@ -70,7 +70,7 @@ public class CompactFileWriterTest extends AbstractCompactTestBase {
             // assert emit EndCheckpoint with Long.MAX_VALUE lastly
             EndCheckpoint endCheckpoint =
                     (EndCheckpoint) coordinatorInputs.get(coordinatorInputs.size() - 1);
-            Assert.assertEquals(Long.MAX_VALUE, endCheckpoint.getCheckpointId());
+            assertThat(endCheckpoint.getCheckpointId()).isEqualTo(Long.MAX_VALUE);
         }
     }
 

--- a/flink-connectors/flink-connector-files/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/flink-connectors/flink-connector-files/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.util.TestLoggerExtension

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/utils/LegacyRowResource.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/utils/LegacyRowResource.java
@@ -37,12 +37,12 @@ public class LegacyRowResource extends ExternalResource {
     }
 
     @Override
-    protected void before() {
+    public void before() {
         RowUtils.USE_LEGACY_TO_STRING = true;
     }
 
     @Override
-    protected void after() {
+    public void after() {
         RowUtils.USE_LEGACY_TO_STRING = false;
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Update the flink-connector-files module to AssertJ and JUnit 5 following the [JUnit 5 Migration Guide](https://docs.google.com/document/d/1514Wa_aNB9bJUen4xm5uiuXOooOJTtXqS_Jqk9KJitU/edit)


## Brief change log

Use JUnit5 and AssertJ in tests instead of JUnit4 and Hamcrest


## Verifying this change

This change is a code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
