### PR TITLE
[hotfix][python] Fix flake8 check E523 error for format method has used arguments

### DIFF
--- a/flink-python/pyflink/table/tests/test_table_environment_api.py
+++ b/flink-python/pyflink/table/tests/test_table_environment_api.py
@@ -555,7 +555,7 @@ class VectorUDT(UserDefinedType):
             values = [float(v) for v in obj._values]
             return 1, None, None, values
         else:
-            raise TypeError("Cannot serialize %r of type %r".format(obj, type(obj)))
+            raise TypeError("Cannot serialize {!r} of type {!r}".format(obj, type(obj)))
 
     def deserialize(self, datum):
         pass


### PR DESCRIPTION
Run `python -m flake8 --config=tox.ini` in `flink-python` dir.
It will throw the following error message.
`./pyflink/table/tests/test_table_environment_api.py:558:29: F523 '...'.format(...) has unused arguments at position(s): 0, 1`
