### PR TITLE
[FLINK-27807][Connectors/JDBC] The improvement of addBatch is empty w…

### DIFF
--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/executor/TableBufferReducedStatementExecutor.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/executor/TableBufferReducedStatementExecutor.java
@@ -90,16 +90,24 @@ public final class TableBufferReducedStatementExecutor
 
     @Override
     public void executeBatch() throws SQLException {
+        boolean upsertExecuteBatchFlag = false;
+        boolean deleteExecuteBatchFlag = false;
         for (Map.Entry<RowData, Tuple2<Boolean, RowData>> entry : reduceBuffer.entrySet()) {
             if (entry.getValue().f0) {
                 upsertExecutor.addToBatch(entry.getValue().f1);
+                upsertExecuteBatchFlag = true;
             } else {
                 // delete by key
                 deleteExecutor.addToBatch(entry.getKey());
+                deleteExecuteBatchFlag = true;
             }
         }
-        upsertExecutor.executeBatch();
-        deleteExecutor.executeBatch();
+        if (upsertExecuteBatchFlag) {
+            upsertExecutor.executeBatch();
+        }
+        if (deleteExecuteBatchFlag) {
+            deleteExecutor.executeBatch();
+        }
         reduceBuffer.clear();
     }
 


### PR DESCRIPTION
## What is the purpose of the change

*The improvement of addBatch is empty when jdbc batch submit*


## Brief change log

*Increase execution flags to ensure empty batches are not executed*


## Verifying this change

This change is already covered by existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
