### PR TITLE
[FLINK-24713][Runtime/Coordination] Support the initial delay for SlotManager to wait fo…

### DIFF
--- a/docs/layouts/shortcodes/generated/expert_scheduling_section.html
+++ b/docs/layouts/shortcodes/generated/expert_scheduling_section.html
@@ -123,6 +123,12 @@
             <td>Defines the maximum number of slots that the Flink cluster allocates. This configuration option is meant for limiting the resource consumption for batch workloads. It is not recommended to configure this option for streaming workloads, which may fail if there are not enough slots. Note that this configuration option does not take effect for standalone clusters, where how many slots are allocated is not controlled by Flink.</td>
         </tr>
         <tr>
+            <td><h5>slotmanager.requirement-check.long-delay</h5></td>
+            <td style="word-wrap: break-word;">1 s</td>
+            <td>Duration</td>
+            <td>The long delay of requirements check. This is only used for waiting for the previous TaskManagers registration and will only take effect in the first requirements check. If redundant TaskManager are launched during the JobManager failover, we could increase this delay to solve it.</td>
+        </tr>
+        <tr>
             <td><h5>slow-task-detector.check-interval</h5></td>
             <td style="word-wrap: break-word;">1 s</td>
             <td>Duration</td>

--- a/docs/layouts/shortcodes/generated/resource_manager_configuration.html
+++ b/docs/layouts/shortcodes/generated/resource_manager_configuration.html
@@ -74,5 +74,11 @@
             <td>Integer</td>
             <td>The number of redundant task managers. Redundant task managers are extra task managers started by Flink, in order to speed up job recovery in case of failures due to task manager lost. Note that this feature is available only to the active deployments (native K8s, Yarn).</td>
         </tr>
+        <tr>
+            <td><h5>slotmanager.requirement-check.long-delay</h5></td>
+            <td style="word-wrap: break-word;">1 s</td>
+            <td>Duration</td>
+            <td>The long delay of requirements check. This is only used for waiting for the previous TaskManagers registration and will only take effect in the first requirements check. If redundant TaskManager are launched during the JobManager failover, we could increase this delay to solve it.</td>
+        </tr>
     </tbody>
 </table>

--- a/flink-core/src/main/java/org/apache/flink/configuration/ResourceManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ResourceManagerOptions.java
@@ -151,6 +151,21 @@ public class ResourceManagerOptions {
                     .withDescription("The delay of the resource requirements check.");
 
     /**
+     * The long delay of requirements check. This is only used for waiting for the previous
+     * TaskManagers registration and will only take effect in the first requirements check.
+     */
+    @Documentation.Section(Documentation.Sections.EXPERT_SCHEDULING)
+    public static final ConfigOption<Duration> REQUIREMENTS_CHECK_LONG_DELAY =
+            ConfigOptions.key("slotmanager.requirement-check.long-delay")
+                    .durationType()
+                    .defaultValue(Duration.ofSeconds(1))
+                    .withDescription(
+                            "The long delay of requirements check. This is only used for waiting for the previous "
+                                    + "TaskManagers registration and will only take effect in the first requirements "
+                                    + "check. If redundant TaskManager are launched during the JobManager failover, "
+                                    + "we could increase this delay to solve it.");
+
+    /**
      * The timeout for a slot request to be discarded, in milliseconds.
      *
      * @deprecated Use {@link JobManagerOptions#SLOT_REQUEST_TIMEOUT}.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -964,6 +964,10 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
                 MetricNames.NUM_REGISTERED_TASK_MANAGERS, () -> (long) taskExecutors.size());
     }
 
+    protected void enlargeRequirementsCheckDelayOnce() {
+        slotManager.enlargeRequirementsCheckDelayOnce();
+    }
+
     private void clearStateInternal() {
         jobManagerRegistrations.clear();
         jmResourceIdRegistrations.clear();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManager.java
@@ -235,6 +235,9 @@ public class ActiveResourceManager<WorkerType extends ResourceIDRetrievable>
     public void onPreviousAttemptWorkersRecovered(Collection<WorkerType> recoveredWorkers) {
         getMainThreadExecutor().assertRunningInMainThread();
         log.info("Recovered {} workers from previous attempt.", recoveredWorkers.size());
+        if (!recoveredWorkers.isEmpty()) {
+            enlargeRequirementsCheckDelayOnce();
+        }
         for (WorkerType worker : recoveredWorkers) {
             final ResourceID resourceId = worker.getResourceID();
             workerNodeMap.put(resourceId, worker);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
@@ -149,4 +149,10 @@ public interface SlotManager extends AutoCloseable {
     void freeSlot(SlotID slotId, AllocationID allocationId);
 
     void setFailUnfulfillableRequest(boolean failUnfulfillableRequest);
+
+    /**
+     * Enlarge the delay of requirements check. This is only used for waiting for the previous
+     * TaskManagers registration and will only take effect in the first requirements check.
+     */
+    void enlargeRequirementsCheckDelayOnce();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfiguration.java
@@ -45,6 +45,7 @@ public class SlotManagerConfiguration {
     private final Time slotRequestTimeout;
     private final Time taskManagerTimeout;
     private final Duration requirementCheckDelay;
+    private final Duration requirementCheckLongDelay;
     private final boolean waitResultConsumedBeforeRelease;
     private final SlotMatchingStrategy slotMatchingStrategy;
     private final WorkerResourceSpec defaultWorkerResourceSpec;
@@ -59,6 +60,7 @@ public class SlotManagerConfiguration {
             Time slotRequestTimeout,
             Time taskManagerTimeout,
             Duration requirementCheckDelay,
+            Duration requirementCheckLongDelay,
             boolean waitResultConsumedBeforeRelease,
             SlotMatchingStrategy slotMatchingStrategy,
             WorkerResourceSpec defaultWorkerResourceSpec,
@@ -72,6 +74,7 @@ public class SlotManagerConfiguration {
         this.slotRequestTimeout = Preconditions.checkNotNull(slotRequestTimeout);
         this.taskManagerTimeout = Preconditions.checkNotNull(taskManagerTimeout);
         this.requirementCheckDelay = Preconditions.checkNotNull(requirementCheckDelay);
+        this.requirementCheckLongDelay = Preconditions.checkNotNull(requirementCheckLongDelay);
         this.waitResultConsumedBeforeRelease = waitResultConsumedBeforeRelease;
         this.slotMatchingStrategy = Preconditions.checkNotNull(slotMatchingStrategy);
         this.defaultWorkerResourceSpec = Preconditions.checkNotNull(defaultWorkerResourceSpec);
@@ -99,6 +102,10 @@ public class SlotManagerConfiguration {
 
     public Duration getRequirementCheckDelay() {
         return requirementCheckDelay;
+    }
+
+    public Duration getRequirementCheckLongDelay() {
+        return requirementCheckLongDelay;
     }
 
     public boolean isWaitResultConsumedBeforeRelease() {
@@ -148,6 +155,9 @@ public class SlotManagerConfiguration {
         final Duration requirementCheckDelay =
                 configuration.get(ResourceManagerOptions.REQUIREMENTS_CHECK_DELAY);
 
+        final Duration requirementCheckLongDelay =
+                configuration.get(ResourceManagerOptions.REQUIREMENTS_CHECK_LONG_DELAY);
+
         boolean waitResultConsumedBeforeRelease =
                 configuration.getBoolean(
                         ResourceManagerOptions.TASK_MANAGER_RELEASE_WHEN_RESULT_CONSUMED);
@@ -171,6 +181,7 @@ public class SlotManagerConfiguration {
                 slotRequestTimeout,
                 taskManagerTimeout,
                 requirementCheckDelay,
+                requirementCheckLongDelay,
                 waitResultConsumedBeforeRelease,
                 slotMatchingStrategy,
                 defaultWorkerResourceSpec,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskExecutorManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskExecutorManager.java
@@ -57,7 +57,7 @@ import java.util.stream.StreamSupport;
  *   <li>tracking registered task executors
  *   <li>allocating new task executors (both on-demand, and for redundancy)
  *   <li>releasing idle task executors
- *   <li>tracking pending slots (expected slots from executors that are currently being allocated
+ *   <li>tracking pending slots (expected slots from executors that are currently being allocated)
  *   <li>tracking how many slots are used on each task executor
  * </ul>
  *

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManagerBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManagerBuilder.java
@@ -49,6 +49,7 @@ public class DeclarativeSlotManagerBuilder {
     private ResourceTracker resourceTracker;
     private SlotTracker slotTracker;
     private Duration requirementCheckDelay;
+    private Duration requirementCheckLongDelay;
 
     private DeclarativeSlotManagerBuilder(ScheduledExecutor scheduledExecutor) {
         this.slotMatchingStrategy = AnyMatchingSlotMatchingStrategy.INSTANCE;
@@ -67,6 +68,7 @@ public class DeclarativeSlotManagerBuilder {
         this.resourceTracker = new DefaultResourceTracker();
         this.slotTracker = new DefaultSlotTracker();
         this.requirementCheckDelay = Duration.ZERO;
+        this.requirementCheckLongDelay = Duration.ZERO;
     }
 
     public static DeclarativeSlotManagerBuilder newBuilder(ScheduledExecutor scheduledExecutor) {
@@ -143,6 +145,12 @@ public class DeclarativeSlotManagerBuilder {
         return this;
     }
 
+    public DeclarativeSlotManagerBuilder setRequirementCheckLongDelay(
+            Duration requirementCheckLongDelay) {
+        this.requirementCheckLongDelay = requirementCheckLongDelay;
+        return this;
+    }
+
     public DeclarativeSlotManager build() {
         final SlotManagerConfiguration slotManagerConfiguration =
                 new SlotManagerConfiguration(
@@ -150,6 +158,7 @@ public class DeclarativeSlotManagerBuilder {
                         slotRequestTimeout,
                         taskManagerTimeout,
                         requirementCheckDelay,
+                        requirementCheckLongDelay,
                         waitResultConsumedBeforeRelease,
                         slotMatchingStrategy,
                         defaultWorkerResourceSpec,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTest.java
@@ -92,7 +92,7 @@ public class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
     }
 
     // ---------------------------------------------------------------------------------------------
-    // Register / unregister TaskManager and and slot status reconciliation
+    // Register / unregister TaskManager and slot status reconciliation
     // ---------------------------------------------------------------------------------------------
 
     /** Tests that we can register task manager at the slot manager. */

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTestBase.java
@@ -152,6 +152,8 @@ public abstract class FineGrainedSlotManagerTestBase extends TestLogger {
         private final Executor mainThreadExecutor = EXECUTOR_RESOURCE.getExecutor();
         private FineGrainedSlotManager slotManager;
         private Duration requirementCheckDelay = Duration.ZERO;
+        private Duration requirementCheckLongDelay =
+                Duration.ofMillis(FUTURE_EXPECT_TIMEOUT_MS * 2);
 
         final TestingResourceAllocationStrategy.Builder resourceAllocationStrategyBuilder =
                 TestingResourceAllocationStrategy.newBuilder();
@@ -181,6 +183,10 @@ public abstract class FineGrainedSlotManagerTestBase extends TestLogger {
             this.requirementCheckDelay = requirementCheckDelay;
         }
 
+        public void setRequirementCheckLongDelay(Duration requirementCheckLongDelay) {
+            this.requirementCheckLongDelay = requirementCheckLongDelay;
+        }
+
         public void setSlotManagerMetricGroup(SlotManagerMetricGroup slotManagerMetricGroup) {
             this.slotManagerMetricGroup = slotManagerMetricGroup;
         }
@@ -203,7 +209,10 @@ public abstract class FineGrainedSlotManagerTestBase extends TestLogger {
             slotManager =
                     new FineGrainedSlotManager(
                             scheduledExecutor,
-                            slotManagerConfigurationBuilder.build(),
+                            slotManagerConfigurationBuilder
+                                    .setRequirementCheckDelay(requirementCheckDelay)
+                                    .setRequirementCheckLongDelay(requirementCheckLongDelay)
+                                    .build(),
                             slotManagerMetricGroup,
                             resourceTracker,
                             taskManagerTracker,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfigurationBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfigurationBuilder.java
@@ -33,6 +33,7 @@ public class SlotManagerConfigurationBuilder {
     private Time slotRequestTimeout;
     private Time taskManagerTimeout;
     private Duration requirementCheckDelay;
+    private Duration requirementCheckLongDelay;
     private boolean waitResultConsumedBeforeRelease;
     private WorkerResourceSpec defaultWorkerResourceSpec;
     private int numSlotsPerWorker;
@@ -46,6 +47,8 @@ public class SlotManagerConfigurationBuilder {
         this.slotRequestTimeout = TestingUtils.infiniteTime();
         this.taskManagerTimeout = TestingUtils.infiniteTime();
         this.requirementCheckDelay = ResourceManagerOptions.REQUIREMENTS_CHECK_DELAY.defaultValue();
+        this.requirementCheckLongDelay =
+                ResourceManagerOptions.REQUIREMENTS_CHECK_LONG_DELAY.defaultValue();
         this.waitResultConsumedBeforeRelease = true;
         this.defaultWorkerResourceSpec = WorkerResourceSpec.ZERO;
         this.numSlotsPerWorker = 1;
@@ -79,6 +82,12 @@ public class SlotManagerConfigurationBuilder {
     public SlotManagerConfigurationBuilder setRequirementCheckDelay(
             Duration requirementCheckDelay) {
         this.requirementCheckDelay = requirementCheckDelay;
+        return this;
+    }
+
+    public SlotManagerConfigurationBuilder setRequirementCheckLongDelay(
+            Duration requirementCheckLongDelay) {
+        this.requirementCheckLongDelay = requirementCheckLongDelay;
         return this;
     }
 
@@ -125,6 +134,7 @@ public class SlotManagerConfigurationBuilder {
                 slotRequestTimeout,
                 taskManagerTimeout,
                 requirementCheckDelay,
+                requirementCheckLongDelay,
                 waitResultConsumedBeforeRelease,
                 AnyMatchingSlotMatchingStrategy.INSTANCE,
                 defaultWorkerResourceSpec,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingSlotManager.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingSlotManager.java
@@ -153,5 +153,8 @@ public class TestingSlotManager implements SlotManager {
     }
 
     @Override
+    public void enlargeRequirementsCheckDelayOnce() {}
+
+    @Override
     public void close() throws Exception {}
 }


### PR DESCRIPTION
…r taskManager to register


## What is the purpose of the change

This PR is another solution to solve the problem of request the extra worker after JobManager failover. After the offline discussion with @KarmaGYZ . We decide not to introduce the new gateway interface `getRecoveryFuture`. Instead, we extend the current `checkResourceRequirementsWithDelay` to enable it to wait for a longer time before trigger the resource check with a configurable long delay and normal delay option. The same to the DeclarativeSlotManager .

This work is basically based on the @KarmaGYZ 's previous work, thanks for the guidance and suggestion :).
