### PR TITLE
[FLINK-26480]Support window_all in Python DataStream API

### DIFF
--- a/docs/content.zh/docs/dev/datastream/operators/windows.md
+++ b/docs/content.zh/docs/dev/datastream/operators/windows.md
@@ -1604,6 +1604,21 @@ val globalResults = resultsPerKey
     .process(new TopKWindowFunction())
 ```
 {{< /tab >}}
+{{< tab "Python" >}}
+```python
+input = ...  # type: DataStream
+
+input \
+    .key_by(<key selector>) \
+    .window(TumblingEventTimeWindows.of(Time.seconds(5)))
+    .reduce(Summer())
+
+input \
+    .key_by(<key selector>) \
+    .window_all(TumblingProcessingTimeWindows.of(Time.seconds(5)))
+    .process(TopKWindowFunction())
+```
+{{< /tab >}}
 {{< /tabs >}}
 
 这个例子中，第一个操作中时间窗口`[0, 5)` 的结果会出现在下一个窗口操作的 `[0, 5)` 窗口中。

--- a/docs/content.zh/docs/dev/datastream/operators/windows.md
+++ b/docs/content.zh/docs/dev/datastream/operators/windows.md
@@ -1608,14 +1608,13 @@ val globalResults = resultsPerKey
 ```python
 input = ...  # type: DataStream
 
-input \
+results_per_key = input \
     .key_by(<key selector>) \
-    .window(TumblingEventTimeWindows.of(Time.seconds(5)))
+    .window(TumblingEventTimeWindows.of(Time.seconds(5))) \
     .reduce(Summer())
 
-input \
-    .key_by(<key selector>) \
-    .window_all(TumblingProcessingTimeWindows.of(Time.seconds(5)))
+global_results = results_per_key \
+    .window_all(TumblingProcessingTimeWindows.of(Time.seconds(5))) \
     .process(TopKWindowFunction())
 ```
 {{< /tab >}}

--- a/docs/content/docs/dev/datastream/operators/windows.md
+++ b/docs/content/docs/dev/datastream/operators/windows.md
@@ -1659,6 +1659,21 @@ val globalResults = resultsPerKey
     .process(new TopKWindowFunction())
 ```
 {{< /tab >}}
+{{< tab "Python" >}}
+```python
+input = ...  # type: DataStream
+
+input \
+    .key_by(<key selector>) \
+    .window(TumblingEventTimeWindows.of(Time.seconds(5)))
+    .reduce(Summer())
+
+input \
+    .key_by(<key selector>) \
+    .window_all(TumblingProcessingTimeWindows.of(Time.seconds(5)))
+    .process(TopKWindowFunction())
+```
+{{< /tab >}}
 {{< /tabs >}}
 
 In this example, the results for time window `[0, 5)` from the first operation will also end up in

--- a/docs/content/docs/dev/datastream/operators/windows.md
+++ b/docs/content/docs/dev/datastream/operators/windows.md
@@ -1663,14 +1663,13 @@ val globalResults = resultsPerKey
 ```python
 input = ...  # type: DataStream
 
-input \
+results_per_key = input \
     .key_by(<key selector>) \
-    .window(TumblingEventTimeWindows.of(Time.seconds(5)))
+    .window(TumblingEventTimeWindows.of(Time.seconds(5))) \
     .reduce(Summer())
 
-input \
-    .key_by(<key selector>) \
-    .window_all(TumblingProcessingTimeWindows.of(Time.seconds(5)))
+global_results = results_per_key \
+    .window_all(TumblingProcessingTimeWindows.of(Time.seconds(5))) \
     .process(TopKWindowFunction())
 ```
 {{< /tab >}}

--- a/flink-python/pyflink/datastream/functions.py
+++ b/flink-python/pyflink/datastream/functions.py
@@ -38,7 +38,6 @@ __all__ = [
     'ReduceFunction',
     'AggregateFunction',
     'KeySelector',
-    'NullByteKeySelector',
     'FilterFunction',
     'Partitioner',
     'SourceFunction',
@@ -916,7 +915,7 @@ class WindowFunction(Function, Generic[IN, OUT, KEY, W]):
 
 class AllWindowFunction(Function, Generic[IN, OUT, W]):
     """
-    Base interface for functions that are evaluated over keyed (grouped) windows.
+    Base interface for functions that are evaluated over non-keyed windows.
     """
 
     @abstractmethod

--- a/flink-python/pyflink/datastream/functions.py
+++ b/flink-python/pyflink/datastream/functions.py
@@ -38,6 +38,7 @@ __all__ = [
     'ReduceFunction',
     'AggregateFunction',
     'KeySelector',
+    'NullByteKeySelector',
     'FilterFunction',
     'Partitioner',
     'SourceFunction',
@@ -48,7 +49,9 @@ __all__ = [
     'KeyedCoProcessFunction',
     'TimerService',
     'WindowFunction',
-    'ProcessWindowFunction']
+    'AllWindowFunction',
+    'ProcessWindowFunction',
+    'ProcessAllWindowFunction']
 
 
 W = TypeVar('W')
@@ -465,6 +468,16 @@ class KeySelector(Function):
         :return: The extracted key.
         """
         pass
+
+
+class NullByteKeySelector(KeySelector):
+    """
+    Used as a dummy KeySelector to allow using keyed operators for non-keyed use cases. Essentially,
+    it gives all incoming records the same key, which is a (byte) 0 value.
+    """
+
+    def get_key(self, value):
+        return 0
 
 
 class FilterFunction(Function):
@@ -901,6 +914,22 @@ class WindowFunction(Function, Generic[IN, OUT, KEY, W]):
         pass
 
 
+class AllWindowFunction(Function, Generic[IN, OUT, W]):
+    """
+    Base interface for functions that are evaluated over keyed (grouped) windows.
+    """
+
+    @abstractmethod
+    def apply(self, window: W, inputs: Iterable[IN]) -> Iterable[OUT]:
+        """
+        Evaluates the window and outputs none or several elements.
+
+        :param window: The window that is being evaluated.
+        :param inputs: The elements in the window being evaluated.
+        """
+        pass
+
+
 class ProcessWindowFunction(Function, Generic[IN, OUT, KEY, W]):
     """
     Base interface for functions that are evaluated over keyed (grouped) windows using a context
@@ -970,6 +999,68 @@ class ProcessWindowFunction(Function, Generic[IN, OUT, KEY, W]):
 
     @abstractmethod
     def clear(self, context: 'ProcessWindowFunction.Context') -> None:
+        """
+        Deletes any state in the :class:`Context` when the Window expires (the watermark passes its
+        max_timestamp + allowed_lateness).
+
+        :param context: The context to which the window is being evaluated.
+        """
+        pass
+
+
+class ProcessAllWindowFunction(Function, Generic[IN, OUT, W]):
+    """
+    Base interface for functions that are evaluated over keyed (grouped) windows using a context
+    for retrieving extra information.
+    """
+
+    class Context(ABC, Generic[W2]):
+        """
+        The context holding window metadata.
+        """
+
+        @abstractmethod
+        def window(self) -> W2:
+            """
+            :return: The window that is being evaluated.
+            """
+            pass
+
+        @abstractmethod
+        def window_state(self) -> KeyedStateStore:
+            """
+            State accessor for per-key and per-window state.
+
+            .. note::
+                If you use per-window state you have to ensure that you clean it up by implementing
+                :func:`~ProcessWindowFunction.clear`.
+
+            :return: The :class:`KeyedStateStore` used to access per-key and per-window states.
+            """
+            pass
+
+        @abstractmethod
+        def global_state(self) -> KeyedStateStore:
+            """
+            State accessor for per-key global state.
+            """
+            pass
+
+    @abstractmethod
+    def process(self,
+                context: 'ProcessAllWindowFunction.Context',
+                elements: Iterable[IN]) -> Iterable[OUT]:
+        """
+        Evaluates the window and outputs none or several elements.
+
+        :param context: The context in which the window is being evaluated.
+        :param elements: The elements in the window being evaluated.
+        :return: The iterable object which produces the elements to emit.
+        """
+        pass
+
+    @abstractmethod
+    def clear(self, context: 'ProcessAllWindowFunction.Context') -> None:
         """
         Deletes any state in the :class:`Context` when the Window expires (the watermark passes its
         max_timestamp + allowed_lateness).
@@ -1064,6 +1155,30 @@ class InternalIterableWindowFunction(InternalWindowFunction[Iterable[IN], OUT, K
         pass
 
 
+class InternalIterableAllWindowFunction(InternalWindowFunction[Iterable[IN], OUT, int, W]):
+
+    def __init__(self, wrapped_function: AllWindowFunction):
+        self._wrapped_function = wrapped_function
+
+    def open(self, runtime_context: RuntimeContext):
+        self._wrapped_function.open(runtime_context)
+
+    def close(self):
+        self._wrapped_function.close()
+
+    def process(self,
+                key: int,
+                window: W,
+                context: InternalWindowFunction.InternalWindowContext,
+                input_data: Iterable[IN]) -> Iterable[OUT]:
+        return self._wrapped_function.apply(window, input_data)
+
+    def clear(self,
+              window: W,
+              context: InternalWindowFunction.InternalWindowContext):
+        pass
+
+
 class InternalProcessWindowContext(ProcessWindowFunction.Context[W]):
 
     def __init__(self):
@@ -1078,6 +1193,22 @@ class InternalProcessWindowContext(ProcessWindowFunction.Context[W]):
 
     def current_watermark(self) -> int:
         return self._underlying.current_watermark()
+
+    def window_state(self) -> KeyedStateStore:
+        return self._underlying.window_state()
+
+    def global_state(self) -> KeyedStateStore:
+        return self._underlying.global_state()
+
+
+class InternalProcessAllWindowContext(ProcessAllWindowFunction.Context[W]):
+
+    def __init__(self):
+        self._underlying = None
+        self._window = None
+
+    def window(self) -> W:
+        return self._window
 
     def window_state(self) -> KeyedStateStore:
         return self._underlying.window_state()
@@ -1135,6 +1266,34 @@ class InternalIterableProcessWindowFunction(InternalWindowFunction[Iterable[IN],
         self._internal_context._window = window
         self._internal_context._underlying = context
         return self._wrapped_function.process(key, self._internal_context, input_data)
+
+    def clear(self, window: W, context: InternalWindowFunction.InternalWindowContext):
+        self._internal_context._window = window
+        self._internal_context._underlying = context
+        self._wrapped_function.clear(self._internal_context)
+
+
+class InternalIterableProcessAllWindowFunction(InternalWindowFunction[Iterable[IN], OUT, int, W]):
+
+    def __init__(self, wrapped_function: ProcessAllWindowFunction):
+        self._wrapped_function = wrapped_function
+        self._internal_context = \
+            InternalProcessAllWindowContext()  # type: InternalProcessAllWindowContext
+
+    def open(self, runtime_context: RuntimeContext):
+        self._wrapped_function.open(runtime_context)
+
+    def close(self):
+        self._wrapped_function.close()
+
+    def process(self,
+                key: int,
+                window: W,
+                context: InternalWindowFunction.InternalWindowContext,
+                input_data: Iterable[IN]) -> Iterable[OUT]:
+        self._internal_context._window = window
+        self._internal_context._underlying = context
+        return self._wrapped_function.process(self._internal_context, input_data)
 
     def clear(self, window: W, context: InternalWindowFunction.InternalWindowContext):
         self._internal_context._window = window

--- a/flink-python/pyflink/datastream/functions.py
+++ b/flink-python/pyflink/datastream/functions.py
@@ -997,7 +997,6 @@ class ProcessWindowFunction(Function, Generic[IN, OUT, KEY, W]):
         """
         pass
 
-    @abstractmethod
     def clear(self, context: 'ProcessWindowFunction.Context') -> None:
         """
         Deletes any state in the :class:`Context` when the Window expires (the watermark passes its
@@ -1010,7 +1009,7 @@ class ProcessWindowFunction(Function, Generic[IN, OUT, KEY, W]):
 
 class ProcessAllWindowFunction(Function, Generic[IN, OUT, W]):
     """
-    Base interface for functions that are evaluated over keyed (grouped) windows using a context
+    Base interface for functions that are evaluated over non-keyed windows using a context
     for retrieving extra information.
     """
 
@@ -1059,7 +1058,6 @@ class ProcessAllWindowFunction(Function, Generic[IN, OUT, W]):
         """
         pass
 
-    @abstractmethod
     def clear(self, context: 'ProcessAllWindowFunction.Context') -> None:
         """
         Deletes any state in the :class:`Context` when the Window expires (the watermark passes its

--- a/flink-python/pyflink/datastream/tests/test_window.py
+++ b/flink-python/pyflink/datastream/tests/test_window.py
@@ -460,7 +460,6 @@ class WindowTests(PyFlinkStreamingTestCase):
                 pass
 
         data_stream.assign_timestamps_and_watermarks(watermark_strategy) \
-            .key_by(lambda x: x[0], key_type=Types.STRING()) \
             .window_all(TumblingEventTimeWindows.of(Time.milliseconds(5))) \
             .process(CountAllWindowProcessFunction(),
                      Types.TUPLE([Types.LONG(), Types.LONG(), Types.INT()])) \


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
