### PR TITLE
[FLINK-27921] Introduce the checkResourceRequirementsWithDelay in Dec…

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/ResourceManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ResourceManagerOptions.java
@@ -142,6 +142,14 @@ public class ResourceManagerOptions {
                                     + START_WORKER_MAX_FAILURE_RATE.key()
                                     + "') is reached.");
 
+    @Documentation.ExcludeFromDocumentation(
+            "This is an expert option, that we do not want to expose in the documentation")
+    public static final ConfigOption<Duration> REQUIREMENTS_CHECK_DELAY =
+            ConfigOptions.key("slotmanager.requirement-check.delay")
+                    .durationType()
+                    .defaultValue(Duration.ofMillis(50))
+                    .withDescription("The delay of the resource requirements check.");
+
     /**
      * The timeout for a slot request to be discarded, in milliseconds.
      *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerRuntimeServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerRuntimeServices.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.resourcemanager;
 
-import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.metrics.groups.SlotManagerMetricGroup;
 import org.apache.flink.runtime.resourcemanager.slotmanager.DeclarativeSlotManager;
@@ -36,9 +35,6 @@ import org.apache.flink.util.concurrent.ScheduledExecutor;
 
 /** Container class for the {@link ResourceManager} services. */
 public class ResourceManagerRuntimeServices {
-    // We currently make the delay of requirements check a constant time. This delay might be
-    // configurable by user in the future.
-    private static final long REQUIREMENTS_CHECK_DELAY_MS = 50L;
 
     private final SlotManager slotManager;
     private final JobLeaderIdService jobLeaderIdService;
@@ -93,8 +89,7 @@ public class ResourceManagerRuntimeServices {
                     new DefaultResourceAllocationStrategy(
                             SlotManagerUtils.generateTaskManagerTotalResourceProfile(
                                     slotManagerConfiguration.getDefaultWorkerResourceSpec()),
-                            slotManagerConfiguration.getNumSlotsPerWorker()),
-                    Time.milliseconds(REQUIREMENTS_CHECK_DELAY_MS));
+                            slotManagerConfiguration.getNumSlotsPerWorker()));
         } else {
             return new DeclarativeSlotManager(
                     scheduledExecutor,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfiguration.java
@@ -34,6 +34,8 @@ import org.apache.flink.util.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Duration;
+
 /** Configuration for the {@link SlotManager}. */
 public class SlotManagerConfiguration {
 
@@ -42,6 +44,7 @@ public class SlotManagerConfiguration {
     private final Time taskManagerRequestTimeout;
     private final Time slotRequestTimeout;
     private final Time taskManagerTimeout;
+    private final Duration requirementCheckDelay;
     private final boolean waitResultConsumedBeforeRelease;
     private final SlotMatchingStrategy slotMatchingStrategy;
     private final WorkerResourceSpec defaultWorkerResourceSpec;
@@ -55,6 +58,7 @@ public class SlotManagerConfiguration {
             Time taskManagerRequestTimeout,
             Time slotRequestTimeout,
             Time taskManagerTimeout,
+            Duration requirementCheckDelay,
             boolean waitResultConsumedBeforeRelease,
             SlotMatchingStrategy slotMatchingStrategy,
             WorkerResourceSpec defaultWorkerResourceSpec,
@@ -67,6 +71,7 @@ public class SlotManagerConfiguration {
         this.taskManagerRequestTimeout = Preconditions.checkNotNull(taskManagerRequestTimeout);
         this.slotRequestTimeout = Preconditions.checkNotNull(slotRequestTimeout);
         this.taskManagerTimeout = Preconditions.checkNotNull(taskManagerTimeout);
+        this.requirementCheckDelay = Preconditions.checkNotNull(requirementCheckDelay);
         this.waitResultConsumedBeforeRelease = waitResultConsumedBeforeRelease;
         this.slotMatchingStrategy = Preconditions.checkNotNull(slotMatchingStrategy);
         this.defaultWorkerResourceSpec = Preconditions.checkNotNull(defaultWorkerResourceSpec);
@@ -90,6 +95,10 @@ public class SlotManagerConfiguration {
 
     public Time getTaskManagerTimeout() {
         return taskManagerTimeout;
+    }
+
+    public Duration getRequirementCheckDelay() {
+        return requirementCheckDelay;
     }
 
     public boolean isWaitResultConsumedBeforeRelease() {
@@ -136,6 +145,9 @@ public class SlotManagerConfiguration {
                 Time.milliseconds(
                         configuration.getLong(ResourceManagerOptions.TASK_MANAGER_TIMEOUT));
 
+        final Duration requirementCheckDelay =
+                configuration.get(ResourceManagerOptions.REQUIREMENTS_CHECK_DELAY);
+
         boolean waitResultConsumedBeforeRelease =
                 configuration.getBoolean(
                         ResourceManagerOptions.TASK_MANAGER_RELEASE_WHEN_RESULT_CONSUMED);
@@ -158,6 +170,7 @@ public class SlotManagerConfiguration {
                 rpcTimeout,
                 slotRequestTimeout,
                 taskManagerTimeout,
+                requirementCheckDelay,
                 waitResultConsumedBeforeRelease,
                 slotMatchingStrategy,
                 defaultWorkerResourceSpec,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManagerBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManagerBuilder.java
@@ -30,6 +30,7 @@ import org.apache.flink.testutils.TestingUtils;
 import org.apache.flink.util.concurrent.Executors;
 import org.apache.flink.util.concurrent.ScheduledExecutor;
 
+import java.time.Duration;
 import java.util.concurrent.Executor;
 
 /** Builder for {@link DeclarativeSlotManager}. */
@@ -47,6 +48,7 @@ public class DeclarativeSlotManagerBuilder {
     private int redundantTaskManagerNum;
     private ResourceTracker resourceTracker;
     private SlotTracker slotTracker;
+    private Duration requirementCheckDelay;
 
     private DeclarativeSlotManagerBuilder(ScheduledExecutor scheduledExecutor) {
         this.slotMatchingStrategy = AnyMatchingSlotMatchingStrategy.INSTANCE;
@@ -64,6 +66,7 @@ public class DeclarativeSlotManagerBuilder {
                 ResourceManagerOptions.REDUNDANT_TASK_MANAGER_NUM.defaultValue();
         this.resourceTracker = new DefaultResourceTracker();
         this.slotTracker = new DefaultSlotTracker();
+        this.requirementCheckDelay = Duration.ZERO;
     }
 
     public static DeclarativeSlotManagerBuilder newBuilder(ScheduledExecutor scheduledExecutor) {
@@ -135,12 +138,18 @@ public class DeclarativeSlotManagerBuilder {
         return this;
     }
 
+    public DeclarativeSlotManagerBuilder setRequirementCheckDelay(Duration requirementCheckDelay) {
+        this.requirementCheckDelay = requirementCheckDelay;
+        return this;
+    }
+
     public DeclarativeSlotManager build() {
         final SlotManagerConfiguration slotManagerConfiguration =
                 new SlotManagerConfiguration(
                         taskManagerRequestTimeout,
                         slotRequestTimeout,
                         taskManagerTimeout,
+                        requirementCheckDelay,
                         waitResultConsumedBeforeRelease,
                         slotMatchingStrategy,
                         defaultWorkerResourceSpec,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTest.java
@@ -43,6 +43,7 @@ import org.apache.flink.util.function.ThrowingConsumer;
 import org.junit.Test;
 
 import java.math.BigDecimal;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -576,7 +577,7 @@ public class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
                 final List<CompletableFuture<Void>> checkRequirementFutures = new ArrayList<>();
                 checkRequirementFutures.add(new CompletableFuture<>());
                 checkRequirementFutures.add(new CompletableFuture<>());
-                final long requirementCheckDelay = 50;
+                final Duration requirementCheckDelay = Duration.ofMillis(50);
                 resourceAllocationStrategyBuilder.setTryFulfillRequirementsFunction(
                         (ignored1, ignored2) -> {
                             if (checkRequirementFutures.get(0).isDone()) {
@@ -619,13 +620,13 @@ public class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
                             final long registrationTime = (System.nanoTime() - start) / 1_000_000;
                             assumeTrue(
                                     "The time of process requirement and register task manager must not take longer than the requirement check delay. If it does, then this indicates a very slow machine.",
-                                    registrationTime < requirementCheckDelay);
+                                    registrationTime < requirementCheckDelay.toMillis());
 
                             assertFutureCompleteAndReturn(checkRequirementFutures.get(0));
                             assertFutureNotComplete(checkRequirementFutures.get(1));
 
                             // checkTimes will not increase when there's no events
-                            Thread.sleep(requirementCheckDelay * 2);
+                            Thread.sleep(requirementCheckDelay.toMillis() * 2);
                             assertFutureNotComplete(checkRequirementFutures.get(1));
 
                             // checkTimes will increase again if there's another

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTestBase.java
@@ -44,6 +44,7 @@ import org.apache.flink.util.function.RunnableWithException;
 
 import org.junit.ClassRule;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
@@ -150,7 +151,7 @@ public abstract class FineGrainedSlotManagerTestBase extends TestLogger {
                 new ScheduledExecutorServiceAdapter(EXECUTOR_RESOURCE.getExecutor());
         private final Executor mainThreadExecutor = EXECUTOR_RESOURCE.getExecutor();
         private FineGrainedSlotManager slotManager;
-        private long requirementCheckDelay = 0;
+        private Duration requirementCheckDelay = Duration.ZERO;
 
         final TestingResourceAllocationStrategy.Builder resourceAllocationStrategyBuilder =
                 TestingResourceAllocationStrategy.newBuilder();
@@ -176,7 +177,7 @@ public abstract class FineGrainedSlotManagerTestBase extends TestLogger {
             return resourceManagerId;
         }
 
-        public void setRequirementCheckDelay(long requirementCheckDelay) {
+        public void setRequirementCheckDelay(Duration requirementCheckDelay) {
             this.requirementCheckDelay = requirementCheckDelay;
         }
 
@@ -208,8 +209,7 @@ public abstract class FineGrainedSlotManagerTestBase extends TestLogger {
                             taskManagerTracker,
                             slotStatusSyncer,
                             getResourceAllocationStrategy()
-                                    .orElse(resourceAllocationStrategyBuilder.build()),
-                            Time.milliseconds(requirementCheckDelay));
+                                    .orElse(resourceAllocationStrategyBuilder.build()));
             runInMainThreadAndWait(
                     () ->
                             slotManager.start(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfigurationBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfigurationBuilder.java
@@ -25,11 +25,14 @@ import org.apache.flink.configuration.ResourceManagerOptions;
 import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 import org.apache.flink.testutils.TestingUtils;
 
+import java.time.Duration;
+
 /** Builder for {@link SlotManagerConfiguration}. */
 public class SlotManagerConfigurationBuilder {
     private Time taskManagerRequestTimeout;
     private Time slotRequestTimeout;
     private Time taskManagerTimeout;
+    private Duration requirementCheckDelay;
     private boolean waitResultConsumedBeforeRelease;
     private WorkerResourceSpec defaultWorkerResourceSpec;
     private int numSlotsPerWorker;
@@ -42,6 +45,7 @@ public class SlotManagerConfigurationBuilder {
         this.taskManagerRequestTimeout = TestingUtils.infiniteTime();
         this.slotRequestTimeout = TestingUtils.infiniteTime();
         this.taskManagerTimeout = TestingUtils.infiniteTime();
+        this.requirementCheckDelay = ResourceManagerOptions.REQUIREMENTS_CHECK_DELAY.defaultValue();
         this.waitResultConsumedBeforeRelease = true;
         this.defaultWorkerResourceSpec = WorkerResourceSpec.ZERO;
         this.numSlotsPerWorker = 1;
@@ -69,6 +73,12 @@ public class SlotManagerConfigurationBuilder {
 
     public SlotManagerConfigurationBuilder setTaskManagerTimeout(Time taskManagerTimeout) {
         this.taskManagerTimeout = taskManagerTimeout;
+        return this;
+    }
+
+    public SlotManagerConfigurationBuilder setRequirementCheckDelay(
+            Duration requirementCheckDelay) {
+        this.requirementCheckDelay = requirementCheckDelay;
         return this;
     }
 
@@ -114,6 +124,7 @@ public class SlotManagerConfigurationBuilder {
                 taskManagerRequestTimeout,
                 slotRequestTimeout,
                 taskManagerTimeout,
+                requirementCheckDelay,
                 waitResultConsumedBeforeRelease,
                 AnyMatchingSlotMatchingStrategy.INSTANCE,
                 defaultWorkerResourceSpec,


### PR DESCRIPTION
…larativeSlotManager


## What is the purpose of the change

This PR is meant to introduce the delay for resource requirements in DeclarativeSlotManager. It is the preceding step to solve the https://github.com/apache/flink/pull/19840 


## Brief change log

- Make the delay option configurable (but exclude from the doc). I think it's an internal optimization
- Use the same mechanism in DeclarativeSlotManager with FineGrainedSlotManager.


## Verifying this change

A test is added to verify it.
