### PR TITLE
[FLINK-27806][table] Support binary & varbinary types in datagen connector

### DIFF
--- a/docs/content.zh/docs/connectors/table/datagen.md
+++ b/docs/content.zh/docs/connectors/table/datagen.md
@@ -45,7 +45,7 @@ DataGen 连接器是内置的。
 
 每个列，都有两种生成数据的方法：
 
-- 随机生成器是默认的生成器，您可以指定随机生成的最大和最小值。char、varchar、string （类型）可以指定长度。它是无界的生成器。
+- 随机生成器是默认的生成器，您可以指定随机生成的最大和最小值。char、varchar、binary、varbinary, string （类型）可以指定长度。它是无界的生成器。
 
 - 序列生成器，您可以指定序列的起始和结束值。它是有界的生成器，当序列数字达到结束值，读取结束。
 
@@ -136,7 +136,7 @@ CREATE TABLE datagen (
       <td>可选</td>
       <td style="word-wrap: break-word;">100</td>
       <td>Integer</td>
-      <td>随机生成器生成字符的长度，适用于 char、varchar、string。</td>
+      <td>随机生成器生成字符的长度，适用于 char、varchar、binary、varbinary、string。</td>
     </tr>
     <tr>
       <td><h5>fields.#.start</h5></td>

--- a/docs/content/docs/connectors/table/datagen.md
+++ b/docs/content/docs/connectors/table/datagen.md
@@ -39,7 +39,7 @@ Usage
 -----
 
 By default, a DataGen table will create an unbounded number of rows with a random value for each column.
-For variable sized types, char/varchar/string/array/map/multiset, the length can be specified.
+For variable sized types, char/varchar/binary/varbinary/string/array/map/multiset, the length can be specified.
 Additionally, a total number of rows can be specified, resulting in a bounded table.
 
 There also exists a sequence generator, where users specify a sequence of start and end values.
@@ -101,6 +101,16 @@ Types
         </tr>
         <tr>
             <td>VARCHAR</td>
+            <td>random / sequence</td>
+            <td></td>
+        </tr>
+        <tr>
+            <td>BINARY</td>
+            <td>random / sequence</td>
+            <td></td>
+        </tr>
+        <tr>
+            <td>VARBINARY</td>
             <td>random / sequence</td>
             <td></td>
         </tr>
@@ -271,7 +281,7 @@ Connector Options
       <td>optional</td>
       <td style="word-wrap: break-word;">100</td>
       <td>Integer</td>
-      <td>Size or length of the collection for generating char/varchar/string/array/map/multiset types.</td>
+      <td>Size or length of the collection for generating char/varchar/binary/varbinary/string/array/map/multiset types.</td>
     </tr>
     <tr>
       <td><h5>fields.#.start</h5></td>


### PR DESCRIPTION
## What is the purpose of the change

Add BYTES type `binary `& `varbinary` support for datagen connector to refine datagen using.  

## Brief change log

Add binary & varbinary type support for datagen connector. 

## Verifying this change

Add case in `DataGenTableSourceFactoryTest`.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature?  no
- If yes, how is the feature documented? yes
