### PR TITLE
[FLINK-27902][runtime] Refactor ResultPartitionType to decouple scheduling and partition release logic

### DIFF
--- a/flink-optimizer/src/test/java/org/apache/flink/optimizer/dataexchange/UnionClosedBranchingTest.java
+++ b/flink-optimizer/src/test/java/org/apache/flink/optimizer/dataexchange/UnionClosedBranchingTest.java
@@ -203,11 +203,11 @@ public class UnionClosedBranchingTest extends CompilerTestBase {
                 if (!executionMode.equals(ExecutionMode.PIPELINED_FORCED)) {
                     assertTrue(
                             "Expected batch exchange, but result type is " + dsType + ".",
-                            dsType.isBlocking());
+                            dsType.isBlockingOrBlockingPersistentResultPartition());
                 } else {
                     assertFalse(
                             "Expected non-batch exchange, but result type is " + dsType + ".",
-                            dsType.isBlocking());
+                            dsType.isBlockingOrBlockingPersistentResultPartition());
                 }
             }
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorFactory.java
@@ -295,7 +295,7 @@ public class TaskDeploymentDescriptorFactory {
             PartitionLocationConstraint partitionDeploymentConstraint,
             @Nullable ResultPartitionDeploymentDescriptor consumedPartitionDescriptor) {
         // The producing task needs to be RUNNING or already FINISHED
-        if ((resultPartitionType.isPipelined() || isConsumable)
+        if ((resultPartitionType.canBePipelinedConsumed() || isConsumable)
                 && consumedPartitionDescriptor != null
                 && isProducerAvailable(producerState)) {
             // partition is already registered

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -1299,7 +1299,7 @@ public class Execution
                                     resultPartitionDeploymentDescriptor ->
                                             resultPartitionDeploymentDescriptor
                                                     .getPartitionType()
-                                                    .isPipelined())
+                                                    .isReleaseByUpstream())
                             .map(ResultPartitionDeploymentDescriptor::getShuffleDescriptor)
                             .peek(shuffleMaster::releasePartitionExternally)
                             .map(ShuffleDescriptor::getResultPartitionID)

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -473,7 +473,7 @@ public class ExecutionVertex
         List<IntermediateResultPartition> finishedBlockingPartitions = null;
 
         for (IntermediateResultPartition partition : resultPartitions.values()) {
-            if (partition.getResultType().isBlocking()) {
+            if (!partition.getResultType().canBePipelinedConsumed()) {
 
                 partition.markFinished();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IntermediateResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IntermediateResultPartition.java
@@ -156,7 +156,7 @@ public class IntermediateResultPartition {
     }
 
     void resetForNewExecution() {
-        if (getResultType().isBlocking() && hasDataProduced) {
+        if (!getResultType().canBePipelinedConsumed() && hasDataProduced) {
             // A BLOCKING result partition with data produced means it is finished
             // Need to add the running producer count of the result on resetting it
             for (ConsumedPartitionGroup consumedPartitionGroup : getConsumedPartitionGroups()) {
@@ -179,7 +179,7 @@ public class IntermediateResultPartition {
 
     void markFinished() {
         // Sanity check that this is only called on blocking partitions.
-        if (!getResultType().isBlocking()) {
+        if (getResultType().canBePipelinedConsumed()) {
             throw new IllegalStateException(
                     "Tried to mark a non-blocking result partition as finished");
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/LogicalPipelinedRegionComputeUtil.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/LogicalPipelinedRegionComputeUtil.java
@@ -39,22 +39,21 @@ public final class LogicalPipelinedRegionComputeUtil {
         final Map<LogicalVertex, Set<LogicalVertex>> vertexToRegion =
                 buildRawRegions(
                         topologicallySortedVertices,
-                        LogicalPipelinedRegionComputeUtil::getNonReconnectableConsumedResults);
+                        LogicalPipelinedRegionComputeUtil::getMustBePipelinedConsumedResults);
 
         // Since LogicalTopology is a DAG, there is no need to do cycle detection nor to merge
         // regions on cycles.
         return uniqueVertexGroups(vertexToRegion);
     }
 
-    private static Iterable<LogicalResult> getNonReconnectableConsumedResults(
-            LogicalVertex vertex) {
-        List<LogicalResult> nonReconnectableConsumedResults = new ArrayList<>();
+    private static Iterable<LogicalResult> getMustBePipelinedConsumedResults(LogicalVertex vertex) {
+        List<LogicalResult> mustBePipelinedConsumedResults = new ArrayList<>();
         for (LogicalResult consumedResult : vertex.getConsumedResults()) {
-            if (!consumedResult.getResultType().isReconnectable()) {
-                nonReconnectableConsumedResults.add(consumedResult);
+            if (consumedResult.getResultType().mustBePipelinedConsumed()) {
+                mustBePipelinedConsumedResults.add(consumedResult);
             }
         }
-        return nonReconnectableConsumedResults;
+        return mustBePipelinedConsumedResults;
     }
 
     private LogicalPipelinedRegionComputeUtil() {}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/PipelinedRegionComputeUtil.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/PipelinedRegionComputeUtil.java
@@ -35,7 +35,7 @@ public final class PipelinedRegionComputeUtil {
     static <V extends Vertex<?, ?, V, R>, R extends Result<?, ?, V, R>>
             Map<V, Set<V>> buildRawRegions(
                     final Iterable<? extends V> topologicallySortedVertices,
-                    final Function<V, Iterable<R>> getNonReconnectableConsumedResults) {
+                    final Function<V, Iterable<R>> getMustBePipelinedConsumedResults) {
 
         final Map<V, Set<V>> vertexToRegion = new IdentityHashMap<>();
 
@@ -45,11 +45,10 @@ public final class PipelinedRegionComputeUtil {
             currentRegion.add(vertex);
             vertexToRegion.put(vertex, currentRegion);
 
-            // Similar to the BLOCKING ResultPartitionType, each vertex connected through
-            // PIPELINED_APPROXIMATE is also considered as a single region. This attribute is
-            // called "reconnectable". Reconnectable will be removed after FLINK-19895, see also
-            // {@link ResultPartitionType#isReconnectable}
-            for (R consumedResult : getNonReconnectableConsumedResults.apply(vertex)) {
+            // Each vertex connected through not mustBePipelined consumingConstraint is considered
+            // as a
+            // single region.
+            for (R consumedResult : getMustBePipelinedConsumedResults.apply(vertex)) {
                 final V producerVertex = consumedResult.getProducer();
                 final Set<V> producerRegion = vertexToRegion.get(producerVertex);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/SchedulingPipelinedRegionComputeUtil.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/SchedulingPipelinedRegionComputeUtil.java
@@ -55,7 +55,7 @@ public final class SchedulingPipelinedRegionComputeUtil {
                 buildRawRegions(
                         topologicallySortedVertices,
                         vertex ->
-                                getNonReconnectableConsumedResults(
+                                getMustBePipelinedConsumedResults(
                                         vertex, resultPartitionRetriever));
 
         return mergeRegionsOnCycles(vertexToRegion, executionVertexRetriever);
@@ -113,7 +113,7 @@ public final class SchedulingPipelinedRegionComputeUtil {
             final List<Integer> currentRegionOutEdges = new ArrayList<>();
             for (SchedulingExecutionVertex vertex : currentRegion) {
                 for (SchedulingResultPartition producedResult : vertex.getProducedResults()) {
-                    if (!producedResult.getResultType().isReconnectable()) {
+                    if (producedResult.getResultType().mustBePipelinedConsumed()) {
                         continue;
                     }
                     final Optional<ConsumerVertexGroup> consumerVertexGroup =
@@ -143,23 +143,23 @@ public final class SchedulingPipelinedRegionComputeUtil {
         return outEdges;
     }
 
-    private static Iterable<SchedulingResultPartition> getNonReconnectableConsumedResults(
+    private static Iterable<SchedulingResultPartition> getMustBePipelinedConsumedResults(
             SchedulingExecutionVertex vertex,
             Function<IntermediateResultPartitionID, ? extends SchedulingResultPartition>
                     resultPartitionRetriever) {
-        List<SchedulingResultPartition> nonReconnectableConsumedResults = new ArrayList<>();
+        List<SchedulingResultPartition> mustBePipelinedConsumedResults = new ArrayList<>();
         for (ConsumedPartitionGroup consumedPartitionGroup : vertex.getConsumedPartitionGroups()) {
             for (IntermediateResultPartitionID partitionId : consumedPartitionGroup) {
                 SchedulingResultPartition consumedResult =
                         resultPartitionRetriever.apply(partitionId);
-                if (consumedResult.getResultType().isReconnectable()) {
+                if (!consumedResult.getResultType().mustBePipelinedConsumed()) {
                     // The result types of partitions in one ConsumedPartitionGroup are all the same
                     break;
                 }
-                nonReconnectableConsumedResults.add(consumedResult);
+                mustBePipelinedConsumedResults.add(consumedResult);
             }
         }
-        return nonReconnectableConsumedResults;
+        return mustBePipelinedConsumedResults;
     }
 
     private SchedulingPipelinedRegionComputeUtil() {}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/partitionrelease/RegionPartitionGroupReleaseStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/partitionrelease/RegionPartitionGroupReleaseStrategy.java
@@ -83,7 +83,7 @@ public class RegionPartitionGroupReleaseStrategy
 
         for (SchedulingPipelinedRegion region : newRegions) {
             for (ConsumedPartitionGroup consumedPartitionGroup :
-                    region.getAllBlockingConsumedPartitionGroups()) {
+                    region.getAllReleaseBySchedulerConsumedPartitionGroups()) {
                 partitionGroupConsumerRegions
                         .computeIfAbsent(
                                 consumedPartitionGroup,
@@ -112,7 +112,7 @@ public class RegionPartitionGroupReleaseStrategy
             consumerRegionGroupExecutionViewMaintainer.regionFinished(pipelinedRegion);
 
             return filterReleasablePartitionGroups(
-                    pipelinedRegion.getAllBlockingConsumedPartitionGroups());
+                    pipelinedRegion.getAllReleaseBySchedulerConsumedPartitionGroups());
         }
         return Collections.emptyList();
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/JobMasterPartitionTrackerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/JobMasterPartitionTrackerImpl.java
@@ -70,10 +70,8 @@ public class JobMasterPartitionTrackerImpl
         Preconditions.checkNotNull(producingTaskExecutorId);
         Preconditions.checkNotNull(resultPartitionDeploymentDescriptor);
 
-        // blocking and PIPELINED_APPROXIMATE partitions require explicit partition release calls
-        // reconnectable will be removed after FLINK-19895, see also {@link
-        // ResultPartitionType#isReconnectable}.
-        if (!resultPartitionDeploymentDescriptor.getPartitionType().isReconnectable()) {
+        // non-releaseByScheduler partitions don't require explicit partition release calls.
+        if (!resultPartitionDeploymentDescriptor.getPartitionType().isReleaseByScheduler()) {
             return;
         }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactory.java
@@ -133,7 +133,8 @@ public class ResultPartitionFactory {
             int maxParallelism,
             SupplierWithException<BufferPool, IOException> bufferPoolFactory) {
         BufferCompressor bufferCompressor = null;
-        if (type.isBlocking() && blockingShuffleCompressionEnabled) {
+        if (type.isBlockingOrBlockingPersistentResultPartition()
+                && blockingShuffleCompressionEnabled) {
             bufferCompressor = new BufferCompressor(networkBufferSize, compressionCodec);
         }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionType.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionType.java
@@ -176,6 +176,21 @@ public enum ResultPartitionType {
         return releaseBy == ReleaseBy.UPSTREAM;
     }
 
+    /**
+     * {@link #isPipelinedOrPipelinedBoundedResultPartition()} is used to judge whether it is the
+     * specified {@link #PIPELINED} or {@link #PIPELINED_BOUNDED} resultPartitionType.
+     *
+     * <p>This method suitable for judgment conditions related to the specific implementation of
+     * {@link ResultPartitionType}.
+     *
+     * <p>This method not related to data consumption and partition release. As for the logic
+     * related to partition release, use {@link #isReleaseByScheduler()} instead, and as consume
+     * type, use {@link #mustBePipelinedConsumed()} or {@link #canBePipelinedConsumed()} instead.
+     */
+    public boolean isPipelinedOrPipelinedBoundedResultPartition() {
+        return this == PIPELINED || this == PIPELINED_BOUNDED;
+    }
+
     public boolean isReconnectable() {
         return isReconnectable;
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionType.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionType.java
@@ -162,6 +162,12 @@ public enum ResultPartitionType {
         return consumingConstraint == ConsumingConstraint.MUST_BE_PIPELINED;
     }
 
+    /** return if this partition's upstream and downstream support scheduling in the same time. */
+    public boolean canBePipelinedConsumed() {
+        return consumingConstraint == ConsumingConstraint.CAN_BE_PIPELINED
+                || consumingConstraint == ConsumingConstraint.MUST_BE_PIPELINED;
+    }
+
     public boolean isReconnectable() {
         return isReconnectable;
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionType.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionType.java
@@ -177,6 +177,21 @@ public enum ResultPartitionType {
     }
 
     /**
+     * {@link #isBlockingOrBlockingPersistentResultPartition()} is used to judge whether it is the
+     * specified {@link #BLOCKING} or {@link #BLOCKING_PERSISTENT} resultPartitionType.
+     *
+     * <p>this method suitable for judgment conditions related to the specific implementation of
+     * {@link ResultPartitionType}.
+     *
+     * <p>this method not related to data consumption and partition release. As for the logic
+     * related to partition release, use {@link #isReleaseByScheduler()} instead, and as consume
+     * type, use {@link #mustBePipelinedConsumed()} or {@link #canBePipelinedConsumed()} instead.
+     */
+    public boolean isBlockingOrBlockingPersistentResultPartition() {
+        return this == BLOCKING || this == BLOCKING_PERSISTENT;
+    }
+
+    /**
      * {@link #isPipelinedOrPipelinedBoundedResultPartition()} is used to judge whether it is the
      * specified {@link #PIPELINED} or {@link #PIPELINED_BOUNDED} resultPartitionType.
      *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionType.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionType.java
@@ -32,7 +32,7 @@ public enum ResultPartitionType {
      * {@link #PIPELINED} partitions), but only released through the scheduler, when it determines
      * that the partition is no longer needed.
      */
-    BLOCKING(false, false, false, false, true),
+    BLOCKING(false, false, false, true),
 
     /**
      * BLOCKING_PERSISTENT partitions are similar to {@link #BLOCKING} partitions, but have a
@@ -45,7 +45,7 @@ public enum ResultPartitionType {
      * scenarios, like when the TaskManager exits or when the TaskManager loses connection to
      * JobManager / ResourceManager for too long.
      */
-    BLOCKING_PERSISTENT(false, false, false, true, true),
+    BLOCKING_PERSISTENT(false, false, true, true),
 
     /**
      * A pipelined streaming data exchange. This is applicable to both bounded and unbounded
@@ -57,7 +57,7 @@ public enum ResultPartitionType {
      * <p>This result partition type may keep an arbitrary amount of data in-flight, in contrast to
      * the {@link #PIPELINED_BOUNDED} variant.
      */
-    PIPELINED(true, true, false, false, false),
+    PIPELINED(true, false, false, false),
 
     /**
      * Pipelined partitions with a bounded (local) buffer pool.
@@ -70,7 +70,7 @@ public enum ResultPartitionType {
      * <p>For batch jobs, it will be best to keep this unlimited ({@link #PIPELINED}) since there
      * are no checkpoint barriers.
      */
-    PIPELINED_BOUNDED(true, true, true, false, false),
+    PIPELINED_BOUNDED(true, true, false, false),
 
     /**
      * Pipelined partitions with a bounded (local) buffer pool to support downstream task to
@@ -81,13 +81,10 @@ public enum ResultPartitionType {
      * in that {@link #PIPELINED_APPROXIMATE} partition can be reconnected after down stream task
      * fails.
      */
-    PIPELINED_APPROXIMATE(true, true, true, false, true);
+    PIPELINED_APPROXIMATE(true, true, false, true);
 
     /** Can the partition be consumed while being produced? */
     private final boolean isPipelined;
-
-    /** Does the partition produce back pressure when not consumed? */
-    private final boolean hasBackPressure;
 
     /** Does this partition use a limited number of (network) buffers? */
     private final boolean isBounded;
@@ -109,20 +106,11 @@ public enum ResultPartitionType {
 
     /** Specifies the behaviour of an intermediate result partition at runtime. */
     ResultPartitionType(
-            boolean isPipelined,
-            boolean hasBackPressure,
-            boolean isBounded,
-            boolean isPersistent,
-            boolean isReconnectable) {
+            boolean isPipelined, boolean isBounded, boolean isPersistent, boolean isReconnectable) {
         this.isPipelined = isPipelined;
-        this.hasBackPressure = hasBackPressure;
         this.isBounded = isBounded;
         this.isPersistent = isPersistent;
         this.isReconnectable = isReconnectable;
-    }
-
-    public boolean hasBackPressure() {
-        return hasBackPressure;
     }
 
     public boolean isBlocking() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionType.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionType.java
@@ -168,6 +168,14 @@ public enum ResultPartitionType {
                 || consumingConstraint == ConsumingConstraint.MUST_BE_PIPELINED;
     }
 
+    public boolean isReleaseByScheduler() {
+        return releaseBy == ReleaseBy.SCHEDULER;
+    }
+
+    public boolean isReleaseByUpstream() {
+        return releaseBy == ReleaseBy.UPSTREAM;
+    }
+
     public boolean isReconnectable() {
         return isReconnectable;
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionType.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionType.java
@@ -157,6 +157,11 @@ public enum ResultPartitionType {
         return isPipelined;
     }
 
+    /** return if this partition's upstream and downstream must be scheduled in the same time. */
+    public boolean mustBePipelinedConsumed() {
+        return consumingConstraint == ConsumingConstraint.MUST_BE_PIPELINED;
+    }
+
     public boolean isReconnectable() {
         return isReconnectable;
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionType.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionType.java
@@ -32,7 +32,7 @@ public enum ResultPartitionType {
      * {@link #PIPELINED} partitions), but only released through the scheduler, when it determines
      * that the partition is no longer needed.
      */
-    BLOCKING(false, false, false, true),
+    BLOCKING(false, false, false, true, ConsumingConstraint.BLOCKING, ReleaseBy.SCHEDULER),
 
     /**
      * BLOCKING_PERSISTENT partitions are similar to {@link #BLOCKING} partitions, but have a
@@ -45,7 +45,8 @@ public enum ResultPartitionType {
      * scenarios, like when the TaskManager exits or when the TaskManager loses connection to
      * JobManager / ResourceManager for too long.
      */
-    BLOCKING_PERSISTENT(false, false, true, true),
+    BLOCKING_PERSISTENT(
+            false, false, true, true, ConsumingConstraint.BLOCKING, ReleaseBy.SCHEDULER),
 
     /**
      * A pipelined streaming data exchange. This is applicable to both bounded and unbounded
@@ -57,7 +58,7 @@ public enum ResultPartitionType {
      * <p>This result partition type may keep an arbitrary amount of data in-flight, in contrast to
      * the {@link #PIPELINED_BOUNDED} variant.
      */
-    PIPELINED(true, false, false, false),
+    PIPELINED(true, false, false, false, ConsumingConstraint.MUST_BE_PIPELINED, ReleaseBy.UPSTREAM),
 
     /**
      * Pipelined partitions with a bounded (local) buffer pool.
@@ -70,7 +71,8 @@ public enum ResultPartitionType {
      * <p>For batch jobs, it will be best to keep this unlimited ({@link #PIPELINED}) since there
      * are no checkpoint barriers.
      */
-    PIPELINED_BOUNDED(true, true, false, false),
+    PIPELINED_BOUNDED(
+            true, true, false, false, ConsumingConstraint.MUST_BE_PIPELINED, ReleaseBy.UPSTREAM),
 
     /**
      * Pipelined partitions with a bounded (local) buffer pool to support downstream task to
@@ -81,7 +83,8 @@ public enum ResultPartitionType {
      * in that {@link #PIPELINED_APPROXIMATE} partition can be reconnected after down stream task
      * fails.
      */
-    PIPELINED_APPROXIMATE(true, true, false, true);
+    PIPELINED_APPROXIMATE(
+            true, true, false, true, ConsumingConstraint.CAN_BE_PIPELINED, ReleaseBy.UPSTREAM);
 
     /** Can the partition be consumed while being produced? */
     private final boolean isPipelined;
@@ -104,13 +107,46 @@ public enum ResultPartitionType {
      */
     private final boolean isReconnectable;
 
+    private final ConsumingConstraint consumingConstraint;
+
+    private final ReleaseBy releaseBy;
+
+    /** ConsumeType indicates when can the downstream consume the upstream. */
+    private enum ConsumingConstraint {
+        /** Upstream must be finished before downstream consume. */
+        BLOCKING,
+        /** Downstream can consume while upstream is running. */
+        CAN_BE_PIPELINED,
+        /** Downstream must consume while upstream is running. */
+        MUST_BE_PIPELINED
+    }
+
+    /**
+     * ReleaseType indicates who is responsible for releasing the result partition.
+     *
+     * <p>Attention: This may only be a short-term solution to deal with the partition release
+     * logic. We can discuss the issue of unifying the partition release logic in FLINK-27948. Once
+     * the ticket is resolved, we can remove the enumeration here.
+     */
+    private enum ReleaseBy {
+        UPSTREAM,
+        SCHEDULER
+    }
+
     /** Specifies the behaviour of an intermediate result partition at runtime. */
     ResultPartitionType(
-            boolean isPipelined, boolean isBounded, boolean isPersistent, boolean isReconnectable) {
+            boolean isPipelined,
+            boolean isBounded,
+            boolean isPersistent,
+            boolean isReconnectable,
+            ConsumingConstraint consumingConstraint,
+            ReleaseBy releaseBy) {
         this.isPipelined = isPipelined;
         this.isBounded = isBounded;
         this.isPersistent = isPersistent;
         this.isReconnectable = isReconnectable;
+        this.consumingConstraint = consumingConstraint;
+        this.releaseBy = releaseBy;
     }
 
     public boolean isBlocking() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateFactory.java
@@ -122,7 +122,8 @@ public class SingleInputGateFactory {
                 createBufferPoolFactory(networkBufferPool, floatingNetworkBuffersPerGate);
 
         BufferDecompressor bufferDecompressor = null;
-        if (igdd.getConsumedPartitionType().isBlocking() && blockingShuffleCompressionEnabled) {
+        if (igdd.getConsumedPartitionType().isBlockingOrBlockingPersistentResultPartition()
+                && blockingShuffleCompressionEnabled) {
             bufferDecompressor = new BufferDecompressor(networkBufferSize, compressionCodec);
         }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultExecutionTopology.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultExecutionTopology.java
@@ -197,13 +197,13 @@ public class DefaultExecutionTopology implements SchedulingTopology {
                         .map(ExecutionJobVertex::getJobVertexId)
                         .collect(Collectors.toSet());
 
-        // any PIPELINED input should be from within this new set so that existing pipelined regions
-        // will not change
+        // any mustBePipelinedConsumed input should be from within this new set so that existing
+        // pipelined regions will not change
         newlyInitializedJobVertices.stream()
                 .map(ExecutionJobVertex::getJobVertex)
                 .flatMap(v -> v.getInputs().stream())
                 .map(JobEdge::getSource)
-                .filter(r -> r.getResultType().isPipelined())
+                .filter(r -> r.getResultType().mustBePipelinedConsumed())
                 .map(IntermediateDataSet::getProducer)
                 .map(JobVertex::getID)
                 .forEach(id -> checkState(newJobVertexIds.contains(id)));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultSchedulingPipelinedRegion.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultSchedulingPipelinedRegion.java
@@ -42,6 +42,8 @@ public class DefaultSchedulingPipelinedRegion implements SchedulingPipelinedRegi
 
     private Set<ConsumedPartitionGroup> blockingConsumedPartitionGroups;
 
+    private Set<ConsumedPartitionGroup> releaseBySchedulerConsumedPartitionGroups;
+
     private final Function<IntermediateResultPartitionID, DefaultResultPartition>
             resultPartitionRetriever;
 
@@ -75,8 +77,10 @@ public class DefaultSchedulingPipelinedRegion implements SchedulingPipelinedRegi
         return executionVertex;
     }
 
-    private void initializeAllBlockingConsumedPartitionGroups() {
-        final Set<ConsumedPartitionGroup> consumedPartitionGroupSet = new HashSet<>();
+    private void initializeConsumedPartitionGroups() {
+        final Set<ConsumedPartitionGroup> blockingConsumedPartitionGroupSet = new HashSet<>();
+        final Set<ConsumedPartitionGroup> releaseBySchedulerConsumedPartitionGroupSet =
+                new HashSet<>();
         for (DefaultExecutionVertex executionVertex : executionVertices.values()) {
             for (ConsumedPartitionGroup consumedPartitionGroup :
                     executionVertex.getConsumedPartitionGroups()) {
@@ -84,21 +88,34 @@ public class DefaultSchedulingPipelinedRegion implements SchedulingPipelinedRegi
                         resultPartitionRetriever.apply(consumedPartitionGroup.getFirst());
 
                 if (consumedPartition.getResultType().isBlocking()) {
-                    consumedPartitionGroupSet.add(consumedPartitionGroup);
+                    blockingConsumedPartitionGroupSet.add(consumedPartitionGroup);
+                }
+                if (consumedPartition.getResultType().isReleaseByScheduler()) {
+                    releaseBySchedulerConsumedPartitionGroupSet.add(consumedPartitionGroup);
                 }
             }
         }
 
         this.blockingConsumedPartitionGroups =
-                Collections.unmodifiableSet(consumedPartitionGroupSet);
+                Collections.unmodifiableSet(blockingConsumedPartitionGroupSet);
+        this.releaseBySchedulerConsumedPartitionGroups =
+                Collections.unmodifiableSet(releaseBySchedulerConsumedPartitionGroupSet);
     }
 
     @Override
     public Iterable<ConsumedPartitionGroup> getAllBlockingConsumedPartitionGroups() {
         if (blockingConsumedPartitionGroups == null) {
-            initializeAllBlockingConsumedPartitionGroups();
+            initializeConsumedPartitionGroups();
         }
         return blockingConsumedPartitionGroups;
+    }
+
+    @Override
+    public Iterable<ConsumedPartitionGroup> getAllReleaseBySchedulerConsumedPartitionGroups() {
+        if (releaseBySchedulerConsumedPartitionGroups == null) {
+            initializeConsumedPartitionGroups();
+        }
+        return releaseBySchedulerConsumedPartitionGroups;
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultSchedulingPipelinedRegion.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultSchedulingPipelinedRegion.java
@@ -87,7 +87,7 @@ public class DefaultSchedulingPipelinedRegion implements SchedulingPipelinedRegi
                 SchedulingResultPartition consumedPartition =
                         resultPartitionRetriever.apply(consumedPartitionGroup.getFirst());
 
-                if (consumedPartition.getResultType().isBlocking()) {
+                if (!consumedPartition.getResultType().canBePipelinedConsumed()) {
                     blockingConsumedPartitionGroupSet.add(consumedPartitionGroup);
                 }
                 if (consumedPartition.getResultType().isReleaseByScheduler()) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
@@ -309,7 +309,9 @@ public class AdaptiveScheduler
                     vertex.getID());
             for (JobEdge jobEdge : vertex.getInputs()) {
                 Preconditions.checkState(
-                        jobEdge.getSource().getResultType().isPipelined(),
+                        jobEdge.getSource()
+                                .getResultType()
+                                .isPipelinedOrPipelinedBoundedResultPartition(),
                         "The adaptive scheduler supports pipelined data exchanges (violated by %s -> %s).",
                         jobEdge.getSource().getProducer(),
                         jobEdge.getTarget().getID());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchSchedulerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchSchedulerFactory.java
@@ -179,7 +179,7 @@ public class AdaptiveBatchSchedulerFactory implements SchedulerNGFactory {
         for (JobVertex jobVertex : jobGraph.getVertices()) {
             for (IntermediateDataSet dataSet : jobVertex.getProducedDataSets()) {
                 checkState(
-                        dataSet.getResultType().isBlocking(),
+                        dataSet.getResultType().isBlockingOrBlockingPersistentResultPartition(),
                         String.format(
                                 "At the moment, adaptive batch scheduler requires batch workloads "
                                         + "to be executed with types of all edges being BLOCKING. "

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/SchedulingPipelinedRegion.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/SchedulingPipelinedRegion.java
@@ -36,4 +36,11 @@ public interface SchedulingPipelinedRegion
      * @return set of {@link ConsumedPartitionGroup}s
      */
     Iterable<ConsumedPartitionGroup> getAllBlockingConsumedPartitionGroups();
+
+    /**
+     * Get all distinct releaseByScheduler {@link ConsumedPartitionGroup}s.
+     *
+     * @return set of {@link ConsumedPartitionGroup}s
+     */
+    Iterable<ConsumedPartitionGroup> getAllReleaseBySchedulerConsumedPartitionGroups();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/NettyShuffleUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/NettyShuffleUtils.java
@@ -136,12 +136,12 @@ public class NettyShuffleUtils {
 
         // In order to avoid network buffer request timeout (see FLINK-12852), we announce
         // network buffer requirement by below:
-        // 1. For pipelined shuffle, the floating buffers may not be returned in time due to back
-        // pressure so we need to include all the floating buffers in the announcement, i.e. we
+        // 1. For canBePipelined shuffle, the floating buffers may not be returned in time due to
+        // back pressure so we need to include all the floating buffers in the announcement, i.e. we
         // should take the max value;
         // 2. For blocking shuffle, it is back pressure free and floating buffers can be recycled
         // in time, so that the minimum required buffers would be enough.
-        int ret = type.isPipelined() ? minAndMax.getRight() : minAndMax.getLeft();
+        int ret = type.canBePipelinedConsumed() ? minAndMax.getRight() : minAndMax.getLeft();
 
         if (ret == Integer.MAX_VALUE) {
             // Should never reach this branch. Result partition will allocate an unbounded

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/NettyShuffleUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/NettyShuffleUtils.java
@@ -64,7 +64,9 @@ public class NettyShuffleUtils {
             final int sortShuffleMinBuffers,
             final int numSubpartitions,
             final ResultPartitionType type) {
-        boolean isSortShuffle = type.isBlocking() && numSubpartitions >= sortShuffleMinParallelism;
+        boolean isSortShuffle =
+                type.isBlockingOrBlockingPersistentResultPartition()
+                        && numSubpartitions >= sortShuffleMinParallelism;
         int min = isSortShuffle ? sortShuffleMinBuffers : numSubpartitions + 1;
         int max =
                 type.isBounded()

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -822,8 +822,8 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
     private Stream<ResultPartitionDeploymentDescriptor> filterPartitionsRequiringRelease(
             Collection<ResultPartitionDeploymentDescriptor> producedResultPartitions) {
         return producedResultPartitions.stream()
-                // only blocking partitions require explicit release call
-                .filter(d -> d.getPartitionType().isBlocking())
+                // only releaseByScheduler partitions require explicit release call
+                .filter(d -> d.getPartitionType().isReleaseByScheduler())
                 // partitions without local resources don't store anything on the TaskExecutor
                 .filter(d -> d.getShuffleDescriptor().storesLocalResourcesOn().isPresent());
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/JobMasterPartitionTrackerImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/JobMasterPartitionTrackerImplTest.java
@@ -80,7 +80,7 @@ public class JobMasterPartitionTrackerImplTest extends TestLogger {
 
         assertThat(
                 partitionTracker.isTrackingPartitionsFor(resourceId),
-                is(resultPartitionType.isReconnectable()));
+                is(resultPartitionType.isReleaseByScheduler()));
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SsgNetworkMemoryCalculationUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SsgNetworkMemoryCalculationUtilsTest.java
@@ -270,7 +270,7 @@ public class SsgNetworkMemoryCalculationUtilsTest {
         map.connectNewDataSetAsInput(source, DistributionPattern.POINTWISE, resultPartitionType);
         sink.connectNewDataSetAsInput(map, DistributionPattern.ALL_TO_ALL, resultPartitionType);
 
-        if (resultPartitionType.isPipelined()) {
+        if (!resultPartitionType.isBlockingOrBlockingPersistentResultPartition()) {
             return JobGraphTestUtils.streamingJobGraph(source, map, sink);
 
         } else {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingPipelinedRegion.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingPipelinedRegion.java
@@ -78,6 +78,11 @@ public class TestingSchedulingPipelinedRegion implements SchedulingPipelinedRegi
     }
 
     @Override
+    public Iterable<ConsumedPartitionGroup> getAllReleaseBySchedulerConsumedPartitionGroups() {
+        return Collections.unmodifiableSet(consumedPartitionGroups);
+    }
+
+    @Override
     public boolean contains(ExecutionVertexID vertexId) {
         return regionVertices.containsKey(vertexId);
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/shuffle/NettyShuffleUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/shuffle/NettyShuffleUtilsTest.java
@@ -206,7 +206,7 @@ public class NettyShuffleUtilsTest extends TestLogger {
     }
 
     private int calculateBuffersConsumption(ResultPartition partition) {
-        if (partition.getPartitionType().isBlocking()) {
+        if (!partition.getPartitionType().canBePipelinedConsumed()) {
             return partition.getBufferPool().getNumberOfRequiredMemorySegments();
         } else {
             return partition.getBufferPool().getMaxNumberOfMemorySegments();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -1014,14 +1014,14 @@ public class StreamingJobGraphGenerator {
 
     private void checkBufferTimeout(ResultPartitionType type, StreamEdge edge) {
         long bufferTimeout = edge.getBufferTimeout();
-        if (type.isBlocking()
+        if (!type.canBePipelinedConsumed()
                 && bufferTimeout != ExecutionOptions.DISABLED_NETWORK_BUFFER_TIMEOUT) {
             throw new UnsupportedOperationException(
-                    "Blocking partition does not support buffer timeout "
+                    "only canBePipelinedConsumed partition support buffer timeout "
                             + bufferTimeout
                             + " for src operator in edge "
                             + edge
-                            + ". \nPlease either disable buffer timeout (via -1) or use the non-blocking partition.");
+                            + ". \nPlease either disable buffer timeout (via -1) or use the canBePipelinedConsumed partition.");
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change

Refactor ResultPartitionType to decouple scheduling and partition release logic


## Brief change log

  - *Introduce ConsumeType indicates when can the downstream consume the upstream. *
  - *Introduce ReleaseType indicates who is responsible for releasing the result partition.*
  - *Using ConsumeType and ReleaseType instead of isPipelined and isReconnectable in scheduling and partition release related code.*
  -  *Remove useless isPipelined, isBlocking and isReconnectable in ResultPartitionType.*


## Verifying this change

This change is already covered by existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
