### PR TITLE
WIP: Refactor FlinkImageBuilder, FlinkContainersBuilder

### DIFF
--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-elasticsearch/src/main/java/org/apache/flink/streaming/tests/ElasticsearchSinkE2ECaseBase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-elasticsearch/src/main/java/org/apache/flink/streaming/tests/ElasticsearchSinkE2ECaseBase.java
@@ -25,7 +25,8 @@ import org.apache.flink.connector.testframe.junit.annotations.TestExternalSystem
 import org.apache.flink.connector.testframe.junit.annotations.TestSemantics;
 import org.apache.flink.connector.testframe.testsuites.SinkTestSuiteBase;
 import org.apache.flink.streaming.api.CheckpointingMode;
-import org.apache.flink.tests.util.flink.FlinkContainerTestEnvironment;
+import org.apache.flink.tests.util.flink.container.FlinkContainerTestEnvironment;
+import org.apache.flink.tests.util.flink.container.FlinkContainersConfig;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,8 +56,18 @@ public abstract class ElasticsearchSinkE2ECaseBase<T extends Comparable<T>>
     CheckpointingMode[] semantics = new CheckpointingMode[] {CheckpointingMode.EXACTLY_ONCE};
 
     // Defines TestEnvironment
+    // TODO: Extract base image name
     @TestEnv
-    protected FlinkContainerTestEnvironment flink = new FlinkContainerTestEnvironment(1, 6);
+    protected FlinkContainerTestEnvironment flink =
+            FlinkContainerTestEnvironment.fromConfig(
+                    FlinkContainersConfig.builder()
+                            .numTaskManagers(1)
+                            .numSlotsPerTaskManager(6)
+                            .baseImage(
+                                    "ghcr.io/afedulov/flink-docker:1.16-snapshot-scala_2.12-java8-debian")
+                            .enableZookeeperHA() // TODO: verify if this is really needed for these
+                            // tests.
+                            .build());
 
     // Defines ConnectorExternalSystem
     @TestExternalSystem

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/KafkaSinkE2ECase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/KafkaSinkE2ECase.java
@@ -27,7 +27,7 @@ import org.apache.flink.connector.testframe.junit.annotations.TestSemantics;
 import org.apache.flink.connector.testframe.testsuites.SinkTestSuiteBase;
 import org.apache.flink.streaming.api.CheckpointingMode;
 import org.apache.flink.tests.util.TestUtils;
-import org.apache.flink.tests.util.flink.FlinkContainerTestEnvironment;
+import org.apache.flink.tests.util.flink.container.FlinkContainerTestEnvironment;
 import org.apache.flink.util.DockerImageVersions;
 
 import org.testcontainers.containers.KafkaContainer;

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/KafkaSourceE2ECase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/KafkaSourceE2ECase.java
@@ -27,7 +27,7 @@ import org.apache.flink.connector.testframe.junit.annotations.TestSemantics;
 import org.apache.flink.connector.testframe.testsuites.SourceTestSuiteBase;
 import org.apache.flink.streaming.api.CheckpointingMode;
 import org.apache.flink.tests.util.TestUtils;
-import org.apache.flink.tests.util.flink.FlinkContainerTestEnvironment;
+import org.apache.flink.tests.util.flink.container.FlinkContainerTestEnvironment;
 import org.apache.flink.util.DockerImageVersions;
 
 import org.testcontainers.containers.KafkaContainer;

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SmokeKafkaITCase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SmokeKafkaITCase.java
@@ -25,6 +25,7 @@ import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
 import org.apache.flink.tests.util.TestUtils;
 import org.apache.flink.tests.util.flink.JobSubmission;
 import org.apache.flink.tests.util.flink.container.FlinkContainers;
+import org.apache.flink.tests.util.flink.container.FlinkContainersConfig;
 import org.apache.flink.testutils.junit.FailsOnJava11;
 import org.apache.flink.util.TestLoggerExtension;
 
@@ -87,8 +88,7 @@ public class SmokeKafkaITCase {
 
     @RegisterExtension
     public static final FlinkContainers FLINK =
-            FlinkContainers.builder()
-                    .setConfiguration(getConfiguration())
+            FlinkContainers.builder(FlinkContainersConfig.basedOn(getConfiguration()))
                     .setLogger(LOG)
                     .dependsOn(KAFKA_CONTAINER)
                     .build();

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/resources/log4j2-test.properties
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/resources/log4j2-test.properties
@@ -18,7 +18,7 @@
 
 # Set root logger level to OFF to not flood build logs
 # set manually to INFO for debugging purposes
-rootLogger.level = OFF
+rootLogger.level = INFO
 rootLogger.appenderRef.test.ref = TestLogger
 
 appender.testlogger.name = TestLogger

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/container/FlinkContainerTestEnvironment.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/container/FlinkContainerTestEnvironment.java
@@ -76,6 +76,7 @@ public class FlinkContainerTestEnvironment implements TestEnvironment, ClusterCo
                                         .numTaskManagers(numTaskManagers)
                                         .numSlotsPerTaskManager(numSlotsPerTaskManager)
                                         .enableZookeeperHA()
+                                        .jarPaths(jarPaths)
                                         .build())
                         .setLogger(LOG)
                         .build();

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/container/FlinkContainers.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/container/FlinkContainers.java
@@ -130,7 +130,11 @@ public class FlinkContainers implements BeforeAllCallback, AfterAllCallback {
 
     /** Creates a builder for {@link FlinkContainers}. */
     public static FlinkContainersBuilder builder() {
-        return new FlinkContainersBuilder();
+        return new FlinkContainersBuilder(FlinkContainersConfig.defaultConfig());
+    }
+
+    public static FlinkContainersBuilder builder(FlinkContainersConfig config) {
+        return new FlinkContainersBuilder(config);
     }
 
     FlinkContainers(

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/container/FlinkContainersBuilder.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/container/FlinkContainersBuilder.java
@@ -18,11 +18,7 @@
 
 package org.apache.flink.tests.util.flink.container;
 
-import org.apache.flink.configuration.CheckpointingOptions;
-import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.HighAvailabilityOptions;
-import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 
@@ -36,59 +32,27 @@ import org.testcontainers.utility.DockerImageName;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
-import java.util.UUID;
-
-import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** A builder class for {@link FlinkContainers}. */
 public class FlinkContainersBuilder {
 
-    // Hostname of components within container network
-    // Hostname of JobManager container
-    public static final String JOB_MANAGER_HOSTNAME = "jobmanager";
-    // Hostname prefix of TaskManagers. Use "taskmanager-0" for example to access TM with index 0
-    public static final String TASK_MANAGER_HOSTNAME_PREFIX = "taskmanager-";
-    // Hostname of Zookeeper container
-    public static final String ZOOKEEPER_HOSTNAME = "zookeeper";
-
-    // Directories for storing states
-    // Path in the JM container for storing checkpoints and savepoints
-    public static final Path CHECKPOINT_PATH = Paths.get("/flink/checkpoint");
-    // Path in the JM container for persisting HA metadata
-    public static final Path HA_STORAGE_PATH = Paths.get("/flink/recovery");
+    private final FlinkContainersConfig config;
 
     private final List<GenericContainer<?>> dependentContainers = new ArrayList<>();
-    private final Configuration conf = new Configuration();
+    private final Configuration flinkConfig;
     private final Map<String, String> envVars = new HashMap<>();
-    private final Properties logProperties = new Properties();
 
-    private int numTaskManagers = 1;
     private Network network = Network.newNetwork();
     private Logger logger;
-    private boolean enableZookeeperHA = false;
+    private String baseImage;
 
-    /** Sets number of TaskManagers. */
-    public FlinkContainersBuilder setNumTaskManagers(int numTaskManagers) {
-        this.numTaskManagers = numTaskManagers;
-        return this;
-    }
-
-    /** Sets a single configuration of the cluster. */
-    public <T> FlinkContainersBuilder setConfiguration(ConfigOption<T> option, T value) {
-        this.conf.set(option, value);
-        return this;
-    }
-
-    /** Sets configurations of the cluster. */
-    public FlinkContainersBuilder setConfiguration(Configuration conf) {
-        this.conf.addAll(conf);
-        return this;
+    public FlinkContainersBuilder(FlinkContainersConfig config) {
+        this.config = config;
+        this.flinkConfig = config.getFlinkConfiguration();
     }
 
     /**
@@ -119,33 +83,8 @@ public class FlinkContainersBuilder {
         return this;
     }
 
-    /**
-     * Sets log4j property.
-     *
-     * <p>Containers will use "log4j-console.properties" under flink-dist as the base configuration
-     * of loggers. Properties specified by this method will be appended to the config file, or
-     * overwrite the property if already exists in the base config file.
-     */
-    public FlinkContainersBuilder setLogProperty(String key, String value) {
-        this.logProperties.setProperty(key, value);
-        return this;
-    }
-
-    /**
-     * Sets log4j properties.
-     *
-     * <p>Containers will use "log4j-console.properties" under flink-dist as the base configuration
-     * of loggers. Properties specified by this method will be appended to the config file, or
-     * overwrite the property if already exists in the base config file.
-     */
-    public FlinkContainersBuilder setLogProperties(Properties logProperties) {
-        this.logProperties.putAll(logProperties);
-        return this;
-    }
-
-    /** Enables high availability service. */
-    public FlinkContainersBuilder enableZookeeperHA() {
-        this.enableZookeeperHA = true;
+    public FlinkContainersBuilder setBaseImage(String baseImage) {
+        this.baseImage = baseImage;
         return this;
     }
 
@@ -153,21 +92,9 @@ public class FlinkContainersBuilder {
     public FlinkContainers build() {
         // Setup Zookeeper HA
         GenericContainer<?> zookeeper = null;
-        if (enableZookeeperHA) {
-            enableZookeeperHAConfigurations();
+        if (config.isZookeeperHA()) {
             zookeeper = buildZookeeperContainer();
         }
-
-        // Add common configurations
-        this.conf.set(JobManagerOptions.ADDRESS, JOB_MANAGER_HOSTNAME);
-        this.conf.set(
-                CheckpointingOptions.CHECKPOINTS_DIRECTORY,
-                CHECKPOINT_PATH.toAbsolutePath().toUri().toString());
-        this.conf.set(RestOptions.BIND_ADDRESS, "0.0.0.0");
-
-        this.conf.set(JobManagerOptions.BIND_HOST, "0.0.0.0");
-        this.conf.set(TaskManagerOptions.BIND_HOST, "0.0.0.0");
-        this.conf.removeConfig(TaskManagerOptions.HOST);
 
         // Create temporary directory for building Flink image
         final Path imageBuildingTempDir;
@@ -185,14 +112,16 @@ public class FlinkContainersBuilder {
                 buildTaskManagerContainers(imageBuildingTempDir);
 
         // Mount HA storage to JobManager
-        if (enableZookeeperHA) {
-            createTempDirAndMountToContainer("flink-recovery", HA_STORAGE_PATH, jobManager);
+        if (config.isZookeeperHA()) {
+            createTempDirAndMountToContainer(
+                    "flink-recovery", config.getHaStoragePath(), jobManager);
         }
 
         // Mount checkpoint storage to JobManager
-        createTempDirAndMountToContainer("flink-checkpoint", CHECKPOINT_PATH, jobManager);
+        createTempDirAndMountToContainer(
+                "flink-checkpoint", config.getCheckpointPath(), jobManager);
 
-        return new FlinkContainers(jobManager, taskManagers, zookeeper, conf);
+        return new FlinkContainers(jobManager, taskManagers, zookeeper, flinkConfig);
     }
 
     // --------------------------- Helper Functions -------------------------------------
@@ -200,7 +129,7 @@ public class FlinkContainersBuilder {
     private GenericContainer<?> buildJobManagerContainer(Path tempDirectory) {
         // Configure JobManager
         final Configuration jobManagerConf = new Configuration();
-        jobManagerConf.addAll(this.conf);
+        jobManagerConf.addAll(this.flinkConfig);
         // Build JobManager container
         final ImageFromDockerfile jobManagerImage;
         try {
@@ -208,24 +137,27 @@ public class FlinkContainersBuilder {
                     new FlinkImageBuilder()
                             .setTempDirectory(tempDirectory)
                             .setConfiguration(jobManagerConf)
-                            .setLogProperties(logProperties)
+                            .setLogProperties(config.getLogProperties())
+                            .setBaseImage(baseImage)
                             .asJobManager()
                             .build();
         } catch (ImageBuildException e) {
             throw new RuntimeException("Failed to build JobManager image", e);
         }
         return configureContainer(
-                        new GenericContainer<>(jobManagerImage), JOB_MANAGER_HOSTNAME, "JobManager")
+                        new GenericContainer<>(jobManagerImage),
+                        config.getJobManagerHostname(),
+                        "JobManager")
                 .withExposedPorts(jobManagerConf.get(RestOptions.PORT));
     }
 
     private List<GenericContainer<?>> buildTaskManagerContainers(Path tempDirectory) {
         List<GenericContainer<?>> taskManagers = new ArrayList<>();
-        for (int i = 0; i < numTaskManagers; i++) {
+        for (int i = 0; i < config.getNumTaskManagers(); i++) {
             // Configure TaskManager
             final Configuration taskManagerConf = new Configuration();
-            taskManagerConf.addAll(this.conf);
-            final String taskManagerHostName = TASK_MANAGER_HOSTNAME_PREFIX + i;
+            taskManagerConf.addAll(this.flinkConfig);
+            final String taskManagerHostName = config.getTaskManagerHostnamePrefix() + i;
             taskManagerConf.set(TaskManagerOptions.HOST, taskManagerHostName);
             // Build TaskManager container
             final ImageFromDockerfile taskManagerImage;
@@ -234,7 +166,8 @@ public class FlinkContainersBuilder {
                         new FlinkImageBuilder()
                                 .setTempDirectory(tempDirectory)
                                 .setConfiguration(taskManagerConf)
-                                .setLogProperties(logProperties)
+                                .setLogProperties(config.getLogProperties())
+                                .setBaseImage(baseImage)
                                 .asTaskManager()
                                 .build();
             } catch (ImageBuildException e) {
@@ -252,7 +185,7 @@ public class FlinkContainersBuilder {
     private GenericContainer<?> buildZookeeperContainer() {
         return configureContainer(
                 new GenericContainer<>(DockerImageName.parse("zookeeper").withTag("3.5.9")),
-                ZOOKEEPER_HOSTNAME,
+                config.getZookeeperHostname(),
                 "Zookeeper");
     }
 
@@ -271,26 +204,15 @@ public class FlinkContainersBuilder {
         }
         // Add environment variables
         container.withEnv(envVars);
+        container.withWorkingDirectory(config.getFlinkHome());
         return container;
     }
 
-    private void enableZookeeperHAConfigurations() {
-        // Set HA related configurations
-        checkNotNull(this.conf, "Configuration should not be null for setting HA service");
-        conf.set(HighAvailabilityOptions.HA_MODE, "zookeeper");
-        conf.set(HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, ZOOKEEPER_HOSTNAME + ":" + "2181");
-        conf.set(HighAvailabilityOptions.HA_ZOOKEEPER_ROOT, "/flink");
-        conf.set(HighAvailabilityOptions.HA_CLUSTER_ID, "flink-container-" + UUID.randomUUID());
-        conf.set(HighAvailabilityOptions.HA_STORAGE_PATH, HA_STORAGE_PATH.toUri().toString());
-    }
-
     private void createTempDirAndMountToContainer(
-            String tempDirPrefix, Path containerPath, GenericContainer<?> container) {
+            String tempDirPrefix, String containerPath, GenericContainer<?> container) {
         try {
             Path tempDirPath = Files.createTempDirectory(tempDirPrefix);
-            container.withFileSystemBind(
-                    tempDirPath.toAbsolutePath().toString(),
-                    containerPath.toAbsolutePath().toString());
+            container.withFileSystemBind(tempDirPath.toAbsolutePath().toString(), containerPath);
         } catch (IOException e) {
             throw new IllegalStateException("Failed to create temporary recovery directory", e);
         }

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/container/FlinkContainersConfig.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/container/FlinkContainersConfig.java
@@ -9,11 +9,11 @@
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.apache.flink.tests.util.flink.container;
@@ -267,6 +267,18 @@ public class FlinkContainersConfig {
          */
         public Builder jarPaths(String... jarPaths) {
             this.jarPaths = Arrays.asList(jarPaths);
+            return this;
+        }
+
+        /**
+         * Sets the {@code jarPaths} and returns a reference to this Builder enabling method
+         * chaining.
+         *
+         * @param jarPaths The {@code jarPaths} to set.
+         * @return A reference to this Builder.
+         */
+        public Builder jarPaths(Collection<String> jarPaths) {
+            this.jarPaths = jarPaths;
             return this;
         }
 

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/container/FlinkContainersConfig.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/container/FlinkContainersConfig.java
@@ -1,0 +1,587 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.flink.tests.util.flink.container;
+
+import org.apache.flink.configuration.CheckpointingOptions;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.HighAvailabilityOptions;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.configuration.TaskManagerOptions;
+
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Properties;
+import java.util.UUID;
+
+import static org.apache.flink.configuration.HeartbeatManagerOptions.HEARTBEAT_INTERVAL;
+import static org.apache.flink.configuration.HeartbeatManagerOptions.HEARTBEAT_TIMEOUT;
+import static org.apache.flink.configuration.JobManagerOptions.SLOT_REQUEST_TIMEOUT;
+import static org.apache.flink.configuration.MetricOptions.METRIC_FETCHER_UPDATE_INTERVAL;
+
+/** The type Flink containers config. */
+public class FlinkContainersConfig {
+    private final String baseImage;
+    private final int numTaskManagers;
+    private final int numSlotsPerTaskManager;
+    private final Collection<String> jarPaths;
+    private final Configuration flinkConfiguration;
+    private final String taskManagerHostnamePrefix;
+    private final Boolean buildFromFlinkDist;
+    private final String flinkDistLocation;
+    private final String flinkHome;
+    private final String checkpointPath;
+    private final String haStoragePath;
+    private final Boolean zookeeperHA;
+    private final String zookeeperHostname;
+    private final Properties logProperties;
+
+    // Defaults
+    private static final long DEFAULT_METRIC_FETCHER_UPDATE_INTERVAL_MS = 1000L;
+    private static final long DEFAULT_SLOT_REQUEST_TIMEOUT_MS = 10_000L;
+    private static final long DEFAULT_HEARTBEAT_TIMEOUT_MS = 5_000L;
+    private static final long DEFAULT_HEARTBEAT_INTERVAL_MS = 1000L;
+    private static final MemorySize DEFAULT_TM_TOTAL_PROCESS_MEMORY = MemorySize.ofMebiBytes(1728);
+    private static final MemorySize DEFAULT_JM_TOTAL_PROCESS_MEMORY = MemorySize.ofMebiBytes(1600);
+
+    private static final int DEFAULT_NUM_TASK_MANAGERS = 1;
+    private static final int DEFAULT_NUM_SLOTS_PER_TASK_MANAGER = 1;
+    private static final String DEFAULT_TASK_MANAGERS_HOSTNAME_PREFIX = "taskmanager-";
+    private static final String DEFAULT_JOB_MANAGER_HOSTNAME = "jobmanager";
+    private static final String DEFAULT_BIND_ADDRESS = "0.0.0.0";
+    private static final String DEFAULT_FLINK_HOME = "/opt/flink";
+    private static final String DEFAULT_CHECKPOINT_PATH = DEFAULT_FLINK_HOME + "/checkpoint";
+    private static final String DEFAULT_HA_STORAGE_PATH = DEFAULT_FLINK_HOME + "/recovery";
+
+    private static final String DEFAULT_ZOOKEEPER_HOSTNAME = "zookeeper";
+    private static final String DEFAULT_ZOOKEEPER_QUORUM = DEFAULT_ZOOKEEPER_HOSTNAME + ":2181";
+    // --
+
+    private FlinkContainersConfig(Builder builder) {
+        baseImage = builder.baseImage;
+        numTaskManagers = builder.numTaskManagers;
+        numSlotsPerTaskManager = builder.numSlotsPerTaskManager;
+        jarPaths = builder.jarPaths;
+        flinkConfiguration = builder.flinkConfiguration;
+        taskManagerHostnamePrefix = builder.taskManagerHostnamePrefix;
+        buildFromFlinkDist = builder.buildFromFlinkDist;
+        flinkDistLocation = builder.flinkDistLocation;
+        flinkHome = builder.flinkHome;
+        checkpointPath = builder.checkpointPath;
+        haStoragePath = builder.haStoragePath;
+        zookeeperHA = builder.zookeeperHA;
+        zookeeperHostname = builder.zookeeperHostname;
+        logProperties = builder.logProperties;
+    }
+
+    /**
+     * Builder builder.
+     *
+     * @return the builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Default config flink containers config.
+     *
+     * @return the flink containers config
+     */
+    public static FlinkContainersConfig defaultConfig() {
+        return builder().build();
+    }
+
+    /**
+     * Based on flink containers config.
+     *
+     * @param config the config
+     * @return the flink containers config
+     */
+    public static FlinkContainersConfig basedOn(Configuration config) {
+        return builder().basedOn(config).build();
+    }
+
+    /** {@code FlinkContainersConfig} builder static inner class. */
+    public static final class Builder {
+        private String baseImage;
+        private int numTaskManagers = DEFAULT_NUM_TASK_MANAGERS;
+        private int numSlotsPerTaskManager = DEFAULT_NUM_SLOTS_PER_TASK_MANAGER;
+        private Collection<String> jarPaths = new ArrayList<>();
+        private Configuration flinkConfiguration = defaultFlinkConfig();
+        private String taskManagerHostnamePrefix = DEFAULT_TASK_MANAGERS_HOSTNAME_PREFIX;
+        private Boolean buildFromFlinkDist = true;
+        private String flinkDistLocation;
+        private String flinkHome = DEFAULT_FLINK_HOME;
+        private String checkpointPath = DEFAULT_CHECKPOINT_PATH;
+        private String haStoragePath = DEFAULT_HA_STORAGE_PATH;
+        private Boolean zookeeperHA = false;
+        private String zookeeperHostname = DEFAULT_ZOOKEEPER_HOSTNAME;
+        private Properties logProperties = defaultLoggingProperties();
+
+        private Builder() {}
+
+        /**
+         * Sets the {@code baseImage} and returns a reference to this Builder enabling method
+         * chaining.
+         *
+         * @param baseImage The {@code baseImage} to set.
+         * @return A reference to this Builder.
+         */
+        public Builder baseImage(String baseImage) {
+            this.baseImage = baseImage;
+            this.buildFromFlinkDist = false;
+            return this;
+        }
+
+        /**
+         * Sets the {@code flinkDistLocation} and returns a reference to this Builder enabling
+         * method chaining.
+         *
+         * @param flinkDistLocation The {@code flinkDistLocation} to set.
+         * @return A reference to this Builder.
+         */
+        public Builder flinkDistLocation(String flinkDistLocation) {
+            this.flinkDistLocation = flinkDistLocation;
+            this.buildFromFlinkDist = true;
+            return this;
+        }
+
+        /**
+         * Sets the path of the Flink distribution inside the container. Returns a reference to this
+         * Builder enabling method chaining.
+         *
+         * @param flinkHome The {@code flinkHome} to set.
+         * @return A reference to this Builder.
+         */
+        public Builder flinkHome(String flinkHome) {
+            this.flinkHome = flinkHome;
+            return this;
+        }
+
+        /**
+         * Sets the {@code checkpointPath} and returns a reference to this Builder enabling method
+         * chaining.
+         *
+         * @param checkpointPath The checkpoint path to set.
+         * @return A reference to this Builder.
+         */
+        public Builder checkpointPath(String checkpointPath) {
+            this.checkpointPath = checkpointPath;
+            return setConfigOption(
+                    CheckpointingOptions.CHECKPOINTS_DIRECTORY, toUri(checkpointPath));
+        }
+
+        /**
+         * Sets the {@code haStoragePath} and returns a reference to this Builder enabling method
+         * chaining.
+         *
+         * @param haStoragePath The path for storing HA data.
+         * @return A reference to this Builder.
+         */
+        public Builder haStoragePath(String haStoragePath) {
+            this.haStoragePath = haStoragePath;
+            return setConfigOption(HighAvailabilityOptions.HA_STORAGE_PATH, toUri(haStoragePath));
+        }
+
+        /**
+         * Sets the {@code zookeeperHostname} and returns a reference to this Builder enabling
+         * method chaining.
+         *
+         * @param zookeeperHostname The Zookeeper hostname.
+         * @return A reference to this Builder.
+         */
+        public Builder zookeeperHostname(String zookeeperHostname) {
+            this.zookeeperHostname = zookeeperHostname;
+            return this;
+        }
+
+        /**
+         * Enables Zookeeper HA. NOTE: this option uses default HA configuration. If you want to use
+         * non-default configuration, you should provide all settings, including the HA_MODE
+         * directly via the {@code basedOn()} method instead.
+         *
+         * @return A reference to this Builder.
+         */
+        public Builder enableZookeeperHA() {
+            zookeeperHA = true;
+            setConfigOption(HighAvailabilityOptions.HA_MODE, "zookeeper");
+            setConfigOption(HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, DEFAULT_ZOOKEEPER_QUORUM);
+            setConfigOption(
+                    HighAvailabilityOptions.HA_CLUSTER_ID, "flink-container-" + UUID.randomUUID());
+            setConfigOption(
+                    HighAvailabilityOptions.HA_STORAGE_PATH, toUri(DEFAULT_HA_STORAGE_PATH));
+            return this;
+        }
+
+        /**
+         * Sets the {@code numTaskManagers} and returns a reference to this Builder enabling method
+         * chaining.
+         *
+         * @param numTaskManagers The {@code numTaskManagers} to set.
+         * @return A reference to this Builder.
+         */
+        public Builder numTaskManagers(int numTaskManagers) {
+            this.numTaskManagers = numTaskManagers;
+            return this;
+        }
+
+        /**
+         * Sets the {@code numSlotsPerTaskManager} and returns a reference to this Builder enabling
+         * method chaining. It also adds this property into the {@code flinkConfiguration} field.
+         *
+         * @param numSlotsPerTaskManager The {@code numSlotsPerTaskManager} to set.
+         * @return A reference to this Builder.
+         */
+        public Builder numSlotsPerTaskManager(int numSlotsPerTaskManager) {
+            this.numSlotsPerTaskManager = numSlotsPerTaskManager;
+            return setConfigOption(TaskManagerOptions.NUM_TASK_SLOTS, numSlotsPerTaskManager);
+        }
+
+        /**
+         * Sets the {@code jarPaths} and returns a reference to this Builder enabling method
+         * chaining.
+         *
+         * @param jarPaths The {@code jarPaths} to set.
+         * @return A reference to this Builder.
+         */
+        public Builder jarPaths(String... jarPaths) {
+            this.jarPaths = Arrays.asList(jarPaths);
+            return this;
+        }
+
+        /**
+         * Sets a single Flink configuration parameter (the options for flink-conf.yaml) and returns
+         * a reference to this Builder enabling method chaining.
+         *
+         * @param <T> The type parameter.
+         * @param option The option.
+         * @param value The value.
+         * @return A reference to this Builder.
+         */
+        public <T> Builder setConfigOption(ConfigOption<T> option, T value) {
+            this.flinkConfiguration.set(option, value);
+            return this;
+        }
+
+        /**
+         * Sets a single Flink logging configuration property in the log4j format and returns a
+         * reference to this Builder enabling method chaining.
+         *
+         * @param key The property key.
+         * @param value The property value.
+         * @return A reference to this Builder.
+         */
+        public Builder setLogProperty(String key, String value) {
+            this.logProperties.setProperty(key, value);
+            return this;
+        }
+
+        /**
+         * Merges the provided {@code config} with the default config, potentially overwriting the
+         * defaults in case of collisions. Returns a reference to this Builder enabling method
+         * chaining.
+         *
+         * @param <T> the type parameter
+         * @param config The {@code config} to add.
+         * @return A reference to this Builder.
+         */
+        public <T> Builder basedOn(Configuration config) {
+            this.flinkConfiguration.addAll(config);
+            return this;
+        }
+
+        /**
+         * Sets the {@code flinkConfiguration} value to {@code config} and returns a reference to
+         * this Builder enabling method chaining.
+         *
+         * @param <T> the type parameter
+         * @param config The {@code config} to set.
+         * @return A reference to this Builder.
+         */
+        public <T> Builder fullConfiguration(Configuration config) {
+            this.flinkConfiguration = config;
+            return this;
+        }
+
+        /**
+         * Sets the {@code taskManagerHostnamePrefix} and returns a reference to this Builder
+         * enabling method chaining.
+         *
+         * @param taskManagerHostnamePrefix The {@code taskManagerHostnamePrefix} to set.
+         * @return A reference to this Builder.
+         */
+        public Builder taskManagerHostnamePrefix(String taskManagerHostnamePrefix) {
+            this.taskManagerHostnamePrefix = taskManagerHostnamePrefix;
+            return this;
+        }
+
+        /**
+         * Sets the job manager hostname and returns a reference to this Builder enabling method
+         * chaining.
+         *
+         * @param jobManagerHostname The job manager hostname to set.
+         * @return A reference to this Builder.
+         */
+        public Builder jobManagerHostname(String jobManagerHostname) {
+            return setConfigOption(JobManagerOptions.ADDRESS, jobManagerHostname);
+        }
+
+        private Configuration defaultFlinkConfig() {
+            final Configuration config = new Configuration();
+            config.set(TaskManagerOptions.TOTAL_PROCESS_MEMORY, DEFAULT_TM_TOTAL_PROCESS_MEMORY);
+            config.set(JobManagerOptions.TOTAL_PROCESS_MEMORY, DEFAULT_JM_TOTAL_PROCESS_MEMORY);
+            config.set(HEARTBEAT_INTERVAL, DEFAULT_HEARTBEAT_INTERVAL_MS);
+            config.set(HEARTBEAT_TIMEOUT, DEFAULT_HEARTBEAT_TIMEOUT_MS);
+            config.set(SLOT_REQUEST_TIMEOUT, DEFAULT_SLOT_REQUEST_TIMEOUT_MS);
+            config.set(METRIC_FETCHER_UPDATE_INTERVAL, DEFAULT_METRIC_FETCHER_UPDATE_INTERVAL_MS);
+            config.set(JobManagerOptions.ADDRESS, DEFAULT_JOB_MANAGER_HOSTNAME);
+
+            config.set(RestOptions.BIND_ADDRESS, DEFAULT_BIND_ADDRESS);
+            config.set(TaskManagerOptions.BIND_HOST, DEFAULT_BIND_ADDRESS);
+            config.set(JobManagerOptions.BIND_HOST, DEFAULT_BIND_ADDRESS);
+
+            config.set(CheckpointingOptions.CHECKPOINTS_DIRECTORY, toUri(DEFAULT_CHECKPOINT_PATH));
+
+            return config;
+        }
+
+        private Properties defaultLoggingProperties() {
+            final Properties logProperties = new Properties();
+            logProperties.setProperty(
+                    "appender.rolling.strategy.max", "${env:MAX_LOG_FILE_NUMBER:-10}");
+            logProperties.setProperty("appender.rolling.policies.size.size", "100MB");
+            logProperties.setProperty("logger.zookeeper.name", "org.apache.zookeeper");
+            logProperties.setProperty(
+                    "logger.shaded_zookeeper.name", "org.apache.flink.shaded.zookeeper3");
+            logProperties.setProperty("logger.zookeeper.level", "INFO");
+            logProperties.setProperty("appender.console.name", "ConsoleAppender");
+            logProperties.setProperty("appender.rolling.fileName", "${sys:log.file}");
+            logProperties.setProperty("appender.rolling.filePattern", "${sys:log.file}.%i");
+            logProperties.setProperty("rootLogger.appenderRef.rolling.ref", "RollingFileAppender");
+            logProperties.setProperty("logger.akka.name", "akka");
+            logProperties.setProperty("appender.console.type", "CONSOLE");
+            logProperties.setProperty("appender.rolling.append", "true");
+            logProperties.setProperty("appender.console.layout.type", "PatternLayout");
+            logProperties.setProperty("appender.rolling.name", "RollingFileAppender");
+            logProperties.setProperty("rootLogger.appenderRef.console.ref", "ConsoleAppender");
+            logProperties.setProperty(
+                    "appender.rolling.policies.size.type", "SizeBasedTriggeringPolicy");
+            logProperties.setProperty(
+                    "appender.console.layout.pattern",
+                    "%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p %-60c %x - %m%n");
+            logProperties.setProperty("rootLogger.level", "INFO");
+            logProperties.setProperty("logger.hadoop.name", "org.apache.hadoop");
+            logProperties.setProperty("logger.shaded_zookeeper.level", "INFO");
+            logProperties.setProperty("appender.rolling.layout.type", "PatternLayout");
+            logProperties.setProperty("logger.kafka.name", "org.apache.kafka");
+            logProperties.setProperty("logger.netty.level", "OFF");
+            logProperties.setProperty("appender.rolling.type", "RollingFile");
+            logProperties.setProperty("logger.akka.level", "INFO");
+            logProperties.setProperty("logger.hadoop.level", "INFO");
+            logProperties.setProperty(
+                    "appender.rolling.layout.pattern",
+                    "%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p %-60c %x - %m%n");
+            logProperties.setProperty(
+                    "appender.rolling.policies.startup.type", "OnStartupTriggeringPolicy");
+            logProperties.setProperty(
+                    "logger.netty.name", "org.jboss.netty.channel.DefaultChannelPipeline");
+            logProperties.setProperty("appender.rolling.strategy.type", "DefaultRolloverStrategy");
+            logProperties.setProperty("appender.rolling.policies.type", "Policies");
+            logProperties.setProperty("monitorInterval", "30");
+            logProperties.setProperty("logger.kafka.level", "INFO");
+            return logProperties;
+        }
+
+        /**
+         * Returns a {@code FlinkContainersConfig} built from the parameters previously set.
+         *
+         * @return A {@code FlinkContainersConfig} built with parameters of this {@code
+         *     FlinkContainersConfig.Builder}.
+         */
+        public FlinkContainersConfig build() {
+            return new FlinkContainersConfig(this);
+        }
+    }
+
+    /**
+     * Gets base image.
+     *
+     * @return The base image.
+     */
+    public String getBaseImage() {
+        return baseImage;
+    }
+
+    /**
+     * Gets number of task managers.
+     *
+     * @return The number task managers.
+     */
+    public int getNumTaskManagers() {
+        return numTaskManagers;
+    }
+
+    /**
+     * Gets number slots per task manager.
+     *
+     * @return The number slots per task manager.
+     */
+    public int getNumSlotsPerTaskManager() {
+        return numSlotsPerTaskManager;
+    }
+
+    /**
+     * Gets jar paths.
+     *
+     * @return The jar paths.
+     */
+    public Collection<String> getJarPaths() {
+        return jarPaths;
+    }
+
+    /**
+     * Gets flink configuration.
+     *
+     * @return The flink configuration.
+     */
+    public Configuration getFlinkConfiguration() {
+        return flinkConfiguration;
+    }
+
+    /**
+     * Gets task manager hostname prefix.
+     *
+     * @return The task manager hostname prefix.
+     */
+    public String getTaskManagerHostnamePrefix() {
+        return taskManagerHostnamePrefix;
+    }
+
+    /**
+     * Gets job manager hostname.
+     *
+     * @return The job manager hostname.
+     */
+    public String getJobManagerHostname() {
+        return flinkConfiguration.getString(JobManagerOptions.ADDRESS);
+    }
+
+    /**
+     * Returns whether to build from flink-dist or from an existing base container. Also see the
+     * {@code baseImage} property.
+     */
+    public Boolean isBuildFromFlinkDist() {
+        return buildFromFlinkDist;
+    }
+
+    /**
+     * Gets flink dist location.
+     *
+     * @return The flink dist location.
+     */
+    public String getFlinkDistLocation() {
+        return flinkDistLocation;
+    }
+
+    /**
+     * Gets flink home.
+     *
+     * @return The flink home path.
+     */
+    public String getFlinkHome() {
+        return flinkHome;
+    }
+
+    /**
+     * Gets checkpoint path.
+     *
+     * @return The checkpoint path.
+     */
+    public String getCheckpointPath() {
+        return checkpointPath;
+    }
+
+    /**
+     * Gets HA storage path.
+     *
+     * @return The ha storage path.
+     */
+    public String getHaStoragePath() {
+        return haStoragePath;
+    }
+
+    /**
+     * Gets ha storage path uri.
+     *
+     * @return The HA storage path as URI (prefixed with file://).
+     */
+    public String getHaStoragePathUri() {
+        return Paths.get(getHaStoragePath()).toUri().toString();
+    }
+
+    /**
+     * Gets default flink home.
+     *
+     * @return The default flink home path.
+     */
+    public static String getDefaultFlinkHome() {
+        return DEFAULT_FLINK_HOME;
+    }
+
+    /**
+     * Gets default checkpoint path.
+     *
+     * @return The default checkpoint path.
+     */
+    public static String getDefaultCheckpointPath() {
+        return DEFAULT_CHECKPOINT_PATH;
+    }
+
+    /** Is zookeeper HA boolean. */
+    public Boolean isZookeeperHA() {
+        return zookeeperHA;
+    }
+
+    /**
+     * Gets Zookeeper hostname.
+     *
+     * @return The Zookeeper hostname.
+     */
+    public String getZookeeperHostname() {
+        return zookeeperHostname;
+    }
+
+    /**
+     * Gets logging properties.
+     *
+     * @return The logging properties.
+     */
+    public Properties getLogProperties() {
+        return logProperties;
+    }
+
+    private static String toUri(String path) {
+        return Paths.get(path).toUri().toString();
+    }
+}

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/container/FlinkImageBuilder.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/container/FlinkImageBuilder.java
@@ -28,10 +28,8 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.DockerClientFactory;
 import org.testcontainers.images.builder.ImageFromDockerfile;
 
-import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -51,8 +49,8 @@ import static org.apache.flink.util.Preconditions.checkState;
 public class FlinkImageBuilder {
 
     private static final Logger LOG = LoggerFactory.getLogger(FlinkImageBuilder.class);
-    private static final String FLINK_BASE_IMAGE_NAME = "flink-dist-base";
-    private static final String DEFAULT_IMAGE_NAME = "flink-dist-configured";
+    private static final String FLINK_BASE_IMAGE_BUILD_NAME = "flink-base";
+    private static final String DEFAULT_IMAGE_NAME_BUILD_PREFIX = "flink-configured";
     private static final Duration DEFAULT_TIMEOUT = Duration.ofMinutes(5);
     private static final String LOG4J_PROPERTIES_FILENAME = "log4j-console.properties";
 
@@ -60,13 +58,15 @@ public class FlinkImageBuilder {
     private final Properties logProperties = new Properties();
 
     private Path tempDirectory;
-    private String imageName = DEFAULT_IMAGE_NAME;
+    private String imageName = DEFAULT_IMAGE_NAME_BUILD_PREFIX;
     private String imageNameSuffix;
-    private Path flinkDist = FileUtils.findFlinkDist();
+    private Path flinkDist;
     private String javaVersion;
     private Configuration conf;
     private Duration timeout = DEFAULT_TIMEOUT;
     private String startupCommand;
+    private String baseImage;
+    private String flinkHome = FlinkContainersConfig.getDefaultFlinkHome();
 
     /**
      * Sets temporary path for holding temp files when building the image.
@@ -80,9 +80,20 @@ public class FlinkImageBuilder {
     }
 
     /**
+     * Sets flink home.
+     *
+     * @param flinkHome The flink home.
+     * @return The flink home.
+     */
+    public FlinkImageBuilder setFlinkHome(String flinkHome) {
+        this.flinkHome = flinkHome;
+        return this;
+    }
+
+    /**
      * Sets the name of building image.
      *
-     * <p>If the name is not specified, {@link #DEFAULT_IMAGE_NAME} will be used.
+     * <p>If the name is not specified, {@link #DEFAULT_IMAGE_NAME_BUILD_PREFIX} will be used.
      */
     public FlinkImageBuilder setImageName(String imageName) {
         this.imageName = imageName;
@@ -149,7 +160,7 @@ public class FlinkImageBuilder {
     /** Use this image for building a JobManager. */
     public FlinkImageBuilder asJobManager() {
         checkStartupCommandNotSet();
-        this.startupCommand = "flink/bin/jobmanager.sh start-foreground && tail -f /dev/null";
+        this.startupCommand = "bin/jobmanager.sh start-foreground && tail -f /dev/null";
         this.imageNameSuffix = "jobmanager";
         return this;
     }
@@ -157,7 +168,7 @@ public class FlinkImageBuilder {
     /** Use this image for building a TaskManager. */
     public FlinkImageBuilder asTaskManager() {
         checkStartupCommandNotSet();
-        this.startupCommand = "flink/bin/taskmanager.sh start-foreground && tail -f /dev/null";
+        this.startupCommand = "bin/taskmanager.sh start-foreground && tail -f /dev/null";
         this.imageNameSuffix = "taskmanager";
         return this;
     }
@@ -170,32 +181,52 @@ public class FlinkImageBuilder {
         return this;
     }
 
+    /**
+     * Sets base image.
+     *
+     * @param baseImage The base image.
+     * @return A reference to this Builder.
+     */
+    public FlinkImageBuilder setBaseImage(String baseImage) {
+        this.baseImage = baseImage;
+        return this;
+    }
+
     /** Build the image. */
     public ImageFromDockerfile build() throws ImageBuildException {
         sanityCheck();
         final String finalImageName = imageName + "-" + imageNameSuffix;
         try {
-            // Build base image first
-            buildBaseImage(flinkDist);
-            final Path flinkConfFile = createTemporaryFlinkConfFile(tempDirectory);
+            if (baseImage == null) {
+                baseImage = FLINK_BASE_IMAGE_BUILD_NAME;
+                if (flinkDist == null) {
+                    flinkDist = FileUtils.findFlinkDist();
+                }
+                // Build base image first
+                buildBaseImage(flinkDist);
+            }
+
+            final Path flinkConfFile = createTemporaryFlinkConfFile(conf, tempDirectory);
+
             final Path log4jPropertiesFile = createTemporaryLog4jPropertiesFile(tempDirectory);
             // Copy flink-conf.yaml into image
             filesToCopy.put(
                     flinkConfFile,
-                    Paths.get("flink", "conf", GlobalConfiguration.FLINK_CONF_FILENAME));
+                    Paths.get(flinkHome, "conf", GlobalConfiguration.FLINK_CONF_FILENAME));
             filesToCopy.put(
-                    log4jPropertiesFile, Paths.get("flink", "conf", LOG4J_PROPERTIES_FILENAME));
+                    log4jPropertiesFile, Paths.get(flinkHome, "conf", LOG4J_PROPERTIES_FILENAME));
 
             final ImageFromDockerfile image =
                     new ImageFromDockerfile(finalImageName)
                             .withDockerfileFromBuilder(
                                     builder -> {
                                         // Build from base image
-                                        builder.from(FLINK_BASE_IMAGE_NAME);
+                                        builder.from(baseImage);
                                         // Copy files into image
                                         filesToCopy.forEach(
                                                 (from, to) ->
                                                         builder.copy(to.toString(), to.toString()));
+                                        builder.user("1000");
                                         builder.cmd(startupCommand);
                                     });
             filesToCopy.forEach((from, to) -> image.withFileFromPath(to.toString(), from));
@@ -212,19 +243,22 @@ public class FlinkImageBuilder {
             return;
         }
         LOG.info("Building Flink base image with flink-dist at {}", flinkDist);
-        new ImageFromDockerfile(FLINK_BASE_IMAGE_NAME)
+        new ImageFromDockerfile(FLINK_BASE_IMAGE_BUILD_NAME)
                 .withDockerfileFromBuilder(
                         builder ->
                                 builder.from("openjdk:" + getJavaVersionSuffix())
-                                        .copy("flink", "flink")
+                                        .copy(flinkHome, flinkHome)
                                         .build())
-                .withFileFromPath("flink", flinkDist)
+                .withFileFromPath(flinkHome, flinkDist)
                 .get(timeout.toMillis(), TimeUnit.MILLISECONDS);
     }
 
     private boolean baseImageExists() {
         try {
-            DockerClientFactory.instance().client().inspectImageCmd(FLINK_BASE_IMAGE_NAME).exec();
+            DockerClientFactory.instance()
+                    .client()
+                    .inspectImageCmd(FLINK_BASE_IMAGE_BUILD_NAME)
+                    .exec();
             return true;
         } catch (NotFoundException e) {
             return false;
@@ -250,17 +284,8 @@ public class FlinkImageBuilder {
         }
     }
 
-    private Path createTemporaryFlinkConfFile(Path tempDirectory) throws IOException {
-        // Load flink-conf.yaml under flink-dist as a base configuration
-        final Configuration finalConfiguration =
-                GlobalConfiguration.loadConfiguration(
-                        flinkDist.resolve("conf").toAbsolutePath().toString());
-
-        // Merge user specific configurations in builder
-        if (this.conf != null) {
-            finalConfiguration.addAll(this.conf);
-        }
-
+    private Path createTemporaryFlinkConfFile(Configuration finalConfiguration, Path tempDirectory)
+            throws IOException {
         // Create a temporary flink-conf.yaml file and write merged configurations into it
         Path flinkConfFile = tempDirectory.resolve(GlobalConfiguration.FLINK_CONF_FILENAME);
         Files.write(
@@ -273,19 +298,10 @@ public class FlinkImageBuilder {
     }
 
     private Path createTemporaryLog4jPropertiesFile(Path tempDirectory) throws IOException {
-        // Load log4j-console.properties under flink-dist as base properties
-        final Path logPropertiesPath = flinkDist.resolve("conf").resolve(LOG4J_PROPERTIES_FILENAME);
-        final Properties mergedLogProperties = new Properties();
-        try (InputStream input = new FileInputStream(logPropertiesPath.toFile())) {
-            mergedLogProperties.load(input);
-            // Merge all log properties
-            mergedLogProperties.putAll(this.logProperties);
-        }
-
         // Create a temporary log4j.properties file and write merged properties into it
         Path log4jPropFile = tempDirectory.resolve(LOG4J_PROPERTIES_FILENAME);
         try (OutputStream output = new FileOutputStream(log4jPropFile.toFile())) {
-            mergedLogProperties.store(output, null);
+            logProperties.store(output, null);
         }
 
         return log4jPropFile;

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/container/FlinkImageBuilder.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/container/FlinkImageBuilder.java
@@ -58,7 +58,7 @@ public class FlinkImageBuilder {
     private final Properties logProperties = new Properties();
 
     private Path tempDirectory;
-    private String imageName = DEFAULT_IMAGE_NAME_BUILD_PREFIX;
+    private String imageNamePrefix = DEFAULT_IMAGE_NAME_BUILD_PREFIX;
     private String imageNameSuffix;
     private Path flinkDist;
     private String javaVersion;
@@ -91,12 +91,12 @@ public class FlinkImageBuilder {
     }
 
     /**
-     * Sets the name of building image.
+     * Sets the prefix name of building image.
      *
      * <p>If the name is not specified, {@link #DEFAULT_IMAGE_NAME_BUILD_PREFIX} will be used.
      */
-    public FlinkImageBuilder setImageName(String imageName) {
-        this.imageName = imageName;
+    public FlinkImageBuilder setImageNamePrefix(String imageNamePrefix) {
+        this.imageNamePrefix = imageNamePrefix;
         return this;
     }
 
@@ -195,7 +195,7 @@ public class FlinkImageBuilder {
     /** Build the image. */
     public ImageFromDockerfile build() throws ImageBuildException {
         sanityCheck();
-        final String finalImageName = imageName + "-" + imageNameSuffix;
+        final String finalImageName = imageNamePrefix + "-" + imageNameSuffix;
         try {
             if (baseImage == null) {
                 baseImage = FLINK_BASE_IMAGE_BUILD_NAME;

--- a/flink-end-to-end-tests/flink-end-to-end-tests-elasticsearch7/src/test/resources/log4j2-test.properties
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-elasticsearch7/src/test/resources/log4j2-test.properties
@@ -17,7 +17,7 @@
 ################################################################################
 # Set root logger level to OFF to not flood build logs
 # set manually to INFO for debugging purposes
-rootLogger.level=OFF
+rootLogger.level=INFO
 rootLogger.appenderRef.test.ref=TestLogger
 appender.testlogger.name=TestLogger
 appender.testlogger.type=CONSOLE

--- a/flink-end-to-end-tests/flink-end-to-end-tests-pulsar/src/test/java/org/apache/flink/tests/util/pulsar/common/FlinkContainerWithPulsarEnvironment.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-pulsar/src/test/java/org/apache/flink/tests/util/pulsar/common/FlinkContainerWithPulsarEnvironment.java
@@ -23,7 +23,7 @@ import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.tests.util.TestUtils;
-import org.apache.flink.tests.util.flink.FlinkContainerTestEnvironment;
+import org.apache.flink.tests.util.flink.container.FlinkContainerTestEnvironment;
 
 /** A Flink Container which would bundles pulsar connector in its classpath. */
 public class FlinkContainerWithPulsarEnvironment extends FlinkContainerTestEnvironment {


### PR DESCRIPTION
`FlinkImageBuilder` and `FlinkContainerBuilder` are tightly coupled with using flink-dist to create Flink images on-the-flight. A lot of configuration is "hardcoded" in those classes and cannot be controlled by the user creating the `FlinkContainerTestEnvironment`. For externalized connectors, we need the setup to also work with the existing images published to GHCR and not rely on `flink-dist`. This is a draft PR for an approach based on introducing a single configuration holder `FlinkContainersConfig` that 

- enables fine-grained control over the container properties
- refactors out hardcoded configuration
- allows test environments based on existing base images rather than on flink-dist
