### PR TITLE
[FLINK-24433][Connector][Elasticsearch] Disable Elasticsearch disk allocation decider

### DIFF
--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-elasticsearch/src/main/java/org/apache/flink/streaming/tests/ElasticsearchSinkE2ECaseBase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-elasticsearch/src/main/java/org/apache/flink/streaming/tests/ElasticsearchSinkE2ECaseBase.java
@@ -65,6 +65,9 @@ public abstract class ElasticsearchSinkE2ECaseBase<T extends Comparable<T>>
                     .fromContainer(
                             new ElasticsearchContainer(
                                             DockerImageName.parse(getElasticsearchContainerName()))
+                                    .withEnv(
+                                            "cluster.routing.allocation.disk.threshold_enabled",
+                                            "false")
                                     .withNetworkAliases(ELASTICSEARCH_HOSTNAME))
                     .bindWithFlinkContainer(flink.getFlinkContainers().getJobManager())
                     .build();


### PR DESCRIPTION
## What is the purpose of the change

* Disable Elasticsearch disk allocation decider. Elasticsearch by default goes into read-only mode when the disk usage is above 85%. On the Azure E2E tests, this is quite common.

We therefore disable the entire disk allocation decider, as documented on https://www.elastic.co/guide/en/elasticsearch/reference/6.2/disk-allocator.html

## Brief change log

* Disable Elasticsearch disk allocation decider by passing through the right config flag.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
