### PR TITLE
[1.15][FLINK-27848][runtime] Fix the problem that ZooKeeperLeaderElectionDr…

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionDriver.java
@@ -166,11 +166,10 @@ public class ZooKeeperLeaderElectionDriver implements LeaderElectionDriver, Lead
     private void retrieveLeaderInformationFromZooKeeper() throws Exception {
         if (leaderLatch.hasLeadership()) {
             ChildData childData = cache.getCurrentData(connectionInformationPath);
-            if (childData != null) {
-                leaderElectionEventHandler.onLeaderInformationChange(
-                        ZooKeeperUtils.readLeaderInformation(childData.getData()));
-            }
-            leaderElectionEventHandler.onLeaderInformationChange(LeaderInformation.empty());
+            leaderElectionEventHandler.onLeaderInformationChange(
+                    childData == null
+                            ? LeaderInformation.empty()
+                            : ZooKeeperUtils.readLeaderInformation(childData.getData()));
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElectionEventHandler.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElectionEventHandler.java
@@ -39,6 +39,8 @@ public class TestingLeaderElectionEventHandler extends TestingLeaderBase
 
     private final OneShotLatch initializationLatch;
 
+    private final Consumer<LeaderInformation> leaderInformationConsumer;
+
     @Nullable private LeaderElectionDriver initializedLeaderElectionDriver = null;
 
     private LeaderInformation confirmedLeaderInformation = LeaderInformation.empty();
@@ -48,6 +50,14 @@ public class TestingLeaderElectionEventHandler extends TestingLeaderBase
     public TestingLeaderElectionEventHandler(String leaderAddress) {
         this.leaderAddress = leaderAddress;
         this.initializationLatch = new OneShotLatch();
+        this.leaderInformationConsumer = (ignore) -> {};
+    }
+
+    public TestingLeaderElectionEventHandler(
+            String leaderAddress, Consumer<LeaderInformation> leaderInformationConsumer) {
+        this.leaderAddress = leaderAddress;
+        this.initializationLatch = new OneShotLatch();
+        this.leaderInformationConsumer = leaderInformationConsumer;
     }
 
     public void init(LeaderElectionDriver leaderElectionDriver) {
@@ -98,6 +108,7 @@ public class TestingLeaderElectionEventHandler extends TestingLeaderBase
                 () ->
                         waitForInitialization(
                                 leaderElectionDriver -> {
+                                    leaderInformationConsumer.accept(leaderInformation);
                                     if (confirmedLeaderInformation.getLeaderSessionID() != null
                                             && !this.confirmedLeaderInformation.equals(
                                                     leaderInformation)) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionTest.java
@@ -49,6 +49,7 @@ import org.apache.flink.shaded.zookeeper3.org.apache.zookeeper.KeeperException;
 import org.apache.flink.shaded.zookeeper3.org.apache.zookeeper.data.ACL;
 
 import org.apache.curator.test.TestingServer;
+import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -69,6 +70,8 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -358,6 +361,42 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
                 if (electionService != null) {
                     electionService.stop();
                 }
+            }
+        }
+    }
+
+    /** Tests that the leader update information will not be notified repeatedly. */
+    @Test
+    public void testLeaderChangeWriteLeaderInformationOnlyOnce() throws Exception {
+        final LeaderInformationConsumer leaderInformationConsumer = new LeaderInformationConsumer();
+        final TestingLeaderElectionEventHandler electionEventHandler =
+                new TestingLeaderElectionEventHandler(LEADER_ADDRESS, leaderInformationConsumer);
+
+        @SuppressWarnings("deprecation")
+        ZooKeeperLeaderElectionDriver leaderElectionDriver = null;
+        try {
+            leaderElectionDriver =
+                    createAndInitLeaderElectionDriver(
+                            curatorFrameworkWrapper.asCuratorFramework(), electionEventHandler);
+
+            electionEventHandler.waitForLeader();
+            final LeaderInformation confirmedLeaderInformation =
+                    electionEventHandler.getConfirmedLeaderInformation();
+            Assertions.assertThat(confirmedLeaderInformation.getLeaderAddress())
+                    .isEqualTo(LEADER_ADDRESS);
+
+            // First update will successfully complete.
+            Assertions.assertThat(leaderInformationConsumer.getFirstUpdateFuture())
+                    .succeedsWithin(5, TimeUnit.SECONDS);
+            // Wait for a while to make sure other updates don't appear.
+            Assertions.assertThat(leaderInformationConsumer.getAnotherUpdateFuture())
+                    .withFailMessage("Another leader information update is not expected.")
+                    .failsWithin(5, TimeUnit.MILLISECONDS)
+                    .withThrowableOfType(TimeoutException.class);
+        } finally {
+            electionEventHandler.close();
+            if (leaderElectionDriver != null) {
+                leaderElectionDriver.close();
             }
         }
     }
@@ -756,5 +795,29 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
                                 LEADER_ADDRESS);
         electionEventHandler.init(leaderElectionDriver);
         return leaderElectionDriver;
+    }
+
+    private static class LeaderInformationConsumer implements Consumer<LeaderInformation> {
+
+        final CompletableFuture<Void> firstUpdateFuture = new CompletableFuture<>();
+
+        final CompletableFuture<Void> anotherUpdateFuture = new CompletableFuture<>();
+
+        @Override
+        public void accept(LeaderInformation leaderInformation) {
+            if (!firstUpdateFuture.isDone()) {
+                firstUpdateFuture.complete(null);
+            } else {
+                anotherUpdateFuture.complete(null);
+            }
+        }
+
+        public CompletableFuture<Void> getFirstUpdateFuture() {
+            return firstUpdateFuture;
+        }
+
+        public CompletableFuture<Void> getAnotherUpdateFuture() {
+            return anotherUpdateFuture;
+        }
     }
 }


### PR DESCRIPTION
…iver keeps writing leader information, using up zxid.

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Fix FLINK-27848


## Brief change log
  -  ZooKeeperLeaderElectionDriver#retrieveLeaderInformationFromZooKeeper no longer trigger redundant notifications when data is not empty.
  - Add a test for this case.


## Verifying this change

This change added a test case in ZooKeeperLeaderElectionTest.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
