### PR TITLE
[FLINK-27586][python] Support non-keyed co-broadcast processing

### DIFF
--- a/flink-python/dev/lint-python.sh
+++ b/flink-python/dev/lint-python.sh
@@ -304,7 +304,7 @@ function install_flake8() {
         fi
     fi
 
-    $CURRENT_DIR/install_command.sh -q flake8==3.7.9 2>&1 >/dev/null
+    $CURRENT_DIR/install_command.sh -q flake8==4.0.1 2>&1 >/dev/null
     if [ $? -ne 0 ]; then
         echo "pip install flake8 failed \
         please try to exec the script again.\

--- a/flink-python/dev/lint-python.sh
+++ b/flink-python/dev/lint-python.sh
@@ -328,7 +328,7 @@ function install_sphinx() {
         fi
     fi
 
-    $CURRENT_DIR/install_command.sh -q Sphinx==3.5.4 Docutils==0.17.1 "Jinja2<3.1.0" 2>&1 >/dev/null
+    $CURRENT_DIR/install_command.sh -q Sphinx==3.5.4 Docutils==0.16 "Jinja2<3.1.0" 2>&1 >/dev/null
     if [ $? -ne 0 ]; then
         echo "pip install sphinx failed \
         please try to exec the script again.\

--- a/flink-python/dev/lint-python.sh
+++ b/flink-python/dev/lint-python.sh
@@ -328,7 +328,7 @@ function install_sphinx() {
         fi
     fi
 
-    $CURRENT_DIR/install_command.sh -q Sphinx==2.4.4 Docutils==0.17.1 "Jinja2<3.1.0" 2>&1 >/dev/null
+    $CURRENT_DIR/install_command.sh -q Sphinx==3.5.4 Docutils==0.17.1 "Jinja2<3.1.0" 2>&1 >/dev/null
     if [ $? -ne 0 ]; then
         echo "pip install sphinx failed \
         please try to exec the script again.\

--- a/flink-python/docs/pyflink.datastream.rst
+++ b/flink-python/docs/pyflink.datastream.rst
@@ -26,12 +26,14 @@ Module contents
     :members:
     :undoc-members:
     :show-inheritance:
+    :inherited-members:
 
 pyflink.datastream.state module
 ------------------------------------
 .. automodule:: pyflink.datastream.state
     :members:
     :undoc-members:
+    :inherited-members:
 
 pyflink.datastream.connectors module
 ------------------------------------

--- a/flink-python/pyflink/datastream/__init__.py
+++ b/flink-python/pyflink/datastream/__init__.py
@@ -209,9 +209,6 @@ Other important classes:
       Tag with a name and type for identifying side output of an operator
 """
 from pyflink.datastream.checkpoint_config import CheckpointConfig, ExternalizedCheckpointCleanup
-from pyflink.datastream.checkpoint_storage import (CheckpointStorage, JobManagerCheckpointStorage,
-                                                   FileSystemCheckpointStorage,
-                                                   CustomCheckpointStorage)
 from pyflink.datastream.checkpointing_mode import CheckpointingMode
 from pyflink.datastream.data_stream import DataStream, KeyedStream, WindowedStream, \
     ConnectedStreams, DataStreamSink, BroadcastStream, BroadcastConnectedStream
@@ -222,19 +219,22 @@ from pyflink.datastream.functions import (MapFunction, CoMapFunction, FlatMapFun
                                           SinkFunction, CoProcessFunction, KeyedProcessFunction,
                                           KeyedCoProcessFunction, AggregateFunction, WindowFunction,
                                           ProcessWindowFunction, BroadcastProcessFunction)
-from pyflink.datastream.functions import ProcessFunction
-from pyflink.datastream.output_tag import OutputTag
 from pyflink.datastream.slot_sharing_group import SlotSharingGroup, MemorySize
 from pyflink.datastream.state_backend import (StateBackend, MemoryStateBackend, FsStateBackend,
                                               RocksDBStateBackend, CustomStateBackend,
                                               PredefinedOptions, HashMapStateBackend,
                                               EmbeddedRocksDBStateBackend)
+from pyflink.datastream.checkpoint_storage import (CheckpointStorage, JobManagerCheckpointStorage,
+                                                   FileSystemCheckpointStorage,
+                                                   CustomCheckpointStorage)
 from pyflink.datastream.stream_execution_environment import StreamExecutionEnvironment
 from pyflink.datastream.time_characteristic import TimeCharacteristic
 from pyflink.datastream.time_domain import TimeDomain
+from pyflink.datastream.functions import ProcessFunction
 from pyflink.datastream.timerservice import TimerService
 from pyflink.datastream.window import Window, TimeWindow, CountWindow, WindowAssigner, \
     MergingWindowAssigner, TriggerResult, Trigger, GlobalWindow
+from pyflink.datastream.output_tag import OutputTag
 
 __all__ = [
     'StreamExecutionEnvironment',

--- a/flink-python/pyflink/datastream/__init__.py
+++ b/flink-python/pyflink/datastream/__init__.py
@@ -35,6 +35,11 @@ Entry point classes of Flink DataStream API:
       Represent two connected streams of (possibly) different data types. Connected
       streams are useful for cases where operations on one stream directly affect the operations on
       the other stream, usually via shared state between the streams.
+    - :class:`BroadcastStream`:
+      Represent a stream with :class:`state.BroadcastState` (s).
+    - :class:`BroadcastConnectedStream`:
+      Represents the result of connecting a keyed or non-keyed stream, with a
+      :class:`BroadcastStream` with :class:`state.BroadcastState` (s)
 
 Functions used to transform a :class:`DataStream` into another :class:`DataStream`:
 
@@ -70,6 +75,10 @@ Functions used to transform a :class:`DataStream` into another :class:`DataStrea
       information such as the current timestamp, the watermark, etc.
     - :class:`AggregateFunction`:
       Base class for a user-defined aggregate function.
+    - :class:`BroadcastProcessFunction`:
+      A function to be applied to a :class:`BroadcastConnectedStream` that connects
+      :class:`BroadcastStream`, i.e. a stream with broadcast state, with a non-keyed
+      :class:`DataStream`.
     - :class:`RuntimeContext`:
       Contains information about the context in which functions are executed. Each
       parallel instance of the function will have a context through which it can access static
@@ -145,7 +154,7 @@ Classes for state operations:
       A type of state that can be created to store the state of a :class:`BroadcastStream`. This
       state assumes that the same elements are sent to all instances of an operator.
     - :class:`state.ReadOnlyBroadcastState`:
-      A read-only view of the :class:`BroadcastState`.
+      A read-only view of the :class:`state.BroadcastState`.
     - :class:`state.StateTtlConfig`:
       Configuration of state TTL logic.
 
@@ -200,32 +209,32 @@ Other important classes:
       Tag with a name and type for identifying side output of an operator
 """
 from pyflink.datastream.checkpoint_config import CheckpointConfig, ExternalizedCheckpointCleanup
+from pyflink.datastream.checkpoint_storage import (CheckpointStorage, JobManagerCheckpointStorage,
+                                                   FileSystemCheckpointStorage,
+                                                   CustomCheckpointStorage)
 from pyflink.datastream.checkpointing_mode import CheckpointingMode
 from pyflink.datastream.data_stream import DataStream, KeyedStream, WindowedStream, \
-    ConnectedStreams, DataStreamSink
+    ConnectedStreams, DataStreamSink, BroadcastStream, BroadcastConnectedStream
 from pyflink.datastream.execution_mode import RuntimeExecutionMode
 from pyflink.datastream.functions import (MapFunction, CoMapFunction, FlatMapFunction,
                                           CoFlatMapFunction, ReduceFunction, RuntimeContext,
                                           KeySelector, FilterFunction, Partitioner, SourceFunction,
                                           SinkFunction, CoProcessFunction, KeyedProcessFunction,
                                           KeyedCoProcessFunction, AggregateFunction, WindowFunction,
-                                          ProcessWindowFunction)
+                                          ProcessWindowFunction, BroadcastProcessFunction)
+from pyflink.datastream.functions import ProcessFunction
+from pyflink.datastream.output_tag import OutputTag
 from pyflink.datastream.slot_sharing_group import SlotSharingGroup, MemorySize
 from pyflink.datastream.state_backend import (StateBackend, MemoryStateBackend, FsStateBackend,
                                               RocksDBStateBackend, CustomStateBackend,
                                               PredefinedOptions, HashMapStateBackend,
                                               EmbeddedRocksDBStateBackend)
-from pyflink.datastream.checkpoint_storage import (CheckpointStorage, JobManagerCheckpointStorage,
-                                                   FileSystemCheckpointStorage,
-                                                   CustomCheckpointStorage)
 from pyflink.datastream.stream_execution_environment import StreamExecutionEnvironment
 from pyflink.datastream.time_characteristic import TimeCharacteristic
 from pyflink.datastream.time_domain import TimeDomain
-from pyflink.datastream.functions import ProcessFunction
 from pyflink.datastream.timerservice import TimerService
 from pyflink.datastream.window import Window, TimeWindow, CountWindow, WindowAssigner, \
     MergingWindowAssigner, TriggerResult, Trigger, GlobalWindow
-from pyflink.datastream.output_tag import OutputTag
 
 __all__ = [
     'StreamExecutionEnvironment',
@@ -233,6 +242,8 @@ __all__ = [
     'KeyedStream',
     'WindowedStream',
     'ConnectedStreams',
+    'BroadcastStream',
+    'BroadcastConnectedStream',
     'DataStreamSink',
     'MapFunction',
     'CoMapFunction',
@@ -247,6 +258,7 @@ __all__ = [
     'WindowFunction',
     'ProcessWindowFunction',
     'AggregateFunction',
+    'BroadcastProcessFunction',
     'RuntimeContext',
     'TimerService',
     'CheckpointingMode',

--- a/flink-python/pyflink/datastream/data_stream.py
+++ b/flink-python/pyflink/datastream/data_stream.py
@@ -585,7 +585,7 @@ class DataStream(object):
         pass
 
     @overload
-    def broadcast(self, *args) -> 'BroadcastStream':
+    def broadcast(self, *broadcast_state_descriptors: MapStateDescriptor) -> 'BroadcastStream':
         pass
 
     def broadcast(self, *args):
@@ -1619,6 +1619,21 @@ class KeyedStream(DataStream):
     def union(self, *streams) -> 'DataStream':
         return self._values().union(*streams)
 
+    @overload
+    def connect(self, ds: 'DataStream') -> 'ConnectedStreams':
+        pass
+
+    def connect(self, ds):
+        """
+        If ds is a :class:`DataStream`, creates a new :class:`ConnectedStreams` by connecting
+        DataStream outputs of (possible) different types with each other. The DataStreams connected
+        using this operator can be used with CoFunctions to apply joint transformations.
+
+        :param ds: The DataStream with which this stream will be connected.
+        :return: The ConnectedStreams.
+        """
+        return super().connect(ds)
+
     def shuffle(self) -> 'DataStream':
         raise Exception('Cannot override partitioning for KeyedStream.')
 
@@ -1635,6 +1650,9 @@ class KeyedStream(DataStream):
         raise Exception('Cannot override partitioning for KeyedStream.')
 
     def broadcast(self, *args):
+        """
+        Not supported, partitioning for KeyedStream cannot be overridden.
+        """
         raise Exception('Cannot override partitioning for KeyedStream.')
 
     def partition_custom(self, partitioner: Union[Callable, Partitioner],

--- a/flink-python/pyflink/datastream/data_stream.py
+++ b/flink-python/pyflink/datastream/data_stream.py
@@ -18,6 +18,7 @@
 import typing
 import uuid
 from enum import Enum
+from py4j.java_collections import ListConverter
 from typing import Callable, Union, List, cast, Optional
 
 from pyflink.common import typeinfo, ExecutionConfig, Row
@@ -39,11 +40,12 @@ from pyflink.datastream.functions import (_get_python_env, FlatMapFunction, MapF
                                           NullByteKeySelector, AllWindowFunction,
                                           InternalIterableAllWindowFunction,
                                           ProcessAllWindowFunction,
-                                          InternalIterableProcessAllWindowFunction)
+                                          InternalIterableProcessAllWindowFunction,
+                                          BroadcastProcessFunction)
 from pyflink.datastream.output_tag import OutputTag
 from pyflink.datastream.slot_sharing_group import SlotSharingGroup
 from pyflink.datastream.state import ValueStateDescriptor, ValueState, ListStateDescriptor, \
-    StateDescriptor, ReducingStateDescriptor, AggregatingStateDescriptor
+    StateDescriptor, ReducingStateDescriptor, AggregatingStateDescriptor, MapStateDescriptor
 from pyflink.datastream.utils import convert_to_python_obj
 from pyflink.datastream.window import (CountTumblingWindowAssigner, CountSlidingWindowAssigner,
                                        CountWindowSerializer, TimeWindowSerializer, Trigger,
@@ -52,7 +54,7 @@ from pyflink.datastream.window import (CountTumblingWindowAssigner, CountSliding
 from pyflink.java_gateway import get_gateway
 
 __all__ = ['CloseableIterator', 'DataStream', 'KeyedStream', 'ConnectedStreams', 'WindowedStream',
-           'DataStreamSink', 'CloseableIterator']
+           'DataStreamSink', 'CloseableIterator', 'BroadcastStream', 'BroadcastConnectedStream']
 
 WINDOW_STATE_NAME = 'window-contents'
 
@@ -484,15 +486,25 @@ class DataStream(object):
         j_united_stream = self._j_data_stream.union(j_data_stream_arr)
         return DataStream(j_data_stream=j_united_stream)
 
-    def connect(self, ds: 'DataStream') -> 'ConnectedStreams':
+    def connect(
+        self, ds: Union["DataStream", "BroadcastStream"]
+    ) -> Union["ConnectedStreams", "BroadcastConnectedStream"]:
         """
-        Creates a new 'ConnectedStreams' by connecting 'DataStream' outputs of (possible)
-        different types with each other. The DataStreams connected using this operator can
-        be used with CoFunctions to apply joint transformations.
+        If ds is a :class:`DataStream`, creates a new :class:`ConnectedStreams` by connecting
+        DataStream outputs of (possible) different types with each other. The DataStreams connected
+        using this operator can be used with CoFunctions to apply joint transformations.
+        If ds is a :class:`BroadcastStream`, creates a new :class:`BroadcastConnectedStream` by
+        connecting the current :class:`DataStream` with a :class:`BroadcastStream`. The latter can
+        be created using the :meth:`broadcast` method. The resulting stream can be further processed
+        using the :meth:`BroadcastConnectedStream.process` method.
 
-        :param ds: The DataStream with which this stream will be connected.
-        :return: The `ConnectedStreams`.
+        :param ds: The DataStream or BroadcastStream with which this stream will be connected.
+        :return: The ConnectedStreams or BroadcastConnectedStream.
         """
+        if isinstance(ds, BroadcastStream):
+            return BroadcastConnectedStream(
+                self, ds, cast(BroadcastStream, ds).broadcast_state_descriptors
+            )
         return ConnectedStreams(self, ds)
 
     def shuffle(self) -> 'DataStream':
@@ -561,13 +573,33 @@ class DataStream(object):
         """
         return DataStream(self._j_data_stream.forward())
 
-    def broadcast(self) -> 'DataStream':
+    def broadcast(self, *args) -> Union["DataStream", "BroadcastStream"]:
         """
         Sets the partitioning of the DataStream so that the output elements are broadcasted to every
         parallel instance of the next operation.
+        If :class:`~state.MapStateDescriptor` (s) are passed in, it returns a
+        :class:`BroadcastStream` with :class:`~state.BroadcastState` (s) implicitly created as the
+        descriptors specified.
 
-        :return: The DataStream with broadcast partitioning set.
+        Example:
+        ::
+
+            >>> map_state_desc1 = MapStateDescriptor("state1", Types.INT(), Types.INT())
+            >>> map_state_desc2 = MapStateDescriptor("state2", Types.INT(), Types.STRING())
+            >>> broadcast_stream = ds1.broadcast(map_state_desc1, map_state_desc2)
+            >>> broadcast_connected_stream = ds2.connect(broadcast_stream)
+
+        :param args: optionally to be a list of MapStateDescriptors describing BroadcastStates.
+        :return: The DataStream with broadcast partitioning set or a BroadcastStream which can be
+            used in :meth:`connect` to create a BroadcastConnectedStream for further processing of
+            the elements.
         """
+        if args:
+            for arg in args:
+                if not isinstance(arg, MapStateDescriptor):
+                    raise TypeError("broadcast_state_descriptor must be MapStateDescriptor")
+            broadcast_state_descriptors = [arg for arg in args]  # type: List[MapStateDescriptor]
+            return BroadcastStream(cast(DataStream, self.broadcast()), broadcast_state_descriptors)
         return DataStream(self._j_data_stream.broadcast())
 
     def process(self, func: ProcessFunction, output_type: TypeInformation = None) -> 'DataStream':
@@ -1586,7 +1618,7 @@ class KeyedStream(DataStream):
     def forward(self) -> 'DataStream':
         raise Exception('Cannot override partitioning for KeyedStream.')
 
-    def broadcast(self) -> 'DataStream':
+    def broadcast(self, *args) -> Union['DataStream', 'BroadcastStream']:
         raise Exception('Cannot override partitioning for KeyedStream.')
 
     def partition_custom(self, partitioner: Union[Callable, Partitioner],
@@ -2277,6 +2309,130 @@ class ConnectedStreams(object):
         return isinstance(self.stream1, KeyedStream) and isinstance(self.stream2, KeyedStream)
 
 
+class BroadcastStream(object):
+    """
+    A BroadcastStream is a stream with :class:`state.BroadcastState` (s). This can be created by any
+    stream using the :meth:`DataStream.broadcast` method and implicitly creates states where the
+    user can store elements of the created :class:`BroadcastStream`. (see
+    :class:`BroadcastConnectedStream`).
+    Note that no further operation can be applied to these streams. The only available option is
+    to connect them with a keyed or non-keyed stream, using the :meth:`KeyedStream.connect` and the
+    :meth:`DataStream.connect` respectively. Applying these methods will result it a
+    :class:`BroadcastConnectedStream` for further processing.
+    """
+
+    def __init__(
+        self,
+        input_stream: "DataStream",
+        broadcast_state_descriptors: List[MapStateDescriptor],
+    ):
+        self.input_stream = input_stream
+        self.broadcast_state_descriptors = broadcast_state_descriptors
+
+
+class BroadcastConnectedStream(object):
+    """
+    A BroadcastConnectedStream represents the result of connecting a keyed or non-keyed stream, with
+    a :class:`BroadcastStream` with :class:`~state.BroadcastState` (s). As in the case of
+    :class:`ConnectedStreams` these streams are useful for cases where operations on one stream
+    directly affect the operations on the other stream, usually via shared state between the
+    streams.
+    An example for the use of such connected streams would be to apply rules that change over time
+    onto another, possibly keyed stream. The stream with the broadcast state has the rules, and will
+    store them in the broadcast state, while the other stream will contain the elements to apply the
+    rules to. By broadcasting the rules, these will be available in all parallel instances, and can
+    be applied to all partitions of the other stream.
+    """
+
+    def __init__(
+        self,
+        non_broadcast_stream: "DataStream",
+        broadcast_stream: "BroadcastStream",
+        broadcast_state_descriptors: List[MapStateDescriptor],
+    ):
+        self.non_broadcast_stream = non_broadcast_stream
+        self.broadcast_stream = broadcast_stream
+        self.broadcast_state_descriptors = broadcast_state_descriptors
+
+    def process(
+        self,
+        func: BroadcastProcessFunction,
+        output_type: TypeInformation = None,
+    ) -> "DataStream":
+        """
+        Assumes as inputs a :class:`BroadcastStream` and a :class:`DataStream` or
+        :class:`KeyedStream` and applies the given :class:`BroadcastProcessFunction` or on them,
+        thereby creating a transformed output stream.
+
+        :param func: The :class:`BroadcastProcessFunction` that is called for each element in the
+            stream.
+        :param output_type: The type of the output elements, should be
+            :class:`common.TypeInformation` or list (implicit :class:`RowTypeInfo`) or None (
+            implicit :meth:`Types.PICKLED_BYTE_ARRAY`).
+        :return: The transformed :class:`DataStream`.
+        """
+        if isinstance(func, BroadcastProcessFunction) and self._is_keyed_stream():
+            raise TypeError("BroadcastProcessFunction should be applied to non-keyed DataStream")
+
+        j_input_transformation1 = self.non_broadcast_stream._j_data_stream.getTransformation()
+        j_input_transformation2 = (
+            self.broadcast_stream.input_stream._j_data_stream.getTransformation()
+        )
+
+        if output_type is None:
+            output_type_info = Types.PICKLED_BYTE_ARRAY()  # type: TypeInformation
+        elif isinstance(output_type, list):
+            output_type_info = RowTypeInfo(output_type)
+        elif isinstance(output_type, TypeInformation):
+            output_type_info = output_type
+        else:
+            raise TypeError("output_type must be None, list or TypeInformation")
+        j_output_type = output_type_info.get_java_type_info()
+
+        from pyflink.fn_execution.flink_fn_execution_pb2 import UserDefinedDataStreamFunction
+
+        func_type = UserDefinedDataStreamFunction.CO_BROADCAST_PROCESS  # type: ignore
+        func_name = "Co-Process-Broadcast"
+
+        gateway = get_gateway()
+        JPythonBroadcastStateTransformation = (
+            gateway.jvm.org.apache.flink.streaming.api.transformations.python
+        ).PythonBroadcastStateTransformation
+        j_state_names = ListConverter().convert(
+            [i.get_name() for i in self.broadcast_state_descriptors], gateway._gateway_client
+        )
+        j_state_descriptors = (
+            JPythonBroadcastStateTransformation.convertStateNamesToStateDescriptors(j_state_names)
+        )
+
+        j_conf = gateway.jvm.org.apache.flink.configuration.Configuration()
+        j_data_stream_python_function_info = _create_j_data_stream_python_function_info(
+            func, func_type
+        )
+        j_env = (
+            self.non_broadcast_stream.get_execution_environment()._j_stream_execution_environment
+        )
+
+        j_transformation = JPythonBroadcastStateTransformation(
+            func_name,
+            j_conf,
+            j_data_stream_python_function_info,
+            j_input_transformation1,
+            j_input_transformation2,
+            j_state_descriptors,
+            j_output_type,
+            j_env.getParallelism(),
+        )
+        j_env.addOperator(j_transformation)
+        JPythonConfigUtil = gateway.jvm.org.apache.flink.python.util.PythonConfigUtil
+        j_data_stream = JPythonConfigUtil.createSingleOutputStreamOperator(j_env, j_transformation)
+
+        return DataStream(j_data_stream)
+
+    def _is_keyed_stream(self):
+        return isinstance(self.non_broadcast_stream, KeyedStream)
+
+
 def _get_one_input_stream_operator(data_stream: DataStream,
                                    func: Union[Function,
                                                FunctionWrapper,
@@ -2293,8 +2449,7 @@ def _get_one_input_stream_operator(data_stream: DataStream,
     """
 
     gateway = get_gateway()
-    import cloudpickle
-    serialized_func = cloudpickle.dumps(func)
+
     j_input_types = data_stream._j_data_stream.getTransformation().getOutputType()
     if output_type is None:
         output_type_info = Types.PICKLED_BYTE_ARRAY()  # type: TypeInformation
@@ -2303,15 +2458,8 @@ def _get_one_input_stream_operator(data_stream: DataStream,
     else:
         output_type_info = output_type
 
+    j_data_stream_python_function_info = _create_j_data_stream_python_function_info(func, func_type)
     j_output_type_info = output_type_info.get_java_type_info()
-
-    j_data_stream_python_function = gateway.jvm.DataStreamPythonFunction(
-        bytearray(serialized_func),
-        _get_python_env())
-    j_data_stream_python_function_info = gateway.jvm.DataStreamPythonFunctionInfo(
-        j_data_stream_python_function,
-        func_type)
-
     j_conf = gateway.jvm.org.apache.flink.configuration.Configuration()
 
     from pyflink.fn_execution.flink_fn_execution_pb2 import UserDefinedDataStreamFunction
@@ -2365,10 +2513,7 @@ def _get_two_input_stream_operator(connected_streams: ConnectedStreams,
     :param type_info: the data type of the function output data.
     :return: A Java operator which is responsible for execution user defined python function.
     """
-
     gateway = get_gateway()
-    import cloudpickle
-    serialized_func = cloudpickle.dumps(func)
 
     j_input_types1 = connected_streams.stream1._j_data_stream.getTransformation().getOutputType()
     j_input_types2 = connected_streams.stream2._j_data_stream.getTransformation().getOutputType()
@@ -2380,14 +2525,9 @@ def _get_two_input_stream_operator(connected_streams: ConnectedStreams,
     else:
         output_type_info = type_info
 
+    j_data_stream_python_function_info = _create_j_data_stream_python_function_info(func, func_type)
     j_output_type_info = output_type_info.get_java_type_info()
-
-    j_data_stream_python_function = gateway.jvm.DataStreamPythonFunction(
-        bytearray(serialized_func),
-        _get_python_env())
-    j_data_stream_python_function_info = gateway.jvm.DataStreamPythonFunctionInfo(
-        j_data_stream_python_function,
-        func_type)
+    j_conf = gateway.jvm.org.apache.flink.configuration.Configuration()
 
     from pyflink.fn_execution.flink_fn_execution_pb2 import UserDefinedDataStreamFunction
     if func_type == UserDefinedDataStreamFunction.CO_PROCESS:  # type: ignore
@@ -2397,8 +2537,6 @@ def _get_two_input_stream_operator(connected_streams: ConnectedStreams,
     else:
         raise TypeError("Unsupported function type: %s" % func_type)
 
-    j_conf = gateway.jvm.org.apache.flink.configuration.Configuration()
-
     j_python_data_stream_function_operator = JTwoInputPythonFunctionOperator(
         j_conf,
         j_data_stream_python_function_info,
@@ -2407,6 +2545,20 @@ def _get_two_input_stream_operator(connected_streams: ConnectedStreams,
         j_output_type_info)
 
     return j_python_data_stream_function_operator, j_output_type_info
+
+
+def _create_j_data_stream_python_function_info(
+    func: Union[Function, FunctionWrapper, WindowOperationDescriptor], func_type: int
+) -> bytes:
+    gateway = get_gateway()
+
+    import cloudpickle
+    serialized_func = cloudpickle.dumps(func)
+
+    j_data_stream_python_function = gateway.jvm.DataStreamPythonFunction(
+        bytearray(serialized_func), _get_python_env()
+    )
+    return gateway.jvm.DataStreamPythonFunctionInfo(j_data_stream_python_function, func_type)
 
 
 class CloseableIterator(object):

--- a/flink-python/pyflink/datastream/functions.py
+++ b/flink-python/pyflink/datastream/functions.py
@@ -124,22 +124,6 @@ class KeyedStateStore(ABC):
         pass
 
 
-class OperatorStateStore(ABC):
-    """
-    Interface for getting operator states. Currently, only :class:`~state.BroadcastState` is
-    supported.
-    .. versionadded:: 1.16.0
-    """
-
-    @abstractmethod
-    def get_broadcast_state(self, state_descriptor: MapStateDescriptor) -> BroadcastState:
-        """
-        Fetches the :class:`~state.BroadcastState` described by :class:`~state.MapStateDescriptor`,
-        which has read/write access to the broadcast operator state.
-        """
-        pass
-
-
 class RuntimeContext(KeyedStateStore):
     """
     A RuntimeContext contains information about the context in which functions are executed.

--- a/flink-python/pyflink/datastream/functions.py
+++ b/flink-python/pyflink/datastream/functions.py
@@ -22,7 +22,7 @@ from typing import Union, Any, Generic, TypeVar, Iterable
 
 from pyflink.datastream.state import ValueState, ValueStateDescriptor, ListStateDescriptor, \
     ListState, MapStateDescriptor, MapState, ReducingStateDescriptor, ReducingState, \
-    AggregatingStateDescriptor, AggregatingState
+    AggregatingStateDescriptor, AggregatingState, BroadcastState, ReadOnlyBroadcastState
 from pyflink.datastream.time_domain import TimeDomain
 from pyflink.datastream.timerservice import TimerService
 from pyflink.java_gateway import get_gateway
@@ -116,6 +116,40 @@ class KeyedStateStore(ABC):
         aggregates values with different types.
 
         This state is only accessible if the function is executed on a KeyedStream.
+        """
+        pass
+
+
+class OperatorStateStore(ABC):
+    """
+    Interface for getting operator states. Currently, only :class:`~state.BroadcastState` is
+    supported.
+    .. versionadded:: 1.16.0
+    """
+
+    @abstractmethod
+    def get_broadcast_state(self, state_descriptor: MapStateDescriptor) -> BroadcastState:
+        """
+        Fetches the :class:`~state.BroadcastState` described by :class:`~state.MapStateDescriptor`,
+        which has read/write access to the broadcast operator state.
+        """
+        pass
+
+    @abstractmethod
+    def get_read_only_broadcast_state(
+        self, state_descriptor: MapStateDescriptor
+    ) -> ReadOnlyBroadcastState:
+        """
+        Fetches the :class:`~state.ReadOnlyBroadcastState` described by
+        :class:`~state.MapStateDescriptor`, which only has read access to the broadcast operator
+        state.
+        """
+        pass
+
+    @abstractmethod
+    def commit(self):
+        """
+        Commits all cached broadcast states at Python side to Java side.
         """
         pass
 

--- a/flink-python/pyflink/datastream/functions.py
+++ b/flink-python/pyflink/datastream/functions.py
@@ -22,7 +22,7 @@ from typing import Union, Any, Generic, TypeVar, Iterable
 
 from pyflink.datastream.state import ValueState, ValueStateDescriptor, ListStateDescriptor, \
     ListState, MapStateDescriptor, MapState, ReducingStateDescriptor, ReducingState, \
-    AggregatingStateDescriptor, AggregatingState, BroadcastState, ReadOnlyBroadcastState
+    AggregatingStateDescriptor, AggregatingState, BroadcastState
 from pyflink.datastream.time_domain import TimeDomain
 from pyflink.datastream.timerservice import TimerService
 from pyflink.java_gateway import get_gateway
@@ -132,24 +132,6 @@ class OperatorStateStore(ABC):
         """
         Fetches the :class:`~state.BroadcastState` described by :class:`~state.MapStateDescriptor`,
         which has read/write access to the broadcast operator state.
-        """
-        pass
-
-    @abstractmethod
-    def get_read_only_broadcast_state(
-        self, state_descriptor: MapStateDescriptor
-    ) -> ReadOnlyBroadcastState:
-        """
-        Fetches the :class:`~state.ReadOnlyBroadcastState` described by
-        :class:`~state.MapStateDescriptor`, which only has read access to the broadcast operator
-        state.
-        """
-        pass
-
-    @abstractmethod
-    def commit(self):
-        """
-        Commits all cached broadcast states at Python side to Java side.
         """
         pass
 

--- a/flink-python/pyflink/datastream/functions.py
+++ b/flink-python/pyflink/datastream/functions.py
@@ -22,7 +22,7 @@ from typing import Union, Any, Generic, TypeVar, Iterable
 
 from pyflink.datastream.state import ValueState, ValueStateDescriptor, ListStateDescriptor, \
     ListState, MapStateDescriptor, MapState, ReducingStateDescriptor, ReducingState, \
-    AggregatingStateDescriptor, AggregatingState, BroadcastState
+    AggregatingStateDescriptor, AggregatingState, BroadcastState, ReadOnlyBroadcastState
 from pyflink.datastream.time_domain import TimeDomain
 from pyflink.datastream.timerservice import TimerService
 from pyflink.java_gateway import get_gateway
@@ -49,12 +49,16 @@ __all__ = [
     'WindowFunction',
     'AllWindowFunction',
     'ProcessWindowFunction',
-    'ProcessAllWindowFunction']
+    'ProcessAllWindowFunction',
+    'BroadcastProcessFunction',
+]
 
 
 W = TypeVar('W')
 W2 = TypeVar('W2')
 IN = TypeVar('IN')
+IN1 = TypeVar('IN1')
+IN2 = TypeVar('IN2')
 OUT = TypeVar('OUT')
 KEY = TypeVar('KEY')
 
@@ -1283,6 +1287,143 @@ class InternalIterableProcessWindowFunction(InternalWindowFunction[Iterable[IN],
         self._internal_context._window = window
         self._internal_context._underlying = context
         self._wrapped_function.clear(self._internal_context)
+
+
+class BaseBroadcastProcessFunction(Function):
+    """
+    The base class containing the functionality available to all broadcast process function. These
+    include the :class:`BroadcastProcessFunction`.
+    """
+
+    class BaseContext(ABC):
+        """
+        The base context available to all methods in a broadcast process function. This include
+        :class:`BroadcastProcessFunction`.
+        """
+
+        @abstractmethod
+        def timestamp(self) -> int:
+            """
+            Timestamp of the element currently being processed or timestamp of a firing timer.
+            This might be None, for example if the time characteristic of your program is
+            set to :attr:`TimeCharacteristic.ProcessingTime`.
+            """
+            pass
+
+        @abstractmethod
+        def current_processing_time(self) -> int:
+            """Returns the current processing time."""
+            pass
+
+        @abstractmethod
+        def current_watermark(self) -> int:
+            """Returns the current watermark."""
+            pass
+
+    class Context(BaseContext):
+        """
+        A base :class`BaseContext` available to the broadcasted stream side of a
+        :class:`BroadcastConnectedStream`.
+        Apart from the basic functionality of a :class:`BaseContext`, this also allows to get and
+        update the elements stored in the :class:`BroadcastState`. In other words, it gives read/
+        write access to the broadcast state.
+        """
+
+        @abstractmethod
+        def get_broadcast_state(self, state_descriptor: MapStateDescriptor) -> BroadcastState:
+            """
+            Fetches the :class:`BroadcastState` with the specified name.
+            :param state_descriptor: the :class:`MapStateDescriptor` of the state to be fetched.
+            :return: The required :class:`BroadcastState`.
+            """
+            pass
+
+    class ReadOnlyContext(BaseContext):
+        """
+        A :class:`BaseContext` available to the non-broadcasted stream side of a
+        :class:`BroadcastConnectedStream`.
+        Apart from the basic functionality of a :class:`BaseContext`, this also allows to get
+        read-only access to the elements stored in the broadcast state.
+        """
+
+        @abstractmethod
+        def get_broadcast_state(
+            self, state_descriptor: MapStateDescriptor
+        ) -> ReadOnlyBroadcastState:
+            """
+            Fetches a read-only view of the broadcast state with the specified name.
+            :param state_descriptor: the class:`MapStateDescriptor` of the state to be fetched.
+            :return: The required read-only view of the broadcast state.
+            """
+            pass
+
+
+class BroadcastProcessFunction(BaseBroadcastProcessFunction, Generic[IN1, IN2, OUT]):
+    """
+    A function to be applied to a :class:`BroadcastConnectedStream` that connects
+    :class:`BroadcastStream`, i.e. a stream with broadcast state, with a non-keyed
+    :class:`DataStream`.
+
+    The stream with the broadcast state can be created using the :meth:`DataStream.broadcast`
+    method.
+
+    The user has to implement two methods:
+    * the :meth:`process_broadcast_element` which will be applied to each element in the broadcast
+    side
+    * the :meth:`process_element` which will be applied to the non-broadcasted/keyed side.
+
+    The :meth:`process_broadcast_element` takes as argument (among others) a context that allows it
+    to read/write to the broadcast state, while the :meth:`process_element` has read-only access to
+    the broadcast state.
+
+    .. versionadded:: 1.16.0
+    """
+
+    class Context(BaseBroadcastProcessFunction.Context, ABC):
+        """
+        A :class:`BaseBroadcastProcessFunction.Context` available to the broadcast side of a
+        :class:`BroadcastConnectedStream`.
+        """
+        pass
+
+    class ReadOnlyContext(BaseBroadcastProcessFunction.ReadOnlyContext, ABC):
+        """
+        A :class:`BaseBroadcastProcessFunction.Context` available to the non-keyed side of a
+        :class:`BroadcastConnectedStream` (if any).
+        """
+        pass
+
+    @abstractmethod
+    def process_element(self, value: IN1, ctx: ReadOnlyContext):
+        """
+        This method is called for each element in the (non-broadcast) :class:`DataStream`.
+        This function can output zero or more elements via :code:`yield` statement, query the
+        current processing/event time, and also query and update the local keyed state. Finally, it
+        has read-only access to the broadcast state. The context is only valid during the invocation
+        of this method, do not store it.
+
+        :param value: The stream element.
+        :param ctx: A :class:`ReadOnlyContext` that allows querying the timestamp of the element,
+            querying the current processing/event time and updating the broadcast state. The context
+            is only valid during the invocation of this method, do not store it.
+        """
+        pass
+
+    @abstractmethod
+    def process_broadcast_element(self, value: IN2, ctx: Context):
+        """
+        This method is called for each element in the :class:`BroadcastStream`.
+        This function can output zero or more elements via :code:`yield` statement, query the
+        current processing/event time, and also query and update the internal
+        :class:`BroadcastState`. These can be done through the provided :class:`Context`. The
+        context is only valid during the invocation of this method, do not store it.
+
+        :param value: The stream element.
+        :param ctx: A :class:`Context` that allows querying the timestamp of the element, querying
+            the current processing/event time and updating the broadcast state. The context is only
+            valid during the invocation of this method, do not store it.
+        """
+        pass
 
 
 class InternalIterableProcessAllWindowFunction(InternalWindowFunction[Iterable[IN], OUT, int, W]):

--- a/flink-python/pyflink/datastream/tests/test_data_stream.py
+++ b/flink-python/pyflink/datastream/tests/test_data_stream.py
@@ -19,6 +19,8 @@ import datetime
 import decimal
 import os
 import uuid
+from collections import defaultdict
+from typing import Tuple
 
 from pyflink.common import Row, Configuration
 from pyflink.common.time import Time
@@ -29,7 +31,8 @@ from pyflink.datastream.data_stream import DataStream
 from pyflink.datastream.functions import (AggregateFunction, CoMapFunction, CoFlatMapFunction,
                                           MapFunction, FilterFunction, FlatMapFunction,
                                           KeyedCoProcessFunction, KeyedProcessFunction, KeySelector,
-                                          ProcessFunction, ReduceFunction, CoProcessFunction)
+                                          ProcessFunction, ReduceFunction, CoProcessFunction,
+                                          BroadcastProcessFunction)
 from pyflink.datastream.output_tag import OutputTag
 from pyflink.datastream.state import (ValueStateDescriptor, ListStateDescriptor, MapStateDescriptor,
                                       ReducingStateDescriptor, ReducingState, AggregatingState,
@@ -938,6 +941,47 @@ class DataStreamTests(object):
         self.assert_equals_sorted(main_expected, main_sink.get_results())
         side_expected = ['1', '1', '2', '2', '3', '3', '4', '4']
         self.assert_equals_sorted(side_expected, side_sink.get_results())
+
+    def test_co_broadcast_process(self):
+        self.env.set_parallelism(1)
+        ds = self.env.from_collection([1, 2, 3, 4, 5], type_info=Types.INT())  # type: DataStream
+        ds_broadcast = self.env.from_collection(
+            [(0, "a"), (1, "b")], type_info=Types.TUPLE([Types.INT(), Types.STRING()])
+        )  # type: DataStream
+
+        class MyBroadcastProcessFunction(BroadcastProcessFunction):
+            def __init__(self, map_state_desc):
+                self._map_state_desc = map_state_desc
+                self._cache = defaultdict(list)
+
+            def process_element(self, value: int, ctx: BroadcastProcessFunction.ReadOnlyContext):
+                ro_broadcast_state = ctx.get_broadcast_state(self._map_state_desc)
+                key = value % 2
+                if ro_broadcast_state.contains(key):
+                    if self._cache.get(key) is not None:
+                        for v in self._cache[key]:
+                            yield ro_broadcast_state.get(key) + str(v)
+                        self._cache[key].clear()
+                    yield ro_broadcast_state.get(key) + str(value)
+                else:
+                    self._cache[key].append(value)
+
+            def process_broadcast_element(
+                self, value: Tuple[int, str], ctx: BroadcastProcessFunction.Context
+            ):
+                broadcast_state = ctx.get_broadcast_state(self._map_state_desc)
+                broadcast_state.put(value[0], value[1])
+
+        map_state_desc = MapStateDescriptor(
+            "mapping", key_type_info=Types.INT(), value_type_info=Types.STRING()
+        )
+        ds.connect(ds_broadcast.broadcast(map_state_desc)).process(
+            MyBroadcastProcessFunction(map_state_desc), output_type=Types.STRING()
+        ).add_sink(self.test_sink)
+
+        self.env.execute("test_co_broadcast_process")
+        expected = ["a2", "a4", "b1", "b3", "b5"]
+        self.assert_equals_sorted(expected, self.test_sink.get_results())
 
 
 class StreamingModeDataStreamTests(DataStreamTests, PyFlinkStreamingTestCase):

--- a/flink-python/pyflink/datastream/tests/test_data_stream.py
+++ b/flink-python/pyflink/datastream/tests/test_data_stream.py
@@ -943,7 +943,6 @@ class DataStreamTests(object):
         self.assert_equals_sorted(side_expected, side_sink.get_results())
 
     def test_co_broadcast_process(self):
-        self.env.set_parallelism(1)
         ds = self.env.from_collection([1, 2, 3, 4, 5], type_info=Types.INT())  # type: DataStream
         ds_broadcast = self.env.from_collection(
             [(0, "a"), (1, "b")], type_info=Types.TUPLE([Types.INT(), Types.STRING()])

--- a/flink-python/pyflink/fn_execution/beam/beam_operations.py
+++ b/flink-python/pyflink/fn_execution/beam/beam_operations.py
@@ -24,7 +24,8 @@ from apache_beam.utils import proto_utils
 from pyflink.fn_execution import flink_fn_execution_pb2
 from pyflink.fn_execution.coders import from_proto, from_type_info_proto, TimeWindowCoder, \
     CountWindowCoder, FlattenRowCoder
-from pyflink.fn_execution.state_impl import RemoteKeyedStateBackend
+from pyflink.fn_execution.state_impl import RemoteKeyedStateBackend, RemoteOperatorStateBackend, \
+    UnsupportedOperatorStateBackend
 
 import pyflink.fn_execution.datastream.operations as datastream_operations
 import pyflink.fn_execution.table.operations as table_operations
@@ -152,8 +153,18 @@ def _create_user_defined_function_operation(factory, transform_proto, consumers,
         side_inputs=None,
         output_coders=[output_coders[tag] for tag in output_tags])
     name = common.NameContext(transform_proto.unique_name)
-
     serialized_fn = spec.serialized_fn
+
+    if isinstance(serialized_fn, flink_fn_execution_pb2.UserDefinedDataStreamFunction):
+        operator_state_backend = RemoteOperatorStateBackend(
+            factory.state_handler,
+            serialized_fn.state_cache_size,
+            serialized_fn.map_state_read_cache_size,
+            serialized_fn.map_state_write_cache_size,
+        )
+    else:
+        operator_state_backend = UnsupportedOperatorStateBackend()
+
     if hasattr(serialized_fn, "key_type"):
         # keyed operation, need to create the KeyedStateBackend.
         row_schema = serialized_fn.key_type.row_schema
@@ -180,7 +191,9 @@ def _create_user_defined_function_operation(factory, transform_proto, consumers,
             factory.state_sampler,
             consumers,
             internal_operation_cls,
-            keyed_state_backend)
+            keyed_state_backend,
+            operator_state_backend,
+        )
     elif internal_operation_cls == datastream_operations.StatefulOperation:
         key_row_coder = from_type_info_proto(serialized_fn.key_type_info)
         keyed_state_backend = RemoteKeyedStateBackend(
@@ -197,7 +210,9 @@ def _create_user_defined_function_operation(factory, transform_proto, consumers,
             factory.state_sampler,
             consumers,
             internal_operation_cls,
-            keyed_state_backend)
+            keyed_state_backend,
+            operator_state_backend,
+        )
     else:
         return beam_operation_cls(
             name,
@@ -205,4 +220,6 @@ def _create_user_defined_function_operation(factory, transform_proto, consumers,
             factory.counter_factory,
             factory.state_sampler,
             consumers,
-            internal_operation_cls)
+            internal_operation_cls,
+            operator_state_backend,
+        )

--- a/flink-python/pyflink/fn_execution/beam/beam_operations.py
+++ b/flink-python/pyflink/fn_execution/beam/beam_operations.py
@@ -24,8 +24,7 @@ from apache_beam.utils import proto_utils
 from pyflink.fn_execution import flink_fn_execution_pb2
 from pyflink.fn_execution.coders import from_proto, from_type_info_proto, TimeWindowCoder, \
     CountWindowCoder, FlattenRowCoder
-from pyflink.fn_execution.state_impl import RemoteKeyedStateBackend, RemoteOperatorStateBackend, \
-    UnsupportedOperatorStateBackend
+from pyflink.fn_execution.state_impl import RemoteKeyedStateBackend, RemoteOperatorStateBackend
 
 import pyflink.fn_execution.datastream.operations as datastream_operations
 import pyflink.fn_execution.table.operations as table_operations
@@ -163,7 +162,7 @@ def _create_user_defined_function_operation(factory, transform_proto, consumers,
             serialized_fn.map_state_write_cache_size,
         )
     else:
-        operator_state_backend = UnsupportedOperatorStateBackend()
+        operator_state_backend = None
 
     if hasattr(serialized_fn, "key_type"):
         # keyed operation, need to create the KeyedStateBackend.

--- a/flink-python/pyflink/fn_execution/beam/beam_operations_fast.pxd
+++ b/flink-python/pyflink/fn_execution/beam/beam_operations_fast.pxd
@@ -17,11 +17,19 @@
 ################################################################################
 # cython: language_level=3
 
-from apache_beam.runners.worker.operations cimport Operation
-from apache_beam.utils.windowed_value cimport WindowedValue
+from apache_beam.runners.worker.operations cimport
 
-from pyflink.fn_execution.beam.beam_coder_impl_fast cimport FlinkLengthPrefixCoderBeamWrapper
-from pyflink.fn_execution.coder_impl_fast cimport InputStreamWrapper
+Operation
+from apache_beam.utils.windowed_value cimport
+
+WindowedValue
+
+from pyflink.fn_execution.beam.beam_coder_impl_fast cimport
+
+FlinkLengthPrefixCoderBeamWrapper
+from pyflink.fn_execution.coder_impl_fast cimport
+
+InputStreamWrapper
 
 cdef class InputProcessor:
     cpdef has_next(self)
@@ -53,6 +61,7 @@ cdef class FunctionOperation(Operation):
     cdef object process_element
     cdef object operation
     cdef object operation_cls
+    cdef object operator_state_backend
     cdef object _profiler
     cdef object generate_operation(self)
 

--- a/flink-python/pyflink/fn_execution/beam/beam_operations_fast.pxd
+++ b/flink-python/pyflink/fn_execution/beam/beam_operations_fast.pxd
@@ -17,19 +17,11 @@
 ################################################################################
 # cython: language_level=3
 
-from apache_beam.runners.worker.operations cimport
+from apache_beam.runners.worker.operations cimport Operation
+from apache_beam.utils.windowed_value cimport WindowedValue
 
-Operation
-from apache_beam.utils.windowed_value cimport
-
-WindowedValue
-
-from pyflink.fn_execution.beam.beam_coder_impl_fast cimport
-
-FlinkLengthPrefixCoderBeamWrapper
-from pyflink.fn_execution.coder_impl_fast cimport
-
-InputStreamWrapper
+from pyflink.fn_execution.beam.beam_coder_impl_fast cimport FlinkLengthPrefixCoderBeamWrapper
+from pyflink.fn_execution.coder_impl_fast cimport InputStreamWrapper
 
 cdef class InputProcessor:
     cpdef has_next(self)

--- a/flink-python/pyflink/fn_execution/beam/beam_operations_fast.pyx
+++ b/flink-python/pyflink/fn_execution/beam/beam_operations_fast.pyx
@@ -243,11 +243,11 @@ cdef class StatelessFunctionOperation(FunctionOperation):
 
 cdef class StatefulFunctionOperation(FunctionOperation):
     def __init__(self, name, spec, counter_factory, sampler, consumers, operation_cls,
-                 keyed_state_backend, operator_stat_backend):
+                 keyed_state_backend, operator_state_backend):
         self._keyed_state_backend = keyed_state_backend
         self._reusable_windowed_value = windowed_value.create(None, -1, None, None)
         super(StatefulFunctionOperation, self).__init__(
-            name, spec, counter_factory, sampler, consumers, operation_cls, operator_stat_backend)
+            name, spec, counter_factory, sampler, consumers, operation_cls, operator_state_backend)
 
     cdef object generate_operation(self):
         if self.operator_state_backend is not None:

--- a/flink-python/pyflink/fn_execution/beam/beam_operations_fast.pyx
+++ b/flink-python/pyflink/fn_execution/beam/beam_operations_fast.pyx
@@ -241,7 +241,10 @@ cdef class StatelessFunctionOperation(FunctionOperation):
             name, spec, counter_factory, sampler, consumers, operation_cls, operator_state_backend)
 
     cdef object generate_operation(self):
-        return self.operation_cls(self.spec.serialized_fn, self.operator_state_backend)
+        if self.operator_state_backend is not None:
+            return self.operation_cls(self.spec.serialized_fn, self.operator_state_backend)
+        else:
+            return self.operation_cls(self.spec.serialized_fn)
 
 
 cdef class StatefulFunctionOperation(FunctionOperation):
@@ -253,8 +256,11 @@ cdef class StatefulFunctionOperation(FunctionOperation):
             name, spec, counter_factory, sampler, consumers, operation_cls, operator_stat_backend)
 
     cdef object generate_operation(self):
-        return self.operation_cls(self.spec.serialized_fn, self._keyed_state_backend,
-                                  self.operator_state_backend)
+        if self.operator_state_backend is not None:
+            return self.operation_cls(self.spec.serialized_fn, self._keyed_state_backend,
+                                      self.operator_state_backend)
+        else:
+            return self.operation_cls(self.spec.serialized_fn, self._keyed_state_backend)
 
     cpdef void add_timer_info(self, timer_family_id, timer_info):
         # ignore timer_family_id

--- a/flink-python/pyflink/fn_execution/beam/beam_operations_fast.pyx
+++ b/flink-python/pyflink/fn_execution/beam/beam_operations_fast.pyx
@@ -19,25 +19,19 @@
 # cython: infer_types = True
 # cython: profile=True
 # cython: boundscheck=False, wraparound=False, initializedcheck=False, cdivision=True
-from apache_beam.coders.coder_impl cimport
-
-OutputStream as BOutputStream
-from apache_beam.runners.worker.bundle_processor import DataOutputOperation
-from apache_beam.utils cimport
-
-windowed_value
-from apache_beam.utils.windowed_value cimport
-
-WindowedValue
 from libc.stdint cimport *
 
-from pyflink.common.constants import DEFAULT_OUTPUT_TAG
-from pyflink.fn_execution.coder_impl_fast cimport
+from apache_beam.coders.coder_impl cimport OutputStream as BOutputStream
+from apache_beam.runners.worker.bundle_processor import DataOutputOperation
+from apache_beam.utils cimport windowed_value
+from apache_beam.utils.windowed_value cimport WindowedValue
 
-InputStreamWrapper
+from pyflink.common.constants import DEFAULT_OUTPUT_TAG
+from pyflink.fn_execution.coder_impl_fast cimport InputStreamWrapper
 from pyflink.fn_execution.flink_fn_execution_pb2 import UserDefinedDataStreamFunction
+from pyflink.fn_execution.table.operations import BundleOperation, BaseOperation as TableOperation
 from pyflink.fn_execution.profiler import Profiler
-from pyflink.fn_execution.table.operations import BundleOperation
+
 
 cdef class InputProcessor:
 

--- a/flink-python/pyflink/fn_execution/beam/beam_operations_slow.py
+++ b/flink-python/pyflink/fn_execution/beam/beam_operations_slow.py
@@ -17,16 +17,17 @@
 ################################################################################
 import abc
 from abc import abstractmethod
+from typing import Iterable, Any, Dict, List
+
 from apache_beam.runners.worker.bundle_processor import TimerInfo, DataOutputOperation
 from apache_beam.runners.worker.operations import Operation
 from apache_beam.utils import windowed_value
 from apache_beam.utils.windowed_value import WindowedValue
-from typing import Iterable, Any, Dict, List
 
 from pyflink.common.constants import DEFAULT_OUTPUT_TAG
 from pyflink.fn_execution.flink_fn_execution_pb2 import UserDefinedDataStreamFunction
-from pyflink.fn_execution.profiler import Profiler
 from pyflink.fn_execution.table.operations import BundleOperation
+from pyflink.fn_execution.profiler import Profiler
 
 
 class OutputProcessor(abc.ABC):

--- a/flink-python/pyflink/fn_execution/beam/beam_operations_slow.py
+++ b/flink-python/pyflink/fn_execution/beam/beam_operations_slow.py
@@ -184,7 +184,10 @@ class StatelessFunctionOperation(FunctionOperation):
         )
 
     def generate_operation(self):
-        return self.operation_cls(self.spec.serialized_fn, self.operator_state_backend)
+        if self.operator_state_backend is not None:
+            return self.operation_cls(self.spec.serialized_fn, self.operator_state_backend)
+        else:
+            return self.operation_cls(self.spec.serialized_fn)
 
 
 class StatefulFunctionOperation(FunctionOperation):
@@ -197,8 +200,11 @@ class StatefulFunctionOperation(FunctionOperation):
         )
 
     def generate_operation(self):
-        return self.operation_cls(self.spec.serialized_fn, self._keyed_state_backend,
-                                  self.operator_state_backend)
+        if self.operator_state_backend is not None:
+            return self.operation_cls(self.spec.serialized_fn, self._keyed_state_backend,
+                                      self.operator_state_backend)
+        else:
+            return self.operation_cls(self.spec.serialized_fn, self._keyed_state_backend)
 
     def add_timer_info(self, timer_family_id: str, timer_info: TimerInfo):
         # ignore timer_family_id

--- a/flink-python/pyflink/fn_execution/beam/beam_operations_slow.py
+++ b/flink-python/pyflink/fn_execution/beam/beam_operations_slow.py
@@ -17,17 +17,16 @@
 ################################################################################
 import abc
 from abc import abstractmethod
-from typing import Iterable, Any, Dict, List
-
 from apache_beam.runners.worker.bundle_processor import TimerInfo, DataOutputOperation
 from apache_beam.runners.worker.operations import Operation
 from apache_beam.utils import windowed_value
 from apache_beam.utils.windowed_value import WindowedValue
+from typing import Iterable, Any, Dict, List
 
 from pyflink.common.constants import DEFAULT_OUTPUT_TAG
 from pyflink.fn_execution.flink_fn_execution_pb2 import UserDefinedDataStreamFunction
-from pyflink.fn_execution.table.operations import BundleOperation
 from pyflink.fn_execution.profiler import Profiler
+from pyflink.fn_execution.table.operations import BundleOperation
 
 
 class OutputProcessor(abc.ABC):
@@ -71,12 +70,14 @@ class FunctionOperation(Operation):
     each input element.
     """
 
-    def __init__(self, name, spec, counter_factory, sampler, consumers, operation_cls):
+    def __init__(self, name, spec, counter_factory, sampler, consumers, operation_cls,
+                 operator_state_backend):
         super(FunctionOperation, self).__init__(name, spec, counter_factory, sampler)
         self._output_processors = self._create_output_processors(
             consumers
         )  # type: Dict[str, List[OutputProcessor]]
         self.operation_cls = operation_cls
+        self.operator_state_backend = operator_state_backend
         self.operation = self.generate_operation()
         self.process_element = self.operation.process_element
         self.operation.open()
@@ -176,34 +177,28 @@ class FunctionOperation(Operation):
 
 
 class StatelessFunctionOperation(FunctionOperation):
-    def __init__(self, name, spec, counter_factory, sampler, consumers, operation_cls):
+    def __init__(self, name, spec, counter_factory, sampler, consumers, operation_cls,
+                 operator_state_backend):
         super(StatelessFunctionOperation, self).__init__(
-            name, spec, counter_factory, sampler, consumers, operation_cls
+            name, spec, counter_factory, sampler, consumers, operation_cls, operator_state_backend
         )
 
     def generate_operation(self):
-        return self.operation_cls(self.spec.serialized_fn)
+        return self.operation_cls(self.spec.serialized_fn, self.operator_state_backend)
 
 
 class StatefulFunctionOperation(FunctionOperation):
-    def __init__(
-        self,
-        name,
-        spec,
-        counter_factory,
-        sampler,
-        consumers,
-        operation_cls,
-        keyed_state_backend,
-    ):
+    def __init__(self, name, spec, counter_factory, sampler, consumers, operation_cls,
+                 keyed_state_backend, operator_state_backend):
         self._keyed_state_backend = keyed_state_backend
         self._reusable_windowed_value = windowed_value.create(None, -1, None, None)
         super(StatefulFunctionOperation, self).__init__(
-            name, spec, counter_factory, sampler, consumers, operation_cls
+            name, spec, counter_factory, sampler, consumers, operation_cls, operator_state_backend
         )
 
     def generate_operation(self):
-        return self.operation_cls(self.spec.serialized_fn, self._keyed_state_backend)
+        return self.operation_cls(self.spec.serialized_fn, self._keyed_state_backend,
+                                  self.operator_state_backend)
 
     def add_timer_info(self, timer_family_id: str, timer_info: TimerInfo):
         # ignore timer_family_id

--- a/flink-python/pyflink/fn_execution/datastream/operations.py
+++ b/flink-python/pyflink/fn_execution/datastream/operations.py
@@ -244,9 +244,13 @@ def extract_stateless_function(
                 timestamp = value[0]
                 watermark = value[1]
                 broadcast_ctx.set_timestamp(timestamp)
-                broadcast_ctx.timer_service().advance_watermark(watermark)
+                cast(
+                    TimerServiceImpl, broadcast_ctx.timer_service()
+                ).advance_watermark(watermark)
                 read_only_broadcast_ctx.set_timestamp(timestamp)
-                read_only_broadcast_ctx.timer_service().advance_watermark(watermark)
+                cast(
+                    TimerServiceImpl, read_only_broadcast_ctx.timer_service()
+                ).advance_watermark(watermark)
 
                 data = value[2]
                 if data[0]:

--- a/flink-python/pyflink/fn_execution/datastream/operations.py
+++ b/flink-python/pyflink/fn_execution/datastream/operations.py
@@ -49,7 +49,7 @@ DATA_STREAM_STATEFUL_FUNCTION_URN = "flink:transform:ds:stateful_function:v1"
 
 
 class Operation(abc.ABC):
-    def __init__(self, serialized_fn, operator_state_backend):
+    def __init__(self, serialized_fn, operator_state_backend=None):
         if serialized_fn.metric_enabled:
             self.base_metric_group = GenericMetricGroup(None, None)
         else:
@@ -58,7 +58,8 @@ class Operation(abc.ABC):
 
     def finish(self):
         self._update_gauge(self.base_metric_group)
-        self.operator_state_backend.commit()
+        if self.operator_state_backend is not None:
+            self.operator_state_backend.commit()
 
     def _update_gauge(self, base_metric_group):
         if base_metric_group is not None:

--- a/flink-python/pyflink/fn_execution/datastream/operations.py
+++ b/flink-python/pyflink/fn_execution/datastream/operations.py
@@ -24,24 +24,25 @@ from pyflink.datastream import TimeDomain, RuntimeContext
 from pyflink.datastream.functions import BroadcastProcessFunction
 from pyflink.datastream.window import WindowOperationDescriptor
 from pyflink.fn_execution import pickle
-from pyflink.fn_execution.datastream.input_handler import (
-    RunnerInputHandler,
-    TimerHandler,
-    _emit_results,
-)
 from pyflink.fn_execution.datastream.process_function import (
     InternalKeyedProcessFunctionOnTimerContext,
     InternalKeyedProcessFunctionContext,
-    InternalProcessFunctionContext, InternalBroadcastProcessFunctionContext,
+    InternalProcessFunctionContext,
+    InternalBroadcastProcessFunctionContext,
     InternalReadOnlyBroadcastProcessFunctionContext,
 )
 from pyflink.fn_execution.datastream.runtime_context import StreamingRuntimeContext
+from pyflink.fn_execution.datastream.window.window_operator import WindowOperator
 from pyflink.fn_execution.datastream.timerservice_impl import (
     TimerServiceImpl,
     InternalTimerServiceImpl,
     NonKeyedTimerServiceImpl,
 )
-from pyflink.fn_execution.datastream.window.window_operator import WindowOperator
+from pyflink.fn_execution.datastream.input_handler import (
+    RunnerInputHandler,
+    TimerHandler,
+    _emit_results,
+)
 from pyflink.metrics.metricbase import GenericMetricGroup
 
 DATA_STREAM_STATELESS_FUNCTION_URN = "flink:transform:ds:stateless_function:v1"

--- a/flink-python/pyflink/fn_execution/datastream/operations.py
+++ b/flink-python/pyflink/fn_execution/datastream/operations.py
@@ -255,10 +255,9 @@ def extract_stateless_function(
                 data = value[2]
                 if data[0]:
                     results = process_element(data[1], read_only_broadcast_ctx)
-                    yield from _emit_results(timestamp, watermark, results, has_side_output)
                 else:
-                    # process_broadcast_element does not produce any results
-                    process_broadcast_element(data[2], broadcast_ctx)
+                    results = process_broadcast_element(data[2], broadcast_ctx)
+                yield from _emit_results(timestamp, watermark, results, has_side_output)
 
             process_element_func = wrapped_func
 

--- a/flink-python/pyflink/fn_execution/datastream/process_function.py
+++ b/flink-python/pyflink/fn_execution/datastream/process_function.py
@@ -19,8 +19,9 @@ from typing import cast
 
 from pyflink.datastream import TimerService, TimeDomain
 from pyflink.datastream.functions import KeyedProcessFunction, KeyedCoProcessFunction, \
-    ProcessFunction, CoProcessFunction, BroadcastProcessFunction, OperatorStateStore
-from pyflink.datastream.state import MapStateDescriptor, BroadcastState, ReadOnlyBroadcastState
+    ProcessFunction, CoProcessFunction, BroadcastProcessFunction
+from pyflink.datastream.state import MapStateDescriptor, BroadcastState, ReadOnlyBroadcastState, \
+    OperatorStateStore
 from pyflink.fn_execution.internal_state import InternalBroadcastState
 
 

--- a/flink-python/pyflink/fn_execution/datastream/process_function.py
+++ b/flink-python/pyflink/fn_execution/datastream/process_function.py
@@ -15,10 +15,13 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
+from typing import cast
 
 from pyflink.datastream import TimerService, TimeDomain
 from pyflink.datastream.functions import KeyedProcessFunction, KeyedCoProcessFunction, \
-    ProcessFunction, CoProcessFunction
+    ProcessFunction, CoProcessFunction, BroadcastProcessFunction, OperatorStateStore
+from pyflink.datastream.state import MapStateDescriptor, BroadcastState, ReadOnlyBroadcastState
+from pyflink.fn_execution.internal_state import InternalBroadcastState
 
 
 class InternalKeyedProcessFunctionOnTimerContext(
@@ -96,6 +99,59 @@ class InternalProcessFunctionContext(ProcessFunction.Context, CoProcessFunction.
 
     def timestamp(self) -> int:
         return self._timestamp
+
+    def set_timestamp(self, ts: int):
+        self._timestamp = ts
+
+
+class InternalBroadcastProcessFunctionContext(BroadcastProcessFunction.Context):
+    def __init__(self, timer_service: TimerService, operator_state_store: OperatorStateStore):
+        self._timer_service = timer_service
+        self._timestamp = None
+        self._operator_state_store = operator_state_store
+
+    def timer_service(self) -> TimerService:
+        return self._timer_service
+
+    def timestamp(self) -> int:
+        return self._timestamp
+
+    def current_processing_time(self) -> int:
+        return self._timer_service.current_processing_time()
+
+    def current_watermark(self) -> int:
+        return self._timer_service.current_watermark()
+
+    def get_broadcast_state(self, state_descriptor: MapStateDescriptor) -> BroadcastState:
+        return self._operator_state_store.get_broadcast_state(state_descriptor)
+
+    def set_timestamp(self, ts: int):
+        self._timestamp = ts
+
+
+class InternalReadOnlyBroadcastProcessFunctionContext(BroadcastProcessFunction.ReadOnlyContext):
+    def __init__(self, timer_server: TimerService, operator_state_store: OperatorStateStore):
+        self._timer_service = timer_server
+        self._timestamp = None
+        self._operator_state_store = operator_state_store
+
+    def timer_service(self) -> TimerService:
+        return self._timer_service
+
+    def timestamp(self) -> int:
+        return self._timestamp
+
+    def current_processing_time(self) -> int:
+        return self._timer_service.current_processing_time()
+
+    def current_watermark(self) -> int:
+        return self._timer_service.current_watermark()
+
+    def get_broadcast_state(self, state_descriptor: MapStateDescriptor) -> ReadOnlyBroadcastState:
+        return cast(
+            InternalBroadcastState,
+            self._operator_state_store.get_broadcast_state(state_descriptor)
+        ).to_read_only_broadcast_state()
 
     def set_timestamp(self, ts: int):
         self._timestamp = ts

--- a/flink-python/pyflink/fn_execution/flink_fn_execution_pb2.py
+++ b/flink-python/pyflink/fn_execution/flink_fn_execution_pb2.py
@@ -36,7 +36,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='flink-fn-execution.proto',
   package='org.apache.flink.fn_execution.v1',
   syntax='proto3',
-  serialized_pb=_b('\n\x18\x66link-fn-execution.proto\x12 org.apache.flink.fn_execution.v1\"\x86\x01\n\x05Input\x12\x44\n\x03udf\x18\x01 \x01(\x0b\x32\x35.org.apache.flink.fn_execution.v1.UserDefinedFunctionH\x00\x12\x15\n\x0binputOffset\x18\x02 \x01(\x05H\x00\x12\x17\n\rinputConstant\x18\x03 \x01(\x0cH\x00\x42\x07\n\x05input\"\xa8\x01\n\x13UserDefinedFunction\x12\x0f\n\x07payload\x18\x01 \x01(\x0c\x12\x37\n\x06inputs\x18\x02 \x03(\x0b\x32\'.org.apache.flink.fn_execution.v1.Input\x12\x14\n\x0cwindow_index\x18\x03 \x01(\x05\x12\x1a\n\x12takes_row_as_input\x18\x04 \x01(\x08\x12\x15\n\ris_pandas_udf\x18\x05 \x01(\x08\"\xcb\x01\n\x14UserDefinedFunctions\x12\x43\n\x04udfs\x18\x01 \x03(\x0b\x32\x35.org.apache.flink.fn_execution.v1.UserDefinedFunction\x12\x16\n\x0emetric_enabled\x18\x02 \x01(\x08\x12=\n\x07windows\x18\x03 \x03(\x0b\x32,.org.apache.flink.fn_execution.v1.OverWindow\x12\x17\n\x0fprofile_enabled\x18\x04 \x01(\x08\"\xdd\x02\n\nOverWindow\x12L\n\x0bwindow_type\x18\x01 \x01(\x0e\x32\x37.org.apache.flink.fn_execution.v1.OverWindow.WindowType\x12\x16\n\x0elower_boundary\x18\x02 \x01(\x03\x12\x16\n\x0eupper_boundary\x18\x03 \x01(\x03\"\xd0\x01\n\nWindowType\x12\x13\n\x0fRANGE_UNBOUNDED\x10\x00\x12\x1d\n\x19RANGE_UNBOUNDED_PRECEDING\x10\x01\x12\x1d\n\x19RANGE_UNBOUNDED_FOLLOWING\x10\x02\x12\x11\n\rRANGE_SLIDING\x10\x03\x12\x11\n\rROW_UNBOUNDED\x10\x04\x12\x1b\n\x17ROW_UNBOUNDED_PRECEDING\x10\x05\x12\x1b\n\x17ROW_UNBOUNDED_FOLLOWING\x10\x06\x12\x0f\n\x0bROW_SLIDING\x10\x07\"\x8b\x06\n\x1cUserDefinedAggregateFunction\x12\x0f\n\x07payload\x18\x01 \x01(\x0c\x12\x37\n\x06inputs\x18\x02 \x03(\x0b\x32\'.org.apache.flink.fn_execution.v1.Input\x12Z\n\x05specs\x18\x03 \x03(\x0b\x32K.org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction.DataViewSpec\x12\x12\n\nfilter_arg\x18\x04 \x01(\x05\x12\x10\n\x08\x64istinct\x18\x05 \x01(\x08\x12\x1a\n\x12takes_row_as_input\x18\x06 \x01(\x08\x1a\x82\x04\n\x0c\x44\x61taViewSpec\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0b\x66ield_index\x18\x02 \x01(\x05\x12i\n\tlist_view\x18\x03 \x01(\x0b\x32T.org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction.DataViewSpec.ListViewH\x00\x12g\n\x08map_view\x18\x04 \x01(\x0b\x32S.org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction.DataViewSpec.MapViewH\x00\x1aT\n\x08ListView\x12H\n\x0c\x65lement_type\x18\x01 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x1a\x97\x01\n\x07MapView\x12\x44\n\x08key_type\x18\x01 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x12\x46\n\nvalue_type\x18\x02 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldTypeB\x0b\n\tdata_view\"\xac\x04\n\x0bGroupWindow\x12M\n\x0bwindow_type\x18\x01 \x01(\x0e\x32\x38.org.apache.flink.fn_execution.v1.GroupWindow.WindowType\x12\x16\n\x0eis_time_window\x18\x02 \x01(\x08\x12\x14\n\x0cwindow_slide\x18\x03 \x01(\x03\x12\x13\n\x0bwindow_size\x18\x04 \x01(\x03\x12\x12\n\nwindow_gap\x18\x05 \x01(\x03\x12\x13\n\x0bis_row_time\x18\x06 \x01(\x08\x12\x18\n\x10time_field_index\x18\x07 \x01(\x05\x12\x17\n\x0f\x61llowedLateness\x18\x08 \x01(\x03\x12U\n\x0fnamedProperties\x18\t \x03(\x0e\x32<.org.apache.flink.fn_execution.v1.GroupWindow.WindowProperty\x12\x16\n\x0eshift_timezone\x18\n \x01(\t\"[\n\nWindowType\x12\x19\n\x15TUMBLING_GROUP_WINDOW\x10\x00\x12\x18\n\x14SLIDING_GROUP_WINDOW\x10\x01\x12\x18\n\x14SESSION_GROUP_WINDOW\x10\x02\"c\n\x0eWindowProperty\x12\x10\n\x0cWINDOW_START\x10\x00\x12\x0e\n\nWINDOW_END\x10\x01\x12\x16\n\x12ROW_TIME_ATTRIBUTE\x10\x02\x12\x17\n\x13PROC_TIME_ATTRIBUTE\x10\x03\"\x96\x04\n\x1dUserDefinedAggregateFunctions\x12L\n\x04udfs\x18\x01 \x03(\x0b\x32>.org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction\x12\x16\n\x0emetric_enabled\x18\x02 \x01(\x08\x12\x10\n\x08grouping\x18\x03 \x03(\x05\x12\x1e\n\x16generate_update_before\x18\x04 \x01(\x08\x12\x44\n\x08key_type\x18\x05 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x12\x1b\n\x13index_of_count_star\x18\x06 \x01(\x05\x12\x1e\n\x16state_cleaning_enabled\x18\x07 \x01(\x08\x12\x18\n\x10state_cache_size\x18\x08 \x01(\x05\x12!\n\x19map_state_read_cache_size\x18\t \x01(\x05\x12\"\n\x1amap_state_write_cache_size\x18\n \x01(\x05\x12\x1b\n\x13\x63ount_star_inserted\x18\x0b \x01(\x08\x12\x43\n\x0cgroup_window\x18\x0c \x01(\x0b\x32-.org.apache.flink.fn_execution.v1.GroupWindow\x12\x17\n\x0fprofile_enabled\x18\r \x01(\x08\"\xec\x0f\n\x06Schema\x12>\n\x06\x66ields\x18\x01 \x03(\x0b\x32..org.apache.flink.fn_execution.v1.Schema.Field\x1a\x97\x01\n\x07MapInfo\x12\x44\n\x08key_type\x18\x01 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x12\x46\n\nvalue_type\x18\x02 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x1a\x1d\n\x08TimeInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a\"\n\rTimestampInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a,\n\x17LocalZonedTimestampInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a\'\n\x12ZonedTimestampInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a/\n\x0b\x44\x65\x63imalInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x12\r\n\x05scale\x18\x02 \x01(\x05\x1a\x1c\n\nBinaryInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\x1f\n\rVarBinaryInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\x1a\n\x08\x43harInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\x1d\n\x0bVarCharInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\xb0\x08\n\tFieldType\x12\x44\n\ttype_name\x18\x01 \x01(\x0e\x32\x31.org.apache.flink.fn_execution.v1.Schema.TypeName\x12\x10\n\x08nullable\x18\x02 \x01(\x08\x12U\n\x17\x63ollection_element_type\x18\x03 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldTypeH\x00\x12\x44\n\x08map_info\x18\x04 \x01(\x0b\x32\x30.org.apache.flink.fn_execution.v1.Schema.MapInfoH\x00\x12>\n\nrow_schema\x18\x05 \x01(\x0b\x32(.org.apache.flink.fn_execution.v1.SchemaH\x00\x12L\n\x0c\x64\x65\x63imal_info\x18\x06 \x01(\x0b\x32\x34.org.apache.flink.fn_execution.v1.Schema.DecimalInfoH\x00\x12\x46\n\ttime_info\x18\x07 \x01(\x0b\x32\x31.org.apache.flink.fn_execution.v1.Schema.TimeInfoH\x00\x12P\n\x0etimestamp_info\x18\x08 \x01(\x0b\x32\x36.org.apache.flink.fn_execution.v1.Schema.TimestampInfoH\x00\x12\x66\n\x1alocal_zoned_timestamp_info\x18\t \x01(\x0b\x32@.org.apache.flink.fn_execution.v1.Schema.LocalZonedTimestampInfoH\x00\x12[\n\x14zoned_timestamp_info\x18\n \x01(\x0b\x32;.org.apache.flink.fn_execution.v1.Schema.ZonedTimestampInfoH\x00\x12J\n\x0b\x62inary_info\x18\x0b \x01(\x0b\x32\x33.org.apache.flink.fn_execution.v1.Schema.BinaryInfoH\x00\x12Q\n\x0fvar_binary_info\x18\x0c \x01(\x0b\x32\x36.org.apache.flink.fn_execution.v1.Schema.VarBinaryInfoH\x00\x12\x46\n\tchar_info\x18\r \x01(\x0b\x32\x31.org.apache.flink.fn_execution.v1.Schema.CharInfoH\x00\x12M\n\rvar_char_info\x18\x0e \x01(\x0b\x32\x34.org.apache.flink.fn_execution.v1.Schema.VarCharInfoH\x00\x42\x0b\n\ttype_info\x1al\n\x05\x46ield\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12@\n\x04type\x18\x03 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\"\xa1\x02\n\x08TypeName\x12\x07\n\x03ROW\x10\x00\x12\x0b\n\x07TINYINT\x10\x01\x12\x0c\n\x08SMALLINT\x10\x02\x12\x07\n\x03INT\x10\x03\x12\n\n\x06\x42IGINT\x10\x04\x12\x0b\n\x07\x44\x45\x43IMAL\x10\x05\x12\t\n\x05\x46LOAT\x10\x06\x12\n\n\x06\x44OUBLE\x10\x07\x12\x08\n\x04\x44\x41TE\x10\x08\x12\x08\n\x04TIME\x10\t\x12\r\n\tTIMESTAMP\x10\n\x12\x0b\n\x07\x42OOLEAN\x10\x0b\x12\n\n\x06\x42INARY\x10\x0c\x12\r\n\tVARBINARY\x10\r\x12\x08\n\x04\x43HAR\x10\x0e\x12\x0b\n\x07VARCHAR\x10\x0f\x12\x0f\n\x0b\x42\x41SIC_ARRAY\x10\x10\x12\x07\n\x03MAP\x10\x11\x12\x0c\n\x08MULTISET\x10\x12\x12\x19\n\x15LOCAL_ZONED_TIMESTAMP\x10\x13\x12\x13\n\x0fZONED_TIMESTAMP\x10\x14\"\xf7\x08\n\x08TypeInfo\x12\x46\n\ttype_name\x18\x01 \x01(\x0e\x32\x33.org.apache.flink.fn_execution.v1.TypeInfo.TypeName\x12M\n\x17\x63ollection_element_type\x18\x02 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfoH\x00\x12O\n\rrow_type_info\x18\x03 \x01(\x0b\x32\x36.org.apache.flink.fn_execution.v1.TypeInfo.RowTypeInfoH\x00\x12S\n\x0ftuple_type_info\x18\x04 \x01(\x0b\x32\x38.org.apache.flink.fn_execution.v1.TypeInfo.TupleTypeInfoH\x00\x12O\n\rmap_type_info\x18\x05 \x01(\x0b\x32\x36.org.apache.flink.fn_execution.v1.TypeInfo.MapTypeInfoH\x00\x1a\x8b\x01\n\x0bMapTypeInfo\x12<\n\x08key_type\x18\x01 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfo\x12>\n\nvalue_type\x18\x02 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfo\x1a\xb8\x01\n\x0bRowTypeInfo\x12L\n\x06\x66ields\x18\x01 \x03(\x0b\x32<.org.apache.flink.fn_execution.v1.TypeInfo.RowTypeInfo.Field\x1a[\n\x05\x46ield\x12\x12\n\nfield_name\x18\x01 \x01(\t\x12>\n\nfield_type\x18\x02 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfo\x1aP\n\rTupleTypeInfo\x12?\n\x0b\x66ield_types\x18\x01 \x03(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfo\"\xb4\x02\n\x08TypeName\x12\x07\n\x03ROW\x10\x00\x12\n\n\x06STRING\x10\x01\x12\x08\n\x04\x42YTE\x10\x02\x12\x0b\n\x07\x42OOLEAN\x10\x03\x12\t\n\x05SHORT\x10\x04\x12\x07\n\x03INT\x10\x05\x12\x08\n\x04LONG\x10\x06\x12\t\n\x05\x46LOAT\x10\x07\x12\n\n\x06\x44OUBLE\x10\x08\x12\x08\n\x04\x43HAR\x10\t\x12\x0b\n\x07\x42IG_INT\x10\n\x12\x0b\n\x07\x42IG_DEC\x10\x0b\x12\x0c\n\x08SQL_DATE\x10\x0c\x12\x0c\n\x08SQL_TIME\x10\r\x12\x11\n\rSQL_TIMESTAMP\x10\x0e\x12\x0f\n\x0b\x42\x41SIC_ARRAY\x10\x0f\x12\x13\n\x0fPRIMITIVE_ARRAY\x10\x10\x12\t\n\x05TUPLE\x10\x11\x12\x08\n\x04LIST\x10\x12\x12\x07\n\x03MAP\x10\x13\x12\x11\n\rPICKLED_BYTES\x10\x14\x12\x10\n\x0cOBJECT_ARRAY\x10\x15\x12\x0b\n\x07INSTANT\x10\x16\x42\x0b\n\ttype_info\"\xe0\x07\n\x1dUserDefinedDataStreamFunction\x12\x63\n\rfunction_type\x18\x01 \x01(\x0e\x32L.org.apache.flink.fn_execution.v1.UserDefinedDataStreamFunction.FunctionType\x12g\n\x0fruntime_context\x18\x02 \x01(\x0b\x32N.org.apache.flink.fn_execution.v1.UserDefinedDataStreamFunction.RuntimeContext\x12\x0f\n\x07payload\x18\x03 \x01(\x0c\x12\x16\n\x0emetric_enabled\x18\x04 \x01(\x08\x12\x41\n\rkey_type_info\x18\x05 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfo\x12\x17\n\x0fprofile_enabled\x18\x06 \x01(\x08\x12\x17\n\x0fhas_side_output\x18\x07 \x01(\x08\x12\x18\n\x10state_cache_size\x18\x08 \x01(\x05\x12!\n\x19map_state_read_cache_size\x18\t \x01(\x05\x12\"\n\x1amap_state_write_cache_size\x18\n \x01(\x05\x1a*\n\x0cJobParameter\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\x1a\xd0\x02\n\x0eRuntimeContext\x12\x11\n\ttask_name\x18\x01 \x01(\t\x12\x1f\n\x17task_name_with_subtasks\x18\x02 \x01(\t\x12#\n\x1bnumber_of_parallel_subtasks\x18\x03 \x01(\x05\x12\'\n\x1fmax_number_of_parallel_subtasks\x18\x04 \x01(\x05\x12\x1d\n\x15index_of_this_subtask\x18\x05 \x01(\x05\x12\x16\n\x0e\x61ttempt_number\x18\x06 \x01(\x05\x12\x64\n\x0ejob_parameters\x18\x07 \x03(\x0b\x32L.org.apache.flink.fn_execution.v1.UserDefinedDataStreamFunction.JobParameter\x12\x1f\n\x17in_batch_execution_mode\x18\x08 \x01(\x08\"s\n\x0c\x46unctionType\x12\x0b\n\x07PROCESS\x10\x00\x12\x0e\n\nCO_PROCESS\x10\x01\x12\x11\n\rKEYED_PROCESS\x10\x02\x12\x14\n\x10KEYED_CO_PROCESS\x10\x03\x12\n\n\x06WINDOW\x10\x04\x12\x11\n\rREVISE_OUTPUT\x10\x64\"\xe4\x0e\n\x0fStateDescriptor\x12\x12\n\nstate_name\x18\x01 \x01(\t\x12Z\n\x10state_ttl_config\x18\x02 \x01(\x0b\x32@.org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig\x1a\xe0\r\n\x0eStateTTLConfig\x12`\n\x0bupdate_type\x18\x01 \x01(\x0e\x32K.org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig.UpdateType\x12j\n\x10state_visibility\x18\x02 \x01(\x0e\x32P.org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig.StateVisibility\x12w\n\x17ttl_time_characteristic\x18\x03 \x01(\x0e\x32V.org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig.TtlTimeCharacteristic\x12\x0b\n\x03ttl\x18\x04 \x01(\x03\x12n\n\x12\x63leanup_strategies\x18\x05 \x01(\x0b\x32R.org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig.CleanupStrategies\x1a\xca\x08\n\x11\x43leanupStrategies\x12 \n\x18is_cleanup_in_background\x18\x01 \x01(\x08\x12y\n\nstrategies\x18\x02 \x03(\x0b\x32\x65.org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig.CleanupStrategies.MapStrategiesEntry\x1aX\n\x1aIncrementalCleanupStrategy\x12\x14\n\x0c\x63leanup_size\x18\x01 \x01(\x05\x12$\n\x1crun_cleanup_for_every_record\x18\x02 \x01(\x08\x1aK\n#RocksdbCompactFilterCleanupStrategy\x12$\n\x1cquery_time_after_num_entries\x18\x01 \x01(\x03\x1a\xe0\x04\n\x12MapStrategiesEntry\x12o\n\x08strategy\x18\x01 \x01(\x0e\x32].org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig.CleanupStrategies.Strategies\x12\x81\x01\n\x0e\x65mpty_strategy\x18\x02 \x01(\x0e\x32g.org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig.CleanupStrategies.EmptyCleanupStrategyH\x00\x12\x95\x01\n\x1cincremental_cleanup_strategy\x18\x03 \x01(\x0b\x32m.org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig.CleanupStrategies.IncrementalCleanupStrategyH\x00\x12\xa9\x01\n\'rocksdb_compact_filter_cleanup_strategy\x18\x04 \x01(\x0b\x32v.org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig.CleanupStrategies.RocksdbCompactFilterCleanupStrategyH\x00\x42\x11\n\x0f\x43leanupStrategy\"b\n\nStrategies\x12\x1c\n\x18\x46ULL_STATE_SCAN_SNAPSHOT\x10\x00\x12\x17\n\x13INCREMENTAL_CLEANUP\x10\x01\x12\x1d\n\x19ROCKSDB_COMPACTION_FILTER\x10\x02\"*\n\x14\x45mptyCleanupStrategy\x12\x12\n\x0e\x45MPTY_STRATEGY\x10\x00\"D\n\nUpdateType\x12\x0c\n\x08\x44isabled\x10\x00\x12\x14\n\x10OnCreateAndWrite\x10\x01\x12\x12\n\x0eOnReadAndWrite\x10\x02\"J\n\x0fStateVisibility\x12\x1f\n\x1bReturnExpiredIfNotCleanedUp\x10\x00\x12\x16\n\x12NeverReturnExpired\x10\x01\"+\n\x15TtlTimeCharacteristic\x12\x12\n\x0eProcessingTime\x10\x00\"\xf1\x07\n\x13\x43oderInfoDescriptor\x12`\n\x10\x66latten_row_type\x18\x01 \x01(\x0b\x32\x44.org.apache.flink.fn_execution.v1.CoderInfoDescriptor.FlattenRowTypeH\x00\x12Q\n\x08row_type\x18\x02 \x01(\x0b\x32=.org.apache.flink.fn_execution.v1.CoderInfoDescriptor.RowTypeH\x00\x12U\n\narrow_type\x18\x03 \x01(\x0b\x32?.org.apache.flink.fn_execution.v1.CoderInfoDescriptor.ArrowTypeH\x00\x12k\n\x16over_window_arrow_type\x18\x04 \x01(\x0b\x32I.org.apache.flink.fn_execution.v1.CoderInfoDescriptor.OverWindowArrowTypeH\x00\x12Q\n\x08raw_type\x18\x05 \x01(\x0b\x32=.org.apache.flink.fn_execution.v1.CoderInfoDescriptor.RawTypeH\x00\x12H\n\x04mode\x18\x06 \x01(\x0e\x32:.org.apache.flink.fn_execution.v1.CoderInfoDescriptor.Mode\x12\"\n\x1aseparated_with_end_message\x18\x07 \x01(\x08\x1aJ\n\x0e\x46lattenRowType\x12\x38\n\x06schema\x18\x01 \x01(\x0b\x32(.org.apache.flink.fn_execution.v1.Schema\x1a\x43\n\x07RowType\x12\x38\n\x06schema\x18\x01 \x01(\x0b\x32(.org.apache.flink.fn_execution.v1.Schema\x1a\x45\n\tArrowType\x12\x38\n\x06schema\x18\x01 \x01(\x0b\x32(.org.apache.flink.fn_execution.v1.Schema\x1aO\n\x13OverWindowArrowType\x12\x38\n\x06schema\x18\x01 \x01(\x0b\x32(.org.apache.flink.fn_execution.v1.Schema\x1aH\n\x07RawType\x12=\n\ttype_info\x18\x01 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfo\" \n\x04Mode\x12\n\n\x06SINGLE\x10\x00\x12\x0c\n\x08MULTIPLE\x10\x01\x42\x0b\n\tdata_typeB-\n\x1forg.apache.flink.fnexecution.v1B\nFlinkFnApib\x06proto3')
+  serialized_pb=_b('\n\x18\x66link-fn-execution.proto\x12 org.apache.flink.fn_execution.v1\"\x86\x01\n\x05Input\x12\x44\n\x03udf\x18\x01 \x01(\x0b\x32\x35.org.apache.flink.fn_execution.v1.UserDefinedFunctionH\x00\x12\x15\n\x0binputOffset\x18\x02 \x01(\x05H\x00\x12\x17\n\rinputConstant\x18\x03 \x01(\x0cH\x00\x42\x07\n\x05input\"\xa8\x01\n\x13UserDefinedFunction\x12\x0f\n\x07payload\x18\x01 \x01(\x0c\x12\x37\n\x06inputs\x18\x02 \x03(\x0b\x32\'.org.apache.flink.fn_execution.v1.Input\x12\x14\n\x0cwindow_index\x18\x03 \x01(\x05\x12\x1a\n\x12takes_row_as_input\x18\x04 \x01(\x08\x12\x15\n\ris_pandas_udf\x18\x05 \x01(\x08\"\xcb\x01\n\x14UserDefinedFunctions\x12\x43\n\x04udfs\x18\x01 \x03(\x0b\x32\x35.org.apache.flink.fn_execution.v1.UserDefinedFunction\x12\x16\n\x0emetric_enabled\x18\x02 \x01(\x08\x12=\n\x07windows\x18\x03 \x03(\x0b\x32,.org.apache.flink.fn_execution.v1.OverWindow\x12\x17\n\x0fprofile_enabled\x18\x04 \x01(\x08\"\xdd\x02\n\nOverWindow\x12L\n\x0bwindow_type\x18\x01 \x01(\x0e\x32\x37.org.apache.flink.fn_execution.v1.OverWindow.WindowType\x12\x16\n\x0elower_boundary\x18\x02 \x01(\x03\x12\x16\n\x0eupper_boundary\x18\x03 \x01(\x03\"\xd0\x01\n\nWindowType\x12\x13\n\x0fRANGE_UNBOUNDED\x10\x00\x12\x1d\n\x19RANGE_UNBOUNDED_PRECEDING\x10\x01\x12\x1d\n\x19RANGE_UNBOUNDED_FOLLOWING\x10\x02\x12\x11\n\rRANGE_SLIDING\x10\x03\x12\x11\n\rROW_UNBOUNDED\x10\x04\x12\x1b\n\x17ROW_UNBOUNDED_PRECEDING\x10\x05\x12\x1b\n\x17ROW_UNBOUNDED_FOLLOWING\x10\x06\x12\x0f\n\x0bROW_SLIDING\x10\x07\"\x8b\x06\n\x1cUserDefinedAggregateFunction\x12\x0f\n\x07payload\x18\x01 \x01(\x0c\x12\x37\n\x06inputs\x18\x02 \x03(\x0b\x32\'.org.apache.flink.fn_execution.v1.Input\x12Z\n\x05specs\x18\x03 \x03(\x0b\x32K.org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction.DataViewSpec\x12\x12\n\nfilter_arg\x18\x04 \x01(\x05\x12\x10\n\x08\x64istinct\x18\x05 \x01(\x08\x12\x1a\n\x12takes_row_as_input\x18\x06 \x01(\x08\x1a\x82\x04\n\x0c\x44\x61taViewSpec\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0b\x66ield_index\x18\x02 \x01(\x05\x12i\n\tlist_view\x18\x03 \x01(\x0b\x32T.org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction.DataViewSpec.ListViewH\x00\x12g\n\x08map_view\x18\x04 \x01(\x0b\x32S.org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction.DataViewSpec.MapViewH\x00\x1aT\n\x08ListView\x12H\n\x0c\x65lement_type\x18\x01 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x1a\x97\x01\n\x07MapView\x12\x44\n\x08key_type\x18\x01 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x12\x46\n\nvalue_type\x18\x02 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldTypeB\x0b\n\tdata_view\"\xac\x04\n\x0bGroupWindow\x12M\n\x0bwindow_type\x18\x01 \x01(\x0e\x32\x38.org.apache.flink.fn_execution.v1.GroupWindow.WindowType\x12\x16\n\x0eis_time_window\x18\x02 \x01(\x08\x12\x14\n\x0cwindow_slide\x18\x03 \x01(\x03\x12\x13\n\x0bwindow_size\x18\x04 \x01(\x03\x12\x12\n\nwindow_gap\x18\x05 \x01(\x03\x12\x13\n\x0bis_row_time\x18\x06 \x01(\x08\x12\x18\n\x10time_field_index\x18\x07 \x01(\x05\x12\x17\n\x0f\x61llowedLateness\x18\x08 \x01(\x03\x12U\n\x0fnamedProperties\x18\t \x03(\x0e\x32<.org.apache.flink.fn_execution.v1.GroupWindow.WindowProperty\x12\x16\n\x0eshift_timezone\x18\n \x01(\t\"[\n\nWindowType\x12\x19\n\x15TUMBLING_GROUP_WINDOW\x10\x00\x12\x18\n\x14SLIDING_GROUP_WINDOW\x10\x01\x12\x18\n\x14SESSION_GROUP_WINDOW\x10\x02\"c\n\x0eWindowProperty\x12\x10\n\x0cWINDOW_START\x10\x00\x12\x0e\n\nWINDOW_END\x10\x01\x12\x16\n\x12ROW_TIME_ATTRIBUTE\x10\x02\x12\x17\n\x13PROC_TIME_ATTRIBUTE\x10\x03\"\x96\x04\n\x1dUserDefinedAggregateFunctions\x12L\n\x04udfs\x18\x01 \x03(\x0b\x32>.org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction\x12\x16\n\x0emetric_enabled\x18\x02 \x01(\x08\x12\x10\n\x08grouping\x18\x03 \x03(\x05\x12\x1e\n\x16generate_update_before\x18\x04 \x01(\x08\x12\x44\n\x08key_type\x18\x05 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x12\x1b\n\x13index_of_count_star\x18\x06 \x01(\x05\x12\x1e\n\x16state_cleaning_enabled\x18\x07 \x01(\x08\x12\x18\n\x10state_cache_size\x18\x08 \x01(\x05\x12!\n\x19map_state_read_cache_size\x18\t \x01(\x05\x12\"\n\x1amap_state_write_cache_size\x18\n \x01(\x05\x12\x1b\n\x13\x63ount_star_inserted\x18\x0b \x01(\x08\x12\x43\n\x0cgroup_window\x18\x0c \x01(\x0b\x32-.org.apache.flink.fn_execution.v1.GroupWindow\x12\x17\n\x0fprofile_enabled\x18\r \x01(\x08\"\xec\x0f\n\x06Schema\x12>\n\x06\x66ields\x18\x01 \x03(\x0b\x32..org.apache.flink.fn_execution.v1.Schema.Field\x1a\x97\x01\n\x07MapInfo\x12\x44\n\x08key_type\x18\x01 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x12\x46\n\nvalue_type\x18\x02 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x1a\x1d\n\x08TimeInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a\"\n\rTimestampInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a,\n\x17LocalZonedTimestampInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a\'\n\x12ZonedTimestampInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a/\n\x0b\x44\x65\x63imalInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x12\r\n\x05scale\x18\x02 \x01(\x05\x1a\x1c\n\nBinaryInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\x1f\n\rVarBinaryInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\x1a\n\x08\x43harInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\x1d\n\x0bVarCharInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\xb0\x08\n\tFieldType\x12\x44\n\ttype_name\x18\x01 \x01(\x0e\x32\x31.org.apache.flink.fn_execution.v1.Schema.TypeName\x12\x10\n\x08nullable\x18\x02 \x01(\x08\x12U\n\x17\x63ollection_element_type\x18\x03 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldTypeH\x00\x12\x44\n\x08map_info\x18\x04 \x01(\x0b\x32\x30.org.apache.flink.fn_execution.v1.Schema.MapInfoH\x00\x12>\n\nrow_schema\x18\x05 \x01(\x0b\x32(.org.apache.flink.fn_execution.v1.SchemaH\x00\x12L\n\x0c\x64\x65\x63imal_info\x18\x06 \x01(\x0b\x32\x34.org.apache.flink.fn_execution.v1.Schema.DecimalInfoH\x00\x12\x46\n\ttime_info\x18\x07 \x01(\x0b\x32\x31.org.apache.flink.fn_execution.v1.Schema.TimeInfoH\x00\x12P\n\x0etimestamp_info\x18\x08 \x01(\x0b\x32\x36.org.apache.flink.fn_execution.v1.Schema.TimestampInfoH\x00\x12\x66\n\x1alocal_zoned_timestamp_info\x18\t \x01(\x0b\x32@.org.apache.flink.fn_execution.v1.Schema.LocalZonedTimestampInfoH\x00\x12[\n\x14zoned_timestamp_info\x18\n \x01(\x0b\x32;.org.apache.flink.fn_execution.v1.Schema.ZonedTimestampInfoH\x00\x12J\n\x0b\x62inary_info\x18\x0b \x01(\x0b\x32\x33.org.apache.flink.fn_execution.v1.Schema.BinaryInfoH\x00\x12Q\n\x0fvar_binary_info\x18\x0c \x01(\x0b\x32\x36.org.apache.flink.fn_execution.v1.Schema.VarBinaryInfoH\x00\x12\x46\n\tchar_info\x18\r \x01(\x0b\x32\x31.org.apache.flink.fn_execution.v1.Schema.CharInfoH\x00\x12M\n\rvar_char_info\x18\x0e \x01(\x0b\x32\x34.org.apache.flink.fn_execution.v1.Schema.VarCharInfoH\x00\x42\x0b\n\ttype_info\x1al\n\x05\x46ield\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12@\n\x04type\x18\x03 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\"\xa1\x02\n\x08TypeName\x12\x07\n\x03ROW\x10\x00\x12\x0b\n\x07TINYINT\x10\x01\x12\x0c\n\x08SMALLINT\x10\x02\x12\x07\n\x03INT\x10\x03\x12\n\n\x06\x42IGINT\x10\x04\x12\x0b\n\x07\x44\x45\x43IMAL\x10\x05\x12\t\n\x05\x46LOAT\x10\x06\x12\n\n\x06\x44OUBLE\x10\x07\x12\x08\n\x04\x44\x41TE\x10\x08\x12\x08\n\x04TIME\x10\t\x12\r\n\tTIMESTAMP\x10\n\x12\x0b\n\x07\x42OOLEAN\x10\x0b\x12\n\n\x06\x42INARY\x10\x0c\x12\r\n\tVARBINARY\x10\r\x12\x08\n\x04\x43HAR\x10\x0e\x12\x0b\n\x07VARCHAR\x10\x0f\x12\x0f\n\x0b\x42\x41SIC_ARRAY\x10\x10\x12\x07\n\x03MAP\x10\x11\x12\x0c\n\x08MULTISET\x10\x12\x12\x19\n\x15LOCAL_ZONED_TIMESTAMP\x10\x13\x12\x13\n\x0fZONED_TIMESTAMP\x10\x14\"\xf7\x08\n\x08TypeInfo\x12\x46\n\ttype_name\x18\x01 \x01(\x0e\x32\x33.org.apache.flink.fn_execution.v1.TypeInfo.TypeName\x12M\n\x17\x63ollection_element_type\x18\x02 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfoH\x00\x12O\n\rrow_type_info\x18\x03 \x01(\x0b\x32\x36.org.apache.flink.fn_execution.v1.TypeInfo.RowTypeInfoH\x00\x12S\n\x0ftuple_type_info\x18\x04 \x01(\x0b\x32\x38.org.apache.flink.fn_execution.v1.TypeInfo.TupleTypeInfoH\x00\x12O\n\rmap_type_info\x18\x05 \x01(\x0b\x32\x36.org.apache.flink.fn_execution.v1.TypeInfo.MapTypeInfoH\x00\x1a\x8b\x01\n\x0bMapTypeInfo\x12<\n\x08key_type\x18\x01 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfo\x12>\n\nvalue_type\x18\x02 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfo\x1a\xb8\x01\n\x0bRowTypeInfo\x12L\n\x06\x66ields\x18\x01 \x03(\x0b\x32<.org.apache.flink.fn_execution.v1.TypeInfo.RowTypeInfo.Field\x1a[\n\x05\x46ield\x12\x12\n\nfield_name\x18\x01 \x01(\t\x12>\n\nfield_type\x18\x02 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfo\x1aP\n\rTupleTypeInfo\x12?\n\x0b\x66ield_types\x18\x01 \x03(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfo\"\xb4\x02\n\x08TypeName\x12\x07\n\x03ROW\x10\x00\x12\n\n\x06STRING\x10\x01\x12\x08\n\x04\x42YTE\x10\x02\x12\x0b\n\x07\x42OOLEAN\x10\x03\x12\t\n\x05SHORT\x10\x04\x12\x07\n\x03INT\x10\x05\x12\x08\n\x04LONG\x10\x06\x12\t\n\x05\x46LOAT\x10\x07\x12\n\n\x06\x44OUBLE\x10\x08\x12\x08\n\x04\x43HAR\x10\t\x12\x0b\n\x07\x42IG_INT\x10\n\x12\x0b\n\x07\x42IG_DEC\x10\x0b\x12\x0c\n\x08SQL_DATE\x10\x0c\x12\x0c\n\x08SQL_TIME\x10\r\x12\x11\n\rSQL_TIMESTAMP\x10\x0e\x12\x0f\n\x0b\x42\x41SIC_ARRAY\x10\x0f\x12\x13\n\x0fPRIMITIVE_ARRAY\x10\x10\x12\t\n\x05TUPLE\x10\x11\x12\x08\n\x04LIST\x10\x12\x12\x07\n\x03MAP\x10\x13\x12\x11\n\rPICKLED_BYTES\x10\x14\x12\x10\n\x0cOBJECT_ARRAY\x10\x15\x12\x0b\n\x07INSTANT\x10\x16\x42\x0b\n\ttype_info\"\xfb\x07\n\x1dUserDefinedDataStreamFunction\x12\x63\n\rfunction_type\x18\x01 \x01(\x0e\x32L.org.apache.flink.fn_execution.v1.UserDefinedDataStreamFunction.FunctionType\x12g\n\x0fruntime_context\x18\x02 \x01(\x0b\x32N.org.apache.flink.fn_execution.v1.UserDefinedDataStreamFunction.RuntimeContext\x12\x0f\n\x07payload\x18\x03 \x01(\x0c\x12\x16\n\x0emetric_enabled\x18\x04 \x01(\x08\x12\x41\n\rkey_type_info\x18\x05 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfo\x12\x17\n\x0fprofile_enabled\x18\x06 \x01(\x08\x12\x17\n\x0fhas_side_output\x18\x07 \x01(\x08\x12\x18\n\x10state_cache_size\x18\x08 \x01(\x05\x12!\n\x19map_state_read_cache_size\x18\t \x01(\x05\x12\"\n\x1amap_state_write_cache_size\x18\n \x01(\x05\x1a*\n\x0cJobParameter\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\x1a\xd0\x02\n\x0eRuntimeContext\x12\x11\n\ttask_name\x18\x01 \x01(\t\x12\x1f\n\x17task_name_with_subtasks\x18\x02 \x01(\t\x12#\n\x1bnumber_of_parallel_subtasks\x18\x03 \x01(\x05\x12\'\n\x1fmax_number_of_parallel_subtasks\x18\x04 \x01(\x05\x12\x1d\n\x15index_of_this_subtask\x18\x05 \x01(\x05\x12\x16\n\x0e\x61ttempt_number\x18\x06 \x01(\x05\x12\x64\n\x0ejob_parameters\x18\x07 \x03(\x0b\x32L.org.apache.flink.fn_execution.v1.UserDefinedDataStreamFunction.JobParameter\x12\x1f\n\x17in_batch_execution_mode\x18\x08 \x01(\x08\"\x8d\x01\n\x0c\x46unctionType\x12\x0b\n\x07PROCESS\x10\x00\x12\x0e\n\nCO_PROCESS\x10\x01\x12\x11\n\rKEYED_PROCESS\x10\x02\x12\x14\n\x10KEYED_CO_PROCESS\x10\x03\x12\n\n\x06WINDOW\x10\x04\x12\x18\n\x14\x43O_BROADCAST_PROCESS\x10\x05\x12\x11\n\rREVISE_OUTPUT\x10\x64\"\xe4\x0e\n\x0fStateDescriptor\x12\x12\n\nstate_name\x18\x01 \x01(\t\x12Z\n\x10state_ttl_config\x18\x02 \x01(\x0b\x32@.org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig\x1a\xe0\r\n\x0eStateTTLConfig\x12`\n\x0bupdate_type\x18\x01 \x01(\x0e\x32K.org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig.UpdateType\x12j\n\x10state_visibility\x18\x02 \x01(\x0e\x32P.org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig.StateVisibility\x12w\n\x17ttl_time_characteristic\x18\x03 \x01(\x0e\x32V.org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig.TtlTimeCharacteristic\x12\x0b\n\x03ttl\x18\x04 \x01(\x03\x12n\n\x12\x63leanup_strategies\x18\x05 \x01(\x0b\x32R.org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig.CleanupStrategies\x1a\xca\x08\n\x11\x43leanupStrategies\x12 \n\x18is_cleanup_in_background\x18\x01 \x01(\x08\x12y\n\nstrategies\x18\x02 \x03(\x0b\x32\x65.org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig.CleanupStrategies.MapStrategiesEntry\x1aX\n\x1aIncrementalCleanupStrategy\x12\x14\n\x0c\x63leanup_size\x18\x01 \x01(\x05\x12$\n\x1crun_cleanup_for_every_record\x18\x02 \x01(\x08\x1aK\n#RocksdbCompactFilterCleanupStrategy\x12$\n\x1cquery_time_after_num_entries\x18\x01 \x01(\x03\x1a\xe0\x04\n\x12MapStrategiesEntry\x12o\n\x08strategy\x18\x01 \x01(\x0e\x32].org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig.CleanupStrategies.Strategies\x12\x81\x01\n\x0e\x65mpty_strategy\x18\x02 \x01(\x0e\x32g.org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig.CleanupStrategies.EmptyCleanupStrategyH\x00\x12\x95\x01\n\x1cincremental_cleanup_strategy\x18\x03 \x01(\x0b\x32m.org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig.CleanupStrategies.IncrementalCleanupStrategyH\x00\x12\xa9\x01\n\'rocksdb_compact_filter_cleanup_strategy\x18\x04 \x01(\x0b\x32v.org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig.CleanupStrategies.RocksdbCompactFilterCleanupStrategyH\x00\x42\x11\n\x0f\x43leanupStrategy\"b\n\nStrategies\x12\x1c\n\x18\x46ULL_STATE_SCAN_SNAPSHOT\x10\x00\x12\x17\n\x13INCREMENTAL_CLEANUP\x10\x01\x12\x1d\n\x19ROCKSDB_COMPACTION_FILTER\x10\x02\"*\n\x14\x45mptyCleanupStrategy\x12\x12\n\x0e\x45MPTY_STRATEGY\x10\x00\"D\n\nUpdateType\x12\x0c\n\x08\x44isabled\x10\x00\x12\x14\n\x10OnCreateAndWrite\x10\x01\x12\x12\n\x0eOnReadAndWrite\x10\x02\"J\n\x0fStateVisibility\x12\x1f\n\x1bReturnExpiredIfNotCleanedUp\x10\x00\x12\x16\n\x12NeverReturnExpired\x10\x01\"+\n\x15TtlTimeCharacteristic\x12\x12\n\x0eProcessingTime\x10\x00\"\xf1\x07\n\x13\x43oderInfoDescriptor\x12`\n\x10\x66latten_row_type\x18\x01 \x01(\x0b\x32\x44.org.apache.flink.fn_execution.v1.CoderInfoDescriptor.FlattenRowTypeH\x00\x12Q\n\x08row_type\x18\x02 \x01(\x0b\x32=.org.apache.flink.fn_execution.v1.CoderInfoDescriptor.RowTypeH\x00\x12U\n\narrow_type\x18\x03 \x01(\x0b\x32?.org.apache.flink.fn_execution.v1.CoderInfoDescriptor.ArrowTypeH\x00\x12k\n\x16over_window_arrow_type\x18\x04 \x01(\x0b\x32I.org.apache.flink.fn_execution.v1.CoderInfoDescriptor.OverWindowArrowTypeH\x00\x12Q\n\x08raw_type\x18\x05 \x01(\x0b\x32=.org.apache.flink.fn_execution.v1.CoderInfoDescriptor.RawTypeH\x00\x12H\n\x04mode\x18\x06 \x01(\x0e\x32:.org.apache.flink.fn_execution.v1.CoderInfoDescriptor.Mode\x12\"\n\x1aseparated_with_end_message\x18\x07 \x01(\x08\x1aJ\n\x0e\x46lattenRowType\x12\x38\n\x06schema\x18\x01 \x01(\x0b\x32(.org.apache.flink.fn_execution.v1.Schema\x1a\x43\n\x07RowType\x12\x38\n\x06schema\x18\x01 \x01(\x0b\x32(.org.apache.flink.fn_execution.v1.Schema\x1a\x45\n\tArrowType\x12\x38\n\x06schema\x18\x01 \x01(\x0b\x32(.org.apache.flink.fn_execution.v1.Schema\x1aO\n\x13OverWindowArrowType\x12\x38\n\x06schema\x18\x01 \x01(\x0b\x32(.org.apache.flink.fn_execution.v1.Schema\x1aH\n\x07RawType\x12=\n\ttype_info\x18\x01 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfo\" \n\x04Mode\x12\n\n\x06SINGLE\x10\x00\x12\x0c\n\x08MULTIPLE\x10\x01\x42\x0b\n\tdata_typeB-\n\x1forg.apache.flink.fnexecution.v1B\nFlinkFnApib\x06proto3')
 )
 
 
@@ -374,14 +374,18 @@ _USERDEFINEDDATASTREAMFUNCTION_FUNCTIONTYPE = _descriptor.EnumDescriptor(
       options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
-      name='REVISE_OUTPUT', index=5, number=100,
+      name='CO_BROADCAST_PROCESS', index=5, number=5,
+      options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name='REVISE_OUTPUT', index=6, number=100,
       options=None,
       type=None),
   ],
   containing_type=None,
   options=None,
-  serialized_start=6861,
-  serialized_end=6976,
+  serialized_start=6862,
+  serialized_end=7003,
 )
 _sym_db.RegisterEnumDescriptor(_USERDEFINEDDATASTREAMFUNCTION_FUNCTIONTYPE)
 
@@ -406,8 +410,8 @@ _STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES_STRATEGIES = _descriptor.EnumD
   ],
   containing_type=None,
   options=None,
-  serialized_start=8538,
-  serialized_end=8636,
+  serialized_start=8565,
+  serialized_end=8663,
 )
 _sym_db.RegisterEnumDescriptor(_STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES_STRATEGIES)
 
@@ -424,8 +428,8 @@ _STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES_EMPTYCLEANUPSTRATEGY = _descri
   ],
   containing_type=None,
   options=None,
-  serialized_start=8638,
-  serialized_end=8680,
+  serialized_start=8665,
+  serialized_end=8707,
 )
 _sym_db.RegisterEnumDescriptor(_STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES_EMPTYCLEANUPSTRATEGY)
 
@@ -450,8 +454,8 @@ _STATEDESCRIPTOR_STATETTLCONFIG_UPDATETYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=8682,
-  serialized_end=8750,
+  serialized_start=8709,
+  serialized_end=8777,
 )
 _sym_db.RegisterEnumDescriptor(_STATEDESCRIPTOR_STATETTLCONFIG_UPDATETYPE)
 
@@ -472,8 +476,8 @@ _STATEDESCRIPTOR_STATETTLCONFIG_STATEVISIBILITY = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=8752,
-  serialized_end=8826,
+  serialized_start=8779,
+  serialized_end=8853,
 )
 _sym_db.RegisterEnumDescriptor(_STATEDESCRIPTOR_STATETTLCONFIG_STATEVISIBILITY)
 
@@ -490,8 +494,8 @@ _STATEDESCRIPTOR_STATETTLCONFIG_TTLTIMECHARACTERISTIC = _descriptor.EnumDescript
   ],
   containing_type=None,
   options=None,
-  serialized_start=8828,
-  serialized_end=8871,
+  serialized_start=8855,
+  serialized_end=8898,
 )
 _sym_db.RegisterEnumDescriptor(_STATEDESCRIPTOR_STATETTLCONFIG_TTLTIMECHARACTERISTIC)
 
@@ -512,8 +516,8 @@ _CODERINFODESCRIPTOR_MODE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=9838,
-  serialized_end=9870,
+  serialized_start=9865,
+  serialized_end=9897,
 )
 _sym_db.RegisterEnumDescriptor(_CODERINFODESCRIPTOR_MODE)
 
@@ -2039,7 +2043,7 @@ _USERDEFINEDDATASTREAMFUNCTION = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=5984,
-  serialized_end=6976,
+  serialized_end=7003,
 )
 
 
@@ -2076,8 +2080,8 @@ _STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES_INCREMENTALCLEANUPSTRATEGY = _
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=7760,
-  serialized_end=7848,
+  serialized_start=7787,
+  serialized_end=7875,
 )
 
 _STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES_ROCKSDBCOMPACTFILTERCLEANUPSTRATEGY = _descriptor.Descriptor(
@@ -2106,8 +2110,8 @@ _STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES_ROCKSDBCOMPACTFILTERCLEANUPSTR
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=7850,
-  serialized_end=7925,
+  serialized_start=7877,
+  serialized_end=7952,
 )
 
 _STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES_MAPSTRATEGIESENTRY = _descriptor.Descriptor(
@@ -2160,8 +2164,8 @@ _STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES_MAPSTRATEGIESENTRY = _descript
       name='CleanupStrategy', full_name='org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig.CleanupStrategies.MapStrategiesEntry.CleanupStrategy',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=7928,
-  serialized_end=8536,
+  serialized_start=7955,
+  serialized_end=8563,
 )
 
 _STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES = _descriptor.Descriptor(
@@ -2199,8 +2203,8 @@ _STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=7582,
-  serialized_end=8680,
+  serialized_start=7609,
+  serialized_end=8707,
 )
 
 _STATEDESCRIPTOR_STATETTLCONFIG = _descriptor.Descriptor(
@@ -2260,8 +2264,8 @@ _STATEDESCRIPTOR_STATETTLCONFIG = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=7111,
-  serialized_end=8871,
+  serialized_start=7138,
+  serialized_end=8898,
 )
 
 _STATEDESCRIPTOR = _descriptor.Descriptor(
@@ -2297,8 +2301,8 @@ _STATEDESCRIPTOR = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=6979,
-  serialized_end=8871,
+  serialized_start=7006,
+  serialized_end=8898,
 )
 
 
@@ -2328,8 +2332,8 @@ _CODERINFODESCRIPTOR_FLATTENROWTYPE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=9467,
-  serialized_end=9541,
+  serialized_start=9494,
+  serialized_end=9568,
 )
 
 _CODERINFODESCRIPTOR_ROWTYPE = _descriptor.Descriptor(
@@ -2358,8 +2362,8 @@ _CODERINFODESCRIPTOR_ROWTYPE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=9543,
-  serialized_end=9610,
+  serialized_start=9570,
+  serialized_end=9637,
 )
 
 _CODERINFODESCRIPTOR_ARROWTYPE = _descriptor.Descriptor(
@@ -2388,8 +2392,8 @@ _CODERINFODESCRIPTOR_ARROWTYPE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=9612,
-  serialized_end=9681,
+  serialized_start=9639,
+  serialized_end=9708,
 )
 
 _CODERINFODESCRIPTOR_OVERWINDOWARROWTYPE = _descriptor.Descriptor(
@@ -2418,8 +2422,8 @@ _CODERINFODESCRIPTOR_OVERWINDOWARROWTYPE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=9683,
-  serialized_end=9762,
+  serialized_start=9710,
+  serialized_end=9789,
 )
 
 _CODERINFODESCRIPTOR_RAWTYPE = _descriptor.Descriptor(
@@ -2448,8 +2452,8 @@ _CODERINFODESCRIPTOR_RAWTYPE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=9764,
-  serialized_end=9836,
+  serialized_start=9791,
+  serialized_end=9863,
 )
 
 _CODERINFODESCRIPTOR = _descriptor.Descriptor(
@@ -2524,8 +2528,8 @@ _CODERINFODESCRIPTOR = _descriptor.Descriptor(
       name='data_type', full_name='org.apache.flink.fn_execution.v1.CoderInfoDescriptor.data_type',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=8874,
-  serialized_end=9883,
+  serialized_start=8901,
+  serialized_end=9910,
 )
 
 _INPUT.fields_by_name['udf'].message_type = _USERDEFINEDFUNCTION

--- a/flink-python/pyflink/fn_execution/internal_state.py
+++ b/flink-python/pyflink/fn_execution/internal_state.py
@@ -114,8 +114,20 @@ class InternalMapState(InternalKvState[N], MapState[K, V], ABC):
 
 
 class InternalReadOnlyBroadcastState(ReadOnlyBroadcastState[K, V], ABC):
+    """
+    The peer to :class:`ReadOnlyBroadcastState`.
+    """
     pass
 
 
 class InternalBroadcastState(InternalReadOnlyBroadcastState[K, V], BroadcastState[K, V], ABC):
-    pass
+    """
+    The peer to :class:`BroadcastState`.
+    """
+
+    @abstractmethod
+    def to_read_only_broadcast_state(self) -> InternalReadOnlyBroadcastState[K, V]:
+        """
+        Convert to :class:`ReadOnlyBroadcastState` interface with the same underlying state.
+        """
+        pass

--- a/flink-python/pyflink/fn_execution/state_impl.py
+++ b/flink-python/pyflink/fn_execution/state_impl.py
@@ -1273,7 +1273,7 @@ class OperatorStateBackend(OperatorStateStore, ABC):
         pass
 
 
-class RemoteOperatorStateBackend(OperatorStateStore):
+class RemoteOperatorStateBackend(OperatorStateBackend):
     def __init__(
         self, state_handler, state_cache_size, map_state_read_cache_size, map_state_write_cache_size
     ):

--- a/flink-python/pyflink/fn_execution/state_impl.py
+++ b/flink-python/pyflink/fn_execution/state_impl.py
@@ -1266,6 +1266,22 @@ class SynchronousBroadcastRuntimeState(
         return SynchronousReadOnlyBroadcastRuntimeState(self._name, self._internal_map_state)
 
 
+class OperatorStateBackend(OperatorStateStore, ABC):
+
+    @abstractmethod
+    def commit(self):
+        pass
+
+
+class UnsupportedOperatorStateBackend(OperatorStateBackend):
+
+    def get_broadcast_state(self, state_descriptor: MapStateDescriptor):
+        raise RuntimeError("Operator state backend is not supported")
+
+    def commit(self):
+        pass
+
+
 class RemoteOperatorStateBackend(OperatorStateStore):
     def __init__(
         self, state_handler, state_cache_size, map_state_read_cache_size, map_state_write_cache_size

--- a/flink-python/pyflink/fn_execution/state_impl.py
+++ b/flink-python/pyflink/fn_execution/state_impl.py
@@ -1273,15 +1273,6 @@ class OperatorStateBackend(OperatorStateStore, ABC):
         pass
 
 
-class UnsupportedOperatorStateBackend(OperatorStateBackend):
-
-    def get_broadcast_state(self, state_descriptor: MapStateDescriptor):
-        raise RuntimeError("Operator state backend is not supported")
-
-    def commit(self):
-        pass
-
-
 class RemoteOperatorStateBackend(OperatorStateStore):
     def __init__(
         self, state_handler, state_cache_size, map_state_read_cache_size, map_state_write_cache_size

--- a/flink-python/pyflink/proto/flink-fn-execution.proto
+++ b/flink-python/pyflink/proto/flink-fn-execution.proto
@@ -346,6 +346,7 @@ message UserDefinedDataStreamFunction {
     KEYED_PROCESS = 2;
     KEYED_CO_PROCESS = 3;
     WINDOW = 4;
+    CO_BROADCAST_PROCESS = 5;
     REVISE_OUTPUT = 100;
   }
 

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/PythonBatchCoBroadcastProcessOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/PythonBatchCoBroadcastProcessOperator.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.python;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.functions.python.DataStreamPythonFunctionInfo;
+import org.apache.flink.streaming.api.operators.BoundedMultiInput;
+import org.apache.flink.streaming.api.operators.InputSelectable;
+import org.apache.flink.streaming.api.operators.InputSelection;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.util.Preconditions;
+
+/**
+ * The {@link PythonBatchCoBroadcastProcessOperator} is responsible for executing the Python
+ * CoBroadcastProcess Function under BATCH mode, {@link PythonCoProcessOperator} is used under
+ * STREAMING mode. This operator forces to run out data from broadcast side first, and then process
+ * data from regular side.
+ *
+ * @param <IN1> The input type of the regular stream
+ * @param <IN2> The input type of the broadcast stream
+ * @param <OUT> The output type of the CoBroadcastProcess function
+ */
+@Internal
+public class PythonBatchCoBroadcastProcessOperator<IN1, IN2, OUT>
+        extends PythonCoProcessOperator<IN1, IN2, OUT>
+        implements BoundedMultiInput, InputSelectable {
+
+    private transient volatile boolean isBroadcastSideDone;
+
+    public PythonBatchCoBroadcastProcessOperator(
+            Configuration config,
+            DataStreamPythonFunctionInfo pythonFunctionInfo,
+            TypeInformation<IN1> inputTypeInfo1,
+            TypeInformation<IN2> inputTypeInfo2,
+            TypeInformation<OUT> outputTypeInfo) {
+        super(config, pythonFunctionInfo, inputTypeInfo1, inputTypeInfo2, outputTypeInfo);
+    }
+
+    @Override
+    public void endInput(int inputId) throws Exception {
+        if (inputId == 2) {
+            isBroadcastSideDone = true;
+        }
+    }
+
+    @Override
+    public InputSelection nextSelection() {
+        if (!isBroadcastSideDone) {
+            return InputSelection.SECOND;
+        } else {
+            return InputSelection.FIRST;
+        }
+    }
+
+    @Override
+    public void processElement1(StreamRecord<IN1> element) throws Exception {
+        Preconditions.checkState(
+                isBroadcastSideDone,
+                "Should not process regular input before broadcast side is done.");
+
+        super.processElement1(element);
+    }
+}

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/transformations/python/PythonBroadcastStateTransformation.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/transformations/python/PythonBroadcastStateTransformation.java
@@ -35,7 +35,8 @@ import java.util.List;
 
 /**
  * A {@link Transformation} representing a Python Co-Broadcast-Process operation, which will be
- * translated into different operations by @{link}.
+ * translated into different operations by {@link
+ * org.apache.flink.streaming.runtime.translators.python.PythonBroadcastStateTransformationTranslator}.
  */
 public class PythonBroadcastStateTransformation<IN1, IN2, OUT>
         extends AbstractBroadcastStateTransformation<IN1, IN2, OUT> {

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/transformations/python/PythonBroadcastStateTransformation.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/transformations/python/PythonBroadcastStateTransformation.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.transformations.python;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.typeinfo.PrimitiveArrayTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.functions.python.DataStreamPythonFunctionInfo;
+import org.apache.flink.streaming.api.transformations.AbstractBroadcastStateTransformation;
+import org.apache.flink.streaming.api.utils.ByteArrayWrapper;
+import org.apache.flink.streaming.api.utils.ByteArrayWrapperSerializer;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * A {@link Transformation} representing a Python Co-Broadcast-Process operation, which will be
+ * translated into different operations by @{link}.
+ */
+public class PythonBroadcastStateTransformation<IN1, IN2, OUT>
+        extends AbstractBroadcastStateTransformation<IN1, IN2, OUT> {
+
+    private final Configuration configuration;
+    private final DataStreamPythonFunctionInfo dataStreamPythonFunctionInfo;
+
+    public PythonBroadcastStateTransformation(
+            String name,
+            Configuration configuration,
+            DataStreamPythonFunctionInfo dataStreamPythonFunctionInfo,
+            Transformation<IN1> regularInput,
+            Transformation<IN2> broadcastInput,
+            List<MapStateDescriptor<?, ?>> broadcastStateDescriptors,
+            TypeInformation<OUT> outTypeInfo,
+            int parallelism) {
+        super(
+                name,
+                regularInput,
+                broadcastInput,
+                broadcastStateDescriptors,
+                outTypeInfo,
+                parallelism);
+        this.configuration = configuration;
+        this.dataStreamPythonFunctionInfo = dataStreamPythonFunctionInfo;
+        updateManagedMemoryStateBackendUseCase(false);
+    }
+
+    public Configuration getConfiguration() {
+        return configuration;
+    }
+
+    public DataStreamPythonFunctionInfo getDataStreamPythonFunctionInfo() {
+        return dataStreamPythonFunctionInfo;
+    }
+
+    public static List<MapStateDescriptor<ByteArrayWrapper, byte[]>>
+            convertStateNamesToStateDescriptors(Collection<String> names) {
+        List<MapStateDescriptor<ByteArrayWrapper, byte[]>> descriptors =
+                new ArrayList<>(names.size());
+        TypeSerializer<byte[]> byteArraySerializer =
+                PrimitiveArrayTypeInfo.BYTE_PRIMITIVE_ARRAY_TYPE_INFO.createSerializer(
+                        new ExecutionConfig());
+        for (String name : names) {
+            descriptors.add(
+                    new MapStateDescriptor<>(
+                            name, ByteArrayWrapperSerializer.INSTANCE, byteArraySerializer));
+        }
+        return descriptors;
+    }
+}

--- a/flink-python/src/main/java/org/apache/flink/streaming/runtime/translators/python/PythonBroadcastStateTransformationTranslator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/runtime/translators/python/PythonBroadcastStateTransformationTranslator.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.translators.python;
+
+import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
+import org.apache.flink.streaming.api.operators.python.PythonBatchCoBroadcastProcessOperator;
+import org.apache.flink.streaming.api.operators.python.PythonCoProcessOperator;
+import org.apache.flink.streaming.api.transformations.python.PythonBroadcastStateTransformation;
+import org.apache.flink.streaming.runtime.translators.AbstractTwoInputTransformationTranslator;
+import org.apache.flink.util.Preconditions;
+
+import java.util.Collection;
+
+/**
+ * A {@link org.apache.flink.streaming.api.graph.TransformationTranslator} that translates {@link
+ * PythonBroadcastStateTransformation} into {@link PythonCoProcessOperator} or {@link
+ * PythonBatchCoBroadcastProcessOperator}.
+ */
+public class PythonBroadcastStateTransformationTranslator<IN1, IN2, OUT>
+        extends AbstractTwoInputTransformationTranslator<
+                IN1, IN2, OUT, PythonBroadcastStateTransformation<IN1, IN2, OUT>> {
+
+    @Override
+    protected Collection<Integer> translateForBatchInternal(
+            PythonBroadcastStateTransformation<IN1, IN2, OUT> transformation, Context context) {
+        Preconditions.checkNotNull(transformation);
+        Preconditions.checkNotNull(context);
+
+        PythonBatchCoBroadcastProcessOperator<IN1, IN2, OUT> operator =
+                new PythonBatchCoBroadcastProcessOperator<>(
+                        transformation.getConfiguration(),
+                        transformation.getDataStreamPythonFunctionInfo(),
+                        transformation.getRegularInput().getOutputType(),
+                        transformation.getBroadcastInput().getOutputType(),
+                        transformation.getOutputType());
+
+        return translateInternal(
+                transformation,
+                transformation.getRegularInput(),
+                transformation.getBroadcastInput(),
+                SimpleOperatorFactory.of(operator),
+                null,
+                null,
+                null,
+                context);
+    }
+
+    @Override
+    protected Collection<Integer> translateForStreamingInternal(
+            PythonBroadcastStateTransformation<IN1, IN2, OUT> transformation, Context context) {
+        Preconditions.checkNotNull(transformation);
+        Preconditions.checkNotNull(context);
+
+        PythonCoProcessOperator<IN1, IN2, OUT> operator =
+                new PythonCoProcessOperator<>(
+                        transformation.getConfiguration(),
+                        transformation.getDataStreamPythonFunctionInfo(),
+                        transformation.getRegularInput().getOutputType(),
+                        transformation.getBroadcastInput().getOutputType(),
+                        transformation.getOutputType());
+
+        return translateInternal(
+                transformation,
+                transformation.getRegularInput(),
+                transformation.getBroadcastInput(),
+                SimpleOperatorFactory.of(operator),
+                null,
+                null,
+                null,
+                context);
+    }
+}


### PR DESCRIPTION

## What is the purpose of the change

This PR implements non-keyed co-broadcast processing interfaces, including `BroadcastStream`, `BroadcastConnectedStream` and `BroadcastProcessFunction`.


## Brief change log

- add `BroadcastStream`, `BroadcastConnectedStream`, `BroadcastProcessFunction` and related internal classes
- add an distinct `CO_BROADCAST_PROCESS` function type for broadcast processing
- introduce `PythonBroadcastStateTransformation` and corresponding translator to translate python broadcast process into different operators for batch or streaming


## Verifying this change

This change added tests and can be verified as follows:

- `test_co_broadcast_process` in test_data_stream.py

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (Python generated doc)
