### PR TITLE
[FLINK-27776][python] Throws exception when udaf used in sliding window does not implement merge method in PyFlink

### DIFF
--- a/flink-python/pyflink/fn_execution/table/operations.py
+++ b/flink-python/pyflink/fn_execution/table/operations.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 ################################################################################
 import abc
+import inspect
 from functools import reduce
 from itertools import chain
 from typing import Tuple
@@ -51,6 +52,7 @@ except ImportError:
     has_cython = False
 
 from pyflink.table import FunctionContext, Row
+from pyflink.table.udf import AggregateFunction
 
 # UDF
 SCALAR_FUNCTION_URN = "flink:transform:scalar_function:v1"
@@ -478,6 +480,10 @@ class StreamGroupWindowAggregateOperation(AbstractStreamGroupAggregateOperation)
         else:
             trigger = CountTrigger(self._window.window_size)
 
+        if isinstance(window_assigner, (SlidingWindowAssigner, SessionWindowAssigner)):
+            for user_defined_agg in user_defined_aggs:
+                self._check_needed_merged_method(user_defined_agg)
+
         window_aggregator = SimpleNamespaceAggsHandleFunction(
             user_defined_aggs,
             input_extractors,
@@ -554,3 +560,17 @@ class StreamGroupWindowAggregateOperation(AbstractStreamGroupAggregateOperation)
             return eval('lambda value: [%s]' % named_property_extractor_str)
         else:
             return None
+
+    def _check_needed_merged_method(self, agg: AggregateFunction):
+        base_merge_method = None
+        for name, method in inspect.getmembers(AggregateFunction, predicate=inspect.isfunction):
+            if name == 'merge':
+                base_merge_method = method
+                break
+
+        assert base_merge_method is not None
+
+        for name, method in inspect.getmembers(agg.__class__, predicate=inspect.isfunction):
+            if name == 'merge' and base_merge_method == method:
+                raise NotImplementedError('You need to implement the `merge` method of {0} since '
+                                          'it is used in Sliding/Session Time Window.'.format(agg))

--- a/flink-python/pyflink/table/udf.py
+++ b/flink-python/pyflink/table/udf.py
@@ -164,7 +164,7 @@ class ImperativeAggregateFunction(UserDefinedFunction, Generic[T, ACC]):
         :param accumulator: the accumulator which contains the current aggregated results
         :param args: the input value (usually obtained from new arrived data).
         """
-        pass
+        raise RuntimeError("This aggregate function should implement `retract` method.")
 
     def merge(self, accumulator: ACC, accumulators):
         """
@@ -178,7 +178,7 @@ class ImperativeAggregateFunction(UserDefinedFunction, Generic[T, ACC]):
                             custom merge method.
         :param accumulators: a group of accumulators that will be merged.
         """
-        pass
+        raise RuntimeError("This aggregate function should implement `merge` method.")
 
     def get_result_type(self) -> DataType:
         """
@@ -187,7 +187,7 @@ class ImperativeAggregateFunction(UserDefinedFunction, Generic[T, ACC]):
         :return: The :class:`~pyflink.table.types.DataType` of the AggregateFunction's result.
 
         """
-        pass
+        raise RuntimeError("This aggregate function should implement `get_result_type` method.")
 
     def get_accumulator_type(self) -> DataType:
         """
@@ -196,7 +196,8 @@ class ImperativeAggregateFunction(UserDefinedFunction, Generic[T, ACC]):
         :return: The :class:`~pyflink.table.types.DataType` of the AggregateFunction's accumulator.
 
         """
-        pass
+        raise RuntimeError(
+            "This aggregate function should implement `get_accumulator_type` method.")
 
 
 class AggregateFunction(ImperativeAggregateFunction):


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will throw exception when udaf used in sliding window does not implement merge method in PyFlink*


## Brief change log

  - *Check udaf whether implement merge method*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
