### PR TITLE
[FLINK-27810][es][tests] Reduce number of bundled dependencies

### DIFF
--- a/flink-end-to-end-tests/flink-end-to-end-tests-elasticsearch6/pom.xml
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-elasticsearch6/pom.xml
@@ -54,11 +54,13 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-end-to-end-tests-common-elasticsearch</artifactId>
 			<version>${project.version}</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>
 			<version>${log4j.version}</version>
+			<scope>provided</scope>
 		</dependency>
 
 		<dependency>
@@ -115,6 +117,15 @@ under the License.
 				</executions>
 				<configuration>
 					<artifactItems>
+						<artifactItem>
+							<groupId>org.apache.flink</groupId>
+							<artifactId>flink-end-to-end-tests-common-elasticsearch</artifactId>
+							<version>${project.version}</version>
+							<destFileName>flink-connector-elasticsearch-test-utils.jar</destFileName>
+							<type>jar</type>
+							<outputDirectory>${project.build.directory}/dependencies
+							</outputDirectory>
+						</artifactItem>
 						<artifactItem>
 							<groupId>org.apache.flink</groupId>
 							<artifactId>flink-connector-test-utils</artifactId>

--- a/flink-end-to-end-tests/flink-end-to-end-tests-elasticsearch6/src/test/java/org/apache/flink/streaming/tests/Elasticsearch6SinkE2ECase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-elasticsearch6/src/test/java/org/apache/flink/streaming/tests/Elasticsearch6SinkE2ECase.java
@@ -51,5 +51,10 @@ public class Elasticsearch6SinkE2ECase
                             TestUtils.getResource("dependencies/flink-connector-test-utils.jar")
                                     .toAbsolutePath()
                                     .toUri()
+                                    .toURL(),
+                            TestUtils.getResource(
+                                            "dependencies/flink-connector-elasticsearch-test-utils.jar")
+                                    .toAbsolutePath()
+                                    .toUri()
                                     .toURL()));
 }

--- a/flink-end-to-end-tests/flink-end-to-end-tests-elasticsearch7/pom.xml
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-elasticsearch7/pom.xml
@@ -54,11 +54,13 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-end-to-end-tests-common-elasticsearch</artifactId>
 			<version>${project.version}</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>
 			<version>${log4j.version}</version>
+			<scope>provided</scope>
 		</dependency>
 
 		<dependency>
@@ -116,6 +118,15 @@ under the License.
 				</executions>
 				<configuration>
 					<artifactItems>
+						<artifactItem>
+							<groupId>org.apache.flink</groupId>
+							<artifactId>flink-end-to-end-tests-common-elasticsearch</artifactId>
+							<version>${project.version}</version>
+							<destFileName>flink-connector-elasticsearch-test-utils.jar</destFileName>
+							<type>jar</type>
+							<outputDirectory>${project.build.directory}/dependencies
+							</outputDirectory>
+						</artifactItem>
 						<artifactItem>
 							<groupId>org.apache.flink</groupId>
 							<artifactId>flink-connector-test-utils</artifactId>

--- a/flink-end-to-end-tests/flink-end-to-end-tests-elasticsearch7/src/test/java/org/apache/flink/streaming/tests/Elasticsearch7SinkE2ECase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-elasticsearch7/src/test/java/org/apache/flink/streaming/tests/Elasticsearch7SinkE2ECase.java
@@ -51,5 +51,10 @@ public class Elasticsearch7SinkE2ECase
                             TestUtils.getResource("dependencies/flink-connector-test-utils.jar")
                                     .toAbsolutePath()
                                     .toUri()
+                                    .toURL(),
+                            TestUtils.getResource(
+                                            "dependencies/flink-connector-elasticsearch-test-utils.jar")
+                                    .toAbsolutePath()
+                                    .toUri()
                                     .toURL()));
 }


### PR DESCRIPTION
No longer bundled log4j (as it is provided by Flink) nor transitive dependencies from flink-end-to-end-tests-common-elasticsearch (as they are necessary).
We still need flink-end-to-end-tests-common-elasticsearch itself for some utility classes though.