### PR TITLE
[hotfix][table] Add objectReuse parameter for AsyncLookupJoinITCase.

### DIFF
--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/AsyncLookupJoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/AsyncLookupJoinITCase.scala
@@ -39,7 +39,9 @@ import scala.collection.JavaConversions._
 
 @RunWith(classOf[Parameterized])
 class AsyncLookupJoinITCase(
-  legacyTableSource: Boolean, backend: StateBackendMode, objectReuse: Boolean)
+    legacyTableSource: Boolean,
+    backend: StateBackendMode,
+    objectReuse: Boolean)
   extends StreamingWithStateTestBase(backend) {
 
   val data = List(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/AsyncLookupJoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/AsyncLookupJoinITCase.scala
@@ -38,7 +38,8 @@ import java.util.{Collection => JCollection}
 import scala.collection.JavaConversions._
 
 @RunWith(classOf[Parameterized])
-class AsyncLookupJoinITCase(legacyTableSource: Boolean, backend: StateBackendMode)
+class AsyncLookupJoinITCase(
+  legacyTableSource: Boolean, backend: StateBackendMode, objectReuse: Boolean)
   extends StreamingWithStateTestBase(backend) {
 
   val data = List(
@@ -53,9 +54,11 @@ class AsyncLookupJoinITCase(legacyTableSource: Boolean, backend: StateBackendMod
   @Before
   override def before(): Unit = {
     super.before()
-    // TODO: remove this until [FLINK-12351] is fixed.
-    //  currently AsyncWaitOperator doesn't copy input element which is a bug
-    env.getConfig.disableObjectReuse()
+    if (objectReuse) {
+      env.getConfig.enableObjectReuse()
+    } else {
+      env.getConfig.disableObjectReuse()
+    }
 
     createScanTable("src", data)
     createLookupTable("user_table", userData)
@@ -298,13 +301,13 @@ class AsyncLookupJoinITCase(legacyTableSource: Boolean, backend: StateBackendMod
 }
 
 object AsyncLookupJoinITCase {
-  @Parameterized.Parameters(name = "LegacyTableSource={0}, StateBackend={1}")
+  @Parameterized.Parameters(name = "LegacyTableSource={0}, StateBackend={1}, ObjectReuse={2}")
   def parameters(): JCollection[Array[Object]] = {
     Seq[Array[AnyRef]](
-      Array(JBoolean.TRUE, HEAP_BACKEND),
-      Array(JBoolean.TRUE, ROCKSDB_BACKEND),
-      Array(JBoolean.FALSE, HEAP_BACKEND),
-      Array(JBoolean.FALSE, ROCKSDB_BACKEND)
+      Array(JBoolean.TRUE, HEAP_BACKEND, JBoolean.TRUE),
+      Array(JBoolean.TRUE, ROCKSDB_BACKEND, JBoolean.FALSE),
+      Array(JBoolean.FALSE, HEAP_BACKEND, JBoolean.FALSE),
+      Array(JBoolean.FALSE, ROCKSDB_BACKEND, JBoolean.TRUE)
     )
   }
 }


### PR DESCRIPTION
## What is the purpose of the change
FLINK-12351 already fix the copy issue in AsyncWaitOperator, so we should cover testing for both object reuse enabled and disabled for AsyncLookupJoinITCase.

## Brief change log
Add objectReuse parameter for AsyncLookupJoinITCase.

## Verifying this change
This change is already covered by existing test: AsyncLookupJoinITCase.

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)


## Documentation
  - Does this pull request introduce a new feature? (no)