### PR TITLE
[FLINK-27936][tests] Migrate flink-connector-cassandra to JUnit5

### DIFF
--- a/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraConnectorITCase.java
+++ b/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraConnectorITCase.java
@@ -45,7 +45,7 @@ import org.apache.flink.streaming.runtime.operators.WriteAheadSinkTestBase;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.table.api.internal.TableEnvironmentInternal;
 import org.apache.flink.testutils.junit.RetryOnException;
-import org.apache.flink.testutils.junit.RetryRule;
+import org.apache.flink.testutils.junit.extensions.retry.RetryExtension;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.DockerImageVersions;
 
@@ -64,18 +64,19 @@ import net.bytebuddy.ByteBuddy;
 import org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.CassandraContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.images.builder.Transferable;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.io.IOException;
 import java.lang.annotation.Annotation;
@@ -100,7 +101,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SuppressWarnings("serial")
 // NoHostAvailableException is raised by Cassandra client under load while connecting to the cluster
 @RetryOnException(times = 3, exception = NoHostAvailableException.class)
-public class CassandraConnectorITCase
+@Testcontainers
+@ExtendWith(RetryExtension.class)
+class CassandraConnectorITCase
         extends WriteAheadSinkTestBase<
                 Tuple3<String, Integer, Integer>,
                 CassandraTupleWriteAheadSink<Tuple3<String, Integer, Integer>>> {
@@ -111,14 +114,11 @@ public class CassandraConnectorITCase
     private static final Logger LOG = LoggerFactory.getLogger(CassandraConnectorITCase.class);
     private static final Slf4jLogConsumer LOG_CONSUMER = new Slf4jLogConsumer(LOG);
 
-    @ClassRule public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
-
-    @ClassRule
-    public static final CassandraContainer CASSANDRA_CONTAINER = createCassandraContainer();
+    @TempDir static Path tmpDir;
 
     private static final int READ_TIMEOUT_MILLIS = 36000;
 
-    @Rule public final RetryRule retryRule = new RetryRule();
+    @Container static final CassandraContainer CASSANDRA_CONTAINER = createCassandraContainer();
 
     private static final int PORT = 9042;
 
@@ -276,7 +276,7 @@ public class CassandraConnectorITCase
 
     private static void raiseCassandraRequestsTimeouts() {
         try {
-            final Path configurationPath = TEMPORARY_FOLDER.newFile().toPath();
+            final Path configurationPath = Files.createTempFile(tmpDir.toAbsolutePath(), "", "");
             CASSANDRA_CONTAINER.copyFileFromContainer(
                     "/etc/cassandra/cassandra.yaml", configurationPath.toAbsolutePath().toString());
             String configuration =
@@ -356,8 +356,8 @@ public class CassandraConnectorITCase
     //  Tests initialization
     // ------------------------------------------------------------------------
 
-    @BeforeClass
-    public static void startAndInitializeCassandra() {
+    @BeforeAll
+    static void startAndInitializeCassandra() {
         raiseCassandraRequestsTimeouts();
         // CASSANDRA_CONTAINER#start() already contains retrials
         CASSANDRA_CONTAINER.start();
@@ -389,14 +389,14 @@ public class CassandraConnectorITCase
         session.execute(requestWithTimeout(CREATE_KEYSPACE_QUERY));
     }
 
-    @Before
-    public void createTable() {
+    @BeforeEach
+    void createTable() {
         tableID = random.nextInt(Integer.MAX_VALUE);
         session.execute(requestWithTimeout(injectTableName(CREATE_TABLE_QUERY)));
     }
 
-    @AfterClass
-    public static void closeCassandra() {
+    @AfterAll
+    static void closeCassandra() {
         if (session != null) {
             session.close();
         }
@@ -410,8 +410,8 @@ public class CassandraConnectorITCase
     //  Technical Tests
     // ------------------------------------------------------------------------
 
-    @Test
-    public void testAnnotatePojoWithTable() {
+    @TestTemplate
+    void testAnnotatePojoWithTable() {
         final String tableName = TABLE_NAME_PREFIX + tableID;
 
         final Class<? extends Pojo> annotatedPojoClass = annotatePojoWithTable(KEYSPACE, tableName);
@@ -419,19 +419,20 @@ public class CassandraConnectorITCase
         assertThat(pojoTableAnnotation.name()).contains(tableName);
     }
 
-    @Test
-    public void testRaiseCassandraRequestsTimeouts() throws IOException {
+    @TestTemplate
+    void testRaiseCassandraRequestsTimeouts() throws IOException {
         // raiseCassandraRequestsTimeouts() was already called in @BeforeClass,
         // do not change the container conf twice, just assert that it was indeed changed in the
         // container
-        final Path configurationPath = TEMPORARY_FOLDER.newFile().toPath();
+        final Path configurationPath = Files.createTempFile(tmpDir.toAbsolutePath(), "", "");
         CASSANDRA_CONTAINER.copyFileFromContainer(
                 "/etc/cassandra/cassandra.yaml", configurationPath.toAbsolutePath().toString());
         final String configuration =
                 new String(Files.readAllBytes(configurationPath), StandardCharsets.UTF_8);
-        assertThat(configuration).contains("request_timeout_in_ms: 30000");
-        assertThat(configuration).contains("read_request_timeout_in_ms: 15000");
-        assertThat(configuration).contains("write_request_timeout_in_ms: 6000");
+        assertThat(configuration)
+                .contains("request_timeout_in_ms: 30000")
+                .contains("read_request_timeout_in_ms: 15000")
+                .contains("write_request_timeout_in_ms: 6000");
     }
 
     // ------------------------------------------------------------------------
@@ -473,7 +474,7 @@ public class CassandraConnectorITCase
             list.remove(new Integer(s.getInt(TUPLE_COUNTER_FIELD)));
         }
         assertThat(list)
-                .as("The following ID's were not found in the ResultSet: " + list.toString())
+                .as("The following ID's were not found in the ResultSet: " + list)
                 .isEmpty();
     }
 
@@ -491,7 +492,7 @@ public class CassandraConnectorITCase
             list.remove(new Integer(s.getInt(TUPLE_COUNTER_FIELD)));
         }
         assertThat(list)
-                .as("The following ID's were not found in the ResultSet: " + list.toString())
+                .as("The following ID's were not found in the ResultSet: " + list)
                 .isEmpty();
     }
 
@@ -512,7 +513,7 @@ public class CassandraConnectorITCase
             list.remove(new Integer(s.getInt(TUPLE_COUNTER_FIELD)));
         }
         assertThat(list)
-                .as("The following ID's were not found in the ResultSet: " + list.toString())
+                .as("The following ID's were not found in the ResultSet: " + list)
                 .isEmpty();
     }
 
@@ -543,8 +544,8 @@ public class CassandraConnectorITCase
         assertThat(actual.toArray()).isEqualTo(expected.toArray());
     }
 
-    @Test
-    public void testCassandraCommitter() throws Exception {
+    @TestTemplate
+    void testCassandraCommitter() throws Exception {
         String jobID = new JobID().toString();
         CassandraCommitter cc1 = new CassandraCommitter(builderForReading, "flink_auxiliary_cc");
         cc1.setJobId(jobID);
@@ -599,8 +600,8 @@ public class CassandraConnectorITCase
     //  At-least-once Tests
     // ------------------------------------------------------------------------
 
-    @Test
-    public void testCassandraTupleAtLeastOnceSink() throws Exception {
+    @TestTemplate
+    void testCassandraTupleAtLeastOnceSink() throws Exception {
         CassandraTupleSink<Tuple3<String, Integer, Integer>> sink =
                 new CassandraTupleSink<>(injectTableName(INSERT_DATA_QUERY), builderForWriting);
         try {
@@ -616,8 +617,8 @@ public class CassandraConnectorITCase
         assertThat(rs.all()).hasSize(20);
     }
 
-    @Test
-    public void testCassandraRowAtLeastOnceSink() throws Exception {
+    @TestTemplate
+    void testCassandraRowAtLeastOnceSink() throws Exception {
         CassandraRowSink sink =
                 new CassandraRowSink(
                         FIELD_TYPES.length, injectTableName(INSERT_DATA_QUERY), builderForWriting);
@@ -634,8 +635,8 @@ public class CassandraConnectorITCase
         assertThat(rs.all()).hasSize(20);
     }
 
-    @Test
-    public void testCassandraPojoAtLeastOnceSink() throws Exception {
+    @TestTemplate
+    void testCassandraPojoAtLeastOnceSink() throws Exception {
         final Class<? extends Pojo> annotatedPojoClass =
                 annotatePojoWithTable(KEYSPACE, TABLE_NAME_PREFIX + tableID);
         writePojos(annotatedPojoClass, null);
@@ -644,8 +645,8 @@ public class CassandraConnectorITCase
         assertThat(rs.all()).hasSize(20);
     }
 
-    @Test
-    public void testCassandraPojoNoAnnotatedKeyspaceAtLeastOnceSink() throws Exception {
+    @TestTemplate
+    void testCassandraPojoNoAnnotatedKeyspaceAtLeastOnceSink() throws Exception {
         final Class<? extends Pojo> annotatedPojoClass =
                 annotatePojoWithTable("", TABLE_NAME_PREFIX + tableID);
         writePojos(annotatedPojoClass, KEYSPACE);
@@ -668,8 +669,8 @@ public class CassandraConnectorITCase
         }
     }
 
-    @Test
-    public void testCassandraTableSink() throws Exception {
+    @TestTemplate
+    void testCassandraTableSink() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.setParallelism(4);
         StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
@@ -709,8 +710,8 @@ public class CassandraConnectorITCase
 
     private static int retrialsCount = 0;
 
-    @Test
-    public void testRetrial() {
+    @TestTemplate
+    void testRetrial() {
         annotatePojoWithTable(KEYSPACE, TABLE_NAME_PREFIX + tableID);
         if (retrialsCount < 2) {
             retrialsCount++;
@@ -718,8 +719,8 @@ public class CassandraConnectorITCase
         }
     }
 
-    @Test
-    public void testCassandraBatchPojoFormat() throws Exception {
+    @TestTemplate
+    void testCassandraBatchPojoFormat() throws Exception {
 
         final Class<? extends Pojo> annotatedPojoClass =
                 annotatePojoWithTable(KEYSPACE, TABLE_NAME_PREFIX + tableID);
@@ -729,8 +730,8 @@ public class CassandraConnectorITCase
         assertThat(rs.all()).hasSize(20);
 
         final List<? extends Pojo> result = readPojosWithInputFormat(annotatedPojoClass);
-        assertThat(result).hasSize(20);
         assertThat(result)
+                .hasSize(20)
                 .usingRecursiveComparison(
                         RecursiveComparisonConfiguration.builder()
                                 .withIgnoreCollectionOrder(true)
@@ -738,8 +739,8 @@ public class CassandraConnectorITCase
                 .isEqualTo(pojos);
     }
 
-    @Test
-    public void testCassandraBatchTupleFormat() throws Exception {
+    @TestTemplate
+    void testCassandraBatchTupleFormat() throws Exception {
         OutputFormat<Tuple3<String, Integer, Integer>> sink =
                 new CassandraTupleOutputFormat<>(
                         injectTableName(INSERT_DATA_QUERY), builderForWriting);
@@ -782,8 +783,8 @@ public class CassandraConnectorITCase
         assertThat(result).hasSize(20);
     }
 
-    @Test
-    public void testCassandraBatchRowFormat() throws Exception {
+    @TestTemplate
+    void testCassandraBatchRowFormat() throws Exception {
         OutputFormat<Row> sink =
                 new CassandraRowOutputFormat(injectTableName(INSERT_DATA_QUERY), builderForWriting);
         try {
@@ -799,11 +800,11 @@ public class CassandraConnectorITCase
 
         ResultSet rs = session.execute(requestWithTimeout(injectTableName(SELECT_DATA_QUERY)));
         List<com.datastax.driver.core.Row> rows = rs.all();
-        assertThat(rows).hasSize(rowCollection.size());
+        assertThat(rows).hasSameSizeAs(rowCollection);
     }
 
-    @Test
-    public void testCassandraScalaTupleAtLeastOnceSinkBuilderDetection() throws Exception {
+    @TestTemplate
+    void testCassandraScalaTupleAtLeastOnceSinkBuilderDetection() throws Exception {
         Class<scala.Tuple1<String>> c =
                 (Class<scala.Tuple1<String>>) new scala.Tuple1<>("hello").getClass();
         Seq<TypeInformation<?>> typeInfos =
@@ -832,8 +833,8 @@ public class CassandraConnectorITCase
         assertThat(sinkBuilder).isInstanceOf(CassandraSink.CassandraScalaProductSinkBuilder.class);
     }
 
-    @Test
-    public void testCassandraScalaTupleAtLeastSink() throws Exception {
+    @TestTemplate
+    void testCassandraScalaTupleAtLeastSink() throws Exception {
         CassandraScalaProductSink<scala.Tuple3<String, Integer, Integer>> sink =
                 new CassandraScalaProductSink<>(
                         injectTableName(INSERT_DATA_QUERY), builderForWriting);
@@ -853,7 +854,7 @@ public class CassandraConnectorITCase
 
         ResultSet rs = session.execute(requestWithTimeout(injectTableName(SELECT_DATA_QUERY)));
         List<com.datastax.driver.core.Row> rows = rs.all();
-        assertThat(rows).hasSize(scalaTupleCollection.size());
+        assertThat(rows).hasSameSizeAs(scalaTupleCollection);
 
         for (com.datastax.driver.core.Row row : rows) {
             scalaTupleCollection.remove(
@@ -865,8 +866,8 @@ public class CassandraConnectorITCase
         assertThat(scalaTupleCollection).isEmpty();
     }
 
-    @Test
-    public void testCassandraScalaTuplePartialColumnUpdate() throws Exception {
+    @TestTemplate
+    void testCassandraScalaTuplePartialColumnUpdate() throws Exception {
         CassandraSinkBaseConfig config =
                 CassandraSinkBaseConfig.newBuilder().setIgnoreNullFields(true).build();
         CassandraScalaProductSink<scala.Tuple3<String, Integer, Integer>> sink =

--- a/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraTupleWriteAheadSinkTest.java
+++ b/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraTupleWriteAheadSinkTest.java
@@ -29,27 +29,30 @@ import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.PreparedStatement;
 import com.datastax.driver.core.ResultSetFuture;
 import com.datastax.driver.core.Session;
-import org.junit.Test;
-import org.mockito.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.mockito.ArgumentMatchers;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import java.util.Collections;
 import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.powermock.api.mockito.PowerMockito.doAnswer;
-import static org.powermock.api.mockito.PowerMockito.mock;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /** Tests for the {@link CassandraTupleWriteAheadSink}. */
-public class CassandraTupleWriteAheadSinkTest {
+class CassandraTupleWriteAheadSinkTest {
 
-    @Test(timeout = 20000)
-    public void testAckLoopExitOnException() throws Exception {
+    @Test
+    @Timeout(value = 20_000, unit = TimeUnit.MILLISECONDS)
+    void testAckLoopExitOnException() throws Exception {
         final AtomicReference<Runnable> runnableFuture = new AtomicReference<>();
 
         final ClusterBuilder clusterBuilder =
@@ -64,7 +67,7 @@ public class CassandraTupleWriteAheadSinkTest {
                                     .thenReturn(boundStatement);
 
                             PreparedStatement preparedStatement = mock(PreparedStatement.class);
-                            when(preparedStatement.bind(Matchers.anyVararg()))
+                            when(preparedStatement.bind(ArgumentMatchers.any()))
                                     .thenReturn(boundStatement);
 
                             ResultSetFuture future = mock(ResultSetFuture.class);

--- a/flink-connectors/flink-connector-cassandra/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/flink-connectors/flink-connector-cassandra/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.util.TestLoggerExtension

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/GenericWriteAheadSinkTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/GenericWriteAheadSinkTest.java
@@ -124,11 +124,11 @@ class GenericWriteAheadSinkTest
         assertThat(sink.values).containsExactlyInAnyOrderElementsOf(list);
     }
 
-    @Test
     /**
      * Verifies that exceptions thrown by a committer do not fail a job and lead to an abort of
      * notify() and later retry of the affected checkpoints.
      */
+    @Test
     void testCommitterException() throws Exception {
 
         ListSink2 sink = new ListSink2();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/GenericWriteAheadSinkTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/GenericWriteAheadSinkTest.java
@@ -26,15 +26,15 @@ import org.apache.flink.api.java.typeutils.TypeExtractor;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /** Tests for {@link GenericWriteAheadSink}. */
-public class GenericWriteAheadSinkTest
+class GenericWriteAheadSinkTest
         extends WriteAheadSinkTestBase<Tuple1<Integer>, GenericWriteAheadSinkTest.ListSink> {
 
     @Override
@@ -63,12 +63,12 @@ public class GenericWriteAheadSinkTest
         for (Integer i : sink.values) {
             list.remove(i);
         }
-        Assert.assertTrue(
-                "The following ID's where not found in the result list: " + list.toString(),
-                list.isEmpty());
-        Assert.assertTrue(
-                "The sink emitted to many values: " + (sink.values.size() - 60),
-                sink.values.size() == 60);
+        assertThat(list)
+                .as("The following ID's where not found in the result list: " + list)
+                .isEmpty();
+        assertThat(sink.values)
+                .as("The sink emitted to many values: " + (sink.values.size() - 60))
+                .hasSize(60);
     }
 
     @Override
@@ -82,12 +82,12 @@ public class GenericWriteAheadSinkTest
         for (Integer i : sink.values) {
             list.remove(i);
         }
-        Assert.assertTrue(
-                "The following ID's where not found in the result list: " + list.toString(),
-                list.isEmpty());
-        Assert.assertTrue(
-                "The sink emitted to many values: " + (sink.values.size() - 60),
-                sink.values.size() == 60);
+        assertThat(list)
+                .as("The following ID's where not found in the result list: " + list)
+                .isEmpty();
+        assertThat(sink.values)
+                .as("The sink emitted to many values: " + (sink.values.size() - 60))
+                .hasSize(60);
     }
 
     @Override
@@ -104,12 +104,12 @@ public class GenericWriteAheadSinkTest
         for (Integer i : sink.values) {
             list.remove(i);
         }
-        Assert.assertTrue(
-                "The following ID's where not found in the result list: " + list.toString(),
-                list.isEmpty());
-        Assert.assertTrue(
-                "The sink emitted to many values: " + (sink.values.size() - 40),
-                sink.values.size() == 40);
+        assertThat(list)
+                .as("The following ID's where not found in the result list: " + list)
+                .isEmpty();
+        assertThat(sink.values)
+                .as("The sink emitted to many values: " + (sink.values.size() - 40))
+                .hasSize(40);
     }
 
     @Override
@@ -121,8 +121,7 @@ public class GenericWriteAheadSinkTest
             list.add(i);
         }
 
-        Collections.sort(sink.values);
-        Assert.assertArrayEquals(list.toArray(), sink.values.toArray());
+        assertThat(sink.values).containsExactlyInAnyOrderElementsOf(list);
     }
 
     @Test
@@ -130,7 +129,7 @@ public class GenericWriteAheadSinkTest
      * Verifies that exceptions thrown by a committer do not fail a job and lead to an abort of
      * notify() and later retry of the affected checkpoints.
      */
-    public void testCommitterException() throws Exception {
+    void testCommitterException() throws Exception {
 
         ListSink2 sink = new ListSink2();
 
@@ -150,7 +149,7 @@ public class GenericWriteAheadSinkTest
         testHarness.notifyOfCompletedCheckpoint(0);
 
         // isCommitted should have failed, thus sendValues() should never have been called
-        Assert.assertEquals(0, sink.values.size());
+        assertThat(sink.values).isEmpty();
 
         for (int x = 0; x < 11; x++) {
             testHarness.processElement(new StreamRecord<>(generateValue(elementCounter, 1)));
@@ -161,7 +160,7 @@ public class GenericWriteAheadSinkTest
         testHarness.notifyOfCompletedCheckpoint(1);
 
         // previous CP should be retried, but will fail the CP commit. Second CP should be skipped.
-        Assert.assertEquals(10, sink.values.size());
+        assertThat(sink.values).hasSize(10);
 
         for (int x = 0; x < 12; x++) {
             testHarness.processElement(new StreamRecord<>(generateValue(elementCounter, 2)));
@@ -173,7 +172,7 @@ public class GenericWriteAheadSinkTest
 
         // all CP's should be retried and succeed; since one CP was written twice we have 2 * 10 +
         // 11 + 12 = 43 values
-        Assert.assertEquals(43, sink.values.size());
+        assertThat(sink.values).hasSize(43);
     }
 
     /** Simple sink that stores all records in a public list. */

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/WriteAheadSinkTestBase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/WriteAheadSinkTestBase.java
@@ -23,13 +23,14 @@ import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.AbstractStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
-import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.TestLoggerExtension;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /** Test base for {@link GenericWriteAheadSink}. */
-public abstract class WriteAheadSinkTestBase<IN, S extends GenericWriteAheadSink<IN>>
-        extends TestLogger {
+@ExtendWith(TestLoggerExtension.class)
+public abstract class WriteAheadSinkTestBase<IN, S extends GenericWriteAheadSink<IN>> {
 
     protected abstract S createSink() throws Exception;
 
@@ -49,7 +50,7 @@ public abstract class WriteAheadSinkTestBase<IN, S extends GenericWriteAheadSink
     private final int maxParallelism = 10;
 
     @Test
-    public void testIdealCircumstances() throws Exception {
+    void testIdealCircumstances() throws Exception {
         S sink = createSink();
 
         OneInputStreamOperatorTestHarness<IN, IN> testHarness =
@@ -88,7 +89,7 @@ public abstract class WriteAheadSinkTestBase<IN, S extends GenericWriteAheadSink
     }
 
     @Test
-    public void testDataPersistenceUponMissedNotify() throws Exception {
+    void testDataPersistenceUponMissedNotify() throws Exception {
         S sink = createSink();
 
         OneInputStreamOperatorTestHarness<IN, IN> testHarness =
@@ -126,7 +127,7 @@ public abstract class WriteAheadSinkTestBase<IN, S extends GenericWriteAheadSink
     }
 
     @Test
-    public void testDataDiscardingUponRestore() throws Exception {
+    void testDataDiscardingUponRestore() throws Exception {
         S sink = createSink();
 
         OneInputStreamOperatorTestHarness<IN, IN> testHarness =
@@ -172,7 +173,7 @@ public abstract class WriteAheadSinkTestBase<IN, S extends GenericWriteAheadSink
     }
 
     @Test
-    public void testScalingDown() throws Exception {
+    void testScalingDown() throws Exception {
         S sink1 = createSink();
         OneInputStreamOperatorTestHarness<IN, IN> testHarness1 =
                 new OneInputStreamOperatorTestHarness<>(sink1, maxParallelism, 2, 0);
@@ -236,7 +237,7 @@ public abstract class WriteAheadSinkTestBase<IN, S extends GenericWriteAheadSink
     }
 
     @Test
-    public void testScalingUp() throws Exception {
+    void testScalingUp() throws Exception {
 
         S sink1 = createSink();
         OneInputStreamOperatorTestHarness<IN, IN> testHarness1 =


### PR DESCRIPTION
## What is the purpose of the change

Migrate `WriteAheadSinkTestBase` and flink-connector-cassandra module to AssertJ and JUnit 5 following the [JUnit 5 Migration Guide](https://docs.google.com/document/d/1514Wa_aNB9bJUen4xm5uiuXOooOJTtXqS_Jqk9KJitU/edit)


## Brief change log

Use JUnit5 and AssertJ in tests instead of JUnit4 and Hamcrest


## Verifying this change

This change is a code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no )
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? (no )
  - If yes, how is the feature documented? (not applicable)
