### PR TITLE
[FLINK-27732][tests] Migrate flink-examples-table to JUnit5

### DIFF
--- a/flink-examples/flink-examples-table/src/test/java/org/apache/flink/table/examples/java/basics/GettingStartedExampleITCase.java
+++ b/flink-examples/flink-examples-table/src/test/java/org/apache/flink/table/examples/java/basics/GettingStartedExampleITCase.java
@@ -20,20 +20,19 @@ package org.apache.flink.table.examples.java.basics;
 
 import org.apache.flink.table.examples.utils.ExampleOutputTestBase;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for Java {@link GettingStartedExample}. */
-public class GettingStartedExampleITCase extends ExampleOutputTestBase {
+class GettingStartedExampleITCase extends ExampleOutputTestBase {
 
     @Test
-    public void testExample() throws Exception {
+    void testExample() throws Exception {
         GettingStartedExample.main(new String[0]);
         final String consoleOutput = getOutputString();
-        assertThat(
-                consoleOutput, containsString("|                    6 |                 1979 |"));
-        assertThat(consoleOutput, containsString("SUCCESS!"));
+        assertThat(consoleOutput)
+                .contains("|                    6 |                 1979 |")
+                .contains("SUCCESS!");
     }
 }

--- a/flink-examples/flink-examples-table/src/test/java/org/apache/flink/table/examples/java/basics/StreamSQLExampleITCase.java
+++ b/flink-examples/flink-examples-table/src/test/java/org/apache/flink/table/examples/java/basics/StreamSQLExampleITCase.java
@@ -20,20 +20,20 @@ package org.apache.flink.table.examples.java.basics;
 
 import org.apache.flink.table.examples.utils.ExampleOutputTestBase;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for Java {@link StreamSQLExample}. */
-public class StreamSQLExampleITCase extends ExampleOutputTestBase {
+class StreamSQLExampleITCase extends ExampleOutputTestBase {
 
     @Test
-    public void testExample() throws Exception {
+    void testExample() throws Exception {
         StreamSQLExample.main(new String[0]);
         final String consoleOutput = getOutputString();
-        assertThat(consoleOutput, containsString("Order{user=1, product='beer', amount=3}"));
-        assertThat(consoleOutput, containsString("Order{user=4, product='beer', amount=1}"));
-        assertThat(consoleOutput, containsString("Order{user=1, product='diaper', amount=4}"));
+        assertThat(consoleOutput)
+                .contains("Order{user=1, product='beer', amount=3}")
+                .contains("Order{user=4, product='beer', amount=1}")
+                .contains("Order{user=1, product='diaper', amount=4}");
     }
 }

--- a/flink-examples/flink-examples-table/src/test/java/org/apache/flink/table/examples/java/basics/UpdatingTopCityExampleITCase.java
+++ b/flink-examples/flink-examples-table/src/test/java/org/apache/flink/table/examples/java/basics/UpdatingTopCityExampleITCase.java
@@ -20,23 +20,23 @@ package org.apache.flink.table.examples.java.basics;
 
 import org.apache.flink.table.examples.utils.ExampleOutputTestBase;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link UpdatingTopCityExample}. */
-public class UpdatingTopCityExampleITCase extends ExampleOutputTestBase {
+class UpdatingTopCityExampleITCase extends ExampleOutputTestBase {
 
     @Test
-    public void testExample() throws Exception {
+    void testExample() throws Exception {
         UpdatingTopCityExample.main(new String[0]);
         final String consoleOutput = getOutputString();
-        assertThat(consoleOutput, containsString("AZ, Phoenix, 2015, 4581120"));
-        assertThat(consoleOutput, containsString("IL, Chicago, 2015, 9557880"));
-        assertThat(consoleOutput, containsString("CA, San Francisco, 2015, 4649540"));
-        assertThat(consoleOutput, containsString("CA, Los Angeles, 2015, 13251000"));
-        assertThat(consoleOutput, containsString("TX, Dallas, 2015, 7109280"));
-        assertThat(consoleOutput, containsString("TX, Houston, 2015, 6676560"));
+        assertThat(consoleOutput)
+                .contains("AZ, Phoenix, 2015, 4581120")
+                .contains("IL, Chicago, 2015, 9557880")
+                .contains("CA, San Francisco, 2015, 4649540")
+                .contains("CA, Los Angeles, 2015, 13251000")
+                .contains("TX, Dallas, 2015, 7109280")
+                .contains("TX, Houston, 2015, 6676560");
     }
 }

--- a/flink-examples/flink-examples-table/src/test/java/org/apache/flink/table/examples/java/basics/WordCountSQLExampleITCase.java
+++ b/flink-examples/flink-examples-table/src/test/java/org/apache/flink/table/examples/java/basics/WordCountSQLExampleITCase.java
@@ -20,21 +20,19 @@ package org.apache.flink.table.examples.java.basics;
 
 import org.apache.flink.table.examples.utils.ExampleOutputTestBase;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for Java {@link WordCountSQLExample}. */
-public class WordCountSQLExampleITCase extends ExampleOutputTestBase {
+class WordCountSQLExampleITCase extends ExampleOutputTestBase {
 
     @Test
-    public void testExample() throws Exception {
+    void testExample() throws Exception {
         WordCountSQLExample.main(new String[0]);
         final String consoleOutput = getOutputString();
-        assertThat(
-                consoleOutput, containsString("|                           Ciao |           1 |"));
-        assertThat(
-                consoleOutput, containsString("|                          Hello |           3 |"));
+        assertThat(consoleOutput)
+                .contains("|                           Ciao |           1 |")
+                .contains("|                          Hello |           3 |");
     }
 }

--- a/flink-examples/flink-examples-table/src/test/java/org/apache/flink/table/examples/java/functions/AdvancedFunctionsExampleITCase.java
+++ b/flink-examples/flink-examples-table/src/test/java/org/apache/flink/table/examples/java/functions/AdvancedFunctionsExampleITCase.java
@@ -20,16 +20,15 @@ package org.apache.flink.table.examples.java.functions;
 
 import org.apache.flink.table.examples.utils.ExampleOutputTestBase;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for Java {@link AdvancedFunctionsExample}. */
-public class AdvancedFunctionsExampleITCase extends ExampleOutputTestBase {
+class AdvancedFunctionsExampleITCase extends ExampleOutputTestBase {
 
     @Test
-    public void testExample() throws Exception {
+    void testExample() throws Exception {
         AdvancedFunctionsExample.main(new String[0]);
         final String consoleOutput = getOutputString();
 
@@ -38,44 +37,19 @@ public class AdvancedFunctionsExampleITCase extends ExampleOutputTestBase {
     }
 
     private void testExecuteLastDatedValueFunction(String consoleOutput) {
-        assertThat(
-                consoleOutput,
-                containsString(
-                        "|                Guillermo Smith |                (5, 2020-12-05) |"));
-        assertThat(
-                consoleOutput,
-                containsString(
-                        "|                    John Turner |               (12, 2020-10-02) |"));
-        assertThat(
-                consoleOutput,
-                containsString(
-                        "|                 Brandy Sanders |                (1, 2020-10-14) |"));
-        assertThat(
-                consoleOutput,
-                containsString(
-                        "|                Valeria Mendoza |               (10, 2020-06-02) |"));
-        assertThat(
-                consoleOutput,
-                containsString(
-                        "|                   Ellen Ortega |              (100, 2020-06-18) |"));
-        assertThat(
-                consoleOutput,
-                containsString(
-                        "|                 Leann Holloway |                (9, 2020-05-26) |"));
+        assertThat(consoleOutput)
+                .contains("|                Guillermo Smith |                (5, 2020-12-05) |")
+                .contains("|                    John Turner |               (12, 2020-10-02) |")
+                .contains("|                 Brandy Sanders |                (1, 2020-10-14) |")
+                .contains("|                Valeria Mendoza |               (10, 2020-06-02) |")
+                .contains("|                   Ellen Ortega |              (100, 2020-06-18) |")
+                .contains("|                 Leann Holloway |                (9, 2020-05-26) |");
     }
 
     private void testExecuteInternalRowMergerFunction(String consoleOutput) {
-        assertThat(
-                consoleOutput,
-                containsString(
-                        "|                Guillermo Smith | (1992-12-12, New Jersey, 81... |"));
-        assertThat(
-                consoleOutput,
-                containsString(
-                        "|                Valeria Mendoza | (1970-03-28, Los Angeles, 9... |"));
-        assertThat(
-                consoleOutput,
-                containsString(
-                        "|                 Leann Holloway | (1989-05-21, Eugene, 614-88... |"));
+        assertThat(consoleOutput)
+                .contains("|                Guillermo Smith | (1992-12-12, New Jersey, 81... |")
+                .contains("|                Valeria Mendoza | (1970-03-28, Los Angeles, 9... |")
+                .contains("|                 Leann Holloway | (1989-05-21, Eugene, 614-88... |");
     }
 }

--- a/flink-examples/flink-examples-table/src/test/java/org/apache/flink/table/examples/scala/basics/GettingStartedExampleITCase.java
+++ b/flink-examples/flink-examples-table/src/test/java/org/apache/flink/table/examples/scala/basics/GettingStartedExampleITCase.java
@@ -20,20 +20,19 @@ package org.apache.flink.table.examples.scala.basics;
 
 import org.apache.flink.table.examples.utils.ExampleOutputTestBase;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for Scala {@link GettingStartedExample}. */
-public class GettingStartedExampleITCase extends ExampleOutputTestBase {
+class GettingStartedExampleITCase extends ExampleOutputTestBase {
 
     @Test
-    public void testExample() {
+    void testExample() {
         GettingStartedExample.main(new String[0]);
         final String consoleOutput = getOutputString();
-        assertThat(
-                consoleOutput, containsString("|                    6 |                 1979 |"));
-        assertThat(consoleOutput, containsString("SUCCESS!"));
+        assertThat(consoleOutput)
+                .contains("|                    6 |                 1979 |")
+                .contains("SUCCESS!");
     }
 }

--- a/flink-examples/flink-examples-table/src/test/java/org/apache/flink/table/examples/scala/basics/StreamSQLExampleITCase.java
+++ b/flink-examples/flink-examples-table/src/test/java/org/apache/flink/table/examples/scala/basics/StreamSQLExampleITCase.java
@@ -20,20 +20,20 @@ package org.apache.flink.table.examples.scala.basics;
 
 import org.apache.flink.table.examples.utils.ExampleOutputTestBase;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for Scala {@link StreamSQLExample}. */
-public class StreamSQLExampleITCase extends ExampleOutputTestBase {
+class StreamSQLExampleITCase extends ExampleOutputTestBase {
 
     @Test
-    public void testExample() {
+    void testExample() {
         StreamSQLExample.main(new String[0]);
         final String consoleOutput = getOutputString();
-        assertThat(consoleOutput, containsString("Order(4,beer,1)"));
-        assertThat(consoleOutput, containsString("Order(1,beer,3)"));
-        assertThat(consoleOutput, containsString("Order(1,diaper,4)"));
+        assertThat(consoleOutput)
+                .contains("Order(4,beer,1)")
+                .contains("Order(1,beer,3)")
+                .contains("Order(1,diaper,4)");
     }
 }

--- a/flink-examples/flink-examples-table/src/test/java/org/apache/flink/table/examples/scala/basics/WordCountSQLExampleITCase.java
+++ b/flink-examples/flink-examples-table/src/test/java/org/apache/flink/table/examples/scala/basics/WordCountSQLExampleITCase.java
@@ -20,21 +20,19 @@ package org.apache.flink.table.examples.scala.basics;
 
 import org.apache.flink.table.examples.utils.ExampleOutputTestBase;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for Scala {@link WordCountSQLExample}. */
-public class WordCountSQLExampleITCase extends ExampleOutputTestBase {
+class WordCountSQLExampleITCase extends ExampleOutputTestBase {
 
     @Test
-    public void testExample() {
+    void testExample() {
         WordCountSQLExample.main(new String[0]);
         final String consoleOutput = getOutputString();
-        assertThat(
-                consoleOutput, containsString("|                           Ciao |           1 |"));
-        assertThat(
-                consoleOutput, containsString("|                          Hello |           3 |"));
+        assertThat(consoleOutput)
+                .contains("|                           Ciao |           1 |")
+                .contains("|                          Hello |           3 |");
     }
 }

--- a/flink-examples/flink-examples-table/src/test/java/org/apache/flink/table/examples/utils/ExampleOutputTestBase.java
+++ b/flink-examples/flink-examples-table/src/test/java/org/apache/flink/table/examples/utils/ExampleOutputTestBase.java
@@ -19,11 +19,11 @@
 package org.apache.flink.table.examples.utils;
 
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
-import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.apache.flink.test.junit5.MiniClusterExtension;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.ClassRule;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -31,9 +31,9 @@ import java.io.PrintStream;
 /** Test base for validating the example output to stdout. */
 public abstract class ExampleOutputTestBase {
 
-    @ClassRule
-    public static MiniClusterWithClientResource miniClusterResource =
-            new MiniClusterWithClientResource(
+    @RegisterExtension
+    private static final MiniClusterExtension MINI_CLUSTER_RESOURCE =
+            new MiniClusterExtension(
                     new MiniClusterResourceConfiguration.Builder()
                             .setNumberTaskManagers(1)
                             .setNumberSlotsPerTaskManager(1)
@@ -43,8 +43,8 @@ public abstract class ExampleOutputTestBase {
 
     private ByteArrayOutputStream testOutputStream;
 
-    @Before
-    public void before() {
+    @BeforeEach
+    void before() {
         originalPrintStream = System.out;
         testOutputStream = new ByteArrayOutputStream();
         System.setOut(new PrintStream(testOutputStream));
@@ -54,8 +54,8 @@ public abstract class ExampleOutputTestBase {
         return testOutputStream.toString();
     }
 
-    @After
-    public void after() {
+    @AfterEach
+    void after() {
         System.setOut(originalPrintStream);
     }
 }

--- a/flink-examples/flink-examples-table/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/flink-examples/flink-examples-table/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.util.TestLoggerExtension


### PR DESCRIPTION
## What is the purpose of the change

Update flink-examples-table to AssertJ and JUnit 5 following the [JUnit 5 Migration Guide](https://docs.google.com/document/d/1514Wa_aNB9bJUen4xm5uiuXOooOJTtXqS_Jqk9KJitU/edit)


## Brief change log

Use JUnit5 and AssertJ in tests instead of JUnit4 and Hamcrest


## Verifying this change

This change is a code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
