### PR TITLE
[FLINK-26993][tests] Wait until checkpoint was actually triggered

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
@@ -389,8 +389,13 @@ public class CheckpointCoordinatorTest extends TestLogger {
             coordinator.triggerCheckpoint(
                     true); // enqueue and later see if it gets executed in the middle of
             // receiveAcknowledgeMessage
-            while (coordinator.getNumberOfPendingCheckpoints()
-                    == 0) { // wait for at least 1 request to be fully processed
+            while (coordinator.getPendingCheckpoints().values().stream()
+                    .noneMatch(pc -> pc.getCheckpointStorageLocation() != null)) {
+                // wait for at least 1 request to be fully processed
+                // explicitly check for the checkpoint storage location to make sure
+                // that the checkpoint was actually triggered
+                // if the checkpoint wasn't triggered yet the acknowledge below
+                // will fail with an error
                 Thread.sleep(10);
             }
             coordinator.receiveAcknowledgeMessage(


### PR DESCRIPTION


## What is the purpose of the change

Backport to release-1.15 of https://github.com/apache/flink/pull/19356

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
