### PR TITLE
[FLINK-27692][state] Support local recovery for materialized part of changelog

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -137,6 +137,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.configuration.ClusterOptions.PROCESS_WORKING_DIR_BASE;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
 
@@ -321,7 +322,7 @@ public class MiniCluster implements AutoCloseableAsync {
                         WorkingDirectory.create(
                                 ClusterEntrypointUtils.generateWorkingDirectoryFile(
                                         configuration,
-                                        Optional.empty(),
+                                        Optional.of(PROCESS_WORKING_DIR_BASE),
                                         "minicluster_" + ResourceID.generate()));
 
                 initializeIOFormatClasses(configuration);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ChangelogTaskLocalStateStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ChangelogTaskLocalStateStore.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
+import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.state.changelog.ChangelogStateBackendHandle;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnegative;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.function.LongPredicate;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.util.Preconditions.checkState;
+
+/** Changelog's implementation of a {@link TaskLocalStateStore}. */
+public class ChangelogTaskLocalStateStore extends TaskLocalStateStoreImpl {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ChangelogTaskLocalStateStore.class);
+
+    private static final String CHANGE_LOG_CHECKPOINT_PREFIX = "changelog_chk_";
+
+    /**
+     * The mapper of checkpointId and materializationId. (cp3, materializationId2) means cp3 refer
+     * to m1.
+     */
+    private final Map<Long, Long> mapToMaterializationId;
+
+    /** Last checkpointId, to check whether checkpoint is out of order. */
+    private long lastCheckpointId = -1L;
+
+    public ChangelogTaskLocalStateStore(
+            @Nonnull JobID jobID,
+            @Nonnull AllocationID allocationID,
+            @Nonnull JobVertexID jobVertexID,
+            @Nonnegative int subtaskIndex,
+            @Nonnull LocalRecoveryConfig localRecoveryConfig,
+            @Nonnull Executor discardExecutor) {
+        super(jobID, allocationID, jobVertexID, subtaskIndex, localRecoveryConfig, discardExecutor);
+        this.mapToMaterializationId = new HashMap<>();
+    }
+
+    private void updateReference(long checkpointId, TaskStateSnapshot localState) {
+        if (localState == null) {
+            localState = NULL_DUMMY;
+        }
+        for (Map.Entry<OperatorID, OperatorSubtaskState> subtaskStateEntry :
+                localState.getSubtaskStateMappings()) {
+            for (KeyedStateHandle keyedStateHandle :
+                    subtaskStateEntry.getValue().getManagedKeyedState()) {
+                if (keyedStateHandle instanceof ChangelogStateBackendHandle) {
+                    ChangelogStateBackendHandle changelogStateBackendHandle =
+                            (ChangelogStateBackendHandle) keyedStateHandle;
+                    long materializationID = changelogStateBackendHandle.getMaterializationID();
+                    if (mapToMaterializationId.containsKey(checkpointId)) {
+                        checkState(
+                                materializationID == mapToMaterializationId.get(checkpointId),
+                                "one checkpoint contains at most one materializationID");
+                    } else {
+                        mapToMaterializationId.put(checkpointId, materializationID);
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    public void storeLocalState(long checkpointId, @Nullable TaskStateSnapshot localState) {
+        if (checkpointId < lastCheckpointId) {
+            LOG.info(
+                    "Current checkpoint {} is out of order, smaller than last CheckpointId {}.",
+                    lastCheckpointId,
+                    checkpointId);
+            return;
+        } else {
+            lastCheckpointId = checkpointId;
+        }
+        synchronized (lock) {
+            updateReference(checkpointId, localState);
+        }
+        super.storeLocalState(checkpointId, localState);
+    }
+
+    @Override
+    protected File getCheckpointDirectory(long checkpointId) {
+        return new File(
+                getLocalRecoveryDirectoryProvider().subtaskBaseDirectory(checkpointId),
+                CHANGE_LOG_CHECKPOINT_PREFIX + checkpointId);
+    }
+
+    private void deleteMaterialization(LongPredicate pruningChecker) {
+        Set<Long> materializationToRemove;
+        synchronized (lock) {
+            Set<Long> checkpoints =
+                    mapToMaterializationId.keySet().stream()
+                            .filter(pruningChecker::test)
+                            .collect(Collectors.toSet());
+            materializationToRemove =
+                    checkpoints.stream()
+                            .map(mapToMaterializationId::remove)
+                            .collect(Collectors.toSet());
+            materializationToRemove.removeAll(mapToMaterializationId.values());
+        }
+
+        discardExecutor.execute(
+                () ->
+                        syncDiscardDirectoryForCollection(
+                                materializationToRemove.stream()
+                                        .map(super::getCheckpointDirectory)
+                                        .collect(Collectors.toList())));
+    }
+
+    private void syncDiscardDirectoryForCollection(Collection<File> toDiscard) {
+        for (File directory : toDiscard) {
+            if (directory.exists()) {
+                try {
+                    // TODO: This is guaranteed by the wrapped backend only using this folder for
+                    // its local state, the materialized handle should be discarded here too.
+                    deleteDirectory(directory);
+                } catch (IOException ex) {
+                    LOG.warn(
+                            "Exception while deleting local state directory of {} in subtask ({} - {} - {}).",
+                            directory,
+                            jobID,
+                            jobVertexID,
+                            subtaskIndex,
+                            ex);
+                }
+            }
+        }
+    }
+
+    @Override
+    public void pruneCheckpoints(LongPredicate pruningChecker, boolean breakOnceCheckerFalse) {
+        // Scenarios:
+        //   c1,m1
+        //   confirm c1, do nothing.
+        //   c2,m1
+        //   confirm c2, delete c1, don't delete m1
+        //   c3,m2
+        //   confirm c3, delete c2, delete m1
+
+        // delete changelog-chk
+        super.pruneCheckpoints(pruningChecker, false);
+        deleteMaterialization(pruningChecker);
+    }
+
+    @Override
+    public CompletableFuture<Void> dispose() {
+        deleteMaterialization(id -> true);
+        synchronized (lock) {
+            mapToMaterializationId.clear();
+        }
+        return super.dispose();
+    }
+
+    @Override
+    public String toString() {
+        return "ChangelogTaskLocalStateStore{"
+                + "jobID="
+                + jobID
+                + ", jobVertexID="
+                + jobVertexID
+                + ", allocationID="
+                + allocationID.toHexString()
+                + ", subtaskIndex="
+                + subtaskIndex
+                + ", localRecoveryConfig="
+                + localRecoveryConfig
+                + ", storedCheckpointIDs="
+                + storedTaskStateByCheckpointID.keySet()
+                + ", mapToMaterializationId="
+                + mapToMaterializationId.entrySet()
+                + '}';
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskExecutorLocalStateStoresManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskExecutorLocalStateStoresManager.java
@@ -20,6 +20,9 @@ package org.apache.flink.runtime.state;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.StateChangelogOptions;
+import org.apache.flink.configuration.StateChangelogOptionsInternal;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.util.FileUtils;
@@ -122,7 +125,9 @@ public class TaskExecutorLocalStateStoresManager {
             @Nonnull JobID jobId,
             @Nonnull AllocationID allocationID,
             @Nonnull JobVertexID jobVertexID,
-            @Nonnegative int subtaskIndex) {
+            @Nonnegative int subtaskIndex,
+            Configuration clusterConfiguration,
+            Configuration jobConfiguration) {
 
         synchronized (lock) {
             if (closed) {
@@ -164,22 +169,37 @@ public class TaskExecutorLocalStateStoresManager {
                 LocalRecoveryConfig localRecoveryConfig =
                         new LocalRecoveryConfig(directoryProvider);
 
-                taskLocalStateStore =
-                        localRecoveryConfig.isLocalRecoveryEnabled()
-                                ?
+                boolean changelogEnabled =
+                        jobConfiguration
+                                .getOptional(
+                                        StateChangelogOptionsInternal
+                                                .ENABLE_CHANGE_LOG_FOR_APPLICATION)
+                                .orElse(
+                                        clusterConfiguration.getBoolean(
+                                                StateChangelogOptions.ENABLE_STATE_CHANGE_LOG));
 
-                                // Real store implementation if local recovery is enabled
-                                new TaskLocalStateStoreImpl(
-                                        jobId,
-                                        allocationID,
-                                        jobVertexID,
-                                        subtaskIndex,
-                                        localRecoveryConfig,
-                                        discardExecutor)
-                                :
-
-                                // NOP implementation if local recovery is disabled
-                                new NoOpTaskLocalStateStoreImpl(localRecoveryConfig);
+                if (localRecoveryConfig.isLocalRecoveryEnabled() && changelogEnabled) {
+                    taskLocalStateStore =
+                            new ChangelogTaskLocalStateStore(
+                                    jobId,
+                                    allocationID,
+                                    jobVertexID,
+                                    subtaskIndex,
+                                    localRecoveryConfig,
+                                    discardExecutor);
+                } else if (localRecoveryConfig.isLocalRecoveryEnabled()) {
+                    taskLocalStateStore =
+                            new TaskLocalStateStoreImpl(
+                                    jobId,
+                                    allocationID,
+                                    jobVertexID,
+                                    subtaskIndex,
+                                    localRecoveryConfig,
+                                    discardExecutor);
+                } else {
+                    // NOP implementation if local recovery is disabled
+                    taskLocalStateStore = new NoOpTaskLocalStateStoreImpl(localRecoveryConfig);
+                }
 
                 taskStateManagers.put(taskKey, taskLocalStateStore);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/ChangelogStateBackendLocalHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/ChangelogStateBackendLocalHandle.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.changelog;
+
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.KeyedStateHandle;
+import org.apache.flink.runtime.state.SharedStateRegistry;
+import org.apache.flink.runtime.state.StateHandleID;
+
+import javax.annotation.Nullable;
+
+import java.util.List;
+
+/**
+ * State handle for local copies of {@link ChangelogStateHandleStreamImpl}. Consists of a
+ * remoteHandle that maintains the mapping of local handle and remote handle, like
+ * sharedStateHandleIDs in {@link org.apache.flink.runtime.state.IncrementalLocalKeyedStateHandle}.
+ */
+public class ChangelogStateBackendLocalHandle implements ChangelogStateBackendHandle {
+    private static final long serialVersionUID = 1L;
+    private final List<KeyedStateHandle> localMaterialized;
+    private final List<ChangelogStateHandle> localNonMaterialized;
+    private final ChangelogStateBackendHandleImpl remoteHandle;
+
+    public ChangelogStateBackendLocalHandle(
+            List<KeyedStateHandle> localMaterialized,
+            List<ChangelogStateHandle> localNonMaterialized,
+            ChangelogStateBackendHandleImpl remoteHandle) {
+        this.localMaterialized = localMaterialized;
+        this.localNonMaterialized = localNonMaterialized;
+        this.remoteHandle = remoteHandle;
+    }
+
+    @Override
+    public List<KeyedStateHandle> getMaterializedStateHandles() {
+        return localMaterialized;
+    }
+
+    @Override
+    public List<ChangelogStateHandle> getNonMaterializedStateHandles() {
+        return localNonMaterialized;
+    }
+
+    @Override
+    public long getMaterializationID() {
+        return remoteHandle.getMaterializationID();
+    }
+
+    @Override
+    public ChangelogStateBackendHandle rebound(long checkpointId) {
+        throw new UnsupportedOperationException("Should not call here.");
+    }
+
+    public List<KeyedStateHandle> getRemoteMaterializedStateHandles() {
+        return remoteHandle.getMaterializedStateHandles();
+    }
+
+    public List<ChangelogStateHandle> getRemoteNonMaterializedStateHandles() {
+        return remoteHandle.getNonMaterializedStateHandles();
+    }
+
+    @Override
+    public long getCheckpointId() {
+        return remoteHandle.getCheckpointId();
+    }
+
+    @Override
+    public void registerSharedStates(SharedStateRegistry stateRegistry, long checkpointID) {
+        remoteHandle.registerSharedStates(stateRegistry, checkpointID);
+    }
+
+    @Override
+    public long getCheckpointedSize() {
+        return remoteHandle.getCheckpointedSize();
+    }
+
+    @Override
+    public KeyGroupRange getKeyGroupRange() {
+        return remoteHandle.getKeyGroupRange();
+    }
+
+    @Nullable
+    @Override
+    public KeyedStateHandle getIntersection(KeyGroupRange keyGroupRange) {
+        throw new UnsupportedOperationException(
+                "This is a local state handle for the TM side only.");
+    }
+
+    @Override
+    public StateHandleID getStateHandleId() {
+        return remoteHandle.getStateHandleId();
+    }
+
+    @Override
+    public void discardState() throws Exception {}
+
+    @Override
+    public long getStateSize() {
+        return remoteHandle.getStateSize();
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -691,7 +691,9 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
                             jobId,
                             tdd.getAllocationId(),
                             taskInformation.getJobVertexId(),
-                            tdd.getSubtaskIndex());
+                            tdd.getSubtaskIndex(),
+                            taskManagerConfiguration.getConfiguration(),
+                            jobInformation.getJobConfiguration());
 
             // TODO: Pass config value from user program and do overriding here.
             final StateChangelogStorage<?> changelogStorage;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ChangelogTaskLocalStateStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ChangelogTaskLocalStateStoreTest.java
@@ -1,0 +1,214 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
+import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.state.changelog.ChangelogStateBackendHandle.ChangelogStateBackendHandleImpl;
+import org.apache.flink.util.FlinkRuntimeException;
+import org.apache.flink.util.concurrent.Executors;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.annotation.Nonnull;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/** Test for {@link ChangelogTaskLocalStateStore}. */
+public class ChangelogTaskLocalStateStoreTest extends TaskLocalStateStoreImplTest {
+
+    private LocalRecoveryDirectoryProvider localRecoveryDirectoryProvider;
+
+    @Before
+    @Override
+    public void before() throws Exception {
+        super.before();
+        this.taskLocalStateStore =
+                createChangelogTaskLocalStateStore(
+                        allocationBaseDirs, jobID, allocationID, jobVertexID, subtaskIdx);
+    }
+
+    @Nonnull
+    private ChangelogTaskLocalStateStore createChangelogTaskLocalStateStore(
+            File[] allocationBaseDirs,
+            JobID jobID,
+            AllocationID allocationID,
+            JobVertexID jobVertexID,
+            int subtaskIdx) {
+        LocalRecoveryDirectoryProviderImpl directoryProvider =
+                new LocalRecoveryDirectoryProviderImpl(
+                        allocationBaseDirs, jobID, jobVertexID, subtaskIdx);
+        this.localRecoveryDirectoryProvider = directoryProvider;
+
+        LocalRecoveryConfig localRecoveryConfig = new LocalRecoveryConfig(directoryProvider);
+        return new ChangelogTaskLocalStateStore(
+                jobID,
+                allocationID,
+                jobVertexID,
+                subtaskIdx,
+                localRecoveryConfig,
+                Executors.directExecutor());
+    }
+
+    @Test
+    @Override
+    public void pruneCheckpoints() throws Exception {
+        TestingTaskStateSnapshot stateSnapshot1 = storeChangelogStates(1, 1);
+        TestingTaskStateSnapshot stateSnapshot2 = storeChangelogStates(2, 1);
+        TestingTaskStateSnapshot stateSnapshot3 = storeChangelogStates(3, 1);
+
+        taskLocalStateStore.pruneMatchingCheckpoints(id -> id != 2);
+        assertNull(taskLocalStateStore.retrieveLocalState(3));
+        assertTrue(stateSnapshot3.isDiscarded());
+        assertNull(taskLocalStateStore.retrieveLocalState(1));
+        assertTrue(stateSnapshot1.isDiscarded());
+        assertTrue(checkMaterializedDirExists(1));
+        assertEquals(stateSnapshot2, taskLocalStateStore.retrieveLocalState(2));
+    }
+
+    @Test
+    @Override
+    public void confirmCheckpoint() throws Exception {
+        TestingTaskStateSnapshot stateSnapshot1 = storeChangelogStates(1, 1);
+        TestingTaskStateSnapshot stateSnapshot2 = storeChangelogStates(2, 1);
+        TestingTaskStateSnapshot stateSnapshot3 = storeChangelogStates(3, 1);
+
+        taskLocalStateStore.confirmCheckpoint(3);
+        assertNull(taskLocalStateStore.retrieveLocalState(2));
+        assertTrue(stateSnapshot2.isDiscarded());
+        assertTrue(stateSnapshot1.isDiscarded());
+        assertTrue(checkMaterializedDirExists(1));
+        assertEquals(stateSnapshot3, taskLocalStateStore.retrieveLocalState(3));
+
+        TestingTaskStateSnapshot stateSnapshot4 = storeChangelogStates(4, 2);
+        taskLocalStateStore.confirmCheckpoint(4);
+        assertNull(taskLocalStateStore.retrieveLocalState(3));
+        assertTrue(stateSnapshot3.isDiscarded());
+        // delete materialization 1
+        assertFalse(checkMaterializedDirExists(1));
+        assertEquals(stateSnapshot4, taskLocalStateStore.retrieveLocalState(4));
+    }
+
+    @Test
+    @Override
+    public void abortCheckpoint() throws Exception {
+        TestingTaskStateSnapshot stateSnapshot1 = storeChangelogStates(1, 1);
+        TestingTaskStateSnapshot stateSnapshot2 = storeChangelogStates(2, 2);
+        TestingTaskStateSnapshot stateSnapshot3 = storeChangelogStates(3, 2);
+        taskLocalStateStore.abortCheckpoint(2);
+        assertNull(taskLocalStateStore.retrieveLocalState(2));
+        assertTrue(stateSnapshot2.isDiscarded());
+        // the materialized part of checkpoint 2 retain, because it still used by checkpoint 3
+        assertTrue(checkMaterializedDirExists(2));
+        assertTrue(checkMaterializedDirExists(1));
+        assertEquals(stateSnapshot3, taskLocalStateStore.retrieveLocalState(3));
+
+        taskLocalStateStore.abortCheckpoint(3);
+        assertFalse(checkMaterializedDirExists(2));
+    }
+
+    @Test
+    public void retrievePersistedLocalStateFromDisc() {
+        final TaskStateSnapshot taskStateSnapshot = createTaskStateSnapshot();
+        final long checkpointId = 0L;
+        taskLocalStateStore.storeLocalState(checkpointId, taskStateSnapshot);
+        final ChangelogTaskLocalStateStore newTaskLocalStateStore =
+                createChangelogTaskLocalStateStore(
+                        allocationBaseDirs, jobID, allocationID, jobVertexID, subtaskIdx);
+
+        final TaskStateSnapshot retrievedTaskStateSnapshot =
+                newTaskLocalStateStore.retrieveLocalState(checkpointId);
+
+        assertThat(retrievedTaskStateSnapshot).isEqualTo(taskStateSnapshot);
+    }
+
+    @Test
+    public void deletesLocalStateIfRetrievalFails() throws IOException {
+        final TaskStateSnapshot taskStateSnapshot = createTaskStateSnapshot();
+        final long checkpointId = 0L;
+        taskLocalStateStore.storeLocalState(checkpointId, taskStateSnapshot);
+
+        final File taskStateSnapshotFile =
+                taskLocalStateStore.getTaskStateSnapshotFile(checkpointId);
+
+        Files.write(
+                taskStateSnapshotFile.toPath(), new byte[] {1, 2, 3, 4}, StandardOpenOption.WRITE);
+
+        final ChangelogTaskLocalStateStore newTaskLocalStateStore =
+                createChangelogTaskLocalStateStore(
+                        allocationBaseDirs, jobID, allocationID, jobVertexID, subtaskIdx);
+
+        assertThat(newTaskLocalStateStore.retrieveLocalState(checkpointId)).isNull();
+        assertThat(taskStateSnapshotFile.getParentFile()).doesNotExist();
+    }
+
+    private boolean checkMaterializedDirExists(long materializationID) {
+        File materializedDir =
+                localRecoveryDirectoryProvider.subtaskSpecificCheckpointDirectory(
+                        materializationID);
+        return materializedDir.exists();
+    }
+
+    private void writeToMaterializedDir(long materializationID) {
+        File materializedDir =
+                localRecoveryDirectoryProvider.subtaskSpecificCheckpointDirectory(
+                        materializationID);
+        if (!materializedDir.exists() && !materializedDir.mkdirs()) {
+            throw new FlinkRuntimeException(
+                    String.format(
+                            "Could not create the materialized directory '%s'", materializedDir));
+        }
+    }
+
+    private TestingTaskStateSnapshot storeChangelogStates(
+            long checkpointID, long materializationID) {
+        writeToMaterializedDir(materializationID);
+        OperatorID operatorID = new OperatorID();
+        TestingTaskStateSnapshot taskStateSnapshot = new TestingTaskStateSnapshot();
+        OperatorSubtaskState operatorSubtaskState =
+                OperatorSubtaskState.builder()
+                        .setManagedKeyedState(
+                                new ChangelogStateBackendHandleImpl(
+                                        Collections.emptyList(),
+                                        Collections.emptyList(),
+                                        new KeyGroupRange(0, 3),
+                                        checkpointID,
+                                        materializationID,
+                                        checkpointID))
+                        .build();
+        taskStateSnapshot.putSubtaskStateByOperatorID(operatorID, operatorSubtaskState);
+        taskLocalStateStore.storeLocalState(checkpointID, taskStateSnapshot);
+        return taskStateSnapshot;
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskExecutorLocalStateStoresManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskExecutorLocalStateStoresManagerTest.java
@@ -166,7 +166,12 @@ public class TaskExecutorLocalStateStoresManagerTest extends TestLogger {
 
         TaskLocalStateStore taskLocalStateStore =
                 storesManager.localStateStoreForSubtask(
-                        jobID, allocationID, jobVertexID, subtaskIdx);
+                        jobID,
+                        allocationID,
+                        jobVertexID,
+                        subtaskIdx,
+                        new Configuration(),
+                        new Configuration());
 
         Assert.assertFalse(taskLocalStateStore.getLocalRecoveryConfig().isLocalRecoveryEnabled());
         Assert.assertNull(
@@ -202,7 +207,12 @@ public class TaskExecutorLocalStateStoresManagerTest extends TestLogger {
 
         TaskLocalStateStore taskLocalStateStore =
                 storesManager.localStateStoreForSubtask(
-                        jobID, allocationID, jobVertexID, subtaskIdx);
+                        jobID,
+                        allocationID,
+                        jobVertexID,
+                        subtaskIdx,
+                        new Configuration(),
+                        new Configuration());
 
         LocalRecoveryDirectoryProvider directoryProvider =
                 taskLocalStateStore
@@ -258,7 +268,12 @@ public class TaskExecutorLocalStateStoresManagerTest extends TestLogger {
 
         taskLocalStateStore =
                 storesManager.localStateStoreForSubtask(
-                        jobID, otherAllocationID, jobVertexID, subtaskIdx);
+                        jobID,
+                        otherAllocationID,
+                        jobVertexID,
+                        subtaskIdx,
+                        new Configuration(),
+                        new Configuration());
 
         directoryProvider =
                 taskLocalStateStore
@@ -338,9 +353,14 @@ public class TaskExecutorLocalStateStoresManagerTest extends TestLogger {
 
         // register local state stores
         taskExecutorLocalStateStoresManager.localStateStoreForSubtask(
-                jobId, retainedAllocationId, jobVertexId, 0);
+                jobId,
+                retainedAllocationId,
+                jobVertexId,
+                0,
+                new Configuration(),
+                new Configuration());
         taskExecutorLocalStateStoresManager.localStateStoreForSubtask(
-                jobId, otherAllocationId, jobVertexId, 1);
+                jobId, otherAllocationId, jobVertexId, 1, new Configuration(), new Configuration());
 
         final Collection<Path> allocationDirectories =
                 TaskExecutorLocalStateStoresManager.listAllocationDirectoriesIn(localStateStore);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskLocalStateStoreImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskLocalStateStoreImplTest.java
@@ -51,13 +51,13 @@ import static org.junit.Assert.assertTrue;
 /** Test for the {@link TaskLocalStateStoreImpl}. */
 public class TaskLocalStateStoreImplTest extends TestLogger {
 
-    private TemporaryFolder temporaryFolder;
-    private File[] allocationBaseDirs;
-    private TaskLocalStateStoreImpl taskLocalStateStore;
-    private JobID jobID;
-    private AllocationID allocationID;
-    private JobVertexID jobVertexID;
-    private int subtaskIdx;
+    protected TemporaryFolder temporaryFolder;
+    protected File[] allocationBaseDirs;
+    protected TaskLocalStateStoreImpl taskLocalStateStore;
+    protected JobID jobID;
+    protected AllocationID allocationID;
+    protected JobVertexID jobVertexID;
+    protected int subtaskIdx;
 
     @Before
     public void before() throws Exception {
@@ -216,7 +216,7 @@ public class TaskLocalStateStoreImplTest extends TestLogger {
     }
 
     @Nonnull
-    private TaskStateSnapshot createTaskStateSnapshot() {
+    protected TaskStateSnapshot createTaskStateSnapshot() {
         final Map<OperatorID, OperatorSubtaskState> operatorSubtaskStates = new HashMap<>();
         operatorSubtaskStates.put(new OperatorID(), OperatorSubtaskState.builder().build());
         operatorSubtaskStates.put(new OperatorID(), OperatorSubtaskState.builder().build());
@@ -273,7 +273,7 @@ public class TaskLocalStateStoreImplTest extends TestLogger {
         return taskStateSnapshots;
     }
 
-    private static final class TestingTaskStateSnapshot extends TaskStateSnapshot {
+    protected static final class TestingTaskStateSnapshot extends TaskStateSnapshot {
         private static final long serialVersionUID = 2046321877379917040L;
 
         private boolean isDiscarded = false;

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
@@ -92,7 +92,6 @@ import java.util.stream.Stream;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
-import static java.util.Collections.unmodifiableList;
 import static org.apache.flink.state.changelog.PeriodicMaterializationManager.MaterializationRunnable;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -405,10 +404,12 @@ public class ChangelogKeyedStateBackend<K>
                         .whenComplete(
                                 (snapshotResult, throwable) ->
                                         metrics.reportSnapshotResult(snapshotResult))
-                        .thenApply(
-                                snapshotResult ->
-                                        SnapshotResult.of(
-                                                snapshotResult.getJobManagerOwnedSnapshot())));
+                        .thenApply(this::castSnapshotResult));
+    }
+
+    @SuppressWarnings("unchecked")
+    private SnapshotResult<KeyedStateHandle> castSnapshotResult(SnapshotResult<?> snapshotResult) {
+        return (SnapshotResult<KeyedStateHandle>) snapshotResult;
     }
 
     private SnapshotResult<ChangelogStateBackendHandle> buildSnapshotResult(
@@ -428,6 +429,26 @@ public class ChangelogKeyedStateBackend<K>
         if (prevDeltaCopy.isEmpty()
                 && changelogStateBackendStateCopy.getMaterializedSnapshot().isEmpty()) {
             return SnapshotResult.empty();
+        } else if (!changelogStateBackendStateCopy.getLocalMaterializedSnapshot().isEmpty()) {
+            return SnapshotResult.withLocalState(
+                    new ChangelogStateBackendHandleImpl(
+                            changelogStateBackendStateCopy.getMaterializedSnapshot(),
+                            prevDeltaCopy,
+                            getKeyGroupRange(),
+                            checkpointId,
+                            changelogStateBackendStateCopy.materializationID,
+                            persistedSizeOfThisCheckpoint),
+                    new ChangelogStateBackendHandleImpl(
+                            changelogStateBackendStateCopy.getLocalMaterializedSnapshot(),
+                            // TODO: Restore ChangelogStateHandles from remote temporarily, because
+                            // ChangelogStateHandles are small(about 10MB).
+                            //  In the future, the double-stream option may be implemented according
+                            // to the test results.
+                            prevDeltaCopy,
+                            getKeyGroupRange(),
+                            checkpointId,
+                            changelogStateBackendStateCopy.materializationID,
+                            persistedSizeOfThisCheckpoint));
         } else {
             return SnapshotResult.of(
                     new ChangelogStateBackendHandleImpl(
@@ -618,7 +639,7 @@ public class ChangelogKeyedStateBackend<K>
             }
         }
         this.materializedId = materializationId + 1;
-
+        // Todo: distinguish whether the handle is local or remote
         return new ChangelogSnapshotState(
                 materialized,
                 restoredNonMaterialized,
@@ -693,11 +714,20 @@ public class ChangelogKeyedStateBackend<K>
                 upTo,
                 materializedSnapshot);
         changelogSnapshotState =
-                new ChangelogSnapshotState(
-                        getMaterializedResult(materializedSnapshot),
-                        Collections.emptyList(),
-                        upTo,
-                        materializationID);
+                materializedSnapshot.getTaskLocalSnapshot() == null
+                        ? new ChangelogSnapshotState(
+                                getMaterializedResult(materializedSnapshot),
+                                Collections.emptyList(),
+                                upTo,
+                                materializationID)
+                        : new ChangelogSnapshotState(
+                                getMaterializedResult(materializedSnapshot),
+                                getLocalMaterializedResult(materializedSnapshot),
+                                Collections.emptyList(),
+                                Collections.emptyList(),
+                                upTo,
+                                materializationID);
+
         changelogTruncateHelper.materialized(upTo);
     }
 
@@ -706,6 +736,12 @@ public class ChangelogKeyedStateBackend<K>
             @Nonnull SnapshotResult<KeyedStateHandle> materializedSnapshot) {
         KeyedStateHandle jobManagerOwned = materializedSnapshot.getJobManagerOwnedSnapshot();
         return jobManagerOwned == null ? emptyList() : singletonList(jobManagerOwned);
+    }
+
+    private List<KeyedStateHandle> getLocalMaterializedResult(
+            @Nonnull SnapshotResult<KeyedStateHandle> materializedSnapshot) {
+        KeyedStateHandle taskLocalSnapshot = materializedSnapshot.getTaskLocalSnapshot();
+        return taskLocalSnapshot == null ? emptyList() : singletonList(taskLocalSnapshot);
     }
 
     @Override
@@ -791,30 +827,22 @@ public class ChangelogKeyedStateBackend<K>
     }
 
     /**
-     * Snapshot State for ChangelogKeyedStatebackend.
+     * Snapshot State for ChangelogKeyedStatebackend, a wrapper over {@link SnapshotResult}.
      *
      * <p>It includes three parts: - materialized snapshot from the underlying delegated state
      * backend - non-materialized part in the current changelog - non-materialized changelog, from
      * previous logs (before failover or rescaling)
      */
-    private static class ChangelogSnapshotState {
-        /**
-         * Materialized snapshot from the underlying delegated state backend. Set initially on
-         * restore and later upon materialization.
-         */
-        private final List<KeyedStateHandle> materializedSnapshot;
+    private class ChangelogSnapshotState {
+
+        /** Set initially on restore and later upon materialization. */
+        private final SnapshotResult<ChangelogStateBackendHandle> changelogSnapshot;
 
         /**
          * The {@link SequenceNumber} up to which the state is materialized, exclusive. This
          * indicates the non-materialized part of the current changelog.
          */
         private final SequenceNumber materializedTo;
-
-        /**
-         * Non-materialized changelog, from previous logs. Set initially on restore and later
-         * cleared upon materialization.
-         */
-        private final List<ChangelogStateHandle> restoredNonMaterialized;
 
         /** ID of this materialization corresponding to the nested backend checkpoint ID. */
         private final long materializationID;
@@ -824,22 +852,74 @@ public class ChangelogKeyedStateBackend<K>
                 List<ChangelogStateHandle> restoredNonMaterialized,
                 SequenceNumber materializedTo,
                 long materializationID) {
-            this.materializedSnapshot = unmodifiableList((materializedSnapshot));
-            this.restoredNonMaterialized = unmodifiableList(restoredNonMaterialized);
+            this.changelogSnapshot =
+                    SnapshotResult.of(
+                            new ChangelogStateBackendHandleImpl(
+                                    materializedSnapshot,
+                                    restoredNonMaterialized,
+                                    getKeyGroupRange(),
+                                    lastCheckpointId,
+                                    materializationID,
+                                    0L));
+            this.materializedTo = materializedTo;
+            this.materializationID = materializationID;
+        }
+
+        public ChangelogSnapshotState(
+                List<KeyedStateHandle> materializedSnapshot,
+                List<KeyedStateHandle> localMaterializedSnapshot,
+                List<ChangelogStateHandle> restoredNonMaterialized,
+                List<ChangelogStateHandle> localRestoredNonMaterialized,
+                SequenceNumber materializedTo,
+                long materializationID) {
+            this.changelogSnapshot =
+                    SnapshotResult.withLocalState(
+                            new ChangelogStateBackendHandleImpl(
+                                    materializedSnapshot,
+                                    restoredNonMaterialized,
+                                    getKeyGroupRange(),
+                                    lastCheckpointId,
+                                    materializationID,
+                                    0L),
+                            new ChangelogStateBackendHandleImpl(
+                                    localMaterializedSnapshot,
+                                    localRestoredNonMaterialized,
+                                    getKeyGroupRange(),
+                                    lastCheckpointId,
+                                    materializationID,
+                                    0L));
             this.materializedTo = materializedTo;
             this.materializationID = materializationID;
         }
 
         public List<KeyedStateHandle> getMaterializedSnapshot() {
-            return materializedSnapshot;
+            return changelogSnapshot.getJobManagerOwnedSnapshot() != null
+                    ? changelogSnapshot.getJobManagerOwnedSnapshot().getMaterializedStateHandles()
+                    : Collections.emptyList();
+        }
+
+        public List<KeyedStateHandle> getLocalMaterializedSnapshot() {
+            return changelogSnapshot.getTaskLocalSnapshot() != null
+                    ? changelogSnapshot.getTaskLocalSnapshot().getMaterializedStateHandles()
+                    : Collections.emptyList();
+        }
+
+        public List<ChangelogStateHandle> getRestoredNonMaterialized() {
+            return changelogSnapshot.getJobManagerOwnedSnapshot() != null
+                    ? changelogSnapshot
+                            .getJobManagerOwnedSnapshot()
+                            .getNonMaterializedStateHandles()
+                    : Collections.emptyList();
+        }
+
+        public List<ChangelogStateHandle> getLocalRestoredNonMaterialized() {
+            return changelogSnapshot.getTaskLocalSnapshot() != null
+                    ? changelogSnapshot.getTaskLocalSnapshot().getNonMaterializedStateHandles()
+                    : Collections.emptyList();
         }
 
         public SequenceNumber lastMaterializedTo() {
             return materializedTo;
-        }
-
-        public List<ChangelogStateHandle> getRestoredNonMaterialized() {
-            return restoredNonMaterialized;
         }
 
         public long getMaterializationID() {

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackendTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackendTest.java
@@ -91,7 +91,7 @@ public class ChangelogKeyedStateBackendTest {
                         IntSerializer.INSTANCE,
                         getClass().getClassLoader(),
                         1,
-                        KeyGroupRange.EMPTY_KEY_GROUP_RANGE,
+                        KeyGroupRange.of(0, 0),
                         new ExecutionConfig(),
                         TtlTimeProvider.DEFAULT,
                         LatencyTrackingStateConfig.disabled(),

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ChangelogLocalRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ChangelogLocalRecoveryITCase.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.checkpointing;
+
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.changelog.fs.FsStateChangelogStorageFactory;
+import org.apache.flink.configuration.CheckpointingOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.StateChangelogOptions;
+import org.apache.flink.contrib.streaming.state.EmbeddedRocksDBStateBackend;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.minicluster.MiniCluster;
+import org.apache.flink.runtime.state.AbstractStateBackend;
+import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.runtime.state.hashmap.HashMapStateBackend;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.streaming.api.environment.CheckpointConfig;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.test.checkpointing.ChangelogPeriodicMaterializationTestBase.CollectionSink;
+import org.apache.flink.test.checkpointing.ChangelogPeriodicMaterializationTestBase.CountFunction;
+import org.apache.flink.test.util.InfiniteIntegerSource;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.File;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.flink.configuration.CheckpointingOptions.LOCAL_RECOVERY;
+import static org.apache.flink.configuration.ClusterOptions.JOB_MANAGER_PROCESS_WORKING_DIR_BASE;
+import static org.apache.flink.configuration.ClusterOptions.PROCESS_WORKING_DIR_BASE;
+import static org.apache.flink.configuration.ClusterOptions.TASK_MANAGER_PROCESS_WORKING_DIR_BASE;
+import static org.apache.flink.runtime.testutils.CommonTestUtils.waitForAllTaskRunning;
+import static org.apache.flink.runtime.testutils.CommonTestUtils.waitUntilCondition;
+import static org.apache.flink.test.checkpointing.ChangelogPeriodicMaterializationTestBase.getAllStateHandleId;
+
+/**
+ * Local recovery IT case for changelog. It never fails because local recovery is nice but not
+ * necessary.
+ */
+@RunWith(Parameterized.class)
+public class ChangelogLocalRecoveryITCase extends TestLogger {
+
+    private static final int NUM_TASK_MANAGERS = 2;
+    private static final int NUM_TASK_SLOTS = 1;
+
+    @ClassRule public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+
+    @Parameterized.Parameter public AbstractStateBackend delegatedStateBackend;
+
+    @Parameterized.Parameters(name = "delegated state backend type = {0}")
+    public static Collection<AbstractStateBackend> parameter() {
+        return Arrays.asList(
+                new HashMapStateBackend(),
+                new EmbeddedRocksDBStateBackend(false),
+                new EmbeddedRocksDBStateBackend(true));
+    }
+
+    private MiniClusterWithClientResource cluster;
+    private static String workingDir;
+
+    @BeforeClass
+    public static void setWorkingDir() throws IOException {
+        workingDir = TEMPORARY_FOLDER.newFolder("work").getAbsolutePath();
+    }
+
+    @Before
+    public void setup() throws Exception {
+        Configuration configuration = new Configuration();
+        configuration.setInteger(CheckpointingOptions.MAX_RETAINED_CHECKPOINTS, 1);
+
+        configuration.setString(PROCESS_WORKING_DIR_BASE, workingDir);
+        configuration.setString(JOB_MANAGER_PROCESS_WORKING_DIR_BASE, workingDir);
+        configuration.setString(TASK_MANAGER_PROCESS_WORKING_DIR_BASE, workingDir);
+        configuration.setBoolean(LOCAL_RECOVERY, true);
+        FsStateChangelogStorageFactory.configure(
+                configuration, TEMPORARY_FOLDER.newFolder(), Duration.ofMillis(1000), 1);
+        cluster =
+                new MiniClusterWithClientResource(
+                        new MiniClusterResourceConfiguration.Builder()
+                                .setConfiguration(configuration)
+                                .setNumberTaskManagers(NUM_TASK_MANAGERS)
+                                .setNumberSlotsPerTaskManager(NUM_TASK_SLOTS)
+                                .build());
+        cluster.before();
+        cluster.getMiniCluster().overrideRestoreModeForChangelogStateBackend();
+    }
+
+    @After
+    public void teardown() {
+        cluster.after();
+    }
+
+    private JobGraph buildJobGraph(StreamExecutionEnvironment env) {
+        env.addSource(new InfiniteIntegerSource())
+                .setParallelism(1)
+                .keyBy(element -> element)
+                .process(new CountFunction())
+                .addSink(new CollectionSink())
+                .setParallelism(1);
+        return env.getStreamGraph().getJobGraph();
+    }
+
+    @Test
+    public void testRestartTM() throws Exception {
+        File checkpointFolder = TEMPORARY_FOLDER.newFolder();
+        MiniCluster miniCluster = cluster.getMiniCluster();
+        StreamExecutionEnvironment env1 =
+                getEnv(delegatedStateBackend, checkpointFolder, true, 200, 800);
+        JobGraph firstJobGraph = buildJobGraph(env1);
+
+        miniCluster.submitJob(firstJobGraph).get();
+        waitForAllTaskRunning(miniCluster, firstJobGraph.getJobID(), false);
+        // wait job for doing materialization.
+        waitUntilCondition(
+                () -> !getAllStateHandleId(firstJobGraph.getJobID(), miniCluster).isEmpty());
+        miniCluster.triggerCheckpoint(firstJobGraph.getJobID()).get();
+        CompletableFuture<Void> terminationFuture = miniCluster.terminateTaskManager(1);
+        terminationFuture.get();
+        miniCluster.startTaskManager();
+        waitForAllTaskRunning(
+                () ->
+                        miniCluster
+                                .getExecutionGraph(firstJobGraph.getJobID())
+                                .get(10000, TimeUnit.SECONDS),
+                false);
+
+        waitForAllTaskRunning(miniCluster, firstJobGraph.getJobID(), false);
+        miniCluster.triggerCheckpoint(firstJobGraph.getJobID()).get();
+    }
+
+    private StreamExecutionEnvironment getEnv(
+            StateBackend stateBackend,
+            File checkpointFile,
+            boolean changelogEnabled,
+            long checkpointInterval,
+            long materializationInterval) {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.enableCheckpointing(checkpointInterval);
+        env.getCheckpointConfig().enableUnalignedCheckpoints(false);
+        env.setStateBackend(stateBackend)
+                .setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 10));
+        env.configure(new Configuration().set(LOCAL_RECOVERY, true));
+
+        env.getCheckpointConfig().setCheckpointStorage(checkpointFile.toURI());
+        env.enableChangelogStateBackend(changelogEnabled);
+        env.configure(
+                new Configuration()
+                        .set(
+                                StateChangelogOptions.PERIODIC_MATERIALIZATION_INTERVAL,
+                                Duration.ofMillis(materializationInterval))
+                        .set(StateChangelogOptions.MATERIALIZATION_MAX_FAILURES_ALLOWED, 1));
+        env.getCheckpointConfig()
+                .setExternalizedCheckpointCleanup(
+                        CheckpointConfig.ExternalizedCheckpointCleanup.RETAIN_ON_CANCELLATION);
+        Configuration configuration = new Configuration();
+        configuration.setInteger(CheckpointingOptions.MAX_RETAINED_CHECKPOINTS, 1);
+        env.configure(configuration);
+        return env;
+    }
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ChangelogPeriodicMaterializationTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ChangelogPeriodicMaterializationTestBase.java
@@ -219,7 +219,7 @@ public abstract class ChangelogPeriodicMaterializationTestBase extends TestLogge
         return JobID.fromByteArray(randomBytes);
     }
 
-    protected static Set<StateHandleID> getAllStateHandleId(JobID jobID, MiniCluster miniCluster)
+    public static Set<StateHandleID> getAllStateHandleId(JobID jobID, MiniCluster miniCluster)
             throws IOException, FlinkJobNotFoundException, ExecutionException,
                     InterruptedException {
         Optional<String> mostRecentCompletedCheckpointPath =


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*Support local recovery for the materialized part of changelog.*

## Brief change log

  - *When doing snapshot, let `ChangelogKeyedStateBackend` return local materialized part from delegate backend.*
  - *Modify `TaskLocalStateStoreImpl` to maintain the relationship between local checkpoints.*
  - *Modify the logic of `confirmCheckpoint()` in `TaskLocalStateStoreImpl` to prevent the materialized part from being discarded.*
  -  *Modify `MiniCluster` to support working-dir.*
 

## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

This change added tests and can be verified as follows:

  - *Added `ChangelogLocalRecoveryITCase`.*
  - *Extended `TaskLocalStateStoreImplTest` for confirming checkpoint and aborting checkpoint.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes, make changelog support local recovery.)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
