### PR TITLE
[FLINK-27955][python] Fix the problem of windows installation failure in PyFlink

### DIFF
--- a/flink-python/dev/dev-requirements.txt
+++ b/flink-python/dev/dev-requirements.txt
@@ -27,4 +27,4 @@ numpy>=1.14.3,<1.20
 fastavro>=0.21.4,<0.24
 grpcio>=1.29.0,<2
 grpcio-tools>=1.3.5,<=1.14.2
-pemja==0.1.4; python_version >= '3.7'
+pemja==0.1.4; python_version >= '3.7' and platform_system != 'Windows'

--- a/flink-python/setup.py
+++ b/flink-python/setup.py
@@ -313,7 +313,8 @@ try:
                           'pandas>=1.0,<1.2.0', 'pyarrow>=0.15.1,<3.0.0',
                           'pytz>=2018.3', 'numpy>=1.14.3,<1.20', 'fastavro>=0.21.4,<0.24',
                           'requests>=2.26.0', 'protobuf<3.18',
-                          'pemja==0.1.4;python_full_version >= "3.7"',
+                          'pemja==0.1.4;'
+                          'python_full_version >= "3.7" and platform_system != "Windows"',
                           apache_flink_libraries_dependency],
         cmdclass={'build_ext': build_ext},
         tests_require=['pytest==4.4.1'],


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will fix the problem of windows installation failure in PyFlink*

## Verifying this change

This change added tests and can be verified as follows:

- I have checked the installation mannually.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
