### PR TITLE
[hotfix][connector][pulsar][docs] Corrected typo in topic partition subscription section

### DIFF
--- a/docs/content/docs/connectors/datastream/pulsar.md
+++ b/docs/content/docs/connectors/datastream/pulsar.md
@@ -80,7 +80,7 @@ You can use it to monitor the performance of your Flink connector and applicatio
 
 ### Topic-partition Subscription
 
-Pulsar source provide two ways of topic-partition subscription:
+Pulsar source provides two ways of topic-partition subscription:
 
 - Topic list, subscribing messages from all partitions in a list of topics. For example:
   ```java


### PR DESCRIPTION

## What is the purpose of the change

* Corrected typo in topic partition subscription description

## Brief change log

* Updated <code>Pulsar source **provide** two ways</code> to <code>Pulsar source **provides** two ways</code>

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive):  no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
