### PR TITLE
[FLINK-24960][flink-yarn-tests] fix race condition with new stdout line

### DIFF
--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionCapacitySchedulerITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionCapacitySchedulerITCase.java
@@ -306,7 +306,7 @@ class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
                                         "-Dfancy-configuration-value=veryFancy",
                                         "-D" + YarnConfigOptions.VCORES.key() + "=2"
                                     },
-                                    "JobManager Web Interface:",
+                                    "Interactive CLI started",
                                     RunTypes.YARN_SESSION);
 
                     try {

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
@@ -872,6 +872,7 @@ public class FlinkYarnSessionCli extends AbstractYarnCli {
     private static void runInteractiveCli(
             YarnApplicationStatusMonitor yarnApplicationStatusMonitor, boolean readConsoleInput) {
         try (BufferedReader in = new BufferedReader(new InputStreamReader(System.in))) {
+            System.out.println("Interactive CLI started");
             boolean continueRepl = true;
             boolean isLastStatusUnknown = true;
             long unknownStatusSince = System.nanoTime();


### PR DESCRIPTION
Alternative to #19852 to avoid a race condition (see https://issues.apache.org/jira/browse/FLINK-24960).