### PR TITLE
[FLINK-27819][rest][docs] Use proper operationIds

### DIFF
--- a/docs/static/generated/rest_v1_dispatcher.yml
+++ b/docs/static/generated/rest_v1_dispatcher.yml
@@ -123,59 +123,6 @@ paths:
         "200":
           description: The request was successful.
   /jars/{jarid}/plan:
-    get:
-      description: Returns the dataflow plan of a job contained in a jar previously
-        uploaded via '/jars/upload'. Program arguments can be passed both via the
-        JSON request (recommended) or query parameters.
-      operationId: retrieveJarPlan
-      parameters:
-      - name: jarid
-        in: path
-        description: "String value that identifies a jar. When uploading the jar a\
-          \ path is returned, where the filename is the ID. This value is equivalent\
-          \ to the `id` field in the list of uploaded jars (/jars)."
-        required: true
-        schema:
-          type: string
-      - name: program-args
-        in: query
-        description: "Deprecated, please use 'programArg' instead. String value that\
-          \ specifies the arguments for the program or plan"
-        required: false
-        style: form
-        schema:
-          type: string
-      - name: programArg
-        in: query
-        description: Comma-separated list of program arguments.
-        required: false
-        style: form
-        schema:
-          type: string
-      - name: entry-class
-        in: query
-        description: String value that specifies the fully qualified name of the entry
-          point class. Overrides the class defined in the jar file manifest.
-        required: false
-        style: form
-        schema:
-          type: string
-      - name: parallelism
-        in: query
-        description: Positive integer value that specifies the desired parallelism
-          for the job.
-        required: false
-        style: form
-        schema:
-          type: integer
-          format: int32
-      responses:
-        "200":
-          description: The request was successful.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JobPlanInfo'
     post:
       description: Returns the dataflow plan of a job contained in a jar previously
         uploaded via '/jars/upload'. Program arguments can be passed both via the

--- a/docs/static/generated/rest_v1_dispatcher.yml
+++ b/docs/static/generated/rest_v1_dispatcher.yml
@@ -11,12 +11,14 @@ paths:
   /cluster:
     delete:
       description: Shuts down the cluster
+      operationId: shutdownCluster
       responses:
         "200":
           description: The request was successful.
   /config:
     get:
       description: Returns the configuration of the WebUI.
+      operationId: getDashboardConfiguration
       responses:
         "200":
           description: The request was successful.
@@ -27,6 +29,7 @@ paths:
   /datasets:
     get:
       description: Returns all cluster data sets.
+      operationId: getClusterDataSetList
       responses:
         "200":
           description: The request was successful.
@@ -37,6 +40,7 @@ paths:
   /datasets/delete/{triggerid}:
     get:
       description: Returns the status for the delete operation of a cluster data set.
+      operationId: getClusterDataSetDeleteStatus
       parameters:
       - name: triggerid
         in: path
@@ -56,6 +60,7 @@ paths:
     delete:
       description: Triggers the deletion of a cluster data set. This async operation
         would return a 'triggerid' for further query identifier.
+      operationId: deleteClusterDataSet
       parameters:
       - name: datasetid
         in: path
@@ -74,6 +79,7 @@ paths:
   /jars:
     get:
       description: Returns a list of all jars previously uploaded via '/jars/upload'.
+      operationId: getJarList
       responses:
         "200":
           description: The request was successful.
@@ -88,6 +94,7 @@ paths:
         , as some http libraries do not add the header by default.\nUsing 'curl' you\
         \ can upload a jar via 'curl -X POST -H \"Expect:\" -F \"jarfile=@path/to/flink-job.jar\"\
         \ http://hostname:port/jars/upload'."
+      operationId: uploadJar
       requestBody:
         content:
           application/x-java-archive: {}
@@ -102,6 +109,7 @@ paths:
   /jars/{jarid}:
     delete:
       description: Deletes a jar previously uploaded via '/jars/upload'.
+      operationId: deleteJar
       parameters:
       - name: jarid
         in: path
@@ -119,6 +127,7 @@ paths:
       description: Returns the dataflow plan of a job contained in a jar previously
         uploaded via '/jars/upload'. Program arguments can be passed both via the
         JSON request (recommended) or query parameters.
+      operationId: retrieveJarPlan
       parameters:
       - name: jarid
         in: path
@@ -171,6 +180,7 @@ paths:
       description: Returns the dataflow plan of a job contained in a jar previously
         uploaded via '/jars/upload'. Program arguments can be passed both via the
         JSON request (recommended) or query parameters.
+      operationId: postJarPlan
       parameters:
       - name: jarid
         in: path
@@ -229,6 +239,7 @@ paths:
       description: Submits a job by running a jar previously uploaded via '/jars/upload'.
         Program arguments can be passed both via the JSON request (recommended) or
         query parameters.
+      operationId: runJar
       parameters:
       - name: jarid
         in: path
@@ -302,6 +313,7 @@ paths:
   /jobmanager/config:
     get:
       description: Returns the cluster configuration.
+      operationId: getClusterConfigurationInfo
       responses:
         "200":
           description: The request was successful.
@@ -317,6 +329,7 @@ paths:
   /jobmanager/logs:
     get:
       description: Returns the list of log files on the JobManager.
+      operationId: getJobManagerLogList
       responses:
         "200":
           description: The request was successful.
@@ -327,6 +340,7 @@ paths:
   /jobmanager/metrics:
     get:
       description: Provides access to job manager metrics.
+      operationId: getJobManagerMetrics
       parameters:
       - name: get
         in: query
@@ -345,6 +359,7 @@ paths:
   /jobmanager/thread-dump:
     get:
       description: Returns the thread dump of the JobManager.
+      operationId: getJobManagerThreadDump
       responses:
         "200":
           description: The request was successful.
@@ -355,6 +370,7 @@ paths:
   /jobs:
     get:
       description: Returns an overview over all jobs and their current state.
+      operationId: getJobIdsWithStatusesOverview
       responses:
         "200":
           description: The request was successful.
@@ -367,6 +383,7 @@ paths:
         \ Flink client. This call expects a multipart/form-data request that consists\
         \ of file uploads for the serialized JobGraph, jars and distributed cache\
         \ artifacts and an attribute named \"request\" for the JSON payload."
+      operationId: submitJob
       requestBody:
         content:
           multipart/form-data:
@@ -390,6 +407,7 @@ paths:
   /jobs/metrics:
     get:
       description: Provides access to aggregated job metrics.
+      operationId: getAggregatedJobMetrics
       parameters:
       - name: get
         in: query
@@ -424,6 +442,7 @@ paths:
   /jobs/overview:
     get:
       description: Returns an overview over all jobs.
+      operationId: getJobsOverview
       responses:
         "200":
           description: The request was successful.
@@ -434,6 +453,7 @@ paths:
   /jobs/{jobid}:
     get:
       description: Returns details of a job.
+      operationId: getJobDetails
       parameters:
       - name: jobid
         in: path
@@ -450,6 +470,7 @@ paths:
                 $ref: '#/components/schemas/JobDetailsInfo'
     patch:
       description: Terminates a job.
+      operationId: cancelJob
       parameters:
       - name: jobid
         in: path
@@ -472,6 +493,7 @@ paths:
     get:
       description: "Returns the accumulators for all tasks of a job, aggregated across\
         \ the respective subtasks."
+      operationId: getJobAccumulators
       parameters:
       - name: jobid
         in: path
@@ -497,6 +519,7 @@ paths:
   /jobs/{jobid}/checkpoints:
     get:
       description: Returns checkpointing statistics for a job.
+      operationId: getCheckpointingStatistics
       parameters:
       - name: jobid
         in: path
@@ -514,6 +537,7 @@ paths:
   /jobs/{jobid}/checkpoints/config:
     get:
       description: Returns the checkpointing configuration.
+      operationId: getCheckpointConfig
       parameters:
       - name: jobid
         in: path
@@ -531,6 +555,7 @@ paths:
   /jobs/{jobid}/checkpoints/details/{checkpointid}:
     get:
       description: Returns details for a checkpoint.
+      operationId: getCheckpointStatisticDetails
       parameters:
       - name: jobid
         in: path
@@ -555,6 +580,7 @@ paths:
   /jobs/{jobid}/checkpoints/details/{checkpointid}/subtasks/{vertexid}:
     get:
       description: Returns checkpoint statistics for a task and its subtasks.
+      operationId: getTaskCheckpointStatistics
       parameters:
       - name: jobid
         in: path
@@ -585,6 +611,7 @@ paths:
   /jobs/{jobid}/config:
     get:
       description: Returns the configuration of a job.
+      operationId: getJobConfig
       parameters:
       - name: jobid
         in: path
@@ -608,6 +635,7 @@ paths:
         \ through web.exception-history-size in the Flink configuration. The following\
         \ first-level members are deprecated: 'root-exception', 'timestamp', 'all-exceptions',\
         \ and 'truncated'. Use the data provided through 'exceptionHistory', instead."
+      operationId: getJobExceptions
       parameters:
       - name: jobid
         in: path
@@ -635,6 +663,7 @@ paths:
     get:
       description: Returns the result of a job execution. Gives access to the execution
         time of the job and to all accumulators created by this job.
+      operationId: getJobExecutionResult
       parameters:
       - name: jobid
         in: path
@@ -652,6 +681,7 @@ paths:
   /jobs/{jobid}/metrics:
     get:
       description: Provides access to job metrics.
+      operationId: getJobMetrics
       parameters:
       - name: jobid
         in: path
@@ -676,6 +706,7 @@ paths:
   /jobs/{jobid}/plan:
     get:
       description: Returns the dataflow plan of a job.
+      operationId: getJobPlan
       parameters:
       - name: jobid
         in: path
@@ -694,6 +725,7 @@ paths:
     patch:
       description: Triggers the rescaling of a job. This async operation would return
         a 'triggerid' for further query identifier.
+      operationId: rescaleJob
       parameters:
       - name: jobid
         in: path
@@ -719,6 +751,7 @@ paths:
   /jobs/{jobid}/rescaling/{triggerid}:
     get:
       description: Returns the status of a rescaling operation.
+      operationId: getRescalingStatus
       parameters:
       - name: jobid
         in: path
@@ -744,6 +777,7 @@ paths:
     post:
       description: "Triggers a savepoint, and optionally cancels the job afterwards.\
         \ This async operation would return a 'triggerid' for further query identifier."
+      operationId: triggerSavepoint
       parameters:
       - name: jobid
         in: path
@@ -766,6 +800,7 @@ paths:
   /jobs/{jobid}/savepoints/{triggerid}:
     get:
       description: Returns the status of a savepoint operation.
+      operationId: getSavepointStatus
       parameters:
       - name: jobid
         in: path
@@ -790,6 +825,7 @@ paths:
   /jobs/{jobid}/status:
     get:
       description: Returns the current status of a job execution.
+      operationId: getJobStatusInfo
       parameters:
       - name: jobid
         in: path
@@ -810,6 +846,7 @@ paths:
         \ before taking the savepoint to flush out any state waiting for timers to\
         \ fire. This async operation would return a 'triggerid' for further query\
         \ identifier."
+      operationId: triggerStopWithSavepoint
       parameters:
       - name: jobid
         in: path
@@ -832,6 +869,7 @@ paths:
   /jobs/{jobid}/vertices/{vertexid}:
     get:
       description: "Returns details for a task, with a summary for each of its subtasks."
+      operationId: getJobVertexDetails
       parameters:
       - name: jobid
         in: path
@@ -856,6 +894,7 @@ paths:
     get:
       description: "Returns user-defined accumulators of a task, aggregated across\
         \ all subtasks."
+      operationId: getJobVertexAccumulators
       parameters:
       - name: jobid
         in: path
@@ -880,6 +919,7 @@ paths:
     get:
       description: "Returns back-pressure information for a job, and may initiate\
         \ back-pressure sampling if necessary."
+      operationId: getJobVertexBackPressure
       parameters:
       - name: jobid
         in: path
@@ -904,6 +944,7 @@ paths:
     get:
       description: "Returns flame graph information for a vertex, and may initiate\
         \ flame graph sampling if necessary."
+      operationId: getJobVertexFlameGraph
       parameters:
       - name: jobid
         in: path
@@ -935,6 +976,7 @@ paths:
   /jobs/{jobid}/vertices/{vertexid}/metrics:
     get:
       description: Provides access to task metrics.
+      operationId: getJobVertexMetrics
       parameters:
       - name: jobid
         in: path
@@ -965,6 +1007,7 @@ paths:
   /jobs/{jobid}/vertices/{vertexid}/subtasks/accumulators:
     get:
       description: Returns all user-defined accumulators for all subtasks of a task.
+      operationId: getSubtasksAllAccumulators
       parameters:
       - name: jobid
         in: path
@@ -988,6 +1031,7 @@ paths:
   /jobs/{jobid}/vertices/{vertexid}/subtasks/metrics:
     get:
       description: Provides access to aggregated subtask metrics.
+      operationId: getAggregatedSubtaskMetrics
       parameters:
       - name: jobid
         in: path
@@ -1035,6 +1079,7 @@ paths:
     get:
       description: Returns details of the current or latest execution attempt of a
         subtask.
+      operationId: getSubtaskCurrentAttemptDetails
       parameters:
       - name: jobid
         in: path
@@ -1066,6 +1111,7 @@ paths:
     get:
       description: Returns details of an execution attempt of a subtask. Multiple
         execution attempts happen in case of failure/recovery.
+      operationId: getSubtaskExecutionAttemptDetails
       parameters:
       - name: jobid
         in: path
@@ -1104,6 +1150,7 @@ paths:
     get:
       description: Returns the accumulators of an execution attempt of a subtask.
         Multiple execution attempts happen in case of failure/recovery.
+      operationId: getSubtaskExecutionAttemptAccumulators
       parameters:
       - name: jobid
         in: path
@@ -1141,6 +1188,7 @@ paths:
   /jobs/{jobid}/vertices/{vertexid}/subtasks/{subtaskindex}/metrics:
     get:
       description: Provides access to subtask metrics.
+      operationId: getSubtaskMetrics
       parameters:
       - name: jobid
         in: path
@@ -1178,6 +1226,7 @@ paths:
   /jobs/{jobid}/vertices/{vertexid}/subtasktimes:
     get:
       description: Returns time-related information for all subtasks of a task.
+      operationId: getSubtasksTimes
       parameters:
       - name: jobid
         in: path
@@ -1201,6 +1250,7 @@ paths:
   /jobs/{jobid}/vertices/{vertexid}/taskmanagers:
     get:
       description: Returns task information aggregated by task manager.
+      operationId: getJobVertexTaskManagers
       parameters:
       - name: jobid
         in: path
@@ -1224,6 +1274,7 @@ paths:
   /jobs/{jobid}/vertices/{vertexid}/watermarks:
     get:
       description: Returns the watermarks for all subtasks of a task.
+      operationId: getJobVertexWatermarks
       parameters:
       - name: jobid
         in: path
@@ -1247,6 +1298,7 @@ paths:
   /overview:
     get:
       description: Returns an overview over the Flink cluster.
+      operationId: getClusterOverview
       responses:
         "200":
           description: The request was successful.
@@ -1258,6 +1310,7 @@ paths:
     post:
       description: Triggers the desposal of a savepoint. This async operation would
         return a 'triggerid' for further query identifier.
+      operationId: triggerSavepointDisposal
       requestBody:
         content:
           application/json:
@@ -1273,6 +1326,7 @@ paths:
   /savepoint-disposal/{triggerid}:
     get:
       description: Returns the status of a savepoint disposal operation.
+      operationId: getSavepointDisposalStatus
       parameters:
       - name: triggerid
         in: path
@@ -1291,6 +1345,7 @@ paths:
   /taskmanagers:
     get:
       description: Returns an overview over all task managers.
+      operationId: getTaskManagers
       responses:
         "200":
           description: The request was successful.
@@ -1301,6 +1356,7 @@ paths:
   /taskmanagers/metrics:
     get:
       description: Provides access to aggregated task manager metrics.
+      operationId: getAggregatedTaskManagerMetrics
       parameters:
       - name: get
         in: query
@@ -1337,6 +1393,7 @@ paths:
       description: Returns details for a task manager. "metrics.memorySegmentsAvailable"
         and "metrics.memorySegmentsTotal" are deprecated. Please use "metrics.nettyShuffleMemorySegmentsAvailable"
         and "metrics.nettyShuffleMemorySegmentsTotal" instead.
+      operationId: getTaskManagerDetails
       parameters:
       - name: taskmanagerid
         in: path
@@ -1354,6 +1411,7 @@ paths:
   /taskmanagers/{taskmanagerid}/logs:
     get:
       description: Returns the list of log files on a TaskManager.
+      operationId: getTaskManagerLogs
       parameters:
       - name: taskmanagerid
         in: path
@@ -1371,6 +1429,7 @@ paths:
   /taskmanagers/{taskmanagerid}/metrics:
     get:
       description: Provides access to task manager metrics.
+      operationId: getTaskManagerMetrics
       parameters:
       - name: taskmanagerid
         in: path
@@ -1395,6 +1454,7 @@ paths:
   /taskmanagers/{taskmanagerid}/thread-dump:
     get:
       description: Returns the thread dump of the requested TaskManager.
+      operationId: getTaskManagerThreadDump
       parameters:
       - name: taskmanagerid
         in: path

--- a/docs/static/generated/rest_v1_dispatcher.yml
+++ b/docs/static/generated/rest_v1_dispatcher.yml
@@ -127,7 +127,7 @@ paths:
       description: Returns the dataflow plan of a job contained in a jar previously
         uploaded via '/jars/upload'. Program arguments can be passed both via the
         JSON request (recommended) or query parameters.
-      operationId: postJarPlan
+      operationId: generatePlanFromJar
       parameters:
       - name: jarid
         in: path
@@ -186,7 +186,7 @@ paths:
       description: Submits a job by running a jar previously uploaded via '/jars/upload'.
         Program arguments can be passed both via the JSON request (recommended) or
         query parameters.
-      operationId: runJar
+      operationId: submitJobFromJar
       parameters:
       - name: jarid
         in: path

--- a/flink-docs/src/main/java/org/apache/flink/docs/rest/OpenApiSpecGenerator.java
+++ b/flink-docs/src/main/java/org/apache/flink/docs/rest/OpenApiSpecGenerator.java
@@ -85,8 +85,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
@@ -96,13 +94,6 @@ import java.util.stream.Collectors;
  * be embedded into .md files using {@code {% include ${generated.docs.dir}/file.yml %}}.
  */
 public class OpenApiSpecGenerator {
-
-    /**
-     * A pattern for filtering verb suffixes in header names, to avoid operationIds like
-     * "deleteJarDelete".
-     */
-    private static final Pattern HTTPS_VERB_SUFFIX_PATTERN =
-            Pattern.compile("(.*?)(?:Get|Post|Delete)?Headers");
 
     private static final ModelConverterContext modelConverterContext;
 
@@ -314,11 +305,7 @@ public class OpenApiSpecGenerator {
             final Operation operation,
             final MessageHeaders<?, ?, ?> spec,
             Set<String> usedOperationIds) {
-        final String baseId = spec.operationId();
-
-        final Matcher matcher = HTTPS_VERB_SUFFIX_PATTERN.matcher(baseId);
-
-        final String operationId = matcher.matches() ? matcher.group(1) : baseId;
+        final String operationId = spec.operationId();
 
         if (!usedOperationIds.add(operationId)) {
             throw new IllegalStateException(

--- a/flink-docs/src/test/java/org/apache/flink/docs/rest/data/TestEmptyMessageHeaders.java
+++ b/flink-docs/src/test/java/org/apache/flink/docs/rest/data/TestEmptyMessageHeaders.java
@@ -27,6 +27,8 @@ import org.apache.flink.runtime.rest.versioning.RestAPIVersion;
 
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
 
+import javax.annotation.Nullable;
+
 import java.util.Collection;
 import java.util.Collections;
 
@@ -42,15 +44,24 @@ public class TestEmptyMessageHeaders
 
     private final String url;
     private final String description;
+    @Nullable private final String operationId;
 
     public TestEmptyMessageHeaders() {
-        this.url = URL;
-        this.description = DESCRIPTION;
+        this(URL, DESCRIPTION, null);
     }
 
     public TestEmptyMessageHeaders(String url, String description) {
+        this(url, description, null);
+    }
+
+    public TestEmptyMessageHeaders(String operationId) {
+        this(URL, DESCRIPTION, operationId);
+    }
+
+    private TestEmptyMessageHeaders(String url, String description, @Nullable String operationId) {
         this.url = url;
         this.description = description;
+        this.operationId = operationId;
     }
 
     @Override
@@ -71,6 +82,11 @@ public class TestEmptyMessageHeaders
     @Override
     public HttpResponseStatus getResponseStatusCode() {
         return HttpResponseStatus.OK;
+    }
+
+    @Override
+    public String operationId() {
+        return operationId != null ? operationId : MessageHeaders.super.operationId();
     }
 
     @Override

--- a/flink-docs/src/test/java/org/apache/flink/docs/rest/data/TestEmptyMessageHeaders.java
+++ b/flink-docs/src/test/java/org/apache/flink/docs/rest/data/TestEmptyMessageHeaders.java
@@ -27,10 +27,9 @@ import org.apache.flink.runtime.rest.versioning.RestAPIVersion;
 
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
 
-import javax.annotation.Nullable;
-
 import java.util.Collection;
 import java.util.Collections;
+import java.util.UUID;
 
 /**
  * A {@link MessageHeaders} for testing purpose. Its request body, response body and message
@@ -44,21 +43,21 @@ public class TestEmptyMessageHeaders
 
     private final String url;
     private final String description;
-    @Nullable private final String operationId;
+    private final String operationId;
 
     public TestEmptyMessageHeaders() {
-        this(URL, DESCRIPTION, null);
+        this(URL, DESCRIPTION, UUID.randomUUID().toString());
     }
 
     public TestEmptyMessageHeaders(String url, String description) {
-        this(url, description, null);
+        this(url, description, UUID.randomUUID().toString());
     }
 
     public TestEmptyMessageHeaders(String operationId) {
         this(URL, DESCRIPTION, operationId);
     }
 
-    private TestEmptyMessageHeaders(String url, String description, @Nullable String operationId) {
+    private TestEmptyMessageHeaders(String url, String description, String operationId) {
         this.url = url;
         this.description = description;
         this.operationId = operationId;
@@ -86,7 +85,7 @@ public class TestEmptyMessageHeaders
 
     @Override
     public String operationId() {
-        return operationId != null ? operationId : MessageHeaders.super.operationId();
+        return operationId;
     }
 
     @Override

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/AbstractJarPlanHeaders.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/AbstractJarPlanHeaders.java
@@ -53,6 +53,11 @@ public abstract class AbstractJarPlanHeaders
     }
 
     @Override
+    public String operationId() {
+        return "generatePlanFromJar";
+    }
+
+    @Override
     public String getDescription() {
         return "Returns the dataflow plan of a job contained in a jar previously uploaded via '"
                 + JarUploadHeaders.URL

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarDeleteHeaders.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarDeleteHeaders.java
@@ -66,6 +66,11 @@ public class JarDeleteHeaders
     }
 
     @Override
+    public String operationId() {
+        return "deleteJar";
+    }
+
+    @Override
     public String getDescription() {
         return "Deletes a jar previously uploaded via '" + JarUploadHeaders.URL + "'.";
     }

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarPlanGetHeaders.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarPlanGetHeaders.java
@@ -18,9 +18,11 @@
 
 package org.apache.flink.runtime.webmonitor.handlers;
 
+import org.apache.flink.annotation.docs.Documentation;
 import org.apache.flink.runtime.rest.HttpMethodWrapper;
 
 /** Message headers for {@link JarPlanHandler}. */
+@Documentation.ExcludeFromDocumentation("Subsumed by JarPlanPostHeaders")
 public class JarPlanGetHeaders extends AbstractJarPlanHeaders {
 
     private static final JarPlanGetHeaders INSTANCE = new JarPlanGetHeaders();
@@ -32,10 +34,5 @@ public class JarPlanGetHeaders extends AbstractJarPlanHeaders {
 
     public static JarPlanGetHeaders getInstance() {
         return INSTANCE;
-    }
-
-    @Override
-    public String operationId() {
-        return "retrieveJarPlan";
     }
 }

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarPlanGetHeaders.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarPlanGetHeaders.java
@@ -33,4 +33,9 @@ public class JarPlanGetHeaders extends AbstractJarPlanHeaders {
     public static JarPlanGetHeaders getInstance() {
         return INSTANCE;
     }
+
+    @Override
+    public String operationId() {
+        return "retrieveJarPlan";
+    }
 }

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHeaders.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHeaders.java
@@ -75,6 +75,6 @@ public class JarRunHeaders
 
     @Override
     public String operationId() {
-        return "runJar";
+        return "submitJobFromJar";
     }
 }

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHeaders.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHeaders.java
@@ -72,4 +72,9 @@ public class JarRunHeaders
                 + "'. "
                 + "Program arguments can be passed both via the JSON request (recommended) or query parameters.";
     }
+
+    @Override
+    public String operationId() {
+        return "runJar";
+    }
 }

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarUploadHeaders.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarUploadHeaders.java
@@ -78,6 +78,11 @@ public final class JarUploadHeaders
     }
 
     @Override
+    public String operationId() {
+        return "uploadJar";
+    }
+
+    @Override
     public boolean acceptsFileUploads() {
         return true;
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/rescaling/RescalingTriggerHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/rescaling/RescalingTriggerHeaders.java
@@ -69,4 +69,9 @@ public class RescalingTriggerHeaders
     protected String getAsyncOperationDescription() {
         return "Triggers the rescaling of a job.";
     }
+
+    @Override
+    public String operationId() {
+        return "rescaleJob";
+    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobCancellationHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobCancellationHeaders.java
@@ -72,4 +72,9 @@ public class JobCancellationHeaders
     public String getDescription() {
         return "Terminates a job.";
     }
+
+    @Override
+    public String operationId() {
+        return "cancelJob";
+    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/MessageHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/MessageHeaders.java
@@ -22,6 +22,7 @@ import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseSt
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Locale;
 
 /**
  * This class links {@link RequestBody}s to {@link ResponseBody}s types and contains meta-data
@@ -66,4 +67,13 @@ public interface MessageHeaders<
      * @return description for the header
      */
     String getDescription();
+
+    /**
+     * Returns a short description for this header suitable for method code generation.
+     *
+     * @return short description
+     */
+    default String operationId() {
+        return getHttpMethod().name().toLowerCase(Locale.ROOT) + getClass().getSimpleName();
+    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/MessageHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/MessageHeaders.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.rest.messages;
 
+import org.apache.flink.runtime.rest.HttpMethodWrapper;
+
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
 
 import java.util.Collection;
@@ -74,6 +76,21 @@ public interface MessageHeaders<
      * @return short description
      */
     default String operationId() {
-        return getHttpMethod().name().toLowerCase(Locale.ROOT) + getClass().getSimpleName();
+        if (getHttpMethod() != HttpMethodWrapper.GET) {
+            throw new UnsupportedOperationException(
+                    "The default implementation is only supported for GET calls. Please override 'operationId()'.");
+        }
+
+        final String className = getClass().getSimpleName();
+        final int headersSuffixStart = className.lastIndexOf("Headers");
+        if (headersSuffixStart == -1) {
+            throw new IllegalStateException(
+                    "Expect name of class "
+                            + getClass()
+                            + " to end on 'Headers'. Please rename the class or override 'operationId()'.");
+        }
+
+        return getHttpMethod().name().toLowerCase(Locale.ROOT)
+                + className.substring(0, headersSuffixStart);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/cluster/ShutdownHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/cluster/ShutdownHeaders.java
@@ -70,4 +70,9 @@ public class ShutdownHeaders
     public String getDescription() {
         return "Shuts down the cluster";
     }
+
+    @Override
+    public String operationId() {
+        return "shutdownCluster";
+    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/dataset/ClusterDataSetDeleteTriggerHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/dataset/ClusterDataSetDeleteTriggerHeaders.java
@@ -69,4 +69,9 @@ public class ClusterDataSetDeleteTriggerHeaders
     public String getTargetRestEndpointURL() {
         return URL;
     }
+
+    @Override
+    public String operationId() {
+        return "deleteClusterDataSet";
+    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobSubmitHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobSubmitHeaders.java
@@ -83,4 +83,9 @@ public class JobSubmitHeaders
     public boolean acceptsFileUploads() {
         return true;
     }
+
+    @Override
+    public String operationId() {
+        return "submitJob";
+    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointDisposalTriggerHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointDisposalTriggerHeaders.java
@@ -73,4 +73,9 @@ public class SavepointDisposalTriggerHeaders
     protected String getAsyncOperationDescription() {
         return "Triggers the desposal of a savepoint.";
     }
+
+    @Override
+    public String operationId() {
+        return "triggerSavepointDisposal";
+    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointTriggerHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointTriggerHeaders.java
@@ -77,4 +77,9 @@ public class SavepointTriggerHeaders
     protected String getAsyncOperationDescription() {
         return "Triggers a savepoint, and optionally cancels the job afterwards.";
     }
+
+    @Override
+    public String operationId() {
+        return "triggerSavepoint";
+    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/stop/StopWithSavepointTriggerHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/stop/StopWithSavepointTriggerHeaders.java
@@ -80,4 +80,9 @@ public class StopWithSavepointTriggerHeaders
         return "Stops a job with a savepoint. Optionally, it can also emit a MAX_WATERMARK before taking"
                 + " the savepoint to flush out any state waiting for timers to fire.";
     }
+
+    @Override
+    public String operationId() {
+        return "triggerStopWithSavepoint";
+    }
 }


### PR DESCRIPTION
Adds some simple generation logic and covers a few edge-cases to have proper operationIds in the OpenAPI spec. These are used for the generated method names.

The naming pattern is similar to what we'd use in Java.