### PR TITLE
[FLINK-27886][pom] Fix the error way for skipping shade plugin in sub-modules

### DIFF
--- a/flink-quickstart/pom.xml
+++ b/flink-quickstart/pom.xml
@@ -61,13 +61,15 @@ under the License.
 					<skip>true</skip>
 				</configuration>
 			</plugin>
-			<!-- deactivate the shade plugin for the quickstart archetypes -->
+
+			<!-- deactivate the parent and own shade plugin for the quickstart archetypes -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
 				<executions>
 					<execution>
-						<phase/>
+						<id>shade-flink</id>
+						<phase>none</phase>
 					</execution>
 				</executions>
 			</plugin>

--- a/flink-walkthroughs/pom.xml
+++ b/flink-walkthroughs/pom.xml
@@ -61,13 +61,15 @@ under the License.
 					<skip>true</skip>
 				</configuration>
 			</plugin>
-			<!-- deactivate the shade plugin for the walkthrough archetypes -->
+
+			<!-- deactivate the parent and own shade plugin for the walkthrough archetypes -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
 				<executions>
 					<execution>
-						<phase/>
+						<id>shade-flink</id>
+						<phase>none</phase>
 					</execution>
 				</executions>
 			</plugin>


### PR DESCRIPTION
## What is the purpose of the change

Fix the error way for skipping shade plugin in sub-modules, e.g. flink-quickstart, flink-walkthroughs

## Brief change log

Fix the error way for skipping shade plugin in sub-modules

## Verifying this change

sub-modules maven build log, it's clean and without shade log. u can find it in FLINK-27886.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature?  no
- If yes, how is the feature documented? no
