### PR TITLE
[FLINK-27733][python] Rework on_timer output behind watermark bug fix

### DIFF
--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/PythonKeyedProcessOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/PythonKeyedProcessOperator.java
@@ -29,7 +29,6 @@ import org.apache.flink.runtime.state.VoidNamespace;
 import org.apache.flink.runtime.state.VoidNamespaceSerializer;
 import org.apache.flink.streaming.api.TimeDomain;
 import org.apache.flink.streaming.api.functions.python.DataStreamPythonFunctionInfo;
-import org.apache.flink.streaming.api.operators.InternalTimeServiceManager;
 import org.apache.flink.streaming.api.operators.InternalTimer;
 import org.apache.flink.streaming.api.operators.InternalTimerService;
 import org.apache.flink.streaming.api.operators.Triggerable;
@@ -38,7 +37,6 @@ import org.apache.flink.streaming.api.operators.python.timer.TimerRegistration;
 import org.apache.flink.streaming.api.runners.python.beam.BeamDataStreamPythonFunctionRunner;
 import org.apache.flink.streaming.api.utils.ProtoUtils;
 import org.apache.flink.streaming.api.utils.PythonTypeUtils;
-import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.types.Row;
 
@@ -69,9 +67,6 @@ public class PythonKeyedProcessOperator<OUT>
 
     /** TimerService for current operator to register or fire timer. */
     private transient InternalTimerService internalTimerService;
-
-    /** TimerRegistration for handling timer registering. */
-    private transient TimerRegistration timerRegistration;
 
     /** The TypeInformation of the key. */
     private transient TypeInformation<Row> keyTypeInfo;
@@ -127,13 +122,6 @@ public class PythonKeyedProcessOperator<OUT>
                         timerDataTypeInfo);
 
         timerHandler = new TimerHandler();
-        timerRegistration =
-                new TimerRegistration(
-                        getKeyedStateBackend(),
-                        internalTimerService,
-                        this,
-                        namespaceSerializer,
-                        timerDataSerializer);
 
         super.open();
     }
@@ -171,7 +159,12 @@ public class PythonKeyedProcessOperator<OUT>
                 getOperatorStateBackend(),
                 keyTypeSerializer,
                 namespaceSerializer,
-                timerRegistration,
+                new TimerRegistration(
+                        getKeyedStateBackend(),
+                        internalTimerService,
+                        this,
+                        namespaceSerializer,
+                        timerDataSerializer),
                 getContainingTask().getEnvironment().getMemoryManager(),
                 getOperatorConfig()
                         .getManagedMemoryFractionOperatorUseCaseOfSlot(
@@ -231,20 +224,6 @@ public class PythonKeyedProcessOperator<OUT>
         elementCount++;
         checkInvokeFinishBundleByCount();
         emitResults();
-    }
-
-    @SuppressWarnings("rawtypes")
-    @Override
-    protected void preEmitWatermark(Watermark mark) throws Exception {
-        if (!getTimeServiceManager().isPresent()) {
-            return;
-        }
-        InternalTimeServiceManager timeServiceManager = getTimeServiceManager().get();
-        long timestamp = mark.getTimestamp();
-        do {
-            timeServiceManager.advanceWatermark(mark);
-            invokeFinishBundle();
-        } while (!timerRegistration.hasEventTimeTimerBeforeTimestamp(timestamp));
     }
 
     /**

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/timer/TimerUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/timer/TimerUtils.java
@@ -22,14 +22,8 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.fnexecution.v1.FlinkFnApi;
-import org.apache.flink.runtime.state.InternalPriorityQueue;
-import org.apache.flink.streaming.api.operators.InternalTimerService;
-import org.apache.flink.streaming.api.operators.TimerHeapInternalTimer;
 import org.apache.flink.streaming.api.utils.ProtoUtils;
 import org.apache.flink.types.Row;
-import org.apache.flink.util.Preconditions;
-
-import java.lang.reflect.Field;
 
 /** Utilities for timer. */
 @Internal
@@ -47,29 +41,5 @@ public final class TimerUtils {
             TypeInformation<Row> timerDataType) {
         return ProtoUtils.createRawTypeCoderInfoDescriptorProto(
                 timerDataType, FlinkFnApi.CoderInfoDescriptor.Mode.SINGLE, false);
-    }
-
-    @SuppressWarnings("unchecked")
-    public static InternalPriorityQueue<TimerHeapInternalTimer<?, ?>>
-            getInternalEventTimeTimersQueue(InternalTimerService<?> internalTimerService)
-                    throws Exception {
-        Field queueField = internalTimerService.getClass().getDeclaredField("eventTimeTimersQueue");
-        queueField.setAccessible(true);
-        return (InternalPriorityQueue<TimerHeapInternalTimer<?, ?>>)
-                queueField.get(internalTimerService);
-    }
-
-    public static boolean hasEventTimeTimerBeforeTimestamp(
-            InternalPriorityQueue<TimerHeapInternalTimer<?, ?>> timerQueue,
-            long timestamp,
-            boolean isBatchMode)
-            throws Exception {
-        if (isBatchMode) {
-            Preconditions.checkArgument(timestamp == Long.MAX_VALUE);
-            return timerQueue.size() == 0;
-        }
-
-        TimerHeapInternalTimer<?, ?> minTimer = timerQueue.peek();
-        return minTimer == null || minTimer.getTimestamp() > timestamp;
     }
 }

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/PythonStreamGroupWindowAggregateOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/PythonStreamGroupWindowAggregateOperatorTest.java
@@ -207,8 +207,6 @@ class PythonStreamGroupWindowAggregateOperatorTest
         testHarness.processElement(newRecord(true, initialTime + 3, "c1", "c6", 2L, 10000L));
         testHarness.processElement(newRecord(true, initialTime + 4, "c2", "c8", 3L, 0L));
         testHarness.processWatermark(new Watermark(20000L));
-        assertOutputEquals(
-                "FinishBundle should not be triggered.", expectedOutput, testHarness.getOutput());
 
         testHarness.setProcessingTime(1000L);
         expectedOutput.add(newWindowRecord(-5000L, 5000L, "c1", 0L));

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/StreamArrowPythonGroupWindowAggregateFunctionOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/StreamArrowPythonGroupWindowAggregateFunctionOperatorTest.java
@@ -94,8 +94,6 @@ class StreamArrowPythonGroupWindowAggregateFunctionOperatorTest
         testHarness.processWatermark(Long.MAX_VALUE);
         testHarness.close();
 
-        expectedOutput.add(new Watermark(Long.MAX_VALUE));
-
         expectedOutput.add(
                 new StreamRecord<>(
                         newRow(
@@ -148,6 +146,8 @@ class StreamArrowPythonGroupWindowAggregateFunctionOperatorTest
                                 2L,
                                 TimestampData.fromEpochMillis(10000L),
                                 TimestampData.fromEpochMillis(20000L))));
+
+        expectedOutput.add(new Watermark(Long.MAX_VALUE));
 
         assertOutputEquals("Output was not correct.", expectedOutput, testHarness.getOutput());
     }
@@ -175,51 +175,49 @@ class StreamArrowPythonGroupWindowAggregateFunctionOperatorTest
         // checkpoint trigger finishBundle
         testHarness.prepareSnapshotPreBarrier(0L);
 
+        expectedOutput.add(
+                new StreamRecord<>(
+                        newRow(
+                                true,
+                                "c1",
+                                0L,
+                                TimestampData.fromEpochMillis(-5000L),
+                                TimestampData.fromEpochMillis(5000L))));
+
+        expectedOutput.add(
+                new StreamRecord<>(
+                        newRow(
+                                true,
+                                "c2",
+                                3L,
+                                TimestampData.fromEpochMillis(-5000L),
+                                TimestampData.fromEpochMillis(5000L))));
+
+        expectedOutput.add(
+                new StreamRecord<>(
+                        newRow(
+                                true,
+                                "c2",
+                                3L,
+                                TimestampData.fromEpochMillis(0L),
+                                TimestampData.fromEpochMillis(10000L))));
+
+        expectedOutput.add(
+                new StreamRecord<>(
+                        newRow(
+                                true,
+                                "c1",
+                                0L,
+                                TimestampData.fromEpochMillis(0L),
+                                TimestampData.fromEpochMillis(10000L))));
+
         expectedOutput.add(new Watermark(10000L));
-
-        expectedOutput.add(
-                new StreamRecord<>(
-                        newRow(
-                                true,
-                                "c1",
-                                0L,
-                                TimestampData.fromEpochMillis(-5000L),
-                                TimestampData.fromEpochMillis(5000L))));
-
-        expectedOutput.add(
-                new StreamRecord<>(
-                        newRow(
-                                true,
-                                "c2",
-                                3L,
-                                TimestampData.fromEpochMillis(-5000L),
-                                TimestampData.fromEpochMillis(5000L))));
-
-        expectedOutput.add(
-                new StreamRecord<>(
-                        newRow(
-                                true,
-                                "c2",
-                                3L,
-                                TimestampData.fromEpochMillis(0L),
-                                TimestampData.fromEpochMillis(10000L))));
-
-        expectedOutput.add(
-                new StreamRecord<>(
-                        newRow(
-                                true,
-                                "c1",
-                                0L,
-                                TimestampData.fromEpochMillis(0L),
-                                TimestampData.fromEpochMillis(10000L))));
 
         assertOutputEquals("Output was not correct.", expectedOutput, testHarness.getOutput());
 
         testHarness.processWatermark(20000L);
 
         testHarness.close();
-
-        expectedOutput.add(new Watermark(20000L));
 
         expectedOutput.add(
                 new StreamRecord<>(
@@ -237,6 +235,8 @@ class StreamArrowPythonGroupWindowAggregateFunctionOperatorTest
                                 2L,
                                 TimestampData.fromEpochMillis(10000L),
                                 TimestampData.fromEpochMillis(20000L))));
+
+        expectedOutput.add(new Watermark(20000L));
 
         assertOutputEquals("Output was not correct.", expectedOutput, testHarness.getOutput());
     }
@@ -304,8 +304,6 @@ class StreamArrowPythonGroupWindowAggregateFunctionOperatorTest
         testHarness.processWatermark(20000L);
         testHarness.close();
 
-        expectedOutput.add(new Watermark(20000L));
-
         expectedOutput.add(
                 new StreamRecord<>(
                         newRow(
@@ -322,6 +320,8 @@ class StreamArrowPythonGroupWindowAggregateFunctionOperatorTest
                                 2L,
                                 TimestampData.fromEpochMillis(10000L),
                                 TimestampData.fromEpochMillis(20000L))));
+
+        expectedOutput.add(new Watermark(20000L));
 
         assertOutputEquals("Output was not correct.", expectedOutput, testHarness.getOutput());
     }
@@ -347,7 +347,6 @@ class StreamArrowPythonGroupWindowAggregateFunctionOperatorTest
         testHarness.processElement(
                 new StreamRecord<>(newBinaryRow(true, "c2", "c8", 3L, 0L), initialTime + 4));
         testHarness.processWatermark(new Watermark(20000L));
-        expectedOutput.add(new Watermark(20000L));
         assertOutputEquals(
                 "FinishBundle should not be triggered.", expectedOutput, testHarness.getOutput());
 
@@ -403,6 +402,8 @@ class StreamArrowPythonGroupWindowAggregateFunctionOperatorTest
                                 2L,
                                 TimestampData.fromEpochMillis(10000L),
                                 TimestampData.fromEpochMillis(20000L))));
+
+        expectedOutput.add(new Watermark(20000L));
 
         assertOutputEquals("Output was not correct.", expectedOutput, testHarness.getOutput());
 

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/StreamArrowPythonRowTimeBoundedRangeOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/StreamArrowPythonRowTimeBoundedRangeOperatorTest.java
@@ -83,11 +83,11 @@ class StreamArrowPythonRowTimeBoundedRangeOperatorTest
 
         testHarness.close();
 
-        expectedOutput.add(new Watermark(Long.MAX_VALUE));
         expectedOutput.add(new StreamRecord<>(newRow(true, "c1", "c2", 0L, 1L, 0L)));
         expectedOutput.add(new StreamRecord<>(newRow(true, "c1", "c4", 1L, 1L, 0L)));
         expectedOutput.add(new StreamRecord<>(newRow(true, "c2", "c8", 3L, 2L, 3L)));
         expectedOutput.add(new StreamRecord<>(newRow(true, "c1", "c6", 2L, 10L, 2L)));
+        expectedOutput.add(new Watermark(Long.MAX_VALUE));
 
         assertOutputEquals("Output was not correct.", expectedOutput, testHarness.getOutput());
     }
@@ -113,7 +113,6 @@ class StreamArrowPythonRowTimeBoundedRangeOperatorTest
                 new StreamRecord<>(newBinaryRow(true, "c2", "c8", 3L, 2L), initialTime + 3));
         testHarness.processWatermark(new Watermark(10000L));
 
-        expectedOutput.add(new Watermark(10000L));
         assertOutputEquals(
                 "FinishBundle should not be triggered.", expectedOutput, testHarness.getOutput());
         // checkpoint trigger finishBundle
@@ -123,6 +122,7 @@ class StreamArrowPythonRowTimeBoundedRangeOperatorTest
         expectedOutput.add(new StreamRecord<>(newRow(true, "c1", "c4", 1L, 1L, 0L)));
         expectedOutput.add(new StreamRecord<>(newRow(true, "c2", "c8", 3L, 2L, 3L)));
         expectedOutput.add(new StreamRecord<>(newRow(true, "c1", "c6", 2L, 10L, 2L)));
+        expectedOutput.add(new Watermark(10000L));
 
         assertOutputEquals("Output was not correct.", expectedOutput, testHarness.getOutput());
 
@@ -185,7 +185,6 @@ class StreamArrowPythonRowTimeBoundedRangeOperatorTest
         testHarness.processElement(
                 new StreamRecord<>(newBinaryRow(true, "c2", "c8", 3L, 2L), initialTime + 3));
         testHarness.processWatermark(new Watermark(10000L));
-        expectedOutput.add(new Watermark(10000L));
         assertOutputEquals(
                 "FinishBundle should not be triggered.", expectedOutput, testHarness.getOutput());
 
@@ -194,6 +193,7 @@ class StreamArrowPythonRowTimeBoundedRangeOperatorTest
         expectedOutput.add(new StreamRecord<>(newRow(true, "c1", "c4", 1L, 1L, 0L)));
         expectedOutput.add(new StreamRecord<>(newRow(true, "c2", "c8", 3L, 2L, 3L)));
         expectedOutput.add(new StreamRecord<>(newRow(true, "c1", "c6", 2L, 10L, 2L)));
+        expectedOutput.add(new Watermark(10000L));
 
         assertOutputEquals("Output was not correct.", expectedOutput, testHarness.getOutput());
 

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/StreamArrowPythonRowTimeBoundedRowsOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/StreamArrowPythonRowTimeBoundedRowsOperatorTest.java
@@ -79,11 +79,11 @@ class StreamArrowPythonRowTimeBoundedRowsOperatorTest
 
         testHarness.close();
 
-        expectedOutput.add(new Watermark(Long.MAX_VALUE));
         expectedOutput.add(new StreamRecord<>(newRow(true, "c1", "c2", 0L, 1L, 0L)));
         expectedOutput.add(new StreamRecord<>(newRow(true, "c1", "c4", 1L, 1L, 0L)));
         expectedOutput.add(new StreamRecord<>(newRow(true, "c2", "c8", 3L, 2L, 3L)));
         expectedOutput.add(new StreamRecord<>(newRow(true, "c1", "c6", 2L, 10L, 1L)));
+        expectedOutput.add(new Watermark(Long.MAX_VALUE));
 
         assertOutputEquals("Output was not correct.", expectedOutput, testHarness.getOutput());
     }
@@ -109,7 +109,6 @@ class StreamArrowPythonRowTimeBoundedRowsOperatorTest
                 new StreamRecord<>(newBinaryRow(true, "c2", "c8", 3L, 2L), initialTime + 3));
         testHarness.processWatermark(new Watermark(10000L));
 
-        expectedOutput.add(new Watermark(10000L));
         assertOutputEquals(
                 "FinishBundle should not be triggered.", expectedOutput, testHarness.getOutput());
         // checkpoint trigger finishBundle
@@ -119,6 +118,7 @@ class StreamArrowPythonRowTimeBoundedRowsOperatorTest
         expectedOutput.add(new StreamRecord<>(newRow(true, "c1", "c4", 1L, 1L, 0L)));
         expectedOutput.add(new StreamRecord<>(newRow(true, "c2", "c8", 3L, 2L, 3L)));
         expectedOutput.add(new StreamRecord<>(newRow(true, "c1", "c6", 2L, 10L, 1L)));
+        expectedOutput.add(new Watermark(10000L));
 
         assertOutputEquals("Output was not correct.", expectedOutput, testHarness.getOutput());
 
@@ -181,7 +181,6 @@ class StreamArrowPythonRowTimeBoundedRowsOperatorTest
         testHarness.processElement(
                 new StreamRecord<>(newBinaryRow(true, "c2", "c8", 3L, 2L), initialTime + 3));
         testHarness.processWatermark(new Watermark(10000L));
-        expectedOutput.add(new Watermark(10000L));
         assertOutputEquals(
                 "FinishBundle should not be triggered.", expectedOutput, testHarness.getOutput());
 
@@ -190,6 +189,7 @@ class StreamArrowPythonRowTimeBoundedRowsOperatorTest
         expectedOutput.add(new StreamRecord<>(newRow(true, "c1", "c4", 1L, 1L, 0L)));
         expectedOutput.add(new StreamRecord<>(newRow(true, "c2", "c8", 3L, 2L, 3L)));
         expectedOutput.add(new StreamRecord<>(newRow(true, "c1", "c6", 2L, 10L, 1L)));
+        expectedOutput.add(new Watermark(10000L));
 
         assertOutputEquals("Output was not correct.", expectedOutput, testHarness.getOutput());
 


### PR DESCRIPTION

## What is the purpose of the change

This PR simplifys the bug fix for [FLINK-27676](https://issues.apache.org/jira/browse/FLINK-27676), plus solving the bug in python group window aggregate.


## Brief change log


## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
