### PR TITLE
[FLINK-27630][table-planner] Add maven-source-plugin for table planne…

### DIFF
--- a/flink-table/flink-table-planner/pom.xml
+++ b/flink-table/flink-table-planner/pom.xml
@@ -428,6 +428,7 @@ under the License.
 				</executions>
 			</plugin>
 
+			<!-- deploy value connector's source code when user uses it. -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
@@ -443,6 +444,7 @@ under the License.
 								<addMavenDescriptor>false</addMavenDescriptor>
 							</archive>
 							<includes>
+								<!-- Only include factories sources, because this is where the value connector is stored. -->
 								<include>**/factories/**</include>
 								<include>META-INF/LICENSE</include>
 								<include>META-INF/NOTICE</include>

--- a/flink-table/flink-table-planner/pom.xml
+++ b/flink-table/flink-table-planner/pom.xml
@@ -427,6 +427,30 @@ under the License.
 					</execution>
 				</executions>
 			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>attach-test-sources</id>
+						<goals>
+							<goal>test-jar-no-fork</goal>
+						</goals>
+						<configuration>
+							<archive>
+								<!-- Globally exclude maven metadata, because it may accidentally bundle files we don't intend to -->
+								<addMavenDescriptor>false</addMavenDescriptor>
+							</archive>
+							<includes>
+								<include>**/factories/**</include>
+								<include>META-INF/LICENSE</include>
+								<include>META-INF/NOTICE</include>
+							</includes>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 </project>


### PR DESCRIPTION
## Brief change log

- add test source jar to reponsitory  when user use this values connector in flink-table-planner just like kafka/pulsar connector. So user can find the values source code.
- and we just need upload the */factories/* because it will be too large to upload all the flink-table-planner test source code.

## Does this pull request potentially affect one of the following parts:
Dependencies (does it add or upgrade a dependency): no
The public API, i.e., is any changed class annotated with @Public(Evolving): no
The serializers: no
The runtime per-record code paths (performance sensitive):no
Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
The S3 file system connector: no