### PR TITLE
[FLINK-27763][kinesis][tests] Remove netty bundling&relocation

### DIFF
--- a/flink-end-to-end-tests/flink-streaming-kinesis-test/pom.xml
+++ b/flink-end-to-end-tests/flink-streaming-kinesis-test/pom.xml
@@ -107,33 +107,6 @@ under the License.
 				<artifactId>maven-shade-plugin</artifactId>
 				<executions>
 					<execution>
-						<id>shade-flink</id>
-						<phase>package</phase>
-						<goals>
-							<goal>shade</goal>
-						</goals>
-						<configuration>
-							<!-- required for the Kinesis e2e test -->
-							<shadeTestJar>true</shadeTestJar>
-							<promoteTransitiveDependencies>true</promoteTransitiveDependencies>
-							<artifactSet combine.children="append">
-								<includes>
-									<include>io.netty:*</include>
-								</includes>
-							</artifactSet>
-							<relocations combine.children="override">
-								<relocation>
-									<pattern>io.netty</pattern>
-									<shadedPattern>org.apache.flink.shaded.netty4.io.netty</shadedPattern>
-								</relocation>
-								<relocation>
-									<pattern>io.netty</pattern>
-									<shadedPattern>org.apache.flink.kinesis.shaded.io.netty</shadedPattern>
-								</relocation>
-							</relocations>
-						</configuration>
-					</execution>
-					<execution>
 						<id>fat-jar-kinesis-example</id>
 						<phase>package</phase>
 						<goals>


### PR DESCRIPTION
flink-streaming-kinesis-tests bundles and relocates netty (and no other dependency). We can safely remove this because no class within this module references netty, nor any other module relies on the relocated versions.