### PR TITLE
[FLINK-27623][table] Add 'table.exec.async-lookup.output-mode' to ExecutionConfigOptions

### DIFF
--- a/docs/layouts/shortcodes/generated/execution_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/execution_config_configuration.html
@@ -18,7 +18,7 @@
             <td><h5>table.exec.async-lookup.output-mode</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>
             <td style="word-wrap: break-word;">ORDERED</td>
             <td><p>Enum</p></td>
-            <td>Output mode for asynchronous operations which will convert to {@see AsyncDataStream.OutputMode}, ORDERED by default.If set to ALLOW_UNORDERED, will attempt to use {@see AsyncDataStream.OutputMode.UNORDERED} when it does not affect the correctness of the result, otherwise ORDERED will be still used.<br /><br />Possible values:<ul><li>"ORDERED"</li><li>"ALLOW_UNORDERED"</li></ul></td>
+            <td>Output mode for asynchronous operations which will convert to {@see AsyncDataStream.OutputMode}, ORDERED by default. If set to ALLOW_UNORDERED, will attempt to use {@see AsyncDataStream.OutputMode.UNORDERED} when it does not affect the correctness of the result, otherwise ORDERED will be still used.<br /><br />Possible values:<ul><li>"ORDERED"</li><li>"ALLOW_UNORDERED"</li></ul></td>
         </tr>
         <tr>
             <td><h5>table.exec.async-lookup.timeout</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>

--- a/docs/layouts/shortcodes/generated/execution_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/execution_config_configuration.html
@@ -15,6 +15,12 @@
             <td>The max number of async i/o operation that the async lookup join can trigger.</td>
         </tr>
         <tr>
+            <td><h5>table.exec.async-lookup.output-mode</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>
+            <td style="word-wrap: break-word;">ORDERED</td>
+            <td><p>Enum</p></td>
+            <td>Output mode for asynchronous operations which will convert to {@see AsyncDataStream.OutputMode}, ORDERED by default.If set to ALLOW_UNORDERED, will attempt to use {@see AsyncDataStream.OutputMode.UNORDERED} when it does not affect the correctness of the result, otherwise ORDERED will be still used.<br /><br />Possible values:<ul><li>"ORDERED"</li><li>"ALLOW_UNORDERED"</li></ul></td>
+        </tr>
+        <tr>
             <td><h5>table.exec.async-lookup.timeout</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>
             <td style="word-wrap: break-word;">3 min</td>
             <td>Duration</td>

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
@@ -323,6 +323,14 @@ public class ExecutionConfigOptions {
                     .withDescription(
                             "The async timeout for the asynchronous operation to complete.");
 
+    @Documentation.TableOption(execMode = Documentation.ExecMode.BATCH_STREAMING)
+    public static final ConfigOption<AsyncOutputMode> TABLE_EXEC_ASYNC_LOOKUP_OUTPUT_MODE =
+            key("table.exec.async-lookup.output-mode")
+                    .enumType(AsyncOutputMode.class)
+                    .defaultValue(AsyncOutputMode.ORDERED)
+                    .withDescription(
+                            "Output mode for asynchronous operations, equivalent to {@see AsyncDataStream.OutputMode}, ordered by default.");
+
     // ------------------------------------------------------------------------
     //  MiniBatch Options
     // ------------------------------------------------------------------------
@@ -379,7 +387,9 @@ public class ExecutionConfigOptions {
                                     + "\"SortMergeJoin\", \"HashAgg\", \"SortAgg\".\n"
                                     + "By default no operator is disabled.");
 
-    /** @deprecated Use {@link ExecutionOptions#BATCH_SHUFFLE_MODE} instead. */
+    /**
+     * @deprecated Use {@link ExecutionOptions#BATCH_SHUFFLE_MODE} instead.
+     */
     @Deprecated
     @Documentation.TableOption(execMode = Documentation.ExecMode.BATCH)
     public static final ConfigOption<String> TABLE_EXEC_SHUFFLE_MODE =
@@ -571,6 +581,17 @@ public class ExecutionConfigOptions {
 
         /** Add keyed shuffle in any case except single parallelism. */
         FORCE
+    }
+
+    /** Output mode for asynchronous operations, equivalent to {@see AsyncDataStream.OutputMode}. */
+    @PublicEvolving
+    public enum AsyncOutputMode {
+
+        /** Ordered output mode, equivalent to {@see AsyncDataStream.OutputMode.ORDERED}. */
+        ORDERED,
+
+        /** Unordered output mode, {@see AsyncDataStream.OutputMode.UNORDERED}. */
+        UNORDERED
     }
 
     /** Determine if CAST operates using the legacy behaviour or the new one. */

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
@@ -329,7 +329,7 @@ public class ExecutionConfigOptions {
                     .enumType(AsyncOutputMode.class)
                     .defaultValue(AsyncOutputMode.ORDERED)
                     .withDescription(
-                            "Output mode for asynchronous operations which will convert to {@see AsyncDataStream.OutputMode}, ORDERED by default."
+                            "Output mode for asynchronous operations which will convert to {@see AsyncDataStream.OutputMode}, ORDERED by default. "
                                     + "If set to ALLOW_UNORDERED, will attempt to use {@see AsyncDataStream.OutputMode.UNORDERED} when it does not "
                                     + "affect the correctness of the result, otherwise ORDERED will be still used.");
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
@@ -329,7 +329,9 @@ public class ExecutionConfigOptions {
                     .enumType(AsyncOutputMode.class)
                     .defaultValue(AsyncOutputMode.ORDERED)
                     .withDescription(
-                            "Output mode for asynchronous operations, equivalent to {@see AsyncDataStream.OutputMode}, ordered by default.");
+                            "Output mode for asynchronous operations which will convert to {@see AsyncDataStream.OutputMode}, ORDERED by default."
+                                    + "If set to ALLOW_UNORDERED, will attempt to use {@see AsyncDataStream.OutputMode.UNORDERED} when it does not "
+                                    + "affect the correctness of the result, otherwise ORDERED will be still used.");
 
     // ------------------------------------------------------------------------
     //  MiniBatch Options
@@ -387,9 +389,7 @@ public class ExecutionConfigOptions {
                                     + "\"SortMergeJoin\", \"HashAgg\", \"SortAgg\".\n"
                                     + "By default no operator is disabled.");
 
-    /**
-     * @deprecated Use {@link ExecutionOptions#BATCH_SHUFFLE_MODE} instead.
-     */
+    /** @deprecated Use {@link ExecutionOptions#BATCH_SHUFFLE_MODE} instead. */
     @Deprecated
     @Documentation.TableOption(execMode = Documentation.ExecMode.BATCH)
     public static final ConfigOption<String> TABLE_EXEC_SHUFFLE_MODE =
@@ -590,8 +590,12 @@ public class ExecutionConfigOptions {
         /** Ordered output mode, equivalent to {@see AsyncDataStream.OutputMode.ORDERED}. */
         ORDERED,
 
-        /** Unordered output mode, {@see AsyncDataStream.OutputMode.UNORDERED}. */
-        UNORDERED
+        /**
+         * Allow unordered output mode, will attempt to use {@see
+         * AsyncDataStream.OutputMode.UNORDERED} when it does not affect the correctness of the
+         * result, otherwise ORDERED will be still used.
+         */
+        ALLOW_UNORDERED
     }
 
     /** Determine if CAST operates using the legacy behaviour or the new one. */

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecLookupJoin.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecLookupJoin.java
@@ -46,7 +46,7 @@ public class BatchExecLookupJoin extends CommonExecLookupJoin implements BatchEx
             Map<Integer, LookupJoinUtil.LookupKey> lookupKeys,
             @Nullable List<RexNode> projectionOnTemporalTable,
             @Nullable RexNode filterOnTemporalTable,
-            @Nullable InputProperty inputProperty,
+            InputProperty inputProperty,
             RowType outputType,
             String description) {
         super(

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecLookupJoin.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecLookupJoin.java
@@ -46,7 +46,7 @@ public class BatchExecLookupJoin extends CommonExecLookupJoin implements BatchEx
             Map<Integer, LookupJoinUtil.LookupKey> lookupKeys,
             @Nullable List<RexNode> projectionOnTemporalTable,
             @Nullable RexNode filterOnTemporalTable,
-            InputProperty inputProperty,
+            @Nullable InputProperty inputProperty,
             RowType outputType,
             String description) {
         super(
@@ -59,6 +59,7 @@ public class BatchExecLookupJoin extends CommonExecLookupJoin implements BatchEx
                 lookupKeys,
                 projectionOnTemporalTable,
                 filterOnTemporalTable,
+                true,
                 Collections.singletonList(inputProperty),
                 outputType,
                 description);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecLookupJoin.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecLookupJoin.java
@@ -57,6 +57,7 @@ public class StreamExecLookupJoin extends CommonExecLookupJoin implements Stream
             Map<Integer, LookupJoinUtil.LookupKey> lookupKeys,
             @Nullable List<RexNode> projectionOnTemporalTable,
             @Nullable RexNode filterOnTemporalTable,
+            boolean inputInsertOnly,
             InputProperty inputProperty,
             RowType outputType,
             String description) {
@@ -70,6 +71,7 @@ public class StreamExecLookupJoin extends CommonExecLookupJoin implements Stream
                 lookupKeys,
                 projectionOnTemporalTable,
                 filterOnTemporalTable,
+                inputInsertOnly,
                 Collections.singletonList(inputProperty),
                 outputType,
                 description);
@@ -89,6 +91,7 @@ public class StreamExecLookupJoin extends CommonExecLookupJoin implements Stream
                     List<RexNode> projectionOnTemporalTable,
             @JsonProperty(FIELD_NAME_FILTER_ON_TEMPORAL_TABLE) @Nullable
                     RexNode filterOnTemporalTable,
+            @JsonProperty(FIELD_NAME_INPUT_INSERT_ONLY) @Nullable Boolean inputInsertOnly,
             @JsonProperty(FIELD_NAME_INPUT_PROPERTIES) List<InputProperty> inputProperties,
             @JsonProperty(FIELD_NAME_OUTPUT_TYPE) RowType outputType,
             @JsonProperty(FIELD_NAME_DESCRIPTION) String description) {
@@ -102,6 +105,7 @@ public class StreamExecLookupJoin extends CommonExecLookupJoin implements Stream
                 lookupKeys,
                 projectionOnTemporalTable,
                 filterOnTemporalTable,
+                inputInsertOnly,
                 inputProperties,
                 outputType,
                 description);

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalLookupJoin.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalLookupJoin.scala
@@ -22,7 +22,7 @@ import org.apache.flink.table.planner.plan.nodes.exec.{ExecNode, InputProperty}
 import org.apache.flink.table.planner.plan.nodes.exec.spec.TemporalTableSourceSpec
 import org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecLookupJoin
 import org.apache.flink.table.planner.plan.nodes.physical.common.CommonPhysicalLookupJoin
-import org.apache.flink.table.planner.plan.utils.{FlinkRexUtil, JoinTypeUtil}
+import org.apache.flink.table.planner.plan.utils.{ChangelogPlanUtils, FlinkRexUtil, JoinTypeUtil}
 import org.apache.flink.table.planner.utils.JavaScalaConversionUtil
 import org.apache.flink.table.planner.utils.ShortcutUtils.unwrapTableConfig
 
@@ -83,6 +83,7 @@ class StreamPhysicalLookupJoin(
       allLookupKeys.map(item => (Int.box(item._1), item._2)).asJava,
       projectionOnTemporalTable,
       filterOnTemporalTable,
+      ChangelogPlanUtils.inputInsertOnly(this),
       InputProperty.DEFAULT,
       FlinkTypeFactory.toLogicalRowType(getRowType),
       getRelDetailedDescription)

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/LookupJoinJsonPlanTest_jsonplan/testJoinTemporalTable.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/LookupJoinJsonPlanTest_jsonplan/testJoinTemporalTable.out
@@ -258,6 +258,7 @@
     },
     "projectionOnTemporalTable" : null,
     "filterOnTemporalTable" : null,
+    "inputInsertOnly" : true,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "UNKNOWN"

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/LookupJoinJsonPlanTest_jsonplan/testJoinTemporalTableWithProjectionPushDown.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/LookupJoinJsonPlanTest_jsonplan/testJoinTemporalTableWithProjectionPushDown.out
@@ -262,6 +262,7 @@
       "type" : "INT"
     } ],
     "filterOnTemporalTable" : null,
+    "inputInsertOnly" : true,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "UNKNOWN"

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/AsyncLookupJoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/AsyncLookupJoinITCase.scala
@@ -316,6 +316,7 @@ object AsyncLookupJoinITCase {
       Array(JBoolean.TRUE, ROCKSDB_BACKEND, JBoolean.FALSE, AsyncOutputMode.ORDERED),
       Array(JBoolean.FALSE, HEAP_BACKEND, JBoolean.FALSE, AsyncOutputMode.ORDERED),
       Array(JBoolean.FALSE, HEAP_BACKEND, JBoolean.TRUE, AsyncOutputMode.ORDERED),
+      Array(JBoolean.FALSE, ROCKSDB_BACKEND, JBoolean.FALSE, AsyncOutputMode.ALLOW_UNORDERED),
       Array(JBoolean.FALSE, ROCKSDB_BACKEND, JBoolean.TRUE, AsyncOutputMode.ALLOW_UNORDERED)
     )
   }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/AsyncLookupJoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/AsyncLookupJoinITCase.scala
@@ -20,6 +20,8 @@ package org.apache.flink.table.planner.runtime.stream.sql
 import org.apache.flink.api.scala._
 import org.apache.flink.table.api.{TableSchema, Types}
 import org.apache.flink.table.api.bridge.scala._
+import org.apache.flink.table.api.config.ExecutionConfigOptions
+import org.apache.flink.table.api.config.ExecutionConfigOptions.AsyncOutputMode
 import org.apache.flink.table.planner.factories.TestValuesTableFactory
 import org.apache.flink.table.planner.runtime.utils.{InMemoryLookupableTableSource, StreamingWithStateTestBase, TestingAppendSink, TestingRetractSink}
 import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.{HEAP_BACKEND, ROCKSDB_BACKEND, StateBackendMode}
@@ -41,7 +43,8 @@ import scala.collection.JavaConversions._
 class AsyncLookupJoinITCase(
     legacyTableSource: Boolean,
     backend: StateBackendMode,
-    objectReuse: Boolean)
+    objectReuse: Boolean,
+    asyncOutputMode: AsyncOutputMode)
   extends StreamingWithStateTestBase(backend) {
 
   val data = List(
@@ -61,6 +64,8 @@ class AsyncLookupJoinITCase(
     } else {
       env.getConfig.disableObjectReuse()
     }
+
+    tEnv.getConfig.set(ExecutionConfigOptions.TABLE_EXEC_ASYNC_LOOKUP_OUTPUT_MODE, asyncOutputMode)
 
     createScanTable("src", data)
     createLookupTable("user_table", userData)
@@ -303,13 +308,15 @@ class AsyncLookupJoinITCase(
 }
 
 object AsyncLookupJoinITCase {
-  @Parameterized.Parameters(name = "LegacyTableSource={0}, StateBackend={1}, ObjectReuse={2}")
+  @Parameterized.Parameters(
+    name = "LegacyTableSource={0}, StateBackend={1}, ObjectReuse={2}, AsyncOutputMode={3}")
   def parameters(): JCollection[Array[Object]] = {
     Seq[Array[AnyRef]](
-      Array(JBoolean.TRUE, HEAP_BACKEND, JBoolean.TRUE),
-      Array(JBoolean.TRUE, ROCKSDB_BACKEND, JBoolean.FALSE),
-      Array(JBoolean.FALSE, HEAP_BACKEND, JBoolean.FALSE),
-      Array(JBoolean.FALSE, ROCKSDB_BACKEND, JBoolean.TRUE)
+      Array(JBoolean.TRUE, HEAP_BACKEND, JBoolean.TRUE, AsyncOutputMode.ALLOW_UNORDERED),
+      Array(JBoolean.TRUE, ROCKSDB_BACKEND, JBoolean.FALSE, AsyncOutputMode.ORDERED),
+      Array(JBoolean.FALSE, HEAP_BACKEND, JBoolean.FALSE, AsyncOutputMode.ORDERED),
+      Array(JBoolean.FALSE, HEAP_BACKEND, JBoolean.TRUE, AsyncOutputMode.ORDERED),
+      Array(JBoolean.FALSE, ROCKSDB_BACKEND, JBoolean.TRUE, AsyncOutputMode.ALLOW_UNORDERED)
     )
   }
 }

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/AsyncLookupJoinHarnessTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/AsyncLookupJoinHarnessTest.java
@@ -51,6 +51,8 @@ import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.util.Collector;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -59,6 +61,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -71,10 +74,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 /** Harness tests for {@link LookupJoinRunner} and {@link LookupJoinWithCalcRunner}. */
+@RunWith(Parameterized.class)
 public class AsyncLookupJoinHarnessTest {
 
     private static final int ASYNC_BUFFER_CAPACITY = 100;
     private static final int ASYNC_TIMEOUT_MS = 3000;
+
+    @Parameterized.Parameter public boolean orderedResult;
+
+    @Parameterized.Parameters(name = "ordered result = {0}")
+    public static Object[] parameters() {
+        return new Object[][] {new Object[] {true}, new Object[] {false}};
+    }
 
     private final TypeSerializer<RowData> inSerializer =
             new RowDataSerializer(
@@ -130,7 +141,7 @@ public class AsyncLookupJoinHarnessTest {
         expectedOutput.add(insertRecord(3, "c", 3, "Jackson"));
         expectedOutput.add(insertRecord(4, "d", 4, "Fabian"));
 
-        assertor.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
+        checkResult(expectedOutput, testHarness.getOutput());
     }
 
     @Test
@@ -159,7 +170,7 @@ public class AsyncLookupJoinHarnessTest {
         expectedOutput.add(insertRecord(3, "c", 3, "Jackson"));
         expectedOutput.add(insertRecord(4, "d", 4, "Fabian"));
 
-        assertor.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
+        checkResult(expectedOutput, testHarness.getOutput());
     }
 
     @Test
@@ -191,7 +202,7 @@ public class AsyncLookupJoinHarnessTest {
         expectedOutput.add(insertRecord(4, "d", 4, "Fabian"));
         expectedOutput.add(insertRecord(5, "e", null, null));
 
-        assertor.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
+        checkResult(expectedOutput, testHarness.getOutput());
     }
 
     @Test
@@ -222,10 +233,18 @@ public class AsyncLookupJoinHarnessTest {
         expectedOutput.add(insertRecord(4, "d", 4, "Fabian"));
         expectedOutput.add(insertRecord(5, "e", null, null));
 
-        assertor.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
+        checkResult(expectedOutput, testHarness.getOutput());
     }
 
     // ---------------------------------------------------------------------------------
+
+    private void checkResult(Collection<Object> expectedOutput, Collection<Object> actualOutput) {
+        if (orderedResult) {
+            assertor.assertOutputEquals("output wrong.", expectedOutput, actualOutput);
+        } else {
+            assertor.assertOutputEqualsSorted("output wrong.", expectedOutput, actualOutput);
+        }
+    }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     private OneInputStreamOperatorTestHarness<RowData, RowData> createHarness(
@@ -258,7 +277,9 @@ public class AsyncLookupJoinHarnessTest {
                         joinRunner,
                         ASYNC_TIMEOUT_MS,
                         ASYNC_BUFFER_CAPACITY,
-                        AsyncDataStream.OutputMode.ORDERED),
+                        orderedResult
+                                ? AsyncDataStream.OutputMode.ORDERED
+                                : AsyncDataStream.OutputMode.UNORDERED),
                 inSerializer);
     }
 
@@ -319,6 +340,8 @@ public class AsyncLookupJoinHarnessTest {
 
         private static final Map<Integer, List<RowData>> data = new HashMap<>();
 
+        private final Random random = new Random();
+
         static {
             data.put(1, Collections.singletonList(GenericRowData.of(1, fromString("Julian"))));
             data.put(
@@ -334,7 +357,8 @@ public class AsyncLookupJoinHarnessTest {
         @Override
         public void open(Configuration parameters) throws Exception {
             super.open(parameters);
-            this.executor = Executors.newSingleThreadExecutor();
+            // generate unordered result for async lookup
+            this.executor = Executors.newFixedThreadPool(2);
         }
 
         @Override
@@ -342,7 +366,16 @@ public class AsyncLookupJoinHarnessTest {
                 throws Exception {
             int id = input.getInt(0);
             CompletableFuture.supplyAsync(
-                            (Supplier<Collection<RowData>>) () -> data.get(id), executor)
+                            (Supplier<Collection<RowData>>)
+                                    () -> {
+                                        try {
+                                            Thread.sleep(random.nextInt(5));
+                                        } catch (InterruptedException e) {
+                                            throw new RuntimeException(e);
+                                        }
+                                        return data.get(id);
+                                    },
+                            executor)
                     .thenAcceptAsync(resultFuture::complete, executor);
         }
 


### PR DESCRIPTION
## What is the purpose of the change
Add 'table.exec.async-lookup.output-mode' to ExecutionConfigOptions so that users can configure the async lookup join's result order if needed. 
* ORDERED by default (behavior the same as now)
* ALLOW_UNORDERED if users allow unordered result and this does not break correctness(if lookup join's input is  insert only) then will turn to `AsyncDataStream.OutputMode.UNORDERED` mode, usually gain higher throughput.

## Brief change log
* add 'table.exec.async-lookup.output-mode' to ExecutionConfigOptions
* add inputInsertOnly attribute to exec lookup join node
* update existing tests ensure unordered mode is covered

## Verifying this change
AsyncLookupJoinHarnessTest  AsyncLookupJoinITCase and xxxJsonPlanTest

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation
  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
