### PR TITLE
[FLINK-27673][tests] Migrate flink-table-api-scala to JUnit5

### DIFF
--- a/flink-table/flink-table-api-scala/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/flink-table/flink-table-api-scala/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.util.TestLoggerExtension

--- a/flink-table/flink-table-api-scala/src/test/scala/org/apache/flink/table/api/ExpressionsConsistencyCheckTest.scala
+++ b/flink-table/flink-table-api-scala/src/test/scala/org/apache/flink/table/api/ExpressionsConsistencyCheckTest.scala
@@ -18,13 +18,11 @@
 package org.apache.flink.table.api
 
 import org.apache.flink.table.expressions.ApiExpressionUtils._
-import org.apache.flink.table.expressions.Expression
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions.{EQUALS, PLUS, TRIM}
 
-import org.hamcrest.CoreMatchers
+import org.assertj.core.api.AssertionsForClassTypes.assertThat
 import org.hamcrest.collection.IsEmptyIterable
-import org.junit.Assert._
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 import java.lang.reflect.Modifier
 
@@ -248,26 +246,23 @@ class ExpressionsConsistencyCheckTest {
     // It should be discouraged though as it might have unforeseen side effects
     val expr = lit("ABC") === $"f0".plus(Expressions.$("f1")).plus($("f2")).trim()
 
-    assertThat(
-      expr,
-      CoreMatchers.equalTo[Expression](
+    assertThat(expr).isEqualTo(
+      unresolvedCall(
+        EQUALS,
+        valueLiteral("ABC"),
         unresolvedCall(
-          EQUALS,
-          valueLiteral("ABC"),
+          TRIM,
+          valueLiteral(true),
+          valueLiteral(true),
+          valueLiteral(" "),
           unresolvedCall(
-            TRIM,
-            valueLiteral(true),
-            valueLiteral(true),
-            valueLiteral(" "),
+            PLUS,
             unresolvedCall(
               PLUS,
-              unresolvedCall(
-                PLUS,
-                unresolvedRef("f0"),
-                unresolvedRef("f1")
-              ),
-              unresolvedRef("f2")
-            )
+              unresolvedRef("f0"),
+              unresolvedRef("f1")
+            ),
+            unresolvedRef("f2")
           )
         )
       )

--- a/flink-table/flink-table-api-scala/src/test/scala/org/apache/flink/table/api/ImplicitConversionsTest.scala
+++ b/flink-table/flink-table-api-scala/src/test/scala/org/apache/flink/table/api/ImplicitConversionsTest.scala
@@ -21,9 +21,8 @@ import org.apache.flink.table.expressions.ApiExpressionUtils.unwrapFromApi
 import org.apache.flink.table.expressions.Expression
 import org.apache.flink.types.Row
 
-import org.hamcrest.CoreMatchers.equalTo
-import org.junit.Assert.assertThat
-import org.junit.Test
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
 
 /** Tests for conversion between objects and [[Expression]]s used in Expression DSL. */
 class ImplicitConversionsTest extends ImplicitExpressionConversions {
@@ -85,6 +84,6 @@ class ImplicitConversionsTest extends ImplicitExpressionConversions {
   }
 
   private def assertThatEquals(actual: Expression, expected: Expression): Unit = {
-    assertThat(unwrapFromApi(actual), equalTo(unwrapFromApi(expected)))
+    assertThat(unwrapFromApi(actual)).isEqualTo(unwrapFromApi(expected))
   }
 }

--- a/flink-table/flink-table-api-scala/src/test/scala/org/apache/flink/table/expressions/ObjectToExpressionScalaTest.scala
+++ b/flink-table/flink-table-api-scala/src/test/scala/org/apache/flink/table/expressions/ObjectToExpressionScalaTest.scala
@@ -20,9 +20,8 @@ package org.apache.flink.table.expressions
 import org.apache.flink.table.api.ImplicitExpressionConversions
 import org.apache.flink.table.expressions.ApiExpressionUtils.unwrapFromApi
 
-import org.hamcrest.CoreMatchers.equalTo
-import org.junit.Assert.assertThat
-import org.junit.Test
+import org.assertj.core.api.AssertionsForClassTypes.assertThat
+import org.junit.jupiter.api.Test
 
 import java.math.{BigDecimal => JBigDecimal}
 
@@ -50,6 +49,6 @@ class ObjectToExpressionScalaTest extends ImplicitExpressionConversions {
   }
 
   private def assertThatEquals(actual: Expression, expected: Expression): Unit = {
-    assertThat(unwrapFromApi(actual), equalTo(unwrapFromApi(expected)))
+    assertThat(unwrapFromApi(actual)).isEqualTo(unwrapFromApi(expected))
   }
 }

--- a/flink-table/flink-table-api-scala/src/test/scala/org/apache/flink/table/types/extraction/DataTypeExtractorScalaTest.scala
+++ b/flink-table/flink-table-api-scala/src/test/scala/org/apache/flink/table/types/extraction/DataTypeExtractorScalaTest.scala
@@ -19,39 +19,35 @@ package org.apache.flink.table.types.extraction
 
 import org.apache.flink.table.annotation.{DataTypeHint, HintFlag}
 import org.apache.flink.table.api.ValidationException
-import org.apache.flink.table.types.extraction.DataTypeExtractorTest.{TestSpec, _}
+import org.apache.flink.table.types.extraction.DataTypeExtractorTest._
 
-import org.junit.{Rule, Test}
-import org.junit.rules.ExpectedException
-import org.junit.runner.RunWith
-import org.junit.runners.Parameterized
-import org.junit.runners.Parameterized.Parameters
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.assertj.core.api.HamcrestCondition
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
 
 import java.util
-
-import scala.annotation.meta.getter
+import java.util.stream
 
 /** Scala tests for [[DataTypeExtractor]]. */
-@RunWith(classOf[Parameterized])
-class DataTypeExtractorScalaTest(testSpec: DataTypeExtractorTest.TestSpec) {
+class DataTypeExtractorScalaTest {
 
-  @(Rule @getter)
-  var thrown: ExpectedException = ExpectedException.none
-
-  @Test
-  def testScalaExtraction(): Unit = {
+  @ParameterizedTest
+  @MethodSource(Array("testData"))
+  def testScalaExtraction(testSpec: DataTypeExtractorTest.TestSpec): Unit = {
     if (testSpec.hasErrorMessage) {
-      thrown.expect(classOf[ValidationException])
-      thrown.expectCause(errorMatcher(testSpec))
+      assertThatThrownBy(() => runExtraction(testSpec))
+        .isInstanceOf(classOf[ValidationException])
+        .is(HamcrestCondition.matching(errorMatcher(testSpec)))
+    } else {
+      runExtraction(testSpec)
     }
-    runExtraction(testSpec)
   }
 }
 
 object DataTypeExtractorScalaTest {
 
-  @Parameters
-  def testData: Array[TestSpec] = Array(
+  def testData: stream.Stream[TestSpec] = java.util.stream.Stream.of(
     // simple structured type without RAW type
     TestSpec
       .forType(classOf[ScalaSimplePojo])

--- a/flink-table/flink-table-api-scala/src/test/scala/org/apache/flink/table/types/extraction/TypeInferenceExtractorScalaTest.scala
+++ b/flink-table/flink-table-api-scala/src/test/scala/org/apache/flink/table/types/extraction/TypeInferenceExtractorScalaTest.scala
@@ -24,38 +24,37 @@ import org.apache.flink.table.types.extraction.TypeInferenceExtractorTest.TestSp
 import org.apache.flink.table.types.inference.{ArgumentTypeStrategy, InputTypeStrategies, TypeStrategies}
 
 import org.assertj.core.api.AssertionsForClassTypes.assertThat
-import org.junit.{Rule, Test}
-import org.junit.rules.ExpectedException
-import org.junit.runner.RunWith
-import org.junit.runners.Parameterized
-import org.junit.runners.Parameterized.Parameters
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
 
-import java.util.Optional
+import java.util.{stream, Optional}
 
 import scala.annotation.varargs
 
 /** Scala tests for [[TypeInferenceExtractor]]. */
-@RunWith(classOf[Parameterized])
-class TypeInferenceExtractorScalaTest(testSpec: TestSpec) {
+class TypeInferenceExtractorScalaTest {
 
-  @Test
-  def testArgumentNames(): Unit = {
+  @ParameterizedTest
+  @MethodSource(Array("testData"))
+  def testArgumentNames(testSpec: TestSpec): Unit = {
     if (testSpec.expectedArgumentNames != null) {
       assertThat(testSpec.typeInferenceExtraction.get.getNamedArguments)
         .isEqualTo(Optional.of(testSpec.expectedArgumentNames))
     }
   }
 
-  @Test
-  def testArgumentTypes(): Unit = {
+  @ParameterizedTest
+  @MethodSource(Array("testData"))
+  def testArgumentTypes(testSpec: TestSpec): Unit = {
     if (testSpec.expectedArgumentTypes != null) {
       assertThat(testSpec.typeInferenceExtraction.get.getTypedArguments)
         .isEqualTo(Optional.of(testSpec.expectedArgumentTypes))
     }
   }
 
-  @Test
-  def testOutputTypeStrategy(): Unit = {
+  @ParameterizedTest
+  @MethodSource(Array("testData"))
+  def testOutputTypeStrategy(testSpec: TestSpec): Unit = {
     if (!testSpec.expectedOutputStrategies.isEmpty) {
       assertThat(testSpec.typeInferenceExtraction.get.getOutputTypeStrategy)
         .isEqualTo(TypeStrategies.mapping(testSpec.expectedOutputStrategies))
@@ -65,8 +64,7 @@ class TypeInferenceExtractorScalaTest(testSpec: TestSpec) {
 
 object TypeInferenceExtractorScalaTest {
 
-  @Parameters
-  def testData: Array[TestSpec] = Array(
+  def testData: stream.Stream[TestSpec] = java.util.stream.Stream.of(
     // Scala function with data type hint
     TestSpec
       .forScalarFunction(classOf[ScalaScalarFunction])


### PR DESCRIPTION
## What is the purpose of the change

Update the flink-table-api-scala module to AssertJ and JUnit 5 following the [JUnit 5 Migration Guide](https://docs.google.com/document/d/1514Wa_aNB9bJUen4xm5uiuXOooOJTtXqS_Jqk9KJitU/edit)

## Brief change log

Use JUnit5 and AssertJ in tests instead of JUnit4 and Hamcrest

## Verifying this change

This change is a code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
