### PR TITLE
[FLINK-27649][connectors/elasticsearch] Remove slf4 dependency causing unwanted log output

### DIFF
--- a/flink-end-to-end-tests/flink-end-to-end-tests-elasticsearch6/pom.xml
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-elasticsearch6/pom.xml
@@ -67,12 +67,6 @@ under the License.
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
-
-	   <dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-simple</artifactId>
-			<version>1.7.25</version>
-		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
## What is the purpose of the change

This PR removes an unnecessary slf4j dependency causing a lot of unwanted log output in the Elasticsearch6End2EndCase test.

## Brief change log

- removed slf4j dependency


## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**yes** / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
