### PR TITLE
[FLINK-27616][Table SQL/Planner] Modify the spelling mistakes of the …

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoSourceScanRuleBase.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoSourceScanRuleBase.java
@@ -143,7 +143,7 @@ public abstract class PushFilterIntoSourceScanRuleBase extends RelOptRule {
     }
 
     /**
-     * Determines wether we can pushdown the filter into the source. we can not push filter twice,
+     * Determines whether we can pushdown the filter into the source. we can not push filter twice,
      * make sure FilterPushDownSpec has not been assigned as a capability.
      *
      * @param tableSourceTable Table scan to attempt to push into


### PR DESCRIPTION
## What is the purpose of the change

This pull request to modify the canPushdownFilter method comment error.

## Brief change log

org.apache.flink.table.planner.plan.rules.logical.PushFilterIntoSourceScanRuleBase#canPushdownFilter comment spelling  error, modified from wether to whether.

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
