### PR TITLE
[hotfix][connector/elasticsearch] Fix typo of ES comment

### DIFF
--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/sink/ElasticsearchSinkBuilderBase.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/sink/ElasticsearchSinkBuilderBase.java
@@ -197,7 +197,7 @@ public abstract class ElasticsearchSinkBuilderBase<
     }
 
     /**
-     * Sets the password used to authenticate the conection with the Elasticsearch cluster.
+     * Sets the password used to authenticate the connection with the Elasticsearch cluster.
      *
      * @param password of the Elasticsearch cluster user
      * @return this builder


### PR DESCRIPTION
## What is the purpose of the change

fix typo

## Brief change log

  - *Fix typo of ElasticsearchSinkBuilderBase#setConnectionPassword comment*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (no)
