### PR TITLE
[FLINK-27699][python][connector/pulsar] Align atPublishTime method of StopCursor class

### DIFF
--- a/flink-python/pyflink/datastream/connectors/pulsar.py
+++ b/flink-python/pyflink/datastream/connectors/pulsar.py
@@ -171,9 +171,20 @@ class StopCursor(object):
 
     @staticmethod
     def at_event_time(timestamp: int) -> 'StopCursor':
+        warnings.warn(
+            "at_event_time is deprecated. Use at_publish_time instead.", DeprecationWarning)
         JStopCursor = get_gateway().jvm \
             .org.apache.flink.connector.pulsar.source.enumerator.cursor.StopCursor
         return StopCursor(JStopCursor.atEventTime(timestamp))
+
+    @staticmethod
+    def at_publish_time(timestamp: int) -> 'StopCursor':
+        """
+        Stop when message publishTime is greater than the specified timestamp.
+        """
+        JStopCursor = get_gateway().jvm \
+            .org.apache.flink.connector.pulsar.source.enumerator.cursor.StopCursor
+        return StopCursor(JStopCursor.atPublishTime(timestamp))
 
 
 class PulsarSource(Source):
@@ -254,7 +265,7 @@ class PulsarSourceBuilder(object):
         ...     .set_topics([TOPIC1, TOPIC2]) \\
         ...     .set_deserialization_schema(
         ...         PulsarDeserializationSchema.flink_schema(SimpleStringSchema())) \\
-        ...     .set_bounded_stop_cursor(StopCursor.at_event_time(int(time.time() * 1000)))
+        ...     .set_bounded_stop_cursor(StopCursor.at_publish_time(int(time.time() * 1000)))
         ...     .build()
     """
 

--- a/flink-python/pyflink/datastream/tests/test_connectors.py
+++ b/flink-python/pyflink/datastream/tests/test_connectors.py
@@ -179,7 +179,7 @@ class FlinkPulsarTest(ConnectorTestBase):
             .set_topics('ada') \
             .set_start_cursor(StartCursor.earliest()) \
             .set_unbounded_stop_cursor(StopCursor.never()) \
-            .set_bounded_stop_cursor(StopCursor.at_event_time(22)) \
+            .set_bounded_stop_cursor(StopCursor.at_publish_time(22)) \
             .set_subscription_name('ff') \
             .set_subscription_type(SubscriptionType.Exclusive) \
             .set_deserialization_schema(
@@ -257,6 +257,7 @@ class FlinkPulsarTest(ConnectorTestBase):
             .set_topics('ada') \
             .set_deserialization_schema(
                 PulsarDeserializationSchema.flink_type_info(Types.STRING(), None)) \
+            .set_unbounded_stop_cursor(StopCursor.at_event_time(4444)) \
             .set_subscription_name('ff') \
             .set_config(test_option, True) \
             .set_config_with_dict({'pulsar.source.autoCommitCursorInterval': '1000'}) \


### PR DESCRIPTION
## What is the purpose of the change

StopCursor#atEventTime is deprecated, align to StopCursor#atPublishTime.

## Brief change log

  - *Add at_publish_time method into StopCursor class of PyFlink*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added test that validates at_publish_time*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (no)
