### PR TITLE
[hotfix][docs][connector/pulsar] Fix doc typo of setDeliveryGuarantee

### DIFF
--- a/docs/content.zh/docs/connectors/datastream/pulsar.md
+++ b/docs/content.zh/docs/connectors/datastream/pulsar.md
@@ -355,7 +355,7 @@ PulsarSink<String> sink = PulsarSink.builder()
     .setAdminUrl(adminUrl)
     .setTopics("topic1")
     .setSerializationSchema(PulsarSerializationSchema.flinkSchema(new SimpleStringSchema()))
-    .setDeliverGuarantee(DeliveryGuarantee.AT_LEAST_ONCE)
+    .setDeliveryGuarantee(DeliveryGuarantee.AT_LEAST_ONCE)
     .build();
 
 stream.sinkTo(sink);

--- a/docs/content/docs/connectors/datastream/pulsar.md
+++ b/docs/content/docs/connectors/datastream/pulsar.md
@@ -434,7 +434,7 @@ PulsarSink<String> sink = PulsarSink.builder()
     .setAdminUrl(adminUrl)
     .setTopics("topic1")
     .setSerializationSchema(PulsarSerializationSchema.flinkSchema(new SimpleStringSchema()))
-    .setDeliverGuarantee(DeliveryGuarantee.AT_LEAST_ONCE)
+    .setDeliveryGuarantee(DeliveryGuarantee.AT_LEAST_ONCE)
     .build();
 
 stream.sinkTo(sink);


### PR DESCRIPTION
Pulsar Connector has not a `setDeliverGuarantee` method. It should be `setDeliveryGuarantee`