### PR TITLE
[FLINK-27731][Documentation][Build] Remove Hugo Modules integration

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,6 @@ https://flink.apache.org/ is also generated from the files found here.
 
 The Flink documentation uses [Hugo](https://gohugo.io/getting-started/installing/) to generate HTML files.  More specifically, it uses the *extended version* of Hugo with Sass/SCSS support. 
 
-As a pre-requisite, you need to have [Go](https://golang.org/doc/install) installed.
 To build the documentation, you can install Hugo locally or use a Docker image. 
 
 Both methods require you to execute commands in the directory of this module (`docs/`). The built site is served at http://localhost:1313/.

--- a/docs/setup_docs.sh
+++ b/docs/setup_docs.sh
@@ -23,18 +23,6 @@ if [[ "$HERE" != "docs" ]]; then
     exit 1;
 fi
 
-# Create a default go.mod file
-cat <<EOF >go.mod
-module github.com/apache/flink
-
-go 1.18
-EOF
-
-echo "Created temporary file" $goModFileLocation/go.mod
-
-# Make Hugo retrieve modules which are used for externally hosted documentation
-currentBranch=$(git rev-parse --abbrev-ref HEAD)
-
 function integrate_connector_docs {
   connector=$1
   ref=$2


### PR DESCRIPTION
## What is the purpose of the change

Remove all the Hugo Modules integration

## Brief change log

Clean-up

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
