### PR TITLE
[FLINK-27955][python] Fix the problem of windows installation failure in PyFlink

### DIFF
--- a/flink-python/dev/dev-requirements.txt
+++ b/flink-python/dev/dev-requirements.txt
@@ -31,5 +31,5 @@ numpy>=1.14.3,<1.20; python_version < '3.7'
 fastavro>=0.21.4,<0.24
 grpcio>=1.29.0,<2
 grpcio-tools>=1.3.5,<=1.14.2
-pemja==0.1.5; python_version >= '3.7'
+pemja==0.1.5; python_version >= '3.7' and platform_system != 'Windows'
 httplib2>=0.8,<0.19.0

--- a/flink-python/setup.py
+++ b/flink-python/setup.py
@@ -300,7 +300,9 @@ try:
     install_requires = ['py4j==0.10.9.3', 'python-dateutil==2.8.0', 'apache-beam==2.38.0',
                         'cloudpickle==2.1.0', 'avro-python3>=1.8.1,!=1.9.2,<1.10.0',
                         'pytz>=2018.3', 'fastavro>=0.21.4,<0.24', 'requests>=2.26.0',
-                        'protobuf<3.18', 'pemja==0.1.5;python_full_version >= "3.7"',
+                        'protobuf<3.18',
+                        'pemja==0.1.5;'
+                        'python_full_version >= "3.7" and platform_system != "Windows"',
                         'httplib2>=0.8,<0.19.0', apache_flink_libraries_dependency]
 
     if sys.version_info < (3, 7):


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will fix the problem of windows installation failure in PyFlink*

## Verifying this change

This change added tests and can be verified as follows:

- I have checked the installation mannually.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
