### PR TITLE
[FLINK-27903][runtime] Introduce and support HYBRID resultPartitionType

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/BatchShuffleMode.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/BatchShuffleMode.java
@@ -18,6 +18,7 @@
 package org.apache.flink.api.common;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.docs.Documentation;
 import org.apache.flink.configuration.DescribedEnum;
 import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.configuration.description.InlineElement;
@@ -60,7 +61,25 @@ public enum BatchShuffleMode implements DescribedEnum {
     ALL_EXCHANGES_BLOCKING(
             text(
                     "Upstream and downstream tasks run subsequently. This reduces the resource usage "
-                            + "as downstream tasks are started after upstream tasks finished."));
+                            + "as downstream tasks are started after upstream tasks finished.")),
+
+    /**
+     * Downstream can start running anytime, as long as the upstream has started.
+     *
+     * <p>This adapts the resource usage to whatever is available.
+     *
+     * <p>Attention: This feature is working in progress, it will rename to ALL_EXCHANGES_HYBRID
+     * when the effort is finished.
+     */
+    // TODO remove the annotation and rename this enum constant when hybrid shuffle effort is
+    // finished.
+    @Documentation.ExcludeFromDocumentation
+    WIP_ALL_EXCHANGES_HYBRID(
+            text(
+                    "Downstream task can start running anytime, as long as the upstream has started."
+                            + " This is a shuffle mode between pipelined and blocking, adapts the "
+                            + "resource usage to whatever is available. Note that the work is not "
+                            + "fully done, please don't use it now."));
 
     private final InlineElement description;
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/BatchShuffleMode.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/BatchShuffleMode.java
@@ -64,22 +64,16 @@ public enum BatchShuffleMode implements DescribedEnum {
                             + "as downstream tasks are started after upstream tasks finished.")),
 
     /**
-     * Downstream can start running anytime, as long as the upstream has started.
+     * *DO NOT USE* - This feature is in progress.
+     *
+     * <p>Downstream can start running anytime, as long as the upstream has started.
      *
      * <p>This adapts the resource usage to whatever is available.
-     *
-     * <p>Attention: This feature is working in progress, it will rename to ALL_EXCHANGES_HYBRID
-     * when the effort is finished.
      */
     // TODO remove the annotation and rename this enum constant when hybrid shuffle effort is
     // finished.
     @Documentation.ExcludeFromDocumentation
-    WIP_ALL_EXCHANGES_HYBRID(
-            text(
-                    "Downstream task can start running anytime, as long as the upstream has started."
-                            + " This is a shuffle mode between pipelined and blocking, adapts the "
-                            + "resource usage to whatever is available. Note that the work is not "
-                            + "fully done, please don't use it now."));
+    WIP_ALL_EXCHANGES_HYBRID(text("DO NOT USE - This feature is in progress."));
 
     private final InlineElement description;
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/ExecutionOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ExecutionOptions.java
@@ -70,6 +70,8 @@ public class ExecutionOptions {
                                                     + "Such an exchange reduces the resources required to execute the "
                                                     + "job as it does not need to run upstream and downstream "
                                                     + "tasks simultaneously.")
+                                    // TODO Add ALL_EXCHANGES_HYBRID's text description when hybrid
+                                    // shuffle mode related codes are all merged.
                                     .build());
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionType.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionType.java
@@ -87,11 +87,7 @@ public enum ResultPartitionType {
      * Hybrid partitions with a bounded (local) buffer pool to support downstream task to
      * simultaneous reading and writing shuffle data.
      *
-     * <p>Hybrid result has the following two characteristics:
-     *
-     * <p>Intermediate data can be consumed any time, whether fully produced or not.
-     *
-     * <p>Intermediate data can be consumed directly from memory as much as possible.
+     * <p>Hybrid partitions can be consumed any time, whether fully produced or not.
      */
     HYBRID(true, false, ConsumingConstraint.CAN_BE_PIPELINED, ReleaseBy.SCHEDULER);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionType.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionType.java
@@ -81,7 +81,19 @@ public enum ResultPartitionType {
      * in that {@link #PIPELINED_APPROXIMATE} partition can be reconnected after down stream task
      * fails.
      */
-    PIPELINED_APPROXIMATE(true, false, ConsumingConstraint.CAN_BE_PIPELINED, ReleaseBy.UPSTREAM);
+    PIPELINED_APPROXIMATE(true, false, ConsumingConstraint.CAN_BE_PIPELINED, ReleaseBy.UPSTREAM),
+
+    /**
+     * Hybrid partitions with a bounded (local) buffer pool to support downstream task to
+     * simultaneous reading and writing shuffle data.
+     *
+     * <p>Hybrid result has the following two characteristics:
+     *
+     * <p>Intermediate data can be consumed any time, whether fully produced or not.
+     *
+     * <p>Intermediate data can be consumed directly from memory as much as possible.
+     */
+    HYBRID(true, false, ConsumingConstraint.CAN_BE_PIPELINED, ReleaseBy.SCHEDULER);
 
     /** Does this partition use a limited number of (network) buffers? */
     private final boolean isBounded;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingPipelinedRegion.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingPipelinedRegion.java
@@ -32,7 +32,10 @@ public class TestingSchedulingPipelinedRegion implements SchedulingPipelinedRegi
     private final Map<ExecutionVertexID, TestingSchedulingExecutionVertex> regionVertices =
             new HashMap<>();
 
-    private final Set<ConsumedPartitionGroup> consumedPartitionGroups =
+    private final Set<ConsumedPartitionGroup> blockingConsumedPartitionGroups =
+            Collections.newSetFromMap(new IdentityHashMap<>());
+
+    private final Set<ConsumedPartitionGroup> releaseBySchedulerConsumedPartitionGroups =
             Collections.newSetFromMap(new IdentityHashMap<>());
 
     public TestingSchedulingPipelinedRegion(final Set<TestingSchedulingExecutionVertex> vertices) {
@@ -48,8 +51,14 @@ public class TestingSchedulingPipelinedRegion implements SchedulingPipelinedRegi
 
             for (ConsumedPartitionGroup consumedGroup : vertex.getConsumedPartitionGroups()) {
                 for (IntermediateResultPartitionID consumerId : consumedGroup) {
-                    if (!vertices.contains(resultPartitionsById.get(consumerId).getProducer())) {
-                        consumedPartitionGroups.add(consumedGroup);
+                    TestingSchedulingResultPartition rp = resultPartitionsById.get(consumerId);
+                    if (!vertices.contains(rp.getProducer())) {
+                        if (!rp.getResultType().canBePipelinedConsumed()) {
+                            blockingConsumedPartitionGroups.add(consumedGroup);
+                        }
+                        if (rp.getResultType().isReleaseByScheduler()) {
+                            releaseBySchedulerConsumedPartitionGroups.add(consumedGroup);
+                        }
                     }
                     break;
                 }
@@ -74,12 +83,12 @@ public class TestingSchedulingPipelinedRegion implements SchedulingPipelinedRegi
 
     @Override
     public Iterable<ConsumedPartitionGroup> getAllBlockingConsumedPartitionGroups() {
-        return Collections.unmodifiableSet(consumedPartitionGroups);
+        return Collections.unmodifiableSet(blockingConsumedPartitionGroups);
     }
 
     @Override
     public Iterable<ConsumedPartitionGroup> getAllReleaseBySchedulerConsumedPartitionGroups() {
-        return Collections.unmodifiableSet(consumedPartitionGroups);
+        return Collections.unmodifiableSet(releaseBySchedulerConsumedPartitionGroups);
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/GlobalStreamExchangeMode.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/GlobalStreamExchangeMode.java
@@ -51,5 +51,8 @@ public enum GlobalStreamExchangeMode {
     ALL_EDGES_PIPELINED,
 
     /** Set all job edges {@link ResultPartitionType#PIPELINED_APPROXIMATE}. */
-    ALL_EDGES_PIPELINED_APPROXIMATE
+    ALL_EDGES_PIPELINED_APPROXIMATE,
+
+    /** Set all job edges {@link ResultPartitionType#HYBRID}. */
+    ALL_EDGES_HYBRID
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -397,6 +397,8 @@ public class StreamGraphGenerator {
                 return GlobalStreamExchangeMode.ALL_EDGES_PIPELINED;
             case ALL_EXCHANGES_BLOCKING:
                 return GlobalStreamExchangeMode.ALL_EDGES_BLOCKING;
+            case WIP_ALL_EXCHANGES_HYBRID:
+                return GlobalStreamExchangeMode.ALL_EDGES_HYBRID;
             default:
                 throw new IllegalArgumentException(
                         String.format(

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -1150,7 +1150,7 @@ public class StreamingJobGraphGenerator {
                 break;
             default:
                 throw new RuntimeException(
-                        "Unknown chaining strategy: " + upStreamOperator.getChainingStrategy());
+                        "Unknown chaining strategy: " + downStreamOperator.getChainingStrategy());
         }
 
         return isChainable;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/StreamExchangeMode.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/StreamExchangeMode.java
@@ -37,6 +37,11 @@ public enum StreamExchangeMode {
     BATCH,
 
     /**
+     * The consumer can start consuming data anytime as long as the producer has started producing.
+     */
+    HYBRID,
+
+    /**
      * The exchange mode is undefined. It leaves it up to the framework to decide the exchange mode.
      * The framework will pick one of {@link StreamExchangeMode#BATCH} or {@link
      * StreamExchangeMode#PIPELINED} in the end.

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorBatchExecutionTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorBatchExecutionTest.java
@@ -104,6 +104,11 @@ public class StreamGraphGeneratorBatchExecutionTest extends TestLogger {
                 RuntimeExecutionMode.BATCH,
                 BatchShuffleMode.ALL_EXCHANGES_PIPELINED,
                 GlobalStreamExchangeMode.ALL_EDGES_PIPELINED);
+
+        testGlobalStreamExchangeMode(
+                RuntimeExecutionMode.BATCH,
+                BatchShuffleMode.WIP_ALL_EXCHANGES_HYBRID,
+                GlobalStreamExchangeMode.ALL_EDGES_HYBRID);
     }
 
     @Test

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.streaming.api.graph;
 
+import org.apache.flink.api.common.BatchShuffleMode;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
@@ -40,6 +41,7 @@ import org.apache.flink.api.java.io.DiscardingOutputFormat;
 import org.apache.flink.api.java.io.TypeSerializerInputFormat;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.configuration.PipelineOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.memory.ManagedMemoryUseCase;
@@ -96,6 +98,7 @@ import org.apache.flink.util.TestLogger;
 
 import org.apache.flink.shaded.guava30.com.google.common.collect.Iterables;
 
+import org.assertj.core.api.Assertions;
 import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
 import org.junit.Assert;
@@ -113,6 +116,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.streaming.api.graph.StreamingJobGraphGenerator.areOperatorsChainable;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -720,6 +724,45 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
                 sourceAndMapVertex.getProducedDataSets().get(0).getResultType());
     }
 
+    /** Test setting exchange mode to {@link StreamExchangeMode#HYBRID}. */
+    @Test
+    public void testExchangeModeHybrid() {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        // fromElements -> Map -> Print
+        DataStream<Integer> sourceDataStream = env.fromElements(1, 2, 3);
+
+        DataStream<Integer> partitionAfterSourceDataStream =
+                new DataStream<>(
+                        env,
+                        new PartitionTransformation<>(
+                                sourceDataStream.getTransformation(),
+                                new ForwardPartitioner<>(),
+                                StreamExchangeMode.HYBRID));
+        DataStream<Integer> mapDataStream =
+                partitionAfterSourceDataStream.map(value -> value).setParallelism(1);
+
+        DataStream<Integer> partitionAfterMapDataStream =
+                new DataStream<>(
+                        env,
+                        new PartitionTransformation<>(
+                                mapDataStream.getTransformation(),
+                                new RescalePartitioner<>(),
+                                StreamExchangeMode.HYBRID));
+        partitionAfterMapDataStream.print().setParallelism(2);
+
+        JobGraph jobGraph = StreamingJobGraphGenerator.createJobGraph(env.getStreamGraph());
+
+        List<JobVertex> verticesSorted = jobGraph.getVerticesSortedTopologicallyFromSources();
+        assertEquals(2, verticesSorted.size());
+
+        // it can be chained with Hybrid exchange mode
+        JobVertex sourceAndMapVertex = verticesSorted.get(0);
+
+        // Hybrid exchange mode is translated into Hybrid result partition
+        Assertions.assertThat(sourceAndMapVertex.getProducedDataSets().get(0).getResultType())
+                .isEqualTo(ResultPartitionType.HYBRID);
+    }
+
     @Test
     public void testStreamingJobTypeByDefault() {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
@@ -1199,6 +1242,26 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
                         tmConfig,
                         ClassLoader.getSystemClassLoader()),
                 delta);
+    }
+
+    @Test
+    public void testSetNonDefaultSlotSharingInHybridMode() {
+        Configuration configuration = new Configuration();
+        // set all edge to HYBRID result partition type.
+        configuration.set(
+                ExecutionOptions.BATCH_SHUFFLE_MODE, BatchShuffleMode.WIP_ALL_EXCHANGES_HYBRID);
+
+        final StreamGraph streamGraph = createStreamGraphForSlotSharingTest(configuration);
+        // specify slot sharing group for map1
+        streamGraph.getStreamNodes().stream()
+                .filter(n -> "map1".equals(n.getOperatorName()))
+                .findFirst()
+                .get()
+                .setSlotSharingGroup("testSlotSharingGroup");
+        assertThatThrownBy(() -> StreamingJobGraphGenerator.createJobGraph(streamGraph))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage(
+                        "hybrid shuffle mode currently does not support setting non-default slot sharing group.");
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

*Introduce and support HYBRID resultPartitionType*


## Brief change log

  - *Introduce HYBRID resultPartitionType.*
  - *Make streamGraph and jobGraph support HYBRID type edge.*
  - *Test that the pipelinedRegionSchedulingStrategy can be adapted to hybrid type edges.*


## Verifying this change

This change added unit tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? Docs and JavaDocs
