### PR TITLE
[hotfix][doc] update javadoc to use DataStream, because DataSet is deprecated.

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/CoGroupFunction.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/CoGroupFunction.java
@@ -24,28 +24,32 @@ import org.apache.flink.util.Collector;
 import java.io.Serializable;
 
 /**
- * The interface for CoGroup functions. CoGroup functions combine two data sets by first grouping
- * each data set after a key and then "joining" the groups by calling this function with the two
- * sets for each key. If a key is present in only one of the two inputs, it may be that one of the
- * groups is empty.
+ * The interface for CoGroup functions. CoGroup functions combine two {@code DataStream}s by first
+ * grouping each data stream after a key and then "joining" the groups by calling this function with
+ * the two streams for each key. If a key is present in only one of the two inputs, it may be that
+ * one of the groups is empty.
  *
- * <p>The basic syntax for using CoGroup on two data sets is as follows:
+ * <p>The basic syntax for using CoGroup on two data streams is as follows:
  *
  * <pre>{@code
- * DataSet<X> set1 = ...;
- * DataSet<Y> set2 = ...;
+ * DataStream<X> stream1 = ...;
+ * DataStream<Y> stream2 = ...;
  *
- * set1.coGroup(set2).where(<key-definition>).equalTo(<key-definition>).with(new MyCoGroupFunction());
+ * stream1.coGroup(stream2)
+ *        .where(<key-definition>)
+ *        .equalTo(<key-definition>)
+ *        .window(<windowAssigner>)
+ *        .apply(new MyCoGroupFunction());
  * }</pre>
  *
- * <p>{@code set1} is here considered the first input, {@code set2} the second input.
+ * <p>{@code stream1} is here considered the first input, {@code stream2} the second input.
  *
- * <p>Some keys may only be contained in one of the two original data sets. In that case, the
- * CoGroup function is invoked with in empty input for the side of the data set that did not contain
- * elements with that specific key.
+ * <p>Some keys may only be contained in one of the two original data streams. In that case, the
+ * CoGroup function is invoked with in empty input for the side of the data stream that did not
+ * contain elements with that specific key.
  *
- * @param <IN1> The data type of the first input data set.
- * @param <IN2> The data type of the second input data set.
+ * @param <IN1> The data type of the first input data stream.
+ * @param <IN2> The data type of the second input data stream.
  * @param <O> The data type of the returned elements.
  */
 @Public


### PR DESCRIPTION
Small change:  update the Javadoc of `CoGroupFunction` to use `DataStream` as code example and in the description.
