### PR TITLE
[FLINK-27968][E2E] Fix failed end-to-end-tests-sql CI test

### DIFF
--- a/flink-end-to-end-tests/flink-end-to-end-tests-sql/pom.xml
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-sql/pom.xml
@@ -36,16 +36,6 @@
             <artifactId>flink-end-to-end-tests-common</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-test-utils-junit</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <scope>compile</scope>
-        </dependency>
 
         <!-- The following dependencies are for connector/format sql-jars that
             we copy using the maven-dependency-plugin. When extending the test
@@ -92,30 +82,6 @@
                         </artifactItem>
                     </artifactItems>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>integration-tests</id>
-                        <phase>integration-test</phase>
-                        <goals>
-                            <goal>test</goal>
-                        </goals>
-                        <configuration>
-                            <includes>
-                                <include>**/*ITCase.*</include>
-                            </includes>
-                            <!-- override reuseForks to true to reduce testing time -->
-                            <reuseForks>true</reuseForks>
-                            <systemPropertyVariables>
-                                <rootDir>${project.basedir}/../../</rootDir>
-                                <moduleDir>${project.basedir}</moduleDir>
-                            </systemPropertyVariables>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/flink-end-to-end-tests/flink-end-to-end-tests-sql/src/test/java/org/apache/flink/table/sql/codegen/PlannerScalaFreeITCase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-sql/src/test/java/org/apache/flink/table/sql/codegen/PlannerScalaFreeITCase.java
@@ -31,7 +31,6 @@ import org.apache.flink.util.TestLogger;
 
 import org.junit.Before;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -65,7 +64,6 @@ import static org.junit.Assert.assertTrue;
  * cover it, so we should add E2E test for these case.
  */
 @RunWith(Parameterized.class)
-@Ignore
 public class PlannerScalaFreeITCase extends TestLogger {
 
     private static final Logger LOG = LoggerFactory.getLogger(PlannerScalaFreeITCase.class);
@@ -106,8 +104,7 @@ public class PlannerScalaFreeITCase extends TestLogger {
     }
 
     @Before
-    public void before() throws Exception {
-        DOWNLOAD_CACHE.before();
+    public void before() {
         Path tmpPath = tmp.getRoot().toPath();
         LOG.info("The current temporary path: {}", tmpPath);
         this.result = tmpPath.resolve("result");


### PR DESCRIPTION

## What is the purpose of the change

*Fix failed end-to-end-tests-sql CI test*


## Brief change log
  - *Fix failed end-to-end-tests-sql CI test*


## Verifying this change

This change is already covered by existing tests.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: ( no )

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
