### PR TITLE
[FLINK-27740][tests] Migrate flink-test-utils-junit to JUnit5

### DIFF
--- a/flink-test-utils-parent/flink-test-utils-junit/src/test/java/org/apache/flink/core/testutils/OneShotLatchTest.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/test/java/org/apache/flink/core/testutils/OneShotLatchTest.java
@@ -18,39 +18,35 @@
 
 package org.apache.flink.core.testutils;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for the OneShotLatch. */
-public class OneShotLatchTest {
+class OneShotLatchTest {
 
     @Test
-    public void testAwaitWithTimeout() throws Exception {
+    void testAwaitWithTimeout() throws Exception {
         OneShotLatch latch = new OneShotLatch();
-        assertFalse(latch.isTriggered());
+        assertThat(latch.isTriggered()).isFalse();
 
-        try {
-            latch.await(1, TimeUnit.MILLISECONDS);
-            fail("should fail with a TimeoutException");
-        } catch (TimeoutException e) {
-            // expected
-        }
+        assertThatThrownBy(() -> latch.await(1, TimeUnit.MILLISECONDS))
+                .withFailMessage(() -> "should fail with a TimeoutException")
+                .isInstanceOf(TimeoutException.class);
 
-        assertFalse(latch.isTriggered());
+        assertThat(latch.isTriggered()).isFalse();
 
         latch.trigger();
-        assertTrue(latch.isTriggered());
+        assertThat(latch.isTriggered()).isTrue();
 
         latch.await(100, TimeUnit.DAYS);
-        assertTrue(latch.isTriggered());
+        assertThat(latch.isTriggered()).isTrue();
 
         latch.await(0, TimeUnit.MILLISECONDS);
-        assertTrue(latch.isTriggered());
+        assertThat(latch.isTriggered()).isTrue();
     }
 }

--- a/flink-test-utils-parent/flink-test-utils-junit/src/test/java/org/apache/flink/testutils/junit/RetryOnExceptionExtensionTest.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/test/java/org/apache/flink/testutils/junit/RetryOnExceptionExtensionTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /** Tests for the RetryOnException annotation. */
 @ExtendWith(RetryExtension.class)
-public class RetryOnExceptionExtensionTest {
+class RetryOnExceptionExtensionTest {
 
     private static final int NUMBER_OF_RUNS = 3;
 
@@ -41,7 +41,7 @@ public class RetryOnExceptionExtensionTest {
     private static int runsForPassAfterOneFailure = 0;
 
     @AfterAll
-    public static void verify() {
+    static void verify() {
         assertEquals(NUMBER_OF_RUNS + 1, runsForTestWithMatchingException);
         assertEquals(NUMBER_OF_RUNS + 1, runsForTestWithSubclassException);
         assertEquals(1, runsForSuccessfulTest);
@@ -50,13 +50,13 @@ public class RetryOnExceptionExtensionTest {
 
     @TestTemplate
     @RetryOnException(times = NUMBER_OF_RUNS, exception = IllegalArgumentException.class)
-    public void testSuccessfulTest() {
+    void testSuccessfulTest() {
         runsForSuccessfulTest++;
     }
 
     @TestTemplate
     @RetryOnException(times = NUMBER_OF_RUNS, exception = IllegalArgumentException.class)
-    public void testMatchingException() {
+    void testMatchingException() {
         runsForTestWithMatchingException++;
         if (runsForTestWithMatchingException <= NUMBER_OF_RUNS) {
             throw new IllegalArgumentException();
@@ -65,7 +65,7 @@ public class RetryOnExceptionExtensionTest {
 
     @TestTemplate
     @RetryOnException(times = NUMBER_OF_RUNS, exception = RuntimeException.class)
-    public void testSubclassException() {
+    void testSubclassException() {
         runsForTestWithSubclassException++;
         if (runsForTestWithSubclassException <= NUMBER_OF_RUNS) {
             throw new IllegalArgumentException();
@@ -74,7 +74,7 @@ public class RetryOnExceptionExtensionTest {
 
     @TestTemplate
     @RetryOnException(times = NUMBER_OF_RUNS, exception = IllegalArgumentException.class)
-    public void testPassAfterOneFailure() {
+    void testPassAfterOneFailure() {
         runsForPassAfterOneFailure++;
         if (runsForPassAfterOneFailure == 1) {
             throw new IllegalArgumentException();

--- a/flink-test-utils-parent/flink-test-utils-junit/src/test/java/org/apache/flink/testutils/junit/RetryOnExceptionTest.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/test/java/org/apache/flink/testutils/junit/RetryOnExceptionTest.java
@@ -18,16 +18,17 @@
 
 package org.apache.flink.testutils.junit;
 
-import org.junit.AfterClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.apache.flink.testutils.junit.extensions.retry.RetryExtension;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for the RetryOnException annotation. */
-public class RetryOnExceptionTest {
-
-    @Rule public RetryRule retryRule = new RetryRule();
+@ExtendWith(RetryExtension.class)
+class RetryOnExceptionTest {
 
     private static final int NUMBER_OF_RUNS = 3;
 
@@ -39,41 +40,41 @@ public class RetryOnExceptionTest {
 
     private static int runsForPassAfterOneFailure = 0;
 
-    @AfterClass
+    @AfterAll
     public static void verify() {
-        assertEquals(NUMBER_OF_RUNS + 1, runsForTestWithMatchingException);
-        assertEquals(NUMBER_OF_RUNS + 1, runsForTestWithSubclassException);
-        assertEquals(1, runsForSuccessfulTest);
-        assertEquals(2, runsForPassAfterOneFailure);
+        assertThat(runsForTestWithMatchingException).isEqualTo(NUMBER_OF_RUNS + 1);
+        assertThat(runsForTestWithSubclassException).isEqualTo(NUMBER_OF_RUNS + 1);
+        assertThat(runsForSuccessfulTest).isEqualTo(1);
+        assertThat(runsForPassAfterOneFailure).isEqualTo(2);
     }
 
-    @Test
+    @TestTemplate
     @RetryOnException(times = NUMBER_OF_RUNS, exception = IllegalArgumentException.class)
-    public void testSuccessfulTest() {
+    void testSuccessfulTest() {
         runsForSuccessfulTest++;
     }
 
-    @Test
+    @TestTemplate
     @RetryOnException(times = NUMBER_OF_RUNS, exception = IllegalArgumentException.class)
-    public void testMatchingException() {
+    void testMatchingException() {
         runsForTestWithMatchingException++;
         if (runsForTestWithMatchingException <= NUMBER_OF_RUNS) {
             throw new IllegalArgumentException();
         }
     }
 
-    @Test
+    @TestTemplate
     @RetryOnException(times = NUMBER_OF_RUNS, exception = RuntimeException.class)
-    public void testSubclassException() {
+    void testSubclassException() {
         runsForTestWithSubclassException++;
         if (runsForTestWithSubclassException <= NUMBER_OF_RUNS) {
             throw new IllegalArgumentException();
         }
     }
 
-    @Test
+    @TestTemplate
     @RetryOnException(times = NUMBER_OF_RUNS, exception = IllegalArgumentException.class)
-    public void testPassAfterOneFailure() {
+    void testPassAfterOneFailure() {
         runsForPassAfterOneFailure++;
         if (runsForPassAfterOneFailure == 1) {
             throw new IllegalArgumentException();

--- a/flink-test-utils-parent/flink-test-utils-junit/src/test/java/org/apache/flink/testutils/junit/RetryOnFailureExtensionTest.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/test/java/org/apache/flink/testutils/junit/RetryOnFailureExtensionTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /** Tests for the RetryOnFailure annotation. */
 @ExtendWith(RetryExtension.class)
-public class RetryOnFailureExtensionTest {
+class RetryOnFailureExtensionTest {
 
     private static final int NUMBER_OF_RUNS = 5;
 
@@ -39,14 +39,14 @@ public class RetryOnFailureExtensionTest {
     private static boolean firstRun = true;
 
     @AfterAll
-    public static void verify() throws Exception {
+    static void verify() {
         assertEquals(NUMBER_OF_RUNS + 1, numberOfFailedRuns);
         assertEquals(3, numberOfSuccessfulRuns);
     }
 
     @TestTemplate
     @RetryOnFailure(times = NUMBER_OF_RUNS)
-    public void testRetryOnFailure() throws Exception {
+    void testRetryOnFailure() {
         // All but the (expected) last run should be successful
         if (numberOfFailedRuns < NUMBER_OF_RUNS) {
             numberOfFailedRuns++;
@@ -58,7 +58,7 @@ public class RetryOnFailureExtensionTest {
 
     @TestTemplate
     @RetryOnFailure(times = NUMBER_OF_RUNS)
-    public void testRetryOnceOnFailure() throws Exception {
+    void testRetryOnceOnFailure() {
         if (firstRun) {
             numberOfFailedRuns++;
             firstRun = false;
@@ -70,7 +70,7 @@ public class RetryOnFailureExtensionTest {
 
     @TestTemplate
     @RetryOnFailure(times = NUMBER_OF_RUNS)
-    public void testNotRetryOnSuccess() throws Exception {
+    void testNotRetryOnSuccess() {
         numberOfSuccessfulRuns++;
     }
 }

--- a/flink-test-utils-parent/flink-test-utils-junit/src/test/java/org/apache/flink/testutils/junit/RetryOnFailureTest.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/test/java/org/apache/flink/testutils/junit/RetryOnFailureTest.java
@@ -18,16 +18,17 @@
 
 package org.apache.flink.testutils.junit;
 
-import org.junit.AfterClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.apache.flink.testutils.junit.extensions.retry.RetryExtension;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for the RetryOnFailure annotation. */
-public class RetryOnFailureTest {
-
-    @Rule public RetryRule retryRule = new RetryRule();
+@ExtendWith(RetryExtension.class)
+class RetryOnFailureTest {
 
     private static final int NUMBER_OF_RUNS = 5;
 
@@ -37,15 +38,15 @@ public class RetryOnFailureTest {
 
     private static boolean firstRun = true;
 
-    @AfterClass
-    public static void verify() throws Exception {
-        assertEquals(NUMBER_OF_RUNS + 1, numberOfFailedRuns);
-        assertEquals(3, numberOfSuccessfulRuns);
+    @AfterAll
+    static void verify() {
+        assertThat(numberOfFailedRuns).isEqualTo(NUMBER_OF_RUNS + 1);
+        assertThat(numberOfSuccessfulRuns).isEqualTo(3);
     }
 
-    @Test
+    @TestTemplate
     @RetryOnFailure(times = NUMBER_OF_RUNS)
-    public void testRetryOnFailure() throws Exception {
+    void testRetryOnFailure() {
         // All but the (expected) last run should be successful
         if (numberOfFailedRuns < NUMBER_OF_RUNS) {
             numberOfFailedRuns++;
@@ -55,9 +56,9 @@ public class RetryOnFailureTest {
         }
     }
 
-    @Test
+    @TestTemplate
     @RetryOnFailure(times = NUMBER_OF_RUNS)
-    public void testRetryOnceOnFailure() throws Exception {
+    void testRetryOnceOnFailure() {
         if (firstRun) {
             numberOfFailedRuns++;
             firstRun = false;
@@ -67,9 +68,9 @@ public class RetryOnFailureTest {
         }
     }
 
-    @Test
+    @TestTemplate
     @RetryOnFailure(times = NUMBER_OF_RUNS)
-    public void testDontRetryOnSuccess() throws Exception {
+    void testDontRetryOnSuccess() {
         numberOfSuccessfulRuns++;
     }
 }

--- a/flink-test-utils-parent/flink-test-utils-junit/src/test/java/org/apache/flink/testutils/junit/RetryRuleTest.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/test/java/org/apache/flink/testutils/junit/RetryRuleTest.java
@@ -17,23 +17,20 @@
 
 package org.apache.flink.testutils.junit;
 
-import org.apache.flink.util.TestLogger;
-
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for the {@link RetryRule}. */
-public class RetryRuleTest extends TestLogger {
+class RetryRuleTest {
     private static final RetryRule RETRY_RULE = new RetryRule();
 
     @Test
-    public void testExpectedExceptionIgnored() throws Throwable {
+    void testExpectedExceptionIgnored() throws Throwable {
         final int numEvaluationsToFail = 1;
 
         final Description testDescription =
@@ -46,24 +43,22 @@ public class RetryRuleTest extends TestLogger {
 
         final TestStatement statement = new TestStatement(numEvaluationsToFail);
 
-        try {
-            RETRY_RULE.apply(statement, testDescription).evaluate();
-            Assert.fail("Should have failed.");
-        } catch (RuntimeException expected) {
-        }
+        assertThatThrownBy(() -> RETRY_RULE.apply(statement, testDescription).evaluate())
+                .withFailMessage("Should have failed.")
+                .isInstanceOf(RuntimeException.class);
 
-        assertThat(statement.getNumEvaluations(), is(numEvaluationsToFail));
+        assertThat(statement.getNumEvaluations()).isEqualTo(numEvaluationsToFail);
     }
 
-    @Ignore // we don't want to actually this run as a test
+    @Disabled // we don't want to actually this run as a test
     private static class TestClassWithTestExpectingRuntimeException {
         @RetryOnFailure(times = 2)
-        @Test(expected = RuntimeException.class)
+        @org.junit.Test(expected = RuntimeException.class)
         public void test() {}
     }
 
     @Test
-    public void testNoAnnotationResultsInZeroRetries() throws Throwable {
+    void testNoAnnotationResultsInZeroRetries() throws Throwable {
         final int numEvaluationsToFail = 1;
 
         final Description testDescription =
@@ -74,23 +69,21 @@ public class RetryRuleTest extends TestLogger {
 
         final TestStatement statement = new TestStatement(numEvaluationsToFail);
 
-        try {
-            RETRY_RULE.apply(statement, testDescription).evaluate();
-            Assert.fail("Should have failed.");
-        } catch (RuntimeException expected) {
-        }
+        assertThatThrownBy(() -> RETRY_RULE.apply(statement, testDescription).evaluate())
+                .withFailMessage("Should have failed.")
+                .isInstanceOf(RuntimeException.class);
 
-        assertThat(statement.getNumEvaluations(), is(numEvaluationsToFail));
+        assertThat(statement.getNumEvaluations()).isEqualTo(numEvaluationsToFail);
     }
 
-    @Ignore // we don't want to actually this run as a test
+    @Disabled // we don't want to actually this run as a test
     private static class TestClassWithoutAnnotation {
-        @Test
+        @org.junit.Test
         public void test() {}
     }
 
     @Test
-    public void testAnnotationOnClassUsedAsFallback() throws Throwable {
+    void testAnnotationOnClassUsedAsFallback() throws Throwable {
         final int numEvaluationsToFail = 1;
 
         final Description testDescription =
@@ -103,18 +96,18 @@ public class RetryRuleTest extends TestLogger {
 
         RETRY_RULE.apply(statement, testDescription).evaluate();
 
-        assertThat(statement.getNumEvaluations(), is(numEvaluationsToFail + 1));
+        assertThat(statement.getNumEvaluations()).isEqualTo(numEvaluationsToFail + 1);
     }
 
-    @Ignore // we don't want to actually this run as a test
+    @Disabled // we don't want to actually this run as a test
     @RetryOnFailure(times = 1)
     private static class TestClassWithAnnotation {
-        @Test
+        @org.junit.Test
         public void test() {}
     }
 
     @Test
-    public void testAnnotationOnMethodTakesPrecedence() throws Throwable {
+    void testAnnotationOnMethodTakesPrecedence() throws Throwable {
         final int numEvaluationsToFail = 2;
 
         final Description testDescription =
@@ -127,14 +120,14 @@ public class RetryRuleTest extends TestLogger {
 
         RETRY_RULE.apply(statement, testDescription).evaluate();
 
-        assertThat(statement.getNumEvaluations(), is(numEvaluationsToFail + 1));
+        assertThat(statement.getNumEvaluations()).isEqualTo(numEvaluationsToFail + 1);
     }
 
-    @Ignore // we don't want to actually this run as a test
+    @Disabled // we don't want to actually this run as a test
     @RetryOnFailure(times = 1)
     private static class TestClassWithAnnotationOnMethod {
         @RetryOnFailure(times = 2)
-        @Test
+        @org.junit.Test
         public void test() {}
     }
 

--- a/flink-test-utils-parent/flink-test-utils-junit/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.util.TestLoggerExtension


### PR DESCRIPTION
## What is the purpose of the change

Migrate `flink-test-utils-junit` to AssertJ and JUnit 5 following the [JUnit 5 Migration Guide](https://docs.google.com/document/d/1514Wa_aNB9bJUen4xm5uiuXOooOJTtXqS_Jqk9KJitU/edit)


## Brief change log

Use JUnit5 and AssertJ in tests instead of JUnit4 and Hamcrest


## Verifying this change

This change is a code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
