### PR TITLE
[hotfix] Fix comment typo in TypeExtractor class

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
@@ -524,7 +524,7 @@ public class TypeExtractor {
                 lambdaOutputTypeArgumentIndices != null,
                 "Indices for output type arguments within lambda not provided");
 
-        // explicit result type has highest precedence
+        // explicit result type has the highest precedence
         if (function instanceof ResultTypeQueryable) {
             return ((ResultTypeQueryable<OUT>) function).getProducedType();
         }
@@ -668,7 +668,7 @@ public class TypeExtractor {
                 lambdaOutputTypeArgumentIndices != null,
                 "Indices for output type arguments within lambda not provided");
 
-        // explicit result type has highest precedence
+        // explicit result type has the highest precedence
         if (function instanceof ResultTypeQueryable) {
             return ((ResultTypeQueryable<OUT>) function).getProducedType();
         }


### PR DESCRIPTION
Fix comment typo in TypeExtractor class. Add a `the` before `highest`.