### PR TITLE
[FLINK-27727][tests] Migrate TypeSerializerUpgradeTestBase to JUnit5

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaSerializerUpgradeTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaSerializerUpgradeTest.java
@@ -26,8 +26,6 @@ import org.apache.flink.api.common.typeutils.TypeSerializerUpgradeTestBase;
 import org.apache.flink.streaming.connectors.kafka.internals.FlinkKafkaInternalProducer;
 
 import org.hamcrest.Matcher;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 import org.mockito.Mockito;
 
 import java.util.ArrayList;
@@ -41,15 +39,9 @@ import static org.hamcrest.Matchers.is;
  * A {@link TypeSerializerUpgradeTestBase} for {@link FlinkKafkaProducer.TransactionStateSerializer}
  * and {@link FlinkKafkaProducer.ContextStateSerializer}.
  */
-@RunWith(Parameterized.class)
-public class KafkaSerializerUpgradeTest extends TypeSerializerUpgradeTestBase<Object, Object> {
+class KafkaSerializerUpgradeTest extends TypeSerializerUpgradeTestBase<Object, Object> {
 
-    public KafkaSerializerUpgradeTest(TestSpecification<Object, Object> testSpecification) {
-        super(testSpecification);
-    }
-
-    @Parameterized.Parameters(name = "Test Specification = {0}")
-    public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
+    public Collection<TestSpecification<?, ?>> createTestSpecifications() throws Exception {
 
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
         for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {

--- a/flink-connectors/flink-hadoop-compatibility/src/test/java/org/apache/flink/api/java/typeutils/runtime/WritableSerializerUpgradeTest.java
+++ b/flink-connectors/flink-hadoop-compatibility/src/test/java/org/apache/flink/api/java/typeutils/runtime/WritableSerializerUpgradeTest.java
@@ -27,8 +27,6 @@ import org.apache.flink.api.java.typeutils.runtime.WritableSerializerUpgradeTest
 
 import org.apache.hadoop.io.Writable;
 import org.hamcrest.Matcher;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -40,17 +38,10 @@ import java.util.Objects;
 import static org.hamcrest.Matchers.is;
 
 /** A {@link TypeSerializerUpgradeTestBase} for {@link WritableSerializer}. */
-@RunWith(Parameterized.class)
-public class WritableSerializerUpgradeTest
+class WritableSerializerUpgradeTest
         extends TypeSerializerUpgradeTestBase<WritableName, WritableName> {
 
-    public WritableSerializerUpgradeTest(
-            TestSpecification<WritableName, WritableName> testSpecification) {
-        super(testSpecification);
-    }
-
-    @Parameterized.Parameters(name = "Test Specification = {0}")
-    public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
+    public Collection<TestSpecification<?, ?>> createTestSpecifications() throws Exception {
 
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
         for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/CompositeTypeSerializerUpgradeTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/CompositeTypeSerializerUpgradeTest.java
@@ -26,8 +26,6 @@ import org.apache.flink.api.java.typeutils.runtime.EitherSerializer;
 import org.apache.flink.types.Either;
 
 import org.hamcrest.Matcher;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -35,16 +33,9 @@ import java.util.Collection;
 import static org.hamcrest.Matchers.is;
 
 /** A {@link TypeSerializerUpgradeTestBase} for {@link GenericArraySerializer}. */
-@RunWith(Parameterized.class)
-public class CompositeTypeSerializerUpgradeTest
-        extends TypeSerializerUpgradeTestBase<Object, Object> {
+class CompositeTypeSerializerUpgradeTest extends TypeSerializerUpgradeTestBase<Object, Object> {
 
-    public CompositeTypeSerializerUpgradeTest(TestSpecification<Object, Object> testSpecification) {
-        super(testSpecification);
-    }
-
-    @Parameterized.Parameters(name = "Test Specification = {0}")
-    public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
+    public Collection<TestSpecification<?, ?>> createTestSpecifications() throws Exception {
 
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
         for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/BasicTypeSerializerUpgradeTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/BasicTypeSerializerUpgradeTest.java
@@ -21,22 +21,13 @@ package org.apache.flink.api.common.typeutils.base;
 import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.common.typeutils.TypeSerializerUpgradeTestBase;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-
 import java.util.ArrayList;
 import java.util.Collection;
 
 /** A {@link TypeSerializerUpgradeTestBase} for BaseType Serializers. */
-@RunWith(Parameterized.class)
-public class BasicTypeSerializerUpgradeTest extends TypeSerializerUpgradeTestBase<Object, Object> {
+class BasicTypeSerializerUpgradeTest extends TypeSerializerUpgradeTestBase<Object, Object> {
 
-    public BasicTypeSerializerUpgradeTest(TestSpecification<Object, Object> testSpecification) {
-        super(testSpecification);
-    }
-
-    @Parameterized.Parameters(name = "Test Specification = {0}")
-    public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
+    public Collection<TestSpecification<?, ?>> createTestSpecifications() throws Exception {
 
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
         for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/EnumSerializerUpgradeTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/EnumSerializerUpgradeTest.java
@@ -28,8 +28,6 @@ import org.apache.flink.api.common.typeutils.TypeSerializerUpgradeTestBase;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -39,16 +37,10 @@ import static org.apache.flink.api.common.typeutils.base.TestEnum.EMMA;
 import static org.hamcrest.Matchers.is;
 
 /** Migration tests for {@link EnumSerializer}. */
-@RunWith(Parameterized.class)
-public class EnumSerializerUpgradeTest extends TypeSerializerUpgradeTestBase<TestEnum, TestEnum> {
+class EnumSerializerUpgradeTest extends TypeSerializerUpgradeTestBase<TestEnum, TestEnum> {
     private static final String SPEC_NAME = "enum-serializer";
 
-    public EnumSerializerUpgradeTest(TestSpecification<TestEnum, TestEnum> enumSerializer) {
-        super(enumSerializer);
-    }
-
-    @Parameterized.Parameters(name = "Test Specification = {0}")
-    public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
+    public Collection<TestSpecification<?, ?>> createTestSpecifications() throws Exception {
 
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
         for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/ListSerializerUpgradeTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/ListSerializerUpgradeTest.java
@@ -25,8 +25,6 @@ import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
 import org.apache.flink.api.common.typeutils.TypeSerializerUpgradeTestBase;
 
 import org.hamcrest.Matcher;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -35,19 +33,11 @@ import java.util.List;
 import static org.hamcrest.Matchers.is;
 
 /** A {@link TypeSerializerUpgradeTestBase} for {@link ListSerializerSnapshot}. */
-@RunWith(Parameterized.class)
-public class ListSerializerUpgradeTest
-        extends TypeSerializerUpgradeTestBase<List<String>, List<String>> {
+class ListSerializerUpgradeTest extends TypeSerializerUpgradeTestBase<List<String>, List<String>> {
 
     private static final String SPEC_NAME = "list-serializer";
 
-    public ListSerializerUpgradeTest(
-            TestSpecification<List<String>, List<String>> testSpecification) {
-        super(testSpecification);
-    }
-
-    @Parameterized.Parameters(name = "Test Specification = {0}")
-    public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
+    public Collection<TestSpecification<?, ?>> createTestSpecifications() throws Exception {
 
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
         for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/MapSerializerUpgradeTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/MapSerializerUpgradeTest.java
@@ -25,8 +25,6 @@ import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
 import org.apache.flink.api.common.typeutils.TypeSerializerUpgradeTestBase;
 
 import org.hamcrest.Matcher;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -36,19 +34,12 @@ import java.util.Map;
 import static org.hamcrest.Matchers.is;
 
 /** A {@link TypeSerializerUpgradeTestBase} for {@link MapSerializerSnapshot}. */
-@RunWith(Parameterized.class)
-public class MapSerializerUpgradeTest
+class MapSerializerUpgradeTest
         extends TypeSerializerUpgradeTestBase<Map<Integer, String>, Map<Integer, String>> {
 
     private static final String SPEC_NAME = "map-serializer";
 
-    public MapSerializerUpgradeTest(
-            TestSpecification<Map<Integer, String>, Map<Integer, String>> testSpecification) {
-        super(testSpecification);
-    }
-
-    @Parameterized.Parameters(name = "Test Specification = {0}")
-    public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
+    public Collection<TestSpecification<?, ?>> createTestSpecifications() throws Exception {
 
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
         for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/PrimitiveArraySerializerUpgradeTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/PrimitiveArraySerializerUpgradeTest.java
@@ -21,23 +21,13 @@ package org.apache.flink.api.common.typeutils.base.array;
 import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.common.typeutils.TypeSerializerUpgradeTestBase;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-
 import java.util.ArrayList;
 import java.util.Collection;
 
 /** Migration tests for primitive array type serializers' snapshots. */
-@RunWith(Parameterized.class)
-public class PrimitiveArraySerializerUpgradeTest
-        extends TypeSerializerUpgradeTestBase<Object, Object> {
-    public PrimitiveArraySerializerUpgradeTest(
-            TestSpecification<Object, Object> testSpecification) {
-        super(testSpecification);
-    }
+class PrimitiveArraySerializerUpgradeTest extends TypeSerializerUpgradeTestBase<Object, Object> {
 
-    @Parameterized.Parameters(name = "Test Specification = {0}")
-    public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
+    public Collection<TestSpecification<?, ?>> createTestSpecifications() throws Exception {
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
         for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {
             testSpecifications.add(

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/CopyableSerializerUpgradeTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/CopyableSerializerUpgradeTest.java
@@ -29,29 +29,20 @@ import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.types.CopyableValue;
 
 import org.hamcrest.Matcher;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.is;
 
 /** A {@link TypeSerializerUpgradeTestBase} for {@link CopyableValueSerializer}. */
-@RunWith(Parameterized.class)
-public class CopyableSerializerUpgradeTest
+class CopyableSerializerUpgradeTest
         extends TypeSerializerUpgradeTestBase<SimpleCopyable, SimpleCopyable> {
 
-    public CopyableSerializerUpgradeTest(
-            TestSpecification<SimpleCopyable, SimpleCopyable> testSpecification) {
-        super(testSpecification);
-    }
-
-    @Parameterized.Parameters(name = "Test Specification = {0}")
-    public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
+    public Collection<TestSpecification<?, ?>> createTestSpecifications() throws Exception {
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
         for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {
             testSpecifications.add(
@@ -168,8 +159,8 @@ public class CopyableSerializerUpgradeTest
     }
 
     @Test
-    public void testF() {
+    void testSimpleCopyableEqualsImplementation() {
         SimpleCopyable a = new SimpleCopyable(123456);
-        Assert.assertThat(a, is(new SimpleCopyable(123456)));
+        assertThat(a).isEqualTo(new SimpleCopyable(123456));
     }
 }

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/NullableSerializerUpgradeTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/NullableSerializerUpgradeTest.java
@@ -26,8 +26,6 @@ import org.apache.flink.api.common.typeutils.TypeSerializerUpgradeTestBase;
 import org.apache.flink.api.common.typeutils.base.LongSerializer;
 
 import org.hamcrest.Matcher;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -35,15 +33,9 @@ import java.util.Collection;
 import static org.hamcrest.CoreMatchers.is;
 
 /** A {@link TypeSerializerUpgradeTestBase} for {@link NullableSerializer}. */
-@RunWith(Parameterized.class)
-public class NullableSerializerUpgradeTest extends TypeSerializerUpgradeTestBase<Long, Long> {
+class NullableSerializerUpgradeTest extends TypeSerializerUpgradeTestBase<Long, Long> {
 
-    public NullableSerializerUpgradeTest(TestSpecification<Long, Long> testSpecification) {
-        super(testSpecification);
-    }
-
-    @Parameterized.Parameters(name = "Test Specification = {0}")
-    public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
+    public Collection<TestSpecification<?, ?>> createTestSpecifications() throws Exception {
 
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
         for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializerUpgradeTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializerUpgradeTest.java
@@ -21,23 +21,14 @@ package org.apache.flink.api.java.typeutils.runtime;
 import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.common.typeutils.TypeSerializerUpgradeTestBase;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
 /** A {@link TypeSerializerUpgradeTestBase} for the {@link PojoSerializer}. */
-@RunWith(Parameterized.class)
-public class PojoSerializerUpgradeTest extends TypeSerializerUpgradeTestBase<Object, Object> {
+class PojoSerializerUpgradeTest extends TypeSerializerUpgradeTestBase<Object, Object> {
 
-    public PojoSerializerUpgradeTest(TestSpecification<Object, Object> testSpecification) {
-        super(testSpecification);
-    }
-
-    @Parameterized.Parameters(name = "Test Specification = {0}")
-    public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
+    public Collection<TestSpecification<?, ?>> createTestSpecifications() throws Exception {
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
         // for PojoSerializer we also test against 1.7, 1.8, and 1.9 because we have snapshots
         // for this which go beyond what we have for the usual subclasses of

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/RowSerializerUpgradeTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/RowSerializerUpgradeTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.api.java.typeutils.runtime;
 
 import org.apache.flink.FlinkVersion;
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -30,8 +31,6 @@ import org.apache.flink.types.Row;
 import org.apache.flink.types.RowKind;
 
 import org.hamcrest.Matcher;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -40,15 +39,10 @@ import java.util.List;
 import static org.hamcrest.Matchers.is;
 
 /** A {@link TypeSerializerUpgradeTestBase} for {@link RowSerializer}. */
-@RunWith(Parameterized.class)
+@VisibleForTesting
 public class RowSerializerUpgradeTest extends TypeSerializerUpgradeTestBase<Row, Row> {
 
-    public RowSerializerUpgradeTest(TestSpecification<Row, Row> testSpecification) {
-        super(testSpecification);
-    }
-
-    @Parameterized.Parameters(name = "Test Specification = {0}")
-    public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
+    public Collection<TestSpecification<?, ?>> createTestSpecifications() throws Exception {
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
         // for RowSerializer we also test against 1.10 and newer because we have snapshots
         // for this which go beyond what we have for the usual subclasses of

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/TupleSerializerUpgradeTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/TupleSerializerUpgradeTest.java
@@ -28,8 +28,6 @@ import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.api.java.tuple.Tuple3;
 
 import org.hamcrest.Matcher;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -37,19 +35,11 @@ import java.util.Collection;
 import static org.hamcrest.Matchers.is;
 
 /** {@link TupleSerializer} upgrade test. */
-@RunWith(Parameterized.class)
-public class TupleSerializerUpgradeTest
+class TupleSerializerUpgradeTest
         extends TypeSerializerUpgradeTestBase<
                 Tuple3<String, String, Integer>, Tuple3<String, String, Integer>> {
 
-    public TupleSerializerUpgradeTest(
-            TestSpecification<Tuple3<String, String, Integer>, Tuple3<String, String, Integer>>
-                    testSpecification) {
-        super(testSpecification);
-    }
-
-    @Parameterized.Parameters(name = "Test Specification = {0}")
-    public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
+    public Collection<TestSpecification<?, ?>> createTestSpecifications() throws Exception {
 
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
         for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/ValueSerializerUpgradeTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/ValueSerializerUpgradeTest.java
@@ -28,8 +28,6 @@ import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.types.Value;
 
 import org.hamcrest.Matcher;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -39,16 +37,11 @@ import java.util.Objects;
 import static org.hamcrest.Matchers.is;
 
 /** State migration test for {@link RowSerializer}. */
-@RunWith(Parameterized.class)
-public class ValueSerializerUpgradeTest
+class ValueSerializerUpgradeTest
         extends TypeSerializerUpgradeTestBase<
                 ValueSerializerUpgradeTest.NameValue, ValueSerializerUpgradeTest.NameValue> {
-    public ValueSerializerUpgradeTest(TestSpecification<NameValue, NameValue> testSpecification) {
-        super(testSpecification);
-    }
 
-    @Parameterized.Parameters(name = "Test Specification = {0}")
-    public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
+    public Collection<TestSpecification<?, ?>> createTestSpecifications() throws Exception {
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
         for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {
             testSpecifications.add(

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializerUpgradeTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializerUpgradeTest.java
@@ -31,8 +31,6 @@ import org.apache.flink.api.java.typeutils.runtime.kryo.KryoPojosForMigrationTes
 
 import com.esotericsoftware.kryo.serializers.DefaultSerializers;
 import org.hamcrest.Matcher;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -43,15 +41,9 @@ import static org.hamcrest.Matchers.is;
 
 /** Tests migrations for {@link KryoSerializerSnapshot}. */
 @SuppressWarnings("WeakerAccess")
-@RunWith(Parameterized.class)
-public class KryoSerializerUpgradeTest extends TypeSerializerUpgradeTestBase<Object, Object> {
+class KryoSerializerUpgradeTest extends TypeSerializerUpgradeTestBase<Object, Object> {
 
-    public KryoSerializerUpgradeTest(TestSpecification<Object, Object> testSpecification) {
-        super(testSpecification);
-    }
-
-    @Parameterized.Parameters(name = "Test Specification = {0}")
-    public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
+    public Collection<TestSpecification<?, ?>> createTestSpecifications() throws Exception {
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
         for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {
             testSpecifications.add(

--- a/flink-core/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/flink-core/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.util.TestLoggerExtension

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroSerializerUpgradeTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroSerializerUpgradeTest.java
@@ -28,8 +28,6 @@ import org.apache.flink.formats.avro.generated.Address;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.hamcrest.Matcher;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -37,15 +35,9 @@ import java.util.Collection;
 import static org.hamcrest.Matchers.is;
 
 /** Tests based on {@link TypeSerializerUpgradeTestBase} for the {@link AvroSerializer}. */
-@RunWith(Parameterized.class)
-public class AvroSerializerUpgradeTest extends TypeSerializerUpgradeTestBase<Object, Object> {
+class AvroSerializerUpgradeTest extends TypeSerializerUpgradeTestBase<Object, Object> {
 
-    public AvroSerializerUpgradeTest(TestSpecification<Object, Object> testSpecification) {
-        super(testSpecification);
-    }
-
-    @Parameterized.Parameters(name = "Test Specification = {0}")
-    public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
+    public Collection<TestSpecification<?, ?>> createTestSpecifications() throws Exception {
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
         for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {
             testSpecifications.add(

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/NFASerializerUpgradeTest.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/NFASerializerUpgradeTest.java
@@ -33,8 +33,6 @@ import org.apache.flink.cep.nfa.sharedbuffer.SharedBufferNode;
 import org.apache.flink.cep.nfa.sharedbuffer.SharedBufferNodeSerializer;
 
 import org.hamcrest.Matcher;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -43,15 +41,9 @@ import java.util.Collections;
 import static org.hamcrest.Matchers.is;
 
 /** Migration tests for NFA-related serializers. */
-@RunWith(Parameterized.class)
-public class NFASerializerUpgradeTest extends TypeSerializerUpgradeTestBase<Object, Object> {
+class NFASerializerUpgradeTest extends TypeSerializerUpgradeTestBase<Object, Object> {
 
-    public NFASerializerUpgradeTest(TestSpecification<Object, Object> testSpecification) {
-        super(testSpecification);
-    }
-
-    @Parameterized.Parameters(name = "Test Specification = {0}")
-    public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
+    public Collection<TestSpecification<?, ?>> createTestSpecifications() throws Exception {
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
         for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {
             testSpecifications.add(

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/sharedbuffer/LockableTypeSerializerUpgradeTest.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/sharedbuffer/LockableTypeSerializerUpgradeTest.java
@@ -26,8 +26,6 @@ import org.apache.flink.api.common.typeutils.TypeSerializerUpgradeTestBase;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 
 import org.hamcrest.Matcher;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -35,19 +33,12 @@ import java.util.Collection;
 import static org.hamcrest.Matchers.is;
 
 /** A {@link TypeSerializerUpgradeTestBase} for {@link Lockable.LockableTypeSerializer}. */
-@RunWith(Parameterized.class)
-public class LockableTypeSerializerUpgradeTest
+class LockableTypeSerializerUpgradeTest
         extends TypeSerializerUpgradeTestBase<Lockable<String>, Lockable<String>> {
 
     private static final String SPEC_NAME = "lockable-type-serializer";
 
-    public LockableTypeSerializerUpgradeTest(
-            TestSpecification<Lockable<String>, Lockable<String>> testSpecification) {
-        super(testSpecification);
-    }
-
-    @Parameterized.Parameters(name = "Test Specification = {0}")
-    public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
+    public Collection<TestSpecification<?, ?>> createTestSpecifications() throws Exception {
 
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
         for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {

--- a/flink-libraries/flink-gelly-examples/src/test/java/org/apache/flink/graph/drivers/transform/LongValueWithProperHashCodeSerializerUpgradeTest.java
+++ b/flink-libraries/flink-gelly-examples/src/test/java/org/apache/flink/graph/drivers/transform/LongValueWithProperHashCodeSerializerUpgradeTest.java
@@ -25,8 +25,6 @@ import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
 import org.apache.flink.api.common.typeutils.TypeSerializerUpgradeTestBase;
 
 import org.hamcrest.Matcher;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -37,19 +35,11 @@ import static org.hamcrest.Matchers.is;
  * A {@link TypeSerializerUpgradeTestBase} for {@link
  * LongValueWithProperHashCode.LongValueWithProperHashCodeSerializer}.
  */
-@RunWith(Parameterized.class)
-public class LongValueWithProperHashCodeSerializerUpgradeTest
+class LongValueWithProperHashCodeSerializerUpgradeTest
         extends TypeSerializerUpgradeTestBase<
                 LongValueWithProperHashCode, LongValueWithProperHashCode> {
 
-    public LongValueWithProperHashCodeSerializerUpgradeTest(
-            TestSpecification<LongValueWithProperHashCode, LongValueWithProperHashCode>
-                    testSpecification) {
-        super(testSpecification);
-    }
-
-    @Parameterized.Parameters(name = "Test Specification = {0}")
-    public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
+    public Collection<TestSpecification<?, ?>> createTestSpecifications() throws Exception {
 
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
         for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/ValueArraySerializerUpgradeTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/ValueArraySerializerUpgradeTest.java
@@ -34,8 +34,6 @@ import org.apache.flink.types.ShortValue;
 import org.apache.flink.types.StringValue;
 
 import org.hamcrest.Matcher;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -43,15 +41,9 @@ import java.util.Collection;
 import static org.hamcrest.Matchers.is;
 
 /** Migration tests for boxed-value array serializer snapshots. */
-@RunWith(Parameterized.class)
-public class ValueArraySerializerUpgradeTest extends TypeSerializerUpgradeTestBase<Object, Object> {
+class ValueArraySerializerUpgradeTest extends TypeSerializerUpgradeTestBase<Object, Object> {
 
-    public ValueArraySerializerUpgradeTest(TestSpecification<Object, Object> testSpecification) {
-        super(testSpecification);
-    }
-
-    @Parameterized.Parameters(name = "Test Specification = {0}")
-    public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
+    public Collection<TestSpecification<?, ?>> createTestSpecifications() throws Exception {
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
         for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {
             testSpecifications.add(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ArrayListSerializerUpgradeTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ArrayListSerializerUpgradeTest.java
@@ -26,8 +26,6 @@ import org.apache.flink.api.common.typeutils.TypeSerializerUpgradeTestBase;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 
 import org.hamcrest.Matcher;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -35,19 +33,12 @@ import java.util.Collection;
 import static org.hamcrest.Matchers.is;
 
 /** A {@link TypeSerializerUpgradeTestBase} for {@link ArrayListSerializerSnapshot}. */
-@RunWith(Parameterized.class)
-public class ArrayListSerializerUpgradeTest
+class ArrayListSerializerUpgradeTest
         extends TypeSerializerUpgradeTestBase<ArrayList<String>, ArrayList<String>> {
 
     private static final String SPEC_NAME = "arraylist-serializer";
 
-    public ArrayListSerializerUpgradeTest(
-            TestSpecification<ArrayList<String>, ArrayList<String>> testSpecification) {
-        super(testSpecification);
-    }
-
-    @Parameterized.Parameters(name = "Test Specification = {0}")
-    public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
+    public Collection<TestSpecification<?, ?>> createTestSpecifications() throws Exception {
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
         for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {
             testSpecifications.add(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/JavaSerializerUpgradeTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/JavaSerializerUpgradeTest.java
@@ -25,8 +25,6 @@ import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
 import org.apache.flink.api.common.typeutils.TypeSerializerUpgradeTestBase;
 
 import org.hamcrest.Matcher;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -35,19 +33,11 @@ import java.util.Collection;
 import static org.hamcrest.Matchers.is;
 
 /** A {@link TypeSerializerUpgradeTestBase} for {@link JavaSerializer}. */
-@RunWith(Parameterized.class)
-public class JavaSerializerUpgradeTest
-        extends TypeSerializerUpgradeTestBase<Serializable, Serializable> {
+class JavaSerializerUpgradeTest extends TypeSerializerUpgradeTestBase<Serializable, Serializable> {
 
     private static final String SPEC_NAME = "java-serializer";
 
-    public JavaSerializerUpgradeTest(
-            TestSpecification<Serializable, Serializable> testSpecification) {
-        super(testSpecification);
-    }
-
-    @Parameterized.Parameters(name = "Test Specification = {0}")
-    public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
+    public Collection<TestSpecification<?, ?>> createTestSpecifications() throws Exception {
 
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/VoidNamespaceSerializerUpgradeTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/VoidNamespaceSerializerUpgradeTest.java
@@ -25,8 +25,6 @@ import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
 import org.apache.flink.api.common.typeutils.TypeSerializerUpgradeTestBase;
 
 import org.hamcrest.Matcher;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -34,19 +32,12 @@ import java.util.Collection;
 import static org.hamcrest.Matchers.is;
 
 /** A {@link TypeSerializerUpgradeTestBase} for {@link VoidNamespaceSerializer}. */
-@RunWith(Parameterized.class)
-public class VoidNamespaceSerializerUpgradeTest
+class VoidNamespaceSerializerUpgradeTest
         extends TypeSerializerUpgradeTestBase<VoidNamespace, VoidNamespace> {
 
     private static final String SPEC_NAME = "void-namespace-serializer";
 
-    public VoidNamespaceSerializerUpgradeTest(
-            TestSpecification<VoidNamespace, VoidNamespace> testSpecification) {
-        super(testSpecification);
-    }
-
-    @Parameterized.Parameters(name = "Test Specification = {0}")
-    public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
+    public Collection<TestSpecification<?, ?>> createTestSpecifications() throws Exception {
 
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
         for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlSerializerUpgradeTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlSerializerUpgradeTest.java
@@ -28,8 +28,6 @@ import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.runtime.state.ttl.TtlStateFactory.TtlSerializer;
 
 import org.hamcrest.Matcher;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -38,17 +36,10 @@ import static org.apache.flink.runtime.state.ttl.TtlValueMatchers.ttlValue;
 import static org.hamcrest.Matchers.is;
 
 /** State migration test for {@link TtlSerializer}. */
-@RunWith(Parameterized.class)
-public class TtlSerializerUpgradeTest
+class TtlSerializerUpgradeTest
         extends TypeSerializerUpgradeTestBase<TtlValue<String>, TtlValue<String>> {
 
-    public TtlSerializerUpgradeTest(
-            TestSpecification<TtlValue<String>, TtlValue<String>> testSpecification) {
-        super(testSpecification);
-    }
-
-    @Parameterized.Parameters(name = "Test Specification = {0}")
-    public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
+    public Collection<TestSpecification<?, ?>> createTestSpecifications() throws Exception {
 
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
         for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {

--- a/flink-scala/src/test/java/org/apache/flink/api/scala/typeutils/OptionSerializerUpgradeTest.java
+++ b/flink-scala/src/test/java/org/apache/flink/api/scala/typeutils/OptionSerializerUpgradeTest.java
@@ -26,8 +26,6 @@ import org.apache.flink.api.common.typeutils.TypeSerializerUpgradeTestBase;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 
 import org.hamcrest.Matcher;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -40,19 +38,12 @@ import static org.hamcrest.CoreMatchers.is;
  * A {@link org.apache.flink.api.common.typeutils.TypeSerializerUpgradeTestBase} for {@link
  * ScalaEitherSerializerSnapshot}.
  */
-@RunWith(Parameterized.class)
-public class OptionSerializerUpgradeTest
+class OptionSerializerUpgradeTest
         extends TypeSerializerUpgradeTestBase<Option<String>, Option<String>> {
 
     private static final String SPEC_NAME = "scala-option-serializer";
 
-    public OptionSerializerUpgradeTest(
-            TestSpecification<Option<String>, Option<String>> testSpecification) {
-        super(testSpecification);
-    }
-
-    @Parameterized.Parameters(name = "Test Specification = {0}")
-    public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
+    public Collection<TestSpecification<?, ?>> createTestSpecifications() throws Exception {
 
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
         for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {

--- a/flink-scala/src/test/java/org/apache/flink/api/scala/typeutils/ScalaEitherSerializerUpgradeTest.java
+++ b/flink-scala/src/test/java/org/apache/flink/api/scala/typeutils/ScalaEitherSerializerUpgradeTest.java
@@ -27,8 +27,6 @@ import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 
 import org.hamcrest.Matcher;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -39,19 +37,12 @@ import scala.util.Right;
 import static org.hamcrest.Matchers.is;
 
 /** A {@link TypeSerializerUpgradeTestBase} for {@link ScalaEitherSerializerSnapshot}. */
-@RunWith(Parameterized.class)
-public class ScalaEitherSerializerUpgradeTest
+class ScalaEitherSerializerUpgradeTest
         extends TypeSerializerUpgradeTestBase<Either<Integer, String>, Either<Integer, String>> {
 
     private static final String SPEC_NAME = "scala-either-serializer";
 
-    public ScalaEitherSerializerUpgradeTest(
-            TestSpecification<Either<Integer, String>, Either<Integer, String>> testSpecification) {
-        super(testSpecification);
-    }
-
-    @Parameterized.Parameters(name = "Test Specification = {0}")
-    public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
+    public Collection<TestSpecification<?, ?>> createTestSpecifications() throws Exception {
 
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
         for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {

--- a/flink-scala/src/test/java/org/apache/flink/api/scala/typeutils/ScalaTrySerializerUpgradeTest.java
+++ b/flink-scala/src/test/java/org/apache/flink/api/scala/typeutils/ScalaTrySerializerUpgradeTest.java
@@ -27,8 +27,6 @@ import org.apache.flink.api.common.typeutils.TypeSerializerUpgradeTestBase;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 
 import org.hamcrest.Matcher;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -40,19 +38,12 @@ import scala.util.Try;
 import static org.hamcrest.Matchers.is;
 
 /** A {@link TypeSerializerUpgradeTestBase} for {@link TrySerializer}. */
-@RunWith(Parameterized.class)
-public class ScalaTrySerializerUpgradeTest
+class ScalaTrySerializerUpgradeTest
         extends TypeSerializerUpgradeTestBase<Try<String>, Try<String>> {
 
     private static final String SPEC_NAME = "scala-try-serializer";
 
-    public ScalaTrySerializerUpgradeTest(
-            TestSpecification<Try<String>, Try<String>> testSpecification) {
-        super(testSpecification);
-    }
-
-    @Parameterized.Parameters(name = "Test Specification = {0}")
-    public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
+    public Collection<TestSpecification<?, ?>> createTestSpecifications() throws Exception {
 
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
         for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {

--- a/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/EnumValueSerializerUpgradeTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/EnumValueSerializerUpgradeTest.scala
@@ -20,29 +20,18 @@ package org.apache.flink.api.scala.typeutils
 import org.apache.flink.FlinkVersion
 import org.apache.flink.api.common.typeutils.{TypeSerializer, TypeSerializerMatchers, TypeSerializerSchemaCompatibility, TypeSerializerUpgradeTestBase}
 import org.apache.flink.api.common.typeutils.TypeSerializerUpgradeTestBase.TestSpecification
+import org.apache.flink.api.scala.typeutils.EnumValueSerializerUpgradeTest.{EnumValueSerializerSetup, EnumValueSerializerVerifier}
 
 import org.hamcrest.Matcher
 import org.hamcrest.Matchers.is
-import org.junit.runner.RunWith
-import org.junit.runners.Parameterized
 
 import java.util
 
 /** A [[TypeSerializerUpgradeTestBase]] for [[EnumValueSerializer]]. */
-@RunWith(classOf[Parameterized])
-class EnumValueSerializerUpgradeTest(spec: TestSpecification[Letters.Value, Letters.Value])
-  extends TypeSerializerUpgradeTestBase[Letters.Value, Letters.Value](spec) {}
+class EnumValueSerializerUpgradeTest
+  extends TypeSerializerUpgradeTestBase[Letters.Value, Letters.Value] {
 
-object EnumValueSerializerUpgradeTest {
-
-  private val supplier =
-    new util.function.Supplier[EnumValueSerializer[Letters.type]] {
-      override def get(): EnumValueSerializer[Letters.type] =
-        new EnumValueSerializer(Letters)
-    }
-
-  @Parameterized.Parameters(name = "Test Specification = {0}")
-  def testSpecifications(): util.Collection[TestSpecification[_, _]] = {
+  override def createTestSpecifications(): util.Collection[TestSpecification[_, _]] = {
     val testSpecifications =
       new util.ArrayList[TypeSerializerUpgradeTestBase.TestSpecification[_, _]]
 
@@ -57,6 +46,15 @@ object EnumValueSerializerUpgradeTest {
 
     testSpecifications
   }
+}
+
+object EnumValueSerializerUpgradeTest {
+
+  private val supplier =
+    new util.function.Supplier[EnumValueSerializer[Letters.type]] {
+      override def get(): EnumValueSerializer[Letters.type] =
+        new EnumValueSerializer(Letters)
+    }
 
   /**
    * This class is only public to work with

--- a/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/ScalaCaseClassSerializerUpgradeTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/ScalaCaseClassSerializerUpgradeTest.scala
@@ -23,32 +23,18 @@ import org.apache.flink.api.common.typeutils.{TypeSerializer, TypeSerializerMatc
 import org.apache.flink.api.common.typeutils.TypeSerializerUpgradeTestBase.TestSpecification
 import org.apache.flink.api.scala.createTypeInformation
 import org.apache.flink.api.scala.types.CustomCaseClass
+import org.apache.flink.api.scala.typeutils.ScalaCaseClassSerializerUpgradeTest.{ScalaCaseClassSerializerSetup, ScalaCaseClassSerializerVerifier}
 
 import org.hamcrest.Matcher
 import org.hamcrest.Matchers.is
-import org.junit.runner.RunWith
-import org.junit.runners.Parameterized
 
 import java.util
 
 /** A [[TypeSerializerUpgradeTestBase]] for [[ScalaCaseClassSerializer]]. */
-@RunWith(classOf[Parameterized])
-class ScalaCaseClassSerializerUpgradeTest(
-    spec: TestSpecification[CustomCaseClass, CustomCaseClass]
-) extends TypeSerializerUpgradeTestBase[CustomCaseClass, CustomCaseClass](spec) {}
+class ScalaCaseClassSerializerUpgradeTest
+  extends TypeSerializerUpgradeTestBase[CustomCaseClass, CustomCaseClass] {
 
-object ScalaCaseClassSerializerUpgradeTest {
-
-  private val typeInfo = createTypeInformation[CustomCaseClass]
-
-  private val supplier =
-    new util.function.Supplier[TypeSerializer[CustomCaseClass]] {
-      override def get(): TypeSerializer[CustomCaseClass] =
-        typeInfo.createSerializer(new ExecutionConfig)
-    }
-
-  @Parameterized.Parameters(name = "Test Specification = {0}")
-  def testSpecifications(): util.Collection[TestSpecification[_, _]] = {
+  override def createTestSpecifications(): util.Collection[TestSpecification[_, _]] = {
     val testSpecifications =
       new util.ArrayList[TypeSerializerUpgradeTestBase.TestSpecification[_, _]]
     TypeSerializerUpgradeTestBase.MIGRATION_VERSIONS.forEach(
@@ -62,6 +48,17 @@ object ScalaCaseClassSerializerUpgradeTest {
 
     testSpecifications
   }
+}
+
+object ScalaCaseClassSerializerUpgradeTest {
+
+  private val typeInfo = createTypeInformation[CustomCaseClass]
+
+  private val supplier =
+    new util.function.Supplier[TypeSerializer[CustomCaseClass]] {
+      override def get(): TypeSerializer[CustomCaseClass] =
+        typeInfo.createSerializer(new ExecutionConfig)
+    }
 
   /**
    * This class is only public to work with

--- a/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/TraversableSerializerUpgradeTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/TraversableSerializerUpgradeTest.scala
@@ -23,11 +23,11 @@ import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.common.typeutils.{TypeSerializer, TypeSerializerMatchers, TypeSerializerSchemaCompatibility, TypeSerializerUpgradeTestBase}
 import org.apache.flink.api.common.typeutils.TypeSerializerUpgradeTestBase.TestSpecification
 import org.apache.flink.api.scala.createTypeInformation
+import org.apache.flink.api.scala.typeutils.TraversableSerializerUpgradeTest._
+import org.apache.flink.api.scala.typeutils.TraversableSerializerUpgradeTest.Types.Pojo
 
 import org.hamcrest.Matcher
 import org.hamcrest.Matchers.is
-import org.junit.runner.RunWith
-import org.junit.runners.Parameterized
 
 import java.util
 import java.util.function.Supplier
@@ -35,46 +35,10 @@ import java.util.function.Supplier
 import scala.collection.{mutable, BitSet, LinearSeq}
 
 /** A [[TypeSerializerUpgradeTestBase]] for [[TraversableSerializer]]. */
-@RunWith(classOf[Parameterized])
-class TraversableSerializerUpgradeTest(
-    testSpecification: TypeSerializerUpgradeTestBase.TestSpecification[
-      TraversableOnce[_],
-      TraversableOnce[_]])
-  extends TypeSerializerUpgradeTestBase[TraversableOnce[_], TraversableOnce[_]](testSpecification)
+class TraversableSerializerUpgradeTest
+  extends TypeSerializerUpgradeTestBase[TraversableOnce[_], TraversableOnce[_]] {
 
-object TraversableSerializerUpgradeTest {
-
-  object Types {
-
-    class Pojo(var name: String, var count: Int) {
-      def this() = this("", -1)
-
-      override def equals(other: Any): Boolean = {
-        other match {
-          case oP: Pojo => name == oP.name && count == oP.count
-          case _ => false
-        }
-      }
-    }
-
-    val seqTypeInfo = implicitly[TypeInformation[Seq[Int]]]
-    val indexedSeqTypeInfo =
-      implicitly[TypeInformation[IndexedSeq[Int]]]
-    val linearSeqTypeInfo = implicitly[TypeInformation[LinearSeq[Int]]]
-    val mapTypeInfo = implicitly[TypeInformation[Map[String, Int]]]
-    val setTypeInfo = implicitly[TypeInformation[Set[Int]]]
-    val bitsetTypeInfo = implicitly[TypeInformation[BitSet]]
-    val mutableListTypeInfo =
-      implicitly[TypeInformation[mutable.MutableList[Int]]]
-    val seqTupleTypeInfo = implicitly[TypeInformation[Seq[(Int, String)]]]
-    val seqPojoTypeInfo = implicitly[TypeInformation[Seq[Pojo]]]
-  }
-
-  import Types._
-
-  @Parameterized.Parameters(name = "Test Specification = {0}")
-  def testSpecifications: util.Collection[TestSpecification[_, _]] = {
-
+  override def createTestSpecifications(): util.Collection[TestSpecification[_, _]] = {
     val testSpecifications =
       new util.ArrayList[TypeSerializerUpgradeTestBase.TestSpecification[_, _]]
     TypeSerializerUpgradeTestBase.MIGRATION_VERSIONS.forEach(
@@ -136,6 +100,37 @@ object TraversableSerializerUpgradeTest {
       })
     testSpecifications
   }
+}
+
+object TraversableSerializerUpgradeTest {
+
+  object Types {
+
+    class Pojo(var name: String, var count: Int) {
+      def this() = this("", -1)
+
+      override def equals(other: Any): Boolean = {
+        other match {
+          case oP: Pojo => name == oP.name && count == oP.count
+          case _ => false
+        }
+      }
+    }
+
+    val seqTypeInfo = implicitly[TypeInformation[Seq[Int]]]
+    val indexedSeqTypeInfo =
+      implicitly[TypeInformation[IndexedSeq[Int]]]
+    val linearSeqTypeInfo = implicitly[TypeInformation[LinearSeq[Int]]]
+    val mapTypeInfo = implicitly[TypeInformation[Map[String, Int]]]
+    val setTypeInfo = implicitly[TypeInformation[Set[Int]]]
+    val bitsetTypeInfo = implicitly[TypeInformation[BitSet]]
+    val mutableListTypeInfo =
+      implicitly[TypeInformation[mutable.MutableList[Int]]]
+    val seqTupleTypeInfo = implicitly[TypeInformation[Seq[(Int, String)]]]
+    val seqPojoTypeInfo = implicitly[TypeInformation[Seq[Pojo]]]
+  }
+
+  import Types._
 
   final class BitsetSerializerSetup extends TypeSerializerUpgradeTestBase.PreUpgradeSetup[BitSet] {
     override def createPriorSerializer: TypeSerializer[BitSet] =

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/datastream/UnionSerializerUpgradeTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/datastream/UnionSerializerUpgradeTest.java
@@ -29,8 +29,6 @@ import org.apache.flink.streaming.api.datastream.CoGroupedStreams.TaggedUnion;
 import org.apache.flink.streaming.api.datastream.CoGroupedStreams.UnionSerializer;
 
 import org.hamcrest.Matcher;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -38,19 +36,11 @@ import java.util.Collection;
 import static org.hamcrest.Matchers.is;
 
 /** A {@link TypeSerializerUpgradeTestBase} for {@link UnionSerializer}. */
-@RunWith(Parameterized.class)
-public class UnionSerializerUpgradeTest
+class UnionSerializerUpgradeTest
         extends TypeSerializerUpgradeTestBase<
                 TaggedUnion<String, Long>, TaggedUnion<String, Long>> {
 
-    public UnionSerializerUpgradeTest(
-            TestSpecification<TaggedUnion<String, Long>, TaggedUnion<String, Long>>
-                    testSpecification) {
-        super(testSpecification);
-    }
-
-    @Parameterized.Parameters(name = "Test Specification = {0}")
-    public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
+    public Collection<TestSpecification<?, ?>> createTestSpecifications() throws Exception {
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
         for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {
             testSpecifications.add(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/TwoPhaseCommitSinkStateSerializerUpgradeTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/TwoPhaseCommitSinkStateSerializerUpgradeTest.java
@@ -18,6 +18,7 @@
 package org.apache.flink.streaming.api.functions.sink;
 
 import org.apache.flink.FlinkVersion;
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerMatchers;
 import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
@@ -26,8 +27,6 @@ import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 
 import org.hamcrest.Matcher;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -39,22 +38,13 @@ import static org.hamcrest.Matchers.is;
 /**
  * A {@link TypeSerializerUpgradeTestBase} for {@link TwoPhaseCommitSinkFunction.StateSerializer}.
  */
-@RunWith(Parameterized.class)
+@VisibleForTesting
 public class TwoPhaseCommitSinkStateSerializerUpgradeTest
         extends TypeSerializerUpgradeTestBase<
                 TwoPhaseCommitSinkFunction.State<Integer, String>,
                 TwoPhaseCommitSinkFunction.State<Integer, String>> {
 
-    public TwoPhaseCommitSinkStateSerializerUpgradeTest(
-            TestSpecification<
-                            TwoPhaseCommitSinkFunction.State<Integer, String>,
-                            TwoPhaseCommitSinkFunction.State<Integer, String>>
-                    testSpecification) {
-        super(testSpecification);
-    }
-
-    @Parameterized.Parameters(name = "Test Specification = {0}")
-    public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
+    public Collection<TestSpecification<?, ?>> createTestSpecifications() throws Exception {
 
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
         for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/TimerSerializerUpgradeTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/TimerSerializerUpgradeTest.java
@@ -51,11 +51,6 @@ class TimerSerializerUpgradeTest
         return testSpecifications;
     }
 
-    private static TypeSerializer<TimerHeapInternalTimer<String, Integer>>
-            stringIntTimerSerializerSupplier() {
-        return new TimerSerializer<>(StringSerializer.INSTANCE, IntSerializer.INSTANCE);
-    }
-
     // ----------------------------------------------------------------------------------------------
     // Specification for "TimerSerializer"
     // ----------------------------------------------------------------------------------------------

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/TimerSerializerUpgradeTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/TimerSerializerUpgradeTest.java
@@ -26,8 +26,6 @@ import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 
 import org.hamcrest.Matcher;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -35,22 +33,11 @@ import java.util.Collection;
 import static org.hamcrest.Matchers.is;
 
 /** Migration test for {@link TimerSerializer}. */
-@RunWith(Parameterized.class)
-public class TimerSerializerUpgradeTest
+class TimerSerializerUpgradeTest
         extends TypeSerializerUpgradeTestBase<
                 TimerHeapInternalTimer<String, Integer>, TimerHeapInternalTimer<String, Integer>> {
 
-    public TimerSerializerUpgradeTest(
-            TestSpecification<
-                            TimerHeapInternalTimer<String, Integer>,
-                            TimerHeapInternalTimer<String, Integer>>
-                    testSpecification) {
-        super(testSpecification);
-    }
-
-    @SuppressWarnings("unchecked")
-    @Parameterized.Parameters(name = "Test Specification = {0}")
-    public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
+    public Collection<TestSpecification<?, ?>> createTestSpecifications() throws Exception {
 
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
         for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/co/BufferEntrySerializerUpgradeTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/co/BufferEntrySerializerUpgradeTest.java
@@ -28,8 +28,6 @@ import org.apache.flink.streaming.api.operators.co.IntervalJoinOperator.BufferEn
 import org.apache.flink.streaming.api.operators.co.IntervalJoinOperator.BufferEntrySerializer;
 
 import org.hamcrest.Matcher;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -38,17 +36,10 @@ import static org.apache.flink.streaming.api.operators.co.BufferEntryMatchers.bu
 import static org.hamcrest.Matchers.is;
 
 /** State migration tests for {@link BufferEntrySerializer}. */
-@RunWith(Parameterized.class)
-public class BufferEntrySerializerUpgradeTest
+class BufferEntrySerializerUpgradeTest
         extends TypeSerializerUpgradeTestBase<BufferEntry<String>, BufferEntry<String>> {
 
-    public BufferEntrySerializerUpgradeTest(
-            TestSpecification<BufferEntry<String>, BufferEntry<String>> testSpecification) {
-        super(testSpecification);
-    }
-
-    @Parameterized.Parameters(name = "Test Specification = {0}")
-    public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
+    public Collection<TestSpecification<?, ?>> createTestSpecifications() throws Exception {
 
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
         for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowSerializerUpgradeTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowSerializerUpgradeTest.java
@@ -27,8 +27,6 @@ import org.apache.flink.streaming.api.windowing.windows.GlobalWindow;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
 
 import org.hamcrest.Matcher;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -39,15 +37,9 @@ import static org.hamcrest.Matchers.is;
  * A {@link TypeSerializerUpgradeTestBase} for {@link TimeWindow.Serializer} and {@link
  * GlobalWindow.Serializer}.
  */
-@RunWith(Parameterized.class)
-public class WindowSerializerUpgradeTest extends TypeSerializerUpgradeTestBase<Object, Object> {
+class WindowSerializerUpgradeTest extends TypeSerializerUpgradeTestBase<Object, Object> {
 
-    public WindowSerializerUpgradeTest(TestSpecification<Object, Object> testSpecification) {
-        super(testSpecification);
-    }
-
-    @Parameterized.Parameters(name = "Test Specification = {0}")
-    public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
+    public Collection<TestSpecification<?, ?>> createTestSpecifications() throws Exception {
 
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
         for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/streamrecord/StreamElementSerializerUpgradeTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/streamrecord/StreamElementSerializerUpgradeTest.java
@@ -26,8 +26,6 @@ import org.apache.flink.api.common.typeutils.TypeSerializerUpgradeTestBase;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 
 import org.hamcrest.Matcher;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -36,17 +34,10 @@ import static org.apache.flink.streaming.util.StreamRecordMatchers.streamRecord;
 import static org.hamcrest.Matchers.is;
 
 /** Migration tests for {@link StreamElementSerializer}. */
-@RunWith(Parameterized.class)
-public class StreamElementSerializerUpgradeTest
+class StreamElementSerializerUpgradeTest
         extends TypeSerializerUpgradeTestBase<StreamElement, StreamElement> {
 
-    public StreamElementSerializerUpgradeTest(
-            TestSpecification<StreamElement, StreamElement> testSpecification) {
-        super(testSpecification);
-    }
-
-    @Parameterized.Parameters(name = "Test Specification = {0}")
-    public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
+    public Collection<TestSpecification<?, ?>> createTestSpecifications() throws Exception {
 
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
         for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/typeutils/LinkedListSerializerUpgradeTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/typeutils/LinkedListSerializerUpgradeTest.java
@@ -40,7 +40,6 @@ import static org.hamcrest.Matchers.is;
 public class LinkedListSerializerUpgradeTest
         extends TypeSerializerUpgradeTestBase<LinkedList<Long>, LinkedList<Long>> {
 
-    @SuppressWarnings("unchecked")
     public Collection<TestSpecification<?, ?>> createTestSpecifications() {
         return FlinkVersion.rangeOf(FlinkVersion.v1_13, CURRENT_VERSION).stream()
                 .map(

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/typeutils/LinkedListSerializerUpgradeTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/typeutils/LinkedListSerializerUpgradeTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.runtime.typeutils;
 
 import org.apache.flink.FlinkVersion;
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerMatchers;
 import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
@@ -27,8 +28,6 @@ import org.apache.flink.api.common.typeutils.base.LongSerializer;
 import org.apache.flink.util.FlinkRuntimeException;
 
 import org.hamcrest.Matcher;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import java.util.Collection;
 import java.util.LinkedList;
@@ -37,17 +36,12 @@ import java.util.stream.Collectors;
 import static org.hamcrest.Matchers.is;
 
 /** A {@link TypeSerializerUpgradeTestBase} for {@link LinkedListSerializer}. */
-@RunWith(Parameterized.class)
+@VisibleForTesting
 public class LinkedListSerializerUpgradeTest
         extends TypeSerializerUpgradeTestBase<LinkedList<Long>, LinkedList<Long>> {
 
-    public LinkedListSerializerUpgradeTest(
-            TestSpecification<LinkedList<Long>, LinkedList<Long>> testSpecification) {
-        super(testSpecification);
-    }
-
-    @Parameterized.Parameters(name = "Test Specification = {0}")
-    public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
+    @SuppressWarnings("unchecked")
+    public Collection<TestSpecification<?, ?>> createTestSpecifications() {
         return FlinkVersion.rangeOf(FlinkVersion.v1_13, CURRENT_VERSION).stream()
                 .map(
                         version -> {


### PR DESCRIPTION
## What is the purpose of the change

Update the `TypeSerializerUpgradeTestBase` class and its successors to AssertJ and JUnit 5 following the [JUnit 5 Migration Guide](https://docs.google.com/document/d/1514Wa_aNB9bJUen4xm5uiuXOooOJTtXqS_Jqk9KJitU/edit)


## Brief change log

Use JUnit5 and AssertJ in tests instead of JUnit4 and Hamcrest


## Verifying this change

This change is a code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
