### PR TITLE
[FLINK-27711][python][connector/pulsar] Align setTopicPattern for Pulsar Connector

### DIFF
--- a/flink-python/pyflink/datastream/connectors/pulsar.py
+++ b/flink-python/pyflink/datastream/connectors/pulsar.py
@@ -311,7 +311,17 @@ class PulsarSourceBuilder(object):
         Set a topic pattern to consume from the java regex str. You can set topics once either with
         setTopics or setTopicPattern in this builder.
         """
+        warnings.warn("set_topics_pattern is deprecated. Use set_topic_pattern instead.",
+                      DeprecationWarning, stacklevel=2)
         self._j_pulsar_source_builder.setTopicPattern(topics_pattern)
+        return self
+
+    def set_topic_pattern(self, topic_pattern: str) -> 'PulsarSourceBuilder':
+        """
+        Set a topic pattern to consume from the java regex str. You can set topics once either with
+        setTopics or setTopicPattern in this builder.
+        """
+        self._j_pulsar_source_builder.setTopicPattern(topic_pattern)
         return self
 
     def set_start_cursor(self, start_cursor: StartCursor) -> 'PulsarSourceBuilder':

--- a/flink-python/pyflink/datastream/tests/test_connectors.py
+++ b/flink-python/pyflink/datastream/tests/test_connectors.py
@@ -242,7 +242,7 @@ class FlinkPulsarTest(ConnectorTestBase):
         PulsarSource.builder() \
             .set_service_url('pulsar://localhost:6650') \
             .set_admin_url('http://localhost:8080') \
-            .set_topics_pattern('ada.*') \
+            .set_topic_pattern('ada.*') \
             .set_subscription_name('ff') \
             .set_deserialization_schema(
                 PulsarDeserializationSchema.flink_schema(SimpleStringSchema())) \
@@ -254,7 +254,7 @@ class FlinkPulsarTest(ConnectorTestBase):
         pulsar_source = PulsarSource.builder() \
             .set_service_url('pulsar://localhost:6650') \
             .set_admin_url('http://localhost:8080') \
-            .set_topics('ada') \
+            .set_topics_pattern('ada.*') \
             .set_deserialization_schema(
                 PulsarDeserializationSchema.flink_type_info(Types.STRING(), None)) \
             .set_subscription_name('ff') \


### PR DESCRIPTION
## What is the purpose of the change

set_topics_pattern is a typo, so I update set_topics_pattern to set_topic_pattern in pulsar.py

## Brief change log

  - *Add set_topic_pattern method in pulsar.py*
  - *set set_topics_pattern deprecated*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added test that validates set_topic_pattern*
  - *Added test that validates set_topics_pattern is deprecated *

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (PyDocs)
