### PR TITLE
[FLINK-27791][tests] Prevent mocked UGI bleeding into other tests

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/KerberosDelegationTokenManagerITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/KerberosDelegationTokenManagerITCase.java
@@ -38,8 +38,13 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-/** Test for {@link DelegationTokenManager}. */
-public class KerberosDelegationTokenManagerTest {
+/**
+ * Test for {@link DelegationTokenManager}.
+ *
+ * <p>This class is an ITCase because the mocking breaks the {@link UserGroupInformation} class for
+ * other tests.
+ */
+public class KerberosDelegationTokenManagerITCase {
 
     @Test
     public void isProviderEnabledMustGiveBackTrueByDefault() {


### PR DESCRIPTION
Marks the KerberosDelegationTokenManagerTest as an ITCase so that it runs in a dedicated JVM to ensure it's static mock doesn't leak into other tests.