### PR TITLE
[FLINK-27669][tests] Migrate flink-file-sink-common to JUnit5

### DIFF
--- a/flink-connectors/flink-file-sink-common/pom.xml
+++ b/flink-connectors/flink-file-sink-common/pom.xml
@@ -52,6 +52,12 @@ under the License.
 						<goals>
 							<goal>test-jar</goal>
 						</goals>
+						<configuration>
+							<excludes>
+								<!-- test-jar is still used by JUnit4 modules -->
+								<exclude>META-INF/services/org.junit.jupiter.api.extension.Extension</exclude>
+							</excludes>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/flink-connectors/flink-file-sink-common/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/OutputStreamBasedPartFileRecoverableMigrationTest.java
+++ b/flink-connectors/flink-file-sink-common/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/OutputStreamBasedPartFileRecoverableMigrationTest.java
@@ -30,39 +30,32 @@ import org.apache.flink.streaming.api.functions.sink.filesystem.OutputStreamBase
 import org.apache.flink.streaming.api.functions.sink.filesystem.OutputStreamBasedPartFileWriter.OutputStreamBasedInProgressFileRecoverableSerializer;
 import org.apache.flink.streaming.api.functions.sink.filesystem.OutputStreamBasedPartFileWriter.OutputStreamBasedPendingFileRecoverable;
 import org.apache.flink.streaming.api.functions.sink.filesystem.OutputStreamBasedPartFileWriter.OutputStreamBasedPendingFileRecoverableSerializer;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Assert;
-import org.junit.ClassRule;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.Collection;
-import java.util.Collections;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for the {@link OutputStreamBasedInProgressFileRecoverableSerializer} and the {@link
  * OutputStreamBasedPendingFileRecoverableSerializer}that verify we can still read the recoverable
  * serialized by the previous versions.
  */
-@RunWith(Parameterized.class)
-public class OutputStreamBasedPartFileRecoverableMigrationTest extends TestLogger {
+public class OutputStreamBasedPartFileRecoverableMigrationTest {
 
     private static final int CURRENT_VERSION = 1;
 
-    @Parameterized.Parameters(name = "Previous Version = {0}")
-    public static Collection<Integer> previousVersions() {
-        return Collections.singletonList(1);
+    static Stream<Integer> previousVersions() {
+        return Stream.of(1);
     }
-
-    @Parameterized.Parameter public Integer previousVersion;
 
     private static final String IN_PROGRESS_CONTENT = "writing";
     private static final String PENDING_CONTENT = "wrote";
@@ -70,11 +63,9 @@ public class OutputStreamBasedPartFileRecoverableMigrationTest extends TestLogge
     private static final java.nio.file.Path BASE_PATH =
             Paths.get("src/test/resources/").resolve("recoverable-serializer-migration");
 
-    @ClassRule public static TemporaryFolder tempFolder = new TemporaryFolder();
-
     @Test
-    @Ignore
-    public void prepareDeserializationInProgress() throws IOException {
+    @Disabled
+    void prepareDeserializationInProgress() throws IOException {
         String scenario = "in-progress";
         java.nio.file.Path path = resolveVersionPath(CURRENT_VERSION, scenario);
 
@@ -94,8 +85,9 @@ public class OutputStreamBasedPartFileRecoverableMigrationTest extends TestLogge
         Files.write(path.resolve("recoverable"), bytes);
     }
 
-    @Test
-    public void testSerializationInProgress() throws IOException {
+    @ParameterizedTest(name = "Previous Version = {0}")
+    @MethodSource("previousVersions")
+    void testSerializationInProgress(int previousVersion) throws IOException {
         String scenario = "in-progress";
         java.nio.file.Path path = resolveVersionPath(previousVersion, scenario);
 
@@ -108,15 +100,15 @@ public class OutputStreamBasedPartFileRecoverableMigrationTest extends TestLogge
                 serializer.deserialize(
                         previousVersion, Files.readAllBytes(path.resolve("recoverable")));
 
-        Assert.assertTrue(recoverable instanceof OutputStreamBasedInProgressFileRecoverable);
+        assertThat(recoverable).isInstanceOf(OutputStreamBasedInProgressFileRecoverable.class);
         // make sure the ResumeRecoverable is valid
         writer.recover(
                 ((OutputStreamBasedInProgressFileRecoverable) recoverable).getResumeRecoverable());
     }
 
     @Test
-    @Ignore
-    public void prepareDeserializationPending() throws IOException {
+    @Disabled
+    void prepareDeserializationPending() throws IOException {
         String scenario = "pending";
         java.nio.file.Path path = resolveVersionPath(CURRENT_VERSION, scenario);
 
@@ -136,8 +128,9 @@ public class OutputStreamBasedPartFileRecoverableMigrationTest extends TestLogge
         Files.write(path.resolve("recoverable"), bytes);
     }
 
-    @Test
-    public void testSerializationPending() throws IOException {
+    @ParameterizedTest(name = "Previous Version = {0}")
+    @MethodSource("previousVersions")
+    void testSerializationPending(int previousVersion) throws IOException {
         String scenario = "pending";
         java.nio.file.Path path = resolveVersionPath(previousVersion, scenario);
 
@@ -150,7 +143,7 @@ public class OutputStreamBasedPartFileRecoverableMigrationTest extends TestLogge
                 serializer.deserialize(
                         previousVersion, Files.readAllBytes(path.resolve("recoverable")));
 
-        Assert.assertTrue(recoverable instanceof OutputStreamBasedPendingFileRecoverable);
+        assertThat(recoverable).isInstanceOf(OutputStreamBasedPendingFileRecoverable.class);
         // make sure the CommitRecoverable is valid
         writer.recoverForCommit(
                 ((OutputStreamBasedPendingFileRecoverable) recoverable).getCommitRecoverable());

--- a/flink-connectors/flink-file-sink-common/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/bucketassigners/DateTimeBucketAssignerTest.java
+++ b/flink-connectors/flink-file-sink-common/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/bucketassigners/DateTimeBucketAssignerTest.java
@@ -20,34 +20,34 @@ package org.apache.flink.streaming.api.functions.sink.filesystem.bucketassigners
 
 import org.apache.flink.streaming.api.functions.sink.filesystem.BucketAssigner;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
 
 import java.time.ZoneId;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link DateTimeBucketAssigner}. */
-public class DateTimeBucketAssignerTest {
+class DateTimeBucketAssignerTest {
     private static final long TEST_TIME_IN_MILLIS = 1533363082011L;
 
     private static final MockedContext mockedContext = new MockedContext();
 
     @Test
-    public void testGetBucketPathWithSpecifiedTimezone() {
+    void testGetBucketPathWithSpecifiedTimezone() {
         DateTimeBucketAssigner bucketAssigner =
                 new DateTimeBucketAssigner(ZoneId.of("America/Los_Angeles"));
 
-        assertEquals("2018-08-03--23", bucketAssigner.getBucketId(null, mockedContext));
+        assertThat(bucketAssigner.getBucketId(null, mockedContext)).isEqualTo("2018-08-03--23");
     }
 
     @Test
-    public void testGetBucketPathWithSpecifiedFormatString() {
+    void testGetBucketPathWithSpecifiedFormatString() {
         DateTimeBucketAssigner bucketAssigner =
                 new DateTimeBucketAssigner("yyyy-MM-dd-HH", ZoneId.of("America/Los_Angeles"));
 
-        assertEquals("2018-08-03-23", bucketAssigner.getBucketId(null, mockedContext));
+        assertThat(bucketAssigner.getBucketId(null, mockedContext)).isEqualTo("2018-08-03-23");
     }
 
     private static class MockedContext implements BucketAssigner.Context {

--- a/flink-connectors/flink-file-sink-common/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/flink-connectors/flink-file-sink-common/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.util.TestLoggerExtension


### PR DESCRIPTION
## What is the purpose of the change

Update the flink-file-sink-common module to AssertJ and JUnit 5 following the [JUnit 5 Migration Guide](https://docs.google.com/document/d/1514Wa_aNB9bJUen4xm5uiuXOooOJTtXqS_Jqk9KJitU/edit)


## Brief change log

Use JUnit5 and AssertJ in tests instead of JUnit4 and Hamcrest


## Verifying this change

This change is a code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no )
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? (no )
  - If yes, how is the feature documented? (not applicable)
