### PR TITLE
[hotfix] fix a typo in NetworkBufferTest

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferTest.java
@@ -92,7 +92,7 @@ public class NetworkBufferTest extends AbstractByteBufTest {
 
     @Test
     public void testDataBufferIsBuffer() {
-        assertFalse(newBuffer(1024, 1024, false).isBuffer());
+        assertTrue(newBuffer(1024, 1024, true).isBuffer());
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change
testDataBufferIsBuffer should test dataBuffer instead of eventBuffer.