### PR TITLE
[FLINK-27884] Move OutputFormatBase to flink-core to offer flush mechanism to all output formats

### DIFF
--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/batch/connectors/cassandra/CassandraColumnarOutputFormatBase.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/batch/connectors/cassandra/CassandraColumnarOutputFormatBase.java
@@ -52,8 +52,8 @@ abstract class CassandraColumnarOutputFormatBase<OUT>
     }
 
     @Override
-    public void open(int taskNumber, int numTasks) {
-        super.open(taskNumber, numTasks);
+    protected void postOpen() {
+        super.postOpen();
         this.prepared = session.prepare(insertQuery);
     }
 

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/batch/connectors/cassandra/CassandraColumnarOutputFormatBase.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/batch/connectors/cassandra/CassandraColumnarOutputFormatBase.java
@@ -24,9 +24,10 @@ import org.apache.flink.shaded.guava30.com.google.common.base.Strings;
 
 import com.datastax.driver.core.PreparedStatement;
 import com.datastax.driver.core.ResultSet;
-import com.google.common.util.concurrent.ListenableFuture;
+import com.datastax.driver.core.ResultSetFuture;
 
 import java.time.Duration;
+import java.util.concurrent.CompletionStage;
 
 /**
  * CassandraColumnarOutputFormatBase is the common abstract class for writing into Apache Cassandra
@@ -57,9 +58,10 @@ abstract class CassandraColumnarOutputFormatBase<OUT>
     }
 
     @Override
-    protected ListenableFuture<ResultSet> send(OUT record) {
+    protected CompletionStage<ResultSet> send(OUT record) {
         Object[] fields = extractFields(record);
-        return session.executeAsync(prepared.bind(fields));
+        final ResultSetFuture result = session.executeAsync(prepared.bind(fields));
+        return listenableFutureToCompletableFuture(result);
     }
 
     protected abstract Object[] extractFields(OUT record);

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/batch/connectors/cassandra/CassandraOutputFormatBase.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/batch/connectors/cassandra/CassandraOutputFormatBase.java
@@ -30,12 +30,8 @@ import com.google.common.util.concurrent.ListenableFuture;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 /**
  * CassandraOutputFormatBase is the common abstract class for writing into Apache Cassandra using
@@ -67,31 +63,26 @@ abstract class CassandraOutputFormatBase<OUT, V> extends OutputFormatBase<OUT, V
 
     /** Opens a Session to Cassandra . */
     @Override
-    public void open(int taskNumber, int numTasks) {
+    protected void postOpen() {
         this.session = cluster.connect();
-        super.open(taskNumber, numTasks);
     }
 
     /** Closes all resources used by Cassandra connection. */
     @Override
-    public void close() throws IOException {
+    protected void postClose() {
         try {
-            super.close();
-        } finally {
-            try {
-                if (session != null) {
-                    session.close();
-                }
-            } catch (Exception e) {
-                LOG.error("Error while closing session.", e);
+            if (session != null) {
+                session.close();
             }
-            try {
-                if (cluster != null) {
-                    cluster.close();
-                }
-            } catch (Exception e) {
-                LOG.error("Error while closing cluster.", e);
+        } catch (Exception e) {
+            LOG.error("Error while closing session.", e);
+        }
+        try {
+            if (cluster != null) {
+                cluster.close();
             }
+        } catch (Exception e) {
+            LOG.error("Error while closing cluster.", e);
         }
     }
 

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/batch/connectors/cassandra/CassandraOutputFormatBase.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/batch/connectors/cassandra/CassandraOutputFormatBase.java
@@ -88,41 +88,7 @@ abstract class CassandraOutputFormatBase<OUT, V> extends OutputFormatBase<OUT, V
 
     protected static <T> CompletableFuture<T> listenableFutureToCompletableFuture(
             final ListenableFuture<T> listenableFuture) {
-        CompletableFuture<T> completable =
-                new CompletableFuture<T>() {
-
-                    @Override
-                    public boolean cancel(boolean mayInterruptIfRunning) {
-                        // propagate cancel to the listenable future
-                        boolean canceledListenableFuture =
-                                listenableFuture.cancel(mayInterruptIfRunning);
-                        final boolean canceledCompletableFuture =
-                                super.cancel(mayInterruptIfRunning);
-                        return canceledListenableFuture && canceledCompletableFuture;
-                    }
-
-                    @Override
-                    public boolean isCancelled() {
-                        return listenableFuture.isCancelled();
-                    }
-
-                    @Override
-                    public boolean isDone() {
-                        return listenableFuture.isDone();
-                    }
-
-                    @Override
-                    public T get() throws InterruptedException, ExecutionException {
-                        return listenableFuture.get();
-                    }
-
-                    @Override
-                    public T get(long timeout, TimeUnit unit)
-                            throws InterruptedException, ExecutionException, TimeoutException {
-                        return listenableFuture.get();
-                    }
-                };
-
+        CompletableFuture<T> completable = new CompletableFuture<T>();
         Futures.addCallback(
                 listenableFuture,
                 new FutureCallback<T>() {

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/batch/connectors/cassandra/CassandraOutputFormatBase.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/batch/connectors/cassandra/CassandraOutputFormatBase.java
@@ -97,7 +97,7 @@ abstract class CassandraOutputFormatBase<OUT, V> extends OutputFormatBase<OUT, V
 
     private static class CompletableFutureCallback<T> implements FutureCallback<T> {
 
-        CompletableFuture<T> completableFuture;
+        private final CompletableFuture<T> completableFuture;
 
         public CompletableFutureCallback(CompletableFuture<T> completableFuture) {
             this.completableFuture = completableFuture;

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/batch/connectors/cassandra/CassandraPojoOutputFormat.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/batch/connectors/cassandra/CassandraPojoOutputFormat.java
@@ -25,7 +25,6 @@ import com.datastax.driver.mapping.Mapper;
 import com.datastax.driver.mapping.MappingManager;
 import com.google.common.util.concurrent.ListenableFuture;
 
-import java.io.IOException;
 import java.time.Duration;
 import java.util.concurrent.CompletionStage;
 
@@ -68,14 +67,10 @@ public class CassandraPojoOutputFormat<OUT> extends CassandraOutputFormatBase<OU
         this.outputClass = outputClass;
     }
 
-    /**
-     * Opens a Session to Cassandra and initializes the prepared statement.
-     *
-     * @param taskNumber The number of the parallel instance.
-     */
+    /** Opens a Session to Cassandra and initializes the prepared statement. */
     @Override
-    public void open(int taskNumber, int numTasks) {
-        super.open(taskNumber, numTasks);
+    protected void postOpen() {
+        super.postOpen();
         MappingManager mappingManager = new MappingManager(session);
         this.mapper = mappingManager.mapper(outputClass);
         if (mapperOptions != null) {
@@ -94,11 +89,8 @@ public class CassandraPojoOutputFormat<OUT> extends CassandraOutputFormatBase<OU
 
     /** Closes all resources used. */
     @Override
-    public void close() throws IOException {
-        try {
-            super.close();
-        } finally {
-            mapper = null;
-        }
+    protected void postClose() {
+        super.postClose();
+        mapper = null;
     }
 }

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/batch/connectors/cassandra/CassandraPojoOutputFormat.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/batch/connectors/cassandra/CassandraPojoOutputFormat.java
@@ -27,6 +27,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 
 import java.io.IOException;
 import java.time.Duration;
+import java.util.concurrent.CompletionStage;
 
 /**
  * OutputFormat to write data to Apache Cassandra and from a custom Cassandra annotated object.
@@ -86,8 +87,9 @@ public class CassandraPojoOutputFormat<OUT> extends CassandraOutputFormatBase<OU
     }
 
     @Override
-    protected ListenableFuture<Void> send(OUT record) {
-        return mapper.saveAsync(record);
+    protected CompletionStage<Void> send(OUT record) {
+        final ListenableFuture<Void> result = mapper.saveAsync(record);
+        return listenableFutureToCompletableFuture(result);
     }
 
     /** Closes all resources used. */

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraSinkBase.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraSinkBase.java
@@ -19,9 +19,9 @@ package org.apache.flink.streaming.connectors.cassandra;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.io.SinkUtils;
 import org.apache.flink.api.java.ClosureCleaner;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.connectors.cassandra.utils.SinkUtils;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
 import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/OutputFormatBase.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/OutputFormatBase.java
@@ -137,8 +137,7 @@ public abstract class OutputFormatBase<OUT, V> extends RichOutputFormat<OUT> {
     /**
      * Send the actual record for writing.
      *
-     * @return Implementers must return a CompletionStage which has a valid {@link
-     *     CompletionStage#toCompletableFuture()} implementation.
+     * @return a CompletionStage that represents the writing task.
      */
     protected abstract CompletionStage<V> send(OUT record);
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/OutputFormatBase.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/OutputFormatBase.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.api.common.io;
 
-import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.Experimental;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.concurrent.Executors;
@@ -47,7 +47,7 @@ import java.util.concurrent.atomic.AtomicReference;
  *
  * @param <OUT> Type of the elements to write.
  */
-@PublicEvolving
+@Experimental
 public abstract class OutputFormatBase<OUT, V> extends RichOutputFormat<OUT> {
     private static final Logger LOG = LoggerFactory.getLogger(OutputFormatBase.class);
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/SinkUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/SinkUtils.java
@@ -18,13 +18,13 @@
 
 package org.apache.flink.api.common.io;
 
+import org.apache.flink.annotation.Experimental;
+
 import java.io.Serializable;
 import java.time.Duration;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-
-import org.apache.flink.annotation.Experimental;
 
 /** Utility class for sinks. */
 @Experimental

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/SinkUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/SinkUtils.java
@@ -18,8 +18,6 @@
 
 package org.apache.flink.api.common.io;
 
-import org.apache.flink.annotation.Internal;
-
 import java.io.Serializable;
 import java.time.Duration;
 import java.util.concurrent.Semaphore;
@@ -27,7 +25,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 /** Utility class for sinks. */
-@Internal
 public class SinkUtils implements Serializable {
 
     /**

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/SinkUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/SinkUtils.java
@@ -16,7 +16,9 @@
  * limitations under the License.
  */
 
-package org.apache.flink.connectors.cassandra.utils;
+package org.apache.flink.api.common.io;
+
+import org.apache.flink.annotation.Internal;
 
 import java.io.Serializable;
 import java.time.Duration;
@@ -25,6 +27,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 /** Utility class for sinks. */
+@Internal
 public class SinkUtils implements Serializable {
 
     /**

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/SinkUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/SinkUtils.java
@@ -24,7 +24,10 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import org.apache.flink.annotation.Experimental;
+
 /** Utility class for sinks. */
+@Experimental
 public class SinkUtils implements Serializable {
 
     /**


### PR DESCRIPTION
## What is the purpose of the change

Move OutputFormatBase to flink-core to offer flush mechanism to all output formats

## Brief change log

Move OutputFormatBase from connectors-cassandra module to flink-core to offer flush mechanism to all output formats.
Main change was to change (not yet public) send method signature so that it returns a `CompletionStage` and not a guava `ListenableFuture`. Implementers can chose their `CompletionStage` implementation as long as it implements `CompletionStage#toCompletableFuture()`


## Verifying this change


This change is already covered by existing tests, such as OutputFormatBaseTest and CassandraConnectorITCase (for first implementation)


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes (not applicable / docs / JavaDocs / not documented)
  - If yes, how is the feature documented? javadocs

R: @zentol  as discussed in [the other PR](https://github.com/apache/flink/pull/19680).