### PR TITLE
[FLINK-27942][tests] Migrate flink-connectors-rabbitmq to JUnit5

### DIFF
--- a/flink-connectors/flink-connector-rabbitmq/src/test/java/org/apache/flink/streaming/connectors/rabbitmq/common/RMQConnectionConfigTest.java
+++ b/flink-connectors/flink-connector-rabbitmq/src/test/java/org/apache/flink/streaming/connectors/rabbitmq/common/RMQConnectionConfigTest.java
@@ -18,7 +18,7 @@
 package org.apache.flink.streaming.connectors.rabbitmq.common;
 
 import com.rabbitmq.client.ConnectionFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.net.URISyntaxException;
 import java.security.KeyManagementException;
@@ -26,55 +26,64 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 /** Tests for the {@link RMQConnectionConfig}. */
-public class RMQConnectionConfigTest {
+class RMQConnectionConfigTest {
 
-    @Test(expected = NullPointerException.class)
-    public void shouldThrowNullPointExceptionIfHostIsNull()
-            throws NoSuchAlgorithmException, KeyManagementException, URISyntaxException {
-        RMQConnectionConfig connectionConfig =
-                new RMQConnectionConfig.Builder()
-                        .setPort(1000)
-                        .setUserName("guest")
-                        .setPassword("guest")
-                        .setVirtualHost("/")
-                        .build();
-        connectionConfig.getConnectionFactory();
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void shouldThrowNullPointExceptionIfPortIsNull()
-            throws NoSuchAlgorithmException, KeyManagementException, URISyntaxException {
-        RMQConnectionConfig connectionConfig =
-                new RMQConnectionConfig.Builder()
-                        .setHost("localhost")
-                        .setUserName("guest")
-                        .setPassword("guest")
-                        .setVirtualHost("/")
-                        .build();
-        connectionConfig.getConnectionFactory();
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void shouldSetDefaultValueIfConnectionTimeoutNotGiven()
-            throws NoSuchAlgorithmException, KeyManagementException, URISyntaxException {
-        RMQConnectionConfig connectionConfig =
-                new RMQConnectionConfig.Builder()
-                        .setHost("localhost")
-                        .setUserName("guest")
-                        .setPassword("guest")
-                        .setVirtualHost("/")
-                        .build();
-        ConnectionFactory factory = connectionConfig.getConnectionFactory();
-        assertEquals(ConnectionFactory.DEFAULT_CONNECTION_TIMEOUT, factory.getConnectionTimeout());
+    @Test
+    void shouldThrowNullPointExceptionIfHostIsNull() {
+        assertThatThrownBy(
+                        () -> {
+                            RMQConnectionConfig connectionConfig =
+                                    new RMQConnectionConfig.Builder()
+                                            .setPort(1000)
+                                            .setUserName("guest")
+                                            .setPassword("guest")
+                                            .setVirtualHost("/")
+                                            .build();
+                            connectionConfig.getConnectionFactory();
+                        })
+                .isInstanceOf(NullPointerException.class);
     }
 
     @Test
-    public void shouldSetProvidedValueIfConnectionTimeoutNotGiven()
+    void shouldThrowNullPointExceptionIfPortIsNull() {
+        assertThatThrownBy(
+                        () -> {
+                            RMQConnectionConfig connectionConfig =
+                                    new RMQConnectionConfig.Builder()
+                                            .setHost("localhost")
+                                            .setUserName("guest")
+                                            .setPassword("guest")
+                                            .setVirtualHost("/")
+                                            .build();
+                            connectionConfig.getConnectionFactory();
+                        })
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void shouldSetDefaultValueIfConnectionTimeoutNotGiven() {
+        assertThatThrownBy(
+                        () -> {
+                            RMQConnectionConfig connectionConfig =
+                                    new RMQConnectionConfig.Builder()
+                                            .setHost("localhost")
+                                            .setUserName("guest")
+                                            .setPassword("guest")
+                                            .setVirtualHost("/")
+                                            .build();
+                            ConnectionFactory factory = connectionConfig.getConnectionFactory();
+                            assertThat(factory.getConnectionTimeout())
+                                    .isEqualTo(ConnectionFactory.DEFAULT_CONNECTION_TIMEOUT);
+                        })
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void shouldSetProvidedValueIfConnectionTimeoutNotGiven()
             throws NoSuchAlgorithmException, KeyManagementException, URISyntaxException {
         RMQConnectionConfig connectionConfig =
                 new RMQConnectionConfig.Builder()
@@ -86,11 +95,11 @@ public class RMQConnectionConfigTest {
                         .setConnectionTimeout(5000)
                         .build();
         ConnectionFactory factory = connectionConfig.getConnectionFactory();
-        assertEquals(5000, factory.getConnectionTimeout());
+        assertThat(factory.getConnectionTimeout()).isEqualTo(5000);
     }
 
     @Test
-    public void shouldSetOptionalPrefetchCount() {
+    void shouldSetOptionalPrefetchCount() {
         RMQConnectionConfig connectionConfig =
                 new RMQConnectionConfig.Builder()
                         .setHost("localhost")
@@ -101,12 +110,12 @@ public class RMQConnectionConfigTest {
                         .setPrefetchCount(500)
                         .build();
         Optional<Integer> prefetch = connectionConfig.getPrefetchCount();
-        assertTrue(prefetch.isPresent());
-        assertEquals(500, (int) prefetch.get());
+        assertThat(prefetch).isPresent();
+        assertThat((int) prefetch.get()).isEqualTo(500);
     }
 
     @Test
-    public void shouldReturnEmptyOptionalPrefetchCount() {
+    void shouldReturnEmptyOptionalPrefetchCount() {
         RMQConnectionConfig connectionConfig =
                 new RMQConnectionConfig.Builder()
                         .setHost("localhost")
@@ -116,11 +125,11 @@ public class RMQConnectionConfigTest {
                         .setVirtualHost("/")
                         .build();
         Optional<Integer> prefetch = connectionConfig.getPrefetchCount();
-        assertFalse(prefetch.isPresent());
+        assertThat(prefetch).isNotPresent();
     }
 
     @Test
-    public void shouldSetDeliveryTimeout() {
+    void shouldSetDeliveryTimeout() {
         RMQConnectionConfig.Builder builder =
                 new RMQConnectionConfig.Builder()
                         .setHost("localhost")
@@ -129,14 +138,14 @@ public class RMQConnectionConfigTest {
                         .setPassword("guest")
                         .setVirtualHost("/");
         RMQConnectionConfig connectionConfig = builder.setDeliveryTimeout(10000).build();
-        assertEquals(10000, connectionConfig.getDeliveryTimeout());
+        assertThat(connectionConfig.getDeliveryTimeout()).isEqualTo(10000);
 
         connectionConfig = builder.setDeliveryTimeout(10, TimeUnit.SECONDS).build();
-        assertEquals(10000, connectionConfig.getDeliveryTimeout());
+        assertThat(connectionConfig.getDeliveryTimeout()).isEqualTo(10000);
     }
 
     @Test
-    public void shouldReturnDefaultDeliveryTimeout() {
+    void shouldReturnDefaultDeliveryTimeout() {
         RMQConnectionConfig connectionConfig =
                 new RMQConnectionConfig.Builder()
                         .setHost("localhost")
@@ -145,30 +154,36 @@ public class RMQConnectionConfigTest {
                         .setPassword("guest")
                         .setVirtualHost("/")
                         .build();
-        assertEquals(30000, connectionConfig.getDeliveryTimeout());
+        assertThat(connectionConfig.getDeliveryTimeout()).isEqualTo(30000);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void shouldThrowIllegalArgumentExceptionIfDeliveryTimeoutIsNegative() {
-        new RMQConnectionConfig.Builder()
-                .setHost("localhost")
-                .setPort(1000)
-                .setUserName("guest")
-                .setPassword("guest")
-                .setVirtualHost("/")
-                .setDeliveryTimeout(-1)
-                .build();
+    @Test
+    void shouldThrowIllegalArgumentExceptionIfDeliveryTimeoutIsNegative() {
+        assertThatThrownBy(
+                        () ->
+                                new RMQConnectionConfig.Builder()
+                                        .setHost("localhost")
+                                        .setPort(1000)
+                                        .setUserName("guest")
+                                        .setPassword("guest")
+                                        .setVirtualHost("/")
+                                        .setDeliveryTimeout(-1)
+                                        .build())
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void shouldThrowIllegalArgumentExceptionIfDeliveryTimeoutWithUnitIsNegative() {
-        new RMQConnectionConfig.Builder()
-                .setHost("localhost")
-                .setPort(1000)
-                .setUserName("guest")
-                .setPassword("guest")
-                .setVirtualHost("/")
-                .setDeliveryTimeout(-1, TimeUnit.SECONDS)
-                .build();
+    @Test
+    void shouldThrowIllegalArgumentExceptionIfDeliveryTimeoutWithUnitIsNegative() {
+        assertThatThrownBy(
+                        () ->
+                                new RMQConnectionConfig.Builder()
+                                        .setHost("localhost")
+                                        .setPort(1000)
+                                        .setUserName("guest")
+                                        .setPassword("guest")
+                                        .setVirtualHost("/")
+                                        .setDeliveryTimeout(-1, TimeUnit.SECONDS)
+                                        .build())
+                .isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/flink-connectors/flink-connector-rabbitmq/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/flink-connectors/flink-connector-rabbitmq/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.util.TestLoggerExtension


### PR DESCRIPTION
## What is the purpose of the change
1. Migrate flink-connectors-rabbitmq module to AssertJ and JUnit 5 following the [JUnit 5 Migration Guide](https://docs.google.com/document/d/1514Wa_aNB9bJUen4xm5uiuXOooOJTtXqS_Jqk9KJitU/edit)
2. Fix RestClusterClient injection

## Brief change log

Use JUnit5 and AssertJ in tests instead of JUnit4 and Hamcrest


## Verifying this change

This change is a code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no )
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? (no )
  - If yes, how is the feature documented? (not applicable)
