### PR TITLE
[hotfix][python] Fix flake8 check E302 error for blank lines

### DIFF
--- a/flink-python/pyflink/table/tests/test_udf.py
+++ b/flink-python/pyflink/table/tests/test_udf.py
@@ -801,6 +801,7 @@ class PyFlinkEmbeddedThreadTests(UserDefinedFunctionTests, PyFlinkBatchTableTest
         super(PyFlinkEmbeddedThreadTests, self).setUp()
         self.t_env.get_config().set("python.execution-mode", "thread")
 
+
 # test specify the input_types
 @udf(input_types=[DataTypes.BIGINT(), DataTypes.BIGINT()], result_type=DataTypes.BIGINT())
 def add(i, j):


### PR DESCRIPTION
I execute `python -m flake8 --config=tox.ini` in `flink-python` dir
It will throw the following error message.

`./pyflink/table/tests/test_udf.py:805:1: E302 expected 2 blank lines, found 1`
