### PR TITLE
[hotfix][docs] Update memory unit Mb.

### DIFF
--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/polling/AdaptivePollingRecordPublisher.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/polling/AdaptivePollingRecordPublisher.java
@@ -32,7 +32,7 @@ import org.apache.flink.streaming.connectors.kinesis.proxy.KinesisProxyInterface
  */
 @Internal
 public class AdaptivePollingRecordPublisher extends PollingRecordPublisher {
-    // AWS Kinesis has a read limit of 2 Mb/sec
+    // AWS Kinesis has a read limit of 2 MB/sec
     // https://docs.aws.amazon.com/kinesis/latest/APIReference/API_GetRecords.html
     private static final long KINESIS_SHARD_BYTES_PER_SECOND_LIMIT = 2 * 1024L * 1024L;
 

--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogOptions.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogOptions.java
@@ -45,7 +45,7 @@ public class FsStateChangelogOptions {
     public static final ConfigOption<MemorySize> PREEMPTIVE_PERSIST_THRESHOLD =
             ConfigOptions.key("dstl.dfs.preemptive-persist-threshold")
                     .memoryType()
-                    .defaultValue(MemorySize.parse("5Mb"))
+                    .defaultValue(MemorySize.parse("5MB"))
                     .withDescription(
                             "Size threshold for state changes of a single operator "
                                     + "beyond which they are persisted pre-emptively without waiting for a checkpoint. "
@@ -65,7 +65,7 @@ public class FsStateChangelogOptions {
     public static final ConfigOption<MemorySize> PERSIST_SIZE_THRESHOLD =
             ConfigOptions.key("dstl.dfs.batch.persist-size-threshold")
                     .memoryType()
-                    .defaultValue(MemorySize.parse("10Mb"))
+                    .defaultValue(MemorySize.parse("10MB"))
                     .withDescription(
                             "Size threshold for state changes that were requested to be persisted but are waiting for "
                                     + PERSIST_DELAY.key()
@@ -79,7 +79,7 @@ public class FsStateChangelogOptions {
     public static final ConfigOption<MemorySize> UPLOAD_BUFFER_SIZE =
             ConfigOptions.key("dstl.dfs.upload.buffer-size")
                     .memoryType()
-                    .defaultValue(MemorySize.parse("1Mb"))
+                    .defaultValue(MemorySize.parse("1MB"))
                     .withDescription("Buffer size used when uploading change sets");
 
     public static final ConfigOption<Integer> NUM_UPLOAD_THREADS =
@@ -98,7 +98,7 @@ public class FsStateChangelogOptions {
     public static final ConfigOption<MemorySize> IN_FLIGHT_DATA_LIMIT =
             ConfigOptions.key("dstl.dfs.upload.max-in-flight")
                     .memoryType()
-                    .defaultValue(MemorySize.parse("100Mb"))
+                    .defaultValue(MemorySize.parse("100MB"))
                     .withDescription(
                             "Max amount of data allowed to be in-flight. "
                                     + "Upon reaching this limit the task will be back-pressured. "

--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogWriter.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogWriter.java
@@ -162,7 +162,7 @@ class FsStateChangelogWriter implements StateChangelogWriter<ChangelogStateHandl
         activeChangeSetSize += value.length;
         if (activeChangeSetSize >= preEmptivePersistThresholdInBytes) {
             LOG.debug(
-                    "pre-emptively flush {}Mb of appended changes to the common store",
+                    "pre-emptively flush {}MB of appended changes to the common store",
                     activeChangeSetSize / 1024 / 1024);
             persistInternal(notUploaded.isEmpty() ? activeSequenceNumber : notUploaded.firstKey());
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
@@ -139,11 +139,11 @@ public class NetworkBufferPool
 
             throw new OutOfMemoryError(
                     "Could not allocate enough memory segments for NetworkBufferPool "
-                            + "(required (Mb): "
+                            + "(required (MB): "
                             + requiredMb
-                            + ", allocated (Mb): "
+                            + ", allocated (MB): "
                             + allocatedMb
-                            + ", missing (Mb): "
+                            + ", missing (MB): "
                             + missingMb
                             + "). Cause: "
                             + err.getMessage());


### PR DESCRIPTION
## What is the purpose of the change

- I think "Mb" in it should be "MB". Because Mb and MB are not the same,in terms of memory, a byte is the smallest storage slot. Your hard drives, SSDs, USB sticks, and system memory are always measured in bytes.
Please see "https://www.lifewire.com/what-is-a-megabit-2483412" for detailed differences.
According to experience, they have the following relationship:

- 8 Mb = 1 MB
- 1Mb = 1/8 MB = 0.125 MB



## Brief change log

- Changed "Mb" in the documentation to "MB".


## Verifying this change
- This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
