### PR TITLE
[FLINK-17232][k8s] Disable the implicit behavior to use the Service e…

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/services/LoadBalancerService.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/services/LoadBalancerService.java
@@ -74,19 +74,10 @@ public class LoadBalancerService extends ServiceType {
         }
 
         LoadBalancerStatus loadBalancer = service.getStatus().getLoadBalancer();
-        boolean hasExternalIP =
-                service.getSpec() != null
-                        && service.getSpec().getExternalIPs() != null
-                        && !service.getSpec().getExternalIPs().isEmpty();
 
         if (loadBalancer != null) {
             return getLoadBalancerRestEndpoint(
                     internalClient, nodePortAddressType, loadBalancer, restPort);
-        } else if (hasExternalIP) {
-            final String address = service.getSpec().getExternalIPs().get(0);
-            if (address != null && !address.isEmpty()) {
-                return Optional.of(new Endpoint(address, restPort));
-            }
         }
         return Optional.empty();
     }


### PR DESCRIPTION
…xternalIP as the address of the Endpoint

## What is the purpose of the change

This PR is to disable the implicit behavior to use the Service externalIp as the endpoint. This will decrease the implicit behavior around generating the endpoint .

Since the external ip can only be used by set explicit, we have not expose the way to set external ip. so I think it will not break the compatibility