### PR TITLE
[hotfix][docs] Fix typo in comment of PojoTypeInfo

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/PojoTypeInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/PojoTypeInfo.java
@@ -46,7 +46,7 @@ import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * TypeInformation for "Java Beans"-style types. Flink refers to them as POJOs, since the conditions
- * are slightly different from Java Beans. A type is considered a FLink POJO type, if it fulfills
+ * are slightly different from Java Beans. A type is considered a Flink POJO type, if it fulfills
  * the conditions below.
  *
  * <ul>


### PR DESCRIPTION
Fix typo in the comment of PojoTypeInfo class.
