### PR TITLE
 [FLINK-27662][tests] Migrate TypeInformationTestBase to JUnit5

### DIFF
--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/compactor/operator/CompactorRequestTypeInfoTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/compactor/operator/CompactorRequestTypeInfoTest.java
@@ -23,8 +23,7 @@ import org.apache.flink.connector.file.sink.FileSinkCommittableSerializer;
 import org.apache.flink.connector.file.sink.utils.FileSinkTestUtils;
 
 /** Test for {@link CompactorRequestTypeInfo}. */
-public class CompactorRequestTypeInfoTest
-        extends TypeInformationTestBase<CompactorRequestTypeInfo> {
+class CompactorRequestTypeInfoTest extends TypeInformationTestBase<CompactorRequestTypeInfo> {
 
     @Override
     protected CompactorRequestTypeInfo[] getTestData() {

--- a/flink-connectors/flink-hadoop-compatibility/src/test/java/org/apache/flink/api/java/typeutils/WritableTypeInfoTest.java
+++ b/flink-connectors/flink-hadoop-compatibility/src/test/java/org/apache/flink/api/java/typeutils/WritableTypeInfoTest.java
@@ -27,7 +27,7 @@ import java.io.DataOutput;
 import java.io.IOException;
 
 /** Test for {@link WritableTypeInfo}. */
-public class WritableTypeInfoTest extends TypeInformationTestBase<WritableTypeInfo<?>> {
+class WritableTypeInfoTest extends TypeInformationTestBase<WritableTypeInfo<?>> {
 
     @Override
     protected WritableTypeInfo<?>[] getTestData() {

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeinfo/BasicArrayTypeInfoTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeinfo/BasicArrayTypeInfoTest.java
@@ -21,7 +21,7 @@ package org.apache.flink.api.common.typeinfo;
 import org.apache.flink.api.common.typeutils.TypeInformationTestBase;
 
 /** Test for {@link BasicArrayTypeInfo}. */
-public class BasicArrayTypeInfoTest extends TypeInformationTestBase<BasicArrayTypeInfo<?, ?>> {
+class BasicArrayTypeInfoTest extends TypeInformationTestBase<BasicArrayTypeInfo<?, ?>> {
 
     @Override
     protected BasicArrayTypeInfo<?, ?>[] getTestData() {

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeinfo/BasicTypeInfoTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeinfo/BasicTypeInfoTest.java
@@ -21,7 +21,7 @@ package org.apache.flink.api.common.typeinfo;
 import org.apache.flink.api.common.typeutils.TypeInformationTestBase;
 
 /** Test for {@link BasicTypeInfo}. */
-public class BasicTypeInfoTest extends TypeInformationTestBase<BasicTypeInfo<?>> {
+class BasicTypeInfoTest extends TypeInformationTestBase<BasicTypeInfo<?>> {
 
     @Override
     protected BasicTypeInfo<?>[] getTestData() {

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeinfo/FractionalTypeInfoTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeinfo/FractionalTypeInfoTest.java
@@ -21,7 +21,7 @@ package org.apache.flink.api.common.typeinfo;
 import org.apache.flink.api.common.typeutils.TypeInformationTestBase;
 
 /** Test for {@link FractionalTypeInfo}. */
-public class FractionalTypeInfoTest extends TypeInformationTestBase<FractionalTypeInfo<?>> {
+class FractionalTypeInfoTest extends TypeInformationTestBase<FractionalTypeInfo<?>> {
 
     @Override
     protected FractionalTypeInfo<?>[] getTestData() {

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeinfo/IntegerTypeInfoTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeinfo/IntegerTypeInfoTest.java
@@ -21,7 +21,7 @@ package org.apache.flink.api.common.typeinfo;
 import org.apache.flink.api.common.typeutils.TypeInformationTestBase;
 
 /** Test for {@link IntegerTypeInfo}. */
-public class IntegerTypeInfoTest extends TypeInformationTestBase<IntegerTypeInfo<?>> {
+class IntegerTypeInfoTest extends TypeInformationTestBase<IntegerTypeInfo<?>> {
 
     @Override
     protected IntegerTypeInfo<?>[] getTestData() {

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeinfo/LocalTimeTypeInfoTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeinfo/LocalTimeTypeInfoTest.java
@@ -21,7 +21,7 @@ package org.apache.flink.api.common.typeinfo;
 import org.apache.flink.api.common.typeutils.TypeInformationTestBase;
 
 /** Test for {@link SqlTimeTypeInfo}. */
-public class LocalTimeTypeInfoTest extends TypeInformationTestBase<LocalTimeTypeInfo<?>> {
+class LocalTimeTypeInfoTest extends TypeInformationTestBase<LocalTimeTypeInfo<?>> {
 
     @Override
     protected LocalTimeTypeInfo<?>[] getTestData() {

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeinfo/NothingTypeInfoTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeinfo/NothingTypeInfoTest.java
@@ -21,7 +21,7 @@ package org.apache.flink.api.common.typeinfo;
 import org.apache.flink.api.common.typeutils.TypeInformationTestBase;
 
 /** Test for {@link NothingTypeInfo}. */
-public class NothingTypeInfoTest extends TypeInformationTestBase<NothingTypeInfo> {
+class NothingTypeInfoTest extends TypeInformationTestBase<NothingTypeInfo> {
 
     @Override
     protected NothingTypeInfo[] getTestData() {

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeinfo/NumericTypeInfoTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeinfo/NumericTypeInfoTest.java
@@ -21,7 +21,7 @@ package org.apache.flink.api.common.typeinfo;
 import org.apache.flink.api.common.typeutils.TypeInformationTestBase;
 
 /** Test for {@link NumericTypeInfo}. */
-public class NumericTypeInfoTest extends TypeInformationTestBase<NumericTypeInfo<?>> {
+class NumericTypeInfoTest extends TypeInformationTestBase<NumericTypeInfo<?>> {
 
     @Override
     protected NumericTypeInfo<?>[] getTestData() {

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeinfo/PrimitiveArrayTypeInfoTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeinfo/PrimitiveArrayTypeInfoTest.java
@@ -21,7 +21,7 @@ package org.apache.flink.api.common.typeinfo;
 import org.apache.flink.api.common.typeutils.TypeInformationTestBase;
 
 /** Test for {@link PrimitiveArrayTypeInfoTest}. */
-public class PrimitiveArrayTypeInfoTest extends TypeInformationTestBase<PrimitiveArrayTypeInfo<?>> {
+class PrimitiveArrayTypeInfoTest extends TypeInformationTestBase<PrimitiveArrayTypeInfo<?>> {
 
     @Override
     protected PrimitiveArrayTypeInfo<?>[] getTestData() {

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeinfo/SqlTimeTypeInfoTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeinfo/SqlTimeTypeInfoTest.java
@@ -21,7 +21,7 @@ package org.apache.flink.api.common.typeinfo;
 import org.apache.flink.api.common.typeutils.TypeInformationTestBase;
 
 /** Test for {@link SqlTimeTypeInfo}. */
-public class SqlTimeTypeInfoTest extends TypeInformationTestBase<SqlTimeTypeInfo<?>> {
+class SqlTimeTypeInfoTest extends TypeInformationTestBase<SqlTimeTypeInfo<?>> {
 
     @Override
     protected SqlTimeTypeInfo<?>[] getTestData() {

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/TypeInformationTestBase.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/TypeInformationTestBase.java
@@ -21,24 +21,23 @@ package org.apache.flink.api.common.typeutils;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.util.InstantiationUtil;
-import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.TestLoggerExtension;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Abstract test base for type information. */
-public abstract class TypeInformationTestBase<T extends TypeInformation<?>> extends TestLogger {
+@ExtendWith(TestLoggerExtension.class)
+public abstract class TypeInformationTestBase<T extends TypeInformation<?>> {
 
     protected abstract T[] getTestData();
 
     @Test
-    public void testHashcodeAndEquals() throws Exception {
+    void testHashcodeAndEquals() throws Exception {
         final T[] testData = getTestData();
         final TypeInformation<?> unrelatedTypeInfo = new UnrelatedTypeInfo();
 
@@ -60,25 +59,26 @@ public abstract class TypeInformationTestBase<T extends TypeInformation<?>> exte
             for (T otherTypeInfo : testData) {
                 // test equality
                 if (typeInfo == otherTypeInfo) {
-                    assertTrue(
-                            "hashCode() returns inconsistent results.",
-                            typeInfo.hashCode() == otherTypeInfo.hashCode());
-                    assertEquals("equals() is false for same object.", typeInfo, otherTypeInfo);
+                    assertThat(typeInfo.hashCode())
+                            .as("hashCode() returns inconsistent results.")
+                            .isEqualTo(otherTypeInfo.hashCode());
+                    assertThat(typeInfo)
+                            .as("equals() is false for same object.")
+                            .isEqualTo(otherTypeInfo);
                 }
                 // test inequality
                 else {
-                    assertNotEquals(
-                            "equals() returned true for different objects.",
-                            typeInfo,
-                            otherTypeInfo);
+                    assertThat(typeInfo)
+                            .as("equals() returned true for different objects.")
+                            .isNotEqualTo(otherTypeInfo);
                 }
             }
 
             // compare with unrelated type
-            assertFalse(
-                    "Type information allows to compare with unrelated type.",
-                    typeInfo.canEqual(unrelatedTypeInfo));
-            assertNotEquals(typeInfo, unrelatedTypeInfo);
+            assertThat(typeInfo.canEqual(unrelatedTypeInfo))
+                    .as("Type information allows to compare with unrelated type.")
+                    .isFalse();
+            assertThat(typeInfo).isNotEqualTo(unrelatedTypeInfo);
         }
     }
 
@@ -112,7 +112,9 @@ public abstract class TypeInformationTestBase<T extends TypeInformation<?>> exte
     public void testGetTotalFields() {
         final T[] testData = getTestData();
         for (T typeInfo : testData) {
-            assertTrue("Number of total fields must be at least 1", typeInfo.getTotalFields() > 0);
+            assertThat(typeInfo.getTotalFields())
+                    .as("Number of total fields must be at least 1")
+                    .isGreaterThan(0);
         }
     }
 

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/EitherTypeInfoTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/EitherTypeInfoTest.java
@@ -23,7 +23,7 @@ import org.apache.flink.api.common.typeutils.TypeInformationTestBase;
 import org.apache.flink.api.java.tuple.Tuple2;
 
 /** Test for {@link EitherTypeInfo}. */
-public class EitherTypeInfoTest extends TypeInformationTestBase<EitherTypeInfo<?, ?>> {
+class EitherTypeInfoTest extends TypeInformationTestBase<EitherTypeInfo<?, ?>> {
 
     @Override
     protected EitherTypeInfo<?, ?>[] getTestData() {

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/EnumTypeInfoTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/EnumTypeInfoTest.java
@@ -21,7 +21,7 @@ package org.apache.flink.api.java.typeutils;
 import org.apache.flink.api.common.typeutils.TypeInformationTestBase;
 
 /** Test for {@link EnumTypeInfo}. */
-public class EnumTypeInfoTest extends TypeInformationTestBase<EnumTypeInfo<?>> {
+class EnumTypeInfoTest extends TypeInformationTestBase<EnumTypeInfo<?>> {
 
     @Override
     @SuppressWarnings("unchecked")

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/GenericTypeInfoTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/GenericTypeInfoTest.java
@@ -21,7 +21,7 @@ package org.apache.flink.api.java.typeutils;
 import org.apache.flink.api.common.typeutils.TypeInformationTestBase;
 
 /** Test for {@link GenericTypeInfo}. */
-public class GenericTypeInfoTest extends TypeInformationTestBase<GenericTypeInfo<?>> {
+class GenericTypeInfoTest extends TypeInformationTestBase<GenericTypeInfo<?>> {
 
     @Override
     protected GenericTypeInfo<?>[] getTestData() {

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/ListTypeInfoTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/ListTypeInfoTest.java
@@ -22,7 +22,7 @@ import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeutils.TypeInformationTestBase;
 
 /** Test for {@link ListTypeInfo}. */
-public class ListTypeInfoTest extends TypeInformationTestBase<ListTypeInfo<?>> {
+class ListTypeInfoTest extends TypeInformationTestBase<ListTypeInfo<?>> {
 
     @Override
     protected ListTypeInfo<?>[] getTestData() {

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/MapTypeInfoTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/MapTypeInfoTest.java
@@ -22,7 +22,7 @@ import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeutils.TypeInformationTestBase;
 
 /** Test for {@link MapTypeInfo}. */
-public class MapTypeInfoTest extends TypeInformationTestBase<MapTypeInfo<?, ?>> {
+class MapTypeInfoTest extends TypeInformationTestBase<MapTypeInfo<?, ?>> {
 
     @Override
     protected MapTypeInfo<?, ?>[] getTestData() {

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/MissingTypeInfoTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/MissingTypeInfoTest.java
@@ -21,7 +21,7 @@ package org.apache.flink.api.java.typeutils;
 import org.apache.flink.api.common.functions.InvalidTypesException;
 import org.apache.flink.api.common.typeutils.TypeInformationTestBase;
 
-public class MissingTypeInfoTest extends TypeInformationTestBase<MissingTypeInfo> {
+class MissingTypeInfoTest extends TypeInformationTestBase<MissingTypeInfo> {
     private static final String functionName = "foobar";
     private static final InvalidTypesException testException =
             new InvalidTypesException("Test exception.");

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/MultisetTypeInfoTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/MultisetTypeInfoTest.java
@@ -22,7 +22,7 @@ import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeutils.TypeInformationTestBase;
 
 /** Test for {@link MultisetTypeInfo}. */
-public class MultisetTypeInfoTest extends TypeInformationTestBase<MultisetTypeInfo<?>> {
+class MultisetTypeInfoTest extends TypeInformationTestBase<MultisetTypeInfo<?>> {
 
     @Override
     protected MultisetTypeInfo<?>[] getTestData() {

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/ObjectArrayTypeInfoTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/ObjectArrayTypeInfoTest.java
@@ -23,7 +23,7 @@ import org.apache.flink.api.common.typeutils.TypeInformationTestBase;
 import java.util.ArrayList;
 
 /** Test for {@link ObjectArrayTypeInfo}. */
-public class ObjectArrayTypeInfoTest extends TypeInformationTestBase<ObjectArrayTypeInfo<?, ?>> {
+class ObjectArrayTypeInfoTest extends TypeInformationTestBase<ObjectArrayTypeInfo<?, ?>> {
 
     @Override
     protected ObjectArrayTypeInfo<?, ?>[] getTestData() {

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/PojoTypeInfoTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/PojoTypeInfoTest.java
@@ -21,7 +21,7 @@ package org.apache.flink.api.java.typeutils;
 import org.apache.flink.api.common.typeutils.TypeInformationTestBase;
 
 /** Test for {@link PojoTypeInfo}. */
-public class PojoTypeInfoTest extends TypeInformationTestBase<PojoTypeInfo<?>> {
+class PojoTypeInfoTest extends TypeInformationTestBase<PojoTypeInfo<?>> {
 
     @Override
     protected PojoTypeInfo<?>[] getTestData() {

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/TupleTypeInfoTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/TupleTypeInfoTest.java
@@ -25,12 +25,12 @@ import org.apache.flink.api.common.typeutils.TypeInformationTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple1;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link TupleTypeInfo}. */
-public class TupleTypeInfoTest extends TypeInformationTestBase<TupleTypeInfo<?>> {
+class TupleTypeInfoTest extends TypeInformationTestBase<TupleTypeInfo<?>> {
 
     @Override
     protected TupleTypeInfo<?>[] getTestData() {
@@ -41,7 +41,7 @@ public class TupleTypeInfoTest extends TypeInformationTestBase<TupleTypeInfo<?>>
     }
 
     @Test
-    public void testTupleTypeInfoSymmetricEqualityRelation() {
+    void testTupleTypeInfoSymmetricEqualityRelation() {
         TupleTypeInfo<Tuple1<Integer>> tupleTypeInfo =
                 new TupleTypeInfo<>(BasicTypeInfo.INT_TYPE_INFO);
 
@@ -75,6 +75,8 @@ public class TupleTypeInfoTest extends TypeInformationTestBase<TupleTypeInfo<?>>
         boolean tupleVsAnonymous = tupleTypeInfo.equals(anonymousTupleTypeInfo);
         boolean anonymousVsTuple = anonymousTupleTypeInfo.equals(tupleTypeInfo);
 
-        assertTrue("Equality relation should be symmetric", tupleVsAnonymous == anonymousVsTuple);
+        assertThat(tupleVsAnonymous)
+                .as("Equality relation should be symmetric")
+                .isEqualTo(anonymousVsTuple);
     }
 }

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/ValueTypeInfoTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/ValueTypeInfoTest.java
@@ -24,13 +24,14 @@ import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.types.Record;
 import org.apache.flink.types.Value;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /** Test for {@link ListTypeInfo}. */
-public class ValueTypeInfoTest extends TypeInformationTestBase<ValueTypeInfo<?>> {
+class ValueTypeInfoTest extends TypeInformationTestBase<ValueTypeInfo<?>> {
 
     @Override
     protected ValueTypeInfo<?>[] getTestData() {
@@ -42,10 +43,10 @@ public class ValueTypeInfoTest extends TypeInformationTestBase<ValueTypeInfo<?>>
     }
 
     @Test
-    public void testValueTypeEqualsWithNull() throws Exception {
+    void testValueTypeEqualsWithNull() {
         ValueTypeInfo<Record> tpeInfo = new ValueTypeInfo<>(Record.class);
 
-        Assert.assertFalse(tpeInfo.equals(null));
+        assertThat(tpeInfo).isNotNull();
     }
 
     public static class TestClass implements Value {

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroGenericRecordTypeInfoTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroGenericRecordTypeInfoTest.java
@@ -29,8 +29,7 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link GenericRecordAvroTypeInfo}. */
-public class AvroGenericRecordTypeInfoTest
-        extends TypeInformationTestBase<GenericRecordAvroTypeInfo> {
+class AvroGenericRecordTypeInfoTest extends TypeInformationTestBase<GenericRecordAvroTypeInfo> {
 
     @Override
     protected GenericRecordAvroTypeInfo[] getTestData() {

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroTypeInfoTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroTypeInfoTest.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link AvroTypeInfo}. */
-public class AvroTypeInfoTest extends TypeInformationTestBase<AvroTypeInfo<?>> {
+class AvroTypeInfoTest extends TypeInformationTestBase<AvroTypeInfo<?>> {
 
     @Override
     protected AvroTypeInfo<?>[] getTestData() {

--- a/flink-queryable-state/flink-queryable-state-client-java/src/test/java/org/apache/flink/queryablestate/client/VoidNamespaceTypeInfoTest.java
+++ b/flink-queryable-state/flink-queryable-state-client-java/src/test/java/org/apache/flink/queryablestate/client/VoidNamespaceTypeInfoTest.java
@@ -21,7 +21,7 @@ package org.apache.flink.queryablestate.client;
 import org.apache.flink.api.common.typeutils.TypeInformationTestBase;
 
 /** Test for {@link VoidNamespaceTypeInfo}. */
-public class VoidNamespaceTypeInfoTest extends TypeInformationTestBase<VoidNamespaceTypeInfo> {
+class VoidNamespaceTypeInfoTest extends TypeInformationTestBase<VoidNamespaceTypeInfo> {
 
     @Override
     protected VoidNamespaceTypeInfo[] getTestData() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/VoidNamespaceTypeInfoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/VoidNamespaceTypeInfoTest.java
@@ -22,7 +22,7 @@ import org.apache.flink.api.common.typeinfo.IntegerTypeInfo;
 import org.apache.flink.api.common.typeutils.TypeInformationTestBase;
 
 /** Test for {@link IntegerTypeInfo}. */
-public class VoidNamespaceTypeInfoTest extends TypeInformationTestBase<VoidNamespaceTypeInfo> {
+class VoidNamespaceTypeInfoTest extends TypeInformationTestBase<VoidNamespaceTypeInfo> {
 
     @Override
     protected VoidNamespaceTypeInfo[] getTestData() {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/connector/sink2/CommittableMessageTypeInfoTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/connector/sink2/CommittableMessageTypeInfoTest.java
@@ -21,7 +21,7 @@ package org.apache.flink.streaming.api.connector.sink2;
 import org.apache.flink.api.common.typeutils.TypeInformationTestBase;
 
 /** Test for {@link CommittableMessageTypeInfo}. */
-public class CommittableMessageTypeInfoTest
+class CommittableMessageTypeInfoTest
         extends TypeInformationTestBase<CommittableMessageTypeInfo<?>> {
 
     @SuppressWarnings("rawtypes")

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/typeutils/BigDecimalTypeInfoTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/typeutils/BigDecimalTypeInfoTest.java
@@ -21,7 +21,7 @@ package org.apache.flink.table.runtime.typeutils;
 import org.apache.flink.api.common.typeutils.TypeInformationTestBase;
 
 /** Test for {@link BigDecimalTypeInfo}. */
-public class BigDecimalTypeInfoTest extends TypeInformationTestBase<BigDecimalTypeInfo> {
+class BigDecimalTypeInfoTest extends TypeInformationTestBase<BigDecimalTypeInfo> {
 
     @Override
     protected BigDecimalTypeInfo[] getTestData() {

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/typeutils/ExternalTypeInfoTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/typeutils/ExternalTypeInfoTest.java
@@ -27,7 +27,7 @@ import java.nio.ByteBuffer;
 import java.time.DayOfWeek;
 
 /** Test for {@link ExternalTypeInfo}. */
-public class ExternalTypeInfoTest extends TypeInformationTestBase<ExternalTypeInfo<?>> {
+class ExternalTypeInfoTest extends TypeInformationTestBase<ExternalTypeInfo<?>> {
 
     @Override
     protected ExternalTypeInfo<?>[] getTestData() {

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/typeutils/InternalTypeInfoTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/typeutils/InternalTypeInfoTest.java
@@ -27,7 +27,7 @@ import java.nio.ByteBuffer;
 import java.time.DayOfWeek;
 
 /** Test for {@link InternalTypeInfo}. */
-public class InternalTypeInfoTest extends TypeInformationTestBase<InternalTypeInfo<?>> {
+class InternalTypeInfoTest extends TypeInformationTestBase<InternalTypeInfo<?>> {
 
     @Override
     protected InternalTypeInfo<?>[] getTestData() {

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/typeutils/InternalTypeInfosTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/typeutils/InternalTypeInfosTest.java
@@ -22,7 +22,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeInformationTestBase;
 
 /** Test for {@link StringDataTypeInfo}, {@link DecimalDataTypeInfo}. */
-public class InternalTypeInfosTest extends TypeInformationTestBase<TypeInformation<?>> {
+class InternalTypeInfosTest extends TypeInformationTestBase<TypeInformation<?>> {
 
     @Override
     protected TypeInformation[] getTestData() {


### PR DESCRIPTION
## What is the purpose of the change

Update the `TypeInformationTestBase` class and its successors to AssertJ and JUnit 5 following the [JUnit 5 Migration Guide](https://docs.google.com/document/d/1514Wa_aNB9bJUen4xm5uiuXOooOJTtXqS_Jqk9KJitU/edit)


## Brief change log

Use JUnit5 and AssertJ in tests instead of JUnit4 and Hamcrest


## Verifying this change

This change is a code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
