### PR TITLE
[BP-1.15][FLINK-27418][table-planner] Fix topN retraction for previously deleted record

### DIFF
--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/rank/RetractableTopNFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/rank/RetractableTopNFunction.java
@@ -18,12 +18,14 @@
 
 package org.apache.flink.table.runtime.operators.rank;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.state.MapState;
 import org.apache.flink.api.common.state.MapStateDescriptor;
 import org.apache.flink.api.common.state.StateTtlConfig;
 import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.typeutils.ListTypeInfo;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.data.RowData;
@@ -80,6 +82,8 @@ public class RetractableTopNFunction extends AbstractTopNFunction {
 
     private final ComparableRecordComparator serializableComparator;
 
+    private final TypeSerializer<RowData> inputRowSer;
+
     public RetractableTopNFunction(
             StateTtlConfig ttlConfig,
             InternalTypeInfo<RowData> inputRowType,
@@ -102,6 +106,7 @@ public class RetractableTopNFunction extends AbstractTopNFunction {
         this.sortKeyType = sortKeySelector.getProducedType();
         this.serializableComparator = comparableRecordComparator;
         this.generatedEqualiser = generatedEqualiser;
+        this.inputRowSer = inputRowType.createSerializer(new ExecutionConfig());
     }
 
     @Override
@@ -320,7 +325,7 @@ public class RetractableTopNFunction extends AbstractTopNFunction {
             }
         }
         if (toDelete != null) {
-            collectDelete(out, toDelete);
+            collectDelete(out, inputRowSer.copy(toDelete));
         }
         if (toCollect != null) {
             collectInsert(out, inputRow);

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/rank/RetractableTopNFunctionTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/rank/RetractableTopNFunctionTest.java
@@ -35,6 +35,7 @@ import static org.apache.flink.table.runtime.util.StreamRecordUtils.deleteRecord
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord;
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.updateAfterRecord;
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.updateBeforeRecord;
+import static org.apache.flink.table.types.logical.VarCharType.MAX_LENGTH;
 
 /** Tests for {@link RetractableTopNFunction}. */
 public class RetractableTopNFunctionTest extends TopNFunctionTestBase {

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/rank/RetractableTopNFunctionTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/rank/RetractableTopNFunctionTest.java
@@ -21,6 +21,10 @@ package org.apache.flink.table.runtime.operators.rank;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.VarCharType;
 
 import org.junit.Test;
 
@@ -506,6 +510,47 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
         expectedOutput.add(updateAfterRecord("a", 3L, 2, 2L));
         expectedOutput.add(updateAfterRecord("a", 3L, 2, 1L));
         expectedOutput.add(updateAfterRecord("a", 5L, 4, 2L));
+        assertorWithRowNumber.assertOutputEquals(
+                "output wrong.", expectedOutput, testHarness.getOutput());
+    }
+
+    @Test
+    public void testRetractAndThenDeleteRecordWithoutRowNumber() throws Exception {
+        AbstractTopNFunction func =
+                new RetractableTopNFunction(
+                        ttlConfig,
+                        InternalTypeInfo.ofFields(
+                                new VarCharType(MAX_LENGTH),
+                                new BigIntType(),
+                                new IntType(),
+                                new IntType()),
+                        comparableRecordComparator,
+                        sortKeySelector,
+                        RankType.ROW_NUMBER,
+                        new ConstantRankRange(1, 1),
+                        generatedEqualiser,
+                        true,
+                        false);
+
+        OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
+        testHarness.open();
+        testHarness.processElement(insertRecord("a", 1L, 10, 0));
+        testHarness.processElement(insertRecord("a", 1L, 9, 0));
+        testHarness.processElement(deleteRecord("a", 1L, 10, 0));
+        testHarness.processElement(deleteRecord("a", 1L, 9, 0));
+        testHarness.processElement(insertRecord("a", 1L, 10, 1));
+        testHarness.processElement(insertRecord("a", 1L, 9, 1));
+        testHarness.close();
+
+        List<Object> expectedOutput = new ArrayList<>();
+        expectedOutput.add(insertRecord("a", 1L, 10, 0));
+        expectedOutput.add(deleteRecord("a", 1L, 10, 0));
+        expectedOutput.add(insertRecord("a", 1L, 9, 0));
+        expectedOutput.add(deleteRecord("a", 1L, 9, 0));
+        expectedOutput.add(insertRecord("a", 1L, 10, 1));
+        expectedOutput.add(deleteRecord("a", 1L, 10, 1));
+        expectedOutput.add(insertRecord("a", 1L, 9, 1));
+
         assertorWithRowNumber.assertOutputEquals(
                 "output wrong.", expectedOutput, testHarness.getOutput());
     }


### PR DESCRIPTION
This is a cherry-pick back to the release-1.15 branch.