### PR TITLE
[FLINK-27340][tests] Migrate module flink-python to JUnit5

### DIFF
--- a/flink-python/src/test/java/org/apache/flink/client/cli/PythonProgramOptionsITCase.java
+++ b/flink-python/src/test/java/org/apache/flink/client/cli/PythonProgramOptionsITCase.java
@@ -22,7 +22,7 @@ import org.apache.flink.client.program.PackagedProgram;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.python.PythonOptions;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -35,11 +35,10 @@ import java.nio.file.attribute.BasicFileAttributes;
 
 import static org.apache.flink.python.PythonOptions.PYTHON_EXECUTABLE;
 import static org.apache.flink.python.PythonOptions.PYTHON_REQUIREMENTS;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** ITCases for {@link PythonProgramOptions}. */
-public class PythonProgramOptionsITCase {
+class PythonProgramOptionsITCase {
 
     /**
      * It requires setting a job jar to build a {@link PackagedProgram}, and the dummy job jar used
@@ -47,7 +46,7 @@ public class PythonProgramOptionsITCase {
      * ITCase.
      */
     @Test
-    public void testConfigurePythonExecution() throws Exception {
+    void testConfigurePythonExecution() throws Exception {
         final String[] args = {
             "--python", "xxx.py",
             "--pyModule", "xxx",
@@ -79,15 +78,13 @@ public class PythonProgramOptionsITCase {
         Configuration configuration = new Configuration();
         ProgramOptionsUtils.configurePythonExecution(configuration, packagedProgram);
 
-        assertEquals(
-                "/absolute/a.py,relative/b.py,relative/c.py",
-                configuration.get(PythonOptions.PYTHON_FILES));
-        assertEquals("d.txt#e_dir", configuration.get(PYTHON_REQUIREMENTS));
-        assertEquals(
-                "g.zip,h.zip#data,h.zip#data2", configuration.get(PythonOptions.PYTHON_ARCHIVES));
-        assertEquals("/usr/bin/python", configuration.get(PYTHON_EXECUTABLE));
-        assertArrayEquals(
-                new String[] {"--python", "xxx.py", "--pyModule", "xxx", "userarg1", "userarg2"},
-                packagedProgram.getArguments());
+        assertThat(configuration.get(PythonOptions.PYTHON_FILES))
+                .isEqualTo("/absolute/a.py,relative/b.py,relative/c.py");
+        assertThat(configuration.get(PYTHON_REQUIREMENTS)).isEqualTo("d.txt#e_dir");
+        assertThat(configuration.get(PythonOptions.PYTHON_ARCHIVES))
+                .isEqualTo("g.zip,h.zip#data,h.zip#data2");
+        assertThat(configuration.get(PYTHON_EXECUTABLE)).isEqualTo("/usr/bin/python");
+        assertThat(packagedProgram.getArguments())
+                .containsExactly("--python", "xxx.py", "--pyModule", "xxx", "userarg1", "userarg2");
     }
 }

--- a/flink-python/src/test/java/org/apache/flink/client/cli/PythonProgramOptionsTest.java
+++ b/flink-python/src/test/java/org/apache/flink/client/cli/PythonProgramOptionsTest.java
@@ -23,8 +23,8 @@ import org.apache.flink.python.PythonOptions;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.flink.client.cli.CliFrontendParser.PYARCHIVE_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.PYEXEC_OPTION;
@@ -34,15 +34,14 @@ import static org.apache.flink.client.cli.CliFrontendParser.PYREQUIREMENTS_OPTIO
 import static org.apache.flink.client.cli.CliFrontendParser.PY_OPTION;
 import static org.apache.flink.python.PythonOptions.PYTHON_EXECUTABLE;
 import static org.apache.flink.python.PythonOptions.PYTHON_REQUIREMENTS;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link PythonProgramOptions}. */
-public class PythonProgramOptionsTest {
+class PythonProgramOptionsTest {
     private Options options;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         options = new Options();
         options.addOption(PY_OPTION);
         options.addOption(PYFILES_OPTION);
@@ -53,7 +52,7 @@ public class PythonProgramOptionsTest {
     }
 
     @Test
-    public void testCreateProgramOptionsWithPythonCommandLine() throws CliArgsException {
+    void testCreateProgramOptionsWithPythonCommandLine() throws CliArgsException {
         String[] parameters = {
             "-py", "test.py",
             "-pym", "test",
@@ -68,18 +67,18 @@ public class PythonProgramOptionsTest {
         PythonProgramOptions programOptions = (PythonProgramOptions) ProgramOptions.create(line);
         Configuration config = new Configuration();
         programOptions.applyToConfiguration(config);
-        assertEquals(
-                "test1.py,test2.zip,test3.egg,test4_dir", config.get(PythonOptions.PYTHON_FILES));
-        assertEquals("a.txt#b_dir", config.get(PYTHON_REQUIREMENTS));
-        assertEquals("c.zip#venv,d.zip", config.get(PythonOptions.PYTHON_ARCHIVES));
-        assertEquals("bin/python", config.get(PYTHON_EXECUTABLE));
-        assertArrayEquals(
-                new String[] {"--python", "test.py", "--pyModule", "test", "userarg1", "userarg2"},
-                programOptions.getProgramArgs());
+        assertThat(config.get(PythonOptions.PYTHON_FILES))
+                .isEqualTo("test1.py,test2.zip,test3.egg,test4_dir");
+        assertThat(config.get(PYTHON_REQUIREMENTS)).isEqualTo("a.txt#b_dir");
+        assertThat(config.get(PythonOptions.PYTHON_ARCHIVES)).isEqualTo("c.zip#venv,d.zip");
+        assertThat(config.get(PYTHON_EXECUTABLE)).isEqualTo("bin/python");
+        assertThat(programOptions.getProgramArgs())
+                .containsExactly(
+                        "--python", "test.py", "--pyModule", "test", "userarg1", "userarg2");
     }
 
     @Test
-    public void testCreateProgramOptionsWithLongOptions() throws CliArgsException {
+    void testCreateProgramOptionsWithLongOptions() throws CliArgsException {
         String[] args = {
             "--python", "xxx.py",
             "--pyModule", "xxx",
@@ -93,14 +92,13 @@ public class PythonProgramOptionsTest {
         PythonProgramOptions programOptions = (PythonProgramOptions) ProgramOptions.create(line);
         Configuration config = new Configuration();
         programOptions.applyToConfiguration(config);
-        assertEquals(
-                "/absolute/a.py,relative/b.py,relative/c.py",
-                config.get(PythonOptions.PYTHON_FILES));
-        assertEquals("d.txt#e_dir", config.get(PYTHON_REQUIREMENTS));
-        assertEquals("g.zip,h.zip#data,h.zip#data2", config.get(PythonOptions.PYTHON_ARCHIVES));
-        assertEquals("/usr/bin/python", config.get(PYTHON_EXECUTABLE));
-        assertArrayEquals(
-                new String[] {"--python", "xxx.py", "--pyModule", "xxx", "userarg1", "userarg2"},
-                programOptions.getProgramArgs());
+        assertThat(config.get(PythonOptions.PYTHON_FILES))
+                .isEqualTo("/absolute/a.py,relative/b.py,relative/c.py");
+        assertThat(config.get(PYTHON_REQUIREMENTS)).isEqualTo("d.txt#e_dir");
+        assertThat(config.get(PythonOptions.PYTHON_ARCHIVES))
+                .isEqualTo("g.zip,h.zip#data,h.zip#data2");
+        assertThat(config.get(PYTHON_EXECUTABLE)).isEqualTo("/usr/bin/python");
+        assertThat(programOptions.getProgramArgs())
+                .containsExactly("--python", "xxx.py", "--pyModule", "xxx", "userarg1", "userarg2");
     }
 }

--- a/flink-python/src/test/java/org/apache/flink/client/python/PythonDriverOptionsParserFactoryTest.java
+++ b/flink-python/src/test/java/org/apache/flink/client/python/PythonDriverOptionsParserFactoryTest.java
@@ -21,61 +21,64 @@ package org.apache.flink.client.python;
 import org.apache.flink.runtime.entrypoint.FlinkParseException;
 import org.apache.flink.runtime.entrypoint.parser.CommandLineParser;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for the {@link PythonDriverOptionsParserFactory}. */
-public class PythonDriverOptionsParserFactoryTest {
+class PythonDriverOptionsParserFactoryTest {
 
     private static final CommandLineParser<PythonDriverOptions> commandLineParser =
             new CommandLineParser<>(new PythonDriverOptionsParserFactory());
 
     @Test
-    public void testPythonDriverOptionsParsing() throws FlinkParseException {
+    void testPythonDriverOptionsParsing() throws FlinkParseException {
         final String[] args = {"--python", "xxx.py", "--input", "in.txt"};
         verifyPythonDriverOptionsParsing(args);
     }
 
     @Test
-    public void testPymoduleOptionParsing() throws FlinkParseException {
+    void testPymoduleOptionParsing() throws FlinkParseException {
         final String[] args = {"--pyModule", "xxx", "--input", "in.txt"};
         verifyPythonDriverOptionsParsing(args);
     }
 
     @Test
-    public void testShortOptions() throws FlinkParseException {
+    void testShortOptions() throws FlinkParseException {
         final String[] args = {"-py", "xxx.py", "--input", "in.txt"};
         verifyPythonDriverOptionsParsing(args);
     }
 
-    @Test(expected = FlinkParseException.class)
-    public void testMultipleEntrypointsSpecified() throws FlinkParseException {
+    @Test
+    void testMultipleEntrypointsSpecified() {
         final String[] args = {"--python", "xxx.py", "--pyModule", "yyy", "--input", "in.txt"};
-        commandLineParser.parse(args);
+        assertThatThrownBy(() -> commandLineParser.parse(args))
+                .isInstanceOf(FlinkParseException.class);
     }
 
-    @Test(expected = FlinkParseException.class)
-    public void testEntrypointNotSpecified() throws FlinkParseException {
+    @Test
+    void testEntrypointNotSpecified() {
         final String[] args = {"--input", "in.txt"};
-        commandLineParser.parse(args);
+        assertThatThrownBy(() -> commandLineParser.parse(args))
+                .isInstanceOf(FlinkParseException.class);
     }
 
     private void verifyPythonDriverOptionsParsing(final String[] args) throws FlinkParseException {
         final PythonDriverOptions pythonCommandOptions = commandLineParser.parse(args);
 
         if (pythonCommandOptions.getEntryPointScript().isPresent()) {
-            assertEquals("xxx.py", pythonCommandOptions.getEntryPointScript().get());
+            assertThat(pythonCommandOptions.getEntryPointScript().get()).isEqualTo("xxx.py");
         } else {
-            assertEquals("xxx", pythonCommandOptions.getEntryPointModule());
+            assertThat(pythonCommandOptions.getEntryPointModule()).isEqualTo("xxx");
         }
 
         // verify the python program arguments
         final List<String> programArgs = pythonCommandOptions.getProgramArgs();
-        assertEquals(2, programArgs.size());
-        assertEquals("--input", programArgs.get(0));
-        assertEquals("in.txt", programArgs.get(1));
+        assertThat(programArgs).hasSize(2);
+        assertThat(programArgs.get(0)).isEqualTo("--input");
+        assertThat(programArgs.get(1)).isEqualTo("in.txt");
     }
 }

--- a/flink-python/src/test/java/org/apache/flink/client/python/PythonDriverOptionsParserFactoryTest.java
+++ b/flink-python/src/test/java/org/apache/flink/client/python/PythonDriverOptionsParserFactoryTest.java
@@ -77,8 +77,6 @@ class PythonDriverOptionsParserFactoryTest {
 
         // verify the python program arguments
         final List<String> programArgs = pythonCommandOptions.getProgramArgs();
-        assertThat(programArgs).hasSize(2);
-        assertThat(programArgs.get(0)).isEqualTo("--input");
-        assertThat(programArgs.get(1)).isEqualTo("in.txt");
+        assertThat(programArgs).containsExactly("--input", "in.txt");
     }
 }

--- a/flink-python/src/test/java/org/apache/flink/client/python/PythonDriverTest.java
+++ b/flink-python/src/test/java/org/apache/flink/client/python/PythonDriverTest.java
@@ -18,8 +18,7 @@
 
 package org.apache.flink.client.python;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import py4j.GatewayServer;
 
 import java.io.IOException;
@@ -28,10 +27,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /** Tests for the {@link PythonDriver}. */
-public class PythonDriverTest {
+class PythonDriverTest {
     @Test
-    public void testStartGatewayServer() throws ExecutionException, InterruptedException {
+    void testStartGatewayServer() throws ExecutionException, InterruptedException {
         GatewayServer gatewayServer = PythonEnvUtils.startGatewayServer();
         try {
             Socket socket = new Socket("localhost", gatewayServer.getListeningPort());
@@ -44,7 +45,7 @@ public class PythonDriverTest {
     }
 
     @Test
-    public void testConstructCommandsWithEntryPointModule() {
+    void testConstructCommandsWithEntryPointModule() {
         List<String> args = new ArrayList<>();
         args.add("--input");
         args.add("in.txt");
@@ -52,25 +53,25 @@ public class PythonDriverTest {
         PythonDriverOptions pythonDriverOptions = new PythonDriverOptions("xxx", null, args);
         List<String> commands = PythonDriver.constructPythonCommands(pythonDriverOptions);
         // verify the generated commands
-        Assert.assertEquals(4, commands.size());
-        Assert.assertEquals(commands.get(0), "-m");
-        Assert.assertEquals(commands.get(1), "xxx");
-        Assert.assertEquals(commands.get(2), "--input");
-        Assert.assertEquals(commands.get(3), "in.txt");
+        assertThat(commands).hasSize(4);
+        assertThat(commands.get(0)).isEqualTo("-m");
+        assertThat(commands.get(1)).isEqualTo("xxx");
+        assertThat(commands.get(2)).isEqualTo("--input");
+        assertThat(commands.get(3)).isEqualTo("in.txt");
     }
 
     @Test
-    public void testConstructCommandsWithEntryPointScript() {
+    void testConstructCommandsWithEntryPointScript() {
         List<String> args = new ArrayList<>();
         args.add("--input");
         args.add("in.txt");
 
         PythonDriverOptions pythonDriverOptions = new PythonDriverOptions(null, "xxx.py", args);
         List<String> commands = PythonDriver.constructPythonCommands(pythonDriverOptions);
-        Assert.assertEquals(4, commands.size());
-        Assert.assertEquals(commands.get(0), "-m");
-        Assert.assertEquals(commands.get(1), "xxx");
-        Assert.assertEquals(commands.get(2), "--input");
-        Assert.assertEquals(commands.get(3), "in.txt");
+        assertThat(commands).hasSize(4);
+        assertThat(commands.get(0)).isEqualTo("-m");
+        assertThat(commands.get(1)).isEqualTo("xxx");
+        assertThat(commands.get(2)).isEqualTo("--input");
+        assertThat(commands.get(3)).isEqualTo("in.txt");
     }
 }

--- a/flink-python/src/test/java/org/apache/flink/client/python/PythonDriverTest.java
+++ b/flink-python/src/test/java/org/apache/flink/client/python/PythonDriverTest.java
@@ -53,11 +53,7 @@ class PythonDriverTest {
         PythonDriverOptions pythonDriverOptions = new PythonDriverOptions("xxx", null, args);
         List<String> commands = PythonDriver.constructPythonCommands(pythonDriverOptions);
         // verify the generated commands
-        assertThat(commands).hasSize(4);
-        assertThat(commands.get(0)).isEqualTo("-m");
-        assertThat(commands.get(1)).isEqualTo("xxx");
-        assertThat(commands.get(2)).isEqualTo("--input");
-        assertThat(commands.get(3)).isEqualTo("in.txt");
+        assertThat(commands).containsExactly("-m", "xxx", "--input", "in.txt");
     }
 
     @Test

--- a/flink-python/src/test/java/org/apache/flink/client/python/PythonDriverTest.java
+++ b/flink-python/src/test/java/org/apache/flink/client/python/PythonDriverTest.java
@@ -64,10 +64,6 @@ class PythonDriverTest {
 
         PythonDriverOptions pythonDriverOptions = new PythonDriverOptions(null, "xxx.py", args);
         List<String> commands = PythonDriver.constructPythonCommands(pythonDriverOptions);
-        assertThat(commands).hasSize(4);
-        assertThat(commands.get(0)).isEqualTo("-m");
-        assertThat(commands.get(1)).isEqualTo("xxx");
-        assertThat(commands.get(2)).isEqualTo("--input");
-        assertThat(commands.get(3)).isEqualTo("in.txt");
+        assertThat(commands).containsExactly("-m", "xxx", "--input", "in.txt");
     }
 }

--- a/flink-python/src/test/java/org/apache/flink/client/python/PythonShellParserTest.java
+++ b/flink-python/src/test/java/org/apache/flink/client/python/PythonShellParserTest.java
@@ -18,44 +18,45 @@
 
 package org.apache.flink.client.python;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /** Tests for the {@link PythonShellParser}. */
-public class PythonShellParserTest {
+class PythonShellParserTest {
     @Test
-    public void testParseLocalWithoutOptions() {
+    void testParseLocalWithoutOptions() {
         String[] args = {"local"};
         List<String> commandOptions = PythonShellParser.parseLocal(args);
         String[] expectedCommandOptions = {"local"};
-        Assert.assertArrayEquals(expectedCommandOptions, commandOptions.toArray());
+        assertThat(commandOptions.toArray()).isEqualTo(expectedCommandOptions);
     }
 
     @Test
-    public void testParseRemoteWithoutOptions() {
+    void testParseRemoteWithoutOptions() {
         String[] args = {"remote", "localhost", "8081"};
         List<String> commandOptions = PythonShellParser.parseRemote(args);
         String[] expectedCommandOptions = {"remote", "-m", "localhost:8081"};
-        Assert.assertArrayEquals(expectedCommandOptions, commandOptions.toArray());
+        assertThat(commandOptions.toArray()).isEqualTo(expectedCommandOptions);
     }
 
     @Test
-    public void testParseYarnWithoutOptions() {
+    void testParseYarnWithoutOptions() {
         String[] args = {"yarn"};
         List<String> commandOptions = PythonShellParser.parseYarn(args);
         String[] expectedCommandOptions = {"yarn", "-m", "yarn-cluster"};
-        Assert.assertArrayEquals(expectedCommandOptions, commandOptions.toArray());
+        assertThat(commandOptions.toArray()).isEqualTo(expectedCommandOptions);
     }
 
     @Test
-    public void testParseYarnWithOptions() {
+    void testParseYarnWithOptions() {
         String[] args = {"yarn", "-jm", "1024m", "-tm", "4096m"};
         List<String> commandOptions = PythonShellParser.parseYarn(args);
         String[] expectedCommandOptions = {
             "yarn", "-m", "yarn-cluster", "-yjm", "1024m", "-ytm", "4096m"
         };
-        Assert.assertArrayEquals(expectedCommandOptions, commandOptions.toArray());
+        assertThat(commandOptions.toArray()).isEqualTo(expectedCommandOptions);
     }
 }

--- a/flink-python/src/test/java/org/apache/flink/python/PythonOptionsTest.java
+++ b/flink-python/src/test/java/org/apache/flink/python/PythonOptionsTest.java
@@ -20,162 +20,156 @@ package org.apache.flink.python;
 
 import org.apache.flink.configuration.Configuration;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test all configurations can be set using configuration. */
-public class PythonOptionsTest {
+class PythonOptionsTest {
 
     @Test
-    public void testBundleSize() {
+    void testBundleSize() {
         final Configuration configuration = new Configuration();
         final int defaultBundleSize = configuration.getInteger(PythonOptions.MAX_BUNDLE_SIZE);
-        assertThat(defaultBundleSize, is(equalTo(PythonOptions.MAX_BUNDLE_SIZE.defaultValue())));
+        assertThat(defaultBundleSize).isEqualTo(PythonOptions.MAX_BUNDLE_SIZE.defaultValue());
 
         final int expectedBundleSize = 100;
         configuration.setInteger(PythonOptions.MAX_BUNDLE_SIZE, expectedBundleSize);
 
         final int actualBundleSize = configuration.getInteger(PythonOptions.MAX_BUNDLE_SIZE);
-        assertThat(actualBundleSize, is(equalTo(expectedBundleSize)));
+        assertThat(actualBundleSize).isEqualTo(expectedBundleSize);
     }
 
     @Test
-    public void testBundleTime() {
+    void testBundleTime() {
         final Configuration configuration = new Configuration();
         final long defaultBundleTime = configuration.getLong(PythonOptions.MAX_BUNDLE_TIME_MILLS);
-        assertThat(
-                defaultBundleTime, is(equalTo(PythonOptions.MAX_BUNDLE_TIME_MILLS.defaultValue())));
+        assertThat(defaultBundleTime).isEqualTo(PythonOptions.MAX_BUNDLE_TIME_MILLS.defaultValue());
 
         final long expectedBundleTime = 100;
         configuration.setLong(PythonOptions.MAX_BUNDLE_TIME_MILLS, expectedBundleTime);
 
         final long actualBundleSize = configuration.getLong(PythonOptions.MAX_BUNDLE_TIME_MILLS);
-        assertThat(actualBundleSize, is(equalTo(expectedBundleTime)));
+        assertThat(actualBundleSize).isEqualTo(expectedBundleTime);
     }
 
     @Test
-    public void testArrowBatchSize() {
+    void testArrowBatchSize() {
         final Configuration configuration = new Configuration();
         final int defaultArrowBatchSize =
                 configuration.getInteger(PythonOptions.MAX_ARROW_BATCH_SIZE);
-        assertThat(
-                defaultArrowBatchSize,
-                is(equalTo(PythonOptions.MAX_ARROW_BATCH_SIZE.defaultValue())));
+        assertThat(defaultArrowBatchSize)
+                .isEqualTo(PythonOptions.MAX_ARROW_BATCH_SIZE.defaultValue());
 
         final int expectedArrowBatchSize = 100;
         configuration.setInteger(PythonOptions.MAX_ARROW_BATCH_SIZE, expectedArrowBatchSize);
 
         final int actualArrowBatchSize =
                 configuration.getInteger(PythonOptions.MAX_ARROW_BATCH_SIZE);
-        assertThat(actualArrowBatchSize, is(equalTo(expectedArrowBatchSize)));
+        assertThat(actualArrowBatchSize).isEqualTo(expectedArrowBatchSize);
     }
 
     @Test
-    public void testPythonMetricEnabled() {
+    void testPythonMetricEnabled() {
         final Configuration configuration = new Configuration();
         final boolean isMetricEnabled =
                 configuration.getBoolean(PythonOptions.PYTHON_METRIC_ENABLED);
-        assertThat(
-                isMetricEnabled, is(equalTo(PythonOptions.PYTHON_METRIC_ENABLED.defaultValue())));
+        assertThat(isMetricEnabled).isEqualTo(PythonOptions.PYTHON_METRIC_ENABLED.defaultValue());
 
         final boolean expectedIsMetricEnabled = false;
         configuration.setBoolean(PythonOptions.PYTHON_METRIC_ENABLED, false);
 
         final boolean actualIsMetricEnabled =
                 configuration.getBoolean(PythonOptions.PYTHON_METRIC_ENABLED);
-        assertThat(actualIsMetricEnabled, is(equalTo(expectedIsMetricEnabled)));
+        assertThat(actualIsMetricEnabled).isEqualTo(expectedIsMetricEnabled);
     }
 
     @Test
-    public void testPythonProfileEnabled() {
+    void testPythonProfileEnabled() {
         final Configuration configuration = new Configuration();
         final boolean isProfileEnabled =
                 configuration.getBoolean(PythonOptions.PYTHON_PROFILE_ENABLED);
-        assertThat(
-                isProfileEnabled, is(equalTo(PythonOptions.PYTHON_PROFILE_ENABLED.defaultValue())));
+        assertThat(isProfileEnabled).isEqualTo(PythonOptions.PYTHON_PROFILE_ENABLED.defaultValue());
 
         final boolean expectedIsProfileEnabled = true;
         configuration.setBoolean(PythonOptions.PYTHON_PROFILE_ENABLED, true);
 
         final boolean actualIsProfileEnabled =
                 configuration.getBoolean(PythonOptions.PYTHON_PROFILE_ENABLED);
-        assertThat(actualIsProfileEnabled, is(equalTo(expectedIsProfileEnabled)));
+        assertThat(actualIsProfileEnabled).isEqualTo(expectedIsProfileEnabled);
     }
 
     @Test
-    public void testPythonFiles() {
+    void testPythonFiles() {
         final Configuration configuration = new Configuration();
         final Optional<String> defaultPythonFiles =
                 configuration.getOptional(PythonOptions.PYTHON_FILES);
-        assertThat(defaultPythonFiles, is(equalTo(Optional.empty())));
+        assertThat(defaultPythonFiles).isEmpty();
 
         final String expectedPythonFiles = "tmp_dir/test1.py,tmp_dir/test2.py";
         configuration.set(PythonOptions.PYTHON_FILES, expectedPythonFiles);
 
         final String actualPythonFiles = configuration.get(PythonOptions.PYTHON_FILES);
-        assertThat(actualPythonFiles, is(equalTo(expectedPythonFiles)));
+        assertThat(actualPythonFiles).isEqualTo(expectedPythonFiles);
     }
 
     @Test
-    public void testPythonRequirements() {
+    void testPythonRequirements() {
         final Configuration configuration = new Configuration();
         final Optional<String> defaultPythonRequirements =
                 configuration.getOptional(PythonOptions.PYTHON_REQUIREMENTS);
-        assertThat(defaultPythonRequirements, is(equalTo(Optional.empty())));
+        assertThat(defaultPythonRequirements).isEmpty();
 
         final String expectedPythonRequirements = "tmp_dir/requirements.txt#tmp_dir/cache";
         configuration.set(PythonOptions.PYTHON_REQUIREMENTS, expectedPythonRequirements);
 
         final String actualPythonRequirements =
                 configuration.get(PythonOptions.PYTHON_REQUIREMENTS);
-        assertThat(actualPythonRequirements, is(equalTo(expectedPythonRequirements)));
+        assertThat(actualPythonRequirements).isEqualTo(expectedPythonRequirements);
     }
 
     @Test
-    public void testPythonArchives() {
+    void testPythonArchives() {
         final Configuration configuration = new Configuration();
         final Optional<String> defaultPythonArchives =
                 configuration.getOptional(PythonOptions.PYTHON_ARCHIVES);
-        assertThat(defaultPythonArchives, is(equalTo(Optional.empty())));
+        assertThat(defaultPythonArchives).isEmpty();
 
         final String expectedPythonArchives = "tmp_dir/py37.zip#venv,tmp_dir/data.zip";
         configuration.set(PythonOptions.PYTHON_ARCHIVES, expectedPythonArchives);
 
         final String actualPythonArchives = configuration.get(PythonOptions.PYTHON_ARCHIVES);
-        assertThat(actualPythonArchives, is(equalTo(expectedPythonArchives)));
+        assertThat(actualPythonArchives).isEqualTo(expectedPythonArchives);
     }
 
     @Test
-    public void testPythonExecutable() {
+    void testPythonExecutable() {
         final Configuration configuration = new Configuration();
         final Optional<String> defaultPythonExecutable =
                 configuration.getOptional(PythonOptions.PYTHON_EXECUTABLE);
-        assertThat(defaultPythonExecutable, is(equalTo(Optional.empty())));
+        assertThat(defaultPythonExecutable).isEmpty();
 
         final String expectedPythonExecutable = "venv/py37/bin/python";
         configuration.set(PythonOptions.PYTHON_EXECUTABLE, expectedPythonExecutable);
 
         final String actualPythonExecutable = configuration.get(PythonOptions.PYTHON_EXECUTABLE);
-        assertThat(actualPythonExecutable, is(equalTo(expectedPythonExecutable)));
+        assertThat(actualPythonExecutable).isEqualTo(expectedPythonExecutable);
     }
 
     @Test
-    public void testPythonClientExecutable() {
+    void testPythonClientExecutable() {
         final Configuration configuration = new Configuration();
         final Optional<String> defaultPythonClientExecutable =
                 configuration.getOptional(PythonOptions.PYTHON_CLIENT_EXECUTABLE);
-        assertThat(defaultPythonClientExecutable, is(equalTo(Optional.empty())));
+        assertThat(defaultPythonClientExecutable).isEmpty();
 
         final String expectedPythonClientExecutable = "tmp_dir/test1.py,tmp_dir/test2.py";
         configuration.set(PythonOptions.PYTHON_CLIENT_EXECUTABLE, expectedPythonClientExecutable);
 
         final String actualPythonClientExecutable =
                 configuration.get(PythonOptions.PYTHON_CLIENT_EXECUTABLE);
-        assertThat(actualPythonClientExecutable, is(equalTo(expectedPythonClientExecutable)));
+        assertThat(actualPythonClientExecutable).isEqualTo(expectedPythonClientExecutable);
     }
 }

--- a/flink-python/src/test/java/org/apache/flink/python/chain/PythonOperatorChainingOptimizerTest.java
+++ b/flink-python/src/test/java/org/apache/flink/python/chain/PythonOperatorChainingOptimizerTest.java
@@ -36,22 +36,19 @@ import org.apache.flink.streaming.api.transformations.OneInputTransformation;
 import org.apache.flink.streaming.api.transformations.SourceTransformation;
 import org.apache.flink.streaming.api.transformations.TwoInputTransformation;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 /** Tests for {@link PythonOperatorChainingOptimizer}. */
-public class PythonOperatorChainingOptimizerTest {
+class PythonOperatorChainingOptimizerTest {
 
     @Test
-    public void testChainedTransformationPropertiesCorrectlySet() {
+    void testChainedTransformationPropertiesCorrectlySet() {
         PythonKeyedProcessOperator<?> keyedProcessOperator =
                 createKeyedProcessOperator(
                         "f1", new RowTypeInfo(Types.INT(), Types.INT()), Types.STRING());
@@ -99,38 +96,41 @@ public class PythonOperatorChainingOptimizerTest {
 
         List<Transformation<?>> optimized =
                 PythonOperatorChainingOptimizer.optimize(transformations);
-        assertEquals(2, optimized.size());
+        assertThat(optimized).hasSize(2);
 
         OneInputTransformation<?, ?> chainedTransformation =
                 (OneInputTransformation<?, ?>) optimized.get(1);
-        assertEquals(2, chainedTransformation.getParallelism());
-        assertEquals(sourceTransformation.getOutputType(), chainedTransformation.getInputType());
-        assertEquals(processOperator.getProducedType(), chainedTransformation.getOutputType());
-        assertEquals(keyedProcessTransformation.getUid(), chainedTransformation.getUid());
-        assertEquals("group", chainedTransformation.getSlotSharingGroup().get().getName());
-        assertEquals("col", chainedTransformation.getCoLocationGroupKey());
-        assertEquals(64, chainedTransformation.getMaxParallelism());
-        assertEquals(500L, chainedTransformation.getBufferTimeout());
-        assertEquals(
-                15,
-                (int)
+        assertThat(chainedTransformation.getParallelism()).isEqualTo(2);
+        assertThat(sourceTransformation.getOutputType())
+                .isEqualTo(chainedTransformation.getInputType());
+        assertThat(processOperator.getProducedType())
+                .isEqualTo(chainedTransformation.getOutputType());
+        assertThat(keyedProcessTransformation.getUid()).isEqualTo(chainedTransformation.getUid());
+        assertThat(chainedTransformation.getSlotSharingGroup().get().getName()).isEqualTo("group");
+        assertThat(chainedTransformation.getCoLocationGroupKey()).isEqualTo("col");
+        assertThat(chainedTransformation.getMaxParallelism()).isEqualTo(64);
+        assertThat(chainedTransformation.getBufferTimeout()).isEqualTo(500L);
+        assertThat(
+                        (int)
+                                chainedTransformation
+                                        .getManagedMemoryOperatorScopeUseCaseWeights()
+                                        .getOrDefault(ManagedMemoryUseCase.OPERATOR, 0))
+                .isEqualTo(15);
+        assertThat(chainedTransformation.getOperatorFactory().getChainingStrategy())
+                .isEqualTo(ChainingStrategy.HEAD);
+        assertThat(
                         chainedTransformation
-                                .getManagedMemoryOperatorScopeUseCaseWeights()
-                                .getOrDefault(ManagedMemoryUseCase.OPERATOR, 0));
-        assertEquals(
-                ChainingStrategy.HEAD,
-                chainedTransformation.getOperatorFactory().getChainingStrategy());
-        assertTrue(
-                chainedTransformation
-                        .getManagedMemorySlotScopeUseCases()
-                        .contains(ManagedMemoryUseCase.PYTHON));
-        assertTrue(
-                chainedTransformation
-                        .getManagedMemorySlotScopeUseCases()
-                        .contains(ManagedMemoryUseCase.STATE_BACKEND));
+                                .getManagedMemorySlotScopeUseCases()
+                                .contains(ManagedMemoryUseCase.PYTHON))
+                .isTrue();
+        assertThat(
+                        chainedTransformation
+                                .getManagedMemorySlotScopeUseCases()
+                                .contains(ManagedMemoryUseCase.STATE_BACKEND))
+                .isTrue();
 
         OneInputStreamOperator<?, ?> chainedOperator = chainedTransformation.getOperator();
-        assertTrue(chainedOperator instanceof PythonKeyedProcessOperator);
+        assertThat(chainedOperator).isInstanceOf(PythonKeyedProcessOperator.class);
         validateChainedPythonFunctions(
                 ((PythonKeyedProcessOperator<?>) chainedOperator).getPythonFunctionInfo(),
                 "f2",
@@ -138,7 +138,7 @@ public class PythonOperatorChainingOptimizerTest {
     }
 
     @Test
-    public void testChainingMultipleOperators() {
+    void testChainingMultipleOperators() {
         PythonKeyedProcessOperator<?> keyedProcessOperator =
                 createKeyedProcessOperator(
                         "f1", new RowTypeInfo(Types.INT(), Types.INT()), Types.STRING());
@@ -178,15 +178,17 @@ public class PythonOperatorChainingOptimizerTest {
 
         List<Transformation<?>> optimized =
                 PythonOperatorChainingOptimizer.optimize(transformations);
-        assertEquals(2, optimized.size());
+        assertThat(optimized).hasSize(2);
 
         OneInputTransformation<?, ?> chainedTransformation =
                 (OneInputTransformation<?, ?>) optimized.get(1);
-        assertEquals(sourceTransformation.getOutputType(), chainedTransformation.getInputType());
-        assertEquals(processOperator2.getProducedType(), chainedTransformation.getOutputType());
+        assertThat(sourceTransformation.getOutputType())
+                .isEqualTo(chainedTransformation.getInputType());
+        assertThat(processOperator2.getProducedType())
+                .isEqualTo(chainedTransformation.getOutputType());
 
         OneInputStreamOperator<?, ?> chainedOperator = chainedTransformation.getOperator();
-        assertTrue(chainedOperator instanceof PythonKeyedProcessOperator);
+        assertThat(chainedOperator).isInstanceOf(PythonKeyedProcessOperator.class);
         validateChainedPythonFunctions(
                 ((PythonKeyedProcessOperator<?>) chainedOperator).getPythonFunctionInfo(),
                 "f3",
@@ -195,7 +197,7 @@ public class PythonOperatorChainingOptimizerTest {
     }
 
     @Test
-    public void testChainingNonKeyedOperators() {
+    void testChainingNonKeyedOperators() {
         PythonProcessOperator<?, ?> processOperator1 =
                 createProcessOperator(
                         "f1", new RowTypeInfo(Types.INT(), Types.INT()), Types.STRING());
@@ -225,15 +227,17 @@ public class PythonOperatorChainingOptimizerTest {
 
         List<Transformation<?>> optimized =
                 PythonOperatorChainingOptimizer.optimize(transformations);
-        assertEquals(2, optimized.size());
+        assertThat(optimized).hasSize(2);
 
         OneInputTransformation<?, ?> chainedTransformation =
                 (OneInputTransformation<?, ?>) optimized.get(1);
-        assertEquals(sourceTransformation.getOutputType(), chainedTransformation.getInputType());
-        assertEquals(processOperator2.getProducedType(), chainedTransformation.getOutputType());
+        assertThat(sourceTransformation.getOutputType())
+                .isEqualTo(chainedTransformation.getInputType());
+        assertThat(processOperator2.getProducedType())
+                .isEqualTo(chainedTransformation.getOutputType());
 
         OneInputStreamOperator<?, ?> chainedOperator = chainedTransformation.getOperator();
-        assertTrue(chainedOperator instanceof PythonProcessOperator);
+        assertThat(chainedOperator).isInstanceOf(PythonProcessOperator.class);
         validateChainedPythonFunctions(
                 ((PythonProcessOperator<?, ?>) chainedOperator).getPythonFunctionInfo(),
                 "f2",
@@ -241,7 +245,7 @@ public class PythonOperatorChainingOptimizerTest {
     }
 
     @Test
-    public void testContinuousKeyedOperators() {
+    void testContinuousKeyedOperators() {
         PythonKeyedProcessOperator<?> keyedProcessOperator1 =
                 createKeyedProcessOperator(
                         "f1",
@@ -274,14 +278,14 @@ public class PythonOperatorChainingOptimizerTest {
 
         List<Transformation<?>> optimized =
                 PythonOperatorChainingOptimizer.optimize(transformations);
-        assertEquals(3, optimized.size());
+        assertThat(optimized).hasSize(3);
 
-        assertEquals(processTransformation1, optimized.get(1));
-        assertEquals(processTransformation2, optimized.get(2));
+        assertThat(optimized.get(1)).isEqualTo(processTransformation1);
+        assertThat(optimized.get(2)).isEqualTo(processTransformation2);
     }
 
     @Test
-    public void testMultipleChainedOperators() {
+    void testMultipleChainedOperators() {
         PythonKeyedProcessOperator<?> keyedProcessOperator1 =
                 createKeyedProcessOperator(
                         "f1", new RowTypeInfo(Types.INT(), Types.INT()), Types.STRING());
@@ -347,20 +351,24 @@ public class PythonOperatorChainingOptimizerTest {
 
         List<Transformation<?>> optimized =
                 PythonOperatorChainingOptimizer.optimize(transformations);
-        assertEquals(3, optimized.size());
+        assertThat(optimized).hasSize(3);
 
         OneInputTransformation<?, ?> chainedTransformation1 =
                 (OneInputTransformation<?, ?>) optimized.get(1);
-        assertEquals(sourceTransformation.getOutputType(), chainedTransformation1.getInputType());
-        assertEquals(processOperator2.getProducedType(), chainedTransformation1.getOutputType());
+        assertThat(sourceTransformation.getOutputType())
+                .isEqualTo(chainedTransformation1.getInputType());
+        assertThat(processOperator2.getProducedType())
+                .isEqualTo(chainedTransformation1.getOutputType());
 
         OneInputTransformation<?, ?> chainedTransformation2 =
                 (OneInputTransformation<?, ?>) optimized.get(2);
-        assertEquals(processOperator2.getProducedType(), chainedTransformation2.getInputType());
-        assertEquals(processOperator3.getProducedType(), chainedTransformation2.getOutputType());
+        assertThat(processOperator2.getProducedType())
+                .isEqualTo(chainedTransformation2.getInputType());
+        assertThat(processOperator3.getProducedType())
+                .isEqualTo(chainedTransformation2.getOutputType());
 
         OneInputStreamOperator<?, ?> chainedOperator1 = chainedTransformation1.getOperator();
-        assertTrue(chainedOperator1 instanceof PythonKeyedProcessOperator);
+        assertThat(chainedOperator1).isInstanceOf(PythonKeyedProcessOperator.class);
         validateChainedPythonFunctions(
                 ((PythonKeyedProcessOperator<?>) chainedOperator1).getPythonFunctionInfo(),
                 "f3",
@@ -368,7 +376,7 @@ public class PythonOperatorChainingOptimizerTest {
                 "f1");
 
         OneInputStreamOperator<?, ?> chainedOperator2 = chainedTransformation2.getOperator();
-        assertTrue(chainedOperator2 instanceof PythonKeyedProcessOperator);
+        assertThat(chainedOperator2).isInstanceOf(PythonKeyedProcessOperator.class);
         validateChainedPythonFunctions(
                 ((PythonKeyedProcessOperator<?>) chainedOperator2).getPythonFunctionInfo(),
                 "f5",
@@ -376,7 +384,7 @@ public class PythonOperatorChainingOptimizerTest {
     }
 
     @Test
-    public void testChainingTwoInputOperators() {
+    void testChainingTwoInputOperators() {
         PythonKeyedCoProcessOperator<?> keyedCoProcessOperator1 =
                 createCoKeyedProcessOperator(
                         "f1",
@@ -448,21 +456,26 @@ public class PythonOperatorChainingOptimizerTest {
 
         List<Transformation<?>> optimized =
                 PythonOperatorChainingOptimizer.optimize(transformations);
-        assertEquals(4, optimized.size());
+        assertThat(optimized).hasSize(4);
 
         TwoInputTransformation<?, ?, ?> chainedTransformation1 =
                 (TwoInputTransformation<?, ?, ?>) optimized.get(2);
-        assertEquals(sourceTransformation1.getOutputType(), chainedTransformation1.getInputType1());
-        assertEquals(sourceTransformation2.getOutputType(), chainedTransformation1.getInputType2());
-        assertEquals(processOperator2.getProducedType(), chainedTransformation1.getOutputType());
+        assertThat(sourceTransformation1.getOutputType())
+                .isEqualTo(chainedTransformation1.getInputType1());
+        assertThat(sourceTransformation2.getOutputType())
+                .isEqualTo(chainedTransformation1.getInputType2());
+        assertThat(processOperator2.getProducedType())
+                .isEqualTo(chainedTransformation1.getOutputType());
 
         OneInputTransformation<?, ?> chainedTransformation2 =
                 (OneInputTransformation<?, ?>) optimized.get(3);
-        assertEquals(processOperator2.getProducedType(), chainedTransformation2.getInputType());
-        assertEquals(processOperator3.getProducedType(), chainedTransformation2.getOutputType());
+        assertThat(processOperator2.getProducedType())
+                .isEqualTo(chainedTransformation2.getInputType());
+        assertThat(processOperator3.getProducedType())
+                .isEqualTo(chainedTransformation2.getOutputType());
 
         TwoInputStreamOperator<?, ?, ?> chainedOperator1 = chainedTransformation1.getOperator();
-        assertTrue(chainedOperator1 instanceof PythonKeyedCoProcessOperator);
+        assertThat(chainedOperator1).isInstanceOf(PythonKeyedCoProcessOperator.class);
         validateChainedPythonFunctions(
                 ((PythonKeyedCoProcessOperator<?>) chainedOperator1).getPythonFunctionInfo(),
                 "f3",
@@ -470,7 +483,7 @@ public class PythonOperatorChainingOptimizerTest {
                 "f1");
 
         OneInputStreamOperator<?, ?> chainedOperator2 = chainedTransformation2.getOperator();
-        assertTrue(chainedOperator2 instanceof PythonKeyedProcessOperator);
+        assertThat(chainedOperator2).isInstanceOf(PythonKeyedProcessOperator.class);
         validateChainedPythonFunctions(
                 ((PythonKeyedProcessOperator<?>) chainedOperator2).getPythonFunctionInfo(),
                 "f5",
@@ -478,7 +491,7 @@ public class PythonOperatorChainingOptimizerTest {
     }
 
     @Test
-    public void testChainingUnorderedTransformations() {
+    void testChainingUnorderedTransformations() {
         PythonKeyedProcessOperator<?> keyedProcessOperator =
                 createKeyedProcessOperator(
                         "f1", new RowTypeInfo(Types.INT(), Types.INT()), Types.STRING());
@@ -518,15 +531,17 @@ public class PythonOperatorChainingOptimizerTest {
 
         List<Transformation<?>> optimized =
                 PythonOperatorChainingOptimizer.optimize(transformations);
-        assertEquals(2, optimized.size());
+        assertThat(optimized).hasSize(2);
 
         OneInputTransformation<?, ?> chainedTransformation =
                 (OneInputTransformation<?, ?>) optimized.get(1);
-        assertEquals(sourceTransformation.getOutputType(), chainedTransformation.getInputType());
-        assertEquals(processOperator2.getProducedType(), chainedTransformation.getOutputType());
+        assertThat(sourceTransformation.getOutputType())
+                .isEqualTo(chainedTransformation.getInputType());
+        assertThat(processOperator2.getProducedType())
+                .isEqualTo(chainedTransformation.getOutputType());
 
         OneInputStreamOperator<?, ?> chainedOperator = chainedTransformation.getOperator();
-        assertTrue(chainedOperator instanceof PythonKeyedProcessOperator);
+        assertThat(chainedOperator).isInstanceOf(PythonKeyedProcessOperator.class);
         validateChainedPythonFunctions(
                 ((PythonKeyedProcessOperator<?>) chainedOperator).getPythonFunctionInfo(),
                 "f3",
@@ -535,7 +550,7 @@ public class PythonOperatorChainingOptimizerTest {
     }
 
     @Test
-    public void testSingleTransformation() {
+    void testSingleTransformation() {
         PythonKeyedProcessOperator<?> keyedProcessOperator =
                 createKeyedProcessOperator(
                         "f1", new RowTypeInfo(Types.INT(), Types.INT()), Types.STRING());
@@ -572,15 +587,17 @@ public class PythonOperatorChainingOptimizerTest {
 
         List<Transformation<?>> optimized =
                 PythonOperatorChainingOptimizer.optimize(transformations);
-        assertEquals(2, optimized.size());
+        assertThat(optimized).hasSize(2);
 
         OneInputTransformation<?, ?> chainedTransformation =
                 (OneInputTransformation<?, ?>) optimized.get(0);
-        assertEquals(sourceTransformation.getOutputType(), chainedTransformation.getInputType());
-        assertEquals(processOperator2.getProducedType(), chainedTransformation.getOutputType());
+        assertThat(sourceTransformation.getOutputType())
+                .isEqualTo(chainedTransformation.getInputType());
+        assertThat(processOperator2.getProducedType())
+                .isEqualTo(chainedTransformation.getOutputType());
 
         OneInputStreamOperator<?, ?> chainedOperator = chainedTransformation.getOperator();
-        assertTrue(chainedOperator instanceof PythonKeyedProcessOperator);
+        assertThat(chainedOperator).isInstanceOf(PythonKeyedProcessOperator.class);
         validateChainedPythonFunctions(
                 ((PythonKeyedProcessOperator<?>) chainedOperator).getPythonFunctionInfo(),
                 "f3",
@@ -589,7 +606,7 @@ public class PythonOperatorChainingOptimizerTest {
     }
 
     @Test
-    public void testTransformationWithMultipleOutputs() {
+    void testTransformationWithMultipleOutputs() {
         PythonProcessOperator<?, ?> processOperator1 =
                 createProcessOperator("f1", Types.STRING(), Types.LONG());
         PythonProcessOperator<?, ?> processOperator2 =
@@ -627,7 +644,7 @@ public class PythonOperatorChainingOptimizerTest {
         List<Transformation<?>> optimized =
                 PythonOperatorChainingOptimizer.optimize(transformations);
         // no chaining optimization occurred
-        assertEquals(4, optimized.size());
+        assertThat(optimized).hasSize(4);
     }
 
     // ----------------------- Utility Methods -----------------------
@@ -636,19 +653,18 @@ public class PythonOperatorChainingOptimizerTest {
             DataStreamPythonFunctionInfo pythonFunctionInfo,
             String... expectedChainedPythonFunctions) {
         for (String expectedPythonFunction : expectedChainedPythonFunctions) {
-            assertArrayEquals(
-                    expectedPythonFunction.getBytes(),
-                    pythonFunctionInfo.getPythonFunction().getSerializedPythonFunction());
+            assertThat(pythonFunctionInfo.getPythonFunction().getSerializedPythonFunction())
+                    .isEqualTo(expectedPythonFunction.getBytes());
             Object[] inputs = pythonFunctionInfo.getInputs();
             if (inputs.length > 0) {
-                assertEquals(1, inputs.length);
+                assertThat(inputs).hasSize(1);
                 pythonFunctionInfo = (DataStreamPythonFunctionInfo) inputs[0];
             } else {
                 pythonFunctionInfo = null;
             }
         }
 
-        assertNull(pythonFunctionInfo);
+        assertThat(pythonFunctionInfo).isNull();
     }
 
     private static <OUT> PythonKeyedProcessOperator<OUT> createKeyedProcessOperator(

--- a/flink-python/src/test/java/org/apache/flink/python/chain/PythonOperatorChainingOptimizerTest.java
+++ b/flink-python/src/test/java/org/apache/flink/python/chain/PythonOperatorChainingOptimizerTest.java
@@ -125,9 +125,8 @@ class PythonOperatorChainingOptimizerTest {
                 .isTrue();
         assertThat(
                         chainedTransformation
-                                .getManagedMemorySlotScopeUseCases()
-                                .contains(ManagedMemoryUseCase.STATE_BACKEND))
-                .isTrue();
+                                .getManagedMemorySlotScopeUseCases())
+                .contains(ManagedMemoryUseCase.STATE_BACKEND);
 
         OneInputStreamOperator<?, ?> chainedOperator = chainedTransformation.getOperator();
         assertThat(chainedOperator).isInstanceOf(PythonKeyedProcessOperator.class);

--- a/flink-python/src/test/java/org/apache/flink/python/chain/PythonOperatorChainingOptimizerTest.java
+++ b/flink-python/src/test/java/org/apache/flink/python/chain/PythonOperatorChainingOptimizerTest.java
@@ -118,14 +118,9 @@ class PythonOperatorChainingOptimizerTest {
                 .isEqualTo(15);
         assertThat(chainedTransformation.getOperatorFactory().getChainingStrategy())
                 .isEqualTo(ChainingStrategy.HEAD);
-        assertThat(
-                        chainedTransformation
-                                .getManagedMemorySlotScopeUseCases()
-                                .contains(ManagedMemoryUseCase.PYTHON))
-                .isTrue();
-        assertThat(
-                        chainedTransformation
-                                .getManagedMemorySlotScopeUseCases())
+        assertThat(chainedTransformation.getManagedMemorySlotScopeUseCases())
+                .contains(ManagedMemoryUseCase.PYTHON);
+        assertThat(chainedTransformation.getManagedMemorySlotScopeUseCases())
                 .contains(ManagedMemoryUseCase.STATE_BACKEND);
 
         OneInputStreamOperator<?, ?> chainedOperator = chainedTransformation.getOperator();

--- a/flink-python/src/test/java/org/apache/flink/python/env/PythonDependencyInfoTest.java
+++ b/flink-python/src/test/java/org/apache/flink/python/env/PythonDependencyInfoTest.java
@@ -25,8 +25,7 @@ import org.apache.flink.python.PythonOptions;
 import org.apache.flink.python.util.PythonDependencyUtils;
 import org.apache.flink.util.OperatingSystem;
 
-import org.junit.Assume;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -37,11 +36,11 @@ import java.util.concurrent.Future;
 import static org.apache.flink.python.PythonOptions.PYTHON_ARCHIVES_DISTRIBUTED_CACHE_INFO;
 import static org.apache.flink.python.PythonOptions.PYTHON_FILES_DISTRIBUTED_CACHE_INFO;
 import static org.apache.flink.python.PythonOptions.PYTHON_REQUIREMENTS_FILE_DISTRIBUTED_CACHE_INFO;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 /** Tests for {@link PythonDependencyInfo}. */
-public class PythonDependencyInfoTest {
+class PythonDependencyInfoTest {
 
     private DistributedCache distributedCache;
 
@@ -69,9 +68,9 @@ public class PythonDependencyInfoTest {
     }
 
     @Test
-    public void testParsePythonFiles() {
+    void testParsePythonFiles() {
         // Skip this test on Windows as we can not control the Window Driver letters.
-        Assume.assumeFalse(OperatingSystem.isWindows());
+        assumeThat(OperatingSystem.isWindows()).isFalse();
 
         Configuration config = new Configuration();
         Map<String, String> pythonFiles = new HashMap<>();
@@ -83,13 +82,13 @@ public class PythonDependencyInfoTest {
         Map<String, String> expected = new HashMap<>();
         expected.put("/distributed_cache/file0", "test_file1.py");
         expected.put("/distributed_cache/file1", "test_file2.py");
-        assertEquals(expected, dependencyInfo.getPythonFiles());
+        assertThat(dependencyInfo.getPythonFiles()).isEqualTo(expected);
     }
 
     @Test
-    public void testParsePythonRequirements() throws IOException {
+    void testParsePythonRequirements() throws IOException {
         // Skip this test on Windows as we can not control the Window Driver letters.
-        Assume.assumeFalse(OperatingSystem.isWindows());
+        assumeThat(OperatingSystem.isWindows()).isFalse();
 
         Configuration config = new Configuration();
         config.set(PYTHON_REQUIREMENTS_FILE_DISTRIBUTED_CACHE_INFO, new HashMap<>());
@@ -97,21 +96,24 @@ public class PythonDependencyInfoTest {
                 .put(PythonDependencyUtils.FILE, "python_requirements_file_{SHA256}");
         PythonDependencyInfo dependencyInfo = PythonDependencyInfo.create(config, distributedCache);
 
-        assertEquals("/distributed_cache/file2", dependencyInfo.getRequirementsFilePath().get());
-        assertFalse(dependencyInfo.getRequirementsCacheDir().isPresent());
+        assertThat(dependencyInfo.getRequirementsFilePath().get())
+                .isEqualTo("/distributed_cache/file2");
+        assertThat(dependencyInfo.getRequirementsCacheDir()).isNotPresent();
 
         config.get(PYTHON_REQUIREMENTS_FILE_DISTRIBUTED_CACHE_INFO)
                 .put(PythonDependencyUtils.CACHE, "python_requirements_cache_{SHA256}");
         dependencyInfo = PythonDependencyInfo.create(config, distributedCache);
 
-        assertEquals("/distributed_cache/file2", dependencyInfo.getRequirementsFilePath().get());
-        assertEquals("/distributed_cache/file3", dependencyInfo.getRequirementsCacheDir().get());
+        assertThat(dependencyInfo.getRequirementsFilePath().get())
+                .isEqualTo("/distributed_cache/file2");
+        assertThat(dependencyInfo.getRequirementsCacheDir().get())
+                .isEqualTo("/distributed_cache/file3");
     }
 
     @Test
-    public void testParsePythonArchives() {
+    void testParsePythonArchives() {
         // Skip this test on Windows as we can not control the Window Driver letters.
-        Assume.assumeFalse(OperatingSystem.isWindows());
+        assumeThat(OperatingSystem.isWindows()).isFalse();
 
         Configuration config = new Configuration();
         Map<String, String> pythonArchives = new HashMap<>();
@@ -123,15 +125,15 @@ public class PythonDependencyInfoTest {
         Map<String, String> expected = new HashMap<>();
         expected.put("/distributed_cache/file4", "py27.zip");
         expected.put("/distributed_cache/file5", "py37");
-        assertEquals(expected, dependencyInfo.getArchives());
+        assertThat(dependencyInfo.getArchives()).isEqualTo(expected);
     }
 
     @Test
-    public void testParsePythonExec() {
+    void testParsePythonExec() {
         Configuration config = new Configuration();
         config.set(PythonOptions.PYTHON_EXECUTABLE, "/usr/bin/python3");
         PythonDependencyInfo dependencyInfo = PythonDependencyInfo.create(config, distributedCache);
 
-        assertEquals("/usr/bin/python3", dependencyInfo.getPythonExec());
+        assertThat(dependencyInfo.getPythonExec()).isEqualTo("/usr/bin/python3");
     }
 }

--- a/flink-python/src/test/java/org/apache/flink/python/metric/FlinkMetricContainerTest.java
+++ b/flink-python/src/test/java/org/apache/flink/python/metric/FlinkMetricContainerTest.java
@@ -38,8 +38,8 @@ import org.apache.beam.sdk.metrics.DistributionResult;
 import org.apache.beam.sdk.metrics.MetricKey;
 import org.apache.beam.sdk.metrics.MetricName;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -47,8 +47,7 @@ import org.mockito.MockitoAnnotations;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.any;
@@ -56,7 +55,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /** Tests for {@link FlinkMetricContainer}. */
-public class FlinkMetricContainerTest {
+class FlinkMetricContainerTest {
 
     @Mock private RuntimeContext runtimeContext;
     @Mock private OperatorMetricGroup metricGroup;
@@ -69,8 +68,8 @@ public class FlinkMetricContainerTest {
     private static final String DEFAULT_NAMESPACE =
             "[\"key\", \"value\", \"MetricGroupType.key\", \"MetricGroupType.value\"]";
 
-    @Before
-    public void beforeTest() {
+    @BeforeEach
+    void beforeTest() {
         MockitoAnnotations.initMocks(this);
         when(runtimeContext.getMetricGroup()).thenReturn(metricGroup);
         when(metricGroup.addGroup(any(), any())).thenReturn(metricGroup);
@@ -79,20 +78,21 @@ public class FlinkMetricContainerTest {
     }
 
     @Test
-    public void testGetNameSpaceArray() {
+    void testGetNameSpaceArray() {
         String json = "[\"key\", \"value\", \"MetricGroupType.key\", \"MetricGroupType.value\"]";
         MetricKey key = MetricKey.create("step", MetricName.named(json, "name"));
-        assertThat(FlinkMetricContainer.getNameSpaceArray(key), is(DEFAULT_SCOPE_COMPONENTS));
+        assertThat(FlinkMetricContainer.getNameSpaceArray(key)).isEqualTo(DEFAULT_SCOPE_COMPONENTS);
     }
 
     @Test
-    public void testGetFlinkMetricIdentifierString() {
+    void testGetFlinkMetricIdentifierString() {
         MetricKey key = MetricKey.create("step", MetricName.named(DEFAULT_NAMESPACE, "name"));
-        assertThat(FlinkMetricContainer.getFlinkMetricIdentifierString(key), is("key.value.name"));
+        assertThat(FlinkMetricContainer.getFlinkMetricIdentifierString(key))
+                .isEqualTo("key.value.name");
     }
 
     @Test
-    public void testRegisterMetricGroup() {
+    void testRegisterMetricGroup() {
         MetricKey key = MetricKey.create("step", MetricName.named(DEFAULT_NAMESPACE, "name"));
 
         MetricRegistry registry = NoOpMetricRegistry.INSTANCE;
@@ -101,13 +101,12 @@ public class FlinkMetricContainerTest {
                         registry, new MetricGroupTest.DummyAbstractMetricGroup(registry), "root");
         MetricGroup metricGroup = FlinkMetricContainer.registerMetricGroup(key, root);
 
-        assertThat(
-                metricGroup.getScopeComponents(),
-                is(Arrays.asList("root", "key", "value").toArray()));
+        assertThat(metricGroup.getScopeComponents())
+                .isEqualTo(Arrays.asList("root", "key", "value").toArray());
     }
 
     @Test
-    public void testCounterMonitoringInfoUpdate() {
+    void testCounterMonitoringInfoUpdate() {
         SimpleCounter userCounter = new SimpleCounter();
         when(metricGroup.counter("myCounter")).thenReturn(userCounter);
 
@@ -120,13 +119,13 @@ public class FlinkMetricContainerTest {
                         .setInt64SumValue(111)
                         .build();
 
-        assertThat(userCounter.getCount(), is(0L));
+        assertThat(userCounter.getCount()).isEqualTo(0L);
         container.updateMetrics("step", ImmutableList.of(userMonitoringInfo));
-        assertThat(userCounter.getCount(), is(111L));
+        assertThat(userCounter.getCount()).isEqualTo(111L);
     }
 
     @Test
-    public void testMeterMonitoringInfoUpdate() {
+    void testMeterMonitoringInfoUpdate() {
         MeterView userMeter = new MeterView(new SimpleCounter());
         when(metricGroup.meter(eq("myMeter"), any(Meter.class))).thenReturn(userMeter);
         String namespace =
@@ -140,16 +139,16 @@ public class FlinkMetricContainerTest {
                         .setLabel(MonitoringInfoConstants.Labels.PTRANSFORM, "anyPTransform")
                         .setInt64SumValue(111)
                         .build();
-        assertThat(userMeter.getCount(), is(0L));
-        assertThat(userMeter.getRate(), is(0.0));
+        assertThat(userMeter.getCount()).isEqualTo(0L);
+        assertThat(userMeter.getRate()).isEqualTo(0.0);
         container.updateMetrics("step", ImmutableList.of(userMonitoringInfo));
         userMeter.update();
-        assertThat(userMeter.getCount(), is(111L));
-        assertThat(userMeter.getRate(), is(1.85)); // 111 div 60 = 1.85
+        assertThat(userMeter.getCount()).isEqualTo(111L);
+        assertThat(userMeter.getRate()).isEqualTo(1.85); // 111 div 60 = 1.85
     }
 
     @Test
-    public void testGaugeMonitoringInfoUpdate() {
+    void testGaugeMonitoringInfoUpdate() {
         MonitoringInfo userMonitoringInfo =
                 new SimpleMonitoringInfoBuilder()
                         .setUrn(MonitoringInfoConstants.Urns.USER_SUM_INT64)
@@ -172,7 +171,7 @@ public class FlinkMetricContainerTest {
     }
 
     @Test
-    public void testDistributionMonitoringInfoUpdate() {
+    void testDistributionMonitoringInfoUpdate() {
         MonitoringInfo userMonitoringInfo =
                 new SimpleMonitoringInfoBuilder()
                         .setUrn(MonitoringInfoConstants.Urns.USER_DISTRIBUTION_INT64)

--- a/flink-python/src/test/java/org/apache/flink/python/util/PythonConfigUtilTest.java
+++ b/flink-python/src/test/java/org/apache/flink/python/util/PythonConfigUtilTest.java
@@ -23,17 +23,17 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.graph.StreamGraph;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** A test class to test PythonConfigUtil getting executionEnvironment correctly. */
-public class PythonConfigUtilTest {
+class PythonConfigUtilTest {
 
     @Test
-    public void testJobName() {
+    void testJobName() {
         String jobName = "MyTestJob";
         Configuration config = new Configuration();
         config.set(PipelineOptions.NAME, jobName);
@@ -41,6 +41,6 @@ public class PythonConfigUtilTest {
 
         env.fromCollection(Collections.singletonList("test")).addSink(new DiscardingSink<>());
         StreamGraph streamGraph = env.getStreamGraph(true);
-        assertEquals(jobName, streamGraph.getJobName());
+        assertThat(streamGraph.getJobName()).isEqualTo(jobName);
     }
 }

--- a/flink-python/src/test/java/org/apache/flink/python/util/PythonDependencyUtilsTest.java
+++ b/flink-python/src/test/java/org/apache/flink/python/util/PythonDependencyUtilsTest.java
@@ -22,8 +22,8 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.python.PythonOptions;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -42,20 +42,20 @@ import static org.apache.flink.python.util.PythonDependencyUtils.CACHE;
 import static org.apache.flink.python.util.PythonDependencyUtils.FILE;
 import static org.apache.flink.python.util.PythonDependencyUtils.configurePythonDependencies;
 import static org.apache.flink.python.util.PythonDependencyUtils.merge;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for PythonDependencyUtils. */
-public class PythonDependencyUtilsTest {
+class PythonDependencyUtilsTest {
 
     private List<Tuple2<String, DistributedCache.DistributedCacheEntry>> cachedFiles;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         cachedFiles = new ArrayList<>();
     }
 
     @Test
-    public void testPythonFiles() {
+    void testPythonFiles() {
         Configuration config = new Configuration();
         config.set(
                 PythonOptions.PYTHON_FILES,
@@ -95,7 +95,7 @@ public class PythonDependencyUtilsTest {
     }
 
     @Test
-    public void testPythonRequirements() {
+    void testPythonRequirements() {
         Configuration config = new Configuration();
         config.set(PYTHON_REQUIREMENTS, "tmp_dir/requirements.txt");
         Configuration actual = configurePythonDependencies(cachedFiles, config);
@@ -143,7 +143,7 @@ public class PythonDependencyUtilsTest {
     }
 
     @Test
-    public void testPythonArchives() {
+    void testPythonArchives() {
         Configuration config = new Configuration();
         config.set(
                 PythonOptions.PYTHON_ARCHIVES,
@@ -195,7 +195,7 @@ public class PythonDependencyUtilsTest {
     }
 
     @Test
-    public void testPythonExecutables() {
+    void testPythonExecutables() {
         Configuration config = new Configuration();
         config.set(PYTHON_EXECUTABLE, "venv/bin/python3");
         config.set(PYTHON_CLIENT_EXECUTABLE, "python37");
@@ -208,7 +208,7 @@ public class PythonDependencyUtilsTest {
     }
 
     @Test
-    public void testPythonDependencyConfigMerge() {
+    void testPythonDependencyConfigMerge() {
         Configuration config = new Configuration();
         config.set(
                 PythonOptions.PYTHON_ARCHIVES,
@@ -238,7 +238,7 @@ public class PythonDependencyUtilsTest {
         Map<String, String> actual =
                 cachedFiles.stream().collect(Collectors.toMap(t -> t.f0, t -> t.f1.filePath));
 
-        assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
     }
 
     private void verifyConfiguration(Configuration expected, Configuration actual) {
@@ -246,6 +246,6 @@ public class PythonDependencyUtilsTest {
         actual.addAllToProperties(actualProperties);
         Properties expectedProperties = new Properties();
         expected.addAllToProperties(expectedProperties);
-        assertEquals(expectedProperties, actualProperties);
+        assertThat(actualProperties).isEqualTo(expectedProperties);
     }
 }

--- a/flink-python/src/test/java/org/apache/flink/streaming/api/utils/ProtoUtilsTest.java
+++ b/flink-python/src/test/java/org/apache/flink/streaming/api/utils/ProtoUtilsTest.java
@@ -22,21 +22,19 @@ import org.apache.flink.api.common.state.StateTtlConfig;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.fnexecution.v1.FlinkFnApi;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Test class for testing utilities used to construct protobuf objects or construct objects from
  * protobuf objects.
  */
-public class ProtoUtilsTest {
+class ProtoUtilsTest {
     @Test
-    public void testParseStateTtlConfigFromProto() {
+    void testParseStateTtlConfigFromProto() {
         FlinkFnApi.StateDescriptor.StateTTLConfig.CleanupStrategies cleanupStrategiesProto =
                 FlinkFnApi.StateDescriptor.StateTTLConfig.CleanupStrategies.newBuilder()
                         .setIsCleanupInBackground(true)
@@ -95,28 +93,28 @@ public class ProtoUtilsTest {
         StateTtlConfig stateTTLConfig =
                 ProtoUtils.parseStateTtlConfigFromProto(stateTTLConfigProto);
 
-        assertEquals(stateTTLConfig.getUpdateType(), StateTtlConfig.UpdateType.OnCreateAndWrite);
-        assertEquals(
-                stateTTLConfig.getStateVisibility(),
-                StateTtlConfig.StateVisibility.NeverReturnExpired);
-        assertEquals(stateTTLConfig.getTtl(), Time.milliseconds(1000));
-        assertEquals(
-                stateTTLConfig.getTtlTimeCharacteristic(),
-                StateTtlConfig.TtlTimeCharacteristic.ProcessingTime);
+        assertThat(stateTTLConfig.getUpdateType())
+                .isEqualTo(StateTtlConfig.UpdateType.OnCreateAndWrite);
+        assertThat(stateTTLConfig.getStateVisibility())
+                .isEqualTo(StateTtlConfig.StateVisibility.NeverReturnExpired);
+        assertThat(stateTTLConfig.getTtl()).isEqualTo(Time.milliseconds(1000));
+        assertThat(stateTTLConfig.getTtlTimeCharacteristic())
+                .isEqualTo(StateTtlConfig.TtlTimeCharacteristic.ProcessingTime);
 
         StateTtlConfig.CleanupStrategies cleanupStrategies = stateTTLConfig.getCleanupStrategies();
-        assertTrue(cleanupStrategies.isCleanupInBackground());
-        assertTrue(cleanupStrategies.inFullSnapshot());
+        assertThat(cleanupStrategies.isCleanupInBackground()).isTrue();
+        assertThat(cleanupStrategies.inFullSnapshot()).isTrue();
 
         StateTtlConfig.IncrementalCleanupStrategy incrementalCleanupStrategy =
                 cleanupStrategies.getIncrementalCleanupStrategy();
-        assertNotNull(incrementalCleanupStrategy);
-        assertEquals(incrementalCleanupStrategy.getCleanupSize(), 10);
-        assertTrue(incrementalCleanupStrategy.runCleanupForEveryRecord());
+        assertThat(incrementalCleanupStrategy).isNotNull();
+        assertThat(incrementalCleanupStrategy.getCleanupSize()).isEqualTo(10);
+        assertThat(incrementalCleanupStrategy.runCleanupForEveryRecord()).isTrue();
 
         StateTtlConfig.RocksdbCompactFilterCleanupStrategy rocksdbCompactFilterCleanupStrategy =
                 cleanupStrategies.getRocksdbCompactFilterCleanupStrategy();
-        assertNotNull(rocksdbCompactFilterCleanupStrategy);
-        assertEquals(rocksdbCompactFilterCleanupStrategy.getQueryTimeAfterNumEntries(), 1000);
+        assertThat(rocksdbCompactFilterCleanupStrategy).isNotNull();
+        assertThat(rocksdbCompactFilterCleanupStrategy.getQueryTimeAfterNumEntries())
+                .isEqualTo(1000);
     }
 }

--- a/flink-python/src/test/java/org/apache/flink/streaming/api/utils/PythonTypeUtilsTest.java
+++ b/flink-python/src/test/java/org/apache/flink/streaming/api/utils/PythonTypeUtilsTest.java
@@ -48,18 +48,18 @@ import org.apache.flink.table.runtime.typeutils.serializers.python.TimeSerialize
 import org.apache.flink.table.runtime.typeutils.serializers.python.TimestampSerializer;
 import org.apache.flink.types.Row;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test class for testing typeinfo to proto converter and typeinfo to type serializer converter. */
-public class PythonTypeUtilsTest {
+class PythonTypeUtilsTest {
 
     @Test
-    public void testTypeInfoToProtoConverter() {
+    void testTypeInfoToProtoConverter() {
         Map<TypeInformation, FlinkFnApi.TypeInfo.TypeName> typeInformationTypeNameMap =
                 new HashMap<>();
         typeInformationTypeNameMap.put(
@@ -94,10 +94,10 @@ public class PythonTypeUtilsTest {
 
         for (Map.Entry<TypeInformation, FlinkFnApi.TypeInfo.TypeName> entry :
                 typeInformationTypeNameMap.entrySet()) {
-            assertEquals(
-                    entry.getValue(),
-                    PythonTypeUtils.TypeInfoToProtoConverter.toTypeInfoProto(entry.getKey())
-                            .getTypeName());
+            assertThat(
+                            PythonTypeUtils.TypeInfoToProtoConverter.toTypeInfoProto(entry.getKey())
+                                    .getTypeName())
+                    .isEqualTo(entry.getValue());
         }
 
         TypeInformation primitiveIntegerArrayTypeInfo =
@@ -105,56 +105,51 @@ public class PythonTypeUtilsTest {
         FlinkFnApi.TypeInfo convertedFieldType =
                 PythonTypeUtils.TypeInfoToProtoConverter.toTypeInfoProto(
                         primitiveIntegerArrayTypeInfo);
-        assertEquals(
-                convertedFieldType.getTypeName(), FlinkFnApi.TypeInfo.TypeName.PRIMITIVE_ARRAY);
-        assertEquals(
-                convertedFieldType.getCollectionElementType().getTypeName(),
-                FlinkFnApi.TypeInfo.TypeName.INT);
+        assertThat(convertedFieldType.getTypeName())
+                .isEqualTo(FlinkFnApi.TypeInfo.TypeName.PRIMITIVE_ARRAY);
+        assertThat(convertedFieldType.getCollectionElementType().getTypeName())
+                .isEqualTo(FlinkFnApi.TypeInfo.TypeName.INT);
 
         TypeInformation basicIntegerArrayTypeInfo = BasicArrayTypeInfo.INT_ARRAY_TYPE_INFO;
         FlinkFnApi.TypeInfo convertedBasicFieldType =
                 PythonTypeUtils.TypeInfoToProtoConverter.toTypeInfoProto(basicIntegerArrayTypeInfo);
-        assertEquals(
-                convertedBasicFieldType.getTypeName(), FlinkFnApi.TypeInfo.TypeName.BASIC_ARRAY);
-        assertEquals(
-                convertedBasicFieldType.getCollectionElementType().getTypeName(),
-                FlinkFnApi.TypeInfo.TypeName.INT);
+        assertThat(convertedBasicFieldType.getTypeName())
+                .isEqualTo(FlinkFnApi.TypeInfo.TypeName.BASIC_ARRAY);
+        assertThat(convertedBasicFieldType.getCollectionElementType().getTypeName())
+                .isEqualTo(FlinkFnApi.TypeInfo.TypeName.INT);
 
         TypeInformation objectArrayTypeInfo = Types.OBJECT_ARRAY(Types.ROW(Types.INT));
         FlinkFnApi.TypeInfo convertedTypeInfoProto =
                 PythonTypeUtils.TypeInfoToProtoConverter.toTypeInfoProto(objectArrayTypeInfo);
-        assertEquals(
-                convertedTypeInfoProto.getTypeName(), FlinkFnApi.TypeInfo.TypeName.OBJECT_ARRAY);
-        assertEquals(
-                convertedTypeInfoProto.getCollectionElementType().getTypeName(),
-                FlinkFnApi.TypeInfo.TypeName.ROW);
-        assertEquals(
-                convertedTypeInfoProto
-                        .getCollectionElementType()
-                        .getRowTypeInfo()
-                        .getFields(0)
-                        .getFieldType()
-                        .getTypeName(),
-                FlinkFnApi.TypeInfo.TypeName.INT);
+        assertThat(convertedTypeInfoProto.getTypeName())
+                .isEqualTo(FlinkFnApi.TypeInfo.TypeName.OBJECT_ARRAY);
+        assertThat(convertedTypeInfoProto.getCollectionElementType().getTypeName())
+                .isEqualTo(FlinkFnApi.TypeInfo.TypeName.ROW);
+        assertThat(
+                        convertedTypeInfoProto
+                                .getCollectionElementType()
+                                .getRowTypeInfo()
+                                .getFields(0)
+                                .getFieldType()
+                                .getTypeName())
+                .isEqualTo(FlinkFnApi.TypeInfo.TypeName.INT);
 
         TypeInformation rowTypeInfo = Types.ROW(Types.INT);
         convertedFieldType = PythonTypeUtils.TypeInfoToProtoConverter.toTypeInfoProto(rowTypeInfo);
-        assertEquals(convertedFieldType.getTypeName(), FlinkFnApi.TypeInfo.TypeName.ROW);
-        assertEquals(
-                convertedFieldType.getRowTypeInfo().getFields(0).getFieldType().getTypeName(),
-                FlinkFnApi.TypeInfo.TypeName.INT);
+        assertThat(convertedFieldType.getTypeName()).isEqualTo(FlinkFnApi.TypeInfo.TypeName.ROW);
+        assertThat(convertedFieldType.getRowTypeInfo().getFields(0).getFieldType().getTypeName())
+                .isEqualTo(FlinkFnApi.TypeInfo.TypeName.INT);
 
         TypeInformation tupleTypeInfo = Types.TUPLE(Types.INT);
         convertedFieldType =
                 PythonTypeUtils.TypeInfoToProtoConverter.toTypeInfoProto(tupleTypeInfo);
-        assertEquals(convertedFieldType.getTypeName(), FlinkFnApi.TypeInfo.TypeName.TUPLE);
-        assertEquals(
-                convertedFieldType.getTupleTypeInfo().getFieldTypes(0).getTypeName(),
-                FlinkFnApi.TypeInfo.TypeName.INT);
+        assertThat(convertedFieldType.getTypeName()).isEqualTo(FlinkFnApi.TypeInfo.TypeName.TUPLE);
+        assertThat(convertedFieldType.getTupleTypeInfo().getFieldTypes(0).getTypeName())
+                .isEqualTo(FlinkFnApi.TypeInfo.TypeName.INT);
     }
 
     @Test
-    public void testTypeInfoToSerializerConverter() {
+    void testTypeInfoToSerializerConverter() {
         Map<TypeInformation, TypeSerializer> typeInformationTypeSerializerMap = new HashMap<>();
         typeInformationTypeSerializerMap.put(BasicTypeInfo.INT_TYPE_INFO, IntSerializer.INSTANCE);
         typeInformationTypeSerializerMap.put(
@@ -183,10 +178,10 @@ public class PythonTypeUtilsTest {
 
         for (Map.Entry<TypeInformation, TypeSerializer> entry :
                 typeInformationTypeSerializerMap.entrySet()) {
-            assertEquals(
-                    entry.getValue(),
-                    PythonTypeUtils.TypeInfoToSerializerConverter.typeInfoSerializerConverter(
-                            entry.getKey()));
+            assertThat(entry.getValue())
+                    .isEqualTo(
+                            PythonTypeUtils.TypeInfoToSerializerConverter
+                                    .typeInfoSerializerConverter(entry.getKey()));
         }
 
         TypeInformation primitiveIntegerArrayTypeInfo =
@@ -194,42 +189,41 @@ public class PythonTypeUtilsTest {
         TypeSerializer convertedTypeSerializer =
                 PythonTypeUtils.TypeInfoToSerializerConverter.typeInfoSerializerConverter(
                         primitiveIntegerArrayTypeInfo);
-        assertEquals(convertedTypeSerializer, IntPrimitiveArraySerializer.INSTANCE);
+        assertThat(convertedTypeSerializer).isEqualTo(IntPrimitiveArraySerializer.INSTANCE);
 
         TypeInformation integerArrayTypeInfo = BasicArrayTypeInfo.INT_ARRAY_TYPE_INFO;
         convertedTypeSerializer =
                 PythonTypeUtils.TypeInfoToSerializerConverter.typeInfoSerializerConverter(
                         integerArrayTypeInfo);
-        assertEquals(
-                convertedTypeSerializer,
-                new GenericArraySerializer(Integer.class, IntSerializer.INSTANCE));
+        assertThat(convertedTypeSerializer)
+                .isEqualTo(new GenericArraySerializer(Integer.class, IntSerializer.INSTANCE));
 
         TypeInformation objectArrayTypeInfo = Types.OBJECT_ARRAY(Types.ROW(Types.INT));
         convertedTypeSerializer =
                 PythonTypeUtils.TypeInfoToSerializerConverter.typeInfoSerializerConverter(
                         objectArrayTypeInfo);
-        assertEquals(
-                convertedTypeSerializer,
-                new GenericArraySerializer(
-                        Row.class,
-                        new RowSerializer(new TypeSerializer[] {IntSerializer.INSTANCE}, null)));
+        assertThat(convertedTypeSerializer)
+                .isEqualTo(
+                        new GenericArraySerializer(
+                                Row.class,
+                                new RowSerializer(
+                                        new TypeSerializer[] {IntSerializer.INSTANCE}, null)));
 
         TypeInformation rowTypeInfo = Types.ROW(Types.INT);
         convertedTypeSerializer =
                 PythonTypeUtils.TypeInfoToSerializerConverter.typeInfoSerializerConverter(
                         rowTypeInfo);
-        assertEquals(
-                convertedTypeSerializer,
-                new RowSerializer(new TypeSerializer[] {IntSerializer.INSTANCE}, null));
+        assertThat(convertedTypeSerializer)
+                .isEqualTo(new RowSerializer(new TypeSerializer[] {IntSerializer.INSTANCE}, null));
 
         TupleTypeInfo tupleTypeInfo = (TupleTypeInfo) Types.TUPLE(Types.INT);
         convertedTypeSerializer =
                 PythonTypeUtils.TypeInfoToSerializerConverter.typeInfoSerializerConverter(
                         tupleTypeInfo);
-        assertEquals(
-                convertedTypeSerializer,
-                new TupleSerializer(
-                        tupleTypeInfo.getTypeClass(),
-                        new TypeSerializer[] {IntSerializer.INSTANCE}));
+        assertThat(convertedTypeSerializer)
+                .isEqualTo(
+                        new TupleSerializer(
+                                tupleTypeInfo.getTypeClass(),
+                                new TypeSerializer[] {IntSerializer.INSTANCE}));
     }
 }

--- a/flink-python/src/test/java/org/apache/flink/table/legacyutils/RichFunc0.java
+++ b/flink-python/src/test/java/org/apache/flink/table/legacyutils/RichFunc0.java
@@ -20,7 +20,7 @@ package org.apache.flink.table.legacyutils;
 import org.apache.flink.table.functions.FunctionContext;
 import org.apache.flink.table.functions.ScalarFunction;
 
-import org.junit.Assert;
+import static org.assertj.core.api.Assertions.fail;
 
 /**
  * Testing scalar function to verify that lifecycle methods are called in the expected order and
@@ -36,21 +36,21 @@ public class RichFunc0 extends ScalarFunction {
     public void open(FunctionContext context) throws Exception {
         super.open(context);
         if (openCalled) {
-            Assert.fail("Open called more than once.");
+            fail("Open called more than once.");
         } else {
             openCalled = true;
         }
         if (closeCalled) {
-            Assert.fail("Close called before open.");
+            fail("Close called before open.");
         }
     }
 
     public void eval(int index) {
         if (!openCalled) {
-            Assert.fail("Open was not called before eval.");
+            fail("Open was not called before eval.");
         }
         if (closeCalled) {
-            Assert.fail("Close called before eval.");
+            fail("Close called before eval.");
         }
     }
 
@@ -58,12 +58,12 @@ public class RichFunc0 extends ScalarFunction {
     public void close() throws Exception {
         super.close();
         if (closeCalled) {
-            Assert.fail("Close called more than once.");
+            fail("Close called more than once.");
         } else {
             closeCalled = true;
         }
         if (!openCalled) {
-            Assert.fail("Open was not called before close.");
+            fail("Open was not called before close.");
         }
     }
 }

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/ArrowReaderWriterTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/ArrowReaderWriterTest.java
@@ -52,7 +52,7 @@ import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.ipc.ArrowStreamReader;
 import org.apache.arrow.vector.ipc.ArrowStreamWriter;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -63,7 +63,7 @@ import java.util.List;
 import java.util.Objects;
 
 /** Tests for {@link ArrowReader} and {@link ArrowWriter} of RowData. */
-public class ArrowReaderWriterTest extends ArrowReaderWriterTestBase<RowData> {
+class ArrowReaderWriterTest extends ArrowReaderWriterTestBase<RowData> {
     private static List<LogicalType> fieldTypes = new ArrayList<>();
     private static RowType rowType;
     private static RowType rowFieldType;
@@ -100,8 +100,8 @@ public class ArrowReaderWriterTest extends ArrowReaderWriterTestBase<RowData> {
         return Objects.equals(row1, row2);
     }
 
-    @BeforeClass
-    public static void init() {
+    @BeforeAll
+    static void init() {
         fieldTypes.add(new TinyIntType());
         fieldTypes.add(new SmallIntType());
         fieldTypes.add(new IntType());

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/ArrowReaderWriterTestBase.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/ArrowReaderWriterTestBase.java
@@ -25,7 +25,8 @@ import org.apache.flink.testutils.DeeplyEqualsChecker;
 import org.apache.flink.util.Preconditions;
 
 import org.apache.arrow.vector.ipc.ArrowStreamWriter;
-import org.junit.Test;
+import org.assertj.core.api.HamcrestCondition;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -33,15 +34,15 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 /**
  * Abstract test base for {@link ArrowReader} and {@link ArrowWriter}.
  *
  * @param <T> the elment type.
  */
-public abstract class ArrowReaderWriterTestBase<T> {
+abstract class ArrowReaderWriterTestBase<T> {
 
     private final DeeplyEqualsChecker checker;
 
@@ -54,7 +55,7 @@ public abstract class ArrowReaderWriterTestBase<T> {
     }
 
     @Test
-    public void testBasicFunctionality() {
+    void testBasicFunctionality() {
         try {
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
             Tuple2<ArrowWriter<T>, ArrowStreamWriter> tuple2 = createArrowWriter(baos);
@@ -72,10 +73,12 @@ public abstract class ArrowReaderWriterTestBase<T> {
                     createArrowReader(new ByteArrayInputStream(baos.toByteArray()));
             for (int i = 0; i < testData.length; i++) {
                 RowData deserialized = arrowReader.read(i);
-                assertThat(
-                        "Deserialized value is wrong.",
-                        deserialized,
-                        CustomEqualityMatcher.deeplyEquals(testData[i]).withChecker(checker));
+                assertThat(deserialized)
+                        .as("Deserialized value is wrong.")
+                        .is(
+                                HamcrestCondition.matching(
+                                        CustomEqualityMatcher.deeplyEquals(testData[i])
+                                                .withChecker(checker)));
             }
         } catch (Exception e) {
             System.err.println(e.getMessage());

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/ArrowUtilsTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/ArrowUtilsTest.java
@@ -82,8 +82,8 @@ import org.apache.arrow.vector.types.TimeUnit;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -93,17 +93,17 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link ArrowUtils}. */
-public class ArrowUtilsTest {
+class ArrowUtilsTest {
 
     private static List<Tuple5<String, LogicalType, ArrowType, Class<?>, Class<?>>> testFields;
     private static RowType rowType;
     private static BufferAllocator allocator;
 
-    @BeforeClass
-    public static void init() {
+    @BeforeAll
+    static void init() {
         testFields = new ArrayList<>();
         testFields.add(
                 Tuple5.of(
@@ -329,42 +329,42 @@ public class ArrowUtilsTest {
     }
 
     @Test
-    public void testConvertBetweenLogicalTypeAndArrowType() {
+    void testConvertBetweenLogicalTypeAndArrowType() {
         Schema schema = ArrowUtils.toArrowSchema(rowType);
 
-        assertEquals(testFields.size(), schema.getFields().size());
+        assertThat(schema.getFields()).hasSize(testFields.size());
         List<Field> fields = schema.getFields();
         for (int i = 0; i < schema.getFields().size(); i++) {
             // verify convert from RowType to ArrowType
-            assertEquals(testFields.get(i).f0, fields.get(i).getName());
-            assertEquals(testFields.get(i).f2, fields.get(i).getType());
+            assertThat(fields.get(i).getName()).isEqualTo(testFields.get(i).f0);
+            assertThat(fields.get(i).getType()).isEqualTo(testFields.get(i).f2);
         }
     }
 
     @Test
-    public void testCreateArrowReader() {
+    void testCreateArrowReader() {
         VectorSchemaRoot root =
                 VectorSchemaRoot.create(ArrowUtils.toArrowSchema(rowType), allocator);
         ArrowReader reader = ArrowUtils.createArrowReader(root, rowType);
         ColumnVector[] columnVectors = reader.getColumnVectors();
         for (int i = 0; i < columnVectors.length; i++) {
-            assertEquals(testFields.get(i).f4, columnVectors[i].getClass());
+            assertThat(columnVectors[i].getClass()).isEqualTo(testFields.get(i).f4);
         }
     }
 
     @Test
-    public void testCreateArrowWriter() {
+    void testCreateArrowWriter() {
         VectorSchemaRoot root =
                 VectorSchemaRoot.create(ArrowUtils.toArrowSchema(rowType), allocator);
         ArrowWriter<RowData> writer = ArrowUtils.createRowDataArrowWriter(root, rowType);
         ArrowFieldWriter<RowData>[] fieldWriters = writer.getFieldWriters();
         for (int i = 0; i < fieldWriters.length; i++) {
-            assertEquals(testFields.get(i).f3, fieldWriters[i].getClass());
+            assertThat(fieldWriters[i].getClass()).isEqualTo(testFields.get(i).f3);
         }
     }
 
     @Test
-    public void testReadArrowBatches() throws IOException {
+    void testReadArrowBatches() throws IOException {
         VectorSchemaRoot root =
                 VectorSchemaRoot.create(ArrowUtils.toArrowSchema(rowType), allocator);
         ArrowWriter<RowData> arrowWriter = ArrowUtils.createRowDataArrowWriter(root, rowType);
@@ -390,10 +390,11 @@ public class ArrowUtilsTest {
             arrowWriter.reset();
         }
 
-        assertEquals(
-                batches,
-                ArrowUtils.readArrowBatches(
-                                Channels.newChannel(new ByteArrayInputStream(baos.toByteArray())))
-                        .length);
+        assertThat(
+                        ArrowUtils.readArrowBatches(
+                                        Channels.newChannel(
+                                                new ByteArrayInputStream(baos.toByteArray())))
+                                .length)
+                .isEqualTo(batches);
     }
 }

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/sources/ArrowSourceFunctionTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/sources/ArrowSourceFunctionTest.java
@@ -35,7 +35,7 @@ import org.apache.flink.testutils.DeeplyEqualsChecker;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.VectorSchemaRoot;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -44,7 +44,7 @@ import java.util.List;
 import java.util.Objects;
 
 /** Tests for {@link ArrowSourceFunction}. */
-public class ArrowSourceFunctionTest extends ArrowSourceFunctionTestBase {
+class ArrowSourceFunctionTest extends ArrowSourceFunctionTestBase {
 
     private static List<LogicalType> fieldTypes = new ArrayList<>();
     private static RowType rowType;
@@ -82,8 +82,8 @@ public class ArrowSourceFunctionTest extends ArrowSourceFunctionTestBase {
         return Objects.equals(row1, row2);
     }
 
-    @BeforeClass
-    public static void init() {
+    @BeforeAll
+    static void init() {
         fieldTypes.add(new VarCharType());
         List<RowType.RowField> rowFields = new ArrayList<>();
         for (int i = 0; i < fieldTypes.size(); i++) {

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/AbstractPythonStreamAggregateOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/AbstractPythonStreamAggregateOperatorTest.java
@@ -46,7 +46,7 @@ import static org.apache.flink.table.runtime.util.StreamRecordUtils.row;
  * PythonStreamGroupTableAggregateOperatorTest} and {@link
  * PythonStreamGroupWindowAggregateOperatorTest}.
  */
-public abstract class AbstractPythonStreamAggregateOperatorTest {
+abstract class AbstractPythonStreamAggregateOperatorTest {
 
     protected LogicalType[] getOutputLogicalType() {
         return new LogicalType[] {

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/PythonStreamGroupAggregateOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/PythonStreamGroupAggregateOperatorTest.java
@@ -37,18 +37,17 @@ import org.apache.flink.table.runtime.utils.PassThroughStreamAggregatePythonFunc
 import org.apache.flink.table.runtime.utils.PythonTestUtils;
 import org.apache.flink.table.types.logical.RowType;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.Function;
 
 /** The tests for {@link PythonStreamGroupAggregateOperator}. */
-public class PythonStreamGroupAggregateOperatorTest
-        extends AbstractPythonStreamAggregateOperatorTest {
+class PythonStreamGroupAggregateOperatorTest extends AbstractPythonStreamAggregateOperatorTest {
 
     @Test
-    public void testFlushDataOnClose() throws Exception {
+    void testFlushDataOnClose() throws Exception {
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
                 getTestHarness(new Configuration());
         long initialTime = 0L;
@@ -67,7 +66,7 @@ public class PythonStreamGroupAggregateOperatorTest
     }
 
     @Test
-    public void testFinishBundleTriggeredOnCheckpoint() throws Exception {
+    void testFinishBundleTriggeredOnCheckpoint() throws Exception {
         Configuration conf = new Configuration();
         conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 10);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = getTestHarness(conf);
@@ -93,7 +92,7 @@ public class PythonStreamGroupAggregateOperatorTest
     }
 
     @Test
-    public void testFinishBundleTriggeredByCount() throws Exception {
+    void testFinishBundleTriggeredByCount() throws Exception {
         Configuration conf = new Configuration();
         conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 3);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = getTestHarness(conf);
@@ -119,7 +118,7 @@ public class PythonStreamGroupAggregateOperatorTest
     }
 
     @Test
-    public void testFinishBundleTriggeredByTime() throws Exception {
+    void testFinishBundleTriggeredByTime() throws Exception {
         Configuration conf = new Configuration();
         conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 10);
         conf.setLong(PythonOptions.MAX_BUNDLE_TIME_MILLS, 1000L);
@@ -146,7 +145,7 @@ public class PythonStreamGroupAggregateOperatorTest
     }
 
     @Test
-    public void testWatermarkProcessedOnFinishBundle() throws Exception {
+    void testWatermarkProcessedOnFinishBundle() throws Exception {
         Configuration conf = new Configuration();
         conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 10);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = getTestHarness(conf);
@@ -173,7 +172,7 @@ public class PythonStreamGroupAggregateOperatorTest
     }
 
     @Test
-    public void testStateCleanupTimer() throws Exception {
+    void testStateCleanupTimer() throws Exception {
         Configuration conf = new Configuration();
         conf.setString("table.exec.state.ttl", "100");
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = getTestHarness(conf);

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/PythonStreamGroupTableAggregateOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/PythonStreamGroupTableAggregateOperatorTest.java
@@ -37,18 +37,18 @@ import org.apache.flink.table.runtime.utils.PassThroughStreamTableAggregatePytho
 import org.apache.flink.table.runtime.utils.PythonTestUtils;
 import org.apache.flink.table.types.logical.RowType;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.Function;
 
 /** The tests for {@link PythonStreamGroupTableAggregateOperator}. */
-public class PythonStreamGroupTableAggregateOperatorTest
+class PythonStreamGroupTableAggregateOperatorTest
         extends AbstractPythonStreamAggregateOperatorTest {
 
     @Test
-    public void testFlushDataOnClose() throws Exception {
+    void testFlushDataOnClose() throws Exception {
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
                 getTestHarness(new Configuration());
         long initialTime = 0L;
@@ -69,7 +69,7 @@ public class PythonStreamGroupTableAggregateOperatorTest
     }
 
     @Test
-    public void testFinishBundleTriggeredOnCheckpoint() throws Exception {
+    void testFinishBundleTriggeredOnCheckpoint() throws Exception {
         Configuration conf = new Configuration();
         conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 10);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = getTestHarness(conf);
@@ -98,7 +98,7 @@ public class PythonStreamGroupTableAggregateOperatorTest
     }
 
     @Test
-    public void testFinishBundleTriggeredByCount() throws Exception {
+    void testFinishBundleTriggeredByCount() throws Exception {
         Configuration conf = new Configuration();
         conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 3);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = getTestHarness(conf);
@@ -127,7 +127,7 @@ public class PythonStreamGroupTableAggregateOperatorTest
     }
 
     @Test
-    public void testFinishBundleTriggeredByTime() throws Exception {
+    void testFinishBundleTriggeredByTime() throws Exception {
         Configuration conf = new Configuration();
         conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 10);
         conf.setLong(PythonOptions.MAX_BUNDLE_TIME_MILLS, 1000L);
@@ -157,7 +157,7 @@ public class PythonStreamGroupTableAggregateOperatorTest
     }
 
     @Test
-    public void testWatermarkProcessedOnFinishBundle() throws Exception {
+    void testWatermarkProcessedOnFinishBundle() throws Exception {
         Configuration conf = new Configuration();
         conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 10);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = getTestHarness(conf);
@@ -186,7 +186,7 @@ public class PythonStreamGroupTableAggregateOperatorTest
     }
 
     @Test
-    public void testStateCleanupTimer() throws Exception {
+    void testStateCleanupTimer() throws Exception {
         Configuration conf = new Configuration();
         conf.setString("table.exec.state.ttl", "100");
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = getTestHarness(conf);

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/PythonStreamGroupWindowAggregateOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/PythonStreamGroupWindowAggregateOperatorTest.java
@@ -41,7 +41,7 @@ import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.VarCharType;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.time.ZoneId;
@@ -59,13 +59,13 @@ import java.util.concurrent.ConcurrentLinkedQueue;
  *   <li>Watermarks are buffered and only sent to downstream when finishedBundle is triggered
  * </ul>
  */
-public class PythonStreamGroupWindowAggregateOperatorTest
+class PythonStreamGroupWindowAggregateOperatorTest
         extends AbstractPythonStreamAggregateOperatorTest {
 
     private static final ZoneId UTC_ZONE_ID = ZoneId.of("UTC");
 
     @Test
-    public void testGroupWindowAggregateFunction() throws Exception {
+    void testGroupWindowAggregateFunction() throws Exception {
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
                 getTestHarness(new Configuration());
         long initialTime = 0L;
@@ -101,7 +101,7 @@ public class PythonStreamGroupWindowAggregateOperatorTest
     }
 
     @Test
-    public void testFinishBundleTriggeredOnCheckpoint() throws Exception {
+    void testFinishBundleTriggeredOnCheckpoint() throws Exception {
         Configuration conf = new Configuration();
         conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 10);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = getTestHarness(conf);
@@ -147,7 +147,7 @@ public class PythonStreamGroupWindowAggregateOperatorTest
     }
 
     @Test
-    public void testFinishBundleTriggeredByCount() throws Exception {
+    void testFinishBundleTriggeredByCount() throws Exception {
         Configuration conf = new Configuration();
         conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 4);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = getTestHarness(conf);
@@ -191,7 +191,7 @@ public class PythonStreamGroupWindowAggregateOperatorTest
     }
 
     @Test
-    public void testFinishBundleTriggeredByTime() throws Exception {
+    void testFinishBundleTriggeredByTime() throws Exception {
         Configuration conf = new Configuration();
         conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 10);
         conf.setLong(PythonOptions.MAX_BUNDLE_TIME_MILLS, 1000L);

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/batch/AbstractBatchArrowPythonAggregateFunctionOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/batch/AbstractBatchArrowPythonAggregateFunctionOperatorTest.java
@@ -30,7 +30,7 @@ import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
 import org.apache.flink.table.types.logical.RowType;
 
 /** Base class for Batch Arrow Python aggregate function operator tests. */
-public abstract class AbstractBatchArrowPythonAggregateFunctionOperatorTest
+abstract class AbstractBatchArrowPythonAggregateFunctionOperatorTest
         extends ArrowPythonAggregateFunctionOperatorTestBase {
 
     public OneInputStreamOperatorTestHarness<RowData, RowData> getTestHarness(Configuration config)

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/batch/BatchArrowPythonGroupAggregateFunctionOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/batch/BatchArrowPythonGroupAggregateFunctionOperatorTest.java
@@ -38,7 +38,7 @@ import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.VarCharType;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -51,11 +51,11 @@ import java.util.concurrent.ConcurrentLinkedQueue;
  *   <li>FinishBundle is called when bundled time reach to max bundle time
  * </ul>
  */
-public class BatchArrowPythonGroupAggregateFunctionOperatorTest
+class BatchArrowPythonGroupAggregateFunctionOperatorTest
         extends AbstractBatchArrowPythonAggregateFunctionOperatorTest {
 
     @Test
-    public void testGroupAggregateFunction() throws Exception {
+    void testGroupAggregateFunction() throws Exception {
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
                 getTestHarness(new Configuration());
         long initialTime = 0L;
@@ -78,7 +78,7 @@ public class BatchArrowPythonGroupAggregateFunctionOperatorTest
     }
 
     @Test
-    public void testFinishBundleTriggeredByCount() throws Exception {
+    void testFinishBundleTriggeredByCount() throws Exception {
         Configuration conf = new Configuration();
         conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 2);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = getTestHarness(conf);
@@ -109,7 +109,7 @@ public class BatchArrowPythonGroupAggregateFunctionOperatorTest
     }
 
     @Test
-    public void testFinishBundleTriggeredByTime() throws Exception {
+    void testFinishBundleTriggeredByTime() throws Exception {
         Configuration conf = new Configuration();
         conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 10);
         conf.setLong(PythonOptions.MAX_BUNDLE_TIME_MILLS, 1000L);

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/batch/BatchArrowPythonGroupWindowAggregateFunctionOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/batch/BatchArrowPythonGroupWindowAggregateFunctionOperatorTest.java
@@ -40,7 +40,7 @@ import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.VarCharType;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -53,10 +53,10 @@ import java.util.concurrent.ConcurrentLinkedQueue;
  *   <li>FinishBundle is called when bundled time reach to max bundle time
  * </ul>
  */
-public class BatchArrowPythonGroupWindowAggregateFunctionOperatorTest
+class BatchArrowPythonGroupWindowAggregateFunctionOperatorTest
         extends AbstractBatchArrowPythonAggregateFunctionOperatorTest {
     @Test
-    public void testGroupAggregateFunction() throws Exception {
+    void testGroupAggregateFunction() throws Exception {
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
                 getTestHarness(new Configuration());
         long initialTime = 0L;
@@ -129,7 +129,7 @@ public class BatchArrowPythonGroupWindowAggregateFunctionOperatorTest
     }
 
     @Test
-    public void testFinishBundleTriggeredByCount() throws Exception {
+    void testFinishBundleTriggeredByCount() throws Exception {
         Configuration conf = new Configuration();
         conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 6);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = getTestHarness(conf);
@@ -210,7 +210,7 @@ public class BatchArrowPythonGroupWindowAggregateFunctionOperatorTest
     }
 
     @Test
-    public void testFinishBundleTriggeredByTime() throws Exception {
+    void testFinishBundleTriggeredByTime() throws Exception {
         Configuration conf = new Configuration();
         conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 10);
         conf.setLong(PythonOptions.MAX_BUNDLE_TIME_MILLS, 1000L);

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/batch/BatchArrowPythonOverWindowAggregateFunctionOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/batch/BatchArrowPythonOverWindowAggregateFunctionOperatorTest.java
@@ -39,13 +39,13 @@ import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.VarCharType;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Test for {@link BatchArrowPythonOverWindowAggregateFunctionOperator}. These test that:
@@ -55,11 +55,11 @@ import static org.junit.Assert.assertEquals;
  *   <li>FinishBundle is called when bundled time reach to max bundle time
  * </ul>
  */
-public class BatchArrowPythonOverWindowAggregateFunctionOperatorTest
+class BatchArrowPythonOverWindowAggregateFunctionOperatorTest
         extends AbstractBatchArrowPythonAggregateFunctionOperatorTest {
 
     @Test
-    public void testOverWindowAggregateFunction() throws Exception {
+    void testOverWindowAggregateFunction() throws Exception {
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
                 getTestHarness(new Configuration());
 
@@ -88,7 +88,7 @@ public class BatchArrowPythonOverWindowAggregateFunctionOperatorTest
     }
 
     @Test
-    public void testFinishBundleTriggeredByCount() throws Exception {
+    void testFinishBundleTriggeredByCount() throws Exception {
         Configuration conf = new Configuration();
         conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 3);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = getTestHarness(conf);
@@ -123,7 +123,7 @@ public class BatchArrowPythonOverWindowAggregateFunctionOperatorTest
     }
 
     @Test
-    public void testFinishBundleTriggeredByTime() throws Exception {
+    void testFinishBundleTriggeredByTime() throws Exception {
         Configuration conf = new Configuration();
         conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 10);
         conf.setLong(PythonOptions.MAX_BUNDLE_TIME_MILLS, 1000L);
@@ -160,7 +160,7 @@ public class BatchArrowPythonOverWindowAggregateFunctionOperatorTest
     }
 
     @Test
-    public void testUserDefinedFunctionsProto() throws Exception {
+    void testUserDefinedFunctionsProto() throws Exception {
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
                 getTestHarness(new Configuration());
         testHarness.open();
@@ -169,18 +169,18 @@ public class BatchArrowPythonOverWindowAggregateFunctionOperatorTest
                         testHarness.getOneInputOperator();
         FlinkFnApi.UserDefinedFunctions functionsProto = operator.getUserDefinedFunctionsProto();
         List<FlinkFnApi.OverWindow> windows = functionsProto.getWindowsList();
-        assertEquals(2, windows.size());
+        assertThat(windows).hasSize(2);
 
         // first window is a range sliding window.
         FlinkFnApi.OverWindow firstWindow = windows.get(0);
-        assertEquals(firstWindow.getWindowType(), FlinkFnApi.OverWindow.WindowType.RANGE_SLIDING);
+        assertThat(firstWindow.getWindowType())
+                .isEqualTo(FlinkFnApi.OverWindow.WindowType.RANGE_SLIDING);
 
         // second window is a row unbounded preceding window.
         FlinkFnApi.OverWindow secondWindow = windows.get(1);
-        assertEquals(
-                secondWindow.getWindowType(),
-                FlinkFnApi.OverWindow.WindowType.ROW_UNBOUNDED_PRECEDING);
-        assertEquals(secondWindow.getUpperBoundary(), 2L);
+        assertThat(secondWindow.getWindowType())
+                .isEqualTo(FlinkFnApi.OverWindow.WindowType.ROW_UNBOUNDED_PRECEDING);
+        assertThat(secondWindow.getUpperBoundary()).isEqualTo(2L);
     }
 
     @Override

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/AbstractStreamArrowPythonAggregateFunctionOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/AbstractStreamArrowPythonAggregateFunctionOperatorTest.java
@@ -34,7 +34,7 @@ import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
 import org.apache.flink.table.types.logical.RowType;
 
 /** Base class for Stream Arrow Python aggregate function operator tests. */
-public abstract class AbstractStreamArrowPythonAggregateFunctionOperatorTest
+abstract class AbstractStreamArrowPythonAggregateFunctionOperatorTest
         extends ArrowPythonAggregateFunctionOperatorTestBase {
 
     public OneInputStreamOperatorTestHarness<RowData, RowData> getTestHarness(Configuration config)

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/StreamArrowPythonGroupWindowAggregateFunctionOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/StreamArrowPythonGroupWindowAggregateFunctionOperatorTest.java
@@ -49,7 +49,7 @@ import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.VarCharType;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.time.ZoneId;
@@ -67,13 +67,13 @@ import java.util.concurrent.ConcurrentLinkedQueue;
  *   <li>Watermarks are buffered and only sent to downstream when finishedBundle is triggered
  * </ul>
  */
-public class StreamArrowPythonGroupWindowAggregateFunctionOperatorTest
+class StreamArrowPythonGroupWindowAggregateFunctionOperatorTest
         extends AbstractStreamArrowPythonAggregateFunctionOperatorTest {
 
     private static final ZoneId UTC_ZONE_ID = ZoneId.of("UTC");
 
     @Test
-    public void testGroupWindowAggregateFunction() throws Exception {
+    void testGroupWindowAggregateFunction() throws Exception {
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
                 getTestHarness(new Configuration());
         long initialTime = 0L;
@@ -153,7 +153,7 @@ public class StreamArrowPythonGroupWindowAggregateFunctionOperatorTest
     }
 
     @Test
-    public void testFinishBundleTriggeredOnCheckpoint() throws Exception {
+    void testFinishBundleTriggeredOnCheckpoint() throws Exception {
         Configuration conf = new Configuration();
         conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 10);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = getTestHarness(conf);
@@ -242,7 +242,7 @@ public class StreamArrowPythonGroupWindowAggregateFunctionOperatorTest
     }
 
     @Test
-    public void testFinishBundleTriggeredByCount() throws Exception {
+    void testFinishBundleTriggeredByCount() throws Exception {
         Configuration conf = new Configuration();
         conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 4);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = getTestHarness(conf);
@@ -327,7 +327,7 @@ public class StreamArrowPythonGroupWindowAggregateFunctionOperatorTest
     }
 
     @Test
-    public void testFinishBundleTriggeredByTime() throws Exception {
+    void testFinishBundleTriggeredByTime() throws Exception {
         Configuration conf = new Configuration();
         conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 10);
         conf.setLong(PythonOptions.MAX_BUNDLE_TIME_MILLS, 1000L);

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/StreamArrowPythonProcTimeBoundedRangeOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/StreamArrowPythonProcTimeBoundedRangeOperatorTest.java
@@ -37,17 +37,17 @@ import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.VarCharType;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 /** Test for {@link StreamArrowPythonProcTimeBoundedRangeOperator}. */
-public class StreamArrowPythonProcTimeBoundedRangeOperatorTest
+class StreamArrowPythonProcTimeBoundedRangeOperatorTest
         extends AbstractStreamArrowPythonAggregateFunctionOperatorTest {
 
     @Test
-    public void testOverWindowAggregateFunction() throws Exception {
+    void testOverWindowAggregateFunction() throws Exception {
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
                 getTestHarness(new Configuration());
 

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/StreamArrowPythonProcTimeBoundedRowsOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/StreamArrowPythonProcTimeBoundedRowsOperatorTest.java
@@ -37,17 +37,17 @@ import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.VarCharType;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 /** Test for {@link StreamArrowPythonProcTimeBoundedRowsOperator}. */
-public class StreamArrowPythonProcTimeBoundedRowsOperatorTest
+class StreamArrowPythonProcTimeBoundedRowsOperatorTest
         extends AbstractStreamArrowPythonAggregateFunctionOperatorTest {
 
     @Test
-    public void testOverWindowAggregateFunction() throws Exception {
+    void testOverWindowAggregateFunction() throws Exception {
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
                 getTestHarness(new Configuration());
 

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/StreamArrowPythonRowTimeBoundedRowsOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/StreamArrowPythonRowTimeBoundedRowsOperatorTest.java
@@ -39,7 +39,7 @@ import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.VarCharType;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -54,11 +54,11 @@ import java.util.concurrent.ConcurrentLinkedQueue;
  *   <li>Watermarks are buffered and only sent to downstream when finishedBundle is triggered
  * </ul>
  */
-public class StreamArrowPythonRowTimeBoundedRowsOperatorTest
+class StreamArrowPythonRowTimeBoundedRowsOperatorTest
         extends AbstractStreamArrowPythonAggregateFunctionOperatorTest {
 
     @Test
-    public void testOverWindowAggregateFunction() throws Exception {
+    void testOverWindowAggregateFunction() throws Exception {
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
                 getTestHarness(new Configuration());
 
@@ -89,7 +89,7 @@ public class StreamArrowPythonRowTimeBoundedRowsOperatorTest
     }
 
     @Test
-    public void testFinishBundleTriggeredOnCheckpoint() throws Exception {
+    void testFinishBundleTriggeredOnCheckpoint() throws Exception {
         Configuration conf = new Configuration();
         conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 10);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = getTestHarness(conf);
@@ -126,7 +126,7 @@ public class StreamArrowPythonRowTimeBoundedRowsOperatorTest
     }
 
     @Test
-    public void testFinishBundleTriggeredByCount() throws Exception {
+    void testFinishBundleTriggeredByCount() throws Exception {
         Configuration conf = new Configuration();
         conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 6);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = getTestHarness(conf);
@@ -161,7 +161,7 @@ public class StreamArrowPythonRowTimeBoundedRowsOperatorTest
     }
 
     @Test
-    public void testFinishBundleTriggeredByTime() throws Exception {
+    void testFinishBundleTriggeredByTime() throws Exception {
         Configuration conf = new Configuration();
         conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 10);
         conf.setLong(PythonOptions.MAX_BUNDLE_TIME_MILLS, 1000L);

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/scalar/PythonScalarFunctionOperatorTestBase.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/scalar/PythonScalarFunctionOperatorTestBase.java
@@ -43,8 +43,7 @@ import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.VarCharType;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -53,6 +52,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 
 import static org.apache.flink.table.api.Expressions.$;
 import static org.apache.flink.table.api.Expressions.call;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Base class for Python scalar function operator test. These test that:
@@ -70,7 +70,7 @@ import static org.apache.flink.table.api.Expressions.call;
 public abstract class PythonScalarFunctionOperatorTestBase<IN, OUT, UDFIN> {
 
     @Test
-    public void testRetractionFieldKept() throws Exception {
+    void testRetractionFieldKept() throws Exception {
         OneInputStreamOperatorTestHarness<IN, OUT> testHarness =
                 getTestHarness(new Configuration());
         long initialTime = 0L;
@@ -227,7 +227,7 @@ public abstract class PythonScalarFunctionOperatorTestBase<IN, OUT, UDFIN> {
         tEnv.toAppendStream(t, BasicTypeInfo.INT_TYPE_INFO);
         JobGraph jobGraph = env.getStreamGraph().getJobGraph();
         List<JobVertex> vertices = jobGraph.getVerticesSortedTopologicallyFromSources();
-        Assert.assertEquals(1, vertices.size());
+        assertThat(vertices).hasSize(1);
     }
 
     private OneInputStreamOperatorTestHarness<IN, OUT> getTestHarness(Configuration config)

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/table/PythonTableFunctionOperatorTestBase.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/table/PythonTableFunctionOperatorTestBase.java
@@ -30,7 +30,7 @@ import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.VarCharType;
 
 import org.apache.calcite.rel.core.JoinRelType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -48,10 +48,10 @@ import java.util.concurrent.ConcurrentLinkedQueue;
  * @param <IN> Type of the input elements.
  * @param <OUT> Type of the output elements.
  */
-public abstract class PythonTableFunctionOperatorTestBase<IN, OUT> {
+abstract class PythonTableFunctionOperatorTestBase<IN, OUT> {
 
     @Test
-    public void testRetractionFieldKept() throws Exception {
+    void testRetractionFieldKept() throws Exception {
         OneInputStreamOperatorTestHarness<IN, OUT> testHarness =
                 getTestHarness(new Configuration(), JoinRelType.INNER);
         long initialTime = 0L;
@@ -75,7 +75,7 @@ public abstract class PythonTableFunctionOperatorTestBase<IN, OUT> {
     }
 
     @Test
-    public void testFinishBundleTriggeredOnCheckpoint() throws Exception {
+    void testFinishBundleTriggeredOnCheckpoint() throws Exception {
         Configuration conf = new Configuration();
         conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 10);
         OneInputStreamOperatorTestHarness<IN, OUT> testHarness =
@@ -100,7 +100,7 @@ public abstract class PythonTableFunctionOperatorTestBase<IN, OUT> {
     }
 
     @Test
-    public void testFinishBundleTriggeredByCount() throws Exception {
+    void testFinishBundleTriggeredByCount() throws Exception {
         Configuration conf = new Configuration();
         conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 2);
         OneInputStreamOperatorTestHarness<IN, OUT> testHarness =
@@ -127,7 +127,7 @@ public abstract class PythonTableFunctionOperatorTestBase<IN, OUT> {
     }
 
     @Test
-    public void testFinishBundleTriggeredByTime() throws Exception {
+    void testFinishBundleTriggeredByTime() throws Exception {
         Configuration conf = new Configuration();
         conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 10);
         conf.setLong(PythonOptions.MAX_BUNDLE_TIME_MILLS, 1000L);
@@ -152,7 +152,7 @@ public abstract class PythonTableFunctionOperatorTestBase<IN, OUT> {
     }
 
     @Test
-    public void testLeftJoin() throws Exception {
+    void testLeftJoin() throws Exception {
         OneInputStreamOperatorTestHarness<IN, OUT> testHarness =
                 getTestHarness(new Configuration(), JoinRelType.LEFT);
         long initialTime = 0L;

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/typeutils/PythonTypeUtilsTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/typeutils/PythonTypeUtilsTest.java
@@ -27,66 +27,61 @@ import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.UnresolvedUserDefinedType;
-import org.apache.flink.util.ExceptionUtils;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link PythonTypeUtils}. */
-public class PythonTypeUtilsTest {
+class PythonTypeUtilsTest {
 
     @Test
-    public void testLogicalTypetoInternalSerializer() {
+    void testLogicalTypetoInternalSerializer() {
         List<RowType.RowField> rowFields = new ArrayList<>();
         rowFields.add(new RowType.RowField("f1", new BigIntType()));
         RowType rowType = new RowType(rowFields);
         TypeSerializer baseSerializer = PythonTypeUtils.toInternalSerializer(rowType);
-        assertTrue(baseSerializer instanceof RowDataSerializer);
+        assertThat(baseSerializer).isInstanceOf(RowDataSerializer.class);
 
-        assertEquals(1, ((RowDataSerializer) baseSerializer).getArity());
+        assertThat(((RowDataSerializer) baseSerializer).getArity()).isEqualTo(1);
     }
 
     @Test
-    public void testLogicalTypeToProto() {
+    void testLogicalTypeToProto() {
         List<RowType.RowField> rowFields = new ArrayList<>();
         rowFields.add(new RowType.RowField("f1", new BigIntType()));
         RowType rowType = new RowType(rowFields);
         FlinkFnApi.Schema.FieldType protoType =
                 rowType.accept(new PythonTypeUtils.LogicalTypeToProtoTypeConverter());
         FlinkFnApi.Schema schema = protoType.getRowSchema();
-        assertEquals(1, schema.getFieldsCount());
-        assertEquals("f1", schema.getFields(0).getName());
-        assertEquals(
-                FlinkFnApi.Schema.TypeName.BIGINT, schema.getFields(0).getType().getTypeName());
+        assertThat(schema.getFieldsCount()).isEqualTo(1);
+        assertThat(schema.getFields(0).getName()).isEqualTo("f1");
+        assertThat(schema.getFields(0).getType().getTypeName())
+                .isEqualTo(FlinkFnApi.Schema.TypeName.BIGINT);
     }
 
     @Test
-    public void testLogicalTypeToDataConverter() {
+    void testLogicalTypeToDataConverter() {
         PythonTypeUtils.DataConverter converter = PythonTypeUtils.toDataConverter(new IntType());
 
         GenericRowData data = new GenericRowData(1);
         data.setField(0, 10);
         Object externalData = converter.toExternal(data, 0);
-        assertTrue(externalData instanceof Long);
-        assertEquals(externalData, 10L);
+        assertThat(externalData).isInstanceOf(Long.class);
+        assertThat(externalData).isEqualTo(10L);
     }
 
     @Test
-    public void testUnsupportedTypeSerializer() {
+    void testUnsupportedTypeSerializer() {
         LogicalType logicalType =
                 new UnresolvedUserDefinedType(UnresolvedIdentifier.of("cat", "db", "MyType"));
         String expectedTestException =
                 "Python UDF doesn't support logical type `cat`.`db`.`MyType` currently.";
-        try {
-            PythonTypeUtils.toInternalSerializer(logicalType);
-        } catch (Exception e) {
-            assertTrue(
-                    ExceptionUtils.findThrowableWithMessage(e, expectedTestException).isPresent());
-        }
+        assertThatThrownBy(() -> PythonTypeUtils.toInternalSerializer(logicalType))
+                .hasStackTraceContaining(expectedTestException);
     }
 }

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/typeutils/serializers/python/TimestampSerializerTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/typeutils/serializers/python/TimestampSerializerTest.java
@@ -23,9 +23,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 
 import java.sql.Timestamp;
 
-/**
- * Test for {@link org.apache.flink.table.runtime.typeutils.serializers.python.TimestampSerializer}.
- */
+/** Test for {@link TimestampSerializer}. */
 abstract class TimestampSerializerTest extends SerializerTestBase<Timestamp> {
 
     @Override

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/typeutils/serializers/python/TimestampSerializerTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/typeutils/serializers/python/TimestampSerializerTest.java
@@ -16,15 +16,16 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.runtime.typeutils.serializers.python.timestamp;
+package org.apache.flink.table.runtime.typeutils.serializers.python;
 
 import org.apache.flink.api.common.typeutils.SerializerTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.table.runtime.typeutils.serializers.python.TimestampSerializer;
 
 import java.sql.Timestamp;
 
-/** Test for {@link TimestampSerializer}. */
+/**
+ * Test for {@link org.apache.flink.table.runtime.typeutils.serializers.python.TimestampSerializer}.
+ */
 abstract class TimestampSerializerTest extends SerializerTestBase<Timestamp> {
 
     @Override

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/typeutils/serializers/python/timestamp/TimestampSerializerTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/typeutils/serializers/python/timestamp/TimestampSerializerTest.java
@@ -16,10 +16,11 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.runtime.typeutils.serializers.python;
+package org.apache.flink.table.runtime.typeutils.serializers.python.timestamp;
 
 import org.apache.flink.api.common.typeutils.SerializerTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.table.runtime.typeutils.serializers.python.TimestampSerializer;
 
 import java.sql.Timestamp;
 

--- a/flink-python/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/flink-python/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.util.TestLoggerExtension


### PR DESCRIPTION
## What is the purpose of the change

Update the flink-python module to AssertJ and JUnit 5 following the [JUnit 5 Migration Guide](https://docs.google.com/document/d/1514Wa_aNB9bJUen4xm5uiuXOooOJTtXqS_Jqk9KJitU/edit)


## Brief change log

Use JUnit5 and AssertJ in tests instead of JUnit4 and Hamcrest


## Verifying this change

This change is a code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
