### PR TITLE
[FLINK-27758][tests][table] Migrate flink-table-runtime to JUnit5

### DIFF
--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/codegen/LongAdaptiveHashJoinGeneratorTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/codegen/LongAdaptiveHashJoinGeneratorTest.java
@@ -34,7 +34,7 @@ import org.apache.flink.table.types.logical.RowType;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for adaptive {@link LongHashJoinGenerator}. */
-public class LongAdaptiveHashJoinGeneratorTest extends Int2AdaptiveHashJoinOperatorTest {
+class LongAdaptiveHashJoinGeneratorTest extends Int2AdaptiveHashJoinOperatorTest {
 
     @Override
     public Object newOperator(
@@ -47,19 +47,19 @@ public class LongAdaptiveHashJoinGeneratorTest extends Int2AdaptiveHashJoinOpera
     }
 
     @Override
-    public void testBuildLeftAntiJoinFallbackToSMJ() {}
+    protected void testBuildLeftAntiJoinFallbackToSMJ() {}
 
     @Override
-    public void testBuildLeftSemiJoinFallbackToSMJ() {}
+    protected void testBuildLeftSemiJoinFallbackToSMJ() {}
 
     @Override
-    public void testBuildFirstHashLeftOutJoinFallbackToSMJ() {}
+    protected void testBuildFirstHashLeftOutJoinFallbackToSMJ() {}
 
     @Override
-    public void testBuildSecondHashRightOutJoinFallbackToSMJ() {}
+    protected void testBuildSecondHashRightOutJoinFallbackToSMJ() {}
 
     @Override
-    public void testBuildFirstHashFullOutJoinFallbackToSMJ() {}
+    protected void testBuildFirstHashFullOutJoinFallbackToSMJ() {}
 
     static Object getLongHashJoinOperator(
             FlinkJoinType flinkJoinType,

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/data/BinaryArrayDataTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/data/BinaryArrayDataTest.java
@@ -36,7 +36,7 @@ import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.VarCharType;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.sql.Timestamp;
@@ -48,10 +48,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.HamcrestCondition.matching;
 
 /** Test of {@link BinaryArrayData} and {@link BinaryArrayWriter}. */
-public class BinaryArrayDataTest {
+class BinaryArrayDataTest {
 
     @Test
-    public void testArray() {
+    void testArray() {
         // 1.array test
         BinaryArrayData array = new BinaryArrayData();
         BinaryArrayWriter writer = new BinaryArrayWriter(array, 3, 4);
@@ -98,7 +98,7 @@ public class BinaryArrayDataTest {
     }
 
     @Test
-    public void testArrayTypes() {
+    void testArrayTypes() {
         {
             // test bool
             BinaryArrayData array = new BinaryArrayData();
@@ -356,7 +356,7 @@ public class BinaryArrayDataTest {
     }
 
     @Test
-    public void testMap() {
+    void testMap() {
         BinaryArrayData array1 = new BinaryArrayData();
         BinaryArrayWriter writer1 = new BinaryArrayWriter(array1, 3, 4);
         writer1.writeInt(0, 6);
@@ -417,7 +417,7 @@ public class BinaryArrayDataTest {
     }
 
     @Test
-    public void testToArray() {
+    void testToArray() {
         BinaryArrayData array = new BinaryArrayData();
         BinaryArrayWriter writer = new BinaryArrayWriter(array, 3, 2);
         writer.writeShort(0, (short) 5);
@@ -442,7 +442,7 @@ public class BinaryArrayDataTest {
     }
 
     @Test
-    public void testDecimal() {
+    void testDecimal() {
 
         BinaryArrayData array = new BinaryArrayData();
         BinaryArrayWriter writer = new BinaryArrayWriter(array, 2, 8);
@@ -484,7 +484,7 @@ public class BinaryArrayDataTest {
     }
 
     @Test
-    public void testGeneric() {
+    void testGeneric() {
         BinaryArrayData array = new BinaryArrayData();
         BinaryArrayWriter writer = new BinaryArrayWriter(array, 2, 8);
         RawValueData<String> generic = RawValueData.fromObject("hahah");
@@ -500,7 +500,7 @@ public class BinaryArrayDataTest {
     }
 
     @Test
-    public void testNested() {
+    void testNested() {
         BinaryArrayData array = new BinaryArrayData();
         BinaryArrayWriter writer = new BinaryArrayWriter(array, 2, 8);
         writer.writeRow(
@@ -517,7 +517,7 @@ public class BinaryArrayDataTest {
     }
 
     @Test
-    public void testBinary() {
+    void testBinary() {
         BinaryArrayData array = new BinaryArrayData();
         BinaryArrayWriter writer = new BinaryArrayWriter(array, 2, 8);
         byte[] bytes1 = new byte[] {1, -1, 5};
@@ -531,7 +531,7 @@ public class BinaryArrayDataTest {
     }
 
     @Test
-    public void testTimestampData() {
+    void testTimestampData() {
         BinaryArrayData array = new BinaryArrayData();
         BinaryArrayWriter writer = new BinaryArrayWriter(array, 2, 8);
 

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/data/BinaryRowDataTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/data/BinaryRowDataTest.java
@@ -53,7 +53,7 @@ import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.types.RowKind;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.EOFException;
 import java.io.IOException;
@@ -84,10 +84,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.HamcrestCondition.matching;
 
 /** Test of {@link BinaryRowData} and {@link BinaryRowWriter}. */
-public class BinaryRowDataTest {
+class BinaryRowDataTest {
 
     @Test
-    public void testBasic() {
+    void testBasic() {
         // consider header 1 byte.
         assertThat(new BinaryRowData(0).getFixedLengthPartSize()).isEqualTo(8);
         assertThat(new BinaryRowData(1).getFixedLengthPartSize()).isEqualTo(16);
@@ -103,7 +103,7 @@ public class BinaryRowDataTest {
     }
 
     @Test
-    public void testSetAndGet() {
+    void testSetAndGet() {
         MemorySegment segment = MemorySegmentFactory.wrap(new byte[80]);
         BinaryRowData row = new BinaryRowData(9);
         row.pointTo(segment, 0, 80);
@@ -127,7 +127,7 @@ public class BinaryRowDataTest {
     }
 
     @Test
-    public void testWriter() {
+    void testWriter() {
 
         int arity = 13;
         BinaryRowData row = new BinaryRowData(arity);
@@ -167,7 +167,7 @@ public class BinaryRowDataTest {
     }
 
     @Test
-    public void testWriteString() {
+    void testWriteString() {
         {
             // litter byte[]
             BinaryRowData row = new BinaryRowData(1);
@@ -198,7 +198,7 @@ public class BinaryRowDataTest {
     }
 
     @Test
-    public void testPagesSer() throws IOException {
+    void testPagesSer() throws IOException {
         MemorySegment[] memorySegments = new MemorySegment[5];
         ArrayList<MemorySegment> memorySegmentList = new ArrayList<>();
         for (int i = 0; i < 5; i++) {
@@ -291,7 +291,7 @@ public class BinaryRowDataTest {
     }
 
     @Test
-    public void testReuseWriter() {
+    void testReuseWriter() {
         BinaryRowData row = new BinaryRowData(2);
         BinaryRowWriter writer = new BinaryRowWriter(row);
         writer.writeString(0, fromString("01234567"));
@@ -309,7 +309,7 @@ public class BinaryRowDataTest {
     }
 
     @Test
-    public void anyNullTest() {
+    void anyNullTest() {
         {
             BinaryRowData row = new BinaryRowData(3);
             BinaryRowWriter writer = new BinaryRowWriter(row);
@@ -342,7 +342,7 @@ public class BinaryRowDataTest {
     }
 
     @Test
-    public void testSingleSegmentBinaryRowHashCode() {
+    void testSingleSegmentBinaryRowHashCode() {
         final Random rnd = new Random(System.currentTimeMillis());
         // test hash stabilization
         BinaryRowData row = new BinaryRowData(13);
@@ -387,7 +387,7 @@ public class BinaryRowDataTest {
     }
 
     @Test
-    public void testHeaderSize() {
+    void testHeaderSize() {
         assertThat(BinaryRowData.calculateBitSetWidthInBytes(56)).isEqualTo(8);
         assertThat(BinaryRowData.calculateBitSetWidthInBytes(57)).isEqualTo(16);
         assertThat(BinaryRowData.calculateBitSetWidthInBytes(120)).isEqualTo(16);
@@ -395,7 +395,7 @@ public class BinaryRowDataTest {
     }
 
     @Test
-    public void testHeader() {
+    void testHeader() {
         BinaryRowData row = new BinaryRowData(2);
         BinaryRowWriter writer = new BinaryRowWriter(row);
 
@@ -413,7 +413,7 @@ public class BinaryRowDataTest {
     }
 
     @Test
-    public void testDecimal() {
+    void testDecimal() {
         // 1.compact
         {
             int precision = 4;
@@ -453,7 +453,7 @@ public class BinaryRowDataTest {
     }
 
     @Test
-    public void testRawValueData() {
+    void testRawValueData() {
         BinaryRowData row = new BinaryRowData(3);
         BinaryRowWriter writer = new BinaryRowWriter(row);
         RawValueDataSerializer<String> binarySerializer =
@@ -472,7 +472,7 @@ public class BinaryRowDataTest {
     }
 
     @Test
-    public void testNested() {
+    void testNested() {
         BinaryRowData row = new BinaryRowData(2);
         BinaryRowWriter writer = new BinaryRowWriter(row);
         writer.writeRow(
@@ -489,7 +489,7 @@ public class BinaryRowDataTest {
     }
 
     @Test
-    public void testBinary() {
+    void testBinary() {
         BinaryRowData row = new BinaryRowData(2);
         BinaryRowWriter writer = new BinaryRowWriter(row);
         byte[] bytes1 = new byte[] {1, -1, 5};
@@ -503,7 +503,7 @@ public class BinaryRowDataTest {
     }
 
     @Test
-    public void testBinaryArray() {
+    void testBinaryArray() {
         // 1. array test
         BinaryArrayData array = new BinaryArrayData();
         BinaryArrayWriter arrayWriter =
@@ -537,7 +537,7 @@ public class BinaryRowDataTest {
     }
 
     @Test
-    public void testGenericArray() {
+    void testGenericArray() {
         // 1. array test
         Integer[] javaArray = {6, null, 666};
         GenericArrayData array = new GenericArrayData(javaArray);
@@ -560,7 +560,7 @@ public class BinaryRowDataTest {
     }
 
     @Test
-    public void testBinaryMap() {
+    void testBinaryMap() {
         BinaryArrayData array1 = new BinaryArrayData();
         BinaryArrayWriter writer1 =
                 new BinaryArrayWriter(
@@ -612,7 +612,7 @@ public class BinaryRowDataTest {
     }
 
     @Test
-    public void testGenericMap() {
+    void testGenericMap() {
         Map<Object, Object> javaMap = new HashMap<>();
         javaMap.put(6, fromString("6"));
         javaMap.put(5, fromString("5"));
@@ -642,7 +642,7 @@ public class BinaryRowDataTest {
     }
 
     @Test
-    public void testGenericObject() throws Exception {
+    void testGenericObject() throws Exception {
 
         GenericTypeInfo<MyObj> info = new GenericTypeInfo<>(MyObj.class);
         TypeSerializer<MyObj> genericSerializer = info.createSerializer(new SerializerConfigImpl());
@@ -690,7 +690,7 @@ public class BinaryRowDataTest {
     }
 
     @Test
-    public void testDateAndTimeAsGenericObject() {
+    void testDateAndTimeAsGenericObject() {
         BinaryRowData row = new BinaryRowData(7);
         BinaryRowWriter writer = new BinaryRowWriter(row);
 
@@ -740,7 +740,7 @@ public class BinaryRowDataTest {
     }
 
     @Test
-    public void testSerializeVariousSize() throws IOException {
+    void testSerializeVariousSize() throws IOException {
         // in this test, we are going to start serializing from the i-th byte (i in 0...`segSize`)
         // and the size of the row we're going to serialize is j bytes
         // (j in `rowFixLength` to the maximum length we can write)
@@ -820,7 +820,7 @@ public class BinaryRowDataTest {
     }
 
     @Test
-    public void testZeroOutPaddingGeneric() {
+    void testZeroOutPaddingGeneric() {
 
         GenericTypeInfo<MyObj> info = new GenericTypeInfo<>(MyObj.class);
         TypeSerializer<MyObj> genericSerializer = info.createSerializer(new SerializerConfigImpl());
@@ -858,7 +858,7 @@ public class BinaryRowDataTest {
     }
 
     @Test
-    public void testZeroOutPaddingString() {
+    void testZeroOutPaddingString() {
 
         Random random = new Random();
         byte[] bytes = new byte[1024];
@@ -886,7 +886,7 @@ public class BinaryRowDataTest {
     }
 
     @Test
-    public void testHashAndCopy() throws IOException {
+    void testHashAndCopy() throws IOException {
         MemorySegment[] segments = new MemorySegment[3];
         for (int i = 0; i < 3; i++) {
             segments[i] = MemorySegmentFactory.wrap(new byte[64]);
@@ -927,7 +927,7 @@ public class BinaryRowDataTest {
     }
 
     @Test
-    public void testSerStringToKryo() throws IOException {
+    void testSerStringToKryo() throws IOException {
         KryoSerializer<BinaryStringData> serializer =
                 new KryoSerializer<>(BinaryStringData.class, new SerializerConfigImpl());
 
@@ -948,7 +948,7 @@ public class BinaryRowDataTest {
     }
 
     @Test
-    public void testSerializerPages() throws IOException {
+    void testSerializerPages() throws IOException {
         // Boundary tests
         BinaryRowData row24 = DataFormatTestUtil.get24BytesBinaryRow();
         BinaryRowData row160 = DataFormatTestUtil.get160BytesBinaryRow();
@@ -1056,7 +1056,7 @@ public class BinaryRowDataTest {
     }
 
     @Test
-    public void testTimestampData() {
+    void testTimestampData() {
         // 1. compact
         {
             final int precision = 3;
@@ -1101,7 +1101,7 @@ public class BinaryRowDataTest {
     }
 
     @Test
-    public void testNestedRowWithBinaryRowEquals() {
+    void testNestedRowWithBinaryRowEquals() {
         BinaryRowData nestedBinaryRow = new BinaryRowData(2);
         {
             BinaryRowWriter writer = new BinaryRowWriter(nestedBinaryRow);

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/data/BinaryStringDataTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/data/BinaryStringDataTest.java
@@ -24,10 +24,11 @@ import org.apache.flink.table.data.binary.BinaryStringData;
 import org.apache.flink.table.data.writer.BinaryRowWriter;
 import org.apache.flink.table.runtime.operators.sort.SortUtil;
 import org.apache.flink.table.runtime.util.StringUtf8Utils;
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.UnsupportedEncodingException;
 import java.math.BigDecimal;
@@ -63,8 +64,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  *
  * <p>Caution that you must construct a string by {@link #fromString} to cover all the test cases.
  */
-@RunWith(Parameterized.class)
-public class BinaryStringDataTest {
+@ExtendWith(ParameterizedTestExtension.class)
+class BinaryStringDataTest {
 
     private BinaryStringData empty = fromString("");
 
@@ -74,7 +75,7 @@ public class BinaryStringDataTest {
         this.mode = mode;
     }
 
-    @Parameterized.Parameters(name = "{0}")
+    @Parameters(name = "mode-{0}")
     public static List<Mode> getVarSeg() {
         return Arrays.asList(Mode.ONE_SEG, Mode.MULTI_SEGS, Mode.STRING, Mode.RANDOM);
     }
@@ -148,8 +149,8 @@ public class BinaryStringDataTest {
         assertThat(s1.endsWith(s1)).isTrue();
     }
 
-    @Test
-    public void basicTest() {
+    @TestTemplate
+    void basicTest() {
         checkBasic("", 0);
         checkBasic(",", 1);
         checkBasic("hello", 5);
@@ -163,16 +164,16 @@ public class BinaryStringDataTest {
         checkBasic("\uD83E\uDD19", 1); // 4 bytes char
     }
 
-    @Test
-    public void emptyStringTest() {
+    @TestTemplate
+    void emptyStringTest() {
         assertThat(fromString("")).isEqualTo(empty);
         assertThat(fromBytes(new byte[0])).isEqualTo(empty);
         assertThat(empty.numChars()).isEqualTo(0);
         assertThat(empty.getSizeInBytes()).isEqualTo(0);
     }
 
-    @Test
-    public void compareTo() {
+    @TestTemplate
+    void compareTo() {
         assertThat(fromString("   ").compareTo(blankString(3))).isEqualTo(0);
         assertThat(fromString("").compareTo(fromString("a"))).isLessThan(0);
         assertThat(fromString("abc").compareTo(fromString("ABC"))).isGreaterThan(0);
@@ -195,8 +196,8 @@ public class BinaryStringDataTest {
         assertThat(segment1.compare(segment2, 0, 0, 9)).isLessThan(0);
     }
 
-    @Test
-    public void testMultiSegments() {
+    @TestTemplate
+    void testMultiSegments() {
 
         // prepare
         MemorySegment[] segments1 = new MemorySegment[2];
@@ -244,8 +245,8 @@ public class BinaryStringDataTest {
         assertThat(binaryString2.compareTo(binaryString1)).isEqualTo(1);
     }
 
-    @Test
-    public void concatTest() {
+    @TestTemplate
+    void concatTest() {
         assertThat(concat()).isEqualTo(empty);
         assertThat(concat((BinaryStringData) null)).isNull();
         assertThat(concat(empty)).isEqualTo(empty);
@@ -259,8 +260,8 @@ public class BinaryStringDataTest {
         assertThat(concat(fromString("数据"), fromString("砖头"))).isEqualTo(fromString("数据砖头"));
     }
 
-    @Test
-    public void concatWsTest() {
+    @TestTemplate
+    void concatWsTest() {
         // Returns empty if the separator is null
         assertThat(concatWs(null, (BinaryStringData) null)).isNull();
         assertThat(concatWs(null, fromString("a"))).isNull();
@@ -280,8 +281,8 @@ public class BinaryStringDataTest {
                 .isEqualTo(fromString("数据哈哈砖头"));
     }
 
-    @Test
-    public void contains() {
+    @TestTemplate
+    void contains() {
         assertThat(empty.contains(empty)).isTrue();
         assertThat(fromString("hello").contains(fromString("ello"))).isTrue();
         assertThat(fromString("hello").contains(fromString("vello"))).isFalse();
@@ -291,8 +292,8 @@ public class BinaryStringDataTest {
         assertThat(fromString("大千世界").contains(fromString("大千世界好"))).isFalse();
     }
 
-    @Test
-    public void startsWith() {
+    @TestTemplate
+    void startsWith() {
         assertThat(empty.startsWith(empty)).isTrue();
         assertThat(fromString("hello").startsWith(fromString("hell"))).isTrue();
         assertThat(fromString("hello").startsWith(fromString("ell"))).isFalse();
@@ -302,8 +303,8 @@ public class BinaryStringDataTest {
         assertThat(fromString("大千世界").startsWith(fromString("大千世界好"))).isFalse();
     }
 
-    @Test
-    public void endsWith() {
+    @TestTemplate
+    void endsWith() {
         assertThat(empty.endsWith(empty)).isTrue();
         assertThat(fromString("hello").endsWith(fromString("ello"))).isTrue();
         assertThat(fromString("hello").endsWith(fromString("ellov"))).isFalse();
@@ -313,8 +314,8 @@ public class BinaryStringDataTest {
         assertThat(fromString("数据砖头").endsWith(fromString("我的数据砖头"))).isFalse();
     }
 
-    @Test
-    public void substring() {
+    @TestTemplate
+    void substring() {
         assertThat(fromString("hello").substring(0, 0)).isEqualTo(empty);
         assertThat(fromString("hello").substring(1, 3)).isEqualTo(fromString("el"));
         assertThat(fromString("数据砖头").substring(0, 1)).isEqualTo(fromString("数"));
@@ -323,8 +324,8 @@ public class BinaryStringDataTest {
         assertThat(fromString("ߵ梷").substring(0, 2)).isEqualTo(fromString("ߵ梷"));
     }
 
-    @Test
-    public void trims() {
+    @TestTemplate
+    void trims() {
         assertThat(fromString("1").trim()).isEqualTo(fromString("1"));
 
         assertThat(fromString("  hello ").trim()).isEqualTo(fromString("hello"));
@@ -381,8 +382,8 @@ public class BinaryStringDataTest {
                 .isEqualTo(fromString(stringStartingWithSpace));
     }
 
-    @Test
-    public void testSqlSubstring() {
+    @TestTemplate
+    void testSqlSubstring() {
         assertThat(substringSQL(fromString("hello"), 2)).isEqualTo(fromString("ello"));
         assertThat(substringSQL(fromString("hello"), 2, 3)).isEqualTo(fromString("ell"));
         assertThat(substringSQL(empty, 2, 3)).isEqualTo(empty);
@@ -393,16 +394,16 @@ public class BinaryStringDataTest {
         assertThat(substringSQL(fromString("hello"), -100, 3)).isEqualTo(empty);
     }
 
-    @Test
-    public void reverseTest() {
+    @TestTemplate
+    void reverseTest() {
         assertThat(reverse(fromString("hello"))).isEqualTo(fromString("olleh"));
         assertThat(reverse(fromString("中国"))).isEqualTo(fromString("国中"));
         assertThat(reverse(fromString("hello, 中国"))).isEqualTo(fromString("国中 ,olleh"));
         assertThat(reverse(empty)).isEqualTo(empty);
     }
 
-    @Test
-    public void indexOf() {
+    @TestTemplate
+    void indexOf() {
         assertThat(empty.indexOf(empty, 0)).isEqualTo(0);
         assertThat(empty.indexOf(fromString("l"), 0)).isEqualTo(-1);
         assertThat(fromString("hello").indexOf(empty, 0)).isEqualTo(0);
@@ -417,8 +418,8 @@ public class BinaryStringDataTest {
         assertThat(fromString("数据砖头").indexOf(fromString("头"), 0)).isEqualTo(3);
     }
 
-    @Test
-    public void testToNumeric() {
+    @TestTemplate
+    void testToNumeric() {
         // Test to integer.
         assertThat(toByte(fromString("123"))).isEqualTo(Byte.parseByte("123"));
         assertThat(toByte(fromString("+123"))).isEqualTo(Byte.parseByte("123"));
@@ -464,8 +465,8 @@ public class BinaryStringDataTest {
                 .isEqualTo(Long.parseLong("123456789"));
     }
 
-    @Test
-    public void testToUpperLowerCase() {
+    @TestTemplate
+    void testToUpperLowerCase() {
         assertThat(fromString("我是中国人").toLowerCase()).isEqualTo(fromString("我是中国人"));
         assertThat(fromString("我是中国人").toUpperCase()).isEqualTo(fromString("我是中国人"));
 
@@ -498,8 +499,8 @@ public class BinaryStringDataTest {
                 .isEqualTo(fromString("!@#$%^*"));
     }
 
-    @Test
-    public void testToDecimal() {
+    @TestTemplate
+    void testToDecimal() {
         class DecimalTestData {
             private String str;
             private int precision, scale;
@@ -585,8 +586,8 @@ public class BinaryStringDataTest {
         }
     }
 
-    @Test
-    public void testEmptyString() {
+    @TestTemplate
+    void testEmptyString() {
         BinaryStringData str2 = fromString("hahahahah");
         BinaryStringData str3;
         {
@@ -609,8 +610,8 @@ public class BinaryStringDataTest {
         assertThat(BinaryStringData.EMPTY_UTF8).isEqualTo(str3);
     }
 
-    @Test
-    public void testEncodeWithIllegalCharacter() throws UnsupportedEncodingException {
+    @TestTemplate
+    void testEncodeWithIllegalCharacter() throws UnsupportedEncodingException {
 
         // Tis char array has some illegal character, such as 55357
         // the jdk ignores theses character and cast them to '?'
@@ -626,8 +627,8 @@ public class BinaryStringDataTest {
         assertThat(StringUtf8Utils.encodeUTF8(str)).isEqualTo(str.getBytes("UTF-8"));
     }
 
-    @Test
-    public void testKeyValue() {
+    @TestTemplate
+    void testKeyValue() {
         assertThat(
                         keyValue(
                                 fromString("k1:v1|k2:v2"),
@@ -757,8 +758,8 @@ public class BinaryStringDataTest {
                 .isEqualTo(fromString("v2"));
     }
 
-    @Test
-    public void testDecodeWithIllegalUtf8Bytes() throws UnsupportedEncodingException {
+    @TestTemplate
+    void testDecodeWithIllegalUtf8Bytes() throws UnsupportedEncodingException {
 
         // illegal utf-8 bytes
         byte[] bytes =
@@ -789,8 +790,8 @@ public class BinaryStringDataTest {
                 .isEqualTo(str);
     }
 
-    @Test
-    public void skipWrongFirstByte() {
+    @TestTemplate
+    void skipWrongFirstByte() {
         int[] wrongFirstBytes = {
             0x80,
             0x9F,
@@ -818,8 +819,8 @@ public class BinaryStringDataTest {
         }
     }
 
-    @Test
-    public void testSplit() {
+    @TestTemplate
+    void testSplit() {
         assertThat(splitByWholeSeparatorPreserveAllTokens(fromString(""), fromString("")))
                 .isEqualTo(EMPTY_STRING_ARRAY);
         assertThat(splitByWholeSeparatorPreserveAllTokens(fromString("ab de fg"), null))
@@ -850,8 +851,8 @@ public class BinaryStringDataTest {
                         });
     }
 
-    @Test
-    public void testLazy() {
+    @TestTemplate
+    void testLazy() {
         String javaStr = "haha";
         BinaryStringData str = BinaryStringData.fromString(javaStr);
         str.ensureMaterialized();
@@ -860,8 +861,8 @@ public class BinaryStringDataTest {
         assertThat(javaStr).isSameAs(str.toString());
     }
 
-    @Test
-    public void testIsEmpty() {
+    @TestTemplate
+    void testIsEmpty() {
         assertThat(isEmpty(fromString(""))).isEqualTo(true);
         assertThat(isEmpty(BinaryStringData.fromBytes(new byte[] {}))).isEqualTo(true);
         assertThat(isEmpty(fromString("hello"))).isEqualTo(false);

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/data/BinaryStringDataTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/data/BinaryStringDataTest.java
@@ -76,7 +76,7 @@ class BinaryStringDataTest {
     }
 
     @Parameters(name = "mode-{0}")
-    public static List<Mode> getVarSeg() {
+    private static List<Mode> getVarSeg() {
         return Arrays.asList(Mode.ONE_SEG, Mode.MULTI_SEGS, Mode.STRING, Mode.RANDOM);
     }
 

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/data/DataFormatConvertersTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/data/DataFormatConvertersTest.java
@@ -50,7 +50,7 @@ import org.apache.flink.table.utils.DateTimeUtils;
 import org.apache.flink.types.Row;
 import org.apache.flink.types.RowKind;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
@@ -61,7 +61,7 @@ import static org.apache.flink.table.data.util.DataFormatConverters.getConverter
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link DataFormatConverters}. */
-public class DataFormatConvertersTest {
+class DataFormatConvertersTest {
 
     private TypeInformation[] simpleTypes =
             new TypeInformation[] {
@@ -177,7 +177,7 @@ public class DataFormatConvertersTest {
     }
 
     @Test
-    public void testTypes() {
+    void testTypes() {
         for (int i = 0; i < simpleTypes.length; i++) {
             test(simpleTypes[i], simpleValues[i]);
         }
@@ -229,7 +229,7 @@ public class DataFormatConvertersTest {
     }
 
     @Test
-    public void testDataTypes() {
+    void testDataTypes() {
         for (int i = 0; i < dataTypes.length; i++) {
             testDataType(dataTypes[i], dataValues[i]);
         }

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/data/DataStructureConvertersTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/data/DataStructureConvertersTest.java
@@ -30,11 +30,8 @@ import org.apache.flink.types.Row;
 import org.apache.flink.types.RowKind;
 import org.apache.flink.util.InstantiationUtil;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.annotation.Nullable;
 
@@ -89,11 +86,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link DataStructureConverters}. */
-@RunWith(Parameterized.class)
-public class DataStructureConvertersTest {
+class DataStructureConvertersTest {
 
-    @Parameters(name = "{index}: {0}")
-    public static List<TestSpec> testData() {
+    static List<TestSpec> testData() {
         // ordered by definition in DataStructureConverters
         return asList(
                 TestSpec.forDataType(CHAR(5))
@@ -363,10 +358,9 @@ public class DataStructureConvertersTest {
                                 GenericPojo.class, new GenericPojo<>(LocalDate.ofEpochDay(123))));
     }
 
-    @Parameter public TestSpec testSpec;
-
-    @Test
-    public void testConversions() {
+    @ParameterizedTest(name = "{index}: {0}")
+    @MethodSource("testData")
+    void testConversions(final TestSpec testSpec) {
         for (Map.Entry<Class<?>, Object> from : testSpec.conversions.entrySet()) {
             final DataType fromDataType = testSpec.dataType.bridgedTo(from.getKey());
 

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/data/DecimalDataTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/data/DecimalDataTest.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.data;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 
@@ -47,11 +47,11 @@ import static org.apache.flink.table.data.DecimalDataUtils.subtract;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link DecimalData}. */
-public class DecimalDataTest {
+class DecimalDataTest {
 
     @SuppressWarnings("ConstantConditions")
     @Test
-    public void testNormal() {
+    void testNormal() {
         BigDecimal bigDecimal1 = new BigDecimal("13145678.90123");
         BigDecimal bigDecimal2 = new BigDecimal("1234567890.0987654321");
         // fromUnscaledBytes
@@ -126,7 +126,7 @@ public class DecimalDataTest {
 
     @SuppressWarnings("ConstantConditions")
     @Test
-    public void testNotCompact() {
+    void testNotCompact() {
         DecimalData decimal1 = DecimalData.fromBigDecimal(new BigDecimal(10), 20, 0);
         DecimalData decimal2 = DecimalData.fromBigDecimal(new BigDecimal(15), 20, 0);
         assertThat(DecimalData.fromBigDecimal(new BigDecimal(10), 20, 0).hashCode())
@@ -175,7 +175,7 @@ public class DecimalDataTest {
     }
 
     @Test
-    public void testToString() {
+    void testToString() {
         String val = "0.0000000000000000001";
         assertThat(castFrom(val, 39, val.length() - 2).toString()).isEqualTo(val);
         val = "123456789012345678901234567890123456789";

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/data/NestedRowDataTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/data/NestedRowDataTest.java
@@ -33,17 +33,17 @@ import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
 import org.apache.flink.table.runtime.typeutils.StringDataSerializer;
 import org.apache.flink.table.types.logical.LogicalType;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.flink.table.data.util.DataFormatTestUtil.MyObj;
 import static org.apache.flink.table.data.util.DataFormatTestUtil.splitBytes;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link NestedRowData}s. */
-public class NestedRowDataTest {
+class NestedRowDataTest {
 
     @Test
-    public void testNestedRowDataWithOneSegment() {
+    void testNestedRowDataWithOneSegment() {
         BinaryRowData row = getBinaryRowData();
         GenericTypeInfo<MyObj> info = new GenericTypeInfo<>(MyObj.class);
         TypeSerializer<MyObj> genericSerializer = info.createSerializer(new SerializerConfigImpl());
@@ -58,7 +58,7 @@ public class NestedRowDataTest {
     }
 
     @Test
-    public void testNestedRowDataWithMultipleSegments() {
+    void testNestedRowDataWithMultipleSegments() {
         BinaryRowData row = getBinaryRowData();
         GenericTypeInfo<MyObj> info = new GenericTypeInfo<>(MyObj.class);
         TypeSerializer<MyObj> genericSerializer = info.createSerializer(new SerializerConfigImpl());
@@ -77,7 +77,7 @@ public class NestedRowDataTest {
     }
 
     @Test
-    public void testNestInNestedRowData() {
+    void testNestInNestedRowData() {
         // layer1
         GenericRowData gRow = new GenericRowData(4);
         gRow.setField(0, 1);

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/data/RowDataTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/data/RowDataTest.java
@@ -34,8 +34,8 @@ import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.types.RowKind;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.sql.Timestamp;
@@ -46,7 +46,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.HamcrestCondition.matching;
 
 /** Test for {@link RowData}s. */
-public class RowDataTest {
+class RowDataTest {
 
     private StringData str;
     private RawValueData<String> generic;
@@ -60,8 +60,8 @@ public class RowDataTest {
     private TimestampData timestamp1;
     private TimestampData timestamp2;
 
-    @Before
-    public void before() {
+    @BeforeEach
+    void before() {
         str = StringData.fromString("haha");
         generic = RawValueData.fromObject("haha");
         genericSerializer = new RawValueDataSerializer<>(StringSerializer.INSTANCE);
@@ -89,14 +89,14 @@ public class RowDataTest {
     }
 
     @Test
-    public void testBinaryRow() {
+    void testBinaryRow() {
         BinaryRowData binaryRow = getBinaryRow();
         testGetters(binaryRow);
         testSetters(binaryRow);
     }
 
     @Test
-    public void testNestedRow() {
+    void testNestedRow() {
         BinaryRowData row = new BinaryRowData(1);
         BinaryRowWriter writer = new BinaryRowWriter(row);
         writer.writeRow(0, getBinaryRow(), null);
@@ -136,7 +136,7 @@ public class RowDataTest {
     }
 
     @Test
-    public void testGenericRow() {
+    void testGenericRow() {
         GenericRowData row = new GenericRowData(18);
         row.setField(0, true);
         row.setField(1, (byte) 1);
@@ -160,7 +160,7 @@ public class RowDataTest {
     }
 
     @Test
-    public void testBoxedWrapperRow() {
+    void testBoxedWrapperRow() {
         BoxedWrapperRowData row = new BoxedWrapperRowData(18);
         row.setBoolean(0, true);
         row.setByte(1, (byte) 1);
@@ -184,7 +184,7 @@ public class RowDataTest {
     }
 
     @Test
-    public void testJoinedRow() {
+    void testJoinedRow() {
         GenericRowData row1 = new GenericRowData(5);
         row1.setField(0, true);
         row1.setField(1, (byte) 1);

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/data/TimestampDataTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/data/TimestampDataTest.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.data;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -27,10 +27,10 @@ import java.util.TimeZone;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link TimestampData}. */
-public class TimestampDataTest {
+class TimestampDataTest {
 
     @Test
-    public void testNormal() {
+    void testNormal() {
         // From long to TimestampData and vice versa
         assertThat(TimestampData.fromEpochMillis(1123L).getMillisecond()).isEqualTo(1123L);
         assertThat(TimestampData.fromEpochMillis(-1123L).getMillisecond()).isEqualTo(-1123L);
@@ -93,7 +93,7 @@ public class TimestampDataTest {
     }
 
     @Test
-    public void testDaylightSavingTime() {
+    void testDaylightSavingTime() {
         TimeZone tz = TimeZone.getDefault();
         TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"));
 
@@ -107,7 +107,7 @@ public class TimestampDataTest {
     }
 
     @Test
-    public void testToString() {
+    void testToString() {
 
         java.sql.Timestamp t = java.sql.Timestamp.valueOf("1969-01-02 00:00:00.123456789");
         assertThat(TimestampData.fromTimestamp(t).toString())

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/data/binary/BinarySegmentUtilsTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/data/binary/BinarySegmentUtilsTest.java
@@ -22,7 +22,7 @@ import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.table.data.util.DataFormatTestUtil;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.flink.table.data.binary.BinaryRowDataUtil.BYTE_ARRAY_BASE_OFFSET;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -31,10 +31,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Test for {@link BinarySegmentUtils}, most is covered by {@link
  * org.apache.flink.table.data.BinaryRowDataTest}, this just test some boundary scenarios testing.
  */
-public class BinarySegmentUtilsTest {
+class BinarySegmentUtilsTest {
 
     @Test
-    public void testCopy() {
+    void testCopy() {
         // test copy the content of the latter Seg
         MemorySegment[] segments = new MemorySegment[2];
         segments[0] = MemorySegmentFactory.wrap(new byte[] {0, 2, 5});
@@ -45,7 +45,7 @@ public class BinarySegmentUtilsTest {
     }
 
     @Test
-    public void testEquals() {
+    void testEquals() {
         // test copy the content of the latter Seg
         MemorySegment[] segments1 = new MemorySegment[3];
         segments1[0] = MemorySegmentFactory.wrap(new byte[] {0, 2, 5});
@@ -63,7 +63,7 @@ public class BinarySegmentUtilsTest {
     }
 
     @Test
-    public void testBoundaryByteArrayEquals() {
+    void testBoundaryByteArrayEquals() {
         byte[] bytes1 = new byte[5];
         bytes1[3] = 81;
         byte[] bytes2 = new byte[100];
@@ -76,7 +76,7 @@ public class BinarySegmentUtilsTest {
     }
 
     @Test
-    public void testBoundaryEquals() {
+    void testBoundaryEquals() {
         BinaryRowData row24 = DataFormatTestUtil.get24BytesBinaryRow();
         BinaryRowData row160 = DataFormatTestUtil.get160BytesBinaryRow();
         BinaryRowData varRow160 = DataFormatTestUtil.getMultiSeg160BytesBinaryRow(row160);
@@ -117,7 +117,7 @@ public class BinarySegmentUtilsTest {
     }
 
     @Test
-    public void testBoundaryCopy() {
+    void testBoundaryCopy() {
         MemorySegment[] segments1 = new MemorySegment[2];
         segments1[0] = MemorySegmentFactory.wrap(new byte[32]);
         segments1[1] = MemorySegmentFactory.wrap(new byte[32]);
@@ -150,7 +150,7 @@ public class BinarySegmentUtilsTest {
     }
 
     @Test
-    public void testCopyToUnsafe() {
+    void testCopyToUnsafe() {
         MemorySegment[] segments1 = new MemorySegment[2];
         segments1[0] = MemorySegmentFactory.wrap(new byte[32]);
         segments1[1] = MemorySegmentFactory.wrap(new byte[32]);
@@ -183,7 +183,7 @@ public class BinarySegmentUtilsTest {
     }
 
     @Test
-    public void testFind() {
+    void testFind() {
         MemorySegment[] segments1 = new MemorySegment[2];
         segments1[0] = MemorySegmentFactory.wrap(new byte[32]);
         segments1[1] = MemorySegmentFactory.wrap(new byte[32]);

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/formats/raw/RawFormatFactoryTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/formats/raw/RawFormatFactoryTest.java
@@ -34,9 +34,8 @@ import org.apache.flink.table.runtime.connector.sink.SinkRuntimeProviderContext;
 import org.apache.flink.table.runtime.connector.source.ScanRuntimeProviderContext;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.types.logical.RowType;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -49,7 +48,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link RawFormatFactory}. */
-public class RawFormatFactoryTest extends TestLogger {
+class RawFormatFactoryTest {
 
     private static final ResolvedSchema SCHEMA =
             ResolvedSchema.of(Column.physical("field1", DataTypes.STRING()));
@@ -58,7 +57,7 @@ public class RawFormatFactoryTest extends TestLogger {
             (RowType) SCHEMA.toPhysicalRowDataType().getLogicalType();
 
     @Test
-    public void testSeDeSchema() {
+    void testSeDeSchema() {
         final Map<String, String> tableOptions = getBasicOptions();
 
         // test deserialization
@@ -77,7 +76,7 @@ public class RawFormatFactoryTest extends TestLogger {
     }
 
     @Test
-    public void testCharsetAndEndiannessOption() {
+    void testCharsetAndEndiannessOption() {
         final Map<String, String> tableOptions =
                 getModifiedOptions(
                         options -> {
@@ -101,7 +100,7 @@ public class RawFormatFactoryTest extends TestLogger {
     }
 
     @Test
-    public void testInvalidSchema() {
+    void testInvalidSchema() {
         ResolvedSchema invalidSchema =
                 ResolvedSchema.of(
                         Column.physical("f0", DataTypes.STRING()),
@@ -118,7 +117,7 @@ public class RawFormatFactoryTest extends TestLogger {
     }
 
     @Test
-    public void testInvalidCharset() {
+    void testInvalidCharset() {
         final Map<String, String> tableOptions =
                 getModifiedOptions(
                         options -> {
@@ -135,7 +134,7 @@ public class RawFormatFactoryTest extends TestLogger {
     }
 
     @Test
-    public void testInvalidEndianness() {
+    void testInvalidEndianness() {
         final Map<String, String> tableOptions =
                 getModifiedOptions(
                         options -> {
@@ -154,7 +153,7 @@ public class RawFormatFactoryTest extends TestLogger {
     }
 
     @Test
-    public void testInvalidFieldTypes() {
+    void testInvalidFieldTypes() {
         assertThatThrownBy(
                         () ->
                                 createDeserializationSchema(

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/formats/raw/RawFormatSerDeSchemaTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/formats/raw/RawFormatSerDeSchemaTest.java
@@ -32,9 +32,8 @@ import org.apache.flink.table.types.DataType;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.StringUtils;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -62,11 +61,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 /** Tests for {@link RawFormatDeserializationSchema} {@link RawFormatSerializationSchema}. */
-@RunWith(Parameterized.class)
-public class RawFormatSerDeSchemaTest {
+class RawFormatSerDeSchemaTest {
 
-    @Parameterized.Parameters(name = "{index}: {0}")
-    public static List<TestSpec> testData() {
+    static List<TestSpec> testData() {
         return Arrays.asList(
                 TestSpec.type(TINYINT()).values(Byte.MAX_VALUE).binary(new byte[] {Byte.MAX_VALUE}),
                 TestSpec.type(SMALLINT()).values(Short.MAX_VALUE).binary(hexStringToByte("7fff")),
@@ -143,10 +140,9 @@ public class RawFormatSerDeSchemaTest {
                         .binary((byte[]) null));
     }
 
-    @Parameterized.Parameter public TestSpec testSpec;
-
-    @Test
-    public void testSerializationAndDeserialization() throws Exception {
+    @ParameterizedTest
+    @MethodSource("testData")
+    void testSerializationAndDeserialization(final TestSpec testSpec) throws Exception {
         RawFormatDeserializationSchema deserializationSchema =
                 new RawFormatDeserializationSchema(
                         testSpec.type.getLogicalType(),

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/functions/aggregate/hyperloglog/HyperLogLogPlusPlusTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/functions/aggregate/hyperloglog/HyperLogLogPlusPlusTest.java
@@ -33,10 +33,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** The test of HyperLogLogPlusPlus is inspired from Apache Spark. */
-public class HyperLogLogPlusPlusTest {
+class HyperLogLogPlusPlusTest {
 
     @Test
-    public void testInvalidRelativeSD() {
+    void testInvalidRelativeSD() {
         assertThatThrownBy(() -> new HyperLogLogPlusPlus(0.4))
                 .satisfies(
                         anyCauseMatches(
@@ -45,7 +45,7 @@ public class HyperLogLogPlusPlusTest {
     }
 
     @Test
-    public void testInputAllNulls() {
+    void testInputAllNulls() {
         HyperLogLogPlusPlus hll = new HyperLogLogPlusPlus(0.01);
         HllBuffer buffer = createHllBuffer(hll);
         long estimate = hll.query(buffer);
@@ -53,7 +53,7 @@ public class HyperLogLogPlusPlusTest {
     }
 
     @Test
-    public void testDeterministicCardinalityEstimation() {
+    void testDeterministicCardinalityEstimation() {
         int repeats = 10;
         testCardinalityEstimates(
                 new double[] {0.1, 0.05, 0.025, 0.01, 0.001},
@@ -63,7 +63,7 @@ public class HyperLogLogPlusPlusTest {
     }
 
     @Test
-    public void testMerge() {
+    void testMerge() {
         HyperLogLogPlusPlus hll = new HyperLogLogPlusPlus(0.05);
         HllBuffer buffer1a = createHllBuffer(hll);
         HllBuffer buffer1b = createHllBuffer(hll);
@@ -98,7 +98,7 @@ public class HyperLogLogPlusPlusTest {
     }
 
     @Test
-    public void testRandomCardinalityEstimation() {
+    void testRandomCardinalityEstimation() {
         Random srng = new Random(323981238L);
         Set<Integer> seen = new HashSet<>();
         Function<Integer, Integer> update =
@@ -118,7 +118,7 @@ public class HyperLogLogPlusPlusTest {
     }
 
     @Test
-    public void testPositiveAndNegativeZero() {
+    void testPositiveAndNegativeZero() {
         HyperLogLogPlusPlus hll = new HyperLogLogPlusPlus(0.05);
         HllBuffer buffer = createHllBuffer(hll);
         hll.updateByHashcode(buffer, hashLong(Double.doubleToLongBits(0.0d), DEFAULT_SEED));
@@ -130,7 +130,7 @@ public class HyperLogLogPlusPlusTest {
     }
 
     @Test
-    public void testNaN() {
+    void testNaN() {
         HyperLogLogPlusPlus hll = new HyperLogLogPlusPlus(0.05);
         HllBuffer buffer = createHllBuffer(hll);
         hll.updateByHashcode(buffer, hashLong(Double.doubleToLongBits(Double.NaN), DEFAULT_SEED));

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/functions/table/fullcache/LookupFullCacheTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/functions/table/fullcache/LookupFullCacheTest.java
@@ -42,7 +42,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Unit test for {@link LookupFullCache}. */
-public class LookupFullCacheTest {
+class LookupFullCacheTest {
 
     private final TestManualCacheReloadTrigger reloadTrigger = new TestManualCacheReloadTrigger();
 

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/generated/CompileUtilsTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/generated/CompileUtilsTest.java
@@ -21,8 +21,8 @@ package org.apache.flink.table.runtime.generated;
 import org.apache.flink.util.FlinkRuntimeException;
 
 import org.codehaus.janino.ExpressionEvaluator;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -32,17 +32,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link CompileUtils}. */
-public class CompileUtilsTest {
+class CompileUtilsTest {
 
-    @Before
-    public void before() {
+    @BeforeEach
+    void before() {
         // cleanup cached class before tests
         CompileUtils.COMPILED_CLASS_CACHE.invalidateAll();
         CompileUtils.COMPILED_EXPRESSION_CACHE.invalidateAll();
     }
 
     @Test
-    public void testCacheReuse() {
+    void testCacheReuse() {
         String code = "public class Main {\n" + "  int i;\n" + "  int j;\n" + "}";
 
         Class<?> class1 = CompileUtils.compile(this.getClass().getClassLoader(), "Main", code);
@@ -53,7 +53,7 @@ public class CompileUtilsTest {
     }
 
     @Test
-    public void testExpressionCacheReuse() {
+    void testExpressionCacheReuse() {
         String code = "a + b";
 
         ExpressionEvaluator evaluator1 =
@@ -79,7 +79,7 @@ public class CompileUtilsTest {
     }
 
     @Test
-    public void testWrongCode() {
+    void testWrongCode() {
         String code = "public class111 Main {\n" + "  int i;\n" + "  int j;\n" + "}";
         assertThatThrownBy(
                         () -> CompileUtils.compile(this.getClass().getClassLoader(), "Main", code))

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/hashtable/BinaryHashTableTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/hashtable/BinaryHashTableTest.java
@@ -35,14 +35,15 @@ import org.apache.flink.table.runtime.operators.join.HashJoinType;
 import org.apache.flink.table.runtime.typeutils.BinaryRowDataSerializer;
 import org.apache.flink.table.runtime.util.RowIterator;
 import org.apache.flink.table.runtime.util.UniformBinaryRowGenerator;
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
 import org.apache.flink.types.IntValue;
 import org.apache.flink.util.MutableObjectIterator;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -56,7 +57,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 /** Hash table it case for binary row. */
-@RunWith(Parameterized.class)
+@ExtendWith(ParameterizedTestExtension.class)
 public class BinaryHashTableTest {
 
     private static final int PAGE_SIZE = 32 * 1024;
@@ -70,13 +71,13 @@ public class BinaryHashTableTest {
         this.useCompress = useCompress;
     }
 
-    @Parameterized.Parameters(name = "useCompress-{0}")
+    @Parameters(name = "useCompress-{0}")
     public static List<Boolean> getVarSeg() {
         return Arrays.asList(true, false);
     }
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         TypeInformation[] types = new TypeInformation[] {Types.INT, Types.INT};
         this.buildSideSerializer = new BinaryRowDataSerializer(types.length);
         this.probeSideSerializer = new BinaryRowDataSerializer(types.length);
@@ -84,14 +85,14 @@ public class BinaryHashTableTest {
         this.ioManager = new IOManagerAsync();
     }
 
-    @After
-    public void tearDown() throws Exception {
+    @AfterEach
+    void tearDown() throws Exception {
         // shut down I/O manager and Memory Manager and verify the correct shutdown
         this.ioManager.close();
     }
 
-    @Test
-    public void testIOBufferCountComputation() {
+    @TestTemplate
+    void testIOBufferCountComputation() {
         assertThat(BinaryHashTable.getNumWriteBehindBuffers(32)).isEqualTo(1);
         assertThat(BinaryHashTable.getNumWriteBehindBuffers(33)).isEqualTo(1);
         assertThat(BinaryHashTable.getNumWriteBehindBuffers(40)).isEqualTo(1);
@@ -113,8 +114,8 @@ public class BinaryHashTableTest {
         assertThat(BinaryHashTable.getNumWriteBehindBuffers(Integer.MAX_VALUE)).isEqualTo(6);
     }
 
-    @Test
-    public void testInMemoryMutableHashTable() throws IOException {
+    @TestTemplate
+    void testInMemoryMutableHashTable() throws IOException {
         final int numKeys = 100000;
         final int buildValsPerKey = 3;
         final int probeValsPerKey = 10;
@@ -209,8 +210,8 @@ public class BinaryHashTableTest {
         return count;
     }
 
-    @Test
-    public void testSpillingHashJoinOneRecursionPerformance() throws IOException {
+    @TestTemplate
+    void testSpillingHashJoinOneRecursionPerformance() throws IOException {
         final int numKeys = 1000000;
         final int buildValsPerKey = 3;
         final int probeValsPerKey = 10;
@@ -254,8 +255,8 @@ public class BinaryHashTableTest {
         table.free();
     }
 
-    @Test
-    public void testSpillingHashJoinOneRecursionValidity() throws IOException {
+    @TestTemplate
+    void testSpillingHashJoinOneRecursionValidity() throws IOException {
         final int numKeys = 1000000;
         final int buildValsPerKey = 3;
         final int probeValsPerKey = 10;
@@ -319,8 +320,8 @@ public class BinaryHashTableTest {
         table.free();
     }
 
-    @Test
-    public void testSpillingHashJoinWithMassiveCollisions() throws IOException {
+    @TestTemplate
+    void testSpillingHashJoinWithMassiveCollisions() throws IOException {
         // the following two values are known to have a hash-code collision on the initial level.
         // we use them to make sure one partition grows over-proportionally large
         final int repeatedValue1 = 40559;
@@ -455,8 +456,8 @@ public class BinaryHashTableTest {
      * of repeated values (causing bucket collisions) are large enough to make sure that their target partition no longer
      * fits into memory by itself and needs to be repartitioned in the recursion again.
      */
-    @Test
-    public void testSpillingHashJoinWithTwoRecursions() throws IOException {
+    @TestTemplate
+    void testSpillingHashJoinWithTwoRecursions() throws IOException {
         // the following two values are known to have a hash-code collision on the first recursion
         // level.
         // we use them to make sure one partition grows over-proportionally large
@@ -556,8 +557,8 @@ public class BinaryHashTableTest {
      * of repeated values (causing bucket collisions) are large enough to make sure that their target partition no longer
      * fits into memory by itself and needs to be repartitioned in the recursion again.
      */
-    @Test
-    public void testSpillingHashJoinWithTooManyRecursions() throws IOException {
+    @TestTemplate
+    void testSpillingHashJoinWithTooManyRecursions() throws IOException {
         // the following two values are known to have a hash-code collision on the first recursion
         // level.
         // we use them to make sure one partition grows over-proportionally large
@@ -675,8 +676,8 @@ public class BinaryHashTableTest {
      * Spills build records, so that probe records are also spilled. But only so
      * few probe records are used that some partitions remain empty.
      */
-    @Test
-    public void testSparseProbeSpilling() throws IOException, MemoryAllocationException {
+    @TestTemplate
+    void testSparseProbeSpilling() throws IOException, MemoryAllocationException {
         final int numBuildKeys = 1000000;
         final int numBuildVals = 1;
         final int numProbeKeys = 20;
@@ -718,8 +719,8 @@ public class BinaryHashTableTest {
      * Same test as {@link #testSparseProbeSpilling} but using a build-side outer join
      * that requires spilled build-side records to be returned and counted.
      */
-    @Test
-    public void testSparseProbeSpillingWithOuterJoin() throws IOException {
+    @TestTemplate
+    void testSparseProbeSpillingWithOuterJoin() throws IOException {
         final int numBuildKeys = 1000000;
         final int numBuildVals = 1;
         final int numProbeKeys = 20;
@@ -772,7 +773,7 @@ public class BinaryHashTableTest {
      * This test validates a bug fix against former memory loss in the case where a partition was spilled
      * during an insert into the same.
      */
-    @Test
+    @TestTemplate
     public void validateSpillingDuringInsertion() throws IOException, MemoryAllocationException {
         final int numBuildKeys = 500000;
         final int numBuildVals = 1;
@@ -811,8 +812,8 @@ public class BinaryHashTableTest {
         table.free();
     }
 
-    @Test
-    public void testBucketsNotFulfillSegment() throws Exception {
+    @TestTemplate
+    void testBucketsNotFulfillSegment() throws Exception {
         final int numKeys = 10000;
         final int buildValsPerKey = 3;
         final int probeValsPerKey = 10;
@@ -880,8 +881,8 @@ public class BinaryHashTableTest {
         table.free();
     }
 
-    @Test
-    public void testHashWithBuildSideOuterJoin1() throws Exception {
+    @TestTemplate
+    void testHashWithBuildSideOuterJoin1() throws Exception {
         final int numKeys = 20000;
         final int buildValsPerKey = 1;
         final int probeValsPerKey = 1;
@@ -927,8 +928,8 @@ public class BinaryHashTableTest {
         table.free();
     }
 
-    @Test
-    public void testHashWithBuildSideOuterJoin2() throws Exception {
+    @TestTemplate
+    void testHashWithBuildSideOuterJoin2() throws Exception {
         final int numKeys = 40000;
         final int buildValsPerKey = 2;
         final int probeValsPerKey = 1;
@@ -969,8 +970,8 @@ public class BinaryHashTableTest {
         table.free();
     }
 
-    @Test
-    public void testRepeatBuildJoin() throws Exception {
+    @TestTemplate
+    void testRepeatBuildJoin() throws Exception {
         final int numKeys = 500;
         final int probeValsPerKey = 1;
         MemoryManager memManager =
@@ -1032,8 +1033,8 @@ public class BinaryHashTableTest {
         table.free();
     }
 
-    @Test
-    public void testRepeatBuildJoinWithSpill() throws Exception {
+    @TestTemplate
+    void testRepeatBuildJoinWithSpill() throws Exception {
         final int numKeys = 30000;
         final int numRows = 300000;
         final int probeValsPerKey = 1;
@@ -1098,8 +1099,8 @@ public class BinaryHashTableTest {
         table.free();
     }
 
-    @Test
-    public void testBinaryHashBucketAreaNotEnoughMem() throws IOException {
+    @TestTemplate
+    void testBinaryHashBucketAreaNotEnoughMem() throws IOException {
         MemoryManager memManager =
                 MemoryManagerBuilder.newBuilder().setMemorySize(35 * PAGE_SIZE).build();
         BinaryHashTable table =

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/hashtable/LongHashTableTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/hashtable/LongHashTableTest.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.operators.testutils.UnionIterator;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.runtime.typeutils.BinaryRowDataSerializer;
+import org.apache.flink.table.runtime.util.ConstantsKeyValuePairsIterator;
 import org.apache.flink.table.runtime.util.RowIterator;
 import org.apache.flink.table.runtime.util.UniformBinaryRowGenerator;
 import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
@@ -68,7 +69,7 @@ class LongHashTableTest {
     }
 
     @Parameters(name = "useCompress-{0}")
-    public static List<Boolean> getVarSeg() {
+    private static List<Boolean> getVarSeg() {
         return Arrays.asList(true, false);
     }
 
@@ -270,11 +271,9 @@ class LongHashTableTest {
         MutableObjectIterator<BinaryRowData> build1 =
                 new UniformBinaryRowGenerator(numKeys, buildValsPerKey, false);
         MutableObjectIterator<BinaryRowData> build2 =
-                new BinaryHashTableTest.ConstantsKeyValuePairsIterator(
-                        repeatedValue1, 17, repeatedValueCountBuild);
+                new ConstantsKeyValuePairsIterator(repeatedValue1, 17, repeatedValueCountBuild);
         MutableObjectIterator<BinaryRowData> build3 =
-                new BinaryHashTableTest.ConstantsKeyValuePairsIterator(
-                        repeatedValue2, 23, repeatedValueCountBuild);
+                new ConstantsKeyValuePairsIterator(repeatedValue2, 23, repeatedValueCountBuild);
         List<MutableObjectIterator<BinaryRowData>> builds = new ArrayList<>();
         builds.add(build1);
         builds.add(build2);
@@ -285,9 +284,9 @@ class LongHashTableTest {
         MutableObjectIterator<BinaryRowData> probe1 =
                 new UniformBinaryRowGenerator(numKeys, probeValsPerKey, true);
         MutableObjectIterator<BinaryRowData> probe2 =
-                new BinaryHashTableTest.ConstantsKeyValuePairsIterator(repeatedValue1, 17, 5);
+                new ConstantsKeyValuePairsIterator(repeatedValue1, 17, 5);
         MutableObjectIterator<BinaryRowData> probe3 =
-                new BinaryHashTableTest.ConstantsKeyValuePairsIterator(repeatedValue2, 23, 5);
+                new ConstantsKeyValuePairsIterator(repeatedValue2, 23, 5);
         List<MutableObjectIterator<BinaryRowData>> probes = new ArrayList<>();
         probes.add(probe1);
         probes.add(probe2);
@@ -356,11 +355,9 @@ class LongHashTableTest {
         MutableObjectIterator<BinaryRowData> build1 =
                 new UniformBinaryRowGenerator(numKeys, buildValsPerKey, false);
         MutableObjectIterator<BinaryRowData> build2 =
-                new BinaryHashTableTest.ConstantsKeyValuePairsIterator(
-                        repeatedValue1, 17, repeatedValueCountBuild);
+                new ConstantsKeyValuePairsIterator(repeatedValue1, 17, repeatedValueCountBuild);
         MutableObjectIterator<BinaryRowData> build3 =
-                new BinaryHashTableTest.ConstantsKeyValuePairsIterator(
-                        repeatedValue2, 23, repeatedValueCountBuild);
+                new ConstantsKeyValuePairsIterator(repeatedValue2, 23, repeatedValueCountBuild);
         List<MutableObjectIterator<BinaryRowData>> builds = new ArrayList<>();
         builds.add(build1);
         builds.add(build2);
@@ -371,9 +368,9 @@ class LongHashTableTest {
         MutableObjectIterator<BinaryRowData> probe1 =
                 new UniformBinaryRowGenerator(numKeys, probeValsPerKey, true);
         MutableObjectIterator<BinaryRowData> probe2 =
-                new BinaryHashTableTest.ConstantsKeyValuePairsIterator(repeatedValue1, 17, 5);
+                new ConstantsKeyValuePairsIterator(repeatedValue1, 17, 5);
         MutableObjectIterator<BinaryRowData> probe3 =
-                new BinaryHashTableTest.ConstantsKeyValuePairsIterator(repeatedValue2, 23, 5);
+                new ConstantsKeyValuePairsIterator(repeatedValue2, 23, 5);
         List<MutableObjectIterator<BinaryRowData>> probes = new ArrayList<>();
         probes.add(probe1);
         probes.add(probe2);
@@ -446,11 +443,9 @@ class LongHashTableTest {
         MutableObjectIterator<BinaryRowData> build1 =
                 new UniformBinaryRowGenerator(numKeys, buildValsPerKey, false);
         MutableObjectIterator<BinaryRowData> build2 =
-                new BinaryHashTableTest.ConstantsKeyValuePairsIterator(
-                        repeatedValue1, 17, repeatedValueCount);
+                new ConstantsKeyValuePairsIterator(repeatedValue1, 17, repeatedValueCount);
         MutableObjectIterator<BinaryRowData> build3 =
-                new BinaryHashTableTest.ConstantsKeyValuePairsIterator(
-                        repeatedValue2, 23, repeatedValueCount);
+                new ConstantsKeyValuePairsIterator(repeatedValue2, 23, repeatedValueCount);
         List<MutableObjectIterator<BinaryRowData>> builds = new ArrayList<>();
         builds.add(build1);
         builds.add(build2);
@@ -461,11 +456,9 @@ class LongHashTableTest {
         MutableObjectIterator<BinaryRowData> probe1 =
                 new UniformBinaryRowGenerator(numKeys, probeValsPerKey, true);
         MutableObjectIterator<BinaryRowData> probe2 =
-                new BinaryHashTableTest.ConstantsKeyValuePairsIterator(
-                        repeatedValue1, 17, repeatedValueCount);
+                new ConstantsKeyValuePairsIterator(repeatedValue1, 17, repeatedValueCount);
         MutableObjectIterator<BinaryRowData> probe3 =
-                new BinaryHashTableTest.ConstantsKeyValuePairsIterator(
-                        repeatedValue2, 23, repeatedValueCount);
+                new ConstantsKeyValuePairsIterator(repeatedValue2, 23, repeatedValueCount);
         List<MutableObjectIterator<BinaryRowData>> probes = new ArrayList<>();
         probes.add(probe1);
         probes.add(probe2);

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/hashtable/LongHashTableTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/hashtable/LongHashTableTest.java
@@ -52,7 +52,7 @@ import static org.assertj.core.api.Fail.fail;
 
 /** Test for {@link LongHashPartition}. */
 @ExtendWith(ParameterizedTestExtension.class)
-public class LongHashTableTest {
+class LongHashTableTest {
 
     private static final int PAGE_SIZE = 32 * 1024;
     private IOManager ioManager;
@@ -73,7 +73,7 @@ public class LongHashTableTest {
     }
 
     @BeforeEach
-    public void init() {
+    void init() {
         TypeInformation[] types = new TypeInformation[] {Types.INT, Types.INT};
         this.buildSideSerializer = new BinaryRowDataSerializer(types.length);
         this.probeSideSerializer = new BinaryRowDataSerializer(types.length);

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/io/CompressedHeaderlessChannelTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/io/CompressedHeaderlessChannelTest.java
@@ -25,12 +25,14 @@ import org.apache.flink.runtime.io.disk.iomanager.FileIOChannel;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 
-import org.junit.After;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Random;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -39,34 +41,41 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for {@link CompressedHeaderlessChannelReaderInputView} and {@link
  * CompressedHeaderlessChannelWriterOutputView}.
  */
-@RunWith(Parameterized.class)
-public class CompressedHeaderlessChannelTest {
+class CompressedHeaderlessChannelTest {
     private static final int BUFFER_SIZE = 256;
 
     private IOManager ioManager;
 
-    @Parameterized.Parameter public static BlockCompressionFactory compressionFactory;
-
-    @Parameterized.Parameters(name = "compressionFactory = {0}")
-    public static BlockCompressionFactory[] compressionFactory() {
-        return new BlockCompressionFactory[] {
-            BlockCompressionFactory.createBlockCompressionFactory(CompressionCodec.LZ4),
-            BlockCompressionFactory.createBlockCompressionFactory(CompressionCodec.LZO),
-            BlockCompressionFactory.createBlockCompressionFactory(CompressionCodec.ZSTD)
-        };
+    static Collection<Arguments> compressionFactory() {
+        return Arrays.asList(
+                Arguments.of(
+                        CompressionCodec.LZ4,
+                        BlockCompressionFactory.createBlockCompressionFactory(
+                                CompressionCodec.LZ4)),
+                Arguments.of(
+                        CompressionCodec.LZO,
+                        BlockCompressionFactory.createBlockCompressionFactory(
+                                CompressionCodec.LZO)),
+                Arguments.of(
+                        CompressionCodec.ZSTD,
+                        BlockCompressionFactory.createBlockCompressionFactory(
+                                CompressionCodec.ZSTD)));
     }
 
-    public CompressedHeaderlessChannelTest() {
+    CompressedHeaderlessChannelTest() {
         ioManager = new IOManagerAsync();
     }
 
-    @After
-    public void afterTest() throws Exception {
+    @AfterEach
+    void afterTest() throws Exception {
         this.ioManager.close();
     }
 
-    @Test
-    public void testCompressedView() throws IOException {
+    @ParameterizedTest(name = "{index}: {0}")
+    @MethodSource("compressionFactory")
+    void testCompressedView(
+            final CompressionCodec codec, final BlockCompressionFactory compressionFactory)
+            throws IOException {
         for (int testTime = 0; testTime < 10; testTime++) {
             int testRounds = new Random().nextInt(20000);
             FileIOChannel.ID channel = ioManager.createChannel();

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/aggregate/HashAggTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/aggregate/HashAggTest.java
@@ -27,9 +27,9 @@ import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.util.Collector;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -37,7 +37,7 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test hash agg. */
-public class HashAggTest {
+class HashAggTest {
 
     private static final int MEMORY_SIZE = 1024 * 1024 * 32;
 
@@ -47,8 +47,8 @@ public class HashAggTest {
     private IOManager ioManager;
     private SumHashAggTestOperator operator;
 
-    @Before
-    public void before() throws Exception {
+    @BeforeEach
+    void before() throws Exception {
         ioManager = new IOManagerAsync();
         operator =
                 new SumHashAggTestOperator(40 * 32 * 1024) {
@@ -88,8 +88,8 @@ public class HashAggTest {
         operator.open();
     }
 
-    @After
-    public void afterTest() throws Exception {
+    @AfterEach
+    void afterTest() throws Exception {
         this.ioManager.close();
 
         if (this.memoryManager != null) {
@@ -106,7 +106,7 @@ public class HashAggTest {
     }
 
     @Test
-    public void testNormal() throws Exception {
+    void testNormal() throws Exception {
         addRow(GenericRowData.of(1, 1L));
         addRow(GenericRowData.of(5, 2L));
         addRow(GenericRowData.of(2, 3L));
@@ -134,7 +134,7 @@ public class HashAggTest {
     }
 
     @Test
-    public void testSpill() throws Exception {
+    void testSpill() throws Exception {
         for (int i = 0; i < 30000; i++) {
             addRow(GenericRowData.of(i, (long) i));
             addRow(GenericRowData.of(i + 1, (long) i));

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/aggregate/window/SlicingWindowAggOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/aggregate/window/SlicingWindowAggOperatorTest.java
@@ -25,10 +25,11 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.operators.window.tvf.common.WindowAggOperator;
 import org.apache.flink.table.runtime.operators.window.tvf.slicing.SliceAssigner;
 import org.apache.flink.table.runtime.operators.window.tvf.slicing.SliceAssigners;
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.time.Duration;
 import java.time.ZoneId;
@@ -42,15 +43,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for slicing window aggregate operators created by {@link WindowAggOperatorBuilder}. */
-@RunWith(Parameterized.class)
-public class SlicingWindowAggOperatorTest extends WindowAggOperatorTestBase {
+@ExtendWith(ParameterizedTestExtension.class)
+class SlicingWindowAggOperatorTest extends WindowAggOperatorTestBase {
 
     public SlicingWindowAggOperatorTest(ZoneId shiftTimeZone) {
         super(shiftTimeZone);
     }
 
-    @Test
-    public void testEventTimeHoppingWindows() throws Exception {
+    @Parameters(name = "TimeZone = {0}")
+    static Collection<Object[]> runMode() {
+        return Arrays.asList(new Object[] {UTC_ZONE_ID}, new Object[] {SHANGHAI_ZONE_ID});
+    }
+
+    @TestTemplate
+    void testEventTimeHoppingWindows() throws Exception {
         final SliceAssigner assigner =
                 SliceAssigners.hopping(
                         2, shiftTimeZone, Duration.ofSeconds(3), Duration.ofSeconds(1));
@@ -158,8 +164,8 @@ public class SlicingWindowAggOperatorTest extends WindowAggOperatorTestBase {
         testHarness.close();
     }
 
-    @Test
-    public void testProcessingTimeHoppingWindows() throws Exception {
+    @TestTemplate
+    void testProcessingTimeHoppingWindows() throws Exception {
         final SliceAssigner assigner =
                 SliceAssigners.hopping(-1, shiftTimeZone, Duration.ofHours(3), Duration.ofHours(1));
         final SlicingSumAndCountAggsFunction aggsFunction =
@@ -280,8 +286,8 @@ public class SlicingWindowAggOperatorTest extends WindowAggOperatorTestBase {
         assertThat(aggsFunction.closeCalled.get()).as("Close was not called.").isGreaterThan(0);
     }
 
-    @Test
-    public void testEventTimeCumulativeWindows() throws Exception {
+    @TestTemplate
+    void testEventTimeCumulativeWindows() throws Exception {
         final SliceAssigner assigner =
                 SliceAssigners.cumulative(
                         2, shiftTimeZone, Duration.ofSeconds(3), Duration.ofSeconds(1));
@@ -397,8 +403,8 @@ public class SlicingWindowAggOperatorTest extends WindowAggOperatorTestBase {
         testHarness.close();
     }
 
-    @Test
-    public void testProcessingTimeCumulativeWindows() throws Exception {
+    @TestTemplate
+    void testProcessingTimeCumulativeWindows() throws Exception {
         final SliceAssigner assigner =
                 SliceAssigners.cumulative(
                         -1, shiftTimeZone, Duration.ofDays(1), Duration.ofHours(8));
@@ -533,8 +539,8 @@ public class SlicingWindowAggOperatorTest extends WindowAggOperatorTestBase {
         assertThat(aggsFunction.closeCalled.get()).as("Close was not called.").isGreaterThan(0);
     }
 
-    @Test
-    public void testEventTimeTumblingWindows() throws Exception {
+    @TestTemplate
+    void testEventTimeTumblingWindows() throws Exception {
         final SliceAssigner assigner =
                 SliceAssigners.tumbling(2, shiftTimeZone, Duration.ofSeconds(3));
         final SlicingSumAndCountAggsFunction aggsFunction =
@@ -635,8 +641,8 @@ public class SlicingWindowAggOperatorTest extends WindowAggOperatorTestBase {
         testHarness.close();
     }
 
-    @Test
-    public void testProcessingTimeTumblingWindows() throws Exception {
+    @TestTemplate
+    void testProcessingTimeTumblingWindows() throws Exception {
 
         final SliceAssigner assigner =
                 SliceAssigners.tumbling(-1, shiftTimeZone, Duration.ofHours(5));
@@ -715,8 +721,8 @@ public class SlicingWindowAggOperatorTest extends WindowAggOperatorTestBase {
         testHarness.close();
     }
 
-    @Test
-    public void testInvalidWindows() {
+    @TestTemplate
+    void testInvalidWindows() {
         final SliceAssigner assigner =
                 SliceAssigners.hopping(
                         2, shiftTimeZone, Duration.ofSeconds(3), Duration.ofSeconds(1));
@@ -756,10 +762,5 @@ public class SlicingWindowAggOperatorTest extends WindowAggOperatorTestBase {
         protected long getWindowEnd(Long window) {
             return window;
         }
-    }
-
-    @Parameterized.Parameters(name = "TimeZone = {0}")
-    public static Collection<Object[]> runMode() {
-        return Arrays.asList(new Object[] {UTC_ZONE_ID}, new Object[] {SHANGHAI_ZONE_ID});
     }
 }

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/aggregate/window/SlicingWindowAggOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/aggregate/window/SlicingWindowAggOperatorTest.java
@@ -51,7 +51,7 @@ class SlicingWindowAggOperatorTest extends WindowAggOperatorTestBase {
     }
 
     @Parameters(name = "TimeZone = {0}")
-    static Collection<Object[]> runMode() {
+    private static Collection<Object[]> runMode() {
         return Arrays.asList(new Object[] {UTC_ZONE_ID}, new Object[] {SHANGHAI_ZONE_ID});
     }
 

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/aggregate/window/UnslicingWindowAggOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/aggregate/window/UnslicingWindowAggOperatorTest.java
@@ -62,7 +62,7 @@ class UnslicingWindowAggOperatorTest extends WindowAggOperatorTestBase {
     }
 
     @Parameters(name = "TimeZone = {0}")
-    static Collection<Object[]> runMode() {
+    private static Collection<Object[]> runMode() {
         return Arrays.asList(new Object[] {UTC_ZONE_ID}, new Object[] {SHANGHAI_ZONE_ID});
     }
 

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/aggregate/window/UnslicingWindowAggOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/aggregate/window/UnslicingWindowAggOperatorTest.java
@@ -35,11 +35,12 @@ import org.apache.flink.table.runtime.util.RowDataHarnessAssertor;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
 import org.apache.flink.types.RowKind;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.time.Duration;
 import java.time.ZoneId;
@@ -53,15 +54,20 @@ import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for unslicing window aggregate operators created by {@link WindowAggOperatorBuilder}. */
-@RunWith(Parameterized.class)
-public class UnslicingWindowAggOperatorTest extends WindowAggOperatorTestBase {
+@ExtendWith(ParameterizedTestExtension.class)
+class UnslicingWindowAggOperatorTest extends WindowAggOperatorTestBase {
 
-    public UnslicingWindowAggOperatorTest(ZoneId shiftTimeZone) {
+    UnslicingWindowAggOperatorTest(ZoneId shiftTimeZone) {
         super(shiftTimeZone);
     }
 
-    @Test
-    public void testEventTimeSessionWindows() throws Exception {
+    @Parameters(name = "TimeZone = {0}")
+    static Collection<Object[]> runMode() {
+        return Arrays.asList(new Object[] {UTC_ZONE_ID}, new Object[] {SHANGHAI_ZONE_ID});
+    }
+
+    @TestTemplate
+    void testEventTimeSessionWindows() throws Exception {
         final UnsliceAssigner<TimeWindow> assigner =
                 UnsliceAssigners.session(2, shiftTimeZone, Duration.ofSeconds(3));
 
@@ -167,8 +173,8 @@ public class UnslicingWindowAggOperatorTest extends WindowAggOperatorTestBase {
         testHarness.close();
     }
 
-    @Test
-    public void testEventTimeSessionWindowsWithChangelog() throws Exception {
+    @TestTemplate
+    void testEventTimeSessionWindowsWithChangelog() throws Exception {
         final UnsliceAssigner<TimeWindow> assigner =
                 UnsliceAssigners.session(2, shiftTimeZone, Duration.ofSeconds(3));
 
@@ -296,8 +302,8 @@ public class UnslicingWindowAggOperatorTest extends WindowAggOperatorTestBase {
         testHarness.close();
     }
 
-    @Test
-    public void testProcessingTimeSessionWindows() throws Exception {
+    @TestTemplate
+    void testProcessingTimeSessionWindows() throws Exception {
         final UnsliceAssigner<TimeWindow> assigner =
                 UnsliceAssigners.session(-1, shiftTimeZone, Duration.ofSeconds(3));
 
@@ -388,8 +394,8 @@ public class UnslicingWindowAggOperatorTest extends WindowAggOperatorTestBase {
         testHarness.close();
     }
 
-    @Test
-    public void testProcessingTimeSessionWindowsWithChangelog() throws Exception {
+    @TestTemplate
+    void testProcessingTimeSessionWindowsWithChangelog() throws Exception {
         final UnsliceAssigner<TimeWindow> assigner =
                 UnsliceAssigners.session(-1, shiftTimeZone, Duration.ofSeconds(3));
 
@@ -521,8 +527,8 @@ public class UnslicingWindowAggOperatorTest extends WindowAggOperatorTestBase {
         testHarness.close();
     }
 
-    @Test
-    public void testSessionWindowsWithoutPartitionKey() throws Exception {
+    @TestTemplate
+    void testSessionWindowsWithoutPartitionKey() throws Exception {
         // there is no key (type string) in the output
         final LogicalType[] outputTypes =
                 new LogicalType[] {
@@ -614,10 +620,5 @@ public class UnslicingWindowAggOperatorTest extends WindowAggOperatorTestBase {
         protected long getWindowEnd(TimeWindow window) {
             return window.getEnd();
         }
-    }
-
-    @Parameterized.Parameters(name = "TimeZone = {0}")
-    public static Collection<Object[]> runMode() {
-        return Arrays.asList(new Object[] {UTC_ZONE_ID}, new Object[] {SHANGHAI_ZONE_ID});
     }
 }

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/aggregate/window/WindowAggOperatorTestBase.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/aggregate/window/WindowAggOperatorTestBase.java
@@ -51,14 +51,14 @@ import static org.apache.flink.table.runtime.util.TimeWindowUtil.toUtcTimestampM
 import static org.assertj.core.api.Assertions.fail;
 
 /** A test base for window aggregate operator. */
-public abstract class WindowAggOperatorTestBase {
+abstract class WindowAggOperatorTestBase {
 
     protected static final ZoneId UTC_ZONE_ID = ZoneId.of("UTC");
     protected static final ZoneId SHANGHAI_ZONE_ID = ZoneId.of("Asia/Shanghai");
 
     protected final ZoneId shiftTimeZone;
 
-    public WindowAggOperatorTestBase(ZoneId shiftTimeZone) {
+    WindowAggOperatorTestBase(ZoneId shiftTimeZone) {
         this.shiftTimeZone = shiftTimeZone;
     }
 

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/bundle/MapBundleOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/bundle/MapBundleOperatorTest.java
@@ -25,7 +25,7 @@ import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.table.runtime.operators.bundle.trigger.CountBundleTrigger;
 import org.apache.flink.util.Collector;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
 
@@ -37,10 +37,10 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link MapBundleOperator}. */
-public class MapBundleOperatorTest {
+class MapBundleOperatorTest {
 
     @Test
-    public void testSimple() throws Exception {
+    void testSimple() throws Exception {
         @SuppressWarnings("unchecked")
         TestMapBundleFunction func = new TestMapBundleFunction();
         CountBundleTrigger<Tuple2<String, String>> trigger = new CountBundleTrigger<>(3);

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/bundle/trigger/CountBundleTriggerTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/bundle/trigger/CountBundleTriggerTest.java
@@ -18,15 +18,15 @@
 
 package org.apache.flink.table.runtime.operators.bundle.trigger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link CountBundleTrigger}. */
-public class CountBundleTriggerTest {
+class CountBundleTriggerTest {
 
     @Test
-    public void testTrigger() throws Exception {
+    void testTrigger() throws Exception {
         CountBundleTrigger<Object> trigger = new CountBundleTrigger<>(2);
         TestTriggerCallback callback = new TestTriggerCallback();
         trigger.registerCallback(callback);

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/bundle/trigger/CountCoBundleTriggerTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/bundle/trigger/CountCoBundleTriggerTest.java
@@ -18,15 +18,15 @@
 
 package org.apache.flink.table.runtime.operators.bundle.trigger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link CountCoBundleTrigger}. */
-public class CountCoBundleTriggerTest {
+class CountCoBundleTriggerTest {
 
     @Test
-    public void testTrigger() throws Exception {
+    void testTrigger() throws Exception {
         CountCoBundleTrigger<Object, Object> trigger = new CountCoBundleTrigger<>(2);
         TestTriggerCallback callback = new TestTriggerCallback();
         trigger.registerCallback(callback);

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/ProcTimeDeduplicateKeepFirstRowFunctionTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/ProcTimeDeduplicateKeepFirstRowFunctionTest.java
@@ -23,7 +23,7 @@ import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.table.data.RowData;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -31,8 +31,7 @@ import java.util.List;
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord;
 
 /** Tests for {@link ProcTimeDeduplicateKeepFirstRowFunction}. */
-public class ProcTimeDeduplicateKeepFirstRowFunctionTest
-        extends ProcTimeDeduplicateFunctionTestBase {
+class ProcTimeDeduplicateKeepFirstRowFunctionTest extends ProcTimeDeduplicateFunctionTestBase {
 
     private OneInputStreamOperatorTestHarness<RowData, RowData> createTestHarness(
             ProcTimeDeduplicateKeepFirstRowFunction func) throws Exception {
@@ -42,7 +41,7 @@ public class ProcTimeDeduplicateKeepFirstRowFunctionTest
     }
 
     @Test
-    public void test() throws Exception {
+    void test() throws Exception {
         ProcTimeDeduplicateKeepFirstRowFunction func =
                 new ProcTimeDeduplicateKeepFirstRowFunction(minTime.toMilliseconds());
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
@@ -60,7 +59,7 @@ public class ProcTimeDeduplicateKeepFirstRowFunctionTest
     }
 
     @Test
-    public void testWithStateTtl() throws Exception {
+    void testWithStateTtl() throws Exception {
         ProcTimeDeduplicateKeepFirstRowFunction func =
                 new ProcTimeDeduplicateKeepFirstRowFunction(minTime.toMilliseconds());
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/ProcTimeDeduplicateKeepLastRowFunctionTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/ProcTimeDeduplicateKeepLastRowFunctionTest.java
@@ -23,7 +23,7 @@ import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.table.data.RowData;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -33,8 +33,7 @@ import static org.apache.flink.table.runtime.util.StreamRecordUtils.updateAfterR
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.updateBeforeRecord;
 
 /** Tests for {@link ProcTimeDeduplicateKeepLastRowFunction}. */
-public class ProcTimeDeduplicateKeepLastRowFunctionTest
-        extends ProcTimeDeduplicateFunctionTestBase {
+class ProcTimeDeduplicateKeepLastRowFunctionTest extends ProcTimeDeduplicateFunctionTestBase {
     private ProcTimeDeduplicateKeepLastRowFunction createFunctionWithoutStateTtl(
             boolean generateUpdateBefore, boolean generateInsert) {
         return new ProcTimeDeduplicateKeepLastRowFunction(
@@ -60,7 +59,7 @@ public class ProcTimeDeduplicateKeepLastRowFunctionTest
     }
 
     @Test
-    public void testWithoutGenerateUpdateBefore() throws Exception {
+    void testWithoutGenerateUpdateBefore() throws Exception {
         ProcTimeDeduplicateKeepLastRowFunction func = createFunction(false, true);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
         testHarness.open();
@@ -78,7 +77,7 @@ public class ProcTimeDeduplicateKeepLastRowFunctionTest
     }
 
     @Test
-    public void testWithoutGenerateUpdateBeforeAndInsert() throws Exception {
+    void testWithoutGenerateUpdateBeforeAndInsert() throws Exception {
         ProcTimeDeduplicateKeepLastRowFunction func = createFunction(false, false);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
         testHarness.open();
@@ -96,7 +95,7 @@ public class ProcTimeDeduplicateKeepLastRowFunctionTest
     }
 
     @Test
-    public void testWithGenerateUpdateBefore() throws Exception {
+    void testWithGenerateUpdateBefore() throws Exception {
         ProcTimeDeduplicateKeepLastRowFunction func = createFunction(true, true);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
         testHarness.open();
@@ -115,7 +114,7 @@ public class ProcTimeDeduplicateKeepLastRowFunctionTest
     }
 
     @Test
-    public void testWithStateTtlDisabled() throws Exception {
+    void testWithStateTtlDisabled() throws Exception {
         ProcTimeDeduplicateKeepLastRowFunction func = createFunctionWithoutStateTtl(true, true);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
         testHarness.open();
@@ -132,7 +131,7 @@ public class ProcTimeDeduplicateKeepLastRowFunctionTest
     }
 
     @Test
-    public void testWithGenerateUpdateBeforeAndStateTtl() throws Exception {
+    void testWithGenerateUpdateBeforeAndStateTtl() throws Exception {
         ProcTimeDeduplicateKeepLastRowFunction func = createFunction(true, true);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
         testHarness.open();

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/ProcTimeMiniBatchDeduplicateKeepFirstRowFunctionTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/ProcTimeMiniBatchDeduplicateKeepFirstRowFunctionTest.java
@@ -27,7 +27,7 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.operators.bundle.KeyedMapBundleOperator;
 import org.apache.flink.table.runtime.operators.bundle.trigger.CountBundleTrigger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -36,7 +36,7 @@ import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link ProcTimeMiniBatchDeduplicateKeepFirstRowFunction}. */
-public class ProcTimeMiniBatchDeduplicateKeepFirstRowFunctionTest
+class ProcTimeMiniBatchDeduplicateKeepFirstRowFunctionTest
         extends ProcTimeDeduplicateFunctionTestBase {
 
     private TypeSerializer<RowData> typeSerializer =
@@ -51,7 +51,7 @@ public class ProcTimeMiniBatchDeduplicateKeepFirstRowFunctionTest
     }
 
     @Test
-    public void testKeepFirstRowWithGenerateUpdateBefore() throws Exception {
+    void testKeepFirstRowWithGenerateUpdateBefore() throws Exception {
         ProcTimeMiniBatchDeduplicateKeepFirstRowFunction func =
                 new ProcTimeMiniBatchDeduplicateKeepFirstRowFunction(
                         typeSerializer, minTime.toMilliseconds());
@@ -74,7 +74,7 @@ public class ProcTimeMiniBatchDeduplicateKeepFirstRowFunctionTest
     }
 
     @Test
-    public void testKeepFirstRowWithStateTtl() throws Exception {
+    void testKeepFirstRowWithStateTtl() throws Exception {
         ProcTimeMiniBatchDeduplicateKeepFirstRowFunction func =
                 new ProcTimeMiniBatchDeduplicateKeepFirstRowFunction(
                         typeSerializer, minTime.toMilliseconds());

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/ProcTimeMiniBatchDeduplicateKeepLastRowFunctionTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/ProcTimeMiniBatchDeduplicateKeepLastRowFunctionTest.java
@@ -27,7 +27,7 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.operators.bundle.KeyedMapBundleOperator;
 import org.apache.flink.table.runtime.operators.bundle.trigger.CountBundleTrigger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -38,7 +38,7 @@ import static org.apache.flink.table.runtime.util.StreamRecordUtils.updateBefore
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link ProcTimeMiniBatchDeduplicateKeepLastRowFunction}. */
-public class ProcTimeMiniBatchDeduplicateKeepLastRowFunctionTest
+class ProcTimeMiniBatchDeduplicateKeepLastRowFunctionTest
         extends ProcTimeDeduplicateFunctionTestBase {
 
     private TypeSerializer<RowData> typeSerializer =
@@ -66,7 +66,7 @@ public class ProcTimeMiniBatchDeduplicateKeepLastRowFunctionTest
     }
 
     @Test
-    public void testWithoutGenerateUpdateBefore() throws Exception {
+    void testWithoutGenerateUpdateBefore() throws Exception {
         ProcTimeMiniBatchDeduplicateKeepLastRowFunction func =
                 createFunction(false, true, minTime.toMilliseconds());
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
@@ -95,7 +95,7 @@ public class ProcTimeMiniBatchDeduplicateKeepLastRowFunctionTest
     }
 
     @Test
-    public void testWithoutGenerateUpdateBeforeAndInsert() throws Exception {
+    void testWithoutGenerateUpdateBeforeAndInsert() throws Exception {
         ProcTimeMiniBatchDeduplicateKeepLastRowFunction func =
                 createFunction(false, false, minTime.toMilliseconds());
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
@@ -124,7 +124,7 @@ public class ProcTimeMiniBatchDeduplicateKeepLastRowFunctionTest
     }
 
     @Test
-    public void testWithGenerateUpdateBefore() throws Exception {
+    void testWithGenerateUpdateBefore() throws Exception {
         ProcTimeMiniBatchDeduplicateKeepLastRowFunction func =
                 createFunction(true, true, minTime.toMilliseconds());
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
@@ -156,7 +156,7 @@ public class ProcTimeMiniBatchDeduplicateKeepLastRowFunctionTest
     }
 
     @Test
-    public void testWithGenerateUpdateBeforeAndStateTtl() throws Exception {
+    void testWithGenerateUpdateBeforeAndStateTtl() throws Exception {
         ProcTimeMiniBatchDeduplicateKeepLastRowFunction func =
                 createFunction(true, true, minTime.toMilliseconds());
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/RowTimeDeduplicateFunctionTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/RowTimeDeduplicateFunctionTest.java
@@ -54,7 +54,7 @@ class RowTimeDeduplicateFunctionTest extends RowTimeDeduplicateFunctionTestBase 
     }
 
     @Parameters(name = "miniBatchEnable = {0}")
-    static Collection<Boolean[]> runMode() {
+    private static Collection<Boolean[]> runMode() {
         return Arrays.asList(new Boolean[] {false}, new Boolean[] {true});
     }
 

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/RowTimeDeduplicateFunctionTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/RowTimeDeduplicateFunctionTest.java
@@ -25,11 +25,12 @@ import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.operators.bundle.KeyedMapBundleOperator;
 import org.apache.flink.table.runtime.operators.bundle.trigger.CountBundleTrigger;
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
 import org.apache.flink.types.RowKind;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -43,17 +44,22 @@ import static org.apache.flink.table.runtime.util.StreamRecordUtils.record;
  * Harness tests for {@link RowTimeDeduplicateFunction} and {@link
  * RowTimeMiniBatchDeduplicateFunction}.
  */
-@RunWith(Parameterized.class)
-public class RowTimeDeduplicateFunctionTest extends RowTimeDeduplicateFunctionTestBase {
+@ExtendWith(ParameterizedTestExtension.class)
+class RowTimeDeduplicateFunctionTest extends RowTimeDeduplicateFunctionTestBase {
 
     private final boolean miniBatchEnable;
 
-    public RowTimeDeduplicateFunctionTest(boolean miniBacthEnable) {
+    RowTimeDeduplicateFunctionTest(boolean miniBacthEnable) {
         this.miniBatchEnable = miniBacthEnable;
     }
 
-    @Test
-    public void testRowTimeDeduplicateKeepFirstRow() throws Exception {
+    @Parameters(name = "miniBatchEnable = {0}")
+    static Collection<Boolean[]> runMode() {
+        return Arrays.asList(new Boolean[] {false}, new Boolean[] {true});
+    }
+
+    @TestTemplate
+    void testRowTimeDeduplicateKeepFirstRow() throws Exception {
         List<Object> expectedOutput = new ArrayList<>();
         expectedOutput.add(record(RowKind.INSERT, "key1", 13, 99L));
         expectedOutput.add(record(RowKind.INSERT, "key2", 11, 101L));
@@ -86,8 +92,8 @@ public class RowTimeDeduplicateFunctionTest extends RowTimeDeduplicateFunctionTe
         testRowTimeDeduplicateKeepFirstRow(false, false, expectedOutput);
     }
 
-    @Test
-    public void testRowTimeDeduplicateKeepLastRow() throws Exception {
+    @TestTemplate
+    void testRowTimeDeduplicateKeepLastRow() throws Exception {
         List<Object> expectedOutput = new ArrayList<>();
         expectedOutput.add(record(RowKind.INSERT, "key1", 13, 99L));
         expectedOutput.add(record(RowKind.UPDATE_BEFORE, "key1", 13, 99L));
@@ -298,10 +304,5 @@ public class RowTimeDeduplicateFunctionTest extends RowTimeDeduplicateFunctionTe
 
         assertor.assertOutputEqualsSorted("output wrong.", expectedOutput, actualOutput);
         testHarness.close();
-    }
-
-    @Parameterized.Parameters(name = "miniBatchEnable = {0}")
-    public static Collection<Boolean[]> runMode() {
-        return Arrays.asList(new Boolean[] {false}, new Boolean[] {true});
     }
 }

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/RowTimeMiniBatchLatestChangeDeduplicateFunctionTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/RowTimeMiniBatchLatestChangeDeduplicateFunctionTest.java
@@ -24,7 +24,7 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.operators.bundle.KeyedMapBundleOperator;
 import org.apache.flink.table.runtime.operators.bundle.trigger.CountBundleTrigger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -35,11 +35,11 @@ import static org.apache.flink.table.runtime.util.StreamRecordUtils.updateBefore
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Harness tests for {@link RowTimeMiniBatchLatestChangeDeduplicateFunction}. */
-public class RowTimeMiniBatchLatestChangeDeduplicateFunctionTest
+class RowTimeMiniBatchLatestChangeDeduplicateFunctionTest
         extends RowTimeDeduplicateFunctionTestBase {
 
     @Test
-    public void testKeepLastRowWithoutGenerateUpdateBeforeAndWithGenerateInsert() throws Exception {
+    void testKeepLastRowWithoutGenerateUpdateBeforeAndWithGenerateInsert() throws Exception {
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
                 createTestHarness(false, true, true);
         testHarness.open();
@@ -65,8 +65,7 @@ public class RowTimeMiniBatchLatestChangeDeduplicateFunctionTest
     }
 
     @Test
-    public void testKeepLastRowWithoutGenerateUpdateBeforeAndWithoutGenerateInsert()
-            throws Exception {
+    void testKeepLastRowWithoutGenerateUpdateBeforeAndWithoutGenerateInsert() throws Exception {
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
                 createTestHarness(false, false, true);
         testHarness.open();
@@ -92,7 +91,7 @@ public class RowTimeMiniBatchLatestChangeDeduplicateFunctionTest
     }
 
     @Test
-    public void testKeepLastRowWithGenerateUpdateBeforeAndWithGenerateInsert() throws Exception {
+    void testKeepLastRowWithGenerateUpdateBeforeAndWithGenerateInsert() throws Exception {
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
                 createTestHarness(true, true, true);
         testHarness.open();
@@ -119,7 +118,7 @@ public class RowTimeMiniBatchLatestChangeDeduplicateFunctionTest
     }
 
     @Test
-    public void testKeepLastRowWithGenerateUpdateBeforeAndWithoutGenerateInsert() throws Exception {
+    void testKeepLastRowWithGenerateUpdateBeforeAndWithoutGenerateInsert() throws Exception {
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
                 createTestHarness(true, false, true);
         testHarness.open();
@@ -146,7 +145,7 @@ public class RowTimeMiniBatchLatestChangeDeduplicateFunctionTest
     }
 
     @Test
-    public void testKeepLastRowWithGenerateUpdateBeforeAndWithGenerateInsertAndStateTtl()
+    void testKeepLastRowWithGenerateUpdateBeforeAndWithGenerateInsertAndStateTtl()
             throws Exception {
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
                 createTestHarness(true, true, true);
@@ -176,8 +175,7 @@ public class RowTimeMiniBatchLatestChangeDeduplicateFunctionTest
     }
 
     @Test
-    public void testKeepFirstRowWithoutGenerateUpdateBeforeAndWithGenerateInsert()
-            throws Exception {
+    void testKeepFirstRowWithoutGenerateUpdateBeforeAndWithGenerateInsert() throws Exception {
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
                 createTestHarness(false, true, false);
         testHarness.open();
@@ -202,8 +200,7 @@ public class RowTimeMiniBatchLatestChangeDeduplicateFunctionTest
     }
 
     @Test
-    public void testKeepFirstRowWithoutGenerateUpdateBeforeAndWithoutGenerateInsert()
-            throws Exception {
+    void testKeepFirstRowWithoutGenerateUpdateBeforeAndWithoutGenerateInsert() throws Exception {
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
                 createTestHarness(false, false, false);
         testHarness.open();
@@ -228,7 +225,7 @@ public class RowTimeMiniBatchLatestChangeDeduplicateFunctionTest
     }
 
     @Test
-    public void testKeepFirstRowWithGenerateUpdateBeforeAndWithGenerateInsert() throws Exception {
+    void testKeepFirstRowWithGenerateUpdateBeforeAndWithGenerateInsert() throws Exception {
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
                 createTestHarness(true, true, false);
         testHarness.open();
@@ -253,8 +250,7 @@ public class RowTimeMiniBatchLatestChangeDeduplicateFunctionTest
     }
 
     @Test
-    public void testKeepFirstRowWithGenerateUpdateBeforeAndWithoutGenerateInsert()
-            throws Exception {
+    void testKeepFirstRowWithGenerateUpdateBeforeAndWithoutGenerateInsert() throws Exception {
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
                 createTestHarness(true, false, false);
         testHarness.open();
@@ -279,7 +275,7 @@ public class RowTimeMiniBatchLatestChangeDeduplicateFunctionTest
     }
 
     @Test
-    public void testKeepFirstRowWithGenerateUpdateBeforeAndWithGenerateInsertAndStateTtl()
+    void testKeepFirstRowWithGenerateUpdateBeforeAndWithGenerateInsertAndStateTtl()
             throws Exception {
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
                 createTestHarness(true, true, false);

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/window/RowTimeWindowDeduplicateOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/window/RowTimeWindowDeduplicateOperatorTest.java
@@ -91,12 +91,12 @@ class RowTimeWindowDeduplicateOperatorTest {
     private static final ZoneId SHANGHAI_ZONE_ID = ZoneId.of("Asia/Shanghai");
     private final ZoneId shiftTimeZone;
 
-    public RowTimeWindowDeduplicateOperatorTest(ZoneId shiftTimeZone) {
+    RowTimeWindowDeduplicateOperatorTest(ZoneId shiftTimeZone) {
         this.shiftTimeZone = shiftTimeZone;
     }
 
     @Parameters(name = "TimeZone = {0}")
-    public static Collection<Object[]> runMode() {
+    private static Collection<Object[]> runMode() {
         return Arrays.asList(new Object[] {UTC_ZONE_ID}, new Object[] {SHANGHAI_ZONE_ID});
     }
 

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/window/RowTimeWindowDeduplicateOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/window/RowTimeWindowDeduplicateOperatorTest.java
@@ -35,10 +35,11 @@ import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.table.utils.HandwrittenSelectorUtil;
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.time.ZoneId;
 import java.util.Arrays;
@@ -53,8 +54,8 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for window deduplicate operators created by {@link
  * RowTimeWindowDeduplicateOperatorBuilder}.
  */
-@RunWith(Parameterized.class)
-public class RowTimeWindowDeduplicateOperatorTest {
+@ExtendWith(ParameterizedTestExtension.class)
+class RowTimeWindowDeduplicateOperatorTest {
 
     private static final RowType INPUT_ROW_TYPE =
             new RowType(
@@ -94,7 +95,7 @@ public class RowTimeWindowDeduplicateOperatorTest {
         this.shiftTimeZone = shiftTimeZone;
     }
 
-    @Parameterized.Parameters(name = "TimeZone = {0}")
+    @Parameters(name = "TimeZone = {0}")
     public static Collection<Object[]> runMode() {
         return Arrays.asList(new Object[] {UTC_ZONE_ID}, new Object[] {SHANGHAI_ZONE_ID});
     }
@@ -105,8 +106,8 @@ public class RowTimeWindowDeduplicateOperatorTest {
                 operator, KEY_SELECTOR, KEY_SELECTOR.getProducedType());
     }
 
-    @Test
-    public void testRowTimeWindowDeduplicateKeepFirstRow() throws Exception {
+    @TestTemplate
+    void testRowTimeWindowDeduplicateKeepFirstRow() throws Exception {
         WindowAggOperator<RowData, ?> operator =
                 RowTimeWindowDeduplicateOperatorBuilder.builder()
                         .inputSerializer(INPUT_ROW_SER)
@@ -204,8 +205,8 @@ public class RowTimeWindowDeduplicateOperatorTest {
         testHarness.close();
     }
 
-    @Test
-    public void testRowTimeWindowDeduplicateKeepLastRow() throws Exception {
+    @TestTemplate
+    void testRowTimeWindowDeduplicateKeepLastRow() throws Exception {
         WindowAggOperator<RowData, ?> operator =
                 RowTimeWindowDeduplicateOperatorBuilder.builder()
                         .inputSerializer(INPUT_ROW_SER)

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/AsyncLookupJoinHarnessTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/AsyncLookupJoinHarnessTest.java
@@ -82,10 +82,10 @@ class AsyncLookupJoinHarnessTest {
     private static final int ASYNC_BUFFER_CAPACITY = 100;
     private static final int ASYNC_TIMEOUT_MS = 3000;
 
-    public boolean orderedResult;
+    private boolean orderedResult;
 
     @Parameters(name = "ordered result = {0}")
-    static Object[] parameters() {
+    private static Object[] parameters() {
         return new Object[][] {new Object[] {true}, new Object[] {false}};
     }
 

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/AsyncLookupJoinHarnessTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/AsyncLookupJoinHarnessTest.java
@@ -49,11 +49,12 @@ import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
 import org.apache.flink.table.runtime.util.RowDataHarnessAssertor;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
 import org.apache.flink.util.Collector;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -75,16 +76,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 /** Harness tests for {@link LookupJoinRunner} and {@link LookupJoinWithCalcRunner}. */
-@RunWith(Parameterized.class)
-public class AsyncLookupJoinHarnessTest {
+@ExtendWith(ParameterizedTestExtension.class)
+class AsyncLookupJoinHarnessTest {
 
     private static final int ASYNC_BUFFER_CAPACITY = 100;
     private static final int ASYNC_TIMEOUT_MS = 3000;
 
-    @Parameterized.Parameter public boolean orderedResult;
+    public boolean orderedResult;
 
-    @Parameterized.Parameters(name = "ordered result = {0}")
-    public static Object[] parameters() {
+    @Parameters(name = "ordered result = {0}")
+    static Object[] parameters() {
         return new Object[][] {new Object[] {true}, new Object[] {false}};
     }
 
@@ -115,8 +116,8 @@ public class AsyncLookupJoinHarnessTest {
             (RowDataSerializer)
                     InternalSerializers.<RowData>create(rightRowDataType.getLogicalType());
 
-    @Test
-    public void testTemporalInnerAsyncJoin() throws Exception {
+    @TestTemplate
+    void testTemporalInnerAsyncJoin() throws Exception {
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
                 createHarness(JoinType.INNER_JOIN, FilterOnTable.WITHOUT_FILTER);
 
@@ -145,8 +146,8 @@ public class AsyncLookupJoinHarnessTest {
         checkResult(expectedOutput, testHarness.getOutput());
     }
 
-    @Test
-    public void testTemporalInnerAsyncJoinWithFilter() throws Exception {
+    @TestTemplate
+    void testTemporalInnerAsyncJoinWithFilter() throws Exception {
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
                 createHarness(JoinType.INNER_JOIN, FilterOnTable.WITH_FILTER);
 
@@ -174,8 +175,8 @@ public class AsyncLookupJoinHarnessTest {
         checkResult(expectedOutput, testHarness.getOutput());
     }
 
-    @Test
-    public void testTemporalLeftAsyncJoin() throws Exception {
+    @TestTemplate
+    void testTemporalLeftAsyncJoin() throws Exception {
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
                 createHarness(JoinType.LEFT_JOIN, FilterOnTable.WITHOUT_FILTER);
 
@@ -208,8 +209,8 @@ public class AsyncLookupJoinHarnessTest {
         checkResult(expectedOutput, testHarness.getOutput());
     }
 
-    @Test
-    public void testTemporalLeftAsyncJoinWithFilter() throws Exception {
+    @TestTemplate
+    void testTemporalLeftAsyncJoinWithFilter() throws Exception {
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
                 createHarness(JoinType.LEFT_JOIN, FilterOnTable.WITH_FILTER);
 
@@ -292,8 +293,8 @@ public class AsyncLookupJoinHarnessTest {
                 inSerializer);
     }
 
-    @Test
-    public void testCloseAsyncLookupJoinRunner() throws Exception {
+    @TestTemplate
+    void testCloseAsyncLookupJoinRunner() throws Exception {
         final AsyncLookupJoinRunner joinRunner =
                 new AsyncLookupJoinRunner(
                         new GeneratedFunctionWrapper(new TestingFetcherFunction()),

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/Int2AdaptiveHashJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/Int2AdaptiveHashJoinOperatorTest.java
@@ -20,7 +20,7 @@ package org.apache.flink.table.runtime.operators.join;
 
 import org.apache.flink.runtime.operators.testutils.UnionIterator;
 import org.apache.flink.table.data.binary.BinaryRowData;
-import org.apache.flink.table.runtime.hashtable.BinaryHashTableTest;
+import org.apache.flink.table.runtime.util.ConstantsKeyValuePairsIterator;
 import org.apache.flink.table.runtime.util.UniformBinaryRowGenerator;
 import org.apache.flink.util.MutableObjectIterator;
 
@@ -35,7 +35,7 @@ public class Int2AdaptiveHashJoinOperatorTest extends Int2HashJoinOperatorTestBa
     // ---------------------- build first inner join -----------------------------------------
     // ------------------- fallback to sort merge join in build or probe phase ---------------
     @Test
-    void testBuildFirstHashInnerJoinFallbackToSMJ() throws Exception {
+    protected void testBuildFirstHashInnerJoinFallbackToSMJ() throws Exception {
         // the following two values are known to have a hash-code collision on the first recursion
         // level. we use them to make sure one partition grows over-proportionally large
         final int repeatedValue1 = 405590;
@@ -52,11 +52,9 @@ public class Int2AdaptiveHashJoinOperatorTest extends Int2HashJoinOperatorTestBa
         MutableObjectIterator<BinaryRowData> build1 =
                 new UniformBinaryRowGenerator(numKeys1, buildValsPerKey, false);
         MutableObjectIterator<BinaryRowData> build2 =
-                new BinaryHashTableTest.ConstantsKeyValuePairsIterator(
-                        repeatedValue1, 17, repeatedValueCountBuild);
+                new ConstantsKeyValuePairsIterator(repeatedValue1, 17, repeatedValueCountBuild);
         MutableObjectIterator<BinaryRowData> build3 =
-                new BinaryHashTableTest.ConstantsKeyValuePairsIterator(
-                        repeatedValue2, 23, repeatedValueCountBuild);
+                new ConstantsKeyValuePairsIterator(repeatedValue2, 23, repeatedValueCountBuild);
         List<MutableObjectIterator<BinaryRowData>> builds = new ArrayList<>();
         builds.add(build1);
         builds.add(build2);
@@ -74,7 +72,7 @@ public class Int2AdaptiveHashJoinOperatorTest extends Int2HashJoinOperatorTestBa
     // ---------------------- build first left out join -----------------------------------------
     // -------------------- fallback to sort merge join in build or probe phase -----------------
     @Test
-    public void testBuildFirstHashLeftOutJoinFallbackToSMJ() throws Exception {
+    protected void testBuildFirstHashLeftOutJoinFallbackToSMJ() throws Exception {
         // the following two values are known to have a hash-code collision on the first recursion
         // level. we use them to make sure one partition grows over-proportionally large
         final int repeatedValue1 = 40559;
@@ -91,11 +89,9 @@ public class Int2AdaptiveHashJoinOperatorTest extends Int2HashJoinOperatorTestBa
         MutableObjectIterator<BinaryRowData> build1 =
                 new UniformBinaryRowGenerator(numKeys1, buildValsPerKey, false);
         MutableObjectIterator<BinaryRowData> build2 =
-                new BinaryHashTableTest.ConstantsKeyValuePairsIterator(
-                        repeatedValue1, 17, repeatedValueCountBuild);
+                new ConstantsKeyValuePairsIterator(repeatedValue1, 17, repeatedValueCountBuild);
         MutableObjectIterator<BinaryRowData> build3 =
-                new BinaryHashTableTest.ConstantsKeyValuePairsIterator(
-                        repeatedValue2, 23, repeatedValueCountBuild);
+                new ConstantsKeyValuePairsIterator(repeatedValue2, 23, repeatedValueCountBuild);
         List<MutableObjectIterator<BinaryRowData>> builds = new ArrayList<>();
         builds.add(build1);
         builds.add(build2);
@@ -117,7 +113,7 @@ public class Int2AdaptiveHashJoinOperatorTest extends Int2HashJoinOperatorTestBa
     // ---------------------- build first right out join -----------------------------------------
     // --------------------- fallback to sort merge join in build or probe phase -----------------
     @Test
-    void testBuildFirstHashRightOutJoinFallbackToSMJ() throws Exception {
+    protected void testBuildFirstHashRightOutJoinFallbackToSMJ() throws Exception {
         // the following two values are known to have a hash-code collision on the first recursion
         // level. we use them to make sure one partition grows over-proportionally large
         final int repeatedValue1 = 40559;
@@ -134,11 +130,9 @@ public class Int2AdaptiveHashJoinOperatorTest extends Int2HashJoinOperatorTestBa
         MutableObjectIterator<BinaryRowData> build1 =
                 new UniformBinaryRowGenerator(numKeys1, buildValsPerKey, false);
         MutableObjectIterator<BinaryRowData> build2 =
-                new BinaryHashTableTest.ConstantsKeyValuePairsIterator(
-                        repeatedValue1, 17, repeatedValueCountBuild);
+                new ConstantsKeyValuePairsIterator(repeatedValue1, 17, repeatedValueCountBuild);
         MutableObjectIterator<BinaryRowData> build3 =
-                new BinaryHashTableTest.ConstantsKeyValuePairsIterator(
-                        repeatedValue2, 23, repeatedValueCountBuild);
+                new ConstantsKeyValuePairsIterator(repeatedValue2, 23, repeatedValueCountBuild);
         List<MutableObjectIterator<BinaryRowData>> builds = new ArrayList<>();
         builds.add(build1);
         builds.add(build2);
@@ -156,7 +150,7 @@ public class Int2AdaptiveHashJoinOperatorTest extends Int2HashJoinOperatorTestBa
     // ---------------------- build first full out join -----------------------------------------
     // --------------------- fallback to sort merge join in build or probe phase ----------------
     @Test
-    public void testBuildFirstHashFullOutJoinFallbackToSMJ() throws Exception {
+    protected void testBuildFirstHashFullOutJoinFallbackToSMJ() throws Exception {
         // the following two values are known to have a hash-code collision on the first recursion
         // level. we use them to make sure one partition grows over-proportionally large
         final int repeatedValue1 = 40559;
@@ -173,11 +167,9 @@ public class Int2AdaptiveHashJoinOperatorTest extends Int2HashJoinOperatorTestBa
         MutableObjectIterator<BinaryRowData> build1 =
                 new UniformBinaryRowGenerator(numKeys1, buildValsPerKey, false);
         MutableObjectIterator<BinaryRowData> build2 =
-                new BinaryHashTableTest.ConstantsKeyValuePairsIterator(
-                        repeatedValue1, 17, repeatedValueCountBuild);
+                new ConstantsKeyValuePairsIterator(repeatedValue1, 17, repeatedValueCountBuild);
         MutableObjectIterator<BinaryRowData> build3 =
-                new BinaryHashTableTest.ConstantsKeyValuePairsIterator(
-                        repeatedValue2, 23, repeatedValueCountBuild);
+                new ConstantsKeyValuePairsIterator(repeatedValue2, 23, repeatedValueCountBuild);
         List<MutableObjectIterator<BinaryRowData>> builds = new ArrayList<>();
         builds.add(build1);
         builds.add(build2);
@@ -199,7 +191,7 @@ public class Int2AdaptiveHashJoinOperatorTest extends Int2HashJoinOperatorTestBa
     // ---------------------- build second left out join -----------------------------------------
     // ---------------------- switch to sort merge join in build or probe phase ------------------
     @Test
-    void testBuildSecondHashLeftOutJoinFallbackToSMJ() throws Exception {
+    protected void testBuildSecondHashLeftOutJoinFallbackToSMJ() throws Exception {
         // the following two values are known to have a hash-code collision on the first recursion
         // level. we use them to make sure one partition grows over-proportionally large
         final int repeatedValue1 = 40559;
@@ -216,11 +208,9 @@ public class Int2AdaptiveHashJoinOperatorTest extends Int2HashJoinOperatorTestBa
         MutableObjectIterator<BinaryRowData> build1 =
                 new UniformBinaryRowGenerator(numKeys1, buildValsPerKey, false);
         MutableObjectIterator<BinaryRowData> build2 =
-                new BinaryHashTableTest.ConstantsKeyValuePairsIterator(
-                        repeatedValue1, 17, repeatedValueCountBuild);
+                new ConstantsKeyValuePairsIterator(repeatedValue1, 17, repeatedValueCountBuild);
         MutableObjectIterator<BinaryRowData> build3 =
-                new BinaryHashTableTest.ConstantsKeyValuePairsIterator(
-                        repeatedValue2, 23, repeatedValueCountBuild);
+                new ConstantsKeyValuePairsIterator(repeatedValue2, 23, repeatedValueCountBuild);
         List<MutableObjectIterator<BinaryRowData>> builds = new ArrayList<>();
         builds.add(build1);
         builds.add(build2);
@@ -238,7 +228,7 @@ public class Int2AdaptiveHashJoinOperatorTest extends Int2HashJoinOperatorTestBa
     // ---------------------- build second right out join -----------------------------------------
     // ---------------------- switch to sort merge join in build or probe phase -------------------
     @Test
-    public void testBuildSecondHashRightOutJoinFallbackToSMJ() throws Exception {
+    protected void testBuildSecondHashRightOutJoinFallbackToSMJ() throws Exception {
         // the following two values are known to have a hash-code collision on the first recursion
         // level. we use them to make sure one partition grows over-proportionally large
         final int repeatedValue1 = 40559;
@@ -255,11 +245,9 @@ public class Int2AdaptiveHashJoinOperatorTest extends Int2HashJoinOperatorTestBa
         MutableObjectIterator<BinaryRowData> build1 =
                 new UniformBinaryRowGenerator(numKeys1, buildValsPerKey, false);
         MutableObjectIterator<BinaryRowData> build2 =
-                new BinaryHashTableTest.ConstantsKeyValuePairsIterator(
-                        repeatedValue1, 17, repeatedValueCountBuild);
+                new ConstantsKeyValuePairsIterator(repeatedValue1, 17, repeatedValueCountBuild);
         MutableObjectIterator<BinaryRowData> build3 =
-                new BinaryHashTableTest.ConstantsKeyValuePairsIterator(
-                        repeatedValue2, 23, repeatedValueCountBuild);
+                new ConstantsKeyValuePairsIterator(repeatedValue2, 23, repeatedValueCountBuild);
         List<MutableObjectIterator<BinaryRowData>> builds = new ArrayList<>();
         builds.add(build1);
         builds.add(build2);
@@ -276,7 +264,7 @@ public class Int2AdaptiveHashJoinOperatorTest extends Int2HashJoinOperatorTestBa
 
     // ---------------------- switch to sort merge join in build or probe phase ------------------
     @Test
-    void testSemiJoinFallbackToSMJ() throws Exception {
+    protected void testSemiJoinFallbackToSMJ() throws Exception {
         // the following two values are known to have a hash-code collision on the first recursion
         // level. we use them to make sure one partition grows over-proportionally large
         final int repeatedValue1 = 40559;
@@ -293,11 +281,9 @@ public class Int2AdaptiveHashJoinOperatorTest extends Int2HashJoinOperatorTestBa
         MutableObjectIterator<BinaryRowData> build1 =
                 new UniformBinaryRowGenerator(numKeys1, buildValsPerKey, false);
         MutableObjectIterator<BinaryRowData> build2 =
-                new BinaryHashTableTest.ConstantsKeyValuePairsIterator(
-                        repeatedValue1, 17, repeatedValueCountBuild);
+                new ConstantsKeyValuePairsIterator(repeatedValue1, 17, repeatedValueCountBuild);
         MutableObjectIterator<BinaryRowData> build3 =
-                new BinaryHashTableTest.ConstantsKeyValuePairsIterator(
-                        repeatedValue2, 23, repeatedValueCountBuild);
+                new ConstantsKeyValuePairsIterator(repeatedValue2, 23, repeatedValueCountBuild);
         List<MutableObjectIterator<BinaryRowData>> builds = new ArrayList<>();
         builds.add(build1);
         builds.add(build2);
@@ -316,7 +302,7 @@ public class Int2AdaptiveHashJoinOperatorTest extends Int2HashJoinOperatorTestBa
 
     // ---------------------- fallback to sort merge join in build or probe phase ------------------
     @Test
-    void testAntiJoinFallbackToSMJ() throws Exception {
+    protected void testAntiJoinFallbackToSMJ() throws Exception {
         // the following two values are known to have a hash-code collision on the first recursion
         // level. we use them to make sure one partition grows over-proportionally large
         final int repeatedValue1 = 40559;
@@ -333,11 +319,9 @@ public class Int2AdaptiveHashJoinOperatorTest extends Int2HashJoinOperatorTestBa
         MutableObjectIterator<BinaryRowData> build1 =
                 new UniformBinaryRowGenerator(numKeys1, buildValsPerKey, false);
         MutableObjectIterator<BinaryRowData> build2 =
-                new BinaryHashTableTest.ConstantsKeyValuePairsIterator(
-                        repeatedValue1, 17, repeatedValueCountBuild);
+                new ConstantsKeyValuePairsIterator(repeatedValue1, 17, repeatedValueCountBuild);
         MutableObjectIterator<BinaryRowData> build3 =
-                new BinaryHashTableTest.ConstantsKeyValuePairsIterator(
-                        repeatedValue2, 23, repeatedValueCountBuild);
+                new ConstantsKeyValuePairsIterator(repeatedValue2, 23, repeatedValueCountBuild);
         List<MutableObjectIterator<BinaryRowData>> builds = new ArrayList<>();
         builds.add(build1);
         builds.add(build2);
@@ -357,7 +341,7 @@ public class Int2AdaptiveHashJoinOperatorTest extends Int2HashJoinOperatorTestBa
 
     // ---------------------- fallback to sort merge join in build or probe phase ------------------
     @Test
-    public void testBuildLeftSemiJoinFallbackToSMJ() throws Exception {
+    protected void testBuildLeftSemiJoinFallbackToSMJ() throws Exception {
         // the following two values are known to have a hash-code collision on the first recursion
         // level. we use them to make sure one partition grows over-proportionally large
         final int repeatedValue1 = 405;
@@ -374,11 +358,9 @@ public class Int2AdaptiveHashJoinOperatorTest extends Int2HashJoinOperatorTestBa
         MutableObjectIterator<BinaryRowData> build1 =
                 new UniformBinaryRowGenerator(numKeys1, buildValsPerKey, false);
         MutableObjectIterator<BinaryRowData> build2 =
-                new BinaryHashTableTest.ConstantsKeyValuePairsIterator(
-                        repeatedValue1, 17, repeatedValueCountBuild);
+                new ConstantsKeyValuePairsIterator(repeatedValue1, 17, repeatedValueCountBuild);
         MutableObjectIterator<BinaryRowData> build3 =
-                new BinaryHashTableTest.ConstantsKeyValuePairsIterator(
-                        repeatedValue2, 23, repeatedValueCountBuild);
+                new ConstantsKeyValuePairsIterator(repeatedValue2, 23, repeatedValueCountBuild);
         List<MutableObjectIterator<BinaryRowData>> builds = new ArrayList<>();
         builds.add(build1);
         builds.add(build2);
@@ -403,7 +385,7 @@ public class Int2AdaptiveHashJoinOperatorTest extends Int2HashJoinOperatorTestBa
 
     // ---------------------- fallback to sort merge join in build or probe phase ------------------
     @Test
-    public void testBuildLeftAntiJoinFallbackToSMJ() throws Exception {
+    protected void testBuildLeftAntiJoinFallbackToSMJ() throws Exception {
         // the following two values are known to have a hash-code collision on the first recursion
         // level. we use them to make sure one partition grows over-proportionally large
         final int repeatedValue1 = 40559;
@@ -420,11 +402,9 @@ public class Int2AdaptiveHashJoinOperatorTest extends Int2HashJoinOperatorTestBa
         MutableObjectIterator<BinaryRowData> build1 =
                 new UniformBinaryRowGenerator(numKeys1, buildValsPerKey, false);
         MutableObjectIterator<BinaryRowData> build2 =
-                new BinaryHashTableTest.ConstantsKeyValuePairsIterator(
-                        repeatedValue1, 17, repeatedValueCountBuild);
+                new ConstantsKeyValuePairsIterator(repeatedValue1, 17, repeatedValueCountBuild);
         MutableObjectIterator<BinaryRowData> build3 =
-                new BinaryHashTableTest.ConstantsKeyValuePairsIterator(
-                        repeatedValue2, 23, repeatedValueCountBuild);
+                new ConstantsKeyValuePairsIterator(repeatedValue2, 23, repeatedValueCountBuild);
         List<MutableObjectIterator<BinaryRowData>> builds = new ArrayList<>();
         builds.add(build1);
         builds.add(build2);

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/Int2AdaptiveHashJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/Int2AdaptiveHashJoinOperatorTest.java
@@ -24,7 +24,7 @@ import org.apache.flink.table.runtime.hashtable.BinaryHashTableTest;
 import org.apache.flink.table.runtime.util.UniformBinaryRowGenerator;
 import org.apache.flink.util.MutableObjectIterator;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -35,7 +35,7 @@ public class Int2AdaptiveHashJoinOperatorTest extends Int2HashJoinOperatorTestBa
     // ---------------------- build first inner join -----------------------------------------
     // ------------------- fallback to sort merge join in build or probe phase ---------------
     @Test
-    public void testBuildFirstHashInnerJoinFallbackToSMJ() throws Exception {
+    void testBuildFirstHashInnerJoinFallbackToSMJ() throws Exception {
         // the following two values are known to have a hash-code collision on the first recursion
         // level. we use them to make sure one partition grows over-proportionally large
         final int repeatedValue1 = 405590;
@@ -117,7 +117,7 @@ public class Int2AdaptiveHashJoinOperatorTest extends Int2HashJoinOperatorTestBa
     // ---------------------- build first right out join -----------------------------------------
     // --------------------- fallback to sort merge join in build or probe phase -----------------
     @Test
-    public void testBuildFirstHashRightOutJoinFallbackToSMJ() throws Exception {
+    void testBuildFirstHashRightOutJoinFallbackToSMJ() throws Exception {
         // the following two values are known to have a hash-code collision on the first recursion
         // level. we use them to make sure one partition grows over-proportionally large
         final int repeatedValue1 = 40559;
@@ -199,7 +199,7 @@ public class Int2AdaptiveHashJoinOperatorTest extends Int2HashJoinOperatorTestBa
     // ---------------------- build second left out join -----------------------------------------
     // ---------------------- switch to sort merge join in build or probe phase ------------------
     @Test
-    public void testBuildSecondHashLeftOutJoinFallbackToSMJ() throws Exception {
+    void testBuildSecondHashLeftOutJoinFallbackToSMJ() throws Exception {
         // the following two values are known to have a hash-code collision on the first recursion
         // level. we use them to make sure one partition grows over-proportionally large
         final int repeatedValue1 = 40559;
@@ -276,7 +276,7 @@ public class Int2AdaptiveHashJoinOperatorTest extends Int2HashJoinOperatorTestBa
 
     // ---------------------- switch to sort merge join in build or probe phase ------------------
     @Test
-    public void testSemiJoinFallbackToSMJ() throws Exception {
+    void testSemiJoinFallbackToSMJ() throws Exception {
         // the following two values are known to have a hash-code collision on the first recursion
         // level. we use them to make sure one partition grows over-proportionally large
         final int repeatedValue1 = 40559;
@@ -316,7 +316,7 @@ public class Int2AdaptiveHashJoinOperatorTest extends Int2HashJoinOperatorTestBa
 
     // ---------------------- fallback to sort merge join in build or probe phase ------------------
     @Test
-    public void testAntiJoinFallbackToSMJ() throws Exception {
+    void testAntiJoinFallbackToSMJ() throws Exception {
         // the following two values are known to have a hash-code collision on the first recursion
         // level. we use them to make sure one partition grows over-proportionally large
         final int repeatedValue1 = 40559;

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/Int2HashJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/Int2HashJoinOperatorTest.java
@@ -29,8 +29,7 @@ public class Int2HashJoinOperatorTest extends Int2HashJoinOperatorTestBase {
 
     // ---------------------- build first inner join -----------------------------------------
     @Test
-    public void testBuildFirstHashInnerJoin() throws Exception {
-
+    protected void testBuildFirstHashInnerJoin() throws Exception {
         int numKeys = 100;
         int buildValsPerKey = 3;
         int probeValsPerKey = 10;
@@ -52,8 +51,7 @@ public class Int2HashJoinOperatorTest extends Int2HashJoinOperatorTestBase {
 
     // ---------------------- build first left out join -----------------------------------------
     @Test
-    public void testBuildFirstHashLeftOutJoin() throws Exception {
-
+    protected void testBuildFirstHashLeftOutJoin() throws Exception {
         int numKeys1 = 9;
         int numKeys2 = 10;
         int buildValsPerKey = 3;
@@ -76,8 +74,7 @@ public class Int2HashJoinOperatorTest extends Int2HashJoinOperatorTestBase {
 
     // ---------------------- build first right out join -----------------------------------------
     @Test
-    public void testBuildFirstHashRightOutJoin() throws Exception {
-
+    protected void testBuildFirstHashRightOutJoin() throws Exception {
         int numKeys1 = 9;
         int numKeys2 = 10;
         int buildValsPerKey = 3;
@@ -92,8 +89,7 @@ public class Int2HashJoinOperatorTest extends Int2HashJoinOperatorTestBase {
 
     // ---------------------- build first full out join -----------------------------------------
     @Test
-    public void testBuildFirstHashFullOutJoin() throws Exception {
-
+    protected void testBuildFirstHashFullOutJoin() throws Exception {
         int numKeys1 = 9;
         int numKeys2 = 10;
         int buildValsPerKey = 3;
@@ -108,8 +104,7 @@ public class Int2HashJoinOperatorTest extends Int2HashJoinOperatorTestBase {
 
     // ---------------------- build second inner join -----------------------------------------
     @Test
-    public void testBuildSecondHashInnerJoin() throws Exception {
-
+    protected void testBuildSecondHashInnerJoin() throws Exception {
         int numKeys = 100;
         int buildValsPerKey = 3;
         int probeValsPerKey = 10;
@@ -131,8 +126,7 @@ public class Int2HashJoinOperatorTest extends Int2HashJoinOperatorTestBase {
 
     // ---------------------- build second left out join -----------------------------------------
     @Test
-    public void testBuildSecondHashLeftOutJoin() throws Exception {
-
+    protected void testBuildSecondHashLeftOutJoin() throws Exception {
         int numKeys1 = 10;
         int numKeys2 = 9;
         int buildValsPerKey = 3;
@@ -155,8 +149,7 @@ public class Int2HashJoinOperatorTest extends Int2HashJoinOperatorTestBase {
 
     // ---------------------- build second right out join -----------------------------------------
     @Test
-    public void testBuildSecondHashRightOutJoin() throws Exception {
-
+    protected void testBuildSecondHashRightOutJoin() throws Exception {
         int numKeys1 = 9;
         int numKeys2 = 10;
         int buildValsPerKey = 3;
@@ -179,8 +172,7 @@ public class Int2HashJoinOperatorTest extends Int2HashJoinOperatorTestBase {
 
     // ---------------------- build second full out join -----------------------------------------
     @Test
-    public void testBuildSecondHashFullOutJoin() throws Exception {
-
+    protected void testBuildSecondHashFullOutJoin() throws Exception {
         int numKeys1 = 9;
         int numKeys2 = 10;
         int buildValsPerKey = 3;
@@ -194,8 +186,7 @@ public class Int2HashJoinOperatorTest extends Int2HashJoinOperatorTestBase {
     }
 
     @Test
-    public void testSemiJoin() throws Exception {
-
+    protected void testSemiJoin() throws Exception {
         int numKeys1 = 9;
         int numKeys2 = 10;
         int buildValsPerKey = 3;
@@ -211,8 +202,7 @@ public class Int2HashJoinOperatorTest extends Int2HashJoinOperatorTestBase {
     }
 
     @Test
-    public void testAntiJoin() throws Exception {
-
+    protected void testAntiJoin() throws Exception {
         int numKeys1 = 9;
         int numKeys2 = 10;
         int buildValsPerKey = 3;
@@ -228,7 +218,7 @@ public class Int2HashJoinOperatorTest extends Int2HashJoinOperatorTestBase {
     }
 
     @Test
-    public void testBuildLeftSemiJoin() throws Exception {
+    protected void testBuildLeftSemiJoin() throws Exception {
         int numKeys1 = 10;
         int numKeys2 = 9;
         int buildValsPerKey = 10;
@@ -249,7 +239,7 @@ public class Int2HashJoinOperatorTest extends Int2HashJoinOperatorTestBase {
     }
 
     @Test
-    public void testBuildLeftAntiJoin() throws Exception {
+    protected void testBuildLeftAntiJoin() throws Exception {
         int numKeys1 = 10;
         int numKeys2 = 9;
         int buildValsPerKey = 10;

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/Int2HashJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/Int2HashJoinOperatorTest.java
@@ -22,7 +22,7 @@ import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.runtime.util.UniformBinaryRowGenerator;
 import org.apache.flink.util.MutableObjectIterator;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Random test for {@link HashJoinOperator}. */
 public class Int2HashJoinOperatorTest extends Int2HashJoinOperatorTestBase {

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/Int2HashJoinOperatorTestBase.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/Int2HashJoinOperatorTestBase.java
@@ -58,7 +58,7 @@ import static org.apache.flink.table.runtime.util.JoinUtil.getJoinType;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Base test class for {@link HashJoinOperator}. */
-public abstract class Int2HashJoinOperatorTestBase implements Serializable {
+abstract class Int2HashJoinOperatorTestBase implements Serializable {
 
     public void buildJoin(
             MutableObjectIterator<BinaryRowData> buildInput,

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/Int2SortMergeJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/Int2SortMergeJoinOperatorTest.java
@@ -37,13 +37,14 @@ import org.apache.flink.table.runtime.operators.join.Int2HashJoinOperatorTestBas
 import org.apache.flink.table.runtime.operators.sort.IntNormalizedKeyComputer;
 import org.apache.flink.table.runtime.operators.sort.IntRecordComparator;
 import org.apache.flink.table.runtime.util.UniformBinaryRowGenerator;
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
 import org.apache.flink.util.MutableObjectIterator;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -52,8 +53,8 @@ import static org.apache.flink.table.runtime.operators.join.Int2HashJoinOperator
 import static org.assertj.core.api.Assertions.fail;
 
 /** Random test for {@link SortMergeJoinOperator}. */
-@RunWith(Parameterized.class)
-public class Int2SortMergeJoinOperatorTest {
+@ExtendWith(ParameterizedTestExtension.class)
+class Int2SortMergeJoinOperatorTest {
 
     private boolean leftIsSmaller;
 
@@ -64,19 +65,19 @@ public class Int2SortMergeJoinOperatorTest {
         this.leftIsSmaller = leftIsSmaller;
     }
 
-    @Parameterized.Parameters
-    public static Collection<Boolean> parameters() {
+    @Parameters(name = "leftIsSmaller={0}")
+    static Collection<Boolean> parameters() {
         return Arrays.asList(true, false);
     }
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         this.memManager = MemoryManagerBuilder.newBuilder().setMemorySize(36 * 1024 * 1024).build();
         this.ioManager = new IOManagerAsync();
     }
 
-    @After
-    public void tearDown() throws Exception {
+    @AfterEach
+    void tearDown() throws Exception {
         // shut down I/O manager and Memory Manager and verify the correct shutdown
         this.ioManager.close();
         if (!this.memManager.verifyEmpty()) {
@@ -84,8 +85,8 @@ public class Int2SortMergeJoinOperatorTest {
         }
     }
 
-    @Test
-    public void testInnerJoin() throws Exception {
+    @TestTemplate
+    void testInnerJoin() throws Exception {
         int numKeys = 100;
         int buildValsPerKey = 3;
         int probeValsPerKey = 10;
@@ -104,8 +105,8 @@ public class Int2SortMergeJoinOperatorTest {
                 165);
     }
 
-    @Test
-    public void testLeftOutJoin() throws Exception {
+    @TestTemplate
+    void testLeftOutJoin() throws Exception {
 
         int numKeys1 = 9;
         int numKeys2 = 10;
@@ -126,8 +127,8 @@ public class Int2SortMergeJoinOperatorTest {
                 165);
     }
 
-    @Test
-    public void testRightOutJoin() throws Exception {
+    @TestTemplate
+    void testRightOutJoin() throws Exception {
         int numKeys1 = 9;
         int numKeys2 = 10;
         int buildValsPerKey = 3;
@@ -141,8 +142,8 @@ public class Int2SortMergeJoinOperatorTest {
         buildJoin(buildInput, probeInput, FlinkJoinType.RIGHT, 280, numKeys2, -1);
     }
 
-    @Test
-    public void testFullOutJoin() throws Exception {
+    @TestTemplate
+    void testFullOutJoin() throws Exception {
         int numKeys1 = 9;
         int numKeys2 = 10;
         int buildValsPerKey = 3;
@@ -156,8 +157,8 @@ public class Int2SortMergeJoinOperatorTest {
         buildJoin(buildInput, probeInput, FlinkJoinType.FULL, 280, numKeys2, -1);
     }
 
-    @Test
-    public void testSemiJoin() throws Exception {
+    @TestTemplate
+    void testSemiJoin() throws Exception {
 
         int numKeys1 = 10;
         int numKeys2 = 9;
@@ -172,8 +173,8 @@ public class Int2SortMergeJoinOperatorTest {
         joinAndAssert(operator, buildInput, probeInput, 90, 9, 45, true);
     }
 
-    @Test
-    public void testAntiJoin() throws Exception {
+    @TestTemplate
+    void testAntiJoin() throws Exception {
 
         int numKeys1 = 10;
         int numKeys2 = 9;

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/Int2SortMergeJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/Int2SortMergeJoinOperatorTest.java
@@ -66,7 +66,7 @@ class Int2SortMergeJoinOperatorTest {
     }
 
     @Parameters(name = "leftIsSmaller={0}")
-    static Collection<Boolean> parameters() {
+    private static Collection<Boolean> parameters() {
         return Arrays.asList(true, false);
     }
 

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/KeyedLookupJoinHarnessTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/KeyedLookupJoinHarnessTest.java
@@ -44,7 +44,7 @@ import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.table.utils.HandwrittenSelectorUtil;
 import org.apache.flink.util.Collector;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -60,7 +60,7 @@ import static org.apache.flink.table.runtime.util.StreamRecordUtils.updateAfterR
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.updateBeforeRecord;
 
 /** Harness tests for {@link KeyedLookupJoinWrapper}. */
-public class KeyedLookupJoinHarnessTest {
+class KeyedLookupJoinHarnessTest {
 
     private final InternalTypeInfo<RowData> inputRowType =
             InternalTypeInfo.ofFields(new IntType(), VarCharType.STRING_TYPE);
@@ -75,7 +75,7 @@ public class KeyedLookupJoinHarnessTest {
                     });
 
     @Test
-    public void testTemporalInnerJoin() throws Exception {
+    void testTemporalInnerJoin() throws Exception {
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
                 createHarness(JoinType.INNER_JOIN, FilterOnTable.WITHOUT_FILTER, false);
 
@@ -112,7 +112,7 @@ public class KeyedLookupJoinHarnessTest {
     }
 
     @Test
-    public void testTemporalInnerJoinLookupKeyContainsPk() throws Exception {
+    void testTemporalInnerJoinLookupKeyContainsPk() throws Exception {
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
                 createHarness(JoinType.INNER_JOIN, FilterOnTable.WITHOUT_FILTER, true);
 
@@ -146,7 +146,7 @@ public class KeyedLookupJoinHarnessTest {
     }
 
     @Test
-    public void testTemporalInnerJoinWithFilter() throws Exception {
+    void testTemporalInnerJoinWithFilter() throws Exception {
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
                 createHarness(JoinType.INNER_JOIN, FilterOnTable.WITH_FILTER, false);
 
@@ -179,7 +179,7 @@ public class KeyedLookupJoinHarnessTest {
     }
 
     @Test
-    public void testTemporalInnerJoinWithFilterLookupKeyContainsPk() throws Exception {
+    void testTemporalInnerJoinWithFilterLookupKeyContainsPk() throws Exception {
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
                 createHarness(JoinType.INNER_JOIN, FilterOnTable.WITH_FILTER, true);
 
@@ -207,7 +207,7 @@ public class KeyedLookupJoinHarnessTest {
     }
 
     @Test
-    public void testTemporalLeftJoin() throws Exception {
+    void testTemporalLeftJoin() throws Exception {
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
                 createHarness(JoinType.LEFT_JOIN, FilterOnTable.WITHOUT_FILTER, false);
 
@@ -238,7 +238,7 @@ public class KeyedLookupJoinHarnessTest {
     }
 
     @Test
-    public void testTemporalLeftJoinLookupKeyContainsPk() throws Exception {
+    void testTemporalLeftJoinLookupKeyContainsPk() throws Exception {
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
                 createHarness(JoinType.LEFT_JOIN, FilterOnTable.WITHOUT_FILTER, true);
 
@@ -268,7 +268,7 @@ public class KeyedLookupJoinHarnessTest {
     }
 
     @Test
-    public void testTemporalLeftJoinWithFilter() throws Exception {
+    void testTemporalLeftJoinWithFilter() throws Exception {
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
                 createHarness(JoinType.LEFT_JOIN, FilterOnTable.WITH_FILTER, false);
 
@@ -311,7 +311,7 @@ public class KeyedLookupJoinHarnessTest {
     }
 
     @Test
-    public void testTemporalLeftJoinWithFilterLookupKeyContainsPk() throws Exception {
+    void testTemporalLeftJoinWithFilterLookupKeyContainsPk() throws Exception {
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
                 createHarness(JoinType.LEFT_JOIN, FilterOnTable.WITH_FILTER, true);
 
@@ -351,7 +351,7 @@ public class KeyedLookupJoinHarnessTest {
     }
 
     @Test
-    public void testTemporalLeftJoinWithTtlLookupKeyContainsPk() throws Exception {
+    void testTemporalLeftJoinWithTtlLookupKeyContainsPk() throws Exception {
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
                 createHarness(JoinType.LEFT_JOIN, FilterOnTable.WITH_FILTER, true, 1_000);
 
@@ -385,7 +385,7 @@ public class KeyedLookupJoinHarnessTest {
     }
 
     @Test
-    public void testTemporalInnerJoinWithTtlLookupKeyContainsPk() throws Exception {
+    void testTemporalInnerJoinWithTtlLookupKeyContainsPk() throws Exception {
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
                 createHarness(JoinType.INNER_JOIN, FilterOnTable.WITH_FILTER, true, 1_000);
 

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/LookupJoinHarnessTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/LookupJoinHarnessTest.java
@@ -43,7 +43,7 @@ import org.apache.flink.table.runtime.util.RowDataHarnessAssertor;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.util.Collector;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -56,7 +56,7 @@ import static org.apache.flink.table.data.StringData.fromString;
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord;
 
 /** Harness tests for {@link LookupJoinRunner} and {@link LookupJoinWithCalcRunner}. */
-public class LookupJoinHarnessTest {
+class LookupJoinHarnessTest {
 
     private final TypeSerializer<RowData> inSerializer =
             new RowDataSerializer(
@@ -72,7 +72,7 @@ public class LookupJoinHarnessTest {
                     });
 
     @Test
-    public void testTemporalInnerJoin() throws Exception {
+    void testTemporalInnerJoin() throws Exception {
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
                 createHarness(JoinType.INNER_JOIN, FilterOnTable.WITHOUT_FILTER);
 
@@ -96,7 +96,7 @@ public class LookupJoinHarnessTest {
     }
 
     @Test
-    public void testTemporalInnerJoinWithFilter() throws Exception {
+    void testTemporalInnerJoinWithFilter() throws Exception {
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
                 createHarness(JoinType.INNER_JOIN, FilterOnTable.WITH_FILTER);
 
@@ -118,7 +118,7 @@ public class LookupJoinHarnessTest {
     }
 
     @Test
-    public void testTemporalLeftJoin() throws Exception {
+    void testTemporalLeftJoin() throws Exception {
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
                 createHarness(JoinType.LEFT_JOIN, FilterOnTable.WITHOUT_FILTER);
 
@@ -145,7 +145,7 @@ public class LookupJoinHarnessTest {
     }
 
     @Test
-    public void testTemporalLeftJoinWithFilter() throws Exception {
+    void testTemporalLeftJoinWithFilter() throws Exception {
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
                 createHarness(JoinType.LEFT_JOIN, FilterOnTable.WITH_FILTER);
 
@@ -171,7 +171,7 @@ public class LookupJoinHarnessTest {
     }
 
     @Test
-    public void testTemporalLeftJoinWithPreFilter() throws Exception {
+    void testTemporalLeftJoinWithPreFilter() throws Exception {
         ProcessFunction<RowData, RowData> joinRunner =
                 new LookupJoinRunner(
                         new GeneratedFunctionWrapper<>(new TestingFetcherFunction()),

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/RandomSortMergeInnerJoinTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/RandomSortMergeInnerJoinTest.java
@@ -45,12 +45,13 @@ import org.apache.flink.table.data.writer.BinaryRowWriter;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
 import org.apache.flink.util.MutableObjectIterator;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -64,8 +65,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 /** Test for sort merge inner join. */
-@RunWith(Parameterized.class)
-public class RandomSortMergeInnerJoinTest {
+@ExtendWith(ParameterizedTestExtension.class)
+class RandomSortMergeInnerJoinTest {
 
     private static final long SEED1 = 561349061987311L;
     private static final long SEED2 = 231434613412342L;
@@ -80,13 +81,13 @@ public class RandomSortMergeInnerJoinTest {
         this.leftIsSmall = leftIsSmall;
     }
 
-    @Parameterized.Parameters
+    @Parameters(name = "leftIsSmaller={0}")
     public static Collection<Boolean> parameters() {
         return Arrays.asList(true, false);
     }
 
-    @Before
-    public void before() {
+    @BeforeEach
+    void before() {
         comparator1 =
                 new TupleComparator<>(
                         new int[] {0},
@@ -99,8 +100,8 @@ public class RandomSortMergeInnerJoinTest {
                         new TypeSerializer<?>[] {IntSerializer.INSTANCE});
     }
 
-    @Test
-    public void test() throws Exception {
+    @TestTemplate
+    void test() throws Exception {
         final TupleGenerator generator1 =
                 new TupleGenerator(SEED1, 500, 4096, KeyMode.SORTED, ValueMode.RANDOM_LENGTH);
         final TupleGenerator generator2 =
@@ -129,8 +130,8 @@ public class RandomSortMergeInnerJoinTest {
         assertThat(expectedMatchesMap).allSatisfy((i, e) -> assertThat(e).isEmpty());
     }
 
-    @Test
-    public void testMergeWithHighNumberOfCommonKeys() throws Exception {
+    @TestTemplate
+    void testMergeWithHighNumberOfCommonKeys() throws Exception {
         // the size of the left and right inputs
         final int input1Size = 200;
         final int input2Size = 100;

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/RandomSortMergeInnerJoinTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/RandomSortMergeInnerJoinTest.java
@@ -77,12 +77,12 @@ class RandomSortMergeInnerJoinTest {
     private TypeComparator<Tuple2<Integer, String>> comparator1;
     private TypeComparator<Tuple2<Integer, String>> comparator2;
 
-    public RandomSortMergeInnerJoinTest(boolean leftIsSmall) {
+    RandomSortMergeInnerJoinTest(boolean leftIsSmall) {
         this.leftIsSmall = leftIsSmall;
     }
 
     @Parameters(name = "leftIsSmaller={0}")
-    public static Collection<Boolean> parameters() {
+    private static Collection<Boolean> parameters() {
         return Arrays.asList(true, false);
     }
 

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/RandomSortMergeOuterJoinTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/RandomSortMergeOuterJoinTest.java
@@ -34,7 +34,7 @@ import org.apache.flink.runtime.operators.testutils.TestData.TupleGeneratorItera
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.util.MutableObjectIterator;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -46,7 +46,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Random test for sort merge outer join. */
-public class RandomSortMergeOuterJoinTest {
+class RandomSortMergeOuterJoinTest {
 
     // random seeds for the left and right input data generators
     private static final long SEED1 = 561349061987311L;
@@ -54,19 +54,19 @@ public class RandomSortMergeOuterJoinTest {
     private static final long SEED2 = 231434613412342L;
 
     @Test
-    public void testFullOuterJoinWithHighNumberOfCommonKeys() throws Exception {
+    void testFullOuterJoinWithHighNumberOfCommonKeys() throws Exception {
         testOuterJoinWithHighNumberOfCommonKeys(
                 FlinkJoinType.FULL, 200, 500, 2048, 0.02f, 200, 500, 2048, 0.02f);
     }
 
     @Test
-    public void testLeftOuterJoinWithHighNumberOfCommonKeys() throws Exception {
+    void testLeftOuterJoinWithHighNumberOfCommonKeys() throws Exception {
         testOuterJoinWithHighNumberOfCommonKeys(
                 FlinkJoinType.LEFT, 200, 10, 4096, 0.02f, 100, 4000, 2048, 0.02f);
     }
 
     @Test
-    public void testRightOuterJoinWithHighNumberOfCommonKeys() throws Exception {
+    void testRightOuterJoinWithHighNumberOfCommonKeys() throws Exception {
         testOuterJoinWithHighNumberOfCommonKeys(
                 FlinkJoinType.RIGHT, 100, 10, 2048, 0.02f, 200, 4000, 4096, 0.02f);
     }

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/RetryableAsyncLookupFunctionDelegatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/RetryableAsyncLookupFunctionDelegatorTest.java
@@ -32,7 +32,7 @@ import org.apache.flink.table.runtime.operators.join.lookup.RetryableAsyncLookup
 import org.apache.flink.table.runtime.util.RowDataHarnessAssertor;
 import org.apache.flink.table.types.logical.LogicalType;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -47,7 +47,7 @@ import java.util.concurrent.Executors;
 import static org.apache.flink.table.data.StringData.fromString;
 
 /** Harness tests for {@link RetryableAsyncLookupFunctionDelegator}. */
-public class RetryableAsyncLookupFunctionDelegatorTest {
+class RetryableAsyncLookupFunctionDelegatorTest {
 
     private final AsyncLookupFunction userLookupFunc = new TestingAsyncLookupFunction();
 
@@ -82,7 +82,7 @@ public class RetryableAsyncLookupFunctionDelegatorTest {
                     });
 
     @Test
-    public void testLookupWithRetry() throws Exception {
+    void testLookupWithRetry() throws Exception {
         final RetryableAsyncLookupFunctionDelegator delegator = createDelegator(retryStrategy);
         delegator.open(new FunctionContext(new MockStreamingRuntimeContext(false, 1, 0)));
         for (int i = 1; i <= 5; i++) {
@@ -96,7 +96,7 @@ public class RetryableAsyncLookupFunctionDelegatorTest {
     }
 
     @Test
-    public void testLookupWithRetryDisabled() throws Exception {
+    void testLookupWithRetryDisabled() throws Exception {
         final RetryableAsyncLookupFunctionDelegator delegator =
                 createDelegator(ResultRetryStrategy.NO_RETRY_STRATEGY);
         delegator.open(new FunctionContext(new MockStreamingRuntimeContext(false, 1, 0)));
@@ -111,7 +111,7 @@ public class RetryableAsyncLookupFunctionDelegatorTest {
     }
 
     @Test
-    public void testLookupWithCustomRetry() throws Exception {
+    void testLookupWithCustomRetry() throws Exception {
         AsyncRetryStrategy retryStrategy =
                 new AsyncRetryStrategies.ExponentialBackoffDelayRetryStrategyBuilder<>(
                                 3, 1, 100, 1.1d)

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/RetryableLookupFunctionDelegatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/RetryableLookupFunctionDelegatorTest.java
@@ -30,7 +30,7 @@ import org.apache.flink.table.runtime.operators.join.lookup.RetryableLookupFunct
 import org.apache.flink.table.runtime.util.RowDataHarnessAssertor;
 import org.apache.flink.table.types.logical.LogicalType;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -42,7 +42,7 @@ import java.util.Map;
 import static org.apache.flink.table.data.StringData.fromString;
 
 /** Harness tests for {@link RetryableLookupFunctionDelegator}. */
-public class RetryableLookupFunctionDelegatorTest {
+class RetryableLookupFunctionDelegatorTest {
 
     private final LookupFunction userLookupFunc = new TestingLookupFunction();
 
@@ -75,7 +75,7 @@ public class RetryableLookupFunctionDelegatorTest {
                     });
 
     @Test
-    public void testLookupWithRetry() throws Exception {
+    void testLookupWithRetry() throws Exception {
         delegator.open(new FunctionContext(new MockStreamingRuntimeContext(false, 1, 0)));
         for (int i = 1; i <= 5; i++) {
             RowData key = GenericRowData.of(i);

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/SortMergeJoinIteratorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/SortMergeJoinIteratorTest.java
@@ -63,12 +63,12 @@ class SortMergeJoinIteratorTest {
     private IOManager ioManager;
     private BinaryRowDataSerializer serializer;
 
-    public SortMergeJoinIteratorTest(boolean leftIsSmall) throws Exception {
+    SortMergeJoinIteratorTest(boolean leftIsSmall) {
         this.leftIsSmall = leftIsSmall;
     }
 
     @Parameters(name = "leftIsSmall = {0}")
-    static Collection<Boolean> parameters() {
+    private static Collection<Boolean> parameters() {
         return Arrays.asList(true, false);
     }
 

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/SortMergeJoinIteratorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/SortMergeJoinIteratorTest.java
@@ -32,12 +32,13 @@ import org.apache.flink.table.runtime.operators.sort.IntRecordComparator;
 import org.apache.flink.table.runtime.typeutils.BinaryRowDataSerializer;
 import org.apache.flink.table.runtime.util.LazyMemorySegmentPool;
 import org.apache.flink.table.runtime.util.ResettableExternalBuffer;
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
 import org.apache.flink.util.MutableObjectIterator;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -51,8 +52,8 @@ import static org.apache.flink.runtime.memory.MemoryManager.DEFAULT_PAGE_SIZE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** UT for sort merge join iterators. */
-@RunWith(Parameterized.class)
-public class SortMergeJoinIteratorTest {
+@ExtendWith(ParameterizedTestExtension.class)
+class SortMergeJoinIteratorTest {
 
     private static final int MEMORY_SIZE = 40 * DEFAULT_PAGE_SIZE;
     private static final int BUFFER_MEMORY = 20;
@@ -66,20 +67,20 @@ public class SortMergeJoinIteratorTest {
         this.leftIsSmall = leftIsSmall;
     }
 
-    @Parameterized.Parameters
-    public static Collection<Boolean> parameters() {
+    @Parameters(name = "leftIsSmall = {0}")
+    static Collection<Boolean> parameters() {
         return Arrays.asList(true, false);
     }
 
-    @Before
-    public void before() throws MemoryAllocationException {
+    @BeforeEach
+    void before() throws MemoryAllocationException {
         this.memManager = MemoryManagerBuilder.newBuilder().setMemorySize(MEMORY_SIZE).build();
         this.ioManager = new IOManagerAsync();
         this.serializer = new BinaryRowDataSerializer(1);
     }
 
-    @Test
-    public void testInner() throws Exception {
+    @TestTemplate
+    void testInner() throws Exception {
         inner(oneEmpty(), emptyList());
         inner(haveNull(), emptyList());
         inner(noJoin(), emptyList());
@@ -88,8 +89,8 @@ public class SortMergeJoinIteratorTest {
         inner(nmMultiJoin(), newExpect1(6));
     }
 
-    @Test
-    public void testOneSideOuter() throws Exception {
+    @TestTemplate
+    void testOneSideOuter() throws Exception {
         List<Tuple2<BinaryRowData, BinaryRowData>> compare1;
         List<Tuple2<BinaryRowData, BinaryRowData>> compare2;
         List<Tuple2<BinaryRowData, BinaryRowData>> compare3;
@@ -120,8 +121,8 @@ public class SortMergeJoinIteratorTest {
         oneSideOuter(nmMultiJoin(), compare6);
     }
 
-    @Test
-    public void testFullOuter() throws Exception {
+    @TestTemplate
+    void testFullOuter() throws Exception {
         fullOuter(oneEmpty(), Arrays.asList(newTuple(newRow(1), null), newTuple(newRow(2), null)));
         fullOuter(
                 haveNull(),

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/String2HashJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/String2HashJoinOperatorTest.java
@@ -46,14 +46,14 @@ import org.apache.flink.table.runtime.util.JoinUtil;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.VarCharType;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.Serializable;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
 /** Test for {@link HashJoinOperator}. */
-public class String2HashJoinOperatorTest implements Serializable {
+class String2HashJoinOperatorTest implements Serializable {
 
     private InternalTypeInfo<RowData> typeInfo =
             InternalTypeInfo.ofFields(VarCharType.STRING_TYPE, VarCharType.STRING_TYPE);
@@ -116,7 +116,7 @@ public class String2HashJoinOperatorTest implements Serializable {
     }
 
     @Test
-    public void testInnerHashJoin() throws Exception {
+    void testInnerHashJoin() throws Exception {
 
         init(false, false, true);
 
@@ -162,7 +162,7 @@ public class String2HashJoinOperatorTest implements Serializable {
     }
 
     @Test
-    public void testProbeOuterHashJoin() throws Exception {
+    void testProbeOuterHashJoin() throws Exception {
 
         init(true, false, false);
 
@@ -209,7 +209,7 @@ public class String2HashJoinOperatorTest implements Serializable {
     }
 
     @Test
-    public void testBuildOuterHashJoin() throws Exception {
+    void testBuildOuterHashJoin() throws Exception {
 
         init(false, true, false);
 
@@ -256,7 +256,7 @@ public class String2HashJoinOperatorTest implements Serializable {
     }
 
     @Test
-    public void testFullOuterHashJoin() throws Exception {
+    void testFullOuterHashJoin() throws Exception {
 
         init(true, true, true);
 

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/String2SortMergeJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/String2SortMergeJoinOperatorTest.java
@@ -43,10 +43,11 @@ import org.apache.flink.table.runtime.operators.sort.StringNormalizedKeyComputer
 import org.apache.flink.table.runtime.operators.sort.StringRecordComparator;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -56,8 +57,8 @@ import static org.apache.flink.table.runtime.operators.join.String2HashJoinOpera
 import static org.apache.flink.table.runtime.operators.join.String2HashJoinOperatorTest.transformToBinary;
 
 /** Test for {@link SortMergeJoinOperator}. */
-@RunWith(Parameterized.class)
-public class String2SortMergeJoinOperatorTest {
+@ExtendWith(ParameterizedTestExtension.class)
+class String2SortMergeJoinOperatorTest {
 
     private boolean leftIsSmall;
     InternalTypeInfo<RowData> typeInfo =
@@ -69,17 +70,17 @@ public class String2SortMergeJoinOperatorTest {
                     VarCharType.STRING_TYPE,
                     VarCharType.STRING_TYPE);
 
-    public String2SortMergeJoinOperatorTest(boolean leftIsSmall) {
+    String2SortMergeJoinOperatorTest(boolean leftIsSmall) {
         this.leftIsSmall = leftIsSmall;
     }
 
-    @Parameterized.Parameters
-    public static Collection<Boolean> parameters() {
+    @Parameters(name = "leftIsSmall = {0}")
+    static Collection<Boolean> parameters() {
         return Arrays.asList(true, false);
     }
 
-    @Test
-    public void testInnerJoin() throws Exception {
+    @TestTemplate
+    void testInnerJoin() throws Exception {
         StreamOperator joinOperator = newOperator(FlinkJoinType.INNER, leftIsSmall);
         TwoInputStreamTaskTestHarness<BinaryRowData, BinaryRowData, JoinedRowData> testHarness =
                 buildSortMergeJoin(joinOperator);
@@ -94,8 +95,8 @@ public class String2SortMergeJoinOperatorTest {
                 transformToBinary(testHarness.getOutput()));
     }
 
-    @Test
-    public void testLeftOuterJoin() throws Exception {
+    @TestTemplate
+    void testLeftOuterJoin() throws Exception {
         StreamOperator joinOperator = newOperator(FlinkJoinType.LEFT, leftIsSmall);
         TwoInputStreamTaskTestHarness<BinaryRowData, BinaryRowData, JoinedRowData> testHarness =
                 buildSortMergeJoin(joinOperator);
@@ -111,8 +112,8 @@ public class String2SortMergeJoinOperatorTest {
                 transformToBinary(testHarness.getOutput()));
     }
 
-    @Test
-    public void testRightOuterJoin() throws Exception {
+    @TestTemplate
+    void testRightOuterJoin() throws Exception {
         StreamOperator joinOperator = newOperator(FlinkJoinType.RIGHT, leftIsSmall);
         TwoInputStreamTaskTestHarness<BinaryRowData, BinaryRowData, JoinedRowData> testHarness =
                 buildSortMergeJoin(joinOperator);
@@ -128,8 +129,8 @@ public class String2SortMergeJoinOperatorTest {
                 transformToBinary(testHarness.getOutput()));
     }
 
-    @Test
-    public void testFullJoin() throws Exception {
+    @TestTemplate
+    void testFullJoin() throws Exception {
         StreamOperator joinOperator = newOperator(FlinkJoinType.FULL, leftIsSmall);
         TwoInputStreamTaskTestHarness<BinaryRowData, BinaryRowData, JoinedRowData> testHarness =
                 buildSortMergeJoin(joinOperator);

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/String2SortMergeJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/String2SortMergeJoinOperatorTest.java
@@ -75,7 +75,7 @@ class String2SortMergeJoinOperatorTest {
     }
 
     @Parameters(name = "leftIsSmall = {0}")
-    static Collection<Boolean> parameters() {
+    private static Collection<Boolean> parameters() {
         return Arrays.asList(true, false);
     }
 

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/interval/ProcTimeIntervalJoinTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/interval/ProcTimeIntervalJoinTest.java
@@ -27,7 +27,7 @@ import org.apache.flink.table.runtime.operators.join.FlinkJoinType;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.utils.HandwrittenSelectorUtil;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -36,7 +36,7 @@ import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link ProcTimeIntervalJoin}. */
-public class ProcTimeIntervalJoinTest extends TimeIntervalStreamJoinTestBase {
+class ProcTimeIntervalJoinTest extends TimeIntervalStreamJoinTestBase {
 
     private int keyIdx = 0;
     private RowDataKeySelector keySelector =
@@ -46,7 +46,7 @@ public class ProcTimeIntervalJoinTest extends TimeIntervalStreamJoinTestBase {
 
     /** a.proctime >= b.proctime - 10 and a.proctime <= b.proctime + 20. * */
     @Test
-    public void testProcTimeInnerJoinWithCommonBounds() throws Exception {
+    void testProcTimeInnerJoinWithCommonBounds() throws Exception {
         ProcTimeIntervalJoin joinProcessFunc =
                 new ProcTimeIntervalJoin(
                         FlinkJoinType.INNER, -10, 20, 15, rowType, rowType, joinFunction);
@@ -105,7 +105,7 @@ public class ProcTimeIntervalJoinTest extends TimeIntervalStreamJoinTestBase {
 
     /** a.proctime >= b.proctime - 10 and a.proctime <= b.proctime - 5. * */
     @Test
-    public void testProcTimeInnerJoinWithNegativeBounds() throws Exception {
+    void testProcTimeInnerJoinWithNegativeBounds() throws Exception {
         ProcTimeIntervalJoin joinProcessFunc =
                 new ProcTimeIntervalJoin(
                         FlinkJoinType.INNER, -10, -5, 2, rowType, rowType, joinFunction);

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/interval/RowTimeIntervalJoinTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/interval/RowTimeIntervalJoinTest.java
@@ -29,7 +29,7 @@ import org.apache.flink.table.runtime.operators.join.KeyedCoProcessOperatorWithW
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.utils.HandwrittenSelectorUtil;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -38,7 +38,7 @@ import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link RowTimeIntervalJoin}. */
-public class RowTimeIntervalJoinTest extends TimeIntervalStreamJoinTestBase {
+class RowTimeIntervalJoinTest extends TimeIntervalStreamJoinTestBase {
 
     private int keyIdx = 1;
     private RowDataKeySelector keySelector =
@@ -48,7 +48,7 @@ public class RowTimeIntervalJoinTest extends TimeIntervalStreamJoinTestBase {
 
     /** a.rowtime >= b.rowtime - 10 and a.rowtime <= b.rowtime + 20. * */
     @Test
-    public void testRowTimeInnerJoinWithCommonBounds() throws Exception {
+    void testRowTimeInnerJoinWithCommonBounds() throws Exception {
         RowTimeIntervalJoin joinProcessFunc =
                 new RowTimeIntervalJoin(
                         FlinkJoinType.INNER, -10, 20, 0, 15, rowType, rowType, joinFunction, 0, 0);
@@ -113,7 +113,7 @@ public class RowTimeIntervalJoinTest extends TimeIntervalStreamJoinTestBase {
 
     /** a.rowtime >= b.rowtime - 10 and a.rowtime <= b.rowtime - 7. * */
     @Test
-    public void testRowTimeInnerJoinWithNegativeBounds() throws Exception {
+    void testRowTimeInnerJoinWithNegativeBounds() throws Exception {
         RowTimeIntervalJoin joinProcessFunc =
                 new RowTimeIntervalJoin(
                         FlinkJoinType.INNER, -10, -7, 0, 0, rowType, rowType, joinFunction, 0, 0);
@@ -168,7 +168,7 @@ public class RowTimeIntervalJoinTest extends TimeIntervalStreamJoinTestBase {
     }
 
     @Test
-    public void testRowTimeInnerJoinRealtimeCleanUp() throws Exception {
+    void testRowTimeInnerJoinRealtimeCleanUp() throws Exception {
         RowTimeIntervalJoin joinProcessFunc =
                 new RowTimeIntervalJoin(
                         FlinkJoinType.LEFT, -5, 9, 0, 0, rowType, rowType, joinFunction, 0, 0);
@@ -197,7 +197,7 @@ public class RowTimeIntervalJoinTest extends TimeIntervalStreamJoinTestBase {
     }
 
     @Test
-    public void testRowTimeLeftOuterJoin() throws Exception {
+    void testRowTimeLeftOuterJoin() throws Exception {
         RowTimeIntervalJoin joinProcessFunc =
                 new RowTimeIntervalJoin(
                         FlinkJoinType.LEFT, -5, 9, 0, 7, rowType, rowType, joinFunction, 0, 0);
@@ -267,7 +267,7 @@ public class RowTimeIntervalJoinTest extends TimeIntervalStreamJoinTestBase {
     }
 
     @Test
-    public void testRowTimeRightOuterJoin() throws Exception {
+    void testRowTimeRightOuterJoin() throws Exception {
         RowTimeIntervalJoin joinProcessFunc =
                 new RowTimeIntervalJoin(
                         FlinkJoinType.RIGHT, -5, 9, 0, 7, rowType, rowType, joinFunction, 0, 0);
@@ -338,7 +338,7 @@ public class RowTimeIntervalJoinTest extends TimeIntervalStreamJoinTestBase {
 
     /** a.rowtime >= b.rowtime - 5 and a.rowtime <= b.rowtime + 9. * */
     @Test
-    public void testRowTimeFullOuterJoin() throws Exception {
+    void testRowTimeFullOuterJoin() throws Exception {
         RowTimeIntervalJoin joinProcessFunc =
                 new RowTimeIntervalJoin(
                         FlinkJoinType.FULL, -5, 9, 0, 7, rowType, rowType, joinFunction, 0, 0);

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/stream/BufferBundleTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/stream/BufferBundleTest.java
@@ -55,7 +55,7 @@ import static org.apache.flink.table.runtime.util.StreamRecordUtils.updateBefore
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /** Test for MiniBatch buffer only which verify the logic of folding in MiniBatch. */
-public class BufferBundleTest {
+class BufferBundleTest {
 
     private BufferBundle<?> buffer;
 
@@ -88,13 +88,13 @@ public class BufferBundleTest {
             JoinInputSideSpec.withUniqueKey(inputTypeInfo, uniqueKeySelector);
 
     @AfterEach
-    public void cleanup() {
+    void cleanup() {
         buffer.clear();
     }
 
     @ParameterizedTest(name = "joinKeyContainsUniqueKey: {0}")
     @ValueSource(booleans = {true, false})
-    public void testAccumulateAccumulatePattern(boolean joinKeyContainsUniqueKey) throws Exception {
+    void testAccumulateAccumulatePattern(boolean joinKeyContainsUniqueKey) throws Exception {
         buffer =
                 joinKeyContainsUniqueKey
                         ? new JoinKeyContainsUniqueKeyBundle()
@@ -104,7 +104,7 @@ public class BufferBundleTest {
 
     @ParameterizedTest(name = "joinKeyContainsUniqueKey: {0}")
     @ValueSource(booleans = {true, false})
-    public void testAccumulateRetractPattern(boolean joinKeyContainsUniqueKey) throws Exception {
+    void testAccumulateRetractPattern(boolean joinKeyContainsUniqueKey) throws Exception {
         buffer =
                 joinKeyContainsUniqueKey
                         ? new JoinKeyContainsUniqueKeyBundle()
@@ -114,7 +114,7 @@ public class BufferBundleTest {
 
     @ParameterizedTest(name = "joinKeyContainsUniqueKey: {0}")
     @ValueSource(booleans = {true, false})
-    public void testRetractAccumulatePattern(boolean joinKeyContainsUniqueKey) throws Exception {
+    void testRetractAccumulatePattern(boolean joinKeyContainsUniqueKey) throws Exception {
         buffer =
                 joinKeyContainsUniqueKey
                         ? new JoinKeyContainsUniqueKeyBundle()
@@ -124,7 +124,7 @@ public class BufferBundleTest {
 
     @ParameterizedTest(name = "joinKeyContainsUniqueKey: {0}")
     @ValueSource(booleans = {true, false})
-    public void testRetractRetractPattern(boolean joinKeyContainsUniqueKey) throws Exception {
+    void testRetractRetractPattern(boolean joinKeyContainsUniqueKey) throws Exception {
         buffer =
                 joinKeyContainsUniqueKey
                         ? new JoinKeyContainsUniqueKeyBundle()
@@ -134,7 +134,7 @@ public class BufferBundleTest {
 
     @ParameterizedTest(name = "joinKeyContainsUniqueKey: {0}")
     @ValueSource(booleans = {true, false})
-    public void testPatternCombination(boolean joinKeyContainsUniqueKey) throws Exception {
+    void testPatternCombination(boolean joinKeyContainsUniqueKey) throws Exception {
         buffer =
                 joinKeyContainsUniqueKey
                         ? new JoinKeyContainsUniqueKeyBundle()
@@ -143,7 +143,7 @@ public class BufferBundleTest {
     }
 
     @Test
-    public void testInputSideHasNoUniqueKey() throws Exception {
+    void testInputSideHasNoUniqueKey() throws Exception {
         // +--------------------------+----------------------------+----------------------------+
         // |   Before the last        |       Last record          |          Result            |
         // |--------------------------|----------------------------|----------------------------|

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/stream/StreamingJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/stream/StreamingJoinOperatorTest.java
@@ -35,7 +35,7 @@ import static org.apache.flink.table.runtime.util.StreamRecordUtils.rowOfKind;
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.updateAfterRecord;
 
 /** Harness tests for {@link StreamingJoinOperator}. */
-public class StreamingJoinOperatorTest extends StreamingJoinOperatorTestBase {
+class StreamingJoinOperatorTest extends StreamingJoinOperatorTestBase {
 
     @Override
     protected StreamingJoinOperator createJoinOperator(TestInfo testInfo) {
@@ -76,7 +76,7 @@ public class StreamingJoinOperatorTest extends StreamingJoinOperatorTestBase {
     @Tag("leftStateRetentionTime=4000")
     @Tag("rightStateRetentionTime=1000")
     @Test
-    public void testInnerJoinWithDifferentStateRetentionTime() throws Exception {
+    void testInnerJoinWithDifferentStateRetentionTime() throws Exception {
         testHarness.setStateTtlProcessingTime(1);
         testHarness.processElement1(
                 insertRecord("Ord#1", "LineOrd#1", "3 Bellevue Drive, Pottstown, PA 19464"));
@@ -142,7 +142,7 @@ public class StreamingJoinOperatorTest extends StreamingJoinOperatorTestBase {
      * only difference is that the state retention is disabled.
      */
     @Test
-    public void testInnerJoinWithStateRetentionDisabled() throws Exception {
+    void testInnerJoinWithStateRetentionDisabled() throws Exception {
         testHarness.setStateTtlProcessingTime(1);
         testHarness.processElement1(
                 insertRecord("Ord#1", "LineOrd#1", "3 Bellevue Drive, Pottstown, PA 19464"));
@@ -231,7 +231,7 @@ public class StreamingJoinOperatorTest extends StreamingJoinOperatorTestBase {
     @Tag("leftStateRetentionTime=4000")
     @Tag("rightStateRetentionTime=4000")
     @Test
-    public void testInnerJoinWithSameStateRetentionTime() throws Exception {
+    void testInnerJoinWithSameStateRetentionTime() throws Exception {
         testHarness.setStateTtlProcessingTime(1);
         testHarness.processElement1(
                 insertRecord("Ord#1", "LineOrd#1", "3 Bellevue Drive, Pottstown, PA 19464"));
@@ -300,7 +300,7 @@ public class StreamingJoinOperatorTest extends StreamingJoinOperatorTestBase {
     @Tag("leftStateRetentionTime=4000")
     @Tag("rightStateRetentionTime=1000")
     @Test
-    public void testLeftOuterJoinWithDifferentStateRetentionTime() throws Exception {
+    void testLeftOuterJoinWithDifferentStateRetentionTime() throws Exception {
         testHarness.setStateTtlProcessingTime(1);
         testHarness.processElement1(
                 insertRecord("Ord#1", "LineOrd#1", "3 Bellevue Drive, Pottstown, PA 19464"));
@@ -412,7 +412,7 @@ public class StreamingJoinOperatorTest extends StreamingJoinOperatorTestBase {
      * retention is disabled.
      */
     @Test
-    public void testLeftOuterJoinWithStateRetentionDisabled() throws Exception {
+    void testLeftOuterJoinWithStateRetentionDisabled() throws Exception {
         testHarness.setStateTtlProcessingTime(1);
         testHarness.processElement1(
                 insertRecord("Ord#1", "LineOrd#1", "3 Bellevue Drive, Pottstown, PA 19464"));
@@ -523,7 +523,7 @@ public class StreamingJoinOperatorTest extends StreamingJoinOperatorTestBase {
     @Tag("leftStateRetentionTime=4000")
     @Tag("rightStateRetentionTime=1000")
     @Test
-    public void testRightOuterJoinWithDifferentStateRetentionTime() throws Exception {
+    void testRightOuterJoinWithDifferentStateRetentionTime() throws Exception {
         testHarness.setStateTtlProcessingTime(1);
         testHarness.processElement1(
                 insertRecord("Ord#1", "LineOrd#1", "3 Bellevue Drive, Pottstown, PA 19464"));
@@ -594,7 +594,7 @@ public class StreamingJoinOperatorTest extends StreamingJoinOperatorTestBase {
      * retention is disabled.
      */
     @Test
-    public void testRightOuterJoinWithDStateRetentionDisabled() throws Exception {
+    void testRightOuterJoinWithDStateRetentionDisabled() throws Exception {
         testHarness.setStateTtlProcessingTime(1);
         testHarness.processElement1(
                 insertRecord("Ord#1", "LineOrd#1", "3 Bellevue Drive, Pottstown, PA 19464"));

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/stream/StreamingJoinOperatorTestBase.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/stream/StreamingJoinOperatorTestBase.java
@@ -100,7 +100,7 @@ public abstract class StreamingJoinOperatorTestBase {
             testHarness;
 
     @BeforeEach
-    public void beforeEach(TestInfo testInfo) throws Exception {
+    void beforeEach(TestInfo testInfo) throws Exception {
         testHarness =
                 new KeyedTwoInputStreamOperatorTestHarness<>(
                         createJoinOperator(testInfo),
@@ -115,7 +115,7 @@ public abstract class StreamingJoinOperatorTestBase {
     }
 
     @AfterEach
-    public void afterEach() throws Exception {
+    void afterEach() throws Exception {
         testHarness.close();
     }
 

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/stream/StreamingMiniBatchJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/stream/StreamingMiniBatchJoinOperatorTest.java
@@ -50,14 +50,14 @@ import static org.apache.flink.table.runtime.util.StreamRecordUtils.updateAfterR
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.updateBeforeRecord;
 
 /** Test for StreamingMiniBatchJoinOperatorTest. */
-public final class StreamingMiniBatchJoinOperatorTest extends StreamingJoinOperatorTestBase {
+final class StreamingMiniBatchJoinOperatorTest extends StreamingJoinOperatorTestBase {
 
     private RowDataKeySelector leftUniqueKeySelector;
     private RowDataKeySelector rightUniqueKeySelector;
 
     @Tag("miniBatchSize=3")
     @Test
-    public void testLeftJoinWithLeftArriveFirst() throws Exception {
+    void testLeftJoinWithLeftArriveFirst() throws Exception {
         // joinKey is LineOrd
         testHarness.processElement1(
                 insertRecord(
@@ -92,7 +92,7 @@ public final class StreamingMiniBatchJoinOperatorTest extends StreamingJoinOpera
 
     @Tag("miniBatchSize=1")
     @Test
-    public void testLeftJoinWithLeftArriveFirstNoMiniBatch() throws Exception {
+    void testLeftJoinWithLeftArriveFirstNoMiniBatch() throws Exception {
         // joinKey is LineOrd
         testHarness.processElement1(
                 insertRecord(
@@ -143,7 +143,7 @@ public final class StreamingMiniBatchJoinOperatorTest extends StreamingJoinOpera
 
     @Tag("miniBatchSize=3")
     @Test
-    public void testRightJoinWithRightArriveFirst() throws Exception {
+    void testRightJoinWithRightArriveFirst() throws Exception {
         // joinKey is LineOrd
         testHarness.processElement2(insertRecord("Ord#X", "LineOrd#2", "AIR")); // right
 
@@ -171,7 +171,7 @@ public final class StreamingMiniBatchJoinOperatorTest extends StreamingJoinOpera
 
     @Tag("miniBatchSize=1")
     @Test
-    public void testRightJoinWithRightArriveFirstWithNoMiniBatch() throws Exception {
+    void testRightJoinWithRightArriveFirstWithNoMiniBatch() throws Exception {
         // joinKey is LineOrd
         testHarness.processElement2(insertRecord("Ord#X", "LineOrd#2", "AIR")); // right
 
@@ -200,7 +200,7 @@ public final class StreamingMiniBatchJoinOperatorTest extends StreamingJoinOpera
 
     @Tag("miniBatchSize=3")
     @Test
-    public void testFullJoinWithRightArriveFirst() throws Exception {
+    void testFullJoinWithRightArriveFirst() throws Exception {
         // joinKey is LineOrd
         testHarness.processElement2(insertRecord("Ord#X", "LineOrd#2", "AIR")); // right
 
@@ -238,7 +238,7 @@ public final class StreamingMiniBatchJoinOperatorTest extends StreamingJoinOpera
 
     @Tag("miniBatchSize=1")
     @Test
-    public void testFullJoinWithRightArriveFirstWithNoMiniBatch() throws Exception {
+    void testFullJoinWithRightArriveFirstWithNoMiniBatch() throws Exception {
         // joinKey is LineOrd
         testHarness.processElement2(insertRecord("Ord#X", "LineOrd#2", "AIR")); // right
 
@@ -275,7 +275,7 @@ public final class StreamingMiniBatchJoinOperatorTest extends StreamingJoinOpera
 
     @Tag("miniBatchSize=4")
     @Test
-    public void testInnerJoinJoinKeyContainsUniqueKeyWithoutFold() throws Exception {
+    void testInnerJoinJoinKeyContainsUniqueKeyWithoutFold() throws Exception {
         // joinKey is LineOrd
         testHarness.setStateTtlProcessingTime(1);
         // basic test for that the mini-batch process could be triggerred normally
@@ -320,7 +320,7 @@ public final class StreamingMiniBatchJoinOperatorTest extends StreamingJoinOpera
 
     @Tag("miniBatchSize=18")
     @Test
-    public void testInnerJoinWithJoinKeyContainsUniqueKeyWithinBatch() throws Exception {
+    void testInnerJoinWithJoinKeyContainsUniqueKeyWithinBatch() throws Exception {
         // joinKey is LineOrd
         // left fold  || right fold
         // +I +U / +U +U / +U -D ||  +I -D / +U -U / +I -U
@@ -407,7 +407,7 @@ public final class StreamingMiniBatchJoinOperatorTest extends StreamingJoinOpera
 
     @Tag("miniBatchSize=10")
     @Test
-    public void testInnerJoinWithJoinKeyContainsUniqueKeyCrossBatches() throws Exception {
+    void testInnerJoinWithJoinKeyContainsUniqueKeyCrossBatches() throws Exception {
         // joinKey is LineOrd
 
         testHarness.processElement1(
@@ -566,7 +566,7 @@ public final class StreamingMiniBatchJoinOperatorTest extends StreamingJoinOpera
 
     @Tag("miniBatchSize=13")
     @Test
-    public void testInnerJoinWithHasUniqueKeyWithinBatch() throws Exception {
+    void testInnerJoinWithHasUniqueKeyWithinBatch() throws Exception {
         // joinKey is LineOrd and uniqueKey is Ord
         // +I +U / +I -U / +I -D / +U -D /+U +U
         List<StreamRecord<RowData>> records =
@@ -646,7 +646,7 @@ public final class StreamingMiniBatchJoinOperatorTest extends StreamingJoinOpera
 
     @Tag("miniBatchSize=8")
     @Test
-    public void testInnerJoinWithHasUniqueKeyCrossBatches() throws Exception {
+    void testInnerJoinWithHasUniqueKeyCrossBatches() throws Exception {
         // joinKey is LineOrd and uniqueKey is Ord
         // fold +I/+U +U (same and different jks)
         testHarness.processElement1(
@@ -743,7 +743,7 @@ public final class StreamingMiniBatchJoinOperatorTest extends StreamingJoinOpera
 
     @Tag("miniBatchSize=20")
     @Test
-    public void testInnerJoinWithNoUniqueKeyWithinBatch() throws Exception {
+    void testInnerJoinWithNoUniqueKeyWithinBatch() throws Exception {
         // joinKey is LineOrd
         // +I -U / +I -D / -U +U / -D +I
         List<StreamRecord<RowData>> records =
@@ -830,7 +830,7 @@ public final class StreamingMiniBatchJoinOperatorTest extends StreamingJoinOpera
 
     @Tag("miniBatchSize=4")
     @Test
-    public void testInnerJoinWithNoUniqueKeyHashCollisionSimpleSchema() throws Exception {
+    void testInnerJoinWithNoUniqueKeyHashCollisionSimpleSchema() throws Exception {
         testHarness.processElement2(insertRecord("1", 1L));
         testHarness.processElement1(insertRecord("1", 4294967296L));
         testHarness.processElement2(insertRecord("1", 4294967296L));
@@ -841,7 +841,7 @@ public final class StreamingMiniBatchJoinOperatorTest extends StreamingJoinOpera
 
     @Tag("miniBatchSize=6")
     @Test
-    public void testInnerJoinWithNoUniqueKeyCrossBatches() throws Exception {
+    void testInnerJoinWithNoUniqueKeyCrossBatches() throws Exception {
         // joinKey is LineOrd
         // completely duplicate records
         testHarness.processElement1(
@@ -931,7 +931,7 @@ public final class StreamingMiniBatchJoinOperatorTest extends StreamingJoinOpera
     /** Outer join only emits INSERT or DELETE Msg. */
     @Tag("miniBatchSize=10")
     @Test
-    public void testLeftJoinWithJoinKeyContainsUniqueKey() throws Exception {
+    void testLeftJoinWithJoinKeyContainsUniqueKey() throws Exception {
         // joinKey is LineOrd
         // left fold  || right fold
         // +I +U / +U +U / +U -D ||  +I -D / +U -U / +I -U
@@ -1056,7 +1056,7 @@ public final class StreamingMiniBatchJoinOperatorTest extends StreamingJoinOpera
     /** Outer join only emits INSERT or DELETE Msg. */
     @Tag("miniBatchSize=4")
     @Test
-    public void testLeftJoinWithHasUniqueKey() throws Exception {
+    void testLeftJoinWithHasUniqueKey() throws Exception {
         // joinKey is LineOrd and uniqueKey is Ord
         // +I +U / +I -U / +I -D /+U +U
         List<StreamRecord<RowData>> records =
@@ -1205,63 +1205,63 @@ public final class StreamingMiniBatchJoinOperatorTest extends StreamingJoinOpera
 
     @Tag("miniBatchSize=2")
     @Test
-    public void testLeftJoinHasUniqueKeyRetAndAcc() throws Exception {
+    void testLeftJoinHasUniqueKeyRetAndAcc() throws Exception {
         // this case would create buffer of JoinHasUniqueKey
         testLeftJoinWithUpdate();
     }
 
     @Tag("miniBatchSize=2")
     @Test
-    public void testLeftJoinJoinKeyContainsUniqueKeyRetAndAcc() throws Exception {
+    void testLeftJoinJoinKeyContainsUniqueKeyRetAndAcc() throws Exception {
         // this case would create buffer of JoinKeyContainsUniqueKey
         testLeftJoinWithUpdate();
     }
 
     @Tag("miniBatchSize=2")
     @Test
-    public void testLeftJoinHasUniqueKeyWithoutRetract() throws Exception {
+    void testLeftJoinHasUniqueKeyWithoutRetract() throws Exception {
         // this case would create buffer of JoinHasUniqueKey
         testLeftJoinWithoutRetract();
     }
 
     @Tag("miniBatchSize=2")
     @Test
-    public void testLeftJoinJoinKeyContainsUniqueKeyWithoutRetract() throws Exception {
+    void testLeftJoinJoinKeyContainsUniqueKeyWithoutRetract() throws Exception {
         // this case would create buffer of JoinKeyContainsUniqueKey
         testLeftJoinWithoutRetract();
     }
 
     @Tag("miniBatchSize=2")
     @Test
-    public void testLeftJoinJoinKeyContainsUniqueKeyWithoutAcc() throws Exception {
+    void testLeftJoinJoinKeyContainsUniqueKeyWithoutAcc() throws Exception {
         // this case would create buffer of JoinKeyContainsUniqueKey
         testLeftJoinWithoutAcc();
     }
 
     @Tag("miniBatchSize=2")
     @Test
-    public void testLeftJoinHasUniqueKeyWithoutAcc() throws Exception {
+    void testLeftJoinHasUniqueKeyWithoutAcc() throws Exception {
         // this case would create buffer of JoinKeyContainsUniqueKey
         testLeftJoinWithoutAcc();
     }
 
     @Tag("miniBatchSize=4")
     @Test
-    public void testLeftJoinHasUniqueKeyWithUpdateMultipleCases() throws Exception {
+    void testLeftJoinHasUniqueKeyWithUpdateMultipleCases() throws Exception {
         // this case would create buffer of JoinKeyContainsUniqueKey
         testLeftJoinWithUpdateRecordsMultipleCases();
     }
 
     @Tag("miniBatchSize=4")
     @Test
-    public void testLeftJoinJoinKeyContainsUniqueKeyWithUpdateMultipleCases() throws Exception {
+    void testLeftJoinJoinKeyContainsUniqueKeyWithUpdateMultipleCases() throws Exception {
         // this case would create buffer of JoinKeyContainsUniqueKey
         testLeftJoinWithUpdateRecordsMultipleCases();
     }
 
     @Tag("miniBatchSize=4")
     @Test
-    public void testRightJoinWithHasUniqueKey() throws Exception {
+    void testRightJoinWithHasUniqueKey() throws Exception {
         List<StreamRecord<RowData>> records =
                 Arrays.asList(
                         insertRecord(
@@ -1336,7 +1336,7 @@ public final class StreamingMiniBatchJoinOperatorTest extends StreamingJoinOpera
 
     @Tag("miniBatchSize=4")
     @Test
-    public void testFullJoinWithHasUniqueKey() throws Exception {
+    void testFullJoinWithHasUniqueKey() throws Exception {
         List<StreamRecord<RowData>> records =
                 Arrays.asList(
                         insertRecord(
@@ -1469,7 +1469,7 @@ public final class StreamingMiniBatchJoinOperatorTest extends StreamingJoinOpera
 
     @Tag("miniBatchSize=15")
     @Test
-    public void testLeftJoinWithNoUniqueKey() throws Exception {
+    void testLeftJoinWithNoUniqueKey() throws Exception {
         // joinKey is LineOrd
         // +I -U / +I -D / -U +U / -D +I
         List<StreamRecord<RowData>> records =

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/stream/StreamingSemiAntiJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/stream/StreamingSemiAntiJoinOperatorTest.java
@@ -33,7 +33,7 @@ import static org.apache.flink.table.runtime.util.StreamRecordUtils.rowOfKind;
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.updateAfterRecord;
 
 /** Test for {@link StreamingSemiAntiJoinOperator}. */
-public class StreamingSemiAntiJoinOperatorTest extends StreamingJoinOperatorTestBase {
+class StreamingSemiAntiJoinOperatorTest extends StreamingJoinOperatorTestBase {
     @Override
     protected StreamingSemiAntiJoinOperator createJoinOperator(TestInfo testInfo) {
         Long[] ttl = STATE_RETENTION_TIME_EXTRACTOR.apply(testInfo.getTags());
@@ -63,7 +63,7 @@ public class StreamingSemiAntiJoinOperatorTest extends StreamingJoinOperatorTest
     @Tag("leftStateRetentionTime=4000")
     @Tag("rightStateRetentionTime=1000")
     @Test
-    public void testLeftSemiJoinWithDifferentStateRetentionTime() throws Exception {
+    void testLeftSemiJoinWithDifferentStateRetentionTime() throws Exception {
         testHarness.setStateTtlProcessingTime(1);
         testHarness.processElement1(
                 insertRecord("Ord#1", "LineOrd#1", "3 Bellevue Drive, Pottstown, PA 19464"));
@@ -116,7 +116,7 @@ public class StreamingSemiAntiJoinOperatorTest extends StreamingJoinOperatorTest
      * The only difference is that the state retention is disabled.
      */
     @Test
-    public void testLeftSemiJoinWithStateRetentionDisabled() throws Exception {
+    void testLeftSemiJoinWithStateRetentionDisabled() throws Exception {
         testHarness.setStateTtlProcessingTime(1);
         testHarness.processElement1(
                 insertRecord("Ord#1", "LineOrd#1", "3 Bellevue Drive, Pottstown, PA 19464"));
@@ -184,7 +184,7 @@ public class StreamingSemiAntiJoinOperatorTest extends StreamingJoinOperatorTest
     @Tag("leftStateRetentionTime=4000")
     @Tag("rightStateRetentionTime=1000")
     @Test
-    public void testLeftAntiJoinWithDifferentStateRetentionTime() throws Exception {
+    void testLeftAntiJoinWithDifferentStateRetentionTime() throws Exception {
         testHarness.setStateTtlProcessingTime(1);
         testHarness.processElement1(
                 insertRecord("Ord#1", "LineOrd#1", "3 Bellevue Drive, Pottstown, PA 19464"));
@@ -240,7 +240,7 @@ public class StreamingSemiAntiJoinOperatorTest extends StreamingJoinOperatorTest
      * The only difference is that the state retention is disabled.
      */
     @Test
-    public void testLeftAntiJoinWithStateRetentionTimeDisabled() throws Exception {
+    void testLeftAntiJoinWithStateRetentionTimeDisabled() throws Exception {
         testHarness.setStateTtlProcessingTime(1);
         testHarness.processElement1(
                 insertRecord("Ord#1", "LineOrd#1", "3 Bellevue Drive, Pottstown, PA 19464"));

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/temporal/TemporalProcessTimeJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/temporal/TemporalProcessTimeJoinOperatorTest.java
@@ -28,7 +28,7 @@ import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.table.utils.HandwrittenSelectorUtil;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -39,7 +39,7 @@ import static org.apache.flink.table.runtime.util.StreamRecordUtils.updateAfterR
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.updateBeforeRecord;
 
 /** Harness tests for {@link TemporalProcessTimeJoinOperator}. */
-public class TemporalProcessTimeJoinOperatorTest extends TemporalTimeJoinOperatorTestBase {
+class TemporalProcessTimeJoinOperatorTest extends TemporalTimeJoinOperatorTestBase {
 
     private int keyIdx = 0;
     private InternalTypeInfo<RowData> rowType =
@@ -59,7 +59,7 @@ public class TemporalProcessTimeJoinOperatorTest extends TemporalTimeJoinOperato
 
     /** Test proctime temporal join. */
     @Test
-    public void testProcTimeTemporalJoin() throws Exception {
+    void testProcTimeTemporalJoin() throws Exception {
         TemporalProcessTimeJoinOperator joinOperator =
                 new TemporalProcessTimeJoinOperator(rowType, joinCondition, 0, 0, false);
         KeyedTwoInputStreamOperatorTestHarness<RowData, RowData, RowData, RowData> testHarness =
@@ -89,7 +89,7 @@ public class TemporalProcessTimeJoinOperatorTest extends TemporalTimeJoinOperato
 
     /** Test proctime temporal join when set idle state retention. */
     @Test
-    public void testProcTimeTemporalJoinWithStateRetention() throws Exception {
+    void testProcTimeTemporalJoinWithStateRetention() throws Exception {
         final int minRetentionTime = 10;
         final int maxRetentionTime = minRetentionTime * 3 / 2;
         TemporalProcessTimeJoinOperator joinOperator =
@@ -119,7 +119,7 @@ public class TemporalProcessTimeJoinOperatorTest extends TemporalTimeJoinOperato
 
     /** Test proctime left temporal join when set idle state retention. */
     @Test
-    public void testLeftProcTimeTemporalJoinWithStateRetention() throws Exception {
+    void testLeftProcTimeTemporalJoinWithStateRetention() throws Exception {
         final int minRetentionTime = 10;
         final int maxRetentionTime = minRetentionTime * 3 / 2;
         TemporalProcessTimeJoinOperator joinOperator =
@@ -151,7 +151,7 @@ public class TemporalProcessTimeJoinOperatorTest extends TemporalTimeJoinOperato
 
     /** Test proctime temporal join changelog stream. */
     @Test
-    public void testProcTimeTemporalJoinOnChangelog() throws Exception {
+    void testProcTimeTemporalJoinOnChangelog() throws Exception {
         TemporalProcessTimeJoinOperator joinOperator =
                 new TemporalProcessTimeJoinOperator(rowType, joinCondition, 0, 0, false);
         KeyedTwoInputStreamOperatorTestHarness<RowData, RowData, RowData, RowData> testHarness =

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/temporal/TemporalRowTimeJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/temporal/TemporalRowTimeJoinOperatorTest.java
@@ -24,7 +24,7 @@ import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.util.KeyedTwoInputStreamOperatorTestHarness;
 import org.apache.flink.table.data.RowData;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -36,10 +36,10 @@ import static org.apache.flink.table.runtime.util.StreamRecordUtils.updateBefore
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Harness tests for {@link TemporalRowTimeJoinOperatorTest}. */
-public class TemporalRowTimeJoinOperatorTest extends TemporalTimeJoinOperatorTestBase {
+class TemporalRowTimeJoinOperatorTest extends TemporalTimeJoinOperatorTestBase {
     /** Test rowtime temporal join. */
     @Test
-    public void testRowTimeTemporalJoin() throws Exception {
+    void testRowTimeTemporalJoin() throws Exception {
         List<Object> expectedOutput = new ArrayList<>();
         expectedOutput.add(new Watermark(1));
         expectedOutput.add(new Watermark(2));
@@ -56,7 +56,7 @@ public class TemporalRowTimeJoinOperatorTest extends TemporalTimeJoinOperatorTes
 
     /** Test rowtime left temporal join. */
     @Test
-    public void testRowTimeLeftTemporalJoin() throws Exception {
+    void testRowTimeLeftTemporalJoin() throws Exception {
         List<Object> expectedOutput = new ArrayList<>();
         expectedOutput.add(new Watermark(1));
         expectedOutput.add(insertRecord(1L, "k1", "1a1", null, null, null));
@@ -121,7 +121,7 @@ public class TemporalRowTimeJoinOperatorTest extends TemporalTimeJoinOperatorTes
 
     /** Test rowtime temporal join when set idle state retention. */
     @Test
-    public void testRowTimeTemporalJoinWithStateRetention() throws Exception {
+    void testRowTimeTemporalJoinWithStateRetention() throws Exception {
         final int minRetentionTime = 4;
         final int maxRetentionTime = minRetentionTime * 3 / 2;
         TemporalRowTimeJoinOperator joinOperator =
@@ -194,7 +194,7 @@ public class TemporalRowTimeJoinOperatorTest extends TemporalTimeJoinOperatorTes
     }
 
     @Test
-    public void testRowTimeTemporalJoinOnUpsertSource() throws Exception {
+    void testRowTimeTemporalJoinOnUpsertSource() throws Exception {
         List<Object> expectedOutput = new ArrayList<>();
         expectedOutput.add(new Watermark(1));
         expectedOutput.add(new Watermark(2));
@@ -210,7 +210,7 @@ public class TemporalRowTimeJoinOperatorTest extends TemporalTimeJoinOperatorTes
     }
 
     @Test
-    public void testRowTimeLeftTemporalJoinOnUpsertSource() throws Exception {
+    void testRowTimeLeftTemporalJoinOnUpsertSource() throws Exception {
         List<Object> expectedOutput = new ArrayList<>();
         expectedOutput.add(new Watermark(1));
         expectedOutput.add(insertRecord(1L, "k1", "1a1", null, null, null));

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/window/WindowJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/window/WindowJoinOperatorTest.java
@@ -30,10 +30,11 @@ import org.apache.flink.table.runtime.util.RowDataHarnessAssertor;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.table.utils.HandwrittenSelectorUtil;
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.time.ZoneId;
 import java.util.ArrayList;
@@ -46,8 +47,8 @@ import static org.apache.flink.table.runtime.util.TimeWindowUtil.toUtcTimestampM
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for window join operators created by {@link WindowJoinOperatorBuilder}. */
-@RunWith(Parameterized.class)
-public class WindowJoinOperatorTest {
+@ExtendWith(ParameterizedTestExtension.class)
+class WindowJoinOperatorTest {
 
     private static final InternalTypeInfo<RowData> INPUT_ROW_TYPE =
             InternalTypeInfo.ofFields(new BigIntType(), VarCharType.STRING_TYPE);
@@ -75,13 +76,13 @@ public class WindowJoinOperatorTest {
         this.shiftTimeZone = shiftTimeZone;
     }
 
-    @Parameterized.Parameters(name = "TimeZone = {0}")
+    @Parameters(name = "TimeZone = {0}")
     public static Collection<Object[]> runMode() {
         return Arrays.asList(new Object[] {UTC_ZONE_ID}, new Object[] {SHANGHAI_ZONE_ID});
     }
 
-    @Test
-    public void testSemiJoin() throws Exception {
+    @TestTemplate
+    void testSemiJoin() throws Exception {
         KeyedTwoInputStreamOperatorTestHarness<RowData, RowData, RowData, RowData> testHarness =
                 createTestHarness(FlinkJoinType.SEMI);
 
@@ -135,8 +136,8 @@ public class WindowJoinOperatorTest {
         testHarness.close();
     }
 
-    @Test
-    public void testAntiJoin() throws Exception {
+    @TestTemplate
+    void testAntiJoin() throws Exception {
         KeyedTwoInputStreamOperatorTestHarness<RowData, RowData, RowData, RowData> testHarness =
                 createTestHarness(FlinkJoinType.ANTI);
         testHarness.open();
@@ -188,8 +189,8 @@ public class WindowJoinOperatorTest {
         testHarness.close();
     }
 
-    @Test
-    public void testInnerJoin() throws Exception {
+    @TestTemplate
+    void testInnerJoin() throws Exception {
         KeyedTwoInputStreamOperatorTestHarness<RowData, RowData, RowData, RowData> testHarness =
                 createTestHarness(FlinkJoinType.INNER);
 
@@ -263,8 +264,8 @@ public class WindowJoinOperatorTest {
         testHarness.close();
     }
 
-    @Test
-    public void testLeftOuterJoin() throws Exception {
+    @TestTemplate
+    void testLeftOuterJoin() throws Exception {
         KeyedTwoInputStreamOperatorTestHarness<RowData, RowData, RowData, RowData> testHarness =
                 createTestHarness(FlinkJoinType.LEFT);
 
@@ -340,8 +341,8 @@ public class WindowJoinOperatorTest {
         testHarness.close();
     }
 
-    @Test
-    public void testRightOuterJoin() throws Exception {
+    @TestTemplate
+    void testRightOuterJoin() throws Exception {
         KeyedTwoInputStreamOperatorTestHarness<RowData, RowData, RowData, RowData> testHarness =
                 createTestHarness(FlinkJoinType.RIGHT);
 
@@ -416,8 +417,8 @@ public class WindowJoinOperatorTest {
         testHarness.close();
     }
 
-    @Test
-    public void testOuterJoin() throws Exception {
+    @TestTemplate
+    void testOuterJoin() throws Exception {
         KeyedTwoInputStreamOperatorTestHarness<RowData, RowData, RowData, RowData> testHarness =
                 createTestHarness(FlinkJoinType.FULL);
 

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/window/WindowJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/window/WindowJoinOperatorTest.java
@@ -72,12 +72,12 @@ class WindowJoinOperatorTest {
 
     private final ZoneId shiftTimeZone;
 
-    public WindowJoinOperatorTest(ZoneId shiftTimeZone) {
+    WindowJoinOperatorTest(ZoneId shiftTimeZone) {
         this.shiftTimeZone = shiftTimeZone;
     }
 
     @Parameters(name = "TimeZone = {0}")
-    public static Collection<Object[]> runMode() {
+    private static Collection<Object[]> runMode() {
         return Arrays.asList(new Object[] {UTC_ZONE_ID}, new Object[] {SHANGHAI_ZONE_ID});
     }
 

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/BatchMultipleInputStreamOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/BatchMultipleInputStreamOperatorTest.java
@@ -39,7 +39,7 @@ import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.types.logical.RowType;
 
 import org.apache.commons.lang3.tuple.Pair;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -49,10 +49,10 @@ import java.util.stream.Collectors;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link BatchMultipleInputStreamOperator}. */
-public class BatchMultipleInputStreamOperatorTest extends MultipleInputTestBase {
+class BatchMultipleInputStreamOperatorTest extends MultipleInputTestBase {
 
     @Test
-    public void testOpen() throws Exception {
+    void testOpen() throws Exception {
         TestingBatchMultipleInputStreamOperator op = createMultipleInputStreamOperator();
         TestingTwoInputStreamOperator joinOp2 =
                 (TestingTwoInputStreamOperator) op.getTailWrapper().getStreamOperator();
@@ -83,7 +83,7 @@ public class BatchMultipleInputStreamOperatorTest extends MultipleInputTestBase 
     }
 
     @Test
-    public void testNextSelectionAndEndInput() throws Exception {
+    void testNextSelectionAndEndInput() throws Exception {
         TestingBatchMultipleInputStreamOperator op = createMultipleInputStreamOperator();
         TestingTwoInputStreamOperator joinOp2 =
                 (TestingTwoInputStreamOperator) op.getTailWrapper().getStreamOperator();
@@ -129,7 +129,7 @@ public class BatchMultipleInputStreamOperatorTest extends MultipleInputTestBase 
     }
 
     @Test
-    public void testClose() throws Exception {
+    void testClose() throws Exception {
         TestingBatchMultipleInputStreamOperator op = createMultipleInputStreamOperator();
         TestingTwoInputStreamOperator joinOp2 =
                 (TestingTwoInputStreamOperator) op.getTailWrapper().getStreamOperator();
@@ -160,7 +160,7 @@ public class BatchMultipleInputStreamOperatorTest extends MultipleInputTestBase 
     }
 
     @Test
-    public void testProcess() throws Exception {
+    void testProcess() throws Exception {
         TestingBatchMultipleInputStreamOperator op = createMultipleInputStreamOperator();
         List<StreamElement> outputData = op.getOutputData();
 

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/TableOperatorWrapperGeneratorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/TableOperatorWrapperGeneratorTest.java
@@ -34,7 +34,7 @@ import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.types.logical.RowType;
 
 import org.apache.commons.lang3.tuple.Pair;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -42,9 +42,10 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link TableOperatorWrapperGenerator}. */
-public class TableOperatorWrapperGeneratorTest extends MultipleInputTestBase {
+class TableOperatorWrapperGeneratorTest extends MultipleInputTestBase {
 
     /**
      * Test for simple sub-graph in a multiple input node.
@@ -60,7 +61,7 @@ public class TableOperatorWrapperGeneratorTest extends MultipleInputTestBase {
      * </pre>
      */
     @Test
-    public void testSimple() {
+    void testSimple() {
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         Transformation<RowData> source1 = createSource(env, "source1");
         Transformation<RowData> source2 = createSource(env, "source2");
@@ -128,7 +129,7 @@ public class TableOperatorWrapperGeneratorTest extends MultipleInputTestBase {
      * </pre>
      */
     @Test
-    public void testComplex() {
+    void testComplex() {
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         Transformation<RowData> source1 = createSource(env, "source1");
         Transformation<RowData> source2 = createSource(env, "source2");
@@ -253,7 +254,7 @@ public class TableOperatorWrapperGeneratorTest extends MultipleInputTestBase {
      * </pre>
      */
     @Test
-    public void testWithUnion() {
+    void testWithUnion() {
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         Transformation<RowData> source1 = createSource(env, "source1");
         Transformation<RowData> source2 = createSource(env, "source2");
@@ -332,7 +333,7 @@ public class TableOperatorWrapperGeneratorTest extends MultipleInputTestBase {
      * </pre>
      */
     @Test
-    public void testDifferentParallelisms() {
+    void testDifferentParallelisms() {
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         Transformation<RowData> source1 = createSource(env, "source1");
         Transformation<RowData> source2 = createSource(env, "source2");
@@ -400,8 +401,8 @@ public class TableOperatorWrapperGeneratorTest extends MultipleInputTestBase {
         assertThat(generator.getPreferredResources()).isEqualTo(ResourceSpec.UNKNOWN);
     }
 
-    @Test(expected = RuntimeException.class)
-    public void testUnsupportedTransformation() {
+    @Test
+    void testUnsupportedTransformation() {
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         Transformation<RowData> source1 = createSource(env, "source1");
         Transformation<RowData> source2 = createSource(env, "source2");
@@ -421,7 +422,7 @@ public class TableOperatorWrapperGeneratorTest extends MultipleInputTestBase {
         TableOperatorWrapperGenerator generator =
                 new TableOperatorWrapperGenerator(
                         Arrays.asList(source1, source2), join, new int[] {0, 0});
-        generator.generate();
+        assertThatThrownBy(() -> generator.generate()).isInstanceOf(RuntimeException.class);
     }
 
     @SafeVarargs

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/TableOperatorWrapperTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/TableOperatorWrapperTest.java
@@ -22,7 +22,7 @@ import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.operators.multipleinput.TableOperatorWrapper.Edge;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 
@@ -30,10 +30,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link TableOperatorWrapper}. */
-public class TableOperatorWrapperTest extends MultipleInputTestBase {
+class TableOperatorWrapperTest extends MultipleInputTestBase {
 
     @Test
-    public void testBasicInfo() {
+    void testBasicInfo() {
         TestingOneInputStreamOperator inOperator1 = new TestingOneInputStreamOperator();
         TestingOneInputStreamOperator inOperator2 = new TestingOneInputStreamOperator();
         TestingTwoInputStreamOperator outOperator = new TestingTwoInputStreamOperator();
@@ -68,7 +68,7 @@ public class TableOperatorWrapperTest extends MultipleInputTestBase {
     }
 
     @Test
-    public void testCreateOperator() throws Exception {
+    void testCreateOperator() throws Exception {
         TestingOneInputStreamOperator operator = new TestingOneInputStreamOperator();
         TableOperatorWrapper<TestingOneInputStreamOperator> wrapper =
                 createOneInputOperatorWrapper(operator, "test");
@@ -83,7 +83,7 @@ public class TableOperatorWrapperTest extends MultipleInputTestBase {
     }
 
     @Test
-    public void testEndInput() throws Exception {
+    void testEndInput() throws Exception {
         StreamOperatorParameters<RowData> parameters = createStreamOperatorParameters();
         TestingOneInputStreamOperator inOperator1 = new TestingOneInputStreamOperator();
         TestingOneInputStreamOperator inOperator2 = new TestingOneInputStreamOperator();
@@ -127,7 +127,7 @@ public class TableOperatorWrapperTest extends MultipleInputTestBase {
     }
 
     @Test
-    public void testClose() throws Exception {
+    void testClose() throws Exception {
         TestingOneInputStreamOperator operator = new TestingOneInputStreamOperator();
         TableOperatorWrapper<TestingOneInputStreamOperator> wrapper =
                 createOneInputOperatorWrapper(operator, "test");

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/input/InputSelectionHandlerTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/input/InputSelectionHandlerTest.java
@@ -21,7 +21,7 @@ package org.apache.flink.table.runtime.operators.multipleinput.input;
 import org.apache.flink.streaming.api.operators.InputSelection;
 import org.apache.flink.table.runtime.operators.multipleinput.MultipleInputTestBase;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -30,10 +30,10 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link InputSelectionHandler}. */
-public class InputSelectionHandlerTest extends MultipleInputTestBase {
+class InputSelectionHandlerTest extends MultipleInputTestBase {
 
     @Test
-    public void testWithSamePriority() {
+    void testWithSamePriority() {
         List<InputSpec> inputSpecs =
                 Arrays.asList(
                         new InputSpec(1, 0, createOneInputOperatorWrapper("input1"), 1),
@@ -53,7 +53,7 @@ public class InputSelectionHandlerTest extends MultipleInputTestBase {
     }
 
     @Test
-    public void testWithDifferentPriority() {
+    void testWithDifferentPriority() {
         List<InputSpec> inputSpecs =
                 Arrays.asList(
                         new InputSpec(1, 1, createOneInputOperatorWrapper("input1"), 1),

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/input/InputTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/input/InputTest.java
@@ -30,27 +30,27 @@ import org.apache.flink.table.runtime.operators.multipleinput.MultipleInputTestB
 import org.apache.flink.table.runtime.operators.multipleinput.TestingOneInputStreamOperator;
 import org.apache.flink.table.runtime.operators.multipleinput.TestingTwoInputStreamOperator;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for the sub-classes of {@link Input}. */
-public class InputTest extends MultipleInputTestBase {
+class InputTest extends MultipleInputTestBase {
 
     private StreamRecord<RowData> element;
     private Watermark watermark;
     private LatencyMarker latencyMarker;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         element = new StreamRecord<>(GenericRowData.of(StringData.fromString("123")), 456);
         watermark = new Watermark(1223456789);
         latencyMarker = new LatencyMarker(122345678, new OperatorID(123, 456), 1);
     }
 
     @Test
-    public void testOneInput() throws Exception {
+    void testOneInput() throws Exception {
         TestingOneInputStreamOperator op = createOneInputStreamOperator();
         OneInput input = new OneInput(op);
 
@@ -65,7 +65,7 @@ public class InputTest extends MultipleInputTestBase {
     }
 
     @Test
-    public void testFirstInputOfTwoInput() throws Exception {
+    void testFirstInputOfTwoInput() throws Exception {
         TestingTwoInputStreamOperator op = createTwoInputStreamOperator();
         FirstInputOfTwoInput input = new FirstInputOfTwoInput(op);
 
@@ -83,7 +83,7 @@ public class InputTest extends MultipleInputTestBase {
     }
 
     @Test
-    public void testSecondInputOfTwoInput() throws Exception {
+    void testSecondInputOfTwoInput() throws Exception {
         TestingTwoInputStreamOperator op = createTwoInputStreamOperator();
         SecondInputOfTwoInput input = new SecondInputOfTwoInput(op);
 

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/output/OutputTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/output/OutputTest.java
@@ -35,21 +35,21 @@ import org.apache.flink.table.runtime.operators.multipleinput.TestingTwoInputStr
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.types.logical.RowType;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for the sub-classes of {@link Output}. */
-public class OutputTest extends MultipleInputTestBase {
+class OutputTest extends MultipleInputTestBase {
 
     private StreamRecord<RowData> element;
     private Watermark watermark;
     private LatencyMarker latencyMarker;
     private TypeSerializer<RowData> serializer;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         element = new StreamRecord<>(GenericRowData.of(StringData.fromString("123")), 456);
         watermark = new Watermark(1223456789);
         latencyMarker = new LatencyMarker(122345678, new OperatorID(123, 456), 1);
@@ -59,7 +59,7 @@ public class OutputTest extends MultipleInputTestBase {
     }
 
     @Test
-    public void testOneInput() throws Exception {
+    void testOneInput() throws Exception {
         TestingOneInputStreamOperator op = createOneInputStreamOperator();
         OneInputStreamOperatorOutput output = new OneInputStreamOperatorOutput(op);
 
@@ -74,7 +74,7 @@ public class OutputTest extends MultipleInputTestBase {
     }
 
     @Test
-    public void testCopyingOneInput() throws Exception {
+    void testCopyingOneInput() throws Exception {
         TestingOneInputStreamOperator op = createOneInputStreamOperator();
         CopyingOneInputStreamOperatorOutput output =
                 new CopyingOneInputStreamOperatorOutput(op, serializer);
@@ -91,7 +91,7 @@ public class OutputTest extends MultipleInputTestBase {
     }
 
     @Test
-    public void testFirstInputOfTwoInput() throws Exception {
+    void testFirstInputOfTwoInput() throws Exception {
         TestingTwoInputStreamOperator op = createTwoInputStreamOperator();
         FirstInputOfTwoInputStreamOperatorOutput output =
                 new FirstInputOfTwoInputStreamOperatorOutput(op);
@@ -110,7 +110,7 @@ public class OutputTest extends MultipleInputTestBase {
     }
 
     @Test
-    public void testCopyingFirstInputOfTwoInput() throws Exception {
+    void testCopyingFirstInputOfTwoInput() throws Exception {
         TestingTwoInputStreamOperator op = createTwoInputStreamOperator();
         CopyingFirstInputOfTwoInputStreamOperatorOutput output =
                 new CopyingFirstInputOfTwoInputStreamOperatorOutput(op, serializer);
@@ -130,7 +130,7 @@ public class OutputTest extends MultipleInputTestBase {
     }
 
     @Test
-    public void testSecondInputOfTwoInput() throws Exception {
+    void testSecondInputOfTwoInput() throws Exception {
         TestingTwoInputStreamOperator op = createTwoInputStreamOperator();
         SecondInputOfTwoInputStreamOperatorOutput output =
                 new SecondInputOfTwoInputStreamOperatorOutput(op);
@@ -149,7 +149,7 @@ public class OutputTest extends MultipleInputTestBase {
     }
 
     @Test
-    public void testCopyingSecondInputOfTwoInput() throws Exception {
+    void testCopyingSecondInputOfTwoInput() throws Exception {
         TestingTwoInputStreamOperator op = createTwoInputStreamOperator();
         CopyingSecondInputOfTwoInputStreamOperatorOutput output =
                 new CopyingSecondInputOfTwoInputStreamOperatorOutput(op, serializer);
@@ -169,7 +169,7 @@ public class OutputTest extends MultipleInputTestBase {
     }
 
     @Test
-    public void testBroadcasting() throws Exception {
+    void testBroadcasting() throws Exception {
         TestingOneInputStreamOperator op1 = createOneInputStreamOperator();
         TestingOneInputStreamOperator op2 = createOneInputStreamOperator();
         BroadcastingOutput output =
@@ -198,7 +198,7 @@ public class OutputTest extends MultipleInputTestBase {
     }
 
     @Test
-    public void testCopyingBroadcasting() throws Exception {
+    void testCopyingBroadcasting() throws Exception {
         TestingOneInputStreamOperator op1 = createOneInputStreamOperator();
         TestingOneInputStreamOperator op2 = createOneInputStreamOperator();
         CopyingBroadcastingOutput output =

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/over/BufferDataOverWindowOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/over/BufferDataOverWindowOperatorTest.java
@@ -46,8 +46,8 @@ import org.apache.flink.table.runtime.operators.over.frame.UnboundedOverWindowFr
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.RowType;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -64,7 +64,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /** Test for {@link BufferDataOverWindowOperator}. */
-public class BufferDataOverWindowOperatorTest {
+class BufferDataOverWindowOperatorTest {
 
     private RowType valueType =
             new RowType(Collections.singletonList(new RowType.RowField("f0", new BigIntType())));
@@ -79,13 +79,13 @@ public class BufferDataOverWindowOperatorTest {
                 }
             };
 
-    @Before
-    public void before() throws Exception {
+    @BeforeEach
+    void before() throws Exception {
         collect = new ArrayList<>();
     }
 
     @Test
-    public void testOffsetWindowFrame() throws Exception {
+    void testOffsetWindowFrame() throws Exception {
         test(
                 new OverWindowFrame[] {
                     new OffsetOverFrame(function, 2L, null),
@@ -105,7 +105,7 @@ public class BufferDataOverWindowOperatorTest {
     }
 
     @Test
-    public void testInsensitiveAndUnbounded() throws Exception {
+    void testInsensitiveAndUnbounded() throws Exception {
         test(
                 new OverWindowFrame[] {
                     new InsensitiveOverFrame(function),
@@ -125,7 +125,7 @@ public class BufferDataOverWindowOperatorTest {
     }
 
     @Test
-    public void testPreceding() throws Exception {
+    void testPreceding() throws Exception {
         test(
                 new OverWindowFrame[] {
                     new RowUnboundedPrecedingOverFrame(function, 1),
@@ -145,7 +145,7 @@ public class BufferDataOverWindowOperatorTest {
     }
 
     @Test
-    public void testFollowing() throws Exception {
+    void testFollowing() throws Exception {
         test(
                 new OverWindowFrame[] {
                     new RowUnboundedFollowingOverFrame(valueType, function, -1),
@@ -165,7 +165,7 @@ public class BufferDataOverWindowOperatorTest {
     }
 
     @Test
-    public void testSliding() throws Exception {
+    void testSliding() throws Exception {
         test(
                 new OverWindowFrame[] {
                     new RowSlidingOverFrame(inputType, valueType, function, -1, 1),

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/over/NonBufferOverWindowOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/over/NonBufferOverWindowOperatorTest.java
@@ -47,8 +47,8 @@ import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.util.OutputTag;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -61,7 +61,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /** Test for {@link NonBufferOverWindowOperator}. */
-public class NonBufferOverWindowOperatorTest {
+class NonBufferOverWindowOperatorTest {
 
     static GeneratedAggsHandleFunction function =
             new GeneratedAggsHandleFunction("Function1", "", new Object[0]) {
@@ -96,13 +96,13 @@ public class NonBufferOverWindowOperatorTest {
     private NonBufferOverWindowOperator operator;
     private List<GenericRowData> collect;
 
-    @Before
-    public void before() throws Exception {
+    @BeforeEach
+    void before() throws Exception {
         collect = new ArrayList<>();
     }
 
     @Test
-    public void testNormal() throws Exception {
+    void testNormal() throws Exception {
         test(
                 new boolean[] {false, false},
                 new GenericRowData[] {
@@ -115,7 +115,7 @@ public class NonBufferOverWindowOperatorTest {
     }
 
     @Test
-    public void testResetAccumulators() throws Exception {
+    void testResetAccumulators() throws Exception {
         test(
                 new boolean[] {true, false},
                 new GenericRowData[] {

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/over/ProcTimeRangeBoundedPrecedingFunctionTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/over/ProcTimeRangeBoundedPrecedingFunctionTest.java
@@ -32,13 +32,13 @@ import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.table.utils.HandwrittenSelectorUtil;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link ProcTimeRangeBoundedPrecedingFunction}. */
-public class ProcTimeRangeBoundedPrecedingFunctionTest {
+class ProcTimeRangeBoundedPrecedingFunctionTest {
 
     private static GeneratedAggsHandleFunction aggsHandleFunction =
             new GeneratedAggsHandleFunction("Function", "", new Object[0]) {
@@ -59,7 +59,7 @@ public class ProcTimeRangeBoundedPrecedingFunctionTest {
     private TypeInformation<RowData> keyType = keySelector.getProducedType();
 
     @Test
-    public void testStateCleanup() throws Exception {
+    void testStateCleanup() throws Exception {
         ProcTimeRangeBoundedPrecedingFunction<RowData> function =
                 new ProcTimeRangeBoundedPrecedingFunction<>(
                         aggsHandleFunction, accTypes, inputFieldTypes, 2000);

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/over/ProcTimeUnboundedPrecedingFunctionTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/over/ProcTimeUnboundedPrecedingFunctionTest.java
@@ -35,7 +35,7 @@ import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.table.utils.HandwrittenSelectorUtil;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -44,7 +44,7 @@ import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link ProcTimeRangeBoundedPrecedingFunction}. */
-public class ProcTimeUnboundedPrecedingFunctionTest {
+class ProcTimeUnboundedPrecedingFunctionTest {
     StateTtlConfig ttlConfig = StateConfigUtil.createTtlConfig(2_000);
 
     private static GeneratedAggsHandleFunction aggsHandleFunction =
@@ -73,7 +73,7 @@ public class ProcTimeUnboundedPrecedingFunctionTest {
     private RowDataHarnessAssertor assertor = new RowDataHarnessAssertor(outputFieldTypes);
 
     @Test
-    public void testStateTtl() throws Exception {
+    void testStateTtl() throws Exception {
         ProcTimeUnboundedPrecedingFunction<RowData> function =
                 new ProcTimeUnboundedPrecedingFunction<>(ttlConfig, aggsHandleFunction, accTypes);
         KeyedProcessOperator<RowData, RowData, RowData> operator =

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/over/RowTimeRangeBoundedPrecedingFunctionTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/over/RowTimeRangeBoundedPrecedingFunctionTest.java
@@ -25,16 +25,16 @@ import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.table.data.RowData;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link RowTimeRangeBoundedPrecedingFunction}. */
-public class RowTimeRangeBoundedPrecedingFunctionTest extends RowTimeOverWindowTestBase {
+class RowTimeRangeBoundedPrecedingFunctionTest extends RowTimeOverWindowTestBase {
 
     @Test
-    public void testStateCleanup() throws Exception {
+    void testStateCleanup() throws Exception {
         RowTimeRangeBoundedPrecedingFunction<RowData> function =
                 new RowTimeRangeBoundedPrecedingFunction<>(
                         aggsHandleFunction, accTypes, inputFieldTypes, 2000, 2);
@@ -70,7 +70,7 @@ public class RowTimeRangeBoundedPrecedingFunctionTest extends RowTimeOverWindowT
     }
 
     @Test
-    public void testLateRecordMetrics() throws Exception {
+    void testLateRecordMetrics() throws Exception {
         RowTimeRangeBoundedPrecedingFunction<RowData> function =
                 new RowTimeRangeBoundedPrecedingFunction<>(
                         aggsHandleFunction, accTypes, inputFieldTypes, 2000, 2);

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/over/RowTimeRangeUnboundedPrecedingFunctionTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/over/RowTimeRangeUnboundedPrecedingFunctionTest.java
@@ -24,16 +24,16 @@ import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.table.data.RowData;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link RowTimeRangeUnboundedPrecedingFunction}. */
-public class RowTimeRangeUnboundedPrecedingFunctionTest extends RowTimeOverWindowTestBase {
+class RowTimeRangeUnboundedPrecedingFunctionTest extends RowTimeOverWindowTestBase {
 
     @Test
-    public void testLateRecordMetrics() throws Exception {
+    void testLateRecordMetrics() throws Exception {
         RowTimeRangeUnboundedPrecedingFunction<RowData> function =
                 new RowTimeRangeUnboundedPrecedingFunction<>(
                         1000, 2000, aggsHandleFunction, accTypes, inputFieldTypes, 2);

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/over/RowTimeRowsBoundedPrecedingFunctionTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/over/RowTimeRowsBoundedPrecedingFunctionTest.java
@@ -24,16 +24,16 @@ import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.table.data.RowData;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link RowTimeRowsBoundedPrecedingFunction}. */
-public class RowTimeRowsBoundedPrecedingFunctionTest extends RowTimeOverWindowTestBase {
+class RowTimeRowsBoundedPrecedingFunctionTest extends RowTimeOverWindowTestBase {
 
     @Test
-    public void testLateRecordMetrics() throws Exception {
+    void testLateRecordMetrics() throws Exception {
         RowTimeRowsBoundedPrecedingFunction<RowData> function =
                 new RowTimeRowsBoundedPrecedingFunction<>(
                         1000, 2000, aggsHandleFunction, accTypes, inputFieldTypes, 2000, 2);

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/over/RowTimeRowsUnboundedPrecedingFunctionTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/over/RowTimeRowsUnboundedPrecedingFunctionTest.java
@@ -24,16 +24,16 @@ import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.table.data.RowData;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link RowTimeRowsUnboundedPrecedingFunction}. */
-public class RowTimeRowsUnboundedPrecedingFunctionTest extends RowTimeOverWindowTestBase {
+class RowTimeRowsUnboundedPrecedingFunctionTest extends RowTimeOverWindowTestBase {
 
     @Test
-    public void testLateRecordMetrics() throws Exception {
+    void testLateRecordMetrics() throws Exception {
         RowTimeRowsUnboundedPrecedingFunction<RowData> function =
                 new RowTimeRowsUnboundedPrecedingFunction<>(
                         1000, 2000, aggsHandleFunction, accTypes, inputFieldTypes, 2);

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/rank/AppendOnlyFirstNFunctionTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/rank/AppendOnlyFirstNFunctionTest.java
@@ -21,7 +21,7 @@ package org.apache.flink.table.runtime.operators.rank;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.table.data.RowData;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -29,7 +29,7 @@ import java.util.List;
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord;
 
 /** Tests for {@link AppendOnlyFirstNFunction}. */
-public class AppendOnlyFirstNFunctionTest extends TopNFunctionTestBase {
+class AppendOnlyFirstNFunctionTest extends TopNFunctionTestBase {
     @Override
     AbstractTopNFunction createFunction(
             RankType rankType,
@@ -49,7 +49,7 @@ public class AppendOnlyFirstNFunctionTest extends TopNFunctionTestBase {
 
     @Override
     @Test
-    public void testDisableGenerateUpdateBefore() throws Exception {
+    void testDisableGenerateUpdateBefore() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 2), false, false);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
@@ -73,7 +73,7 @@ public class AppendOnlyFirstNFunctionTest extends TopNFunctionTestBase {
 
     @Override
     @Test
-    public void testDisableGenerateUpdateBeforeAndOutputRankNumber() throws Exception {
+    void testDisableGenerateUpdateBeforeAndOutputRankNumber() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 2), false, true);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
@@ -97,7 +97,7 @@ public class AppendOnlyFirstNFunctionTest extends TopNFunctionTestBase {
 
     @Override
     @Test
-    public void testOutputRankNumberWithConstantRankRange() throws Exception {
+    void testOutputRankNumberWithConstantRankRange() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 2), true, true);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
@@ -121,7 +121,7 @@ public class AppendOnlyFirstNFunctionTest extends TopNFunctionTestBase {
 
     @Override
     @Test
-    public void testConstantRankRangeWithOffset() throws Exception {
+    void testConstantRankRangeWithOffset() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(2, 2), true, false);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
@@ -143,7 +143,7 @@ public class AppendOnlyFirstNFunctionTest extends TopNFunctionTestBase {
 
     @Override
     @Test
-    public void testConstantRankRangeWithoutOffset() throws Exception {
+    void testConstantRankRangeWithoutOffset() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 2), true, false);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
@@ -167,7 +167,7 @@ public class AppendOnlyFirstNFunctionTest extends TopNFunctionTestBase {
 
     @Override
     @Test
-    public void testOutputRankNumberWithVariableRankRange() throws Exception {
+    void testOutputRankNumberWithVariableRankRange() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new VariableRankRange(1), false, true);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/rank/AppendOnlyTopNFunctionTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/rank/AppendOnlyTopNFunctionTest.java
@@ -21,7 +21,7 @@ package org.apache.flink.table.runtime.operators.rank;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.table.data.RowData;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -30,7 +30,7 @@ import static org.apache.flink.table.runtime.util.StreamRecordUtils.deleteRecord
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord;
 
 /** Tests for {@link AppendOnlyTopNFunction}. */
-public class AppendOnlyTopNFunctionTest extends TopNFunctionTestBase {
+class AppendOnlyTopNFunctionTest extends TopNFunctionTestBase {
 
     @Override
     protected AbstractTopNFunction createFunction(
@@ -51,7 +51,7 @@ public class AppendOnlyTopNFunctionTest extends TopNFunctionTestBase {
     }
 
     @Test
-    public void testVariableRankRange() throws Exception {
+    void testVariableRankRange() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new VariableRankRange(1), true, false);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/rank/FastTop1FunctionTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/rank/FastTop1FunctionTest.java
@@ -22,7 +22,7 @@ import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.table.data.RowData;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -52,7 +52,7 @@ public class FastTop1FunctionTest extends TopNFunctionTestBase {
     }
 
     @Override
-    public void testDisableGenerateUpdateBefore() throws Exception {
+    void testDisableGenerateUpdateBefore() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 1), false, false);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
@@ -78,7 +78,7 @@ public class FastTop1FunctionTest extends TopNFunctionTestBase {
     }
 
     @Override
-    public void testOutputRankNumberWithConstantRankRange() throws Exception {
+    void testOutputRankNumberWithConstantRankRange() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 1), true, true);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
@@ -104,7 +104,7 @@ public class FastTop1FunctionTest extends TopNFunctionTestBase {
     }
 
     @Override
-    public void testDisableGenerateUpdateBeforeAndOutputRankNumber() throws Exception {
+    void testDisableGenerateUpdateBeforeAndOutputRankNumber() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 1), false, true);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
@@ -129,7 +129,7 @@ public class FastTop1FunctionTest extends TopNFunctionTestBase {
     }
 
     @Override
-    public void testConstantRankRangeWithoutOffset() throws Exception {
+    void testConstantRankRangeWithoutOffset() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 1), true, false);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
@@ -174,7 +174,7 @@ public class FastTop1FunctionTest extends TopNFunctionTestBase {
     // ------------ Tests with UPDATE input records ---------------
 
     @Test
-    public void testVariableRankRange() throws Exception {
+    void testVariableRankRange() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 1), true, false);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
@@ -200,7 +200,7 @@ public class FastTop1FunctionTest extends TopNFunctionTestBase {
     }
 
     @Test
-    public void testOutputRankNumberWithUpdateInputs() throws Exception {
+    void testOutputRankNumberWithUpdateInputs() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 1), true, true);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
@@ -229,7 +229,7 @@ public class FastTop1FunctionTest extends TopNFunctionTestBase {
     }
 
     @Test
-    public void testSortKeyChangesWhenOutputRankNumber() throws Exception {
+    void testSortKeyChangesWhenOutputRankNumber() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 1), true, true);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
@@ -263,8 +263,7 @@ public class FastTop1FunctionTest extends TopNFunctionTestBase {
     }
 
     @Test
-    public void testSortKeyChangesWhenOutputRankNumberAndNotGenerateUpdateBefore()
-            throws Exception {
+    void testSortKeyChangesWhenOutputRankNumberAndNotGenerateUpdateBefore() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 1), false, true);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
@@ -294,7 +293,7 @@ public class FastTop1FunctionTest extends TopNFunctionTestBase {
     }
 
     @Test
-    public void testSortKeyChangesWhenNotOutputRankNumber() throws Exception {
+    void testSortKeyChangesWhenNotOutputRankNumber() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 1), true, false);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
@@ -323,8 +322,7 @@ public class FastTop1FunctionTest extends TopNFunctionTestBase {
     }
 
     @Test
-    public void testSortKeyChangesWhenNotOutputRankNumberAndNotGenerateUpdateBefore()
-            throws Exception {
+    void testSortKeyChangesWhenNotOutputRankNumberAndNotGenerateUpdateBefore() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 1), false, false);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
@@ -349,12 +347,12 @@ public class FastTop1FunctionTest extends TopNFunctionTestBase {
     }
 
     @Override
-    public void testConstantRankRangeWithOffset() throws Exception {
+    void testConstantRankRangeWithOffset() throws Exception {
         // skip
     }
 
     @Override
-    public void testOutputRankNumberWithVariableRankRange() throws Exception {
+    void testOutputRankNumberWithVariableRankRange() throws Exception {
         // skip
     }
 }

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/rank/RetractableTopNFunctionTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/rank/RetractableTopNFunctionTest.java
@@ -28,7 +28,7 @@ import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.VarCharType;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -60,7 +60,7 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
     }
 
     @Test
-    public void testProcessRetractMessageWithNotGenerateUpdateBefore() throws Exception {
+    void testProcessRetractMessageWithNotGenerateUpdateBefore() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 2), false, true);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
@@ -99,7 +99,7 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
     }
 
     @Test
-    public void testProcessRetractMessageWithGenerateUpdateBefore() throws Exception {
+    void testProcessRetractMessageWithGenerateUpdateBefore() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 2), true, true);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
@@ -143,7 +143,7 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
     }
 
     @Test
-    public void testConstantRankRangeWithoutOffsetWithRowNumber() throws Exception {
+    void testConstantRankRangeWithoutOffsetWithRowNumber() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 2), true, true);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
@@ -199,7 +199,7 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
     }
 
     @Test
-    public void testConstantRankRangeWithoutOffsetWithoutRowNumber() throws Exception {
+    void testConstantRankRangeWithoutOffsetWithoutRowNumber() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 2), true, false);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
@@ -243,7 +243,7 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
     }
 
     @Test
-    public void testVariableRankRangeWithRowNumber() throws Exception {
+    void testVariableRankRangeWithRowNumber() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new VariableRankRange(1), true, true);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
@@ -280,7 +280,7 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
     }
 
     @Test
-    public void testVariableRankRangeWithoutRowNumber() throws Exception {
+    void testVariableRankRangeWithoutRowNumber() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new VariableRankRange(1), true, false);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
@@ -306,7 +306,7 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
     }
 
     @Test
-    public void testDisableGenerateUpdateBeforeWithRowNumber() throws Exception {
+    void testDisableGenerateUpdateBeforeWithRowNumber() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 2), false, true);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
@@ -339,7 +339,7 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
     }
 
     @Test
-    public void testDisableGenerateUpdateBeforeWithoutRowNumber() throws Exception {
+    void testDisableGenerateUpdateBeforeWithoutRowNumber() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 2), false, false);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
@@ -366,7 +366,7 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
     }
 
     @Test
-    public void testCleanIdleState() throws Exception {
+    void testCleanIdleState() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 2), true, true);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
@@ -409,7 +409,7 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
     }
 
     @Test
-    public void testConstantRankRangeWithoutRowNumber() throws Exception {
+    void testConstantRankRangeWithoutRowNumber() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 3), false, false);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
@@ -434,7 +434,7 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
     }
 
     @Test
-    public void testConstantRankRangeWithRowNumber() throws Exception {
+    void testConstantRankRangeWithRowNumber() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 3), false, true);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
@@ -459,7 +459,7 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
     }
 
     @Test
-    public void testRetractRecordOutOfRankRangeWithoutRowNumber() throws Exception {
+    void testRetractRecordOutOfRankRangeWithoutRowNumber() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 2), false, false);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
@@ -488,7 +488,7 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
     }
 
     @Test
-    public void testRetractRecordOutOfRankRangeWithRowNumber() throws Exception {
+    void testRetractRecordOutOfRankRangeWithRowNumber() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 2), false, true);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
@@ -517,7 +517,7 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
     }
 
     @Test
-    public void testRetractAndThenDeleteRecordWithoutRowNumber() throws Exception {
+    void testRetractAndThenDeleteRecordWithoutRowNumber() throws Exception {
         AbstractTopNFunction func =
                 new RetractableTopNFunction(
                         ttlConfig,
@@ -558,7 +558,7 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
     }
 
     @Test
-    public void testRetractAnStaledRecordWithRowNumber() throws Exception {
+    void testRetractAnStaledRecordWithRowNumber() throws Exception {
         StateTtlConfig ttlConfig = StateConfigUtil.createTtlConfig(1_000);
         AbstractTopNFunction func =
                 new RetractableTopNFunction(

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/rank/TopNFunctionTestBase.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/rank/TopNFunctionTestBase.java
@@ -41,7 +41,7 @@ import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.table.utils.HandwrittenSelectorUtil;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -50,6 +50,7 @@ import static org.apache.flink.table.runtime.util.StreamRecordUtils.deleteRecord
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord;
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.updateAfterRecord;
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.updateBeforeRecord;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Base Tests for all subclass of {@link AbstractTopNFunction}. */
 abstract class TopNFunctionTestBase {
@@ -127,31 +128,50 @@ abstract class TopNFunctionTestBase {
                     new int[] {rowKeyIdx}, inputRowType.toRowFieldTypes());
 
     /** RankEnd column must be long, int or short type, but could not be string type yet. */
-    @Test(expected = UnsupportedOperationException.class)
-    public void testInvalidVariableRankRangeWithIntType() throws Exception {
+    @Test
+    void testInvalidVariableRankRangeWithIntType() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new VariableRankRange(0), true, false);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
-        testHarness.open();
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testNotSupportRank() throws Exception {
-        createFunction(RankType.RANK, new ConstantRankRange(1, 10), true, true);
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testNotSupportDenseRank() throws Exception {
-        createFunction(RankType.DENSE_RANK, new ConstantRankRange(1, 10), true, true);
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testNotSupportWithoutRankEnd() throws Exception {
-        createFunction(RankType.ROW_NUMBER, new ConstantRankRangeWithoutEnd(1), true, true);
+        assertThatThrownBy(() -> testHarness.open())
+                .isInstanceOf(UnsupportedOperationException.class);
     }
 
     @Test
-    public void testDisableGenerateUpdateBefore() throws Exception {
+    void testNotSupportRank() throws Exception {
+        assertThatThrownBy(
+                        () ->
+                                createFunction(
+                                        RankType.RANK, new ConstantRankRange(1, 10), true, true))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void testNotSupportDenseRank() throws Exception {
+        assertThatThrownBy(
+                        () ->
+                                createFunction(
+                                        RankType.DENSE_RANK,
+                                        new ConstantRankRange(1, 10),
+                                        true,
+                                        true))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void testNotSupportWithoutRankEnd() throws Exception {
+        assertThatThrownBy(
+                        () ->
+                                createFunction(
+                                        RankType.ROW_NUMBER,
+                                        new ConstantRankRangeWithoutEnd(1),
+                                        true,
+                                        true))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void testDisableGenerateUpdateBefore() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 2), false, false);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
@@ -184,7 +204,7 @@ abstract class TopNFunctionTestBase {
     }
 
     @Test
-    public void testDisableGenerateUpdateBeforeAndOutputRankNumber() throws Exception {
+    void testDisableGenerateUpdateBeforeAndOutputRankNumber() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 2), false, true);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
@@ -216,7 +236,7 @@ abstract class TopNFunctionTestBase {
     }
 
     @Test
-    public void testOutputRankNumberWithConstantRankRange() throws Exception {
+    void testOutputRankNumberWithConstantRankRange() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 2), true, true);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
@@ -250,7 +270,7 @@ abstract class TopNFunctionTestBase {
     }
 
     @Test
-    public void testConstantRankRangeWithOffset() throws Exception {
+    void testConstantRankRangeWithOffset() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(2, 2), true, false);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
@@ -275,7 +295,7 @@ abstract class TopNFunctionTestBase {
     }
 
     @Test
-    public void testOutputRankNumberWithVariableRankRange() throws Exception {
+    void testOutputRankNumberWithVariableRankRange() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new VariableRankRange(1), true, true);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
@@ -303,7 +323,7 @@ abstract class TopNFunctionTestBase {
     }
 
     @Test
-    public void testConstantRankRangeWithoutOffset() throws Exception {
+    void testConstantRankRangeWithoutOffset() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 2), true, false);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/rank/UpdatableTopNFunctionTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/rank/UpdatableTopNFunctionTest.java
@@ -21,7 +21,7 @@ package org.apache.flink.table.runtime.operators.rank;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.table.data.RowData;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,7 +32,7 @@ import static org.apache.flink.table.runtime.util.StreamRecordUtils.updateAfterR
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.updateBeforeRecord;
 
 /** Tests for {@link UpdatableTopNFunction}. */
-public class UpdatableTopNFunctionTest extends TopNFunctionTestBase {
+class UpdatableTopNFunctionTest extends TopNFunctionTestBase {
 
     @Override
     protected AbstractTopNFunction createFunction(
@@ -54,7 +54,7 @@ public class UpdatableTopNFunctionTest extends TopNFunctionTestBase {
     }
 
     @Test
-    public void testVariableRankRange() throws Exception {
+    void testVariableRankRange() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new VariableRankRange(1), true, false);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
@@ -81,7 +81,7 @@ public class UpdatableTopNFunctionTest extends TopNFunctionTestBase {
 
     @Override
     @Test
-    public void testOutputRankNumberWithVariableRankRange() throws Exception {
+    void testOutputRankNumberWithVariableRankRange() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new VariableRankRange(1), true, true);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
@@ -110,7 +110,7 @@ public class UpdatableTopNFunctionTest extends TopNFunctionTestBase {
     }
 
     @Test
-    public void testSortKeyChangesWhenOutputRankNumber() throws Exception {
+    void testSortKeyChangesWhenOutputRankNumber() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 2), true, true);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
@@ -154,8 +154,7 @@ public class UpdatableTopNFunctionTest extends TopNFunctionTestBase {
     }
 
     @Test
-    public void testSortKeyChangesWhenOutputRankNumberAndNotGenerateUpdateBefore()
-            throws Exception {
+    void testSortKeyChangesWhenOutputRankNumberAndNotGenerateUpdateBefore() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 2), false, true);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
@@ -191,7 +190,7 @@ public class UpdatableTopNFunctionTest extends TopNFunctionTestBase {
     }
 
     @Test
-    public void testSortKeyChangesWhenNotOutputRankNumber() throws Exception {
+    void testSortKeyChangesWhenNotOutputRankNumber() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 2), true, false);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
@@ -221,8 +220,7 @@ public class UpdatableTopNFunctionTest extends TopNFunctionTestBase {
     }
 
     @Test
-    public void testSortKeyChangesWhenNotOutputRankNumberAndNotGenerateUpdateBefore()
-            throws Exception {
+    void testSortKeyChangesWhenNotOutputRankNumberAndNotGenerateUpdateBefore() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 2), false, false);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/rank/window/WindowRankOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/rank/window/WindowRankOperatorTest.java
@@ -39,10 +39,11 @@ import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.table.utils.HandwrittenSelectorUtil;
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.time.ZoneId;
 import java.util.Arrays;
@@ -54,8 +55,8 @@ import static org.apache.flink.table.runtime.util.TimeWindowUtil.toUtcTimestampM
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for window rank operators created by {@link WindowRankOperatorBuilder}. */
-@RunWith(Parameterized.class)
-public class WindowRankOperatorTest {
+@ExtendWith(ParameterizedTestExtension.class)
+class WindowRankOperatorTest {
 
     private static final RowType INPUT_ROW_TYPE =
             new RowType(
@@ -127,7 +128,7 @@ public class WindowRankOperatorTest {
         this.shiftTimeZone = shiftTimeZone;
     }
 
-    @Parameterized.Parameters(name = "TimeZone = {0}")
+    @Parameters(name = "TimeZone = {0}")
     public static Collection<Object[]> runMode() {
         return Arrays.asList(new Object[] {UTC_ZONE_ID}, new Object[] {SHANGHAI_ZONE_ID});
     }
@@ -138,8 +139,8 @@ public class WindowRankOperatorTest {
                 operator, KEY_SELECTOR, KEY_SELECTOR.getProducedType());
     }
 
-    @Test
-    public void testTop2Windows() throws Exception {
+    @TestTemplate
+    void testTop2Windows() throws Exception {
         WindowAggOperator<RowData, ?> operator =
                 WindowRankOperatorBuilder.builder()
                         .inputSerializer(INPUT_ROW_SER)
@@ -245,8 +246,8 @@ public class WindowRankOperatorTest {
         testHarness.close();
     }
 
-    @Test
-    public void testTop2WindowsWithOffset() throws Exception {
+    @TestTemplate
+    void testTop2WindowsWithOffset() throws Exception {
         WindowAggOperator<RowData, ?> operator =
                 WindowRankOperatorBuilder.builder()
                         .inputSerializer(INPUT_ROW_SER)
@@ -335,8 +336,8 @@ public class WindowRankOperatorTest {
         testHarness.close();
     }
 
-    @Test
-    public void testTop2WindowsWithoutRankNumber() throws Exception {
+    @TestTemplate
+    void testTop2WindowsWithoutRankNumber() throws Exception {
         WindowAggOperator<RowData, ?> operator =
                 WindowRankOperatorBuilder.builder()
                         .inputSerializer(INPUT_ROW_SER)

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/rank/window/WindowRankOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/rank/window/WindowRankOperatorTest.java
@@ -124,12 +124,12 @@ class WindowRankOperatorTest {
     private static final ZoneId SHANGHAI_ZONE_ID = ZoneId.of("Asia/Shanghai");
     private final ZoneId shiftTimeZone;
 
-    public WindowRankOperatorTest(ZoneId shiftTimeZone) {
+    WindowRankOperatorTest(ZoneId shiftTimeZone) {
         this.shiftTimeZone = shiftTimeZone;
     }
 
     @Parameters(name = "TimeZone = {0}")
-    public static Collection<Object[]> runMode() {
+    private static Collection<Object[]> runMode() {
         return Arrays.asList(new Object[] {UTC_ZONE_ID}, new Object[] {SHANGHAI_ZONE_ID});
     }
 

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/sink/RowKindSetterTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/sink/RowKindSetterTest.java
@@ -32,10 +32,10 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link RowKindSetter}. */
-public class RowKindSetterTest {
+class RowKindSetterTest {
 
     @Test
-    public void testSetRowKind() throws Exception {
+    void testSetRowKind() throws Exception {
         // test set to all row kind
         for (RowKind targetRowKind : RowKind.values()) {
             RowKindSetter rowKindSetter = new RowKindSetter(targetRowKind);

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/sink/SinkOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/sink/SinkOperatorTest.java
@@ -30,10 +30,10 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link SinkOperator}. */
-public class SinkOperatorTest {
+class SinkOperatorTest {
 
     @Test
-    public void testSinkOperatorWithOutputFormat() {
+    void testSinkOperatorWithOutputFormat() {
         SinkOperator operator =
                 new SinkOperator(
                         new OutputFormatSinkFunction<>(

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/sink/SinkUpsertMaterializerTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/sink/SinkUpsertMaterializerTest.java
@@ -34,7 +34,7 @@ import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.table.utils.HandwrittenSelectorUtil;
 import org.apache.flink.types.RowKind;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.deleteRecord;
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord;
@@ -42,7 +42,7 @@ import static org.apache.flink.table.runtime.util.StreamRecordUtils.rowOfKind;
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.updateAfterRecord;
 
 /** Test for {@link SinkUpsertMaterializer}. */
-public class SinkUpsertMaterializerTest {
+class SinkUpsertMaterializerTest {
 
     private final StateTtlConfig ttlConfig = StateConfigUtil.createTtlConfig(1000);
     private final LogicalType[] types =
@@ -71,7 +71,7 @@ public class SinkUpsertMaterializerTest {
             };
 
     @Test
-    public void test() throws Exception {
+    void test() throws Exception {
         SinkUpsertMaterializer materializer =
                 new SinkUpsertMaterializer(
                         ttlConfig, serializer, equaliser, upsertKeyEqualiser, null);
@@ -113,7 +113,7 @@ public class SinkUpsertMaterializerTest {
     }
 
     @Test
-    public void testInputHasUpsertKeyWithNonDeterministicColumn() throws Exception {
+    void testInputHasUpsertKeyWithNonDeterministicColumn() throws Exception {
         SinkUpsertMaterializer materializer =
                 new SinkUpsertMaterializer(
                         ttlConfig, serializer, equaliser, upsertKeyEqualiser, new int[] {0});

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/sort/BinaryExternalSorterTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/sort/BinaryExternalSorterTest.java
@@ -74,7 +74,7 @@ class BinaryExternalSorterTest {
     }
 
     @Parameters(name = "spillCompress-{0} asyncMerge-{1}")
-    public static Collection<Boolean[]> parameters() {
+    private static Collection<Boolean[]> parameters() {
         return Arrays.asList(
                 new Boolean[] {false, false},
                 new Boolean[] {false, true},

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/sort/BinaryExternalSorterTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/sort/BinaryExternalSorterTest.java
@@ -31,13 +31,14 @@ import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.data.writer.BinaryRowWriter;
 import org.apache.flink.table.runtime.typeutils.AbstractRowDataSerializer;
 import org.apache.flink.table.runtime.typeutils.BinaryRowDataSerializer;
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
 import org.apache.flink.util.MutableObjectIterator;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,8 +52,8 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Sort test for binary row. */
-@RunWith(Parameterized.class)
-public class BinaryExternalSorterTest {
+@ExtendWith(ParameterizedTestExtension.class)
+class BinaryExternalSorterTest {
 
     private static final int MEMORY_SIZE = 1024 * 1024 * 32;
     private static final Logger LOG = LoggerFactory.getLogger(BinaryExternalSorterTest.class);
@@ -72,7 +73,7 @@ public class BinaryExternalSorterTest {
         }
     }
 
-    @Parameterized.Parameters(name = "spillCompress-{0} asyncMerge-{1}")
+    @Parameters(name = "spillCompress-{0} asyncMerge-{1}")
     public static Collection<Boolean[]> parameters() {
         return Arrays.asList(
                 new Boolean[] {false, false},
@@ -90,15 +91,15 @@ public class BinaryExternalSorterTest {
     }
 
     @SuppressWarnings("unchecked")
-    @Before
-    public void beforeTest() {
+    @BeforeEach
+    void beforeTest() {
         this.memoryManager = MemoryManagerBuilder.newBuilder().setMemorySize(MEMORY_SIZE).build();
         this.serializer = new BinaryRowDataSerializer(2);
         this.conf.set(ExecutionConfigOptions.TABLE_EXEC_SORT_MAX_NUM_FILE_HANDLES, 128);
     }
 
-    @After
-    public void afterTest() throws Exception {
+    @AfterEach
+    void afterTest() throws Exception {
         this.ioManager.close();
 
         if (this.memoryManager != null) {
@@ -110,8 +111,8 @@ public class BinaryExternalSorterTest {
         }
     }
 
-    @Test
-    public void testSortTwoBufferInMemory() throws Exception {
+    @TestTemplate
+    void testSortTwoBufferInMemory() throws Exception {
 
         int size = 1_000_000;
 
@@ -160,8 +161,8 @@ public class BinaryExternalSorterTest {
         memoryManager.shutdown();
     }
 
-    @Test
-    public void testSort() throws Exception {
+    @TestTemplate
+    void testSort() throws Exception {
 
         int size = 10_000;
 
@@ -205,8 +206,8 @@ public class BinaryExternalSorterTest {
         sorter.close();
     }
 
-    @Test
-    public void testSortIntStringWithRepeat() throws Exception {
+    @TestTemplate
+    void testSortIntStringWithRepeat() throws Exception {
 
         int size = 10_000;
 
@@ -257,8 +258,8 @@ public class BinaryExternalSorterTest {
         sorter.close();
     }
 
-    @Test
-    public void testSpilling() throws Exception {
+    @TestTemplate
+    void testSpilling() throws Exception {
 
         int size = 1000_000;
 
@@ -302,8 +303,8 @@ public class BinaryExternalSorterTest {
         sorter.close();
     }
 
-    @Test
-    public void testSpillingDesc() throws Exception {
+    @TestTemplate
+    void testSpillingDesc() throws Exception {
 
         int size = 1000_000;
 
@@ -363,8 +364,8 @@ public class BinaryExternalSorterTest {
         sorter.close();
     }
 
-    @Test
-    public void testMergeManyTimes() throws Exception {
+    @TestTemplate
+    void testMergeManyTimes() throws Exception {
 
         int size = 1000_000;
 
@@ -410,8 +411,8 @@ public class BinaryExternalSorterTest {
         sorter.close();
     }
 
-    @Test
-    public void testSpillingRandom() throws Exception {
+    @TestTemplate
+    void testSpillingRandom() throws Exception {
 
         int size = 1000_000;
 

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/sort/BinaryMergeIteratorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/sort/BinaryMergeIteratorTest.java
@@ -27,8 +27,8 @@ import org.apache.flink.table.runtime.generated.RecordComparator;
 import org.apache.flink.table.runtime.typeutils.BinaryRowDataSerializer;
 import org.apache.flink.util.MutableObjectIterator;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -37,13 +37,13 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test of {@link BinaryMergeIterator}. */
-public class BinaryMergeIteratorTest {
+class BinaryMergeIteratorTest {
 
     private RecordComparator comparator;
     private BinaryRowDataSerializer serializer;
 
-    @Before
-    public void setup() throws InstantiationException, IllegalAccessException {
+    @BeforeEach
+    void setup() throws InstantiationException, IllegalAccessException {
         serializer = new BinaryRowDataSerializer(2);
         comparator = IntRecordComparator.INSTANCE;
     }
@@ -81,7 +81,7 @@ public class BinaryMergeIteratorTest {
     }
 
     @Test
-    public void testOneStream() throws Exception {
+    void testOneStream() throws Exception {
         List<MutableObjectIterator<BinaryRowData>> iterators = new ArrayList<>();
         iterators.add(
                 newIterator(new int[] {1, 2, 4, 5, 10}, new String[] {"1", "2", "4", "5", "10"}));
@@ -103,7 +103,7 @@ public class BinaryMergeIteratorTest {
     }
 
     @Test
-    public void testMergeOfTwoStreams() throws Exception {
+    void testMergeOfTwoStreams() throws Exception {
         List<MutableObjectIterator<BinaryRowData>> iterators = new ArrayList<>();
         iterators.add(
                 newIterator(new int[] {1, 2, 4, 5, 10}, new String[] {"1", "2", "4", "5", "10"}));
@@ -125,7 +125,7 @@ public class BinaryMergeIteratorTest {
     }
 
     @Test
-    public void testMergeOfTenStreams() throws Exception {
+    void testMergeOfTenStreams() throws Exception {
         List<MutableObjectIterator<BinaryRowData>> iterators = new ArrayList<>();
         iterators.add(
                 newIterator(new int[] {1, 2, 17, 23, 23}, new String[] {"A", "B", "C", "D", "E"}));

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/sort/BufferedKVExternalSorterTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/sort/BufferedKVExternalSorterTest.java
@@ -32,14 +32,15 @@ import org.apache.flink.table.data.writer.BinaryRowWriter;
 import org.apache.flink.table.runtime.generated.NormalizedKeyComputer;
 import org.apache.flink.table.runtime.generated.RecordComparator;
 import org.apache.flink.table.runtime.typeutils.BinaryRowDataSerializer;
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
 import org.apache.flink.util.MutableObjectIterator;
 
 import org.apache.commons.lang3.RandomStringUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -50,8 +51,8 @@ import java.util.Random;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** UT for BufferedKVExternalSorter. */
-@RunWith(Parameterized.class)
-public class BufferedKVExternalSorterTest {
+@ExtendWith(ParameterizedTestExtension.class)
+class BufferedKVExternalSorterTest {
     private static final int PAGE_SIZE = MemoryManager.DEFAULT_PAGE_SIZE;
 
     private IOManager ioManager;
@@ -77,8 +78,8 @@ public class BufferedKVExternalSorterTest {
         this.recordNumberPerFile = recordNumberPerFile;
     }
 
-    @Parameterized.Parameters
-    public static List<Object[]> getDataSize() {
+    @Parameters(name = "spillNumber-{0} recordNumberPerFile-{1} spillCompress-{2}")
+    static List<Object[]> getDataSize() {
         List<Object[]> paras = new ArrayList<>();
         paras.add(new Object[] {3, 1000, true});
         paras.add(new Object[] {3, 1000, false});
@@ -89,8 +90,8 @@ public class BufferedKVExternalSorterTest {
         return paras;
     }
 
-    @Before
-    public void beforeTest() throws InstantiationException, IllegalAccessException {
+    @BeforeEach
+    void beforeTest() throws InstantiationException, IllegalAccessException {
         this.ioManager = new IOManagerAsync();
 
         this.keySerializer = new BinaryRowDataSerializer(2);
@@ -100,13 +101,13 @@ public class BufferedKVExternalSorterTest {
         this.comparator = IntRecordComparator.INSTANCE;
     }
 
-    @After
-    public void afterTest() throws Exception {
+    @AfterEach
+    void afterTest() throws Exception {
         this.ioManager.close();
     }
 
-    @Test
-    public void test() throws Exception {
+    @TestTemplate
+    void test() throws Exception {
         BufferedKVExternalSorter sorter =
                 new BufferedKVExternalSorter(
                         ioManager,

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/sort/BufferedKVExternalSorterTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/sort/BufferedKVExternalSorterTest.java
@@ -66,8 +66,7 @@ class BufferedKVExternalSorterTest {
 
     private Configuration conf;
 
-    public BufferedKVExternalSorterTest(
-            int spillNumber, int recordNumberPerFile, boolean spillCompress) {
+    BufferedKVExternalSorterTest(int spillNumber, int recordNumberPerFile, boolean spillCompress) {
         ioManager = new IOManagerAsync();
         conf = new Configuration();
         conf.set(ExecutionConfigOptions.TABLE_EXEC_SORT_MAX_NUM_FILE_HANDLES, 5);
@@ -79,7 +78,7 @@ class BufferedKVExternalSorterTest {
     }
 
     @Parameters(name = "spillNumber-{0} recordNumberPerFile-{1} spillCompress-{2}")
-    static List<Object[]> getDataSize() {
+    private static List<Object[]> getDataSize() {
         List<Object[]> paras = new ArrayList<>();
         paras.add(new Object[] {3, 1000, true});
         paras.add(new Object[] {3, 1000, false});

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/sort/ProcTimeSortOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/sort/ProcTimeSortOperatorTest.java
@@ -31,7 +31,7 @@ import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.VarCharType;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -39,7 +39,7 @@ import java.util.List;
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord;
 
 /** Tests for {@link ProcTimeSortOperator}. */
-public class ProcTimeSortOperatorTest {
+class ProcTimeSortOperatorTest {
 
     private InternalTypeInfo<RowData> inputRowType =
             InternalTypeInfo.ofFields(
@@ -61,7 +61,7 @@ public class ProcTimeSortOperatorTest {
             new RowDataHarnessAssertor(inputRowType.toRowFieldTypes());
 
     @Test
-    public void test() throws Exception {
+    void test() throws Exception {
         ProcTimeSortOperator operator = createSortOperator();
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
                 createTestHarness(operator);

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/sort/RowTimeSortOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/sort/RowTimeSortOperatorTest.java
@@ -32,7 +32,7 @@ import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.VarCharType;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -40,10 +40,10 @@ import java.util.List;
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord;
 
 /** Tests for {@link RowTimeSortOperator}. */
-public class RowTimeSortOperatorTest {
+class RowTimeSortOperatorTest {
 
     @Test
-    public void testSortOnTwoFields() throws Exception {
+    void testSortOnTwoFields() throws Exception {
         InternalTypeInfo<RowData> inputRowType =
                 InternalTypeInfo.ofFields(
                         new IntType(), new BigIntType(), VarCharType.STRING_TYPE, new IntType());
@@ -128,7 +128,7 @@ public class RowTimeSortOperatorTest {
     }
 
     @Test
-    public void testOnlySortOnRowTime() throws Exception {
+    void testOnlySortOnRowTime() throws Exception {
         InternalTypeInfo<RowData> inputRowType =
                 InternalTypeInfo.ofFields(
                         new BigIntType(), new BigIntType(), VarCharType.STRING_TYPE, new IntType());

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/sort/SortUtilTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/sort/SortUtilTest.java
@@ -24,7 +24,7 @@ import org.apache.flink.table.data.DecimalData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.binary.BinaryStringData;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.util.Arrays;
@@ -33,10 +33,10 @@ import java.util.Random;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link SortUtil}. */
-public class SortUtilTest {
+class SortUtilTest {
 
     @Test
-    public void testNormalizedKey() {
+    void testNormalizedKey() {
         int len = 10;
         Random random = new Random();
         MemorySegment[] segments = new MemorySegment[len];

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/sort/StreamSortOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/sort/StreamSortOperatorTest.java
@@ -29,7 +29,7 @@ import org.apache.flink.table.runtime.util.RowDataHarnessAssertor;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.VarCharType;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -37,7 +37,7 @@ import java.util.List;
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord;
 
 /** Tests for {@link StreamSortOperator}. */
-public class StreamSortOperatorTest {
+class StreamSortOperatorTest {
 
     private InternalTypeInfo<RowData> inputRowType =
             InternalTypeInfo.ofFields(VarCharType.STRING_TYPE, new IntType());
@@ -58,7 +58,7 @@ public class StreamSortOperatorTest {
             new RowDataHarnessAssertor(inputRowType.toRowFieldTypes());
 
     @Test
-    public void test() throws Exception {
+    void test() throws Exception {
         StreamSortOperator operator = createSortOperator();
         OneInputStreamOperatorTestHarness<RowData, BinaryRowData> testHarness =
                 createTestHarness(operator);

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/source/InputConversionOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/source/InputConversionOperatorTest.java
@@ -29,7 +29,7 @@ import org.apache.flink.types.Row;
 import org.apache.flink.types.RowKind;
 import org.apache.flink.util.FlinkRuntimeException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
 
@@ -37,10 +37,10 @@ import static org.apache.flink.core.testutils.FlinkAssertions.anyCauseMatches;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link InputConversionOperator}. */
-public class InputConversionOperatorTest {
+class InputConversionOperatorTest {
 
     @Test
-    public void testInvalidRecords() {
+    void testInvalidRecords() {
         final InputConversionOperator<Row> operator =
                 new InputConversionOperator<>(
                         createConverter(DataTypes.ROW(DataTypes.FIELD("f", DataTypes.INT()))),
@@ -72,7 +72,7 @@ public class InputConversionOperatorTest {
     }
 
     @Test
-    public void testInvalidEventTime() {
+    void testInvalidEventTime() {
         final InputConversionOperator<Row> operator =
                 new InputConversionOperator<>(
                         createConverter(DataTypes.ROW(DataTypes.FIELD("f", DataTypes.INT()))),
@@ -91,7 +91,7 @@ public class InputConversionOperatorTest {
     }
 
     @Test
-    public void testWatermarkSuppression() throws Exception {
+    void testWatermarkSuppression() throws Exception {
         final InputConversionOperator<Row> operator =
                 new InputConversionOperator<>(
                         createConverter(DataTypes.ROW(DataTypes.FIELD("f", DataTypes.INT()))),
@@ -104,8 +104,8 @@ public class InputConversionOperatorTest {
         operator.processWatermark(new Watermark(1000));
     }
 
-    @Test(expected = NullPointerException.class)
-    public void testReceiveMaxWatermark() throws Exception {
+    @Test
+    void testReceiveMaxWatermark() throws Exception {
         final InputConversionOperator<Row> operator =
                 new InputConversionOperator<>(
                         createConverter(DataTypes.ROW(DataTypes.FIELD("f", DataTypes.INT()))),
@@ -115,7 +115,8 @@ public class InputConversionOperatorTest {
                         true);
 
         // would throw an exception because it always emits Watermark.MAX_WATERMARK
-        operator.processWatermark(Watermark.MAX_WATERMARK);
+        assertThatThrownBy(() -> operator.processWatermark(Watermark.MAX_WATERMARK))
+                .isInstanceOf(NullPointerException.class);
     }
 
     private static DynamicTableSource.DataStructureConverter createConverter(DataType dataType) {

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/window/groupwindow/assigners/CumulativeWindowAssignerTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/window/groupwindow/assigners/CumulativeWindowAssignerTest.java
@@ -24,7 +24,7 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.runtime.operators.window.TimeWindow;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 
@@ -34,12 +34,12 @@ import static org.assertj.core.api.HamcrestCondition.matching;
 import static org.hamcrest.Matchers.contains;
 
 /** Tests for {@link CumulativeWindowAssigner}. */
-public class CumulativeWindowAssignerTest {
+class CumulativeWindowAssignerTest {
 
     private static final RowData ELEMENT = GenericRowData.of(StringData.fromString("String"));
 
     @Test
-    public void testWindowAssignment() {
+    void testWindowAssignment() {
         CumulativeWindowAssigner assigner =
                 CumulativeWindowAssigner.of(Duration.ofMillis(5000), Duration.ofMillis(1000));
 
@@ -89,7 +89,7 @@ public class CumulativeWindowAssignerTest {
     }
 
     @Test
-    public void testWindowAssignmentWithOffset() {
+    void testWindowAssignmentWithOffset() {
         CumulativeWindowAssigner assigner =
                 CumulativeWindowAssigner.of(Duration.ofMillis(5000), Duration.ofMillis(1000))
                         .withOffset(Duration.ofMillis(100));
@@ -140,7 +140,7 @@ public class CumulativeWindowAssignerTest {
     }
 
     @Test
-    public void testInvalidParameters1() {
+    void testInvalidParameters1() {
         assertThatThrownBy(
                         () ->
                                 CumulativeWindowAssigner.of(
@@ -150,7 +150,7 @@ public class CumulativeWindowAssignerTest {
     }
 
     @Test
-    public void testInvalidParameters2() {
+    void testInvalidParameters2() {
         assertThatThrownBy(
                         () ->
                                 CumulativeWindowAssigner.of(
@@ -160,7 +160,7 @@ public class CumulativeWindowAssignerTest {
     }
 
     @Test
-    public void testInvalidParameters3() {
+    void testInvalidParameters3() {
         assertThatThrownBy(
                         () ->
                                 CumulativeWindowAssigner.of(
@@ -170,7 +170,7 @@ public class CumulativeWindowAssignerTest {
     }
 
     @Test
-    public void testProperties() {
+    void testProperties() {
         CumulativeWindowAssigner assigner =
                 CumulativeWindowAssigner.of(Duration.ofMillis(5000), Duration.ofMillis(1000));
 

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/window/groupwindow/assigners/SessionWindowAssignerTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/window/groupwindow/assigners/SessionWindowAssignerTest.java
@@ -24,9 +24,8 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.operators.window.MergeCallback;
 import org.apache.flink.table.runtime.operators.window.TimeWindow;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatcher;
-import org.mockito.Matchers;
 
 import java.time.Duration;
 import java.util.Arrays;
@@ -35,22 +34,22 @@ import java.util.TreeSet;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.mockito.Matchers.anyCollection;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.argThat;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.anyObject;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 /** Tests for {@link SessionWindowAssigner}. */
-public class SessionWindowAssignerTest {
+class SessionWindowAssignerTest {
 
     private static final RowData ELEMENT = GenericRowData.of("String");
 
     @Test
-    public void testWindowAssignment() {
+    void testWindowAssignment() {
         final int sessionGap = 5000;
 
         SessionWindowAssigner assigner =
@@ -65,18 +64,18 @@ public class SessionWindowAssignerTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void testMergeEmptyWindow() throws Exception {
+    void testMergeEmptyWindow() throws Exception {
         MergeCallback<TimeWindow, Collection<TimeWindow>> callback = mock(MergeCallback.class);
         SessionWindowAssigner assigner = SessionWindowAssigner.withGap(Duration.ofMillis(5000));
 
         assigner.mergeWindows(TimeWindow.of(0, 1), new TreeSet<>(), callback);
 
-        verify(callback, never()).merge(anyObject(), Matchers.anyCollection());
+        verify(callback, never()).merge(anyObject(), anyCollection());
     }
 
     @SuppressWarnings("unchecked")
     @Test
-    public void testMergeSingleWindow() throws Exception {
+    void testMergeSingleWindow() throws Exception {
         MergeCallback<TimeWindow, Collection<TimeWindow>> callback = mock(MergeCallback.class);
         SessionWindowAssigner assigner = SessionWindowAssigner.withGap(Duration.ofMillis(5000));
 
@@ -89,7 +88,7 @@ public class SessionWindowAssignerTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void testMergeConsecutiveWindows() throws Exception {
+    void testMergeConsecutiveWindows() throws Exception {
         MergeCallback<TimeWindow, Collection<TimeWindow>> callback = mock(MergeCallback.class);
         SessionWindowAssigner assigner = SessionWindowAssigner.withGap(Duration.ofMillis(5000));
 
@@ -117,7 +116,7 @@ public class SessionWindowAssignerTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void testMergeCoveringWindow() throws Exception {
+    void testMergeCoveringWindow() throws Exception {
         MergeCallback<TimeWindow, Collection<TimeWindow>> callback = mock(MergeCallback.class);
         SessionWindowAssigner assigner = SessionWindowAssigner.withGap(Duration.ofMillis(5000));
 
@@ -140,7 +139,7 @@ public class SessionWindowAssignerTest {
     }
 
     @Test
-    public void testProperties() {
+    void testProperties() {
         SessionWindowAssigner assigner = SessionWindowAssigner.withGap(Duration.ofMillis(5000));
 
         assertThat(assigner.isEventTime()).isTrue();

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/window/groupwindow/assigners/SlidingWindowAssignerTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/window/groupwindow/assigners/SlidingWindowAssignerTest.java
@@ -23,7 +23,7 @@ import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.operators.window.TimeWindow;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 
@@ -31,12 +31,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link SlidingWindowAssigner}. */
-public class SlidingWindowAssignerTest {
+class SlidingWindowAssignerTest {
 
     private static final RowData ELEMENT = GenericRowData.of("String");
 
     @Test
-    public void testWindowAssignment() {
+    void testWindowAssignment() {
         SlidingWindowAssigner assigner =
                 SlidingWindowAssigner.of(Duration.ofMillis(5000), Duration.ofMillis(1000));
 
@@ -90,7 +90,7 @@ public class SlidingWindowAssignerTest {
     }
 
     @Test
-    public void testWindowAssignmentWithOffset() {
+    void testWindowAssignmentWithOffset() {
         SlidingWindowAssigner assigner =
                 SlidingWindowAssigner.of(Duration.ofMillis(5000), Duration.ofMillis(1000))
                         .withOffset(Duration.ofMillis(100));
@@ -145,7 +145,7 @@ public class SlidingWindowAssignerTest {
     }
 
     @Test
-    public void testInvalidParameters() {
+    void testInvalidParameters() {
         assertThatThrownBy(
                         () ->
                                 SlidingWindowAssigner.of(
@@ -165,7 +165,7 @@ public class SlidingWindowAssignerTest {
     }
 
     @Test
-    public void testProperties() {
+    void testProperties() {
         SlidingWindowAssigner assigner =
                 SlidingWindowAssigner.of(Duration.ofMillis(5000), Duration.ofMillis(1000));
 

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/window/groupwindow/assigners/TumblingWindowAssignerTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/window/groupwindow/assigners/TumblingWindowAssignerTest.java
@@ -23,7 +23,7 @@ import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.operators.window.TimeWindow;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 
@@ -31,12 +31,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link TumblingWindowAssigner}. */
-public class TumblingWindowAssignerTest {
+class TumblingWindowAssignerTest {
 
     private static final RowData ELEMENT = GenericRowData.of("String");
 
     @Test
-    public void testWindowAssignment() {
+    void testWindowAssignment() {
         TumblingWindowAssigner assigner = TumblingWindowAssigner.of(Duration.ofMillis(5000));
 
         assertThat(assigner.assignWindows(ELEMENT, 0L)).contains(new TimeWindow(0, 5000));
@@ -45,7 +45,7 @@ public class TumblingWindowAssignerTest {
     }
 
     @Test
-    public void testWindowAssignmentWithOffset() {
+    void testWindowAssignmentWithOffset() {
         TumblingWindowAssigner assigner =
                 TumblingWindowAssigner.of(Duration.ofMillis(5000))
                         .withOffset(Duration.ofMillis(100));
@@ -56,7 +56,7 @@ public class TumblingWindowAssignerTest {
     }
 
     @Test
-    public void testInvalidParameters() {
+    void testInvalidParameters() {
         assertThatThrownBy(() -> TumblingWindowAssigner.of(Duration.ofSeconds(-1)))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("TumblingWindowAssigner parameters must satisfy size > 0");
@@ -66,7 +66,7 @@ public class TumblingWindowAssignerTest {
     }
 
     @Test
-    public void testProperties() {
+    void testProperties() {
         TumblingWindowAssigner assigner = TumblingWindowAssigner.of(Duration.ofMillis(5000));
 
         assertThat(assigner.isEventTime()).isTrue();

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/window/groupwindow/internal/MergingWindowSetTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/window/groupwindow/internal/MergingWindowSetTest.java
@@ -27,7 +27,7 @@ import org.apache.flink.table.runtime.operators.window.TimeWindow;
 import org.apache.flink.table.runtime.operators.window.groupwindow.assigners.MergingWindowAssigner;
 import org.apache.flink.table.runtime.operators.window.groupwindow.assigners.SessionWindowAssigner;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -47,7 +47,7 @@ import static org.assertj.core.api.Assertions.fail;
  * Tests for verifying that {@link MergingWindowSet} correctly merges windows in various situations
  * and that the merge callback is called with the correct sets of windows.
  */
-public class MergingWindowSetTest {
+class MergingWindowSetTest {
 
     /**
      * This test uses a special (misbehaving) {@code MergingWindowAssigner} that produces cases
@@ -55,7 +55,7 @@ public class MergingWindowSetTest {
      * the merging window set is nevertheless correct and contains all added windows.
      */
     @Test
-    public void testNonEagerMerging() throws Exception {
+    void testNonEagerMerging() throws Exception {
         MapState<TimeWindow, TimeWindow> mockState = new HeapMapState<>();
 
         MergingWindowSet<TimeWindow> windowSet =
@@ -84,7 +84,7 @@ public class MergingWindowSetTest {
     }
 
     @Test
-    public void testIncrementalMerging() throws Exception {
+    void testIncrementalMerging() throws Exception {
         MapState<TimeWindow, TimeWindow> mockState = new HeapMapState<>();
 
         MergingWindowSet<TimeWindow> windowSet =
@@ -203,7 +203,7 @@ public class MergingWindowSetTest {
     }
 
     @Test
-    public void testLateMerging() throws Exception {
+    void testLateMerging() throws Exception {
         MapState<TimeWindow, TimeWindow> mockState = new HeapMapState<>();
 
         MergingWindowSet<TimeWindow> windowSet =
@@ -289,7 +289,7 @@ public class MergingWindowSetTest {
 
     /** Test merging of a large new window that covers one existing windows. */
     @Test
-    public void testMergeLargeWindowCoveringSingleWindow() throws Exception {
+    void testMergeLargeWindowCoveringSingleWindow() throws Exception {
         MapState<TimeWindow, TimeWindow> mockState = new HeapMapState<>();
 
         MergingWindowSet<TimeWindow> windowSet =
@@ -321,7 +321,7 @@ public class MergingWindowSetTest {
      * merge.
      */
     @Test
-    public void testAddingIdenticalWindows() throws Exception {
+    void testAddingIdenticalWindows() throws Exception {
         MapState<TimeWindow, TimeWindow> mockState = new HeapMapState<>();
 
         MergingWindowSet<TimeWindow> windowSet =
@@ -346,7 +346,7 @@ public class MergingWindowSetTest {
 
     /** Test merging of a large new window that covers multiple existing windows. */
     @Test
-    public void testMergeLargeWindowCoveringMultipleWindows() throws Exception {
+    void testMergeLargeWindowCoveringMultipleWindows() throws Exception {
         MapState<TimeWindow, TimeWindow> mockState = new HeapMapState<>();
 
         MergingWindowSet<TimeWindow> windowSet =

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/window/groupwindow/operator/WindowOperatorContractTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/window/groupwindow/operator/WindowOperatorContractTest.java
@@ -41,7 +41,7 @@ import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.table.utils.HandwrittenSelectorUtil;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Matchers;
 import org.mockito.Mockito;
 
@@ -67,12 +67,12 @@ import static org.mockito.Mockito.when;
  *
  * <p>These tests document the implicit contract that exists between the windowing components.
  */
-public class WindowOperatorContractTest {
+class WindowOperatorContractTest {
 
     private static final ZoneId UTC_ZONE_ID = ZoneId.of("UTC");
 
     @Test
-    public void testAssignerIsInvokedOncePerElement() throws Exception {
+    void testAssignerIsInvokedOncePerElement() throws Exception {
         GroupWindowAssigner<TimeWindow> mockAssigner = mockTimeWindowAssigner();
         Trigger<TimeWindow> mockTrigger = mockTrigger();
         NamespaceAggsHandleFunction<TimeWindow> mockAggregate = mockAggsHandleFunction();
@@ -95,7 +95,7 @@ public class WindowOperatorContractTest {
     }
 
     @Test
-    public void testAssignerWithMultipleWindowsForAggregate() throws Exception {
+    void testAssignerWithMultipleWindowsForAggregate() throws Exception {
         GroupWindowAssigner<TimeWindow> mockAssigner = mockTimeWindowAssigner();
         Trigger<TimeWindow> mockTrigger = mockTrigger();
         NamespaceAggsHandleFunction<TimeWindow> mockAggregate = mockAggsHandleFunction();
@@ -118,7 +118,7 @@ public class WindowOperatorContractTest {
     }
 
     @Test
-    public void testAssignerWithMultipleWindowsForTableAggregate() throws Exception {
+    void testAssignerWithMultipleWindowsForTableAggregate() throws Exception {
         GroupWindowAssigner<TimeWindow> mockAssigner = mockTimeWindowAssigner();
         Trigger<TimeWindow> mockTrigger = mockTrigger();
         NamespaceTableAggsHandleFunction<TimeWindow> mockAggregate = mockTableAggsHandleFunction();
@@ -141,7 +141,7 @@ public class WindowOperatorContractTest {
     }
 
     @Test
-    public void testOnElementCalledPerWindow() throws Exception {
+    void testOnElementCalledPerWindow() throws Exception {
 
         GroupWindowAssigner<TimeWindow> mockAssigner = mockTimeWindowAssigner();
         Trigger<TimeWindow> mockTrigger = mockTrigger();
@@ -163,7 +163,7 @@ public class WindowOperatorContractTest {
     }
 
     @Test
-    public void testMergeWindowsIsCalled() throws Exception {
+    void testMergeWindowsIsCalled() throws Exception {
         MergingWindowAssigner<TimeWindow> mockAssigner = mockMergingAssigner();
         Trigger<TimeWindow> mockTrigger = mockTrigger();
         NamespaceAggsHandleFunction<TimeWindow> mockAggregate = mockAggsHandleFunction();

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/window/groupwindow/operator/WindowOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/window/groupwindow/operator/WindowOperatorTest.java
@@ -52,11 +52,12 @@ import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.table.utils.HandwrittenSelectorUtil;
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
 import org.apache.flink.util.Collector;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.time.Duration;
 import java.time.ZoneId;
@@ -81,16 +82,16 @@ import static org.assertj.core.api.Assertions.fail;
  * <p>To simplify the testing logic, the table aggregate outputs same value with the aggregate
  * except that the table aggregate outputs two same records each time.
  */
-@RunWith(Parameterized.class)
-public class WindowOperatorTest {
+@ExtendWith(ParameterizedTestExtension.class)
+class WindowOperatorTest {
 
     private static final ZoneId UTC_ZONE_ID = ZoneId.of("UTC");
     private static final ZoneId SHANGHAI_ZONE_ID = ZoneId.of("Asia/Shanghai");
     private final boolean isTableAggregate;
     private final ZoneId shiftTimeZone;
 
-    @Parameterized.Parameters(name = "isTableAggregate = {0}, TimeZone = {1}")
-    public static Collection<Object[]> runMode() {
+    @Parameters(name = "isTableAggregate = {0}, TimeZone = {1}")
+    static Collection<Object[]> runMode() {
         return Arrays.asList(
                 new Object[] {false, UTC_ZONE_ID},
                 new Object[] {true, UTC_ZONE_ID},
@@ -159,8 +160,8 @@ public class WindowOperatorTest {
         return results;
     }
 
-    @Test
-    public void testEventTimeSlidingWindows() throws Exception {
+    @TestTemplate
+    void testEventTimeSlidingWindows() throws Exception {
         closeCalled.set(0);
 
         WindowOperator operator =
@@ -331,8 +332,8 @@ public class WindowOperatorTest {
         assertThat(closeCalled.get()).as("Close was not called.").isEqualTo(2);
     }
 
-    @Test
-    public void testProcessingTimeSlidingWindows() throws Throwable {
+    @TestTemplate
+    void testProcessingTimeSlidingWindows() throws Throwable {
         closeCalled.set(0);
 
         WindowOperator operator =
@@ -475,8 +476,8 @@ public class WindowOperatorTest {
         testHarness.close();
     }
 
-    @Test
-    public void testEventTimeCumulativeWindows() throws Exception {
+    @TestTemplate
+    void testEventTimeCumulativeWindows() throws Exception {
         closeCalled.set(0);
 
         WindowOperator operator =
@@ -647,8 +648,8 @@ public class WindowOperatorTest {
         assertThat(closeCalled.get()).as("Close was not called.").isEqualTo(2);
     }
 
-    @Test
-    public void testEventTimeCumulativeWindowsWithLateArrival() throws Exception {
+    @TestTemplate
+    void testEventTimeCumulativeWindowsWithLateArrival() throws Exception {
         WindowOperator operator =
                 WindowOperatorBuilder.builder()
                         .withInputFields(inputFieldTypes)
@@ -715,8 +716,8 @@ public class WindowOperatorTest {
         testHarness.close();
     }
 
-    @Test
-    public void testProcessingTimeCumulativeWindows() throws Throwable {
+    @TestTemplate
+    void testProcessingTimeCumulativeWindows() throws Throwable {
         closeCalled.set(0);
 
         WindowOperator operator =
@@ -879,9 +880,9 @@ public class WindowOperatorTest {
         testHarness.close();
     }
 
-    @Test
+    @TestTemplate
     @SuppressWarnings("unchecked")
-    public void testEventTimeTumblingWindows() throws Exception {
+    void testEventTimeTumblingWindows() throws Exception {
         closeCalled.set(0);
 
         WindowOperator operator =
@@ -1001,9 +1002,9 @@ public class WindowOperatorTest {
         assertThat(closeCalled.get()).as("Close was not called.").isEqualTo(2);
     }
 
-    @Test
+    @TestTemplate
     @SuppressWarnings("unchecked")
-    public void testEventTimeTumblingWindowsWithEarlyFiring() throws Exception {
+    void testEventTimeTumblingWindowsWithEarlyFiring() throws Exception {
         closeCalled.set(0);
 
         WindowOperator operator =
@@ -1150,9 +1151,9 @@ public class WindowOperatorTest {
         assertThat(closeCalled.get()).as("Close was not called.").isEqualTo(2);
     }
 
-    @Test
+    @TestTemplate
     @SuppressWarnings("unchecked")
-    public void testEventTimeTumblingWindowsWithEarlyAndLateFirings() throws Exception {
+    void testEventTimeTumblingWindowsWithEarlyAndLateFirings() throws Exception {
         closeCalled.set(0);
 
         WindowOperator operator =
@@ -1316,9 +1317,9 @@ public class WindowOperatorTest {
         assertThat(closeCalled.get()).as("Close was not called.").isEqualTo(2);
     }
 
-    @Test
+    @TestTemplate
     @SuppressWarnings("unchecked")
-    public void testProcessingTimeTumblingWindows() throws Exception {
+    void testProcessingTimeTumblingWindows() throws Exception {
         closeCalled.set(0);
 
         WindowOperator operator =
@@ -1401,9 +1402,9 @@ public class WindowOperatorTest {
         testHarness.close();
     }
 
-    @Test
+    @TestTemplate
     @SuppressWarnings("unchecked")
-    public void testEventTimeSessionWindows() throws Exception {
+    void testEventTimeSessionWindows() throws Exception {
         closeCalled.set(0);
 
         WindowOperator operator =
@@ -1520,8 +1521,8 @@ public class WindowOperatorTest {
         assertThat(operator.getNumLateRecordsDropped().getCount()).isEqualTo(1);
     }
 
-    @Test
-    public void testProcessingTimeSessionWindows() throws Throwable {
+    @TestTemplate
+    void testProcessingTimeSessionWindows() throws Throwable {
         closeCalled.set(0);
 
         WindowOperator operator =
@@ -1614,9 +1615,9 @@ public class WindowOperatorTest {
      * <p>In this test, elements that have 33 as the second tuple field will be put into a point
      * window.
      */
-    @Test
+    @TestTemplate
     @SuppressWarnings("unchecked")
-    public void testPointSessions() throws Exception {
+    void testPointSessions() throws Exception {
         closeCalled.set(0);
 
         WindowOperator operator =
@@ -1691,8 +1692,8 @@ public class WindowOperatorTest {
         assertThat(closeCalled.get()).as("Close was not called.").isEqualTo(2);
     }
 
-    @Test
-    public void testLateness() throws Exception {
+    @TestTemplate
+    void testLateness() throws Exception {
         WindowOperator operator =
                 WindowOperatorBuilder.builder()
                         .withInputFields(inputFieldTypes)
@@ -1755,8 +1756,8 @@ public class WindowOperatorTest {
         testHarness.close();
     }
 
-    @Test
-    public void testCleanupTimerWithEmptyReduceStateForTumblingWindows() throws Exception {
+    @TestTemplate
+    void testCleanupTimerWithEmptyReduceStateForTumblingWindows() throws Exception {
         final int windowSize = 2;
         final long lateness = 1;
 
@@ -1801,8 +1802,8 @@ public class WindowOperatorTest {
         testHarness.close();
     }
 
-    @Test
-    public void testCleanupTimeOverflow() throws Exception {
+    @TestTemplate
+    void testCleanupTimeOverflow() throws Exception {
         if (!UTC_ZONE_ID.equals(shiftTimeZone)) {
             return;
         }
@@ -1869,8 +1870,8 @@ public class WindowOperatorTest {
         testHarness.close();
     }
 
-    @Test
-    public void testTumblingCountWindow() throws Exception {
+    @TestTemplate
+    void testTumblingCountWindow() throws Exception {
         if (!UTC_ZONE_ID.equals(shiftTimeZone)) {
             return;
         }
@@ -1953,8 +1954,8 @@ public class WindowOperatorTest {
         assertThat(closeCalled.get()).as("Close was not called.").isEqualTo(2);
     }
 
-    @Test
-    public void testSlidingCountWindow() throws Exception {
+    @TestTemplate
+    void testSlidingCountWindow() throws Exception {
         if (!UTC_ZONE_ID.equals(shiftTimeZone)) {
             return;
         }
@@ -2038,8 +2039,8 @@ public class WindowOperatorTest {
         assertThat(closeCalled.get()).as("Close was not called.").isEqualTo(2);
     }
 
-    @Test
-    public void testWindowCloseWithoutOpen() throws Exception {
+    @TestTemplate
+    void testWindowCloseWithoutOpen() throws Exception {
         if (!UTC_ZONE_ID.equals(shiftTimeZone)) {
             return;
         }

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/window/groupwindow/operator/WindowOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/window/groupwindow/operator/WindowOperatorTest.java
@@ -91,7 +91,7 @@ class WindowOperatorTest {
     private final ZoneId shiftTimeZone;
 
     @Parameters(name = "isTableAggregate = {0}, TimeZone = {1}")
-    static Collection<Object[]> runMode() {
+    private static Collection<Object[]> runMode() {
         return Arrays.asList(
                 new Object[] {false, UTC_ZONE_ID},
                 new Object[] {true, UTC_ZONE_ID},

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/window/groupwindow/triggers/TriggersTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/window/groupwindow/triggers/TriggersTest.java
@@ -18,17 +18,17 @@
 
 package org.apache.flink.table.runtime.operators.window.groupwindow.triggers;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for triggers. */
-public class TriggersTest {
+class TriggersTest {
 
     @Test
-    public void testEventTime() {
+    void testEventTime() {
         Trigger<?> trigger;
         String expected;
 
@@ -83,7 +83,7 @@ public class TriggersTest {
     }
 
     @Test
-    public void testProcessingTime() {
+    void testProcessingTime() {
         Trigger<?> trigger;
         String expected;
 

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/window/tvf/operator/AlignedWindowTableFunctionOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/window/tvf/operator/AlignedWindowTableFunctionOperatorTest.java
@@ -26,11 +26,12 @@ import org.apache.flink.table.runtime.operators.window.groupwindow.assigners.Cum
 import org.apache.flink.table.runtime.operators.window.groupwindow.assigners.GroupWindowAssigner;
 import org.apache.flink.table.runtime.operators.window.groupwindow.assigners.SlidingWindowAssigner;
 import org.apache.flink.table.runtime.operators.window.groupwindow.assigners.TumblingWindowAssigner;
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
 import org.apache.flink.types.RowKind;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.time.Duration;
 import java.time.ZoneId;
@@ -42,20 +43,20 @@ import static org.apache.flink.table.runtime.util.StreamRecordUtils.binaryRecord
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link AlignedWindowTableFunctionOperator}. */
-@RunWith(Parameterized.class)
-public class AlignedWindowTableFunctionOperatorTest extends WindowTableFunctionOperatorTestBase {
+@ExtendWith(ParameterizedTestExtension.class)
+class AlignedWindowTableFunctionOperatorTest extends WindowTableFunctionOperatorTestBase {
 
-    public AlignedWindowTableFunctionOperatorTest(ZoneId shiftTimeZone) {
+    AlignedWindowTableFunctionOperatorTest(ZoneId shiftTimeZone) {
         super(shiftTimeZone);
     }
 
-    @Parameterized.Parameters(name = "TimeZone = {0}")
-    public static Collection<Object[]> runMode() {
+    @Parameters(name = "TimeZone = {0}")
+    static Collection<Object[]> runMode() {
         return Arrays.asList(new Object[] {UTC_ZONE_ID}, new Object[] {SHANGHAI_ZONE_ID});
     }
 
-    @Test
-    public void testTumblingWindows() throws Exception {
+    @TestTemplate
+    void testTumblingWindows() throws Exception {
         final TumblingWindowAssigner assigner = TumblingWindowAssigner.of(Duration.ofSeconds(3));
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
                 createTestHarness(assigner, shiftTimeZone);
@@ -92,8 +93,8 @@ public class AlignedWindowTableFunctionOperatorTest extends WindowTableFunctionO
         testHarness.close();
     }
 
-    @Test
-    public void testProcessingTimeTumblingWindows() throws Exception {
+    @TestTemplate
+    void testProcessingTimeTumblingWindows() throws Exception {
         final TumblingWindowAssigner assigner =
                 TumblingWindowAssigner.of(Duration.ofSeconds(3)).withProcessingTime();
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
@@ -119,8 +120,8 @@ public class AlignedWindowTableFunctionOperatorTest extends WindowTableFunctionO
         testHarness.close();
     }
 
-    @Test
-    public void testHopWindows() throws Exception {
+    @TestTemplate
+    void testHopWindows() throws Exception {
         final SlidingWindowAssigner assigner =
                 SlidingWindowAssigner.of(Duration.ofSeconds(3), Duration.ofSeconds(1));
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
@@ -161,8 +162,8 @@ public class AlignedWindowTableFunctionOperatorTest extends WindowTableFunctionO
         testHarness.close();
     }
 
-    @Test
-    public void testProcessingTimeHopWindows() throws Exception {
+    @TestTemplate
+    void testProcessingTimeHopWindows() throws Exception {
         final SlidingWindowAssigner assigner =
                 SlidingWindowAssigner.of(Duration.ofSeconds(3), Duration.ofSeconds(1))
                         .withProcessingTime();
@@ -201,8 +202,8 @@ public class AlignedWindowTableFunctionOperatorTest extends WindowTableFunctionO
         testHarness.close();
     }
 
-    @Test
-    public void testCumulativeWindows() throws Exception {
+    @TestTemplate
+    void testCumulativeWindows() throws Exception {
         final CumulativeWindowAssigner assigner =
                 CumulativeWindowAssigner.of(Duration.ofSeconds(3), Duration.ofSeconds(1));
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
@@ -239,8 +240,8 @@ public class AlignedWindowTableFunctionOperatorTest extends WindowTableFunctionO
         testHarness.close();
     }
 
-    @Test
-    public void testProcessingCumulativeWindows() throws Exception {
+    @TestTemplate
+    void testProcessingCumulativeWindows() throws Exception {
         final CumulativeWindowAssigner assigner =
                 CumulativeWindowAssigner.of(Duration.ofSeconds(3), Duration.ofSeconds(1))
                         .withProcessingTime();
@@ -277,8 +278,8 @@ public class AlignedWindowTableFunctionOperatorTest extends WindowTableFunctionO
         testHarness.close();
     }
 
-    @Test
-    public void testConsumingChangelogRecords() throws Exception {
+    @TestTemplate
+    void testConsumingChangelogRecords() throws Exception {
         final TumblingWindowAssigner assigner = TumblingWindowAssigner.of(Duration.ofSeconds(3));
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
                 createTestHarness(assigner, shiftTimeZone);

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/window/tvf/operator/AlignedWindowTableFunctionOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/window/tvf/operator/AlignedWindowTableFunctionOperatorTest.java
@@ -51,7 +51,7 @@ class AlignedWindowTableFunctionOperatorTest extends WindowTableFunctionOperator
     }
 
     @Parameters(name = "TimeZone = {0}")
-    static Collection<Object[]> runMode() {
+    private static Collection<Object[]> runMode() {
         return Arrays.asList(new Object[] {UTC_ZONE_ID}, new Object[] {SHANGHAI_ZONE_ID});
     }
 

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/window/tvf/operator/UnalignedWindowTableFunctionOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/window/tvf/operator/UnalignedWindowTableFunctionOperatorTest.java
@@ -57,7 +57,7 @@ class UnalignedWindowTableFunctionOperatorTest extends WindowTableFunctionOperat
     }
 
     @Parameters(name = "TimeZone = {0}")
-    public static Collection<Object[]> runMode() {
+    private static Collection<Object[]> runMode() {
         return Arrays.asList(new Object[] {UTC_ZONE_ID}, new Object[] {SHANGHAI_ZONE_ID});
     }
 

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/window/tvf/operator/UnalignedWindowTableFunctionOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/window/tvf/operator/UnalignedWindowTableFunctionOperatorTest.java
@@ -32,11 +32,12 @@ import org.apache.flink.table.runtime.operators.window.groupwindow.assigners.Ses
 import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.utils.HandwrittenSelectorUtil;
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
 import org.apache.flink.types.RowKind;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.time.Duration;
 import java.time.ZoneId;
@@ -48,15 +49,20 @@ import static org.apache.flink.table.runtime.util.StreamRecordUtils.binaryRecord
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link UnalignedWindowTableFunctionOperator}. */
-@RunWith(Parameterized.class)
-public class UnalignedWindowTableFunctionOperatorTest extends WindowTableFunctionOperatorTestBase {
+@ExtendWith(ParameterizedTestExtension.class)
+class UnalignedWindowTableFunctionOperatorTest extends WindowTableFunctionOperatorTestBase {
 
-    public UnalignedWindowTableFunctionOperatorTest(ZoneId shiftTimeZone) {
+    UnalignedWindowTableFunctionOperatorTest(ZoneId shiftTimeZone) {
         super(shiftTimeZone);
     }
 
-    @Test
-    public void testEventTimeSessionWindows() throws Exception {
+    @Parameters(name = "TimeZone = {0}")
+    public static Collection<Object[]> runMode() {
+        return Arrays.asList(new Object[] {UTC_ZONE_ID}, new Object[] {SHANGHAI_ZONE_ID});
+    }
+
+    @TestTemplate
+    void testEventTimeSessionWindows() throws Exception {
         final SessionWindowAssigner assigner = SessionWindowAssigner.withGap(Duration.ofSeconds(3));
         UnalignedWindowTableFunctionOperator operator = createOperator(assigner, ROW_TIME_INDEX);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
@@ -158,8 +164,8 @@ public class UnalignedWindowTableFunctionOperatorTest extends WindowTableFunctio
         testHarness.close();
     }
 
-    @Test
-    public void testEventTimeSessionWindowsWithChangelog() throws Exception {
+    @TestTemplate
+    void testEventTimeSessionWindowsWithChangelog() throws Exception {
         final SessionWindowAssigner assigner = SessionWindowAssigner.withGap(Duration.ofSeconds(3));
         UnalignedWindowTableFunctionOperator operator = createOperator(assigner, ROW_TIME_INDEX);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
@@ -292,8 +298,8 @@ public class UnalignedWindowTableFunctionOperatorTest extends WindowTableFunctio
         testHarness.close();
     }
 
-    @Test
-    public void testProcessTimeSessionWindows() throws Exception {
+    @TestTemplate
+    void testProcessTimeSessionWindows() throws Exception {
         final SessionWindowAssigner assigner =
                 SessionWindowAssigner.withGap(Duration.ofSeconds(3)).withProcessingTime();
         UnalignedWindowTableFunctionOperator operator = createOperator(assigner, -1);
@@ -382,8 +388,8 @@ public class UnalignedWindowTableFunctionOperatorTest extends WindowTableFunctio
         testHarness.close();
     }
 
-    @Test
-    public void testProcessTimeSessionWindowsWithChangelog() throws Exception {
+    @TestTemplate
+    void testProcessTimeSessionWindowsWithChangelog() throws Exception {
         final SessionWindowAssigner assigner =
                 SessionWindowAssigner.withGap(Duration.ofSeconds(3)).withProcessingTime();
         UnalignedWindowTableFunctionOperator operator = createOperator(assigner, -1);
@@ -477,8 +483,8 @@ public class UnalignedWindowTableFunctionOperatorTest extends WindowTableFunctio
         testHarness.close();
     }
 
-    @Test
-    public void testSessionWindowsWithoutPartitionKeys() throws Exception {
+    @TestTemplate
+    void testSessionWindowsWithoutPartitionKeys() throws Exception {
         final SessionWindowAssigner assigner = SessionWindowAssigner.withGap(Duration.ofSeconds(3));
         UnalignedWindowTableFunctionOperator operator = createOperator(assigner, ROW_TIME_INDEX);
 
@@ -558,10 +564,5 @@ public class UnalignedWindowTableFunctionOperatorTest extends WindowTableFunctio
                 new RowDataSerializer(INPUT_ROW_TYPE),
                 rowTimeIndex,
                 shiftTimeZone);
-    }
-
-    @Parameterized.Parameters(name = "TimeZone = {0}")
-    public static Collection<Object[]> runMode() {
-        return Arrays.asList(new Object[] {UTC_ZONE_ID}, new Object[] {SHANGHAI_ZONE_ID});
     }
 }

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/window/tvf/operator/WindowTableFunctionOperatorTestBase.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/window/tvf/operator/WindowTableFunctionOperatorTestBase.java
@@ -38,7 +38,7 @@ import static org.apache.flink.table.runtime.util.StreamRecordUtils.row;
 import static org.apache.flink.table.runtime.util.TimeWindowUtil.toUtcTimestampMills;
 
 /** A test base to test window table function operator . */
-public abstract class WindowTableFunctionOperatorTestBase {
+abstract class WindowTableFunctionOperatorTestBase {
 
     protected static final ZoneId UTC_ZONE_ID = ZoneId.of("UTC");
     protected static final ZoneId SHANGHAI_ZONE_ID = ZoneId.of("Asia/Shanghai");

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/window/tvf/slicing/SliceAssignerTestBase.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/window/tvf/slicing/SliceAssignerTestBase.java
@@ -30,6 +30,8 @@ import org.apache.flink.shaded.guava32.com.google.common.collect.Lists;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 
 import static org.apache.flink.core.testutils.FlinkMatchers.containsMessage;
@@ -38,11 +40,15 @@ import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.api.HamcrestCondition.matching;
 
 /** Utilities for testing {@link SliceAssigner}s. */
-public abstract class SliceAssignerTestBase {
+abstract class SliceAssignerTestBase {
 
     private static final ClockService CLOCK_SERVICE = System::currentTimeMillis;
 
     private static final ZoneId UTC_ZONE_ID = ZoneId.of("UTC");
+
+    static Collection<ZoneId> zoneIds() {
+        return Arrays.asList(ZoneId.of("America/Los_Angeles"), ZoneId.of("Asia/Shanghai"));
+    }
 
     protected static void assertErrorMessage(Runnable runnable, String errorMessage) {
         try {

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/window/tvf/slicing/WindowedSliceAssignerTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/window/tvf/slicing/WindowedSliceAssignerTest.java
@@ -36,10 +36,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ExtendWith(ParameterizedTestExtension.class)
 class WindowedSliceAssignerTest extends SliceAssignerTestBase {
 
-    public ZoneId shiftTimeZone;
+    private ZoneId shiftTimeZone;
 
     @Parameters(name = "timezone = {0}")
-    static Collection<ZoneId> parameters() {
+    private static Collection<ZoneId> parameters() {
         return Arrays.asList(ZoneId.of("America/Los_Angeles"), ZoneId.of("Asia/Shanghai"));
     }
 

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/window/tvf/slicing/WindowedSliceAssignerTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/window/tvf/slicing/WindowedSliceAssignerTest.java
@@ -18,10 +18,12 @@
 
 package org.apache.flink.table.runtime.operators.window.tvf.slicing;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.time.Duration;
 import java.time.ZoneId;
@@ -31,13 +33,13 @@ import java.util.Collection;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link SliceAssigners.WindowedSliceAssigner}. */
-@RunWith(Parameterized.class)
-public class WindowedSliceAssignerTest extends SliceAssignerTestBase {
+@ExtendWith(ParameterizedTestExtension.class)
+class WindowedSliceAssignerTest extends SliceAssignerTestBase {
 
-    @Parameterized.Parameter public ZoneId shiftTimeZone;
+    public ZoneId shiftTimeZone;
 
-    @Parameterized.Parameters(name = "timezone = {0}")
-    public static Collection<ZoneId> parameters() {
+    @Parameters(name = "timezone = {0}")
+    static Collection<ZoneId> parameters() {
         return Arrays.asList(ZoneId.of("America/Los_Angeles"), ZoneId.of("Asia/Shanghai"));
     }
 
@@ -45,8 +47,8 @@ public class WindowedSliceAssignerTest extends SliceAssignerTestBase {
     private SliceAssigner hopAssigner;
     private SliceAssigner cumulateAssigner;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         this.tumbleAssigner = SliceAssigners.tumbling(-1, shiftTimeZone, Duration.ofHours(4));
         this.hopAssigner =
                 SliceAssigners.hopping(0, shiftTimeZone, Duration.ofHours(5), Duration.ofHours(1));
@@ -55,8 +57,8 @@ public class WindowedSliceAssignerTest extends SliceAssignerTestBase {
                         0, shiftTimeZone, Duration.ofHours(5), Duration.ofHours(1));
     }
 
-    @Test
-    public void testSliceAssignment() {
+    @TestTemplate
+    void testSliceAssignment() {
         SliceAssigner assigner = SliceAssigners.windowed(0, tumbleAssigner);
 
         assertThat(assignSliceEnd(assigner, utcMills("1970-01-01T00:00:00")))
@@ -67,8 +69,8 @@ public class WindowedSliceAssignerTest extends SliceAssignerTestBase {
                 .isEqualTo(utcMills("1970-01-01T10:00:00"));
     }
 
-    @Test
-    public void testGetWindowStartForTumble() {
+    @TestTemplate
+    void testGetWindowStartForTumble() {
         SliceAssigner assigner = SliceAssigners.windowed(0, tumbleAssigner);
 
         assertThat(assigner.getWindowStart(utcMills("1970-01-01T00:00:00")))
@@ -79,8 +81,8 @@ public class WindowedSliceAssignerTest extends SliceAssignerTestBase {
                 .isEqualTo(utcMills("1970-01-01T04:00:00"));
     }
 
-    @Test
-    public void testGetWindowStartForHop() {
+    @TestTemplate
+    void testGetWindowStartForHop() {
         SliceAssigner assigner = SliceAssigners.windowed(0, hopAssigner);
 
         assertThat(assigner.getWindowStart(utcMills("1970-01-01T00:00:00")))
@@ -101,8 +103,8 @@ public class WindowedSliceAssignerTest extends SliceAssignerTestBase {
                 .isEqualTo(utcMills("1970-01-01T05:00:00"));
     }
 
-    @Test
-    public void testGetWindowStartForCumulate() {
+    @TestTemplate
+    void testGetWindowStartForCumulate() {
         SliceAssigner assigner = SliceAssigners.windowed(0, cumulateAssigner);
 
         assertThat(assigner.getWindowStart(utcMills("1970-01-01T00:00:00")))
@@ -123,8 +125,8 @@ public class WindowedSliceAssignerTest extends SliceAssignerTestBase {
                 .isEqualTo(utcMills("1970-01-01T05:00:00"));
     }
 
-    @Test
-    public void testExpiredSlices() {
+    @TestTemplate
+    void testExpiredSlices() {
         SliceAssigner assigner = SliceAssigners.windowed(0, tumbleAssigner);
 
         assertThat(expiredSlices(assigner, utcMills("1970-01-01T00:00:00")))
@@ -135,14 +137,14 @@ public class WindowedSliceAssignerTest extends SliceAssignerTestBase {
                 .containsExactly(utcMills("1970-01-01T10:00:00"));
     }
 
-    @Test
-    public void testEventTime() {
+    @TestTemplate
+    void testEventTime() {
         SliceAssigner assigner = SliceAssigners.windowed(0, tumbleAssigner);
         assertThat(assigner.isEventTime()).isTrue();
     }
 
-    @Test
-    public void testInvalidParameters() {
+    @TestTemplate
+    void testInvalidParameters() {
         assertErrorMessage(
                 () -> SliceAssigners.windowed(-1, tumbleAssigner),
                 "Windowed slice assigner must have a positive window end index.");

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/wmassigners/ProcTimeMiniBatchAssignerOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/wmassigners/ProcTimeMiniBatchAssignerOperatorTest.java
@@ -25,17 +25,17 @@ import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests of {@link ProcTimeMiniBatchAssignerOperator}. */
-public class ProcTimeMiniBatchAssignerOperatorTest extends WatermarkAssignerOperatorTestBase {
+class ProcTimeMiniBatchAssignerOperatorTest extends WatermarkAssignerOperatorTestBase {
 
     @Test
-    public void testMiniBatchAssignerOperator() throws Exception {
+    void testMiniBatchAssignerOperator() throws Exception {
         final ProcTimeMiniBatchAssignerOperator operator =
                 new ProcTimeMiniBatchAssignerOperator(100);
 

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/wmassigners/RowTimeMiniBatchAssginerOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/wmassigners/RowTimeMiniBatchAssginerOperatorTest.java
@@ -24,7 +24,7 @@ import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -33,10 +33,10 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests of {@link RowTimeMiniBatchAssginerOperator}. */
-public class RowTimeMiniBatchAssginerOperatorTest extends WatermarkAssignerOperatorTestBase {
+class RowTimeMiniBatchAssginerOperatorTest extends WatermarkAssignerOperatorTestBase {
 
     @Test
-    public void testRowTimeWatermarkAssigner() throws Exception {
+    void testRowTimeWatermarkAssigner() throws Exception {
         final RowTimeMiniBatchAssginerOperator operator = new RowTimeMiniBatchAssginerOperator(5);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
                 new OneInputStreamOperatorTestHarness<>(operator);
@@ -85,7 +85,7 @@ public class RowTimeMiniBatchAssginerOperatorTest extends WatermarkAssignerOpera
     }
 
     @Test
-    public void testEndWatermarkIsForwarded() throws Exception {
+    void testEndWatermarkIsForwarded() throws Exception {
         final RowTimeMiniBatchAssginerOperator operator = new RowTimeMiniBatchAssginerOperator(50);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
                 new OneInputStreamOperatorTestHarness<>(operator);

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/wmassigners/WatermarkAssignerOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/wmassigners/WatermarkAssignerOperatorTest.java
@@ -30,7 +30,7 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.generated.GeneratedWatermarkGenerator;
 import org.apache.flink.table.runtime.generated.WatermarkGenerator;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
 
@@ -43,13 +43,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 /** Tests of {@link WatermarkAssignerOperator}. */
-public class WatermarkAssignerOperatorTest extends WatermarkAssignerOperatorTestBase {
+class WatermarkAssignerOperatorTest extends WatermarkAssignerOperatorTestBase {
 
     private static final WatermarkGenerator WATERMARK_GENERATOR =
             new BoundedOutOfOrderWatermarkGenerator(0, 1);
 
     @Test
-    public void testCalculateProcessingTimeTimerInterval() {
+    void testCalculateProcessingTimeTimerInterval() {
         assertThat(calculateProcessingTimeTimerInterval(5, 0)).isEqualTo(5);
         assertThat(calculateProcessingTimeTimerInterval(5, -1)).isEqualTo(5);
 
@@ -67,7 +67,7 @@ public class WatermarkAssignerOperatorTest extends WatermarkAssignerOperatorTest
     }
 
     @Test
-    public void testWatermarkAssignerWithIdleSource() throws Exception {
+    void testWatermarkAssignerWithIdleSource() throws Exception {
         // with timeout 1000 ms
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
                 createTestHarness(0, WATERMARK_GENERATOR, 1000);
@@ -110,12 +110,12 @@ public class WatermarkAssignerOperatorTest extends WatermarkAssignerOperatorTest
     }
 
     @Test
-    public void testWatermarkIntervalSmallerThanIdleTimeout() throws Exception {
+    void testWatermarkIntervalSmallerThanIdleTimeout() throws Exception {
         testIdleTimeout(1000, 50);
     }
 
     @Test
-    public void testIdleTimeoutSmallerThanWatermarkInterval() throws Exception {
+    void testIdleTimeoutSmallerThanWatermarkInterval() throws Exception {
         testIdleTimeout(50, 1000);
     }
 
@@ -141,7 +141,7 @@ public class WatermarkAssignerOperatorTest extends WatermarkAssignerOperatorTest
     }
 
     @Test
-    public void testIdleTimeoutUnderBackpressure() throws Exception {
+    void testIdleTimeoutUnderBackpressure() throws Exception {
         long idleTimeout = 100;
 
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
@@ -182,7 +182,7 @@ public class WatermarkAssignerOperatorTest extends WatermarkAssignerOperatorTest
     }
 
     @Test
-    public void testWatermarkAssignerOperator() throws Exception {
+    void testWatermarkAssignerOperator() throws Exception {
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
                 createTestHarness(0, WATERMARK_GENERATOR, -1);
 
@@ -264,7 +264,7 @@ public class WatermarkAssignerOperatorTest extends WatermarkAssignerOperatorTest
     }
 
     @Test
-    public void testCustomizedWatermarkGenerator() throws Exception {
+    void testCustomizedWatermarkGenerator() throws Exception {
         MyWatermarkGenerator.openCalled = false;
         MyWatermarkGenerator.closeCalled = false;
         WatermarkGenerator generator = new MyWatermarkGenerator(1);

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/wmassigners/WatermarkAssignerOperatorTestBase.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/wmassigners/WatermarkAssignerOperatorTestBase.java
@@ -33,7 +33,7 @@ import java.util.stream.Collectors;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Base class for watermark assigner operator test. */
-public abstract class WatermarkAssignerOperatorTestBase {
+abstract class WatermarkAssignerOperatorTestBase {
 
     protected Tuple2<Long, Long> validateElement(
             Object element, long nextElementValue, long currentWatermark) {

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/types/DataTypePrecisionFixerTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/types/DataTypePrecisionFixerTest.java
@@ -113,7 +113,7 @@ public class DataTypePrecisionFixerTest {
 
     @ParameterizedTest(name = "{index}: [From: {0}, To: {1}]")
     @MethodSource("testData")
-    public void testPrecisionFixing(final TestSpec testSpec) {
+    void testPrecisionFixing(final TestSpec testSpec) {
         DataType dataType = fromLegacyInfoToDataType(testSpec.typeInfo);
         DataType newDataType = dataType.accept(new DataTypePrecisionFixer(testSpec.logicalType));
         assertThat(newDataType).isEqualTo(testSpec.expectedType);

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/types/DataTypePrecisionFixerTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/types/DataTypePrecisionFixerTest.java
@@ -48,9 +48,9 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link DataTypePrecisionFixer}. */
-public class DataTypePrecisionFixerTest {
+class DataTypePrecisionFixerTest {
 
-    public static List<TestSpec> testData() {
+    private static List<TestSpec> testData() {
         return Arrays.asList(
                 TestSpecs.fix(Types.BIG_DEC)
                         .logicalType(new DecimalType(10, 5))

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/types/DataTypePrecisionFixerTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/types/DataTypePrecisionFixerTest.java
@@ -33,9 +33,8 @@ import org.apache.flink.table.types.logical.TimeType;
 import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.VarCharType;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.sql.Date;
 import java.sql.Time;
@@ -49,10 +48,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link DataTypePrecisionFixer}. */
-@RunWith(Parameterized.class)
 public class DataTypePrecisionFixerTest {
 
-    @Parameterized.Parameters(name = "{index}: [From: {0}, To: {1}]")
     public static List<TestSpec> testData() {
         return Arrays.asList(
                 TestSpecs.fix(Types.BIG_DEC)
@@ -114,10 +111,9 @@ public class DataTypePrecisionFixerTest {
                                                                 .bridgedTo(Time.class))))));
     }
 
-    @Parameterized.Parameter public TestSpec testSpec;
-
-    @Test
-    public void testPrecisionFixing() {
+    @ParameterizedTest(name = "{index}: [From: {0}, To: {1}]")
+    @MethodSource("testData")
+    public void testPrecisionFixing(final TestSpec testSpec) {
         DataType dataType = fromLegacyInfoToDataType(testSpec.typeInfo);
         DataType newDataType = dataType.accept(new DataTypePrecisionFixer(testSpec.logicalType));
         assertThat(newDataType).isEqualTo(testSpec.expectedType);

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/types/LogicalTypeAssignableTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/types/LogicalTypeAssignableTest.java
@@ -60,9 +60,9 @@ import java.util.stream.Collectors;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link PlannerTypeUtils#isAssignable(LogicalType, LogicalType)}. */
-public class LogicalTypeAssignableTest {
+class LogicalTypeAssignableTest {
 
-    public static List<Object[]> testData() {
+    private static List<Object[]> testData() {
         return Arrays.asList(
                 new Object[][] {
                     {new CharType(), new CharType(5), true},
@@ -203,7 +203,7 @@ public class LogicalTypeAssignableTest {
 
     @ParameterizedTest(name = "{index}: [{0} COMPATIBLE {1} => {2}")
     @MethodSource("testData")
-    public void testAreTypesCompatible(
+    void testAreTypesCompatible(
             final LogicalType sourceType, final LogicalType targetType, final boolean equals) {
         assertThat(PlannerTypeUtils.isAssignable(sourceType, targetType)).isEqualTo(equals);
         assertThat(PlannerTypeUtils.isAssignable(sourceType, sourceType.copy())).isTrue();

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/types/LogicalTypeAssignableTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/types/LogicalTypeAssignableTest.java
@@ -49,11 +49,8 @@ import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.table.types.logical.YearMonthIntervalType;
 import org.apache.flink.table.types.logical.ZonedTimestampType;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Arrays;
 import java.util.List;
@@ -63,10 +60,8 @@ import java.util.stream.Collectors;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link PlannerTypeUtils#isAssignable(LogicalType, LogicalType)}. */
-@RunWith(Parameterized.class)
 public class LogicalTypeAssignableTest {
 
-    @Parameters(name = "{index}: [{0} COMPATIBLE {1} => {2}")
     public static List<Object[]> testData() {
         return Arrays.asList(
                 new Object[][] {
@@ -206,16 +201,10 @@ public class LogicalTypeAssignableTest {
                 });
     }
 
-    @Parameter public LogicalType sourceType;
-
-    @Parameter(1)
-    public LogicalType targetType;
-
-    @Parameter(2)
-    public boolean equals;
-
-    @Test
-    public void testAreTypesCompatible() {
+    @ParameterizedTest(name = "{index}: [{0} COMPATIBLE {1} => {2}")
+    @MethodSource("testData")
+    public void testAreTypesCompatible(
+            final LogicalType sourceType, final LogicalType targetType, final boolean equals) {
         assertThat(PlannerTypeUtils.isAssignable(sourceType, targetType)).isEqualTo(equals);
         assertThat(PlannerTypeUtils.isAssignable(sourceType, sourceType.copy())).isTrue();
         assertThat(PlannerTypeUtils.isAssignable(targetType, targetType.copy())).isTrue();

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/typeutils/RowDataSerializerTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/typeutils/RowDataSerializerTest.java
@@ -41,7 +41,7 @@ import org.apache.flink.table.types.logical.RawType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.testutils.DeeplyEqualsChecker;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Objects;
 

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/util/ConstantsKeyValuePairsIterator.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/util/ConstantsKeyValuePairsIterator.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.util;
+
+import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.data.writer.BinaryRowWriter;
+import org.apache.flink.types.IntValue;
+import org.apache.flink.util.MutableObjectIterator;
+
+/** An iterator that returns the Key/Value pairs with identical value a given number of times. */
+public final class ConstantsKeyValuePairsIterator implements MutableObjectIterator<BinaryRowData> {
+
+    private final IntValue key;
+    private final IntValue value;
+
+    private int numLeft;
+
+    public ConstantsKeyValuePairsIterator(int key, int value, int count) {
+        this.key = new IntValue(key);
+        this.value = new IntValue(value);
+        this.numLeft = count;
+    }
+
+    @Override
+    public BinaryRowData next(BinaryRowData reuse) {
+        if (this.numLeft > 0) {
+            this.numLeft--;
+
+            BinaryRowWriter writer = new BinaryRowWriter(reuse);
+            writer.writeInt(0, this.key.getValue());
+            writer.writeInt(1, this.value.getValue());
+            writer.complete();
+            return reuse;
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public BinaryRowData next() {
+        return next(new BinaryRowData(2));
+    }
+}

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/util/ResettableExternalBufferTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/util/ResettableExternalBufferTest.java
@@ -27,8 +27,8 @@ import org.apache.flink.table.data.writer.BinaryRowWriter;
 import org.apache.flink.table.runtime.typeutils.BinaryRowDataSerializer;
 
 import org.apache.commons.lang3.RandomStringUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -41,7 +41,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test for {@link ResettableExternalBuffer}. */
-public class ResettableExternalBufferTest {
+class ResettableExternalBufferTest {
 
     private static final int MEMORY_SIZE = 1024 * DEFAULT_PAGE_SIZE;
 
@@ -52,8 +52,8 @@ public class ResettableExternalBufferTest {
     private BinaryRowDataSerializer multiColumnFixedLengthSerializer;
     private BinaryRowDataSerializer multiColumnVariableLengthSerializer;
 
-    @Before
-    public void before() {
+    @BeforeEach
+    void before() {
         this.memManager = MemoryManagerBuilder.newBuilder().setMemorySize(MEMORY_SIZE).build();
         this.ioManager = new IOManagerAsync();
         this.random = new Random();
@@ -77,7 +77,7 @@ public class ResettableExternalBufferTest {
     }
 
     @Test
-    public void testLess() throws Exception {
+    void testLess() throws Exception {
         ResettableExternalBuffer buffer = newBuffer(DEFAULT_PAGE_SIZE * 2);
 
         int number = 100;
@@ -95,7 +95,7 @@ public class ResettableExternalBufferTest {
     }
 
     @Test
-    public void testSpill() throws Exception {
+    void testSpill() throws Exception {
         ResettableExternalBuffer buffer = newBuffer(DEFAULT_PAGE_SIZE * 2);
 
         int number = 5000; // 16 * 5000
@@ -113,7 +113,7 @@ public class ResettableExternalBufferTest {
     }
 
     @Test
-    public void testBufferReset() throws Exception {
+    void testBufferReset() throws Exception {
         ResettableExternalBuffer buffer = newBuffer(DEFAULT_PAGE_SIZE * 2);
 
         // less
@@ -136,7 +136,7 @@ public class ResettableExternalBufferTest {
     }
 
     @Test
-    public void testBufferResetWithSpill() throws Exception {
+    void testBufferResetWithSpill() throws Exception {
         int inMemoryThreshold = 20;
         ResettableExternalBuffer buffer = newBuffer(DEFAULT_PAGE_SIZE * 2);
 
@@ -168,7 +168,7 @@ public class ResettableExternalBufferTest {
     }
 
     @Test
-    public void testHugeRecord() throws Exception {
+    void testHugeRecord() throws Exception {
         try (ResettableExternalBuffer buffer =
                 new ResettableExternalBuffer(
                         ioManager,
@@ -186,7 +186,7 @@ public class ResettableExternalBufferTest {
     }
 
     @Test
-    public void testRandomAccessLess() throws Exception {
+    void testRandomAccessLess() throws Exception {
         ResettableExternalBuffer buffer = newBuffer(DEFAULT_PAGE_SIZE * 2);
 
         int number = 100;
@@ -209,7 +209,7 @@ public class ResettableExternalBufferTest {
     }
 
     @Test
-    public void testRandomAccessSpill() throws Exception {
+    void testRandomAccessSpill() throws Exception {
         ResettableExternalBuffer buffer = newBuffer(DEFAULT_PAGE_SIZE * 2);
 
         int number = 5000;
@@ -232,7 +232,7 @@ public class ResettableExternalBufferTest {
     }
 
     @Test
-    public void testBufferResetWithSpillAndRandomAccess() throws Exception {
+    void testBufferResetWithSpillAndRandomAccess() throws Exception {
         final int tries = 100;
         ResettableExternalBuffer buffer = newBuffer(DEFAULT_PAGE_SIZE * 2);
 
@@ -273,66 +273,65 @@ public class ResettableExternalBufferTest {
     }
 
     @Test
-    public void testMultiColumnFixedLengthRandomAccessLess() throws Exception {
+    void testMultiColumnFixedLengthRandomAccessLess() throws Exception {
         testMultiColumnRandomAccessLess(
                 multiColumnFixedLengthSerializer, FixedLengthRowData.class, true);
     }
 
     @Test
-    public void testMultiColumnFixedLengthRandomAccessSpill() throws Exception {
+    void testMultiColumnFixedLengthRandomAccessSpill() throws Exception {
         testMultiColumnRandomAccessSpill(
                 multiColumnFixedLengthSerializer, FixedLengthRowData.class, true);
     }
 
     @Test
-    public void testBufferResetWithSpillAndMultiColumnFixedLengthRandomAccess() throws Exception {
+    void testBufferResetWithSpillAndMultiColumnFixedLengthRandomAccess() throws Exception {
         testBufferResetWithSpillAndMultiColumnRandomAccess(
                 multiColumnFixedLengthSerializer, FixedLengthRowData.class, true);
     }
 
     @Test
-    public void testMultiColumnVariableLengthRandomAccessLess() throws Exception {
+    void testMultiColumnVariableLengthRandomAccessLess() throws Exception {
         testMultiColumnRandomAccessLess(
                 multiColumnVariableLengthSerializer, VariableLengthRowData.class, false);
     }
 
     @Test
-    public void testMultiColumnVariableLengthRandomAccessSpill() throws Exception {
+    void testMultiColumnVariableLengthRandomAccessSpill() throws Exception {
         testMultiColumnRandomAccessSpill(
                 multiColumnVariableLengthSerializer, VariableLengthRowData.class, false);
     }
 
     @Test
-    public void testBufferResetWithSpillAndMultiColumnVariableLengthRandomAccess()
-            throws Exception {
+    void testBufferResetWithSpillAndMultiColumnVariableLengthRandomAccess() throws Exception {
         testBufferResetWithSpillAndMultiColumnRandomAccess(
                 multiColumnVariableLengthSerializer, VariableLengthRowData.class, false);
     }
 
     @Test
-    public void testIteratorOnFixedLengthEmptyBuffer() throws Exception {
+    void testIteratorOnFixedLengthEmptyBuffer() throws Exception {
         testIteratorOnMultiColumnEmptyBuffer(multiColumnFixedLengthSerializer, true);
     }
 
     @Test
-    public void testFixedLengthRandomAccessOutOfRange() throws Exception {
+    void testFixedLengthRandomAccessOutOfRange() throws Exception {
         testRandomAccessOutOfRange(
                 multiColumnFixedLengthSerializer, FixedLengthRowData.class, true);
     }
 
     @Test
-    public void testIteratorOnVariableLengthEmptyBuffer() throws Exception {
+    void testIteratorOnVariableLengthEmptyBuffer() throws Exception {
         testIteratorOnMultiColumnEmptyBuffer(multiColumnVariableLengthSerializer, false);
     }
 
     @Test
-    public void testVariableLengthRandomAccessOutOfRange() throws Exception {
+    void testVariableLengthRandomAccessOutOfRange() throws Exception {
         testRandomAccessOutOfRange(
                 multiColumnVariableLengthSerializer, VariableLengthRowData.class, false);
     }
 
     @Test
-    public void testIteratorReset() throws Exception {
+    void testIteratorReset() throws Exception {
         ResettableExternalBuffer buffer = newBuffer(DEFAULT_PAGE_SIZE * 2);
 
         int number = 100;
@@ -352,7 +351,7 @@ public class ResettableExternalBufferTest {
     }
 
     @Test
-    public void testIteratorResetWithSpill() throws Exception {
+    void testIteratorResetWithSpill() throws Exception {
         ResettableExternalBuffer buffer = newBuffer(DEFAULT_PAGE_SIZE * 2);
 
         int number = 5000; // 16 * 5000
@@ -372,7 +371,7 @@ public class ResettableExternalBufferTest {
     }
 
     @Test
-    public void testIteratorResetWithRandomAccess() throws Exception {
+    void testIteratorResetWithRandomAccess() throws Exception {
         ResettableExternalBuffer buffer = newBuffer(DEFAULT_PAGE_SIZE * 2);
 
         int number = 100;
@@ -400,7 +399,7 @@ public class ResettableExternalBufferTest {
     }
 
     @Test
-    public void testIteratorResetWithRandomAccessSpill() throws Exception {
+    void testIteratorResetWithRandomAccessSpill() throws Exception {
         ResettableExternalBuffer buffer = newBuffer(DEFAULT_PAGE_SIZE * 2);
 
         int number = 5000;
@@ -428,7 +427,7 @@ public class ResettableExternalBufferTest {
     }
 
     @Test
-    public void testMultipleIteratorsLess() throws Exception {
+    void testMultipleIteratorsLess() throws Exception {
         ResettableExternalBuffer buffer = newBuffer(DEFAULT_PAGE_SIZE * 2);
 
         int number = 100;
@@ -456,7 +455,7 @@ public class ResettableExternalBufferTest {
     }
 
     @Test
-    public void testMultipleIteratorsSpill() throws Exception {
+    void testMultipleIteratorsSpill() throws Exception {
         ResettableExternalBuffer buffer = newBuffer(DEFAULT_PAGE_SIZE * 2);
 
         int number = 5000;
@@ -484,7 +483,7 @@ public class ResettableExternalBufferTest {
     }
 
     @Test
-    public void testMultipleIteratorsWithIteratorReset() throws Exception {
+    void testMultipleIteratorsWithIteratorReset() throws Exception {
         ResettableExternalBuffer buffer = newBuffer(DEFAULT_PAGE_SIZE * 2);
 
         int number = 5000; // 16 * 5000
@@ -518,26 +517,48 @@ public class ResettableExternalBufferTest {
         buffer.close();
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void testUpdateIteratorFixedLengthLess() throws Exception {
-        testUpdateIteratorLess(multiColumnFixedLengthSerializer, FixedLengthRowData.class, true);
+    @Test
+    void testUpdateIteratorFixedLengthLess() {
+        assertThatThrownBy(
+                        () ->
+                                testUpdateIteratorLess(
+                                        multiColumnFixedLengthSerializer,
+                                        FixedLengthRowData.class,
+                                        true))
+                .isInstanceOf(IllegalStateException.class);
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void testUpdateIteratorFixedLengthSpill() throws Exception {
-        testUpdateIteratorSpill(multiColumnFixedLengthSerializer, FixedLengthRowData.class, true);
+    @Test
+    void testUpdateIteratorFixedLengthSpill() {
+        assertThatThrownBy(
+                        () ->
+                                testUpdateIteratorSpill(
+                                        multiColumnFixedLengthSerializer,
+                                        FixedLengthRowData.class,
+                                        true))
+                .isInstanceOf(IllegalStateException.class);
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void testUpdateIteratorVariableLengthLess() throws Exception {
-        testUpdateIteratorLess(
-                multiColumnVariableLengthSerializer, VariableLengthRowData.class, false);
+    @Test
+    void testUpdateIteratorVariableLengthLess() {
+        assertThatThrownBy(
+                        () ->
+                                testUpdateIteratorLess(
+                                        multiColumnVariableLengthSerializer,
+                                        VariableLengthRowData.class,
+                                        false))
+                .isInstanceOf(IllegalStateException.class);
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void testUpdateIteratorVariableLengthSpill() throws Exception {
-        testUpdateIteratorSpill(
-                multiColumnVariableLengthSerializer, VariableLengthRowData.class, false);
+    @Test
+    void testUpdateIteratorVariableLengthSpill() {
+        assertThatThrownBy(
+                        () ->
+                                testUpdateIteratorSpill(
+                                        multiColumnVariableLengthSerializer,
+                                        VariableLengthRowData.class,
+                                        false))
+                .isInstanceOf(IllegalStateException.class);
     }
 
     private <T extends RowData> void testMultiColumnRandomAccessLess(

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/util/TimeWindowUtilTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/util/TimeWindowUtilTest.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.runtime.util;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -30,12 +30,12 @@ import static org.apache.flink.table.runtime.util.TimeWindowUtil.toUtcTimestampM
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link org.apache.flink.table.runtime.util.TimeWindowUtil}. */
-public class TimeWindowUtilTest {
+class TimeWindowUtilTest {
 
     private static final ZoneId UTC_ZONE_ID = TimeZone.getTimeZone("UTC").toZoneId();
 
     @Test
-    public void testShiftedTimeZone() {
+    void testShiftedTimeZone() {
         ZoneId zoneId = ZoneId.of("Asia/Shanghai");
         assertThat(toEpochMillsForTimer(utcMills("1970-01-01T00:00:01"), zoneId))
                 .isEqualTo(-28799000L);
@@ -51,7 +51,7 @@ public class TimeWindowUtilTest {
     }
 
     @Test
-    public void testDaylightSaving() {
+    void testDaylightSaving() {
         ZoneId zoneId = ZoneId.of("America/Los_Angeles");
         /*
          * The DaylightTime in Los_Angele start at time 2021-03-14 02:00:00
@@ -126,7 +126,7 @@ public class TimeWindowUtilTest {
     }
 
     @Test
-    public void testMaxWatermark() {
+    void testMaxWatermark() {
         ZoneId zoneId = ZoneId.of("Asia/Shanghai");
         assertThat(toUtcTimestampMills(Long.MAX_VALUE, zoneId)).isEqualTo(Long.MAX_VALUE);
         assertThat(toEpochMillsForTimer(Long.MAX_VALUE, zoneId)).isEqualTo(Long.MAX_VALUE);

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/util/collections/binary/BytesHashMapTestBase.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/util/collections/binary/BytesHashMapTestBase.java
@@ -37,7 +37,7 @@ import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.SmallIntType;
 import org.apache.flink.table.types.logical.VarCharType;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -102,7 +102,7 @@ public abstract class BytesHashMapTestBase<K> extends BytesMapTestBase {
     // ------------------------------------------------------------------------------------------
 
     @Test
-    public void testHashSetMode() throws IOException {
+    void testHashSetMode() throws IOException {
         final int numMemSegments =
                 needNumMemSegments(
                         NUM_ENTRIES,
@@ -124,7 +124,7 @@ public abstract class BytesHashMapTestBase<K> extends BytesMapTestBase {
     }
 
     @Test
-    public void testBuildAndRetrieve() throws Exception {
+    void testBuildAndRetrieve() throws Exception {
 
         final int numMemSegments =
                 needNumMemSegments(
@@ -147,7 +147,7 @@ public abstract class BytesHashMapTestBase<K> extends BytesMapTestBase {
     }
 
     @Test
-    public void testBuildAndUpdate() throws Exception {
+    void testBuildAndUpdate() throws Exception {
         final int numMemSegments =
                 needNumMemSegments(
                         NUM_ENTRIES,
@@ -170,7 +170,7 @@ public abstract class BytesHashMapTestBase<K> extends BytesMapTestBase {
     }
 
     @Test
-    public void testRest() throws Exception {
+    void testRest() throws Exception {
         final int numMemSegments =
                 needNumMemSegments(
                         NUM_ENTRIES,
@@ -202,7 +202,7 @@ public abstract class BytesHashMapTestBase<K> extends BytesMapTestBase {
     }
 
     @Test
-    public void testResetAndOutput() throws Exception {
+    void testResetAndOutput() throws Exception {
         final Random rnd = new Random(RANDOM_SEED);
         final int reservedMemSegments = 64;
 
@@ -267,7 +267,7 @@ public abstract class BytesHashMapTestBase<K> extends BytesMapTestBase {
     }
 
     @Test
-    public void testSingleKeyMultipleOps() throws Exception {
+    void testSingleKeyMultipleOps() throws Exception {
         final int numMemSegments =
                 needNumMemSegments(
                         NUM_ENTRIES,

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/util/collections/binary/BytesHashMapTestBase.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/util/collections/binary/BytesHashMapTestBase.java
@@ -47,7 +47,7 @@ import java.util.Random;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Base test class for both {@link BytesHashMap} and {@link WindowBytesHashMap}. */
-public abstract class BytesHashMapTestBase<K> extends BytesMapTestBase {
+abstract class BytesHashMapTestBase<K> extends BytesMapTestBase {
 
     private static final int NUM_REWRITES = 10;
 

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/util/collections/binary/BytesMultiMapTestBase.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/util/collections/binary/BytesMultiMapTestBase.java
@@ -37,7 +37,7 @@ import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.SmallIntType;
 import org.apache.flink.table.types.logical.VarCharType;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Iterator;
 import java.util.Random;
@@ -92,7 +92,7 @@ public abstract class BytesMultiMapTestBase<K> extends BytesMapTestBase {
     // ------------------------------------------------------------------------------------------
 
     @Test
-    public void testBuildAndRetrieve() throws Exception {
+    void testBuildAndRetrieve() throws Exception {
         final int numMemSegments =
                 needNumMemSegments(
                         NUM_ENTRIES,


### PR DESCRIPTION
## What is the purpose of the change

Update the flink-table-runtime module to AssertJ and JUnit 5 following the [JUnit 5 Migration Guide](https://docs.google.com/document/d/1514Wa_aNB9bJUen4xm5uiuXOooOJTtXqS_Jqk9KJitU/edit)


## Brief change log

Use JUnit5 and AssertJ in tests instead of JUnit4 and Hamcrest

## Verifying this change

This change is a code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
