### PR TITLE
[FLINK-27391][hive] Hive dialect supports create/alter/write/read Hive's bucketed table

### DIFF
--- a/docs/content.zh/docs/connectors/table/hive/hive_read_write.md
+++ b/docs/content.zh/docs/connectors/table/hive/hive_read_write.md
@@ -170,10 +170,18 @@ following parameters in `TableConfig` (note that these parameters affect all sou
 
 Multi-thread is used to split hive's partitions. You can use `table.exec.hive.load-partition-splits.thread-num` to configure the thread number. The default value is 3 and the configured value should be bigger than 0.
 
+### Write Hive's bucketed table
+
+For writing Hive's bucketed table, the data will be clustered and sorted just like what Hive does.
+
+**NOTE:** This feature is only supported in Hive dialect and Flink `batch` mode, and you have to load [HiveModule]({{< ref "docs/dev/table/modules" >}}#hivemodule) firstly.
+
 ### Read bucketed table
 
 By default, for Hive bucketed table, all the data files belonged to same bucket will be read by same reader. The default behavior will limit source parallelism when reading Hive bucketed table for the maximum parallelism is up to the number of buckets .
 You can use to disable the default behavior by setting `table.exec.hive.bucketing.enabled` to `false`, which means the data files can be read by any reader.
+
+**Note**: Such bucketed read behavior only works in batch mode. In stream mode, the bucketed table will always be considered as normal table.
 
 ## Temporal Table Join
 

--- a/docs/content.zh/docs/connectors/table/hive/hive_read_write.md
+++ b/docs/content.zh/docs/connectors/table/hive/hive_read_write.md
@@ -170,6 +170,11 @@ following parameters in `TableConfig` (note that these parameters affect all sou
 
 Multi-thread is used to split hive's partitions. You can use `table.exec.hive.load-partition-splits.thread-num` to configure the thread number. The default value is 3 and the configured value should be bigger than 0.
 
+### Read bucketed table
+
+By default, for Hive bucketed table, all the data files belonged to same bucket will be read by same reader. The default behavior will limit source parallelism when reading Hive bucketed table for the maximum parallelism is up to the number of buckets .
+You can use to disable the default behavior by setting `table.exec.hive.bucketing.enabled` to `false`, which means the data files can be read by any reader.
+
 ## Temporal Table Join
 
 You can use a Hive table as a temporal table, and then a stream can correlate the Hive table by temporal join. 

--- a/docs/content/docs/connectors/table/hive/hive_read_write.md
+++ b/docs/content/docs/connectors/table/hive/hive_read_write.md
@@ -170,6 +170,11 @@ following parameters in `TableConfig` (note that these parameters affect all sou
 
 Multi-thread is used to split hive's partitions. You can use `table.exec.hive.load-partition-splits.thread-num` to configure the thread number. The default value is 3 and the configured value should be bigger than 0.
 
+### Read bucketed table
+
+By default, for Hive bucketed table, all the data files belonged to same bucket will be read by same reader. The default behavior will limit source parallelism when reading Hive bucketed table for the maximum parallelism is up to the number of buckets . 
+You can use to disable the default behavior by setting `table.exec.hive.bucketing.enabled` to `false`, which means the data files can be read by any reader.
+
 ## Temporal Table Join
 
 You can use a Hive table as a temporal table, and then a stream can correlate the Hive table by temporal join. 

--- a/docs/content/docs/connectors/table/hive/hive_read_write.md
+++ b/docs/content/docs/connectors/table/hive/hive_read_write.md
@@ -170,10 +170,18 @@ following parameters in `TableConfig` (note that these parameters affect all sou
 
 Multi-thread is used to split hive's partitions. You can use `table.exec.hive.load-partition-splits.thread-num` to configure the thread number. The default value is 3 and the configured value should be bigger than 0.
 
-### Read bucketed table
+### Write Hive's bucketed table
+
+For writing Hive's bucketed table, the data will be clustered and sorted just like what Hive does.
+
+**NOTE:** This feature is only supported in Hive dialect and Flink `batch` mode, and you have to load [HiveModule]({{< ref "docs/dev/table/modules" >}}#hivemodule) firstly.
+
+### Read Hive's bucketed table
 
 By default, for Hive bucketed table, all the data files belonged to same bucket will be read by same reader. The default behavior will limit source parallelism when reading Hive bucketed table for the maximum parallelism is up to the number of buckets . 
 You can use to disable the default behavior by setting `table.exec.hive.bucketing.enabled` to `false`, which means the data files can be read by any reader.
+
+**Note**: Such bucketed read behavior only works in batch mode. In stream mode, the bucketed table will always be considered as normal table.
 
 ## Temporal Table Join
 

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/assigners/FileSplitAssigner.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/assigners/FileSplitAssigner.java
@@ -40,7 +40,7 @@ public interface FileSplitAssigner {
      * <p>When this method returns an empty {@code Optional}, then the set of splits is assumed to
      * be done and the source will finish once the readers finished their current splits.
      */
-    Optional<FileSourceSplit> getNext(@Nullable String hostname);
+    Optional<FileSourceSplit> getNext(int subTask, @Nullable String hostname);
 
     /**
      * Adds a set of splits to this assigner. This happens for example when some split processing

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/assigners/FileSplitAssigner.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/assigners/FileSplitAssigner.java
@@ -39,8 +39,11 @@ public interface FileSplitAssigner {
      *
      * <p>When this method returns an empty {@code Optional}, then the set of splits is assumed to
      * be done and the source will finish once the readers finished their current splits.
+     *
+     * @param subTaskId the subtask id of the source reader node.
+     * @param hostname the host name of the source reader node.
      */
-    Optional<FileSourceSplit> getNext(int subTask, @Nullable String hostname);
+    Optional<FileSourceSplit> getNext(int subTaskId, @Nullable String hostname);
 
     /**
      * Adds a set of splits to this assigner. This happens for example when some split processing

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/assigners/LocalityAwareSplitAssigner.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/assigners/LocalityAwareSplitAssigner.java
@@ -84,7 +84,7 @@ public class LocalityAwareSplitAssigner implements FileSplitAssigner {
     // --------------------------------------------------------------------------------------------
 
     @Override
-    public Optional<FileSourceSplit> getNext(int subTask, @Nullable String host) {
+    public Optional<FileSourceSplit> getNext(int subTaskId, @Nullable String host) {
         // for a null host, we always return a remote split
         if (StringUtils.isNullOrWhitespaceOnly(host)) {
             final Optional<FileSourceSplit> split = getRemoteSplit();

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/assigners/LocalityAwareSplitAssigner.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/assigners/LocalityAwareSplitAssigner.java
@@ -84,7 +84,7 @@ public class LocalityAwareSplitAssigner implements FileSplitAssigner {
     // --------------------------------------------------------------------------------------------
 
     @Override
-    public Optional<FileSourceSplit> getNext(@Nullable String host) {
+    public Optional<FileSourceSplit> getNext(int subTask, @Nullable String host) {
         // for a null host, we always return a remote split
         if (StringUtils.isNullOrWhitespaceOnly(host)) {
             final Optional<FileSourceSplit> split = getRemoteSplit();

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/assigners/SimpleSplitAssigner.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/assigners/SimpleSplitAssigner.java
@@ -41,7 +41,7 @@ public class SimpleSplitAssigner implements FileSplitAssigner {
     // ------------------------------------------------------------------------
 
     @Override
-    public Optional<FileSourceSplit> getNext(int subTask, String hostname) {
+    public Optional<FileSourceSplit> getNext(int subTaskId, String hostname) {
         final int size = splits.size();
         return size == 0 ? Optional.empty() : Optional.of(splits.remove(size - 1));
     }

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/assigners/SimpleSplitAssigner.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/assigners/SimpleSplitAssigner.java
@@ -41,7 +41,7 @@ public class SimpleSplitAssigner implements FileSplitAssigner {
     // ------------------------------------------------------------------------
 
     @Override
-    public Optional<FileSourceSplit> getNext(String hostname) {
+    public Optional<FileSourceSplit> getNext(int subTask, String hostname) {
         final int size = splits.size();
         return size == 0 ? Optional.empty() : Optional.of(splits.remove(size - 1));
     }

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/impl/ContinuousFileSplitEnumerator.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/impl/ContinuousFileSplitEnumerator.java
@@ -167,7 +167,8 @@ public class ContinuousFileSplitEnumerator
 
             final String hostname = nextAwaiting.getValue();
             final int awaitingSubtask = nextAwaiting.getKey();
-            final Optional<FileSourceSplit> nextSplit = splitAssigner.getNext(hostname);
+            final Optional<FileSourceSplit> nextSplit =
+                    splitAssigner.getNext(awaitingSubtask, hostname);
             if (nextSplit.isPresent()) {
                 context.assignSplit(nextSplit.get(), awaitingSubtask);
                 awaitingReader.remove();

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/impl/StaticFileSplitEnumerator.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/impl/StaticFileSplitEnumerator.java
@@ -95,7 +95,7 @@ public class StaticFileSplitEnumerator
             LOG.info("Subtask {} {} is requesting a file source split", subtask, hostInfo);
         }
 
-        final Optional<FileSourceSplit> nextSplit = splitAssigner.getNext(hostname);
+        final Optional<FileSourceSplit> nextSplit = splitAssigner.getNext(subtask, hostname);
         if (nextSplit.isPresent()) {
             final FileSourceSplit split = nextSplit.get();
             context.assignSplit(split, subtask);

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/BaseBucketFileWriter.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/BaseBucketFileWriter.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.file.table;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.io.OutputFormat;
+import org.apache.flink.core.fs.Path;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+
+/**
+ * A base class for writing bucket. A bucket is exactly files with same bucket id (the bucket id
+ * will be a prefix of the file name) written by the {@link FileSystemOutputFormat}. The class
+ * provide the ability to renew output format directly or when bucket id assigned to consumed record
+ * changes.
+ */
+@Internal
+public class BaseBucketFileWriter<T> {
+    protected final PartitionWriter.Context<T> context;
+    protected final PartitionTempFileManager manager;
+    protected final BucketIdComputer<T> bucketIdComputer;
+    protected OutputFormat<T> currentOutputFormat;
+    protected int currentBucketId = -1;
+
+    public BaseBucketFileWriter(
+            PartitionWriter.Context<T> context,
+            PartitionTempFileManager manager,
+            BucketIdComputer<T> bucketIdComputer) {
+        this.context = context;
+        this.manager = manager;
+        this.bucketIdComputer = bucketIdComputer;
+    }
+
+    /** Always renew a current writer. */
+    protected void forceRenewCurrentOutputFormat(T in, @Nullable String partition)
+            throws IOException {
+        renewCurrentOutputFormat(bucketIdComputer.getBucketId(in), partition);
+    }
+
+    /** Only renew the current writer when the record's bucket id changes. */
+    protected void mayRenewCurrentOutputFormat(T in, @Nullable String partition)
+            throws IOException {
+        int nextBucketId = bucketIdComputer.getBucketId(in);
+        if (currentBucketId != nextBucketId) {
+            renewCurrentOutputFormat(nextBucketId, partition);
+        }
+    }
+
+    /** Renew the current writer with the specific bucket id. */
+    private void renewCurrentOutputFormat(int nextBucketId, @Nullable String partition)
+            throws IOException {
+        if (currentOutputFormat != null) {
+            currentOutputFormat.close();
+        }
+        currentOutputFormat = createNewOutputFormat(nextBucketId, partition);
+        // renew current bucket id
+        currentBucketId = nextBucketId;
+    }
+
+    protected OutputFormat<T> createNewOutputFormat(int bucketId, @Nullable String partition)
+            throws IOException {
+        String bucketFilePrefix = bucketIdComputer.getBucketFilePrefix(bucketId);
+        Path partitionPath =
+                partition == null
+                        ? manager.createPartitionFile(bucketFilePrefix)
+                        : manager.createPartitionFile(partition, bucketFilePrefix);
+        return context.createNewOutputFormat(partitionPath);
+    }
+
+    public void close() throws Exception {
+        if (currentOutputFormat != null) {
+            currentOutputFormat.close();
+            currentOutputFormat = null;
+        }
+    }
+}

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/BucketIdComputer.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/BucketIdComputer.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.file.table;
+
+import org.apache.flink.annotation.Internal;
+
+import java.io.Serializable;
+
+/** A computer to compute a bucket id for the record as well as the bucket file's prefix. */
+@Internal
+public interface BucketIdComputer<T> extends Serializable {
+
+    int getBucketId(T in);
+
+    String getBucketFilePrefix(int bucketId);
+
+    int DEFAULT_BUCKET_ID = 0;
+
+    /**
+     * A default implementation for {@link BucketIdComputer}. All the records will be assigned the
+     * same bucket, and prefix of the bucket file is an empty string.
+     */
+    class DefaultBucketIdComputer<T> implements BucketIdComputer<T> {
+
+        @Override
+        public int getBucketId(T in) {
+            return DEFAULT_BUCKET_ID;
+        }
+
+        @Override
+        public String getBucketFilePrefix(int bucketId) {
+            return "";
+        }
+    }
+}

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/GroupedPartitionWriter.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/GroupedPartitionWriter.java
@@ -29,7 +29,8 @@ import static org.apache.flink.table.utils.PartitionPathUtils.generatePartitionP
  * @param <T> The type of the consumed records.
  */
 @Internal
-public class GroupedPartitionWriter<T> extends BaseBucketFileWriter<T> implements PartitionWriter<T> {
+public class GroupedPartitionWriter<T> extends BaseBucketFileWriter<T>
+        implements PartitionWriter<T> {
 
     private final PartitionComputer<T> partitionComputer;
     private String currentPartition;

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/PartitionTempFileManager.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/PartitionTempFileManager.java
@@ -71,18 +71,18 @@ public class PartitionTempFileManager {
         factory.create(taskTmpDir.toUri()).delete(taskTmpDir, true);
     }
 
-    /** Generate a new partition directory with partitions. */
-    public Path createPartitionDir(String... partitions) {
-        Path parentPath = taskTmpDir;
-        for (String dir : partitions) {
-            parentPath = new Path(parentPath, dir);
-        }
-        return new Path(parentPath, newFileName());
+    public Path createPartitionFile(String partition, String filePrefix) {
+        return new Path(new Path(taskTmpDir, partition), newFileName(filePrefix));
     }
 
-    private String newFileName() {
+    public Path createPartitionFile(String filePrefix) {
+        return new Path(taskTmpDir, newFileName(filePrefix));
+    }
+
+    private String newFileName(String filePrefix) {
         return String.format(
-                "%s-%s-file-%d%s",
+                "%s%s-%s-file-%d%s",
+                filePrefix,
                 outputFileConfig.getPartPrefix(),
                 taskName(taskNumber),
                 nameCounter++,

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/PartitionWriterFactory.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/PartitionWriterFactory.java
@@ -29,7 +29,10 @@ import java.util.LinkedHashMap;
 public interface PartitionWriterFactory<T> extends Serializable {
 
     PartitionWriter<T> create(
-            Context<T> context, PartitionTempFileManager manager, PartitionComputer<T> computer)
+            Context<T> context,
+            PartitionTempFileManager manager,
+            PartitionComputer<T> partitionComputer,
+            BucketIdComputer<T> bucketIdComputer)
             throws Exception;
 
     /** Util for get a {@link PartitionWriterFactory}. */
@@ -41,9 +44,13 @@ public interface PartitionWriterFactory<T> extends Serializable {
             return grouped ? GroupedPartitionWriter::new : DynamicPartitionWriter::new;
         } else {
             return (PartitionWriterFactory<T>)
-                    (context, manager, computer) ->
+                    (context, manager, partitionComputer, bucketIdComputer) ->
                             new SingleDirectoryWriter<>(
-                                    context, manager, computer, staticPartitions);
+                                    context,
+                                    manager,
+                                    partitionComputer,
+                                    bucketIdComputer,
+                                    staticPartitions);
         }
     }
 }

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/SingleDirectoryWriter.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/SingleDirectoryWriter.java
@@ -19,61 +19,46 @@
 package org.apache.flink.connector.file.table;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.api.common.io.OutputFormat;
 
-import java.io.IOException;
+import javax.annotation.Nullable;
+
 import java.util.LinkedHashMap;
 
 import static org.apache.flink.table.utils.PartitionPathUtils.generatePartitionPath;
 
 /**
- * {@link PartitionWriter} for single directory writer. It just use one format to write.
+ * {@link PartitionWriter} for single directory writer. It'll create a new format when the bucket id
+ * assigned to the consumed record changed.
  *
  * @param <T> The type of the consumed records.
  */
 @Internal
-public class SingleDirectoryWriter<T> implements PartitionWriter<T> {
+public class SingleDirectoryWriter<T> extends BaseBucketFileWriter<T>
+        implements PartitionWriter<T> {
 
-    private final Context<T> context;
-    private final PartitionTempFileManager manager;
-    private final PartitionComputer<T> computer;
-    private final LinkedHashMap<String, String> staticPartitions;
-
-    private OutputFormat<T> format;
+    private final PartitionComputer<T> partitionComputer;
+    @Nullable private final String partitionPath;
 
     public SingleDirectoryWriter(
             Context<T> context,
             PartitionTempFileManager manager,
-            PartitionComputer<T> computer,
+            PartitionComputer<T> partitionComputer,
+            BucketIdComputer<T> bucketIdComputer,
             LinkedHashMap<String, String> staticPartitions) {
-        this.context = context;
-        this.manager = manager;
-        this.computer = computer;
-        this.staticPartitions = staticPartitions;
-    }
-
-    private void createFormat() throws IOException {
-        this.format =
-                context.createNewOutputFormat(
-                        staticPartitions.size() == 0
-                                ? manager.createPartitionDir()
-                                : manager.createPartitionDir(
-                                        generatePartitionPath(staticPartitions)));
+        super(context, manager, bucketIdComputer);
+        this.partitionComputer = partitionComputer;
+        this.partitionPath =
+                staticPartitions.size() == 0 ? null : generatePartitionPath(staticPartitions);
     }
 
     @Override
     public void write(T in) throws Exception {
-        if (format == null) {
-            createFormat();
-        }
-        format.writeRecord(computer.projectColumnsToWrite(in));
+        mayRenewCurrentOutputFormat(in, partitionPath);
+        currentOutputFormat.writeRecord(partitionComputer.projectColumnsToWrite(in));
     }
 
     @Override
     public void close() throws Exception {
-        if (format != null) {
-            format.close();
-            format = null;
-        }
+        super.close();
     }
 }

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/assigners/LocalityAwareSplitAssignerTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/assigners/LocalityAwareSplitAssignerTest.java
@@ -37,6 +37,7 @@ class LocalityAwareSplitAssignerTest {
 
     private static final Path TEST_PATH =
             Path.fromLocalFile(new File(System.getProperty("java.io.tmpdir")));
+    private static final int TASK_Id = 0;
 
     // ------------------------------------------------------------------------
 
@@ -54,13 +55,13 @@ class LocalityAwareSplitAssignerTest {
         // get all available splits
         final LocalityAwareSplitAssigner ia = new LocalityAwareSplitAssigner(splits);
         Optional<FileSourceSplit> is;
-        while ((is = ia.getNext(null)).isPresent()) {
+        while ((is = ia.getNext(TASK_Id, null)).isPresent()) {
             assertThat(splits.remove(is.get())).isTrue();
         }
 
         // check we had all
         assertThat(splits).isEmpty();
-        assertThat(ia.getNext("")).isNotPresent();
+        assertThat(ia.getNext(TASK_Id, "")).isNotPresent();
         assertThat(ia.getNumberOfRemoteAssignments()).isEqualTo(numSplits);
         assertThat(ia.getNumberOfLocalAssignments()).isEqualTo(0);
     }
@@ -78,13 +79,13 @@ class LocalityAwareSplitAssignerTest {
         // get all available splits
         LocalityAwareSplitAssigner ia = new LocalityAwareSplitAssigner(splits);
         Optional<FileSourceSplit> is;
-        while ((is = ia.getNext("testhost")).isPresent()) {
+        while ((is = ia.getNext(TASK_Id, "testhost")).isPresent()) {
             assertThat(splits.remove(is.get())).isTrue();
         }
 
         // check we had all
         assertThat(splits).isEmpty();
-        assertThat(ia.getNext("")).isNotPresent();
+        assertThat(ia.getNext(TASK_Id, "")).isNotPresent();
 
         assertThat(ia.getNumberOfRemoteAssignments()).isEqualTo(0);
         assertThat(ia.getNumberOfLocalAssignments()).isEqualTo(numSplits);
@@ -104,13 +105,13 @@ class LocalityAwareSplitAssignerTest {
         // get all available splits
         final LocalityAwareSplitAssigner ia = new LocalityAwareSplitAssigner(splits);
         Optional<FileSourceSplit> is;
-        while ((is = ia.getNext("testhost")).isPresent()) {
+        while ((is = ia.getNext(TASK_Id, "testhost")).isPresent()) {
             assertThat(splits.remove(is.get())).isTrue();
         }
 
         // check we had all
         assertThat(splits).isEmpty();
-        assertThat(ia.getNext("anotherHost")).isNotPresent();
+        assertThat(ia.getNext(TASK_Id, "anotherHost")).isNotPresent();
 
         assertThat(ia.getNumberOfRemoteAssignments()).isEqualTo(numSplits);
         assertThat(ia.getNumberOfLocalAssignments()).isEqualTo(0);
@@ -147,13 +148,13 @@ class LocalityAwareSplitAssignerTest {
         final LocalityAwareSplitAssigner ia = new LocalityAwareSplitAssigner(splits);
         Optional<FileSourceSplit> is;
         int i = 0;
-        while ((is = ia.getNext(hosts[i++ % hosts.length])).isPresent()) {
+        while ((is = ia.getNext(TASK_Id, hosts[i++ % hosts.length])).isPresent()) {
             assertThat(splits.remove(is.get())).isTrue();
         }
 
         // check we had all
         assertThat(splits).isEmpty();
-        assertThat(ia.getNext("anotherHost")).isNotPresent();
+        assertThat(ia.getNext(TASK_Id, "anotherHost")).isNotPresent();
 
         assertThat(ia.getNumberOfRemoteAssignments()).isEqualTo(numRemoteSplits);
         assertThat(ia.getNumberOfLocalAssignments()).isEqualTo(numLocalSplits);
@@ -202,7 +203,7 @@ class LocalityAwareSplitAssignerTest {
         for (int i = 0; i < numSplits; i++) {
             final String host = requestingHosts[i % requestingHosts.length];
 
-            final Optional<FileSourceSplit> ois = ia.getNext(host);
+            final Optional<FileSourceSplit> ois = ia.getNext(TASK_Id, host);
             assertThat(ois).isPresent();
 
             final FileSourceSplit is = ois.get();
@@ -220,7 +221,7 @@ class LocalityAwareSplitAssignerTest {
         }
         // check we had all
         assertThat(splits).isEmpty();
-        assertThat(ia.getNext("anotherHost")).isNotPresent();
+        assertThat(ia.getNext(TASK_Id, "anotherHost")).isNotPresent();
 
         assertThat(ia.getNumberOfRemoteAssignments()).isEqualTo(numRemoteSplits);
         assertThat(ia.getNumberOfLocalAssignments()).isEqualTo(numLocalSplits);
@@ -241,13 +242,13 @@ class LocalityAwareSplitAssignerTest {
         LocalityAwareSplitAssigner ia = new LocalityAwareSplitAssigner(splits);
         Optional<FileSourceSplit> is;
         int i = 0;
-        while ((is = ia.getNext(hosts[i++ % hosts.length])).isPresent()) {
+        while ((is = ia.getNext(TASK_Id, hosts[i++ % hosts.length])).isPresent()) {
             assertThat(splits.remove(is.get())).isTrue();
         }
 
         // check we had all
         assertThat(splits).isEmpty();
-        assertThat(ia.getNext("anotherHost")).isNotPresent();
+        assertThat(ia.getNext(TASK_Id, "anotherHost")).isNotPresent();
 
         assertThat(ia.getNumberOfRemoteAssignments()).isEqualTo(0);
         assertThat(ia.getNumberOfLocalAssignments()).isEqualTo(numSplits);
@@ -288,13 +289,13 @@ class LocalityAwareSplitAssignerTest {
 
         for (int i = 0; i < numSplits; i++) {
             final Optional<FileSourceSplit> split =
-                    ia.getNext(requestingHosts[rand.nextInt(requestingHosts.length)]);
+                    ia.getNext(TASK_Id, requestingHosts[rand.nextInt(requestingHosts.length)]);
             assertThat(split).isPresent();
             assertThat(splits.remove(split.get())).isTrue();
         }
 
         assertThat(splits).isEmpty();
-        assertThat(ia.getNext("testHost")).isNotPresent();
+        assertThat(ia.getNext(TASK_Id, "testHost")).isNotPresent();
     }
 
     // ------------------------------------------------------------------------

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/PartitionWriterTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/PartitionWriterTest.java
@@ -120,7 +120,8 @@ class PartitionWriterTest {
     @Test
     void testEmptySingleDirectoryWriter() throws Exception {
         SingleDirectoryWriter<Row> writer =
-                new SingleDirectoryWriter<>(context, manager, computer, bucketIdComputer, new LinkedHashMap<>());
+                new SingleDirectoryWriter<>(
+                        context, manager, computer, bucketIdComputer, new LinkedHashMap<>());
         writer.close();
         assertThat(records).isEmpty();
     }
@@ -128,7 +129,8 @@ class PartitionWriterTest {
     @Test
     void testSingleDirectoryWriter() throws Exception {
         SingleDirectoryWriter<Row> writer =
-                new SingleDirectoryWriter<>(context, manager, computer, bucketIdComputer, new LinkedHashMap<>());
+                new SingleDirectoryWriter<>(
+                        context, manager, computer, bucketIdComputer, new LinkedHashMap<>());
 
         writer.write(Row.of("p1", 1));
         writer.write(Row.of("p1", 2));
@@ -137,7 +139,9 @@ class PartitionWriterTest {
         assertThat(records.toString()).isEqualTo("{task-0=[p1,1, p1,2, p2,2]}");
 
         manager = new PartitionTempFileManager(fsFactory, new Path(tmpDir.toUri()), 1);
-        writer = new SingleDirectoryWriter<>(context, manager, computer, bucketIdComputer, new LinkedHashMap<>());
+        writer =
+                new SingleDirectoryWriter<>(
+                        context, manager, computer, bucketIdComputer, new LinkedHashMap<>());
         writer.write(Row.of("p3", 3));
         writer.write(Row.of("p5", 5));
         writer.write(Row.of("p2", 2));

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/PartitionWriterTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/PartitionWriterTest.java
@@ -60,6 +60,8 @@ class PartitionWriterTest {
     }
 
     private final Map<String, List<Row>> records = new LinkedHashMap<>();
+    private final BucketIdComputer<Row> bucketIdComputer =
+            new BucketIdComputer.DefaultBucketIdComputer<>();
 
     private final OutputFormatFactory<Row> factory =
             path ->
@@ -118,7 +120,7 @@ class PartitionWriterTest {
     @Test
     void testEmptySingleDirectoryWriter() throws Exception {
         SingleDirectoryWriter<Row> writer =
-                new SingleDirectoryWriter<>(context, manager, computer, new LinkedHashMap<>());
+                new SingleDirectoryWriter<>(context, manager, computer, bucketIdComputer, new LinkedHashMap<>());
         writer.close();
         assertThat(records).isEmpty();
     }
@@ -126,7 +128,7 @@ class PartitionWriterTest {
     @Test
     void testSingleDirectoryWriter() throws Exception {
         SingleDirectoryWriter<Row> writer =
-                new SingleDirectoryWriter<>(context, manager, computer, new LinkedHashMap<>());
+                new SingleDirectoryWriter<>(context, manager, computer, bucketIdComputer, new LinkedHashMap<>());
 
         writer.write(Row.of("p1", 1));
         writer.write(Row.of("p1", 2));
@@ -135,7 +137,7 @@ class PartitionWriterTest {
         assertThat(records.toString()).isEqualTo("{task-0=[p1,1, p1,2, p2,2]}");
 
         manager = new PartitionTempFileManager(fsFactory, new Path(tmpDir.toUri()), 1);
-        writer = new SingleDirectoryWriter<>(context, manager, computer, new LinkedHashMap<>());
+        writer = new SingleDirectoryWriter<>(context, manager, computer, bucketIdComputer, new LinkedHashMap<>());
         writer.write(Row.of("p3", 3));
         writer.write(Row.of("p5", 5));
         writer.write(Row.of("p2", 2));
@@ -147,7 +149,7 @@ class PartitionWriterTest {
     @Test
     void testGroupedPartitionWriter() throws Exception {
         GroupedPartitionWriter<Row> writer =
-                new GroupedPartitionWriter<>(context, manager, computer);
+                new GroupedPartitionWriter<>(context, manager, computer, bucketIdComputer);
 
         writer.write(Row.of("p1", 1));
         writer.write(Row.of("p1", 2));
@@ -156,7 +158,7 @@ class PartitionWriterTest {
         assertThat(records.toString()).isEqualTo("{task-0/p=p1=[p1,1, p1,2], task-0/p=p2=[p2,2]}");
 
         manager = new PartitionTempFileManager(fsFactory, new Path(tmpDir.toUri()), 1);
-        writer = new GroupedPartitionWriter<>(context, manager, computer);
+        writer = new GroupedPartitionWriter<>(context, manager, computer, bucketIdComputer);
         writer.write(Row.of("p3", 3));
         writer.write(Row.of("p4", 5));
         writer.write(Row.of("p5", 2));
@@ -169,7 +171,7 @@ class PartitionWriterTest {
     @Test
     void testDynamicPartitionWriter() throws Exception {
         DynamicPartitionWriter<Row> writer =
-                new DynamicPartitionWriter<>(context, manager, computer);
+                new DynamicPartitionWriter<>(context, manager, computer, bucketIdComputer);
 
         writer.write(Row.of("p1", 1));
         writer.write(Row.of("p2", 2));
@@ -178,7 +180,7 @@ class PartitionWriterTest {
         assertThat(records.toString()).isEqualTo("{task-0/p=p1=[p1,1, p1,2], task-0/p=p2=[p2,2]}");
 
         manager = new PartitionTempFileManager(fsFactory, new Path(tmpDir.toUri()), 1);
-        writer = new DynamicPartitionWriter<>(context, manager, computer);
+        writer = new DynamicPartitionWriter<>(context, manager, computer, bucketIdComputer);
         writer.write(Row.of("p4", 5));
         writer.write(Row.of("p3", 3));
         writer.write(Row.of("p5", 2));

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/ContinuousHiveSplitEnumerator.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/ContinuousHiveSplitEnumerator.java
@@ -169,7 +169,8 @@ public class ContinuousHiveSplitEnumerator<T extends Comparable<T>>
             final Map.Entry<Integer, String> nextAwaiting = awaitingReader.next();
             final String hostname = nextAwaiting.getValue();
             final int awaitingSubtask = nextAwaiting.getKey();
-            final Optional<FileSourceSplit> nextSplit = splitAssigner.getNext(hostname);
+            final Optional<FileSourceSplit> nextSplit =
+                    splitAssigner.getNext(awaitingSubtask, hostname);
             if (nextSplit.isPresent()) {
                 enumeratorContext.assignSplit((HiveSourceSplit) nextSplit.get(), awaitingSubtask);
                 awaitingReader.remove();

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveOptions.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveOptions.java
@@ -68,6 +68,14 @@ public class HiveOptions {
                     .withDescription(
                             "The thread number to split hive's partitions to splits. It should be bigger than 0.");
 
+    public static final ConfigOption<Boolean> TABLE_EXEC_HIVE_BUCKETING_ENABLE =
+            key("table.exec.hive.bucketing.enabled")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            "If it's true, for Hive bucketed table, all data files belonged to same bucket will be read by same reader."
+                                    + " Otherwise, these files can be read by different reader");
+
     public static final ConfigOption<Boolean> STREAMING_SOURCE_ENABLE =
             key("streaming-source.enable")
                     .booleanType()

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveParallelismInference.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveParallelismInference.java
@@ -36,13 +36,15 @@ class HiveParallelismInference {
 
     private final ObjectPath tablePath;
     private final boolean infer;
+    private final int bucketNum;
     private final int inferMaxParallelism;
 
     private int parallelism;
 
-    HiveParallelismInference(ObjectPath tablePath, ReadableConfig flinkConf) {
+    HiveParallelismInference(ObjectPath tablePath, ReadableConfig flinkConf, int bucketNum) {
         this.tablePath = tablePath;
         this.infer = flinkConf.get(HiveOptions.TABLE_EXEC_HIVE_INFER_SOURCE_PARALLELISM);
+        this.bucketNum = bucketNum;
         this.inferMaxParallelism =
                 flinkConf.get(HiveOptions.TABLE_EXEC_HIVE_INFER_SOURCE_PARALLELISM_MAX);
         Preconditions.checkArgument(
@@ -79,6 +81,12 @@ class HiveParallelismInference {
             SupplierWithException<Integer, IOException> numFiles,
             SupplierWithException<Integer, IOException> numSplits) {
         if (!infer) {
+            return this;
+        }
+
+        // bucket number as the inferred parallelism
+        if (bucketNum > 0) {
+            parallelism = Math.min(bucketNum, inferMaxParallelism);
             return this;
         }
 

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveRowDataBucketIdComputer.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveRowDataBucketIdComputer.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connectors.hive;
+
+import org.apache.flink.connector.file.table.BucketIdComputer;
+import org.apache.flink.table.catalog.hive.client.HiveShim;
+import org.apache.flink.table.functions.hive.conversion.HiveInspectors;
+import org.apache.flink.table.functions.hive.conversion.HiveObjectConversion;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.types.Row;
+
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorUtils;
+
+import java.util.Arrays;
+import java.util.List;
+
+/** Hive's implementation for {@link BucketIdComputer}. */
+public class HiveRowDataBucketIdComputer implements BucketIdComputer<Row> {
+
+    private static final long serialVersionUID = 1L;
+
+    private final int numberOfBuckets;
+    private final DataType[] columnTypes;
+    private final int[] bucketedColIndexes;
+    private final HiveObjectConversion[] bucketColHiveObjectConversions;
+
+    private transient ObjectInspector[] bucketColObjectInspectors;
+
+    public HiveRowDataBucketIdComputer(
+            int numberOfBuckets,
+            HiveShim hiveShim,
+            String[] columnNames,
+            DataType[] columnTypes,
+            String[] bucketColumns) {
+        this.numberOfBuckets = numberOfBuckets;
+        this.columnTypes = columnTypes;
+        List<String> columnList = Arrays.asList(columnNames);
+        this.bucketedColIndexes =
+                Arrays.stream(bucketColumns).mapToInt(columnList::indexOf).toArray();
+        this.bucketColHiveObjectConversions = new HiveObjectConversion[bucketColumns.length];
+        for (int i = 0; i < bucketedColIndexes.length; i++) {
+            DataType bucketColType = columnTypes[bucketedColIndexes[i]];
+            bucketColHiveObjectConversions[i] =
+                    HiveInspectors.getConversion(
+                            HiveInspectors.getObjectInspector(bucketColType),
+                            bucketColType.getLogicalType(),
+                            hiveShim);
+        }
+    }
+
+    private void initBucketColObjectInspector() {
+        bucketColObjectInspectors = new ObjectInspector[bucketedColIndexes.length];
+        for (int i = 0; i < bucketedColIndexes.length; i++) {
+            DataType bucketColType = columnTypes[bucketedColIndexes[i]];
+            ObjectInspector objectInspector = HiveInspectors.getObjectInspector(bucketColType);
+            bucketColObjectInspectors[i] = objectInspector;
+        }
+    }
+
+    @Override
+    public int getBucketId(Row in) {
+        // follow Hive's behavior to calculate bucket id
+        if (bucketColObjectInspectors == null) {
+            initBucketColObjectInspector();
+        }
+        Object[] bucketFields = new Object[bucketColObjectInspectors.length];
+        for (int i = 0; i < bucketedColIndexes.length; i++) {
+            Object field = in.getField(bucketedColIndexes[i]);
+            bucketFields[i] = bucketColHiveObjectConversions[i].toHiveObject(field);
+        }
+        int hashCode =
+                ObjectInspectorUtils.getBucketHashCode(bucketFields, bucketColObjectInspectors);
+
+        return ObjectInspectorUtils.getBucketNumber(hashCode, numberOfBuckets);
+    }
+
+    @Override
+    public String getBucketFilePrefix(int bucketId) {
+        // The bucket file name prefix is following Hive conversion, Presto and Trino conversion to
+        // make sure the bucket files written by Flink can be read by other engines.
+        // Hive: `org.apache.hadoop.hive.ql.exec.Utilities#getBucketIdFromFile()`.
+        // Trino: `io.trino.plugin.hive.BackgroundHiveSplitLoader#BUCKET_PATTERNS`.
+        return String.format("%05d_0_", bucketId);
+    }
+}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveBucketFileSplitAssigner.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveBucketFileSplitAssigner.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connectors.hive.read;
+
+import org.apache.flink.connector.file.src.FileSourceSplit;
+import org.apache.flink.connector.file.src.assigners.FileSplitAssigner;
+
+import org.apache.hadoop.hive.ql.exec.Utilities;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * A split assigner for Hive's bucket files. All the files belonged to same bucket will be assigned
+ * to same reader.
+ *
+ * <p>NOTE: currently, the assigner can't guarantee such assignment in stream mode for the assigner
+ * can't restore the previous assignment of bucket files after fail over.
+ */
+public class HiveBucketFileSplitAssigner implements FileSplitAssigner {
+
+    // mapping from bucket id to splits
+    private final Map<Integer, List<FileSourceSplit>> remainingBucketSplits = new HashMap<>();
+    // mapping from reader to bucket id
+    private final Map<Integer, Integer> assignments = new HashMap<>();
+
+    public HiveBucketFileSplitAssigner(Collection<FileSourceSplit> splits) {
+        addSplits(splits);
+    }
+
+    @Override
+    public Optional<FileSourceSplit> getNext(int subTask, @Nullable String hostname) {
+        // we have assigned one split of a bucket to the reader, still assign the splits with same
+        // bucket id to it
+        if (assignments.get(subTask) != null) {
+            List<FileSourceSplit> splits = remainingBucketSplits.get(assignments.get(subTask));
+            // there isn't any split for the bucket, try to assign it a new bucket
+            if (splits.isEmpty()) {
+                return assignNewBucketSplit(subTask);
+            }
+            // return a split belonged to the bucket
+            return Optional.of(splits.remove(splits.size() - 1));
+        } else {
+            return assignNewBucketSplit(subTask);
+        }
+    }
+
+    private Optional<FileSourceSplit> assignNewBucketSplit(int subTask) {
+        // find any one bucket that there isn't any reader is reading it, and then assign it a split
+        // belonged to the bucket
+        for (Map.Entry<Integer, List<FileSourceSplit>> bucketSplitEntry :
+                remainingBucketSplits.entrySet()) {
+            int bucketId = bucketSplitEntry.getKey();
+            // there isn't any reader is reading the bucket
+            if (!assignments.containsValue(bucketId)) {
+                List<FileSourceSplit> splits = bucketSplitEntry.getValue();
+                // if there remains splits for the bucket, assign the split to the reader,
+                // and update the assignment for the bucket
+                if (splits.size() > 0) {
+                    FileSourceSplit split = splits.remove(splits.size() - 1);
+                    assignments.put(subTask, bucketId);
+                    return Optional.of(split);
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public void addSplits(Collection<FileSourceSplit> splits) {
+        for (FileSourceSplit split : splits) {
+            Integer bucketId = Utilities.getBucketIdFromFile(split.path().getName());
+            remainingBucketSplits.putIfAbsent(bucketId, new ArrayList<>());
+            remainingBucketSplits.get(bucketId).add(split);
+        }
+    }
+
+    @Override
+    public Collection<FileSourceSplit> remainingSplits() {
+        Set<FileSourceSplit> remainingSplits = new HashSet<>();
+        remainingBucketSplits.forEach((bucketId, splits) -> remainingSplits.addAll(splits));
+        return remainingSplits;
+    }
+}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveBucketFileSplitAssigner.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveBucketFileSplitAssigner.java
@@ -53,19 +53,19 @@ public class HiveBucketFileSplitAssigner implements FileSplitAssigner {
     }
 
     @Override
-    public Optional<FileSourceSplit> getNext(int subTask, @Nullable String hostname) {
+    public Optional<FileSourceSplit> getNext(int subTaskId, @Nullable String hostname) {
         // we have assigned one split of a bucket to the reader, still assign the splits with same
         // bucket id to it
-        if (assignments.get(subTask) != null) {
-            List<FileSourceSplit> splits = remainingBucketSplits.get(assignments.get(subTask));
+        if (assignments.get(subTaskId) != null) {
+            List<FileSourceSplit> splits = remainingBucketSplits.get(assignments.get(subTaskId));
             // there isn't any split for the bucket, try to assign it a new bucket
             if (splits.isEmpty()) {
-                return assignNewBucketSplit(subTask);
+                return assignNewBucketSplit(subTaskId);
             }
             // return a split belonged to the bucket
             return Optional.of(splits.remove(splits.size() - 1));
         } else {
-            return assignNewBucketSplit(subTask);
+            return assignNewBucketSplit(subTaskId);
         }
     }
 

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
@@ -1753,6 +1753,9 @@ public class HiveCatalog extends AbstractCatalog {
                     }
                 }
                 break;
+            case ALTER_BUCKET:
+                HiveTableUtil.extractBucketSpec(sd, newProps);
+                break;
             default:
                 throw new CatalogException("Unsupported alter table operation " + alterOp);
         }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShim.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShim.java
@@ -241,4 +241,9 @@ public interface HiveShim extends Serializable {
     }
 
     void registerTemporaryFunction(String funcName, Class funcClass);
+
+    /** Get Hive's hash function to do bucketing. */
+    default String getHashFuncName() {
+        return "hash";
+    }
 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV310.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV310.java
@@ -319,6 +319,11 @@ public class HiveShimV310 extends HiveShimV239 {
         }
     }
 
+    @Override
+    public String getHashFuncName() {
+        return "murmur_hash";
+    }
+
     List<Object> createHiveNNs(
             Table table, Configuration conf, List<String> nnCols, List<Byte> traits)
             throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException,

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveBucketSpec.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveBucketSpec.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.delegation.hive;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.table.catalog.CatalogPropertiesUtil;
+
+import javax.annotation.Nullable;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/** A wrapper for Hive table bucketing information. */
+public class HiveBucketSpec {
+    private static final String BUCKET_NUM =
+            CatalogPropertiesUtil.FLINK_PROPERTY_PREFIX + "hive.bucket.bucket_num";
+    private static final String BUCKET_COL =
+            CatalogPropertiesUtil.FLINK_PROPERTY_PREFIX + "hive.bucket.bucket_col";
+    private static final String BUCKET_SORT_COL =
+            CatalogPropertiesUtil.FLINK_PROPERTY_PREFIX + "hive.bucket.sort_col";
+    private static final String BUCKET_SORT_ORDER =
+            CatalogPropertiesUtil.FLINK_PROPERTY_PREFIX + "hive.bucket.sort_order";
+    private static final String DELIMITER = ",";
+
+    @Nullable private final Integer bucketNum;
+    @Nullable private final List<String> bucketColumns;
+    @Nullable private final Tuple2<List<String>, List<Integer>> columnNamesOrder;
+
+    public HiveBucketSpec(
+            @Nullable Integer bucketNum,
+            @Nullable List<String> bucketColumns,
+            @Nullable Tuple2<List<String>, List<Integer>> sortColumnNameOrders) {
+        this.bucketNum = bucketNum;
+        this.bucketColumns = bucketColumns;
+        this.columnNamesOrder = sortColumnNameOrders;
+    }
+
+    public Optional<Integer> getBucketNum() {
+        return Optional.ofNullable(bucketNum);
+    }
+
+    public Optional<List<String>> getBucketColumns() {
+        return Optional.ofNullable(bucketColumns);
+    }
+
+    public Optional<Tuple2<List<String>, List<Integer>>> getColumnNamesOrder() {
+        return Optional.ofNullable(columnNamesOrder);
+    }
+
+    public void dumpToProps(Map<String, String> props) {
+        getBucketNum().ifPresent(n -> dumpBucketNumToProp(n, props));
+        getBucketColumns().ifPresent(bucketCols -> dumpBucketColumnsToProp(bucketCols, props));
+        getColumnNamesOrder().ifPresent(colOrder -> dumpSortColumnsToProp(colOrder, props));
+    }
+
+    public static void dumpBucketColumnsToProp(
+            List<String> bucketColumns, Map<String, String> props) {
+        props.put(BUCKET_COL, String.join(DELIMITER, bucketColumns));
+    }
+
+    public static void dumpBucketNumToProp(int bucketNum, Map<String, String> props) {
+        props.put(BUCKET_NUM, String.valueOf(bucketNum));
+    }
+
+    public static void dumpSortColumnsToProp(
+            Tuple2<List<String>, List<Integer>> columnNamesOrder, Map<String, String> props) {
+        props.put(BUCKET_SORT_COL, String.join(DELIMITER, columnNamesOrder.f0));
+        props.put(
+                BUCKET_SORT_ORDER,
+                String.join(
+                        DELIMITER,
+                        columnNamesOrder.f1.stream()
+                                .map(String::valueOf)
+                                .collect(Collectors.joining(DELIMITER))));
+    }
+
+    public static HiveBucketSpec extractBucketSpec(Map<String, String> props) {
+        Integer bucketNum = null;
+        String bucketNumProp = props.remove(BUCKET_NUM);
+        if (bucketNumProp != null) {
+            bucketNum = Integer.parseInt(bucketNumProp);
+        }
+        List<String> bucketColumns =
+                extractListValueFromProp(props, BUCKET_COL, Function.identity());
+        List<String> sortColumnNames =
+                extractListValueFromProp(props, BUCKET_SORT_COL, Function.identity());
+        List<Integer> sortColumnOrder =
+                extractListValueFromProp(props, BUCKET_SORT_ORDER, Integer::valueOf);
+        Tuple2<List<String>, List<Integer>> columnNamesOrder = null;
+        if (sortColumnNames != null && sortColumnOrder != null) {
+            columnNamesOrder = new Tuple2<>(sortColumnNames, sortColumnOrder);
+        }
+        return new HiveBucketSpec(bucketNum, bucketColumns, columnNamesOrder);
+    }
+
+    private static <T> List<T> extractListValueFromProp(
+            Map<String, String> props,
+            String key,
+            Function<? super String, ? extends T> elementConverter) {
+        String value = props.remove(key);
+        if (value == null) {
+            return null;
+        }
+        if (value.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return Arrays.stream(value.split(DELIMITER))
+                .map(elementConverter)
+                .collect(Collectors.toList());
+    }
+}

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectITCase.java
@@ -35,8 +35,6 @@ import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.flink.table.catalog.hive.HiveCatalog;
 import org.apache.flink.table.catalog.hive.HiveTestUtils;
 import org.apache.flink.table.delegation.Parser;
-import org.apache.flink.table.module.CoreModule;
-import org.apache.flink.table.module.hive.HiveModule;
 import org.apache.flink.table.operations.DescribeTableOperation;
 import org.apache.flink.table.operations.command.ClearOperation;
 import org.apache.flink.table.operations.command.HelpOperation;
@@ -359,33 +357,6 @@ public class HiveDialectITCase {
         assertThat(results.toString())
                 .isEqualTo(
                         "[+I[1, 0, static], +I[1, 1, a], +I[1, 2, b], +I[1, 3, c], +I[2, 0, static], +I[2, 1, b], +I[3, 0, static], +I[3, 1, c]]");
-    }
-
-    @Test
-    public void t1() throws Exception {
-        tableEnv.executeSql("create table src (x int,y string)");
-        tableEnv.executeSql(
-                "create table dest2 (x int) partitioned by (p1 int,p2 string) clustered by (x) sorted by (p2 desc) into 20 buckets");
-        tableEnv.executeSql("insert into dest2 partition (p1=1,p2) select x,y from src").await();
-    }
-
-    @Test
-    public void testInsert1() throws Exception {
-        // automatically load hive module in hive-compatible mode
-        HiveModule hiveModule = new HiveModule(hiveCatalog.getHiveVersion());
-        CoreModule coreModule = CoreModule.INSTANCE;
-        for (String loaded : tableEnv.listModules()) {
-            tableEnv.unloadModule(loaded);
-        }
-        tableEnv.loadModule("hive", hiveModule);
-        tableEnv.loadModule("core", coreModule);
-
-        // src table
-        tableEnv.executeSql(
-                "create table dest (x int,y string) clustered by (x) sorted by (x,y) into 20 buckets");
-        tableEnv.executeSql("create table src (x int, y string)");
-        tableEnv.executeSql("insert into src values (1,'a'),(2,'b'),(3,'c')").await();
-        tableEnv.executeSql("insert into dest select * from src distribute by y").await();
     }
 
     @Test

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceITCase.java
@@ -556,6 +556,11 @@ public class HiveTableSourceITCase extends BatchAbstractTestBase {
     }
 
     @Test
+    public void testParallelismOnBucketedTable() {
+        // todo add test
+    }
+
+    @Test
     public void testSourceConfig() throws Exception {
         // vector reader not available for 1.x and we're not testing orc for 2.0.x
         Assume.assumeTrue(HiveVersionTestUtil.HIVE_230_OR_LATER);

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/read/HiveBucketFileSplitAssignerTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/read/HiveBucketFileSplitAssignerTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connectors.hive.read;
+
+import org.apache.flink.connector.file.src.FileSourceSplit;
+import org.apache.flink.connector.file.src.assigners.FileSplitAssigner;
+import org.apache.flink.core.fs.Path;
+
+import org.apache.hadoop.hive.ql.exec.Utilities;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Unit tests for the {@link HiveBucketFileSplitAssigner}. */
+public class HiveBucketFileSplitAssignerTest {
+
+    @Test
+    public void testBucketFileSplitAssignment() {
+        // case1: 2 reader, 2 buckets, each bucket has 2 files,
+        List<FileSourceSplit> splits = createSplits(2, 2);
+        FileSplitAssigner assigner = new HiveBucketFileSplitAssigner(splits);
+        // reader0 should read bucket_0
+        verifySplitBucketId(assigner.getNext(0, null), 0);
+        // reader1 should read bucket_1
+        verifySplitBucketId(assigner.getNext(1, null), 1);
+        // reader1 should still read bucket_1
+        verifySplitBucketId(assigner.getNext(1, null), 1);
+        // reader1 should read nothing
+        assertThat(assigner.getNext(1, null).isPresent()).isFalse();
+        // reader0 should read bucket_0
+        verifySplitBucketId(assigner.getNext(0, null), 0);
+        // reader0 should read nothing
+        assertThat(assigner.getNext(0, null).isPresent()).isFalse();
+
+        // case2: 1 reader, 2 buckets, each bucket has 1 files
+        splits = createSplits(2, 1);
+        assigner = new HiveBucketFileSplitAssigner(splits);
+        // reader0 should read bucket_0
+        verifySplitBucketId(assigner.getNext(0, null), 0);
+        // now reader0 should move to next bucket, that's bucket_1
+        verifySplitBucketId(assigner.getNext(0, null), 1);
+        // reader0 should read nothing
+        assertThat(assigner.getNext(0, null).isPresent()).isFalse();
+
+        // case3: 2 reader, 1 bucket, each bucket has 2 file
+        splits = createSplits(1, 2);
+        assigner = new HiveBucketFileSplitAssigner(splits);
+        // reader0 should read bucket_0
+        verifySplitBucketId(assigner.getNext(0, null), 0);
+        // reader1 should read nothing
+        assertThat(assigner.getNext(1, null).isPresent()).isFalse();
+        // reader0 should read bucket_0
+        verifySplitBucketId(assigner.getNext(0, null), 0);
+        // reader0 should nothing
+        assertThat(assigner.getNext(0, null).isPresent()).isFalse();
+    }
+
+    // ------------------------------------------------------------------------
+    //  utilities
+    // ------------------------------------------------------------------------
+
+    private static List<FileSourceSplit> createSplits(int bucketNum, int filesOfBucket) {
+        List<FileSourceSplit> splits = new ArrayList<>();
+        for (int bucket = 0; bucket < bucketNum; bucket++) {
+            for (int i = 0; i < filesOfBucket; i++) {
+                String splitId = String.valueOf(bucket * bucketNum + i);
+                String fileName = String.format("%05d_0_%s", bucket, splitId);
+                splits.add(
+                        new FileSourceSplit(
+                                splitId, new Path(fileName), 0, 1024, 0, 1024, new String[0]));
+            }
+        }
+        return splits;
+    }
+
+    private static void verifySplitBucketId(Optional<FileSourceSplit> split, int expectedBucketId) {
+        assertThat(split.isPresent()).isTrue();
+        int actualBucketId = Utilities.getBucketIdFromFile(split.get().path().getName());
+        assertThat(actualBucketId).isEqualTo(expectedBucketId);
+    }
+}

--- a/flink-end-to-end-tests/flink-end-to-end-tests-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/table/test/KinesisStreamsTableApiIT.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/table/test/KinesisStreamsTableApiIT.java
@@ -199,7 +199,7 @@ public class KinesisStreamsTableApiIT {
     private <T> T fromJson(final String json, final Class<T> type) {
         try {
             return new ObjectMapper().readValue(json, type);
-        } catch (JsonProcessingException e) {
+        } catch (Exception e) {
             throw new RuntimeException("Test Failure.", e);
         }
     }

--- a/flink-end-to-end-tests/flink-end-to-end-tests-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/table/test/KinesisStreamsTableApiIT.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/table/test/KinesisStreamsTableApiIT.java
@@ -199,7 +199,7 @@ public class KinesisStreamsTableApiIT {
     private <T> T fromJson(final String json, final Class<T> type) {
         try {
             return new ObjectMapper().readValue(json, type);
-        } catch (Exception e) {
+        } catch (JsonProcessingException e) {
             throw new RuntimeException("Test Failure.", e);
         }
     }

--- a/flink-table/flink-sql-parser-hive/src/main/java/org/apache/flink/sql/parser/hive/ddl/SqlAlterHiveTable.java
+++ b/flink-table/flink-sql-parser-hive/src/main/java/org/apache/flink/sql/parser/hive/ddl/SqlAlterHiveTable.java
@@ -62,6 +62,7 @@ public abstract class SqlAlterHiveTable extends SqlAlterTableOptions {
         CHANGE_SERDE_PROPS,
         CHANGE_FILE_FORMAT,
         CHANGE_LOCATION,
-        ALTER_COLUMNS
+        ALTER_COLUMNS,
+        ALTER_BUCKET
     }
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
Hive dialect supports Create/Alter/Write/Read for Hive's bucket table.


## Brief change log
  -  Support create/alter Hive's buckted table in [...a/org/apache/flink/table/planner/delegation/hive/parse/HiveParserDDLSemanticAnalyzer.java](https://github.com/apache/flink/pull/19731/commits/892dea8ef719507313f13e909512378b13c5376b#diff-0b21bf88735d44c7d6196e6967a23fa7754d60dbcfd183090669c2459b8df413). See more in this [commit](https://github.com/apache/flink/pull/19731/commits/892dea8ef719507313f13e909512378b13c5376b)
  - When use Hive dialect, if it's for insert bucketed table, add a distributed by node. See more in this [commit](https://github.com/apache/flink/pull/19731/commits/ea051753e100da51f5e23d1aa31948375407f430)
  - When reading Hive's bucketed table, enable bucket reading which guarantees the files belonged to same bucket should read by same reader. This behavior is by [...hive/src/main/java/org/apache/flink/connectors/hive/read/HiveBucketFileSplitAssigner.java](https://github.com/apache/flink/pull/19731/commits/22000d15384efce10c9c288f0481620c054c7e24#diff-8a68bd483ad9d5d07105b526f2969ae6fbd75a6df2eb63d7341aef5064153242).  See more in this [commit](https://github.com/apache/flink/pull/19731/commits/22000d15384efce10c9c288f0481620c054c7e24).

## Verifying this change
UT && test with Flink cluster manually.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature?  no
  - If yes, how is the feature documented? N/A
