### PR TITLE
[FLINK-28000][runtime][security] Throw exception when principal is set in the configuration without keytab

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/SecurityConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/SecurityConfiguration.java
@@ -40,6 +40,9 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  */
 public class SecurityConfiguration {
 
+    private static final String KERBEROS_CONFIG_ERROR_PREFIX =
+            "Kerberos login configuration is invalid: ";
+
     private final List<String> securityContextFactory;
 
     private final List<String> securityModuleFactories;
@@ -82,6 +85,7 @@ public class SecurityConfiguration {
             Configuration flinkConf,
             List<String> securityContextFactory,
             List<String> securityModuleFactories) {
+        this.flinkConfig = checkNotNull(flinkConf);
         this.isZkSaslDisable = flinkConf.getBoolean(SecurityOptions.ZOOKEEPER_SASL_DISABLE);
         this.keytab = flinkConf.getString(SecurityOptions.KERBEROS_LOGIN_KEYTAB);
         this.principal = flinkConf.getString(SecurityOptions.KERBEROS_LOGIN_PRINCIPAL);
@@ -93,7 +97,6 @@ public class SecurityConfiguration {
                 flinkConf.getString(SecurityOptions.ZOOKEEPER_SASL_LOGIN_CONTEXT_NAME);
         this.securityModuleFactories = Collections.unmodifiableList(securityModuleFactories);
         this.securityContextFactory = securityContextFactory;
-        this.flinkConfig = checkNotNull(flinkConf);
         validate();
     }
 
@@ -138,25 +141,20 @@ public class SecurityConfiguration {
     }
 
     private void validate() {
-        if (!StringUtils.isBlank(keytab)) {
-            // principal is required
-            if (StringUtils.isBlank(principal)) {
-                throw new IllegalConfigurationException(
-                        "Kerberos login configuration is invalid: keytab requires a principal.");
-            }
+        if (StringUtils.isBlank(keytab) != StringUtils.isBlank(principal)) {
+            throw new IllegalConfigurationException(
+                    KERBEROS_CONFIG_ERROR_PREFIX
+                            + "either both keytab and principal must be defined, or neither.");
+        }
 
-            // check the keytab is readable
+        if (!StringUtils.isBlank(keytab)) {
             File keytabFile = new File(keytab);
             if (!keytabFile.exists() || !keytabFile.isFile()) {
                 throw new IllegalConfigurationException(
-                        "Kerberos login configuration is invalid: keytab ["
-                                + keytab
-                                + "] doesn't exist!");
+                        KERBEROS_CONFIG_ERROR_PREFIX + "keytab [" + keytab + "] doesn't exist!");
             } else if (!keytabFile.canRead()) {
                 throw new IllegalConfigurationException(
-                        "Kerberos login configuration is invalid: keytab ["
-                                + keytab
-                                + "] is unreadable!");
+                        KERBEROS_CONFIG_ERROR_PREFIX + "keytab [" + keytab + "] is unreadable!");
             }
         }
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/SecurityConfigurationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/SecurityConfigurationTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.security;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.IllegalConfigurationException;
+
+import org.junit.jupiter.api.Test;
+
+import static org.apache.flink.configuration.SecurityOptions.KERBEROS_LOGIN_KEYTAB;
+import static org.apache.flink.configuration.SecurityOptions.KERBEROS_LOGIN_PRINCIPAL;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Tests for the {@link SecurityConfiguration}. */
+class SecurityConfigurationTest {
+
+    @Test
+    public void keytabWithoutPrincipalShouldThrowException() {
+        Configuration configuration = new Configuration();
+        configuration.set(KERBEROS_LOGIN_KEYTAB, "keytab.file");
+
+        IllegalConfigurationException e =
+                assertThrows(
+                        IllegalConfigurationException.class,
+                        () -> new SecurityConfiguration(configuration));
+        assertTrue(
+                e.getMessage()
+                        .contains("either both keytab and principal must be defined, or neither"));
+    }
+
+    @Test
+    public void principalWithoutKeytabShouldThrowException() {
+        Configuration configuration = new Configuration();
+        configuration.set(KERBEROS_LOGIN_PRINCIPAL, "principal");
+
+        IllegalConfigurationException e =
+                assertThrows(
+                        IllegalConfigurationException.class,
+                        () -> new SecurityConfiguration(configuration));
+        assertTrue(
+                e.getMessage()
+                        .contains("either both keytab and principal must be defined, or neither"));
+    }
+
+    @Test
+    public void notExistingKeytabShouldThrowException() {
+        Configuration configuration = new Configuration();
+        configuration.set(KERBEROS_LOGIN_KEYTAB, "nonexistingkeytab.file");
+        configuration.set(KERBEROS_LOGIN_PRINCIPAL, "principal");
+
+        IllegalConfigurationException e =
+                assertThrows(
+                        IllegalConfigurationException.class,
+                        () -> new SecurityConfiguration(configuration));
+        assertTrue(e.getMessage().contains("nonexistingkeytab.file"));
+        assertTrue(e.getMessage().contains("doesn't exist"));
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

`security.kerberos.login.principal` can be set in the configuration without `security.kerberos.login.keytab` which is wrong configuration. The principal is always bound to a keytab file, please see the official documentation snippet:
![image](https://user-images.githubusercontent.com/18561820/173063470-a9fe5121-70f8-4b8a-9f18-5f17f68aae89.png)
In this PR I've added a code to throw exception such cases.

## Brief change log

* Exception thrown when wrong config provided
* Added unit tests to cover `SecurityConfiguration`
* Minor fixes

## Verifying this change

Additional unit tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
