### PR TITLE
[FLINK-27522][network] Ignore max buffers per channel when allocate buffer

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPool.java
@@ -372,12 +372,6 @@ class LocalBufferPool implements BufferPool {
         synchronized (availableMemorySegments) {
             checkDestroyed();
 
-            // target channel over quota; do not return a segment
-            if (targetChannel != UNKNOWN_CHANNEL
-                    && subpartitionBuffersCount[targetChannel] >= maxBuffersPerChannel) {
-                return null;
-            }
-
             segment = availableMemorySegments.poll();
 
             if (segment == null) {


### PR DESCRIPTION
## What is the purpose of the change

Ignore max buffers per channel when allocate buffer

## Brief change log

Ignore max buffers per channel when allocate buffer


## Verifying this change

This change is already covered by existing tests, such as `LocalBufferPoolTest#testMaxBuffersPerChannelAndAvailability`.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not documented
