### PR TITLE
[FLINK-27682][tests] Migrate ComparatorTestBase to JUnit5

### DIFF
--- a/flink-connectors/flink-hadoop-compatibility/src/test/java/org/apache/flink/api/java/typeutils/runtime/WritableComparatorTest.java
+++ b/flink-connectors/flink-hadoop-compatibility/src/test/java/org/apache/flink/api/java/typeutils/runtime/WritableComparatorTest.java
@@ -23,7 +23,7 @@ import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 
 /** Tests for the {@link WritableComparator}. */
-public class WritableComparatorTest extends ComparatorTestBase<StringArrayWritable> {
+class WritableComparatorTest extends ComparatorTestBase<StringArrayWritable> {
 
     StringArrayWritable[] data =
             new StringArrayWritable[] {

--- a/flink-connectors/flink-hadoop-compatibility/src/test/java/org/apache/flink/api/java/typeutils/runtime/WritableComparatorUUIDTest.java
+++ b/flink-connectors/flink-hadoop-compatibility/src/test/java/org/apache/flink/api/java/typeutils/runtime/WritableComparatorUUIDTest.java
@@ -25,7 +25,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import java.util.UUID;
 
 /** Tests for the {@link WritableComparator} with {@link WritableID}. */
-public class WritableComparatorUUIDTest extends ComparatorTestBase<WritableID> {
+class WritableComparatorUUIDTest extends ComparatorTestBase<WritableID> {
     @Override
     protected TypeComparator<WritableID> createComparator(boolean ascending) {
         return new WritableComparator<>(ascending, WritableID.class);

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/BigDecComparatorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/BigDecComparatorTest.java
@@ -24,7 +24,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 
 import java.math.BigDecimal;
 
-public class BigDecComparatorTest extends ComparatorTestBase<BigDecimal> {
+class BigDecComparatorTest extends ComparatorTestBase<BigDecimal> {
 
     @Override
     protected TypeComparator<BigDecimal> createComparator(boolean ascending) {

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/BigIntComparatorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/BigIntComparatorTest.java
@@ -24,7 +24,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 
 import java.math.BigInteger;
 
-public class BigIntComparatorTest extends ComparatorTestBase<BigInteger> {
+class BigIntComparatorTest extends ComparatorTestBase<BigInteger> {
 
     @Override
     protected TypeComparator<BigInteger> createComparator(boolean ascending) {

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/BooleanComparatorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/BooleanComparatorTest.java
@@ -22,7 +22,7 @@ import org.apache.flink.api.common.typeutils.ComparatorTestBase;
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 
-public class BooleanComparatorTest extends ComparatorTestBase<Boolean> {
+class BooleanComparatorTest extends ComparatorTestBase<Boolean> {
 
     @Override
     protected TypeComparator<Boolean> createComparator(boolean ascending) {

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/BooleanValueComparatorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/BooleanValueComparatorTest.java
@@ -23,7 +23,7 @@ import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.types.BooleanValue;
 
-public class BooleanValueComparatorTest extends ComparatorTestBase<BooleanValue> {
+class BooleanValueComparatorTest extends ComparatorTestBase<BooleanValue> {
 
     @Override
     protected TypeComparator<BooleanValue> createComparator(boolean ascending) {

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/ByteComparatorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/ByteComparatorTest.java
@@ -24,7 +24,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 
 import java.util.Random;
 
-public class ByteComparatorTest extends ComparatorTestBase<Byte> {
+class ByteComparatorTest extends ComparatorTestBase<Byte> {
 
     @Override
     protected TypeComparator<Byte> createComparator(boolean ascending) {

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/ByteValueComparatorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/ByteValueComparatorTest.java
@@ -25,7 +25,7 @@ import org.apache.flink.types.ByteValue;
 
 import java.util.Random;
 
-public class ByteValueComparatorTest extends ComparatorTestBase<ByteValue> {
+class ByteValueComparatorTest extends ComparatorTestBase<ByteValue> {
 
     @Override
     protected TypeComparator<ByteValue> createComparator(boolean ascending) {

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/CharComparatorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/CharComparatorTest.java
@@ -24,7 +24,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 
 import java.util.Random;
 
-public class CharComparatorTest extends ComparatorTestBase<Character> {
+class CharComparatorTest extends ComparatorTestBase<Character> {
 
     @Override
     protected TypeComparator<Character> createComparator(boolean ascending) {

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/CharValueComparatorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/CharValueComparatorTest.java
@@ -25,7 +25,7 @@ import org.apache.flink.types.CharValue;
 
 import java.util.Random;
 
-public class CharValueComparatorTest extends ComparatorTestBase<CharValue> {
+class CharValueComparatorTest extends ComparatorTestBase<CharValue> {
 
     @Override
     protected TypeComparator<CharValue> createComparator(boolean ascending) {

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/DateComparatorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/DateComparatorTest.java
@@ -25,7 +25,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import java.util.Date;
 import java.util.Random;
 
-public class DateComparatorTest extends ComparatorTestBase<Date> {
+class DateComparatorTest extends ComparatorTestBase<Date> {
 
     @Override
     protected TypeComparator<Date> createComparator(boolean ascending) {

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/DoubleComparatorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/DoubleComparatorTest.java
@@ -24,7 +24,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 
 import java.util.Random;
 
-public class DoubleComparatorTest extends ComparatorTestBase<Double> {
+class DoubleComparatorTest extends ComparatorTestBase<Double> {
 
     @Override
     protected TypeComparator<Double> createComparator(boolean ascending) {

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/DoubleValueComparatorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/DoubleValueComparatorTest.java
@@ -25,7 +25,7 @@ import org.apache.flink.types.DoubleValue;
 
 import java.util.Random;
 
-public class DoubleValueComparatorTest extends ComparatorTestBase<DoubleValue> {
+class DoubleValueComparatorTest extends ComparatorTestBase<DoubleValue> {
 
     @Override
     protected TypeComparator<DoubleValue> createComparator(boolean ascending) {

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/FloatComparatorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/FloatComparatorTest.java
@@ -24,7 +24,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 
 import java.util.Random;
 
-public class FloatComparatorTest extends ComparatorTestBase<Float> {
+class FloatComparatorTest extends ComparatorTestBase<Float> {
 
     @Override
     protected TypeComparator<Float> createComparator(boolean ascending) {

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/FloatValueComparatorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/FloatValueComparatorTest.java
@@ -25,7 +25,7 @@ import org.apache.flink.types.FloatValue;
 
 import java.util.Random;
 
-public class FloatValueComparatorTest extends ComparatorTestBase<FloatValue> {
+class FloatValueComparatorTest extends ComparatorTestBase<FloatValue> {
 
     @Override
     protected TypeComparator<FloatValue> createComparator(boolean ascending) {

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/InstantComparatorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/InstantComparatorTest.java
@@ -25,7 +25,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import java.time.Instant;
 
 /** A test for the {@link InstantComparator}. */
-public class InstantComparatorTest extends ComparatorTestBase<Instant> {
+class InstantComparatorTest extends ComparatorTestBase<Instant> {
 
     @Override
     protected TypeComparator<Instant> createComparator(boolean ascending) {

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/IntComparatorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/IntComparatorTest.java
@@ -24,7 +24,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 
 import java.util.Random;
 
-public class IntComparatorTest extends ComparatorTestBase<Integer> {
+class IntComparatorTest extends ComparatorTestBase<Integer> {
 
     @Override
     protected TypeComparator<Integer> createComparator(boolean ascending) {

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/IntValueComparatorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/IntValueComparatorTest.java
@@ -25,7 +25,7 @@ import org.apache.flink.types.IntValue;
 
 import java.util.Random;
 
-public class IntValueComparatorTest extends ComparatorTestBase<IntValue> {
+class IntValueComparatorTest extends ComparatorTestBase<IntValue> {
 
     @Override
     protected TypeComparator<IntValue> createComparator(boolean ascending) {

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/LocalDateComparatorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/LocalDateComparatorTest.java
@@ -24,7 +24,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 
 import java.time.LocalDate;
 
-public class LocalDateComparatorTest extends ComparatorTestBase<LocalDate> {
+class LocalDateComparatorTest extends ComparatorTestBase<LocalDate> {
 
     @Override
     protected TypeComparator<LocalDate> createComparator(boolean ascending) {

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/LocalDateTimeComparatorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/LocalDateTimeComparatorTest.java
@@ -24,7 +24,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 
 import java.time.LocalDateTime;
 
-public class LocalDateTimeComparatorTest extends ComparatorTestBase<LocalDateTime> {
+class LocalDateTimeComparatorTest extends ComparatorTestBase<LocalDateTime> {
 
     @Override
     protected TypeComparator<LocalDateTime> createComparator(boolean ascending) {

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/LocalTimeComparatorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/LocalTimeComparatorTest.java
@@ -24,7 +24,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 
 import java.time.LocalTime;
 
-public class LocalTimeComparatorTest extends ComparatorTestBase<LocalTime> {
+class LocalTimeComparatorTest extends ComparatorTestBase<LocalTime> {
 
     @Override
     protected TypeComparator<LocalTime> createComparator(boolean ascending) {

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/LongComparatorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/LongComparatorTest.java
@@ -24,7 +24,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 
 import java.util.Random;
 
-public class LongComparatorTest extends ComparatorTestBase<Long> {
+class LongComparatorTest extends ComparatorTestBase<Long> {
 
     @Override
     protected TypeComparator<Long> createComparator(boolean ascending) {

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/LongValueComparatorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/LongValueComparatorTest.java
@@ -25,7 +25,7 @@ import org.apache.flink.types.LongValue;
 
 import java.util.Random;
 
-public class LongValueComparatorTest extends ComparatorTestBase<LongValue> {
+class LongValueComparatorTest extends ComparatorTestBase<LongValue> {
 
     @Override
     protected TypeComparator<LongValue> createComparator(boolean ascending) {

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/ShortComparatorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/ShortComparatorTest.java
@@ -24,7 +24,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 
 import java.util.Random;
 
-public class ShortComparatorTest extends ComparatorTestBase<Short> {
+class ShortComparatorTest extends ComparatorTestBase<Short> {
 
     @Override
     protected TypeComparator<Short> createComparator(boolean ascending) {

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/ShortValueComparatorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/ShortValueComparatorTest.java
@@ -25,7 +25,7 @@ import org.apache.flink.types.ShortValue;
 
 import java.util.Random;
 
-public class ShortValueComparatorTest extends ComparatorTestBase<ShortValue> {
+class ShortValueComparatorTest extends ComparatorTestBase<ShortValue> {
 
     @Override
     protected TypeComparator<ShortValue> createComparator(boolean ascending) {

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/SqlDateComparatorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/SqlDateComparatorTest.java
@@ -24,7 +24,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 
 import java.sql.Date;
 
-public class SqlDateComparatorTest extends ComparatorTestBase<Date> {
+class SqlDateComparatorTest extends ComparatorTestBase<Date> {
 
     @SuppressWarnings("unchecked")
     @Override

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/SqlTimeComparatorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/SqlTimeComparatorTest.java
@@ -24,7 +24,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 
 import java.sql.Time;
 
-public class SqlTimeComparatorTest extends ComparatorTestBase<Time> {
+class SqlTimeComparatorTest extends ComparatorTestBase<Time> {
 
     @SuppressWarnings("unchecked")
     @Override

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/SqlTimestampComparatorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/SqlTimestampComparatorTest.java
@@ -24,7 +24,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 
 import java.sql.Timestamp;
 
-public class SqlTimestampComparatorTest extends ComparatorTestBase<Timestamp> {
+class SqlTimestampComparatorTest extends ComparatorTestBase<Timestamp> {
 
     @SuppressWarnings("unchecked")
     @Override

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/StringComparatorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/StringComparatorTest.java
@@ -22,7 +22,7 @@ import org.apache.flink.api.common.typeutils.ComparatorTestBase;
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 
-public class StringComparatorTest extends ComparatorTestBase<String> {
+class StringComparatorTest extends ComparatorTestBase<String> {
 
     @Override
     protected TypeComparator<String> createComparator(boolean ascending) {

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/StringValueComparatorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/StringValueComparatorTest.java
@@ -23,7 +23,7 @@ import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.types.StringValue;
 
-public class StringValueComparatorTest extends ComparatorTestBase<StringValue> {
+class StringValueComparatorTest extends ComparatorTestBase<StringValue> {
 
     @Override
     protected TypeComparator<StringValue> createComparator(boolean ascending) {

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/BooleanPrimitiveArrayComparatorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/BooleanPrimitiveArrayComparatorTest.java
@@ -19,7 +19,7 @@ package org.apache.flink.api.common.typeutils.base.array;
 
 import org.apache.flink.api.common.typeinfo.PrimitiveArrayTypeInfo;
 
-import org.junit.Assert;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class BooleanPrimitiveArrayComparatorTest
         extends PrimitiveArrayComparatorTestBase<boolean[]> {
@@ -29,10 +29,7 @@ public class BooleanPrimitiveArrayComparatorTest
 
     @Override
     protected void deepEquals(String message, boolean[] should, boolean[] is) {
-        Assert.assertTrue(should.length == is.length);
-        for (int x = 0; x < should.length; x++) {
-            Assert.assertEquals(should[x], is[x]);
-        }
+        assertThat(is).as(message).containsExactly(should);
     }
 
     @Override

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/BytePrimitiveArrayComparatorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/BytePrimitiveArrayComparatorTest.java
@@ -19,16 +19,16 @@ package org.apache.flink.api.common.typeutils.base.array;
 
 import org.apache.flink.api.common.typeinfo.PrimitiveArrayTypeInfo;
 
-import org.junit.Assert;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public class BytePrimitiveArrayComparatorTest extends PrimitiveArrayComparatorTestBase<byte[]> {
+class BytePrimitiveArrayComparatorTest extends PrimitiveArrayComparatorTestBase<byte[]> {
     public BytePrimitiveArrayComparatorTest() {
         super(PrimitiveArrayTypeInfo.BYTE_PRIMITIVE_ARRAY_TYPE_INFO);
     }
 
     @Override
     protected void deepEquals(String message, byte[] should, byte[] is) {
-        Assert.assertArrayEquals(message, should, is);
+        assertThat(is).as(message).containsExactly(should);
     }
 
     @Override

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/CharPrimitiveArrayComparatorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/CharPrimitiveArrayComparatorTest.java
@@ -19,16 +19,16 @@ package org.apache.flink.api.common.typeutils.base.array;
 
 import org.apache.flink.api.common.typeinfo.PrimitiveArrayTypeInfo;
 
-import org.junit.Assert;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public class CharPrimitiveArrayComparatorTest extends PrimitiveArrayComparatorTestBase<char[]> {
+class CharPrimitiveArrayComparatorTest extends PrimitiveArrayComparatorTestBase<char[]> {
     public CharPrimitiveArrayComparatorTest() {
         super(PrimitiveArrayTypeInfo.CHAR_PRIMITIVE_ARRAY_TYPE_INFO);
     }
 
     @Override
     protected void deepEquals(String message, char[] should, char[] is) {
-        Assert.assertArrayEquals(message, should, is);
+        assertThat(is).as(message).containsExactly(is);
     }
 
     @Override

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/DoublePrimitiveArrayComparatorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/DoublePrimitiveArrayComparatorTest.java
@@ -19,16 +19,17 @@ package org.apache.flink.api.common.typeutils.base.array;
 
 import org.apache.flink.api.common.typeinfo.PrimitiveArrayTypeInfo;
 
-import org.junit.Assert;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
 
-public class DoublePrimitiveArrayComparatorTest extends PrimitiveArrayComparatorTestBase<double[]> {
+class DoublePrimitiveArrayComparatorTest extends PrimitiveArrayComparatorTestBase<double[]> {
     public DoublePrimitiveArrayComparatorTest() {
         super(PrimitiveArrayTypeInfo.DOUBLE_PRIMITIVE_ARRAY_TYPE_INFO);
     }
 
     @Override
     protected void deepEquals(String message, double[] should, double[] is) {
-        Assert.assertArrayEquals(message, should, is, 0.00001);
+        assertThat(is).as(message).containsExactly(should, within(0.00001));
     }
 
     @Override

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/FloatPrimitiveArrayComparatorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/FloatPrimitiveArrayComparatorTest.java
@@ -19,16 +19,17 @@ package org.apache.flink.api.common.typeutils.base.array;
 
 import org.apache.flink.api.common.typeinfo.PrimitiveArrayTypeInfo;
 
-import org.junit.Assert;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
 
-public class FloatPrimitiveArrayComparatorTest extends PrimitiveArrayComparatorTestBase<float[]> {
+class FloatPrimitiveArrayComparatorTest extends PrimitiveArrayComparatorTestBase<float[]> {
     public FloatPrimitiveArrayComparatorTest() {
         super(PrimitiveArrayTypeInfo.FLOAT_PRIMITIVE_ARRAY_TYPE_INFO);
     }
 
     @Override
     protected void deepEquals(String message, float[] should, float[] is) {
-        Assert.assertArrayEquals(message, should, is, (float) 0.00001);
+        assertThat(is).as(message).containsExactly(should, within((float) 0.00001));
     }
 
     @Override

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/IntPrimitiveArrayComparatorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/IntPrimitiveArrayComparatorTest.java
@@ -19,16 +19,16 @@ package org.apache.flink.api.common.typeutils.base.array;
 
 import org.apache.flink.api.common.typeinfo.PrimitiveArrayTypeInfo;
 
-import org.junit.Assert;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public class IntPrimitiveArrayComparatorTest extends PrimitiveArrayComparatorTestBase<int[]> {
+class IntPrimitiveArrayComparatorTest extends PrimitiveArrayComparatorTestBase<int[]> {
     public IntPrimitiveArrayComparatorTest() {
         super(PrimitiveArrayTypeInfo.INT_PRIMITIVE_ARRAY_TYPE_INFO);
     }
 
     @Override
     protected void deepEquals(String message, int[] should, int[] is) {
-        Assert.assertArrayEquals(message, should, is);
+        assertThat(is).as(message).isEqualTo(should);
     }
 
     @Override

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/LongPrimitiveArrayComparatorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/LongPrimitiveArrayComparatorTest.java
@@ -19,16 +19,16 @@ package org.apache.flink.api.common.typeutils.base.array;
 
 import org.apache.flink.api.common.typeinfo.PrimitiveArrayTypeInfo;
 
-import org.junit.Assert;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public class LongPrimitiveArrayComparatorTest extends PrimitiveArrayComparatorTestBase<long[]> {
+class LongPrimitiveArrayComparatorTest extends PrimitiveArrayComparatorTestBase<long[]> {
     public LongPrimitiveArrayComparatorTest() {
         super(PrimitiveArrayTypeInfo.LONG_PRIMITIVE_ARRAY_TYPE_INFO);
     }
 
     @Override
     protected void deepEquals(String message, long[] should, long[] is) {
-        Assert.assertArrayEquals(message, should, is);
+        assertThat(is).as(message).containsExactly(is);
     }
 
     @Override

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/PrimitiveArrayComparatorTestBase.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/PrimitiveArrayComparatorTestBase.java
@@ -22,7 +22,7 @@ import org.apache.flink.api.common.typeutils.ComparatorTestBase;
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 
-public abstract class PrimitiveArrayComparatorTestBase<T> extends ComparatorTestBase<T> {
+abstract class PrimitiveArrayComparatorTestBase<T> extends ComparatorTestBase<T> {
     private PrimitiveArrayTypeInfo<T> info;
 
     public PrimitiveArrayComparatorTestBase(PrimitiveArrayTypeInfo<T> info) {

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/ShortPrimitiveArrayComparatorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/ShortPrimitiveArrayComparatorTest.java
@@ -19,16 +19,16 @@ package org.apache.flink.api.common.typeutils.base.array;
 
 import org.apache.flink.api.common.typeinfo.PrimitiveArrayTypeInfo;
 
-import org.junit.Assert;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public class ShortPrimitiveArrayComparatorTest extends PrimitiveArrayComparatorTestBase<short[]> {
+class ShortPrimitiveArrayComparatorTest extends PrimitiveArrayComparatorTestBase<short[]> {
     public ShortPrimitiveArrayComparatorTest() {
         super(PrimitiveArrayTypeInfo.SHORT_PRIMITIVE_ARRAY_TYPE_INFO);
     }
 
     @Override
     protected void deepEquals(String message, short[] should, short[] is) {
-        Assert.assertArrayEquals(message, should, is);
+        assertThat(is).as(message).containsExactly(should);
     }
 
     @Override

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/CopyableValueComparatorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/CopyableValueComparatorTest.java
@@ -23,7 +23,7 @@ import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.types.StringValue;
 
-public class CopyableValueComparatorTest extends ComparatorTestBase<StringValue> {
+class CopyableValueComparatorTest extends ComparatorTestBase<StringValue> {
 
     StringValue[] data =
             new StringValue[] {

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/PojoComparatorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/PojoComparatorTest.java
@@ -27,11 +27,11 @@ import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
 
-import org.junit.Assert;
-
 import java.util.Arrays;
 
-public class PojoComparatorTest extends ComparatorTestBase<PojoContainingTuple> {
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PojoComparatorTest extends ComparatorTestBase<PojoContainingTuple> {
     TypeInformation<PojoContainingTuple> type =
             TypeExtractor.getForClass(PojoContainingTuple.class);
 
@@ -45,7 +45,7 @@ public class PojoComparatorTest extends ComparatorTestBase<PojoContainingTuple> 
 
     @Override
     protected TypeComparator<PojoContainingTuple> createComparator(boolean ascending) {
-        Assert.assertTrue(type instanceof CompositeType);
+        assertThat(type).isInstanceOf(CompositeType.class);
         CompositeType<PojoContainingTuple> cType = (CompositeType<PojoContainingTuple>) type;
         ExpressionKeys<PojoContainingTuple> keys =
                 new ExpressionKeys<PojoContainingTuple>(new String[] {"theTuple.*"}, cType);

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/PojoSubclassComparatorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/PojoSubclassComparatorTest.java
@@ -27,11 +27,11 @@ import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
 
-import org.junit.Assert;
-
 import java.util.Arrays;
 
-public class PojoSubclassComparatorTest extends ComparatorTestBase<PojoContainingTuple> {
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PojoSubclassComparatorTest extends ComparatorTestBase<PojoContainingTuple> {
     TypeInformation<PojoContainingTuple> type =
             TypeExtractor.getForClass(PojoContainingTuple.class);
 
@@ -45,7 +45,7 @@ public class PojoSubclassComparatorTest extends ComparatorTestBase<PojoContainin
 
     @Override
     protected TypeComparator<PojoContainingTuple> createComparator(boolean ascending) {
-        Assert.assertTrue(type instanceof CompositeType);
+        assertThat(type).isInstanceOf(CompositeType.class);
         CompositeType<PojoContainingTuple> cType = (CompositeType<PojoContainingTuple>) type;
         ExpressionKeys<PojoContainingTuple> keys =
                 new ExpressionKeys<PojoContainingTuple>(new String[] {"theTuple.*"}, cType);

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/RowComparatorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/RowComparatorTest.java
@@ -29,13 +29,13 @@ import org.apache.flink.api.java.typeutils.TypeExtractor;
 import org.apache.flink.types.Row;
 import org.apache.flink.types.RowKind;
 
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 
 import java.io.Serializable;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public class RowComparatorTest extends ComparatorTestBase<Row> {
+class RowComparatorTest extends ComparatorTestBase<Row> {
 
     private static final RowTypeInfo typeInfo =
             new RowTypeInfo(
@@ -74,8 +74,8 @@ public class RowComparatorTest extends ComparatorTestBase<Row> {
                 createRow(RowKind.DELETE, 1, 1.0, "b", new Tuple3<>(2, true, (short) 3), testPojo3)
             };
 
-    @BeforeClass
-    public static void init() {
+    @BeforeAll
+    static void init() {
         // TODO we cannot test null here as PojoComparator has no support for null keys
         testPojo1.name = "";
         testPojo2.name = "Test1";
@@ -85,11 +85,11 @@ public class RowComparatorTest extends ComparatorTestBase<Row> {
     @Override
     protected void deepEquals(String message, Row should, Row is) {
         int arity = should.getArity();
-        assertEquals(message, arity, is.getArity());
+        assertThat(is.getArity()).as(message).isEqualTo(arity);
         for (int i = 0; i < arity; i++) {
             Object copiedValue = should.getField(i);
             Object element = is.getField(i);
-            assertEquals(message, element, copiedValue);
+            assertThat(element).as(message).isEqualTo(copiedValue);
         }
     }
 

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/RowComparatorWithManyFieldsTests.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/RowComparatorWithManyFieldsTests.java
@@ -26,14 +26,14 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
 import org.apache.flink.types.Row;
 
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests {@link org.apache.flink.api.java.typeutils.runtime.RowComparator} for wide rows. */
-public class RowComparatorWithManyFieldsTests extends ComparatorTestBase<Row> {
+class RowComparatorWithManyFieldsTests extends ComparatorTestBase<Row> {
 
     private static final int numberOfFields = 10;
     private static RowTypeInfo typeInfo;
@@ -45,8 +45,8 @@ public class RowComparatorWithManyFieldsTests extends ComparatorTestBase<Row> {
                 createRow("a3", "b3", "c3", "d3", "e3", "f3", "g3", "h3", "i3", "j3")
             };
 
-    @BeforeClass
-    public static void setUp() throws Exception {
+    @BeforeAll
+    static void setUp() throws Exception {
         TypeInformation<?>[] fieldTypes = new TypeInformation[numberOfFields];
         for (int i = 0; i < numberOfFields; i++) {
             fieldTypes[i] = BasicTypeInfo.STRING_TYPE_INFO;
@@ -57,11 +57,11 @@ public class RowComparatorWithManyFieldsTests extends ComparatorTestBase<Row> {
     @Override
     protected void deepEquals(String message, Row should, Row is) {
         int arity = should.getArity();
-        assertEquals(message, arity, is.getArity());
+        assertThat(is.getArity()).as(message).isEqualTo(arity);
         for (int i = 0; i < arity; i++) {
             Object copiedValue = should.getField(i);
             Object element = is.getField(i);
-            assertEquals(message, element, copiedValue);
+            assertThat(element).as(message).isEqualTo(copiedValue);
         }
     }
 

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/TupleComparatorILD2Test.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/TupleComparatorILD2Test.java
@@ -28,8 +28,7 @@ import org.apache.flink.api.common.typeutils.base.LongSerializer;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.api.java.typeutils.runtime.tuple.base.TupleComparatorTestBase;
 
-public class TupleComparatorILD2Test
-        extends TupleComparatorTestBase<Tuple3<Integer, Long, Double>> {
+class TupleComparatorILD2Test extends TupleComparatorTestBase<Tuple3<Integer, Long, Double>> {
 
     @SuppressWarnings("unchecked")
     Tuple3<Integer, Long, Double>[] dataISD =

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/TupleComparatorILD3Test.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/TupleComparatorILD3Test.java
@@ -29,8 +29,7 @@ import org.apache.flink.api.common.typeutils.base.LongSerializer;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.api.java.typeutils.runtime.tuple.base.TupleComparatorTestBase;
 
-public class TupleComparatorILD3Test
-        extends TupleComparatorTestBase<Tuple3<Integer, Long, Double>> {
+class TupleComparatorILD3Test extends TupleComparatorTestBase<Tuple3<Integer, Long, Double>> {
 
     @SuppressWarnings("unchecked")
     Tuple3<Integer, Long, Double>[] dataISD =

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/TupleComparatorILDC3Test.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/TupleComparatorILDC3Test.java
@@ -29,8 +29,7 @@ import org.apache.flink.api.common.typeutils.base.LongSerializer;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.api.java.typeutils.runtime.tuple.base.TupleComparatorTestBase;
 
-public class TupleComparatorILDC3Test
-        extends TupleComparatorTestBase<Tuple3<Integer, Long, Double>> {
+class TupleComparatorILDC3Test extends TupleComparatorTestBase<Tuple3<Integer, Long, Double>> {
 
     @SuppressWarnings("unchecked")
     Tuple3<Integer, Long, Double>[] dataISD =

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/TupleComparatorILDX1Test.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/TupleComparatorILDX1Test.java
@@ -27,8 +27,7 @@ import org.apache.flink.api.common.typeutils.base.LongSerializer;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.api.java.typeutils.runtime.tuple.base.TupleComparatorTestBase;
 
-public class TupleComparatorILDX1Test
-        extends TupleComparatorTestBase<Tuple3<Integer, Long, Double>> {
+class TupleComparatorILDX1Test extends TupleComparatorTestBase<Tuple3<Integer, Long, Double>> {
 
     @SuppressWarnings("unchecked")
     Tuple3<Integer, Long, Double>[] dataISD =

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/TupleComparatorILDXC2Test.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/TupleComparatorILDXC2Test.java
@@ -28,8 +28,7 @@ import org.apache.flink.api.common.typeutils.base.LongSerializer;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.api.java.typeutils.runtime.tuple.base.TupleComparatorTestBase;
 
-public class TupleComparatorILDXC2Test
-        extends TupleComparatorTestBase<Tuple3<Integer, Long, Double>> {
+class TupleComparatorILDXC2Test extends TupleComparatorTestBase<Tuple3<Integer, Long, Double>> {
 
     @SuppressWarnings("unchecked")
     Tuple3<Integer, Long, Double>[] dataISD =

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/TupleComparatorISD1Test.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/TupleComparatorISD1Test.java
@@ -27,8 +27,7 @@ import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.api.java.typeutils.runtime.tuple.base.TupleComparatorTestBase;
 
-public class TupleComparatorISD1Test
-        extends TupleComparatorTestBase<Tuple3<Integer, String, Double>> {
+class TupleComparatorISD1Test extends TupleComparatorTestBase<Tuple3<Integer, String, Double>> {
 
     @SuppressWarnings("unchecked")
     Tuple3<Integer, String, Double>[] dataISD =

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/TupleComparatorISD2Test.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/TupleComparatorISD2Test.java
@@ -28,8 +28,7 @@ import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.api.java.typeutils.runtime.tuple.base.TupleComparatorTestBase;
 
-public class TupleComparatorISD2Test
-        extends TupleComparatorTestBase<Tuple3<Integer, String, Double>> {
+class TupleComparatorISD2Test extends TupleComparatorTestBase<Tuple3<Integer, String, Double>> {
 
     @SuppressWarnings("unchecked")
     Tuple3<Integer, String, Double>[] dataISD =

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/TupleComparatorISD3Test.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/TupleComparatorISD3Test.java
@@ -29,8 +29,7 @@ import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.api.java.typeutils.runtime.tuple.base.TupleComparatorTestBase;
 
-public class TupleComparatorISD3Test
-        extends TupleComparatorTestBase<Tuple3<Integer, String, Double>> {
+class TupleComparatorISD3Test extends TupleComparatorTestBase<Tuple3<Integer, String, Double>> {
 
     @SuppressWarnings("unchecked")
     Tuple3<Integer, String, Double>[] dataISD =

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/TupleComparatorTTT1Test.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/TupleComparatorTTT1Test.java
@@ -29,9 +29,9 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.api.java.typeutils.runtime.tuple.base.TupleComparatorTestBase;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public class TupleComparatorTTT1Test
+class TupleComparatorTTT1Test
         extends TupleComparatorTestBase<
                 Tuple3<Tuple2<String, Double>, Tuple2<Long, Long>, Tuple2<Integer, Long>>> {
 
@@ -160,14 +160,14 @@ public class TupleComparatorTTT1Test
                 this.deepEquals(
                         message, (Tuple2<?, ?>) should.getField(x), (Tuple2<?, ?>) is.getField(x));
             } else {
-                assertEquals(message, should.getField(x), is.getField(x));
+                assertThat((Object) is.getField(x)).as(message).isEqualTo(should.getField(x));
             }
         } // For
     }
 
     protected void deepEquals(String message, Tuple2<?, ?> should, Tuple2<?, ?> is) {
         for (int x = 0; x < should.getArity(); x++) {
-            assertEquals(message, (Object) should.getField(x), is.getField(x));
+            assertThat((Object) is.getField(x)).as(message).isEqualTo(should.getField(x));
         }
     }
 }

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/TupleComparatorTTT2Test.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/TupleComparatorTTT2Test.java
@@ -31,9 +31,9 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.api.java.typeutils.runtime.tuple.base.TupleComparatorTestBase;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public class TupleComparatorTTT2Test
+class TupleComparatorTTT2Test
         extends TupleComparatorTestBase<
                 Tuple3<Tuple2<String, Double>, Tuple2<Long, Long>, Tuple2<Integer, Long>>> {
 
@@ -168,14 +168,14 @@ public class TupleComparatorTTT2Test
                 this.deepEquals(
                         message, (Tuple2<?, ?>) should.getField(x), (Tuple2<?, ?>) is.getField(x));
             } else {
-                assertEquals(message, should.getField(x), is.getField(x));
+                assertThat((Object) is.getField(x)).as(message).isEqualTo(should.getField(x));
             }
         } // For
     }
 
     protected void deepEquals(String message, Tuple2<?, ?> should, Tuple2<?, ?> is) {
         for (int x = 0; x < should.getArity(); x++) {
-            assertEquals(message, (Object) should.getField(x), is.getField(x));
+            assertThat((Object) is.getField(x)).as(message).isEqualTo(should.getField(x));
         }
     }
 }

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/TupleComparatorTTT3Test.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/TupleComparatorTTT3Test.java
@@ -31,9 +31,9 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.api.java.typeutils.runtime.tuple.base.TupleComparatorTestBase;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public class TupleComparatorTTT3Test
+class TupleComparatorTTT3Test
         extends TupleComparatorTestBase<
                 Tuple3<Tuple2<String, Double>, Tuple2<Long, Long>, Tuple2<Integer, Long>>> {
     @SuppressWarnings("unchecked")
@@ -175,14 +175,14 @@ public class TupleComparatorTTT3Test
                 this.deepEquals(
                         message, (Tuple2<?, ?>) should.getField(x), (Tuple2<?, ?>) is.getField(x));
             } else {
-                assertEquals(message, should.getField(x), is.getField(x));
+                assertThat((Object) is.getField(x)).as(message).isEqualTo(should.getField(x));
             }
         } // For
     }
 
     protected void deepEquals(String message, Tuple2<?, ?> should, Tuple2<?, ?> is) {
         for (int x = 0; x < should.getArity(); x++) {
-            assertEquals(message, (Object) should.getField(x), is.getField(x));
+            assertThat((Object) is.getField(x)).as(message).isEqualTo(should.getField(x));
         }
     }
 }

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/ValueComparatorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/ValueComparatorTest.java
@@ -23,7 +23,7 @@ import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.types.StringValue;
 
-public class ValueComparatorTest extends ComparatorTestBase<StringValue> {
+class ValueComparatorTest extends ComparatorTestBase<StringValue> {
 
     StringValue[] data =
             new StringValue[] {

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/ValueComparatorUUIDTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/ValueComparatorUUIDTest.java
@@ -24,7 +24,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 
 import java.util.UUID;
 
-public class ValueComparatorUUIDTest extends ComparatorTestBase<ValueID> {
+class ValueComparatorUUIDTest extends ComparatorTestBase<ValueID> {
     @Override
     protected TypeComparator<ValueID> createComparator(boolean ascending) {
         return new ValueComparator<>(ascending, ValueID.class);

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/tuple/base/TupleComparatorTestBase.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/tuple/base/TupleComparatorTestBase.java
@@ -23,14 +23,14 @@ import org.apache.flink.api.java.tuple.Tuple;
 import org.apache.flink.api.java.typeutils.runtime.TupleComparator;
 import org.apache.flink.api.java.typeutils.runtime.TupleSerializer;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public abstract class TupleComparatorTestBase<T extends Tuple> extends ComparatorTestBase<T> {
 
     @Override
     protected void deepEquals(String message, T should, T is) {
         for (int x = 0; x < should.getArity(); x++) {
-            assertEquals((Object) should.getField(x), is.getField(x));
+            assertThat((Object) is.getField(x)).isEqualTo(should.getField(x));
         }
     }
 

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/ByteValueArrayComparatorTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/ByteValueArrayComparatorTest.java
@@ -25,7 +25,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.types.ByteValue;
 
 /** Tests for {@link ByteValueArrayComparator}. */
-public class ByteValueArrayComparatorTest extends ComparatorTestBase<ByteValueArray> {
+class ByteValueArrayComparatorTest extends ComparatorTestBase<ByteValueArray> {
 
     @Override
     protected TypeComparator<ByteValueArray> createComparator(boolean ascending) {

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/CharValueArrayComparatorTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/CharValueArrayComparatorTest.java
@@ -25,7 +25,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.types.CharValue;
 
 /** Tests for {@link CharValueArrayComparator}. */
-public class CharValueArrayComparatorTest extends ComparatorTestBase<CharValueArray> {
+class CharValueArrayComparatorTest extends ComparatorTestBase<CharValueArray> {
 
     @Override
     protected TypeComparator<CharValueArray> createComparator(boolean ascending) {

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/DoubleValueArrayComparatorTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/DoubleValueArrayComparatorTest.java
@@ -25,7 +25,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.types.DoubleValue;
 
 /** Tests for {@link DoubleValueArrayComparator}. */
-public class DoubleValueArrayComparatorTest extends ComparatorTestBase<DoubleValueArray> {
+class DoubleValueArrayComparatorTest extends ComparatorTestBase<DoubleValueArray> {
 
     @Override
     protected TypeComparator<DoubleValueArray> createComparator(boolean ascending) {

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/FloatValueArrayComparatorTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/FloatValueArrayComparatorTest.java
@@ -25,7 +25,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.types.FloatValue;
 
 /** Tests for {@link FloatValueArrayComparator}. */
-public class FloatValueArrayComparatorTest extends ComparatorTestBase<FloatValueArray> {
+class FloatValueArrayComparatorTest extends ComparatorTestBase<FloatValueArray> {
 
     @Override
     protected TypeComparator<FloatValueArray> createComparator(boolean ascending) {

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/IntValueArrayComparatorTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/IntValueArrayComparatorTest.java
@@ -24,7 +24,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.types.IntValue;
 
 /** Tests for {@link IntValueArrayComparator}. */
-public class IntValueArrayComparatorTest extends ComparatorTestBase<IntValueArray> {
+class IntValueArrayComparatorTest extends ComparatorTestBase<IntValueArray> {
 
     @Override
     protected TypeComparator<IntValueArray> createComparator(boolean ascending) {

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/LongValueArrayComparatorTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/LongValueArrayComparatorTest.java
@@ -24,7 +24,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.types.LongValue;
 
 /** Tests for {@link LongValueArrayComparator}. */
-public class LongValueArrayComparatorTest extends ComparatorTestBase<LongValueArray> {
+class LongValueArrayComparatorTest extends ComparatorTestBase<LongValueArray> {
 
     @Override
     protected TypeComparator<LongValueArray> createComparator(boolean ascending) {

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/NullValueArrayComparatorTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/NullValueArrayComparatorTest.java
@@ -24,7 +24,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.types.NullValue;
 
 /** Tests for {@link NullValueArrayComparator}. */
-public class NullValueArrayComparatorTest extends ComparatorTestBase<NullValueArray> {
+class NullValueArrayComparatorTest extends ComparatorTestBase<NullValueArray> {
 
     @Override
     protected TypeComparator<NullValueArray> createComparator(boolean ascending) {

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/ShortValueArrayComparatorTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/ShortValueArrayComparatorTest.java
@@ -25,7 +25,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.types.ShortValue;
 
 /** Tests for {@link ShortValueArrayComparator}. */
-public class ShortValueArrayComparatorTest extends ComparatorTestBase<ShortValueArray> {
+class ShortValueArrayComparatorTest extends ComparatorTestBase<ShortValueArray> {
 
     @Override
     protected TypeComparator<ShortValueArray> createComparator(boolean ascending) {

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/StringValueArrayComparatorTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/StringValueArrayComparatorTest.java
@@ -24,7 +24,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.types.StringValue;
 
 /** Tests for {@link StringValueArrayComparator}. */
-public class StringValueArrayComparatorTest extends ComparatorTestBase<StringValueArray> {
+class StringValueArrayComparatorTest extends ComparatorTestBase<StringValueArray> {
 
     @Override
     protected TypeComparator<StringValueArray> createComparator(boolean ascending) {

--- a/flink-scala/src/test/scala/org/apache/flink/api/scala/runtime/tuple/base/TupleComparatorTestBase.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/scala/runtime/tuple/base/TupleComparatorTestBase.scala
@@ -18,14 +18,13 @@
 package org.apache.flink.api.scala.runtime.tuple.base
 
 import org.apache.flink.api.common.typeutils.ComparatorTestBase
-import org.apache.flink.api.scala.typeutils.{CaseClassComparator, CaseClassSerializer}
 
-import org.junit.Assert._
+import org.assertj.core.api.AssertionsForClassTypes.assertThat
 
 abstract class TupleComparatorTestBase[T <: Product] extends ComparatorTestBase[T] {
   override protected def deepEquals(message: String, should: T, is: T) {
     for (i <- 0 until should.productArity) {
-      assertEquals(should.productElement(i), is.productElement(i))
+      assertThat(is.productElement(i)).isEqualTo(should.productElement(i))
     }
   }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sort/FixedLengthByteKeyComparatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sort/FixedLengthByteKeyComparatorTest.java
@@ -26,11 +26,10 @@ import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link FixedLengthByteKeyComparator}. */
-public class FixedLengthByteKeyComparatorTest
+class FixedLengthByteKeyComparatorTest
         extends ComparatorTestBase<Tuple2<byte[], StreamRecord<Integer>>> {
     @Override
     protected Order[] getTestedOrder() {
@@ -54,8 +53,8 @@ public class FixedLengthByteKeyComparatorTest
             String message,
             Tuple2<byte[], StreamRecord<Integer>> should,
             Tuple2<byte[], StreamRecord<Integer>> is) {
-        assertThat(message, should.f0, equalTo(is.f0));
-        assertThat(message, should.f1, equalTo(is.f1));
+        assertThat(is.f0).as(message).isEqualTo(should.f0);
+        assertThat(is.f1).as(message).isEqualTo(should.f1);
     }
 
     @Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sort/VariableLengthByteKeyComparatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sort/VariableLengthByteKeyComparatorTest.java
@@ -26,11 +26,10 @@ import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link VariableLengthByteKeyComparator}. */
-public class VariableLengthByteKeyComparatorTest
+class VariableLengthByteKeyComparatorTest
         extends ComparatorTestBase<Tuple2<byte[], StreamRecord<String>>> {
     @Override
     protected Order[] getTestedOrder() {
@@ -54,8 +53,8 @@ public class VariableLengthByteKeyComparatorTest
             String message,
             Tuple2<byte[], StreamRecord<String>> should,
             Tuple2<byte[], StreamRecord<String>> is) {
-        assertThat(message, should.f0, equalTo(is.f0));
-        assertThat(message, should.f1, equalTo(is.f1));
+        assertThat(is.f0).as(message).isEqualTo(should.f0);
+        assertThat(is.f1).as(message).isEqualTo(should.f1);
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change

Update the `ComparatorTestBase` class and its successors to AssertJ and JUnit 5 following the [JUnit 5 Migration Guide](https://docs.google.com/document/d/1514Wa_aNB9bJUen4xm5uiuXOooOJTtXqS_Jqk9KJitU/edit)


## Brief change log

Use JUnit5 and AssertJ in tests instead of JUnit4 and Hamcrest


## Verifying this change

This change is a code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
