### PR TITLE
[FLINK-27937][tests][pubsub] Migrate flink-connectors-gcp-pubsub to JUnit 5

### DIFF
--- a/flink-connectors/flink-connector-gcp-pubsub/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/DeserializationSchemaWrapperTest.java
+++ b/flink-connectors/flink-connector-gcp-pubsub/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/DeserializationSchemaWrapperTest.java
@@ -23,17 +23,15 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 
 import com.google.protobuf.ByteString;
 import com.google.pubsub.v1.PubsubMessage;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.internal.verification.VerificationModeFactory;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -42,43 +40,44 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /** Unit tests for {@link DeserializationSchema}. */
-@RunWith(MockitoJUnitRunner.class)
-public class DeserializationSchemaWrapperTest {
-
-    @Rule public ExpectedException thrown = ExpectedException.none();
+@ExtendWith(MockitoExtension.class)
+class DeserializationSchemaWrapperTest {
 
     @Mock private DeserializationSchema<String> deserializationSchema;
 
     @InjectMocks private DeserializationSchemaWrapper<String> deserializationSchemaWrapper;
 
     @Test
-    public void testProducedType() {
+    void testProducedType() {
         TypeInformation<String> typeInformation = TypeInformation.of(String.class);
         when(deserializationSchema.getProducedType()).thenReturn(typeInformation);
 
-        assertThat(deserializationSchemaWrapper.getProducedType(), is(typeInformation));
+        assertThat(deserializationSchemaWrapper.getProducedType()).isEqualTo(typeInformation);
         verify(deserializationSchema, times(1)).getProducedType();
     }
 
     @Test
-    public void testEndOfStream() {
+    void testEndOfStream() {
         String input = "some-input";
         when(deserializationSchema.isEndOfStream(any())).thenReturn(true);
 
-        assertThat(deserializationSchemaWrapper.isEndOfStream(input), is(true));
+        assertThat(deserializationSchemaWrapper.isEndOfStream(input)).isTrue();
         verify(deserializationSchema, times(1)).isEndOfStream(input);
     }
 
     @Test
-    public void testDeserialize() throws Exception {
+    void testDeserialize() {
         String inputAsString = "some-input";
 
-        thrown.expect(UnsupportedOperationException.class);
-        deserializationSchemaWrapper.deserialize(pubSubMessage(inputAsString));
+        assertThatThrownBy(
+                        () ->
+                                deserializationSchemaWrapper.deserialize(
+                                        pubSubMessage(inputAsString)))
+                .isInstanceOf(UnsupportedOperationException.class);
     }
 
     @Test
-    public void testOpen() throws Exception {
+    void testOpen() throws Exception {
         InitializationContext initContext = mock(InitializationContext.class);
         deserializationSchemaWrapper.open(initContext);
 

--- a/flink-connectors/flink-connector-gcp-pubsub/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/PubSubConsumingTest.java
+++ b/flink-connectors/flink-connector-gcp-pubsub/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/PubSubConsumingTest.java
@@ -30,7 +30,7 @@ import com.google.auth.Credentials;
 import com.google.protobuf.ByteString;
 import com.google.pubsub.v1.PubsubMessage;
 import com.google.pubsub.v1.ReceivedMessage;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -41,15 +41,14 @@ import java.util.Queue;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 /** Tests for consuming records with {@link PubSubSource}. */
-public class PubSubConsumingTest {
+class PubSubConsumingTest {
 
     @Test
-    public void testProcessMessage() throws Exception {
+    void testProcessMessage() throws Exception {
         TestPubSubSubscriber testPubSubSubscriber =
                 new TestPubSubSubscriber(
                         receivedMessage("1", pubSubMessage("A")),
@@ -70,10 +69,11 @@ public class PubSubConsumingTest {
             thread.start();
             awaitRecordCount(results, 2);
 
-            assertThat(new ArrayList<>(results), equalTo(Arrays.asList("A", "B")));
+            assertThat(new ArrayList<>(results)).isEqualTo(Arrays.asList("A", "B"));
             pubSubSource.snapshotState(0, 0);
             pubSubSource.notifyCheckpointComplete(0);
-            assertThat(testPubSubSubscriber.getAcknowledgedIds(), equalTo(Arrays.asList("1", "2")));
+            assertThat(testPubSubSubscriber.getAcknowledgedIds())
+                    .isEqualTo(Arrays.asList("1", "2"));
         } finally {
             pubSubSource.cancel();
             thread.join();
@@ -81,8 +81,7 @@ public class PubSubConsumingTest {
     }
 
     @Test
-    public void testStoppingConnectorWhenDeserializationSchemaIndicatesEndOfStream()
-            throws Exception {
+    void testStoppingConnectorWhenDeserializationSchemaIndicatesEndOfStream() throws Exception {
         TestPubSubSubscriber testPubSubSubscriber =
                 new TestPubSubSubscriber(
                         receivedMessage("1", pubSubMessage("A")),
@@ -112,13 +111,12 @@ public class PubSubConsumingTest {
             awaitRecordCount(results, 2);
 
             // we do not emit the end of stream record
-            assertThat(new ArrayList<>(results), equalTo(Arrays.asList("A", "B")));
+            assertThat(new ArrayList<>(results)).isEqualTo(Arrays.asList("A", "B"));
             pubSubSource.snapshotState(0, 0);
             pubSubSource.notifyCheckpointComplete(0);
             // we acknowledge also the end of the stream record
-            assertThat(
-                    testPubSubSubscriber.getAcknowledgedIds(),
-                    equalTo(Arrays.asList("1", "2", "3")));
+            assertThat(testPubSubSubscriber.getAcknowledgedIds())
+                    .isEqualTo(Arrays.asList("1", "2", "3"));
         } finally {
             pubSubSource.cancel();
             thread.join();
@@ -126,7 +124,7 @@ public class PubSubConsumingTest {
     }
 
     @Test
-    public void testProducingMultipleResults() throws Exception {
+    void testProducingMultipleResults() throws Exception {
         TestPubSubSubscriber testPubSubSubscriber =
                 new TestPubSubSubscriber(
                         receivedMessage("1", pubSubMessage("A")),
@@ -163,11 +161,12 @@ public class PubSubConsumingTest {
             awaitRecordCount(results, 2);
 
             // we emit only the records prior to the end of the stream
-            assertThat(new ArrayList<>(results), equalTo(Arrays.asList("A", "B")));
+            assertThat(new ArrayList<>(results)).isEqualTo(Arrays.asList("A", "B"));
             pubSubSource.snapshotState(0, 0);
             pubSubSource.notifyCheckpointComplete(0);
             // we acknowledge also the end of the stream record
-            assertThat(testPubSubSubscriber.getAcknowledgedIds(), equalTo(Arrays.asList("1", "2")));
+            assertThat(testPubSubSubscriber.getAcknowledgedIds())
+                    .isEqualTo(Arrays.asList("1", "2"));
         } finally {
             pubSubSource.cancel();
             thread.join();

--- a/flink-connectors/flink-connector-gcp-pubsub/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/common/AcknowledgeOnCheckpointTest.java
+++ b/flink-connectors/flink-connector-gcp-pubsub/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/common/AcknowledgeOnCheckpointTest.java
@@ -17,28 +17,24 @@
 
 package org.apache.flink.streaming.connectors.gcp.pubsub.common;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static java.util.Arrays.asList;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 /** Unit tests for {@link AcknowledgeOnCheckpoint}. */
-public class AcknowledgeOnCheckpointTest {
+class AcknowledgeOnCheckpointTest {
     private final Acknowledger<String> mockedAcknowledger = mock(Acknowledger.class);
 
     @Test
-    public void testRestoreStateAndSnapshot() {
+    void testRestoreStateAndSnapshot() {
         List<AcknowledgeIdsForCheckpoint<String>> input = new ArrayList<>();
         input.add(new AcknowledgeIdsForCheckpoint<>(0, asList("idsFor0", "moreIdsFor0")));
         input.add(new AcknowledgeIdsForCheckpoint<>(1, asList("idsFor1", "moreIdsFor1")));
@@ -50,17 +46,17 @@ public class AcknowledgeOnCheckpointTest {
         List<AcknowledgeIdsForCheckpoint<String>> actual =
                 acknowledgeOnCheckpoint.snapshotState(2, 100);
 
-        assertThat(actual, hasSize(3));
-        assertThat(actual.get(0), equalTo(input.get(0)));
-        assertThat(actual.get(1), equalTo(input.get(1)));
-        assertThat(actual.get(2).getCheckpointId(), is(2L));
-        assertThat(actual.get(2).getAcknowledgeIds(), hasSize(0));
+        assertThat(actual).hasSize(3);
+        assertThat(actual.get(0)).isEqualTo(input.get(0));
+        assertThat(actual.get(1)).isEqualTo(input.get(1));
+        assertThat(actual.get(2).getCheckpointId()).isEqualTo(2L);
+        assertThat(actual.get(2).getAcknowledgeIds()).isEmpty();
 
-        assertThat(acknowledgeOnCheckpoint.numberOfOutstandingAcknowledgements(), is(4));
+        assertThat(acknowledgeOnCheckpoint.numberOfOutstandingAcknowledgements()).isEqualTo(4);
     }
 
     @Test
-    public void testAddAcknowledgeIdOnEmptyState() {
+    void testAddAcknowledgeIdOnEmptyState() {
         AcknowledgeOnCheckpoint<String> acknowledgeOnCheckpoint =
                 new AcknowledgeOnCheckpoint<>(mockedAcknowledger);
 
@@ -69,14 +65,14 @@ public class AcknowledgeOnCheckpointTest {
         List<AcknowledgeIdsForCheckpoint<String>> actual =
                 acknowledgeOnCheckpoint.snapshotState(2, 100);
 
-        assertThat(actual.get(0).getCheckpointId(), is(2L));
-        assertThat(actual.get(0).getAcknowledgeIds(), containsInAnyOrder("ackId"));
+        assertThat(actual.get(0).getCheckpointId()).isEqualTo(2L);
+        assertThat(actual.get(0).getAcknowledgeIds()).contains("ackId");
 
-        assertThat(acknowledgeOnCheckpoint.numberOfOutstandingAcknowledgements(), is(1));
+        assertThat(acknowledgeOnCheckpoint.numberOfOutstandingAcknowledgements()).isEqualTo(1);
     }
 
     @Test
-    public void testAddAcknowledgeIdOnExistingState() {
+    void testAddAcknowledgeIdOnExistingState() {
         List<AcknowledgeIdsForCheckpoint<String>> input = new ArrayList<>();
         input.add(new AcknowledgeIdsForCheckpoint<>(0, asList("idsFor0", "moreIdsFor0")));
         input.add(new AcknowledgeIdsForCheckpoint<>(1, asList("idsFor1", "moreIdsFor1")));
@@ -91,16 +87,16 @@ public class AcknowledgeOnCheckpointTest {
         List<AcknowledgeIdsForCheckpoint<String>> actual =
                 acknowledgeOnCheckpoint.snapshotState(94, 100);
 
-        assertThat(actual.get(0), equalTo(input.get(0)));
-        assertThat(actual.get(1), equalTo(input.get(1)));
-        assertThat(actual.get(2).getCheckpointId(), is(94L));
-        assertThat(actual.get(2).getAcknowledgeIds(), containsInAnyOrder("ackId"));
+        assertThat(actual.get(0)).isEqualTo(input.get(0));
+        assertThat(actual.get(1)).isEqualTo(input.get(1));
+        assertThat(actual.get(2).getCheckpointId()).isEqualTo(94L);
+        assertThat(actual.get(2).getAcknowledgeIds()).contains("ackId");
 
-        assertThat(acknowledgeOnCheckpoint.numberOfOutstandingAcknowledgements(), is(5));
+        assertThat(acknowledgeOnCheckpoint.numberOfOutstandingAcknowledgements()).isEqualTo(5);
     }
 
     @Test
-    public void testAddMultipleAcknowledgeIds() {
+    void testAddMultipleAcknowledgeIds() {
         AcknowledgeOnCheckpoint<String> acknowledgeOnCheckpoint =
                 new AcknowledgeOnCheckpoint<>(mockedAcknowledger);
 
@@ -110,14 +106,14 @@ public class AcknowledgeOnCheckpointTest {
         List<AcknowledgeIdsForCheckpoint<String>> actual =
                 acknowledgeOnCheckpoint.snapshotState(2, 100);
 
-        assertThat(actual.get(0).getCheckpointId(), is(2L));
-        assertThat(actual.get(0).getAcknowledgeIds(), containsInAnyOrder("ackId", "ackId2"));
+        assertThat(actual.get(0).getCheckpointId()).isEqualTo(2L);
+        assertThat(actual.get(0).getAcknowledgeIds()).contains("ackId", "ackId2");
 
-        assertThat(acknowledgeOnCheckpoint.numberOfOutstandingAcknowledgements(), is(2));
+        assertThat(acknowledgeOnCheckpoint.numberOfOutstandingAcknowledgements()).isEqualTo(2);
     }
 
     @Test
-    public void testAcknowledgeIdsForCheckpoint() {
+    void testAcknowledgeIdsForCheckpoint() {
         List<AcknowledgeIdsForCheckpoint<String>> input = new ArrayList<>();
         input.add(new AcknowledgeIdsForCheckpoint<>(0, asList("idsFor0", "moreIdsFor0")));
         input.add(new AcknowledgeIdsForCheckpoint<>(1, asList("idsFor1", "moreIdsFor1")));
@@ -132,20 +128,19 @@ public class AcknowledgeOnCheckpointTest {
 
         ArgumentCaptor<List<String>> argumentCaptor = ArgumentCaptor.forClass(List.class);
         verify(mockedAcknowledger, times(1)).acknowledge(argumentCaptor.capture());
-        assertThat(
-                argumentCaptor.getValue(),
-                containsInAnyOrder(
+        assertThat(argumentCaptor.getValue())
+                .contains(
                         "idsFor0", "moreIdsFor0",
                         "idsFor1", "moreIdsFor1",
-                        "idsFor2", "moreIdsFor2"));
+                        "idsFor2", "moreIdsFor2");
 
-        assertThat(acknowledgeOnCheckpoint.numberOfOutstandingAcknowledgements(), is(2));
+        assertThat(acknowledgeOnCheckpoint.numberOfOutstandingAcknowledgements()).isEqualTo(2);
     }
 
     @Test
-    public void testNumberOfOutstandingAcknowledgementsOnEmptyState() {
+    void testNumberOfOutstandingAcknowledgementsOnEmptyState() {
         AcknowledgeOnCheckpoint<String> acknowledgeOnCheckpoint =
                 new AcknowledgeOnCheckpoint<>(mockedAcknowledger);
-        assertThat(acknowledgeOnCheckpoint.numberOfOutstandingAcknowledgements(), is(0));
+        assertThat(acknowledgeOnCheckpoint.numberOfOutstandingAcknowledgements()).isEqualTo(0);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -257,6 +257,14 @@ under the License.
 		</dependency>
 
 		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-junit-jupiter</artifactId>
+			<version>${mockito.version}</version>
+			<type>jar</type>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>org.powermock</groupId>
 			<artifactId>powermock-module-junit4</artifactId>
 			<version>${powermock.version}</version>


### PR DESCRIPTION
## What is the purpose of the change

Migrate flink-connectors-gcp-pubsub module to AssertJ and JUnit 5 following the [JUnit 5 Migration Guide](https://docs.google.com/document/d/1514Wa_aNB9bJUen4xm5uiuXOooOJTtXqS_Jqk9KJitU/edit)


## Brief change log

1. Use JUnit5 and AssertJ in tests instead of JUnit4 and Hamcrest
2. Add dependency on `mockito-junit-jupiter` since pubsub connector requires it

## Verifying this change

This change is a code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no )
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? (no )
  - If yes, how is the feature documented? (not applicable)
