### PR TITLE
[FLINK-27694][python][build] Move lint-python log location

### DIFF
--- a/flink-python/dev/lint-python.sh
+++ b/flink-python/dev/lint-python.sh
@@ -187,8 +187,8 @@ function install_wget() {
 function install_miniconda() {
     OS_TO_CONDA_URL=("https://repo.continuum.io/miniconda/Miniconda3-4.7.10-MacOSX-x86_64.sh" \
         "https://repo.continuum.io/miniconda/Miniconda3-4.7.10-Linux-x86_64.sh")
-    print_function "STEP" "download miniconda..."
     if [ ! -f "$CONDA_INSTALL" ]; then
+        print_function "STEP" "download miniconda..."
         download ${OS_TO_CONDA_URL[$1]} $CONDA_INSTALL_SH
         chmod +x $CONDA_INSTALL_SH
         if [ $? -ne 0 ]; then
@@ -203,18 +203,18 @@ function install_miniconda() {
                 exit 1
             fi
         fi
+        print_function "STEP" "download miniconda... [SUCCESS]"
     fi
-    print_function "STEP" "download miniconda... [SUCCESS]"
 
-    print_function "STEP" "installing conda..."
     if [ ! -d "$CURRENT_DIR/.conda" ]; then
+        print_function "STEP" "installing conda..."
         $CONDA_INSTALL_SH -b -p $CURRENT_DIR/.conda 2>&1 >/dev/null
         if [ $? -ne 0 ]; then
             echo "install miniconda failed"
             exit $CONDA_INSTALL_STATUS
         fi
+        print_function "STEP" "install conda ... [SUCCESS]"
     fi
-    print_function "STEP" "install conda ... [SUCCESS]"
 }
 
 # Install some kinds of py env.
@@ -378,23 +378,23 @@ function install_environment() {
     # step-1 install wget
     # the file size of the miniconda.sh is too big to use "wget" tool to download instead
     # of the "curl" in the weak network environment.
-    print_function "STEP" "installing wget..."
     if [ $STEP -lt 1 ]; then
+        print_function "STEP" "installing wget..."
         install_wget ${SUPPORT_OS[$os_index]}
         STEP=1
         checkpoint_stage $STAGE $STEP
+        print_function "STEP" "install wget... [SUCCESS]"
     fi
-    print_function "STEP" "install wget... [SUCCESS]"
 
     # step-2 install miniconda
-    print_function "STEP" "installing miniconda..."
     if [ $STEP -lt 2 ]; then
+        print_function "STEP" "installing miniconda..."
         create_dir $CURRENT_DIR/download
         install_miniconda $os_index
         STEP=2
         checkpoint_stage $STAGE $STEP
+        print_function "STEP" "install miniconda... [SUCCESS]"
     fi
-    print_function "STEP" "install miniconda... [SUCCESS]"
 
     # step-3 install python environment which includes
     # 3.6 3.7 3.8


### PR DESCRIPTION
## What is the purpose of the change

Some logs are in the wrong location, we need to move them to the inside of the 'if' statement.

## Brief change log

  - *Move log of lint-python.sh to the inside of 'if' statement*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (no)
