### PR TITLE
[FLINK-27901][python] support TableEnvironment.create(configuration)

### DIFF
--- a/docs/content.zh/docs/dev/python/python_config.md
+++ b/docs/content.zh/docs/dev/python/python_config.md
@@ -65,6 +65,9 @@ env_settings = EnvironmentSettings \
     .with_configuration(config) \
     .build()
 table_env = TableEnvironment.create(env_settings)
+
+# or directly pass config into create method
+table_env = TableEnvironment.create(config)
 ```
 
 ## Python Options

--- a/docs/content/docs/dev/python/python_config.md
+++ b/docs/content/docs/dev/python/python_config.md
@@ -65,6 +65,9 @@ env_settings = EnvironmentSettings \
     .with_configuration(config) \
     .build()
 table_env = TableEnvironment.create(env_settings)
+
+# or directly pass config into create method
+table_env = TableEnvironment.create(config)
 ```
 
 ## Python Options

--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -99,22 +99,21 @@ class TableEnvironment(object):
         self._open()
 
     @staticmethod
-    def create(conf_or_settings: Union[EnvironmentSettings, Configuration]) -> 'TableEnvironment':
+    def create(environment_settings: Union[EnvironmentSettings, Configuration]) \
+            -> 'TableEnvironment':
         """
         Creates a table environment that is the entry point and central context for creating Table
         and SQL API programs.
 
-        :param conf_or_settings: The configuration or environment settings used to instantiate the
-                                     :class:`~pyflink.table.TableEnvironment`.
+        :param environment_settings: The configuration or environment settings used to instantiate
+            the :class:`~pyflink.table.TableEnvironment`, the name is for backward compatability.
         :return: The :class:`~pyflink.table.TableEnvironment`.
         """
         gateway = get_gateway()
-        if isinstance(conf_or_settings, EnvironmentSettings):
-            environment_settings = conf_or_settings
-        elif isinstance(conf_or_settings, Configuration):
+        if isinstance(environment_settings, Configuration):
             environment_settings = EnvironmentSettings.new_instance() \
-                .with_configuration(conf_or_settings).build()
-        else:
+                .with_configuration(environment_settings).build()
+        elif not isinstance(environment_settings, EnvironmentSettings):
             raise TypeError("argument should be EnvironmentSettings or Configuration")
 
         j_tenv = gateway.jvm.TableEnvironment.create(environment_settings._j_environment_settings)


### PR DESCRIPTION

## What is the purpose of the change

This PR support `TableEnvironment.create(Configuration)` API in PyFlink, which is an alignment to Java API.

## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (Python generated doc)
