### PR TITLE
[FLINK-27167][test] change the junit-jupiter dependency scope to compile

### DIFF
--- a/flink-architecture-tests/flink-architecture-tests-production/pom.xml
+++ b/flink-architecture-tests/flink-architecture-tests-production/pom.xml
@@ -60,6 +60,13 @@ under the License.
 			<scope>compile</scope>
 		</dependency>
 
+		<!-- test dependencies required for javadoc-plugin, reference: FLINK-27167-->
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<scope>compile</scope>
+		</dependency>
+
 		<!-- Tested Flink modules -->
 
 		<dependency>


### PR DESCRIPTION
Backport of #19541 (cherry picked from commit 45afc031a222ec8ff1b02fb9a1d8b2826e43dc4f)
