### PR TITLE
[FLINK-27169][tests] Set timeout for operator lifecycle tests and increase changelog upload timeout

### DIFF
--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogStorageFactory.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogStorageFactory.java
@@ -26,8 +26,11 @@ import org.apache.flink.runtime.state.changelog.StateChangelogStorageView;
 
 import java.io.File;
 import java.io.IOException;
+import java.time.Duration;
 
 import static org.apache.flink.changelog.fs.FsStateChangelogOptions.BASE_PATH;
+import static org.apache.flink.changelog.fs.FsStateChangelogOptions.RETRY_MAX_ATTEMPTS;
+import static org.apache.flink.changelog.fs.FsStateChangelogOptions.UPLOAD_TIMEOUT;
 import static org.apache.flink.configuration.StateChangelogOptions.STATE_CHANGE_LOG_STORAGE;
 
 /** {@link FsStateChangelogStorage} factory. */
@@ -52,8 +55,14 @@ public class FsStateChangelogStorageFactory implements StateChangelogStorageFact
         return new FsStateChangelogStorageForRecovery();
     }
 
-    public static void configure(Configuration configuration, File newFolder) {
+    public static void configure(
+            Configuration configuration,
+            File newFolder,
+            Duration uploadTimeout,
+            int maxUploadAttempts) {
         configuration.setString(STATE_CHANGE_LOG_STORAGE, IDENTIFIER);
         configuration.setString(BASE_PATH, newFolder.getAbsolutePath());
+        configuration.set(UPLOAD_TIMEOUT, uploadTimeout);
+        configuration.set(RETRY_MAX_ATTEMPTS, maxUploadAttempts);
     }
 }

--- a/flink-tests/src/test/java/org/apache/flink/runtime/operators/lifecycle/BoundedSourceITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/operators/lifecycle/BoundedSourceITCase.java
@@ -37,6 +37,7 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 
 import java.io.IOException;
+import java.time.Duration;
 
 import static org.apache.flink.runtime.operators.lifecycle.command.TestCommand.FINISH_SOURCES;
 import static org.apache.flink.runtime.operators.lifecycle.command.TestCommandDispatcher.TestCommandScope.ALL_SUBTASKS;
@@ -73,7 +74,8 @@ public class BoundedSourceITCase extends TestLogger {
         Configuration conf = new Configuration();
 
         try {
-            FsStateChangelogStorageFactory.configure(conf, TEMPORARY_FOLDER.newFolder());
+            FsStateChangelogStorageFactory.configure(
+                    conf, TEMPORARY_FOLDER.newFolder(), Duration.ofMinutes(1), 10);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/flink-tests/src/test/java/org/apache/flink/runtime/operators/lifecycle/BoundedSourceITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/operators/lifecycle/BoundedSourceITCase.java
@@ -32,12 +32,14 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 
 import java.io.IOException;
 import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 
 import static org.apache.flink.runtime.operators.lifecycle.command.TestCommand.FINISH_SOURCES;
 import static org.apache.flink.runtime.operators.lifecycle.command.TestCommandDispatcher.TestCommandScope.ALL_SUBTASKS;
@@ -69,6 +71,8 @@ public class BoundedSourceITCase extends TestLogger {
                             .build());
 
     @Rule public final SharedObjects sharedObjects = SharedObjects.create();
+
+    @Rule public Timeout timeoutRule = new Timeout(10, TimeUnit.MINUTES);
 
     private static Configuration configuration() {
         Configuration conf = new Configuration();

--- a/flink-tests/src/test/java/org/apache/flink/runtime/operators/lifecycle/PartiallyFinishedSourcesITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/operators/lifecycle/PartiallyFinishedSourcesITCase.java
@@ -37,6 +37,7 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
@@ -45,6 +46,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static java.util.Arrays.asList;
 import static java.util.stream.StreamSupport.stream;
@@ -73,6 +75,8 @@ public class PartiallyFinishedSourcesITCase extends TestLogger {
     @ClassRule public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
 
     @Rule public final SharedObjects sharedObjects = SharedObjects.create();
+
+    @Rule public Timeout timeoutRule = new Timeout(10, TimeUnit.MINUTES);
 
     private MiniClusterWithClientResource miniClusterResource;
 

--- a/flink-tests/src/test/java/org/apache/flink/runtime/operators/lifecycle/PartiallyFinishedSourcesITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/operators/lifecycle/PartiallyFinishedSourcesITCase.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.runtime.operators.lifecycle;
 
+import org.apache.flink.changelog.fs.FsStateChangelogStorageFactory;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.OperatorIDPair;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
@@ -40,6 +41,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -47,10 +49,7 @@ import java.util.List;
 import static java.util.Arrays.asList;
 import static java.util.stream.StreamSupport.stream;
 import static org.apache.flink.api.common.restartstrategy.RestartStrategies.fixedDelayRestart;
-import static org.apache.flink.changelog.fs.FsStateChangelogOptions.BASE_PATH;
-import static org.apache.flink.changelog.fs.FsStateChangelogStorageFactory.IDENTIFIER;
 import static org.apache.flink.configuration.JobManagerOptions.EXECUTION_FAILOVER_STRATEGY;
-import static org.apache.flink.configuration.StateChangelogOptions.STATE_CHANGE_LOG_STORAGE;
 import static org.apache.flink.runtime.operators.lifecycle.command.TestCommand.FINISH_SOURCES;
 import static org.apache.flink.runtime.operators.lifecycle.command.TestCommandDispatcher.TestCommandScope.ALL_SUBTASKS;
 import static org.apache.flink.runtime.operators.lifecycle.command.TestCommandDispatcher.TestCommandScope.SINGLE_SUBTASK;
@@ -90,8 +89,8 @@ public class PartiallyFinishedSourcesITCase extends TestLogger {
         // implementation - use fs-based instead.
         // The randomization currently happens on the job level (environment); while this factory
         // can only be set on the cluster level; so we do it unconditionally here.
-        configuration.setString(STATE_CHANGE_LOG_STORAGE, IDENTIFIER);
-        configuration.setString(BASE_PATH, TEMPORARY_FOLDER.newFolder().getAbsolutePath());
+        FsStateChangelogStorageFactory.configure(
+                configuration, TEMPORARY_FOLDER.newFolder(), Duration.ofMinutes(1), 10);
 
         miniClusterResource =
                 new MiniClusterWithClientResource(

--- a/flink-tests/src/test/java/org/apache/flink/runtime/operators/lifecycle/StopWithSavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/operators/lifecycle/StopWithSavepointITCase.java
@@ -36,11 +36,13 @@ import org.apache.flink.testutils.junit.SharedObjects;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static org.apache.flink.runtime.operators.lifecycle.graph.TestJobBuilders.COMPLEX_GRAPH_BUILDER;
 import static org.apache.flink.runtime.operators.lifecycle.graph.TestJobBuilders.SIMPLE_GRAPH_BUILDER;
@@ -98,6 +100,7 @@ public class StopWithSavepointITCase extends AbstractTestBase {
 
     @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
     @Rule public final SharedObjects sharedObjects = SharedObjects.create();
+    @Rule public Timeout timeoutRule = new Timeout(10, TimeUnit.MINUTES);
 
     @Parameter(0)
     public boolean withDrain;

--- a/flink-tests/src/test/java/org/apache/flink/runtime/operators/lifecycle/TestJobExecutor.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/operators/lifecycle/TestJobExecutor.java
@@ -77,20 +77,20 @@ public class TestJobExecutor {
     public static TestJobExecutor execute(
             TestJobWithDescription testJob, MiniClusterWithClientResource miniClusterResource)
             throws Exception {
-        LOG.debug("submitGraph: {}", testJob.jobGraph);
+        LOG.info("submitGraph: {}", testJob.jobGraph);
         JobID job = miniClusterResource.getClusterClient().submitJob(testJob.jobGraph).get();
         waitForAllTaskRunning(miniClusterResource.getMiniCluster(), job, false);
         return new TestJobExecutor(testJob, job, miniClusterResource);
     }
 
     public TestJobExecutor waitForAllRunning() throws Exception {
-        LOG.debug("waitForAllRunning in {}", jobID);
+        LOG.info("waitForAllRunning in {}", jobID);
         waitForAllTaskRunning(miniClusterResource.getMiniCluster(), jobID, true);
         return this;
     }
 
     public TestJobExecutor waitForEvent(Class<? extends TestEvent> eventClass) throws Exception {
-        LOG.debug("waitForEvent: {}", eventClass.getSimpleName());
+        LOG.info("waitForEvent: {}", eventClass.getSimpleName());
         testJob.eventQueue.withHandler(
                 e -> eventClass.isAssignableFrom(e.getClass()) ? STOP : CONTINUE);
         return this;
@@ -98,7 +98,7 @@ public class TestJobExecutor {
 
     public TestJobExecutor stopWithSavepoint(TemporaryFolder folder, boolean withDrain)
             throws Exception {
-        LOG.debug("stopWithSavepoint: {} (withDrain: {})", folder, withDrain);
+        LOG.info("stopWithSavepoint: {} (withDrain: {})", folder, withDrain);
         ClusterClient<?> client = miniClusterResource.getClusterClient();
         client.stopWithSavepoint(
                         jobID,
@@ -111,13 +111,13 @@ public class TestJobExecutor {
 
     public TestJobExecutor sendOperatorCommand(
             String operatorID, TestCommand command, TestCommandScope scope) {
-        LOG.debug("send command: {} to {}/{}", command, operatorID, scope);
+        LOG.info("send command: {} to {}/{}", command, operatorID, scope);
         testJob.commandQueue.dispatch(command, scope, operatorID);
         return this;
     }
 
     public void triggerFailover(String operatorID) throws Exception {
-        LOG.debug("sendCommand: {}", FAIL);
+        LOG.info("sendCommand: {}", FAIL);
         BlockingQueue<TestEvent> queue = new LinkedBlockingQueue<>();
         Consumer<TestEvent> listener = queue::add;
         testJob.eventQueue.addListener(listener);
@@ -183,13 +183,13 @@ public class TestJobExecutor {
     }
 
     public TestJobExecutor sendBroadcastCommand(TestCommand command, TestCommandScope scope) {
-        LOG.debug("sendCommand: {}", command);
+        LOG.info("sendCommand: {}", command);
         testJob.commandQueue.broadcast(command, scope);
         return this;
     }
 
     public TestJobExecutor waitForTermination() throws Exception {
-        LOG.debug("waitForTermination");
+        LOG.info("waitForTermination");
         while (!miniClusterResource
                 .getClusterClient()
                 .getJobStatus(jobID)
@@ -201,7 +201,7 @@ public class TestJobExecutor {
     }
 
     public TestJobExecutor assertFinishedSuccessfully() throws Exception {
-        LOG.debug("assertFinishedSuccessfully");
+        LOG.info("assertFinishedSuccessfully");
         JobStatus jobStatus = miniClusterResource.getClusterClient().getJobStatus(jobID).get();
         if (!jobStatus.equals(FINISHED)) {
             String message = String.format("Job didn't finish successfully, status: %s", jobStatus);
@@ -222,7 +222,7 @@ public class TestJobExecutor {
 
     public TestJobExecutor waitForSubtasksToFinish(JobVertexID id, TestCommandScope scope)
             throws Exception {
-        LOG.debug("waitForSubtasksToFinish vertex {}, all subtasks: {}", id, scope);
+        LOG.info("waitForSubtasksToFinish vertex {}, all subtasks: {}", id, scope);
         CommonTestUtils.waitForSubtasksToFinish(
                 miniClusterResource.getMiniCluster(), jobID, id, scope == ALL_SUBTASKS);
         return this;

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ChangelogPeriodicMaterializationTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ChangelogPeriodicMaterializationTestBase.java
@@ -269,7 +269,8 @@ public abstract class ChangelogPeriodicMaterializationTestBase extends TestLogge
 
     private Configuration configure() throws IOException {
         Configuration configuration = new Configuration();
-        FsStateChangelogStorageFactory.configure(configuration, TEMPORARY_FOLDER.newFolder());
+        FsStateChangelogStorageFactory.configure(
+                configuration, TEMPORARY_FOLDER.newFolder(), Duration.ofMinutes(1), 10);
         return configuration;
     }
 

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/EventTimeWindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/EventTimeWindowCheckpointingITCase.java
@@ -68,6 +68,7 @@ import org.junit.runners.Parameterized;
 
 import java.io.File;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
@@ -203,7 +204,8 @@ public class EventTimeWindowCheckpointingITCase extends TestLogger {
         // ChangelogStateBackend is used.
         // Doing it on cluster level unconditionally as randomization currently happens on the job
         // level (environment); while this factory can only be set on the cluster level.
-        FsStateChangelogStorageFactory.configure(config, tempFolder.newFolder());
+        FsStateChangelogStorageFactory.configure(
+                config, tempFolder.newFolder(), Duration.ofMinutes(1), 10);
 
         return config;
     }

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/IncrementalStateReuseAfterFailureITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/IncrementalStateReuseAfterFailureITCase.java
@@ -45,6 +45,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import java.time.Duration;
+
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static org.apache.flink.runtime.operators.lifecycle.command.TestCommand.DELAY_SNAPSHOT;
@@ -150,7 +152,8 @@ public class IncrementalStateReuseAfterFailureITCase {
     @Before
     public void before() throws Exception {
         Configuration configuration = new Configuration();
-        FsStateChangelogStorageFactory.configure(configuration, temporaryFolder.newFolder());
+        FsStateChangelogStorageFactory.configure(
+                configuration, temporaryFolder.newFolder(), Duration.ofMinutes(1), 10);
         miniClusterResource =
                 new MiniClusterWithClientResource(
                         new MiniClusterResourceConfiguration.Builder()

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ResumeCheckpointManuallyITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ResumeCheckpointManuallyITCase.java
@@ -57,6 +57,7 @@ import javax.annotation.Nullable;
 
 import java.io.File;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
 
 import static org.apache.flink.runtime.testutils.CommonTestUtils.getLatestCompletedCheckpointPath;
@@ -284,7 +285,8 @@ public class ResumeCheckpointManuallyITCase extends TestLogger {
         // ChangelogStateBackend is used.
         // Doing it on cluster level unconditionally as randomization currently happens on the job
         // level (environment); while this factory can only be set on the cluster level.
-        FsStateChangelogStorageFactory.configure(config, temporaryFolder.newFolder());
+        FsStateChangelogStorageFactory.configure(
+                config, temporaryFolder.newFolder(), Duration.ofMinutes(1), 10);
 
         // ZooKeeper recovery mode?
         if (zooKeeperQuorum != null) {

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/StreamFaultToleranceTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/StreamFaultToleranceTestBase.java
@@ -40,6 +40,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.io.Serializable;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
 
@@ -87,7 +88,8 @@ public abstract class StreamFaultToleranceTestBase extends TestLogger {
         // ChangelogStateBackend is used.
         // Doing it on cluster level unconditionally as randomization currently happens on the job
         // level (environment); while this factory can only be set on the cluster level.
-        FsStateChangelogStorageFactory.configure(configuration, tempFolder.newFolder());
+        FsStateChangelogStorageFactory.configure(
+                configuration, tempFolder.newFolder(), Duration.ofMinutes(1), 10);
         cluster =
                 new MiniClusterWithClientResource(
                         new MiniClusterResourceConfiguration.Builder()

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointStressITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointStressITCase.java
@@ -128,7 +128,8 @@ public class UnalignedCheckpointStressITCase extends TestLogger {
         // ChangelogStateBackend is used.
         // Doing it on cluster level unconditionally as randomization currently happens on the job
         // level (environment); while this factory can only be set on the cluster level.
-        FsStateChangelogStorageFactory.configure(configuration, changelogFolder.newFolder());
+        FsStateChangelogStorageFactory.configure(
+                configuration, changelogFolder.newFolder(), Duration.ofMinutes(1), 10);
 
         cluster =
                 new MiniClusterWithClientResource(

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointTestBase.java
@@ -148,7 +148,7 @@ public abstract class UnalignedCheckpointTestBase extends TestLogger {
         // ChangelogStateBackend is used.
         // Doing it on cluster level unconditionally as randomization currently happens on the job
         // level (environment); while this factory can only be set on the cluster level.
-        FsStateChangelogStorageFactory.configure(conf, temp.newFolder());
+        FsStateChangelogStorageFactory.configure(conf, temp.newFolder(), Duration.ofMinutes(1), 10);
 
         final StreamGraph streamGraph = getStreamGraph(settings, conf);
         final int requiredSlots =

--- a/flink-tests/src/test/java/org/apache/flink/test/state/ChangelogCompatibilityITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/ChangelogCompatibilityITCase.java
@@ -38,6 +38,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.io.File;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -292,7 +293,8 @@ public class ChangelogCompatibilityITCase {
         Configuration config = new Configuration();
         config.setString(CHECKPOINTS_DIRECTORY, pathToString(checkpointDir));
         config.setString(SAVEPOINT_DIRECTORY, pathToString(savepointDir));
-        FsStateChangelogStorageFactory.configure(config, TEMPORARY_FOLDER.newFolder());
+        FsStateChangelogStorageFactory.configure(
+                config, TEMPORARY_FOLDER.newFolder(), Duration.ofMinutes(1), 10);
         miniClusterResource =
                 new MiniClusterWithClientResource(
                         new MiniClusterResourceConfiguration.Builder()

--- a/flink-tests/src/test/java/org/apache/flink/test/state/ChangelogRescalingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/ChangelogRescalingITCase.java
@@ -128,7 +128,8 @@ public class ChangelogRescalingITCase extends TestLogger {
     @Before
     public void before() throws Exception {
         Configuration configuration = new Configuration();
-        FsStateChangelogStorageFactory.configure(configuration, temporaryFolder.newFolder());
+        FsStateChangelogStorageFactory.configure(
+                configuration, temporaryFolder.newFolder(), Duration.ofMinutes(1), 10);
         cluster =
                 new MiniClusterWithClientResource(
                         new MiniClusterResourceConfiguration.Builder()


### PR DESCRIPTION
## What is the purpose of the change

Fix test instability caused by changelog write timeouts.

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
