### PR TITLE
[BP-1.15][FLINK-24960][yarn-tests] backport 1.15: reorder statements to fix instability with yarn properties file

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
@@ -611,10 +611,12 @@ public class FlinkYarnSessionCli extends AbstractYarnCli {
                     yarnApplicationId = clusterClient.getClusterId();
 
                     try {
+                        // Other threads use the Yarn properties file to connect to the YARN session
+                        writeYarnPropertiesFile(yarnApplicationId, dynamicPropertiesEncoded);
+
+                        // Multiple tests match on the following output
                         System.out.println(
                                 "JobManager Web Interface: " + clusterClient.getWebInterfaceURL());
-
-                        writeYarnPropertiesFile(yarnApplicationId, dynamicPropertiesEncoded);
                     } catch (Exception e) {
                         try {
                             clusterClient.close();


### PR DESCRIPTION
see https://github.com/apache/flink/pull/19852