### PR TITLE
[FLINK-24433][Tests][Buildsystem] Remove additional pre-installed pac…

### DIFF
--- a/tools/azure-pipelines/free_disk_space.sh
+++ b/tools/azure-pipelines/free_disk_space.sh
@@ -33,11 +33,12 @@ echo "Listing 100 largest packages"
 dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 100
 df -h
 echo "Removing large packages"
-sudo apt-get remove -y '^ghc-8.*'
 sudo apt-get remove -y '^dotnet-.*'
 sudo apt-get remove -y '^llvm-.*'
 sudo apt-get remove -y 'php.*'
-sudo apt-get remove -y azure-cli google-cloud-sdk hhvm google-chrome-stable firefox powershell mono-devel
+sudo apt-get remove -y '^mongodb-.*'
+sudo apt-get remove -y '^mysql-.*'
+sudo apt-get remove -y azure-cli google-cloud-sdk hhvm google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri
 sudo apt-get autoremove -y
 sudo apt-get clean
 df -h


### PR DESCRIPTION
…kages to clean up more diskspace before starting the E2E tests. Also removing the line that removes `^ghc-8.*` since that doesn't exist anymore on the machines.

(cherry picked from commit db6baf47130872ccdcd56949510704bbdf69c387)

Unchanged backport of https://github.com/apache/flink/pull/19733