### PR TITLE
[FLINK-24713][Runtime/Coordination] Postpone resourceManager serving …

### DIFF
--- a/docs/layouts/shortcodes/generated/resource_manager_configuration.html
+++ b/docs/layouts/shortcodes/generated/resource_manager_configuration.html
@@ -15,6 +15,12 @@
             <td>Timeout for jobs which don't have a job manager as leader assigned.</td>
         </tr>
         <tr>
+            <td><h5>resourcemanager.previous-worker.recovery.timeout</h5></td>
+            <td style="word-wrap: break-word;">5 s</td>
+            <td>Duration</td>
+            <td>Timeout for resource manager to recover all the previous attempts workers.</td>
+        </tr>
+        <tr>
             <td><h5>resourcemanager.rpc.port</h5></td>
             <td style="word-wrap: break-word;">0</td>
             <td>Integer</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/ResourceManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ResourceManagerOptions.java
@@ -253,6 +253,14 @@ public class ResourceManagerOptions {
                                     + TaskManagerOptions.REGISTRATION_TIMEOUT.key()
                                     + "'.");
 
+    /** Timeout for ResourceManager to recover all the previous attempts workers. */
+    public static final ConfigOption<Duration> RESOURCE_MANAGER_PREVIOUS_WORKER_RECOVERY_TIMEOUT =
+            ConfigOptions.key("resourcemanager.previous-worker.recovery.timeout")
+                    .durationType()
+                    .defaultValue(Duration.ofSeconds(5))
+                    .withDescription(
+                            "Timeout for resource manager to recover all the previous attempts workers.");
+
     // ---------------------------------------------------------------------------------------------
 
     /** Not intended to be instantiated. */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerGateway.java
@@ -264,4 +264,12 @@ public interface ResourceManagerGateway
      */
     CompletableFuture<TaskExecutorThreadInfoGateway> requestTaskExecutorThreadInfoGateway(
             ResourceID taskManagerId, @RpcTimeout Time timeout);
+
+    /**
+     * Get the recovery future of the resource manager.
+     *
+     * @return The recovery future of the resource manager, which indicated whether it is ready to
+     *     serve.
+     */
+    CompletableFuture<Acknowledge> getRecoveryFuture();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/StandaloneResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/StandaloneResourceManager.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.io.network.partition.ResourceManagerPartitionTrackerFactory;
+import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.metrics.groups.ResourceManagerMetricGroup;
 import org.apache.flink.runtime.resourcemanager.exceptions.ResourceManagerException;
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
@@ -35,6 +36,7 @@ import org.apache.flink.util.Preconditions;
 import javax.annotation.Nullable;
 
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 
@@ -122,5 +124,10 @@ public class StandaloneResourceManager extends ResourceManager<ResourceID> {
                     startupPeriodMillis,
                     TimeUnit.MILLISECONDS);
         }
+    }
+
+    @Override
+    public CompletableFuture<Acknowledge> getRecoveryFuture() {
+        return CompletableFuture.completedFuture(Acknowledge.get());
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerFactory.java
@@ -108,6 +108,10 @@ public abstract class ActiveResourceManagerFactory<WorkerType extends ResourceID
                 configuration.get(ResourceManagerOptions.START_WORKER_RETRY_INTERVAL);
         final Duration workerRegistrationTimeout =
                 configuration.get(ResourceManagerOptions.TASK_MANAGER_REGISTRATION_TIMEOUT);
+        final Duration previousWorkerRecoverTimeout =
+                configuration.get(
+                        ResourceManagerOptions.RESOURCE_MANAGER_PREVIOUS_WORKER_RECOVERY_TIMEOUT);
+
         return new ActiveResourceManager<>(
                 createResourceManagerDriver(
                         configuration, webInterfaceUrl, rpcService.getAddress()),
@@ -126,6 +130,7 @@ public abstract class ActiveResourceManagerFactory<WorkerType extends ResourceID
                 failureRater,
                 retryInterval,
                 workerRegistrationTimeout,
+                previousWorkerRecoverTimeout,
                 ioExecutor);
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/TestingResourceManager.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/TestingResourceManager.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.io.network.partition.ResourceManagerPartitionTrackerFactory;
+import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.metrics.groups.ResourceManagerMetricGroup;
 import org.apache.flink.runtime.resourcemanager.exceptions.ResourceManagerException;
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
@@ -34,6 +35,7 @@ import org.apache.flink.runtime.security.token.DelegationTokenManager;
 import javax.annotation.Nullable;
 
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ForkJoinPool;
 import java.util.function.Function;
 
@@ -102,5 +104,10 @@ public class TestingResourceManager extends ResourceManager<ResourceID> {
     @Override
     public boolean stopWorker(ResourceID worker) {
         return stopWorkerFunction.apply(worker);
+    }
+
+    @Override
+    public CompletableFuture<Acknowledge> getRecoveryFuture() {
+        return CompletableFuture.completedFuture(Acknowledge.get());
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/TestingResourceManagerFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/TestingResourceManagerFactory.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.entrypoint.ClusterInformation;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.io.network.partition.ResourceManagerPartitionTrackerFactory;
 import org.apache.flink.runtime.io.network.partition.ResourceManagerPartitionTrackerImpl;
+import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.metrics.groups.ResourceManagerMetricGroup;
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
@@ -232,6 +233,11 @@ public class TestingResourceManagerFactory extends ResourceManagerFactory<Resour
         public CompletableFuture<Void> getTerminationFuture() {
             return getTerminationFutureFunction.apply(
                     MockResourceManager.this, super.getTerminationFuture());
+        }
+
+        @Override
+        public CompletableFuture<Acknowledge> getRecoveryFuture() {
+            return CompletableFuture.completedFuture(Acknowledge.get());
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/utils/TestingResourceManagerGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/utils/TestingResourceManagerGateway.java
@@ -120,6 +120,9 @@ public class TestingResourceManagerGateway implements ResourceManagerGateway {
                             FutureUtils.completedExceptionally(new UnsupportedOperationException());
     private volatile Function<ResourceID, CompletableFuture<Void>> jobMasterHeartbeatFunction;
 
+    private volatile CompletableFuture<Acknowledge> recoveryFuture =
+            CompletableFuture.completedFuture(Acknowledge.get());
+
     public TestingResourceManagerGateway() {
         this(
                 ResourceManagerId.generate(),
@@ -233,6 +236,10 @@ public class TestingResourceManagerGateway implements ResourceManagerGateway {
             BiFunction<JobMasterId, ResourceRequirements, CompletableFuture<Acknowledge>>
                     declareRequiredResourcesFunction) {
         this.declareRequiredResourcesFunction = declareRequiredResourcesFunction;
+    }
+
+    public void setRecoveryFuture(CompletableFuture<Acknowledge> recoveryFuture) {
+        this.recoveryFuture = recoveryFuture;
     }
 
     @Override
@@ -465,6 +472,11 @@ public class TestingResourceManagerGateway implements ResourceManagerGateway {
             return FutureUtils.completedExceptionally(
                     new UnknownTaskExecutorException(taskManagerId));
         }
+    }
+
+    @Override
+    public CompletableFuture<Acknowledge> getRecoveryFuture() {
+        return this.recoveryFuture;
     }
 
     @Override


### PR DESCRIPTION
…after the recovery phase has finished

## What is the purpose of the change

This PR is meant to solve the problem of request the extra worker after JobManager failover. Related issue:

https://issues.apache.org/jira/browse/FLINK-24713
https://issues.apache.org/jira/browse/FLINK-27576

## Brief change log

  -  Add the interface in `ResourceManagerGateway` to tell the JobMaster whether recovery is finished
  -  Postpone the slotPool connect to resource manager until the recovery is finished or timeout.
  - Avoid to slotManagr#checkResourceRequirements when the resourceManager not finished recover


## Verifying this change

Two tests are added to verify the change.

