### PR TITLE
[FLINK-24490][docs] The sample code is wrong in Apache Kafka Connecto…

### DIFF
--- a/docs/content.zh/docs/connectors/datastream/kafka.md
+++ b/docs/content.zh/docs/connectors/datastream/kafka.md
@@ -78,7 +78,7 @@ Kafka Source 提供了 3 种 Topic / Partition 的订阅方式：
   ```
 - 正则表达式匹配，订阅与正则表达式所匹配的 Topic 下的所有 Partition：
   ```java
-  KafkaSource.builder().setTopicPattern("topic.*");
+  KafkaSource.builder().setTopicPattern(Pattern.compile("topic.*"));
   ```
 - Partition 列表，订阅指定的 Partition：
   ```java

--- a/docs/content/docs/connectors/datastream/kafka.md
+++ b/docs/content/docs/connectors/datastream/kafka.md
@@ -78,7 +78,7 @@ Kafka source provide 3 ways of topic-partition subscription:
 - Topic pattern, subscribing messages from all topics whose name matches the provided regular
   expression. For example:
   ```java
-  KafkaSource.builder().setTopicPattern("topic.*");
+  KafkaSource.builder().setTopicPattern(Pattern.compile("topic.*"));
   ```
 - Partition set, subscribing partitions in the provided partition set. For example:
   ```java


### PR DESCRIPTION

## What is the purpose of the change

*Modify the code error in the document*


## Brief change log

*Modify the code error in the document*


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
