### PR TITLE
[FLINK-27762][connector/kafka] Catch WakeupException and retry KafkaConsumer invocations in split assignment

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
@@ -424,14 +424,13 @@ public class KafkaPartitionSplitReader
      * <p>Under this case we need to catch the {@link WakeupException} and retry the operation.
      */
     private <V> V retryOnWakeup(Supplier<V> consumerCall, String description) {
-        while (true) {
-            try {
-                return consumerCall.get();
-            } catch (WakeupException we) {
-                LOG.debug(
-                        "Caught WakeupException while executing Kafka consumer call for {}. Will retry the consumer call.",
-                        description);
-            }
+        try {
+            return consumerCall.get();
+        } catch (WakeupException we) {
+            LOG.info(
+                    "Caught WakeupException while executing Kafka consumer call for {}. Will retry the consumer call.",
+                    description);
+            return consumerCall.get();
         }
     }
 

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
@@ -56,6 +56,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.StringJoiner;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 /** A {@link SplitReader} implementation that reads records from Kafka partitions. */
@@ -302,7 +303,7 @@ public class KafkaPartitionSplitReader
         Map<TopicPartition, Long> endOffset = consumer.endOffsets(partitionsStoppingAtLatest);
         stoppingOffsets.putAll(endOffset);
         if (!partitionsStoppingAtCommitted.isEmpty()) {
-            consumer.committed(partitionsStoppingAtCommitted)
+            retryOnWakeup(() -> consumer.committed(partitionsStoppingAtCommitted))
                     .forEach(
                             (tp, offsetAndMetadata) -> {
                                 Preconditions.checkNotNull(
@@ -320,7 +321,7 @@ public class KafkaPartitionSplitReader
         List<TopicPartition> emptyPartitions = new ArrayList<>();
         // If none of the partitions have any records,
         for (TopicPartition tp : consumer.assignment()) {
-            if (consumer.position(tp) >= getStoppingOffset(tp)) {
+            if (retryOnWakeup(() -> consumer.position(tp)) >= getStoppingOffset(tp)) {
                 emptyPartitions.add(tp);
             }
         }
@@ -343,7 +344,8 @@ public class KafkaPartitionSplitReader
         if (LOG.isDebugEnabled()) {
             StringJoiner splitsInfo = new StringJoiner(",");
             for (KafkaPartitionSplit split : splitsChange.splits()) {
-                long startingOffset = consumer.position(split.getTopicPartition());
+                long startingOffset =
+                        retryOnWakeup(() -> consumer.position(split.getTopicPartition()));
                 long stoppingOffset = getStoppingOffset(split.getTopicPartition());
                 splitsInfo.add(
                         String.format(
@@ -395,6 +397,32 @@ public class KafkaPartitionSplitReader
                         Boolean::parseBoolean);
         if (needToRegister) {
             kafkaSourceReaderMetrics.registerKafkaConsumerMetrics(consumer);
+        }
+    }
+
+    /**
+     * Catch {@link WakeupException} in Kafka consumer call and retry the invocation on exception.
+     *
+     * <p>This helper function handles a race condition as below:
+     *
+     * <ol>
+     *   <li>Fetcher thread finishes a {@link KafkaConsumer#poll(Duration)} call
+     *   <li>Task thread assigns new splits so invokes {@link #wakeUp()}, then the wakeup is
+     *       recorded and held by the consumer
+     *   <li>Later fetcher thread invokes {@link #handleSplitsChanges(SplitsChange)}, and
+     *       interactions with consumer will throw {@link WakeupException} because of the previously
+     *       held wakeup in the consumer
+     * </ol>
+     *
+     * <p>Under this case we need to catch the {@link WakeupException} and retry the operation.
+     */
+    private <V> V retryOnWakeup(Supplier<V> consumerCall) {
+        while (true) {
+            try {
+                return consumerCall.get();
+            } catch (WakeupException we) {
+                // Do nothing here and the loop will retry the consumer call.
+            }
         }
     }
 

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReaderTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReaderTest.java
@@ -133,6 +133,24 @@ public class KafkaPartitionSplitReaderTest {
     }
 
     @Test
+    public void testWakeupThenAssign() throws IOException {
+        KafkaPartitionSplitReader reader = createReader();
+        // Assign splits with records
+        assignSplits(reader, splitsByOwners.get(0));
+        // Run a fetch operation, and it should not block
+        reader.fetch();
+        // Wake the reader up then assign a new split. This assignment should not throw
+        // WakeupException.
+        reader.wakeUp();
+        TopicPartition tp = new TopicPartition(TOPIC1, 0);
+        assignSplits(
+                reader,
+                Collections.singletonMap(
+                        KafkaPartitionSplit.toSplitId(tp),
+                        new KafkaPartitionSplit(tp, KafkaPartitionSplit.EARLIEST_OFFSET)));
+    }
+
+    @Test
     public void testNumBytesInCounter() throws Exception {
         final OperatorMetricGroup operatorMetricGroup =
                 UnregisteredMetricGroups.createUnregisteredOperatorMetricGroup();


### PR DESCRIPTION
## What is the purpose of the change

This pull request improves the logic of `KafkaPartitionSplitReader` that `wakeup()` should only wake up the blocking `KafkaConsumer#poll` operation, otherwise the wake-up might be delayed to the next `ConsumerNetworkClient#poll` call when handling new splits, which will throw a `WakeupException`.

## Brief change log

- Add a volatile variable `isPolling` to make sure the wakeup method only unblocks KafkaConsumer#poll
- Add new unit test for `KafkaPartitionSplitReader`


## Verifying this change

This change is covered by the new `KafkaPartitionSplitReaderTest#testWakeupThenAssign` case.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
