### PR TITLE
[FLINK-27754][shell] Add stderr when 1 flink-dist*.jar cannot be resolved.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Prerequisites for building Flink:
 ```
 git clone https://github.com/apache/flink.git
 cd flink
-mvn clean package -DskipTests # this will take up to 10 minutes
+./mvnw clean package -DskipTests # this will take up to 10 minutes
 ```
 
 Flink is now installed in `build-target`.

--- a/flink-dist/src/main/flink-bin/bin/config.sh
+++ b/flink-dist/src/main/flink-bin/bin/config.sh
@@ -31,11 +31,16 @@ constructFlinkClassPath() {
         fi
     done < <(find "$FLINK_LIB_DIR" ! -type d -name '*.jar' -print0 | sort -z)
 
-    if [[ "$FLINK_DIST" == "" ]]; then
-        # write error message to stderr since stdout is stored as the classpath
-        (>&2 echo "[ERROR] Flink distribution jar not found in $FLINK_LIB_DIR.")
+    local FLINK_DIST_COUNT
+    FLINK_DIST_COUNT="$(echo "$FLINK_DIST" | wc -l)"
 
-        # exit function with empty classpath to force process failure
+    # If flink-dist*.jar cannot be resolved write error messages to stderr since stdout is stored
+    # as the classpath and exit function with empty classpath to force process failure
+    if [[ "$FLINK_DIST" == "" ]]; then
+        (>&2 echo "[ERROR] Flink distribution jar not found in $FLINK_LIB_DIR.")
+        exit 1
+    elif [[ "$FLINK_DIST_COUNT" -gt 1 ]]; then
+        (>&2 echo "[ERROR] Multiple flink-dist*.jar found in $FLINK_LIB_DIR. Please resolve.")
         exit 1
     fi
 
@@ -43,13 +48,18 @@ constructFlinkClassPath() {
 }
 
 findFlinkDistJar() {
-    local FLINK_DIST="`find "$FLINK_LIB_DIR" -name 'flink-dist*.jar'`"
+    local FLINK_DIST
+    FLINK_DIST="$(find "$FLINK_LIB_DIR" -name 'flink-dist*.jar')"
+    local FLINK_DIST_COUNT
+    FLINK_DIST_COUNT="$(echo "$FLINK_DIST" | wc -l)"
 
+    # If flink-dist*.jar cannot be resolved write error messages to stderr since stdout is stored
+    # as the classpath and exit function with empty classpath to force process failure
     if [[ "$FLINK_DIST" == "" ]]; then
-        # write error message to stderr since stdout is stored as the classpath
         (>&2 echo "[ERROR] Flink distribution jar not found in $FLINK_LIB_DIR.")
-
-        # exit function with empty classpath to force process failure
+        exit 1
+    elif [[ "$FLINK_DIST_COUNT" -gt 1 ]]; then
+        (>&2 echo "[ERROR] Multiple flink-dist*.jar found in $FLINK_LIB_DIR. Please resolve.")
         exit 1
     fi
 


### PR DESCRIPTION
## What is the purpose of the change

When adding jars to the `/lib` directory any extra jar files that match the pattern `flink-dist*.jar` provoke an error when trying to use `BashJavaUtils` to get JVM parameters and dynamic configurations in `config.sh`. Although niche, this can be difficult to debug because there is no error message to describe the issue. 

We already print a useful error message if no `flink-dist*.jar` can be found at all. This pull request adds another error message when more than one `flink-dist*.jar` is found at this point.


## Brief change log

- Fix minor typo in README.md
- Add error message for when more than one file matching `flink-dist*.jar` exists in `/lib`.
- Actioned a few minor shellcheck issues on the lines changed.


## Verifying this change

This change can be verified as follows:

- `./mvnw clean install -DskipTests -Dfast`
- `cp flink-dist-scala/target/flink-dist-scala_2.12-1.16-SNAPSHOT.jar build-target/lib/`
- `build-target/bin/start-cluster.sh`
- You should see the error message "[ERROR] Multiple flink-dist*.jar found in /path/to/lib. Please resolve."
- `rm build-target/lib/flink-dist-scala_2.12-1.16-SNAPSHOT.jar`
- `build-target/bin/start-cluster.sh`
- The cluster should start successfully.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): No
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: No
  - The serializers: No
  - The runtime per-record code paths (performance sensitive): No
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: No
  - The S3 file system connector: No

## Documentation

  - Does this pull request introduce a new feature? No
  - If yes, how is the feature documented? Not applicable