### PR TITLE
[hotfix] [docs] Fix use cases for HashMapStateBackend

### DIFF
--- a/docs/content/docs/ops/state/state_backends.md
+++ b/docs/content/docs/ops/state/state_backends.md
@@ -55,7 +55,8 @@ that store the values, triggers, etc.
 
 The HashMapStateBackend is encouraged for:
 
-  - Jobs with small state, short windows, small key/value states.
+  - Jobs with not-very-large state, short windows, not-very-large key/value states.
+  - All high-availability setups.
 
 It is also recommended to set [managed memory]({{< ref "docs/deployment/memory/mem_setup_tm" >}}#managed-memory) to zero.
 This will ensure that the maximum amount of memory is allocated for user code on the JVM.


### PR DESCRIPTION
The use cases for HashMapStateBackend were a copy of the ones for EmbeddedRocksDBStateBackend