### PR TITLE
[FLINK-27800][streaming] Fix the error check in StreamNode#addInEdge

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamNode.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamNode.java
@@ -124,8 +124,8 @@ public class StreamNode {
 
     public void addInEdge(StreamEdge inEdge) {
         checkState(
-                outEdges.stream().noneMatch(inEdge::equals),
-                "Adding not unique edge = %s to existing outEdges = %s",
+                inEdges.stream().noneMatch(inEdge::equals),
+                "Adding not unique edge = %s to existing inEdges = %s",
                 inEdge,
                 inEdges);
         if (inEdge.getTargetId() != getId()) {


### PR DESCRIPTION
[FLINK-27800](https://issues.apache.org/jira/browse/FLINK-27800)


## What is the purpose of the change
This pull request try to fix when addInEdge, if this edge is already in InEdge list, but can still be added, because the checkState function is to check outEdge list now.

## Brief change log
- change addInEdge to check whether the new edge has already is exists.
