### PR TITLE
[FLINK-27983][FLINK-27984][FLINK-27985] Introduce SupportsStatisticsReport, FileBasedStatisticsReportableDecodingFormat, FlinkRecomputeStatisticsProgram to compute statistics after filter push and partition pruning

### DIFF
--- a/docs/layouts/shortcodes/generated/optimizer_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/optimizer_config_configuration.html
@@ -71,5 +71,11 @@ ONE_PHASE: Enforce to use one stage aggregate which only has CompleteGlobalAggre
             <td>Boolean</td>
             <td>When it is true, the optimizer will push down predicates into the FilterableTableSource. Default value is true.</td>
         </tr>
+        <tr>
+            <td><h5>table.optimizer.source.report-statistics-enabled</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>When it is true, the optimizer will collect and use the statistics from source connectors if the source extends from SupportsStatisticReport and the statistics from catalog is UNKNOWN.Default value is true.</td>
+        </tr>
     </tbody>
 </table>

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemConnectorOptions.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemConnectorOptions.java
@@ -59,6 +59,15 @@ public class FileSystemConnectorOptions {
                                     + "but also imply more frequent listing or directory traversal of the file system / object store. "
                                     + "If this config option is not set, the provided path will be scanned once, hence the source will be bounded.");
 
+    public static final ConfigOption<FileStatisticsType> SOURCE_REPORT_STATISTICS =
+            key("source.report-statistics")
+                    .enumType(FileStatisticsType.class)
+                    .defaultValue(FileStatisticsType.ALL)
+                    .withDescription(
+                            "The file statistics type which the source could provide. "
+                                    + "The statistics reporting is a heavy operation in some cases,"
+                                    + "this config allows users to choose the statistics type according to different situations.");
+
     public static final ConfigOption<MemorySize> SINK_ROLLING_POLICY_FILE_SIZE =
             key("sink.rolling-policy.file-size")
                     .memoryType()
@@ -252,13 +261,37 @@ public class FileSystemConnectorOptions {
         PARTITION_TIME(
                 "partition-time",
                 text(
-                        "Based on the  time extracted from partition values, requires watermark generation. "
+                        "Based on the time extracted from partition values, requires watermark generation. "
                                 + "Commits partition once the watermark passes the time extracted from partition values plus delay."));
 
         private final String value;
         private final InlineElement description;
 
         PartitionCommitTriggerType(String value, InlineElement description) {
+            this.value = value;
+            this.description = description;
+        }
+
+        @Override
+        public String toString() {
+            return value;
+        }
+
+        @Override
+        public InlineElement getDescription() {
+            return description;
+        }
+    }
+
+    /** Statistics types for file system, see {@link #SOURCE_REPORT_STATISTICS}. */
+    public enum FileStatisticsType implements DescribedEnum {
+        NONE("NONE", text("Do not report any file statistics.")),
+        ALL("ALL", text("Report all file statistics that the format can provide."));
+
+        private final String value;
+        private final InlineElement description;
+
+        FileStatisticsType(String value, InlineElement description) {
             this.value = value;
             this.description = description;
         }

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemTableFactory.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemTableFactory.java
@@ -106,6 +106,7 @@ public class FileSystemTableFactory implements DynamicTableSourceFactory, Dynami
         Set<ConfigOption<?>> options = new HashSet<>();
         options.add(FileSystemConnectorOptions.PARTITION_DEFAULT_NAME);
         options.add(FileSystemConnectorOptions.SOURCE_MONITOR_INTERVAL);
+        options.add(FileSystemConnectorOptions.SOURCE_REPORT_STATISTICS);
         options.add(FileSystemConnectorOptions.SINK_ROLLING_POLICY_FILE_SIZE);
         options.add(FileSystemConnectorOptions.SINK_ROLLING_POLICY_ROLLOVER_INTERVAL);
         options.add(FileSystemConnectorOptions.SINK_ROLLING_POLICY_INACTIVITY_INTERVAL);

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemTableSource.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemTableSource.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.java.io.CollectionInputFormat;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.connector.file.src.FileSource;
 import org.apache.flink.connector.file.src.FileSourceSplit;
+import org.apache.flink.connector.file.src.enumerate.NonSplittingRecursiveEnumerator;
 import org.apache.flink.connector.file.src.reader.BulkFormat;
 import org.apache.flink.connector.file.table.format.BulkDecodingFormat;
 import org.apache.flink.core.fs.Path;
@@ -34,6 +35,7 @@ import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.connector.Projection;
 import org.apache.flink.table.connector.format.DecodingFormat;
+import org.apache.flink.table.connector.format.FileBasedStatisticsReportableDecodingFormat;
 import org.apache.flink.table.connector.format.ProjectableDecodingFormat;
 import org.apache.flink.table.connector.source.InputFormatProvider;
 import org.apache.flink.table.connector.source.ScanTableSource;
@@ -43,11 +45,13 @@ import org.apache.flink.table.connector.source.abilities.SupportsLimitPushDown;
 import org.apache.flink.table.connector.source.abilities.SupportsPartitionPushDown;
 import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushDown;
 import org.apache.flink.table.connector.source.abilities.SupportsReadingMetadata;
+import org.apache.flink.table.connector.source.abilities.SupportsStatisticReport;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.expressions.ResolvedExpression;
 import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.flink.table.plan.stats.TableStats;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.utils.PartitionPathUtils;
 
@@ -55,8 +59,10 @@ import javax.annotation.Nullable;
 
 import java.io.Serializable;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -77,7 +83,8 @@ public class FileSystemTableSource extends AbstractFileSystemTable
                 SupportsLimitPushDown,
                 SupportsPartitionPushDown,
                 SupportsFilterPushDown,
-                SupportsReadingMetadata {
+                SupportsReadingMetadata,
+                SupportsStatisticReport {
 
     @Nullable private final DecodingFormat<BulkFormat<RowData, FileSourceSplit>> bulkReaderFormat;
     @Nullable private final DecodingFormat<DeserializationSchema<RowData>> deserializationFormat;
@@ -329,6 +336,41 @@ public class FileSystemTableSource extends AbstractFileSystemTable
     @Override
     public boolean supportsNestedProjection() {
         return false;
+    }
+
+    @Override
+    public TableStats reportStatistics() {
+        try {
+            // only support BOUNDED source
+            Optional<Duration> monitorIntervalOpt =
+                    tableOptions.getOptional(FileSystemConnectorOptions.SOURCE_MONITOR_INTERVAL);
+            if (monitorIntervalOpt.isPresent() && monitorIntervalOpt.get().toMillis() <= 0) {
+                return TableStats.UNKNOWN;
+            }
+            if (tableOptions.get(FileSystemConnectorOptions.SOURCE_REPORT_STATISTICS)
+                    == FileSystemConnectorOptions.FileStatisticsType.NONE) {
+                return TableStats.UNKNOWN;
+            }
+
+            // use NonSplittingRecursiveEnumerator to get all files
+            NonSplittingRecursiveEnumerator enumerator = new NonSplittingRecursiveEnumerator();
+            Collection<FileSourceSplit> splits = enumerator.enumerateSplits(paths(), 1);
+            List<Path> files =
+                    splits.stream().map(FileSourceSplit::path).collect(Collectors.toList());
+
+            if (bulkReaderFormat instanceof FileBasedStatisticsReportableDecodingFormat) {
+                return ((FileBasedStatisticsReportableDecodingFormat<?>) bulkReaderFormat)
+                        .reportStatistics(files, producedDataType);
+            } else if (deserializationFormat
+                    instanceof FileBasedStatisticsReportableDecodingFormat) {
+                return ((FileBasedStatisticsReportableDecodingFormat<?>) deserializationFormat)
+                        .reportStatistics(files, producedDataType);
+            } else {
+                return TableStats.UNKNOWN;
+            }
+        } catch (Exception e) {
+            return TableStats.UNKNOWN;
+        }
     }
 
     @Override

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemTableSource.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemTableSource.java
@@ -35,7 +35,7 @@ import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.connector.Projection;
 import org.apache.flink.table.connector.format.DecodingFormat;
-import org.apache.flink.table.connector.format.FileBasedStatisticsReportableDecodingFormat;
+import org.apache.flink.table.connector.format.FileBasedStatisticsReportableInputFormat;
 import org.apache.flink.table.connector.format.ProjectableDecodingFormat;
 import org.apache.flink.table.connector.source.InputFormatProvider;
 import org.apache.flink.table.connector.source.ScanTableSource;
@@ -358,12 +358,11 @@ public class FileSystemTableSource extends AbstractFileSystemTable
             List<Path> files =
                     splits.stream().map(FileSourceSplit::path).collect(Collectors.toList());
 
-            if (bulkReaderFormat instanceof FileBasedStatisticsReportableDecodingFormat) {
-                return ((FileBasedStatisticsReportableDecodingFormat<?>) bulkReaderFormat)
+            if (bulkReaderFormat instanceof FileBasedStatisticsReportableInputFormat) {
+                return ((FileBasedStatisticsReportableInputFormat) bulkReaderFormat)
                         .reportStatistics(files, producedDataType);
-            } else if (deserializationFormat
-                    instanceof FileBasedStatisticsReportableDecodingFormat) {
-                return ((FileBasedStatisticsReportableDecodingFormat<?>) deserializationFormat)
+            } else if (deserializationFormat instanceof FileBasedStatisticsReportableInputFormat) {
+                return ((FileBasedStatisticsReportableInputFormat) deserializationFormat)
                         .reportStatistics(files, producedDataType);
             } else {
                 return TableStats.UNKNOWN;

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/OptimizerConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/OptimizerConfigOptions.java
@@ -118,6 +118,16 @@ public class OptimizerConfigOptions {
                                     + "Default value is true.");
 
     @Documentation.TableOption(execMode = Documentation.ExecMode.BATCH_STREAMING)
+    public static final ConfigOption<Boolean> TABLE_OPTIMIZER_SOURCE_REPORT_STATISTICS_ENABLED =
+            key("table.optimizer.source.report-statistics-enabled")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            "When it is true, the optimizer will collect and use the statistics from source connectors"
+                                    + " if the source extends from SupportsStatisticReport and the statistics from catalog is UNKNOWN."
+                                    + "Default value is true.");
+
+    @Documentation.TableOption(execMode = Documentation.ExecMode.BATCH_STREAMING)
     public static final ConfigOption<Boolean> TABLE_OPTIMIZER_JOIN_REORDER_ENABLED =
             key("table.optimizer.join-reorder-enabled")
                     .booleanType()

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/stats/CatalogTableStatistics.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/stats/CatalogTableStatistics.java
@@ -40,7 +40,7 @@ public class CatalogTableStatistics {
     /** The raw data size (size when loaded in memory) in bytes. */
     private final long rawDataSize;
 
-    private Map<String, String> properties;
+    private final Map<String, String> properties;
 
     public CatalogTableStatistics(long rowCount, int fileCount, long totalSize, long rawDataSize) {
         this(rowCount, fileCount, totalSize, rawDataSize, new HashMap<>());

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/stats/Date.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/stats/Date.java
@@ -20,7 +20,7 @@ package org.apache.flink.table.catalog.stats;
 
 /** Class representing a date value in statistics. */
 public class Date {
-    private long daysSinceEpoch;
+    private final long daysSinceEpoch;
 
     public Date(long daysSinceEpoch) {
         this.daysSinceEpoch = daysSinceEpoch;

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/format/FileBasedStatisticsReportableInputFormat.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/format/FileBasedStatisticsReportableInputFormat.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.connector.format;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.table.connector.source.abilities.SupportsStatisticReport;
+import org.apache.flink.table.plan.stats.TableStats;
+import org.apache.flink.table.types.DataType;
+
+import java.util.List;
+
+/**
+ * Extension of input format which is able to report estimated statistics for file based connector.
+ *
+ * <p>This interface is used by file-based connectors which should also implement {@link
+ * SupportsStatisticReport}. Since file have different formats, and each format has a different way
+ * of storing and obtaining statistics information. For example: for Parquet and Orc, they both
+ * store the metadata information in the file footer, which including row count, max/min, null
+ * count, etc. While, for csv, there is no other metadata information excluding file size, one
+ * approach to estimate row count is: the entire file size divided by the average length of the
+ * sampled rows.
+ *
+ * <p>Note: This method is called at plan optimization phase, the implementation of this interface
+ * should be as light as possible, but more complete information.
+ */
+@PublicEvolving
+public interface FileBasedStatisticsReportableInputFormat {
+
+    /**
+     * Returns the estimated statistics of this input format.
+     *
+     * @param files The files to be estimated.
+     * @param producedDataType the final output type of the format.
+     */
+    TableStats reportStatistics(List<Path> files, DataType producedDataType);
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsStatisticReport.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsStatisticReport.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.connector.source.abilities;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.plan.stats.TableStats;
+
+/**
+ * Enables to report the estimated statistics provided by the {@link DynamicTableSource}.
+ *
+ * <p>Statistics are one of the most important inputs to the optimizer cost model, which will
+ * generate the most effective execution plan with the lowest cost among all considered candidate
+ * plans.
+ *
+ * <p>This interface is used to compensate for the missing of statistics in the catalog. The planner
+ * will call {@link #reportStatistics} method when the planner detects the statistics from catalog
+ * is unknown. Therefore, the method will be executed as needed.
+ *
+ * <p>Note: This method is called at plan optimization phase, the implementation of this interface
+ * should be as light as possible, but more complete information.
+ */
+@PublicEvolving
+public interface SupportsStatisticReport {
+
+    /**
+     * Returns the estimated statistics of this {@link DynamicTableSource}, else {@link
+     * TableStats#UNKNOWN} if some situations are not supported or cannot be handled.
+     */
+    TableStats reportStatistics();
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/source/FilterPushDownSpec.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/source/FilterPushDownSpec.java
@@ -31,6 +31,7 @@ import org.apache.flink.table.planner.utils.TableConfigUtils;
 import org.apache.flink.table.types.logical.RowType;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonTypeName;
 
@@ -57,9 +58,26 @@ public final class FilterPushDownSpec extends SourceAbilitySpecBase {
     @JsonProperty(FIELD_NAME_PREDICATES)
     private final List<RexNode> predicates;
 
+    /**
+     * A flag which indicates all predicates are retained in the outer Filter operator.
+     *
+     * <p>This flog is only used for optimization phase, and should not be serialized.
+     */
+    @JsonIgnore private final boolean allPredicatesRetained;
+
+    public FilterPushDownSpec(List<RexNode> predicates, boolean allPredicatesRetained) {
+        this.predicates = new ArrayList<>(checkNotNull(predicates));
+        this.allPredicatesRetained = allPredicatesRetained;
+    }
+
     @JsonCreator
     public FilterPushDownSpec(@JsonProperty(FIELD_NAME_PREDICATES) List<RexNode> predicates) {
-        this.predicates = new ArrayList<>(checkNotNull(predicates));
+        this(predicates, true);
+    }
+
+    @JsonIgnore
+    public boolean isAllPredicatesRetained() {
+        return allPredicatesRetained;
     }
 
     @Override

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/source/PartitionPushDownSpec.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/source/PartitionPushDownSpec.java
@@ -63,6 +63,10 @@ public final class PartitionPushDownSpec extends SourceAbilitySpecBase {
         }
     }
 
+    public List<Map<String, String>> getPartitions() {
+        return partitions;
+    }
+
     @Override
     public String getDigests(SourceAbilityContext context) {
         return "partitions=["

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushPartitionIntoTableSourceScanRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushPartitionIntoTableSourceScanRule.java
@@ -26,28 +26,22 @@ import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.flink.table.catalog.ResolvedCatalogTable;
 import org.apache.flink.table.catalog.exceptions.CatalogException;
-import org.apache.flink.table.catalog.exceptions.PartitionNotExistException;
 import org.apache.flink.table.catalog.exceptions.TableNotExistException;
 import org.apache.flink.table.catalog.exceptions.TableNotPartitionedException;
-import org.apache.flink.table.catalog.stats.CatalogColumnStatistics;
-import org.apache.flink.table.catalog.stats.CatalogTableStatistics;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.connector.source.abilities.SupportsPartitionPushDown;
 import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.expressions.ResolvedExpression;
-import org.apache.flink.table.plan.stats.TableStats;
 import org.apache.flink.table.planner.calcite.FlinkContext;
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
 import org.apache.flink.table.planner.plan.abilities.source.PartitionPushDownSpec;
 import org.apache.flink.table.planner.plan.abilities.source.SourceAbilityContext;
 import org.apache.flink.table.planner.plan.abilities.source.SourceAbilitySpec;
 import org.apache.flink.table.planner.plan.schema.TableSourceTable;
-import org.apache.flink.table.planner.plan.stats.FlinkStatistic;
 import org.apache.flink.table.planner.plan.utils.FlinkRelOptUtil;
 import org.apache.flink.table.planner.plan.utils.PartitionPruner;
 import org.apache.flink.table.planner.plan.utils.RexNodeExtractor;
 import org.apache.flink.table.planner.plan.utils.RexNodeToExpressionConverter;
-import org.apache.flink.table.planner.utils.CatalogTableStatisticsConverter;
 import org.apache.flink.table.planner.utils.ShortcutUtils;
 import org.apache.flink.table.planner.utils.TableConfigUtils;
 import org.apache.flink.table.types.logical.LogicalType;
@@ -188,37 +182,11 @@ public class PushPartitionIntoTableSourceScanRule extends RelOptRule {
                 new PartitionPushDownSpec(remainingPartitions);
         partitionPushDownSpec.apply(dynamicTableSource, SourceAbilityContext.from(scan));
 
-        // build new statistic
-        TableStats newTableStat = null;
-        if (tableSourceTable.contextResolvedTable().isPermanent()) {
-            ObjectIdentifier identifier = tableSourceTable.contextResolvedTable().getIdentifier();
-            ObjectPath tablePath = identifier.toObjectPath();
-            Catalog catalog = tableSourceTable.contextResolvedTable().getCatalog().get();
-            for (Map<String, String> partition : remainingPartitions) {
-                Optional<TableStats> partitionStats =
-                        getPartitionStats(catalog, tablePath, partition);
-                if (!partitionStats.isPresent()) {
-                    // clear all information before
-                    newTableStat = null;
-                    break;
-                } else {
-                    newTableStat =
-                            newTableStat == null
-                                    ? partitionStats.get()
-                                    : newTableStat.merge(partitionStats.get());
-                }
-            }
-        }
-        FlinkStatistic newStatistic =
-                FlinkStatistic.builder()
-                        .statistic(tableSourceTable.getStatistic())
-                        .tableStats(newTableStat)
-                        .build();
-
         TableSourceTable newTableSourceTable =
                 tableSourceTable.copy(
                         dynamicTableSource,
-                        newStatistic,
+                        // the statistics will be updated in FlinkCollectStatisticsProgram
+                        tableSourceTable.getStatistic(),
                         new SourceAbilitySpec[] {partitionPushDownSpec});
         LogicalTableScan newScan =
                 LogicalTableScan.create(scan.getCluster(), newTableSourceTable, scan.getHints());
@@ -376,21 +344,5 @@ public class PushPartitionIntoTableSourceScanRule extends RelOptRule {
                         .collect(Collectors.toList());
         // prune partitions
         return pruner.apply(allPartitions);
-    }
-
-    private Optional<TableStats> getPartitionStats(
-            Catalog catalog, ObjectPath tablePath, Map<String, String> partition) {
-        try {
-            CatalogPartitionSpec spec = new CatalogPartitionSpec(partition);
-            CatalogTableStatistics partitionStat = catalog.getPartitionStatistics(tablePath, spec);
-            CatalogColumnStatistics partitionColStat =
-                    catalog.getPartitionColumnStatistics(tablePath, spec);
-            TableStats stats =
-                    CatalogTableStatisticsConverter.convertToTableStats(
-                            partitionStat, partitionColStat);
-            return Optional.of(stats);
-        } catch (PartitionNotExistException e) {
-            return Optional.empty();
-        }
     }
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkBatchProgram.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkBatchProgram.scala
@@ -183,6 +183,7 @@ object FlinkBatchProgram {
             .build(),
           "prune empty after predicate push down"
         )
+        .addProgram(new FlinkRecomputeStatisticsProgram, "recompute statistics")
         .build()
     )
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkRecomputeStatisticsProgram.java
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkRecomputeStatisticsProgram.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.optimize.program;
+
+import org.apache.flink.table.catalog.Catalog;
+import org.apache.flink.table.catalog.CatalogPartitionSpec;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.exceptions.PartitionNotExistException;
+import org.apache.flink.table.catalog.stats.CatalogColumnStatistics;
+import org.apache.flink.table.catalog.stats.CatalogTableStatistics;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.source.abilities.SupportsStatisticReport;
+import org.apache.flink.table.plan.stats.TableStats;
+import org.apache.flink.table.planner.calcite.FlinkContext;
+import org.apache.flink.table.planner.plan.abilities.source.FilterPushDownSpec;
+import org.apache.flink.table.planner.plan.abilities.source.PartitionPushDownSpec;
+import org.apache.flink.table.planner.plan.abilities.source.SourceAbilitySpec;
+import org.apache.flink.table.planner.plan.schema.TableSourceTable;
+import org.apache.flink.table.planner.plan.stats.FlinkStatistic;
+import org.apache.flink.table.planner.plan.utils.DefaultRelShuttle;
+import org.apache.flink.table.planner.utils.CatalogTableStatisticsConverter;
+import org.apache.flink.table.planner.utils.ShortcutUtils;
+
+import org.apache.calcite.plan.RelOptTable;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.TableScan;
+import org.apache.calcite.rel.logical.LogicalTableScan;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.apache.flink.table.api.config.OptimizerConfigOptions.TABLE_OPTIMIZER_SOURCE_REPORT_STATISTICS_ENABLED;
+
+/**
+ * A FlinkOptimizeProgram that recompute statistics after partition pruning and filter push down.
+ *
+ * <p>It's a very heavy operation to get statistics from catalogs or connectors, so this centralized
+ * way can avoid getting statistics again and again.
+ */
+public class FlinkRecomputeStatisticsProgram implements FlinkOptimizeProgram<BatchOptimizeContext> {
+
+    @Override
+    public RelNode optimize(RelNode root, BatchOptimizeContext context) {
+        DefaultRelShuttle shuttle =
+                new DefaultRelShuttle() {
+                    @Override
+                    public RelNode visit(TableScan scan) {
+                        if (scan instanceof LogicalTableScan) {
+                            return recomputeStatistics((LogicalTableScan) scan);
+                        }
+                        return super.visit(scan);
+                    }
+                };
+        return shuttle.visit(root);
+    }
+
+    private LogicalTableScan recomputeStatistics(LogicalTableScan scan) {
+        final RelOptTable scanTable = scan.getTable();
+        if (!(scanTable instanceof TableSourceTable)) {
+            return scan;
+        }
+
+        FlinkContext context = ShortcutUtils.unwrapContext(scan);
+        TableSourceTable table = (TableSourceTable) scanTable;
+        boolean reportStatEnabled =
+                context.getTableConfig().get(TABLE_OPTIMIZER_SOURCE_REPORT_STATISTICS_ENABLED)
+                        && table.tableSource() instanceof SupportsStatisticReport;
+
+        SourceAbilitySpec[] specs = table.abilitySpecs();
+        PartitionPushDownSpec partitionPushDownSpec = getSpec(specs, PartitionPushDownSpec.class);
+
+        FilterPushDownSpec filterPushDownSpec = getSpec(specs, FilterPushDownSpec.class);
+        TableStats newTableStat =
+                recomputeStatistics(
+                        table, partitionPushDownSpec, filterPushDownSpec, reportStatEnabled);
+        FlinkStatistic newStatistic =
+                FlinkStatistic.builder()
+                        .statistic(table.getStatistic())
+                        .tableStats(newTableStat)
+                        .build();
+        TableSourceTable newTable = table.copy(newStatistic);
+        return new LogicalTableScan(
+                scan.getCluster(), scan.getTraitSet(), scan.getHints(), newTable);
+    }
+
+    private TableStats recomputeStatistics(
+            TableSourceTable table,
+            PartitionPushDownSpec partitionPushDownSpec,
+            FilterPushDownSpec filterPushDownSpec,
+            boolean reportStatEnabled) {
+        TableStats origTableStats = table.getStatistic().getTableStats();
+        DynamicTableSource tableSource = table.tableSource();
+        if (filterPushDownSpec != null && !filterPushDownSpec.isAllPredicatesRetained()) {
+            // filter push down but some predicates are accepted by source and not in reaming
+            // predicates
+            // the catalog do not support get statistics with filters,
+            // so only call reportStatistics method if reportStatEnabled is true
+            // TODO estimate statistics by selectivity
+            return reportStatEnabled
+                    ? ((SupportsStatisticReport) tableSource).reportStatistics()
+                    : null;
+        } else {
+            // ignore filter push down if all pushdown predicates are also in outer Filter operator
+            // otherwise the result will be estimated twice.
+            if (partitionPushDownSpec != null) {
+                // partition push down
+                // try to get the statistics for the remaining partitions
+                TableStats newTableStat = getPartitionsTableStats(table, partitionPushDownSpec);
+                // call reportStatistics method if reportStatEnabled is true and the partition
+                // statistics is unknown
+                if (reportStatEnabled && isUnknownTableStats(newTableStat)) {
+                    return ((SupportsStatisticReport) tableSource).reportStatistics();
+                } else {
+                    return newTableStat;
+                }
+            } else {
+                // call reportStatistics method if reportStatEnabled is true and the original
+                // catalog statistics is unknown
+                if (reportStatEnabled && isUnknownTableStats(origTableStats)) {
+                    return ((SupportsStatisticReport) tableSource).reportStatistics();
+                } else {
+                    return origTableStats;
+                }
+            }
+        }
+    }
+
+    private boolean isUnknownTableStats(TableStats stats) {
+        return stats == null || stats.getRowCount() < 0 && stats.getColumnStats().isEmpty();
+    }
+
+    private TableStats getPartitionsTableStats(
+            TableSourceTable table, PartitionPushDownSpec partitionPushDownSpec) {
+        TableStats newTableStat = null;
+        if (table.contextResolvedTable().isPermanent()) {
+            ObjectIdentifier identifier = table.contextResolvedTable().getIdentifier();
+            ObjectPath tablePath = identifier.toObjectPath();
+            Catalog catalog = table.contextResolvedTable().getCatalog().get();
+            for (Map<String, String> partition : partitionPushDownSpec.getPartitions()) {
+                Optional<TableStats> partitionStats =
+                        getPartitionStats(catalog, tablePath, partition);
+                if (!partitionStats.isPresent()) {
+                    // clear all information before
+                    newTableStat = null;
+                    break;
+                } else {
+                    newTableStat =
+                            newTableStat == null
+                                    ? partitionStats.get()
+                                    : newTableStat.merge(partitionStats.get());
+                }
+            }
+        }
+
+        return newTableStat;
+    }
+
+    private Optional<TableStats> getPartitionStats(
+            Catalog catalog, ObjectPath tablePath, Map<String, String> partition) {
+        try {
+            CatalogPartitionSpec spec = new CatalogPartitionSpec(partition);
+            CatalogTableStatistics partitionStat = catalog.getPartitionStatistics(tablePath, spec);
+            CatalogColumnStatistics partitionColStat =
+                    catalog.getPartitionColumnStatistics(tablePath, spec);
+            TableStats stats =
+                    CatalogTableStatisticsConverter.convertToTableStats(
+                            partitionStat, partitionColStat);
+            return Optional.of(stats);
+        } catch (PartitionNotExistException e) {
+            return Optional.empty();
+        }
+    }
+
+    @SuppressWarnings({"unchecked", "raw"})
+    private <T extends SourceAbilitySpec> T getSpec(SourceAbilitySpec[] specs, Class<T> specClass) {
+        if (specs == null) {
+            return null;
+        }
+        for (SourceAbilitySpec spec : specs) {
+            if (spec.getClass().equals(specClass)) {
+                return (T) spec;
+            }
+        }
+        return null;
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/connector/file/table/FileSystemStatisticsReportTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/connector/file/table/FileSystemStatisticsReportTest.java
@@ -1,0 +1,309 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.file.table;
+
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.config.OptimizerConfigOptions;
+import org.apache.flink.table.catalog.CatalogPartitionImpl;
+import org.apache.flink.table.catalog.CatalogPartitionSpec;
+import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.exceptions.PartitionNotExistException;
+import org.apache.flink.table.catalog.exceptions.TableNotExistException;
+import org.apache.flink.table.catalog.stats.CatalogTableStatistics;
+import org.apache.flink.table.plan.stats.TableStats;
+import org.apache.flink.table.planner.plan.optimize.program.FlinkBatchProgram;
+import org.apache.flink.table.planner.plan.schema.TableSourceTable;
+import org.apache.flink.table.planner.plan.stats.FlinkStatistic;
+import org.apache.flink.table.planner.utils.BatchTableTestUtil;
+import org.apache.flink.table.planner.utils.TableTestBase;
+import org.apache.flink.table.planner.utils.TableTestUtil;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelVisitor;
+import org.apache.calcite.rel.core.TableScan;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for statistics functionality in {@link FileSystemTableSource}. */
+public class FileSystemStatisticsReportTest extends TableTestBase {
+
+    private BatchTableTestUtil util;
+    private TableEnvironment tEnv;
+
+    @Before
+    public void setup() throws Exception {
+        util = batchTestUtil(TableConfig.getDefault());
+        util.buildBatchProgram(FlinkBatchProgram.JOIN_REORDER());
+        tEnv = util.getTableEnv();
+        String path1 = tempFolder().newFile().getAbsolutePath();
+        writeData(new File(path1), Arrays.asList("1,1,hi", "2,1,hello", "3,2,hello world"));
+
+        String ddl1 =
+                String.format(
+                        "CREATE TABLE NonPartTable (\n"
+                                + "  a bigint,\n"
+                                + "  b int,\n"
+                                + "  c varchar\n"
+                                + ") with (\n"
+                                + " 'connector' = 'filesystem',"
+                                + " 'format' = 'testcsv',"
+                                + " 'path' = '%s')",
+                        path1);
+        tEnv.executeSql(ddl1);
+
+        String path2 = tempFolder().newFolder().getAbsolutePath();
+        writeData(new File(path2, "b=1"), Arrays.asList("1,1,hi", "2,1,hello"));
+        writeData(new File(path2, "b=2"), Arrays.asList("3,2,hello world"));
+        String ddl2 =
+                String.format(
+                        "CREATE TABLE PartTable (\n"
+                                + "  a bigint,\n"
+                                + "  b int,\n"
+                                + "  c varchar\n"
+                                + ") partitioned by(b) with (\n"
+                                + " 'connector' = 'filesystem',"
+                                + " 'format' = 'testcsv',"
+                                + " 'path' = '%s')",
+                        path2);
+        tEnv.executeSql(ddl2);
+        tEnv.getCatalog(tEnv.getCurrentCatalog())
+                .get()
+                .createPartition(
+                        new ObjectPath(tEnv.getCurrentDatabase(), "PartTable"),
+                        new CatalogPartitionSpec(Collections.singletonMap("b", "1")),
+                        new CatalogPartitionImpl(new HashMap<>(), ""),
+                        false);
+        tEnv.getCatalog(tEnv.getCurrentCatalog())
+                .get()
+                .createPartition(
+                        new ObjectPath(tEnv.getCurrentDatabase(), "PartTable"),
+                        new CatalogPartitionSpec(Collections.singletonMap("b", "2")),
+                        new CatalogPartitionImpl(new HashMap<>(), ""),
+                        false);
+
+        String path3 = tempFolder().newFile().getAbsolutePath();
+        writeData(new File(path1), Arrays.asList("1,1,hi", "2,1,hello", "3,2,hello world"));
+
+        String ddl3 =
+                String.format(
+                        "CREATE TABLE DisableSourceReportTable (\n"
+                                + "  a bigint,\n"
+                                + "  b int,\n"
+                                + "  c varchar\n"
+                                + ") with (\n"
+                                + " 'connector' = 'filesystem',"
+                                + " 'format' = 'testcsv',"
+                                + " 'source.report-statistics' = 'NONE',"
+                                + " 'path' = '%s')",
+                        path3);
+        tEnv.executeSql(ddl3);
+    }
+
+    private void writeData(File file, List<String> data) throws IOException {
+        Files.write(file.toPath(), String.join("\n", data).getBytes());
+    }
+
+    @Test
+    public void testCatalogStatisticsExist() throws Exception {
+        tEnv.getCatalog(tEnv.getCurrentCatalog())
+                .get()
+                .alterTableStatistics(
+                        new ObjectPath(tEnv.getCurrentDatabase(), "NonPartTable"),
+                        new CatalogTableStatistics(10L, 1, 100L, 100L),
+                        false);
+
+        FlinkStatistic statistic = getStatisticsFromOptimizedPlan("select * from NonPartTable");
+        assertThat(statistic.getTableStats()).isEqualTo(new TableStats(10));
+    }
+
+    @Test
+    public void testCatalogStatisticsDoNotExist() {
+        FlinkStatistic statistic = getStatisticsFromOptimizedPlan("select * from NonPartTable");
+        assertThat(statistic.getTableStats()).isEqualTo(new TableStats(3));
+    }
+
+    @Test
+    public void testDisableSourceReport() {
+        FlinkStatistic statistic =
+                getStatisticsFromOptimizedPlan("select * from DisableSourceReportTable");
+        assertThat(statistic.getTableStats()).isEqualTo(TableStats.UNKNOWN);
+    }
+
+    @Test
+    public void testFilterPushDownAndCatalogStatisticsExist() throws TableNotExistException {
+        tEnv.getCatalog(tEnv.getCurrentCatalog())
+                .get()
+                .alterTableStatistics(
+                        new ObjectPath(tEnv.getCurrentDatabase(), "NonPartTable"),
+                        new CatalogTableStatistics(10L, 1, 100L, 100L),
+                        false);
+
+        FlinkStatistic statistic =
+                getStatisticsFromOptimizedPlan("select * from NonPartTable where a > 10");
+        assertThat(statistic.getTableStats()).isEqualTo(new TableStats(10));
+    }
+
+    @Test
+    public void testFilterPushDownAndCatalogStatisticsDoNotExist() {
+        FlinkStatistic statistic =
+                getStatisticsFromOptimizedPlan("select * from NonPartTable where a > 10");
+        assertThat(statistic.getTableStats()).isEqualTo(new TableStats(3));
+    }
+
+    @Test
+    public void testFilterPushDownAndReportStatisticsDisabled() {
+        tEnv.getConfig()
+                .set(
+                        OptimizerConfigOptions.TABLE_OPTIMIZER_SOURCE_REPORT_STATISTICS_ENABLED,
+                        false);
+        FlinkStatistic statistic =
+                getStatisticsFromOptimizedPlan("select * from NonPartTable where a > 10");
+        assertThat(statistic.getTableStats()).isEqualTo(TableStats.UNKNOWN);
+    }
+
+    @Test
+    public void testNoPartitionPushDownAndCatalogStatisticsExist()
+            throws PartitionNotExistException {
+        tEnv.getCatalog(tEnv.getCurrentCatalog())
+                .get()
+                .alterPartitionStatistics(
+                        new ObjectPath(tEnv.getCurrentDatabase(), "PartTable"),
+                        new CatalogPartitionSpec(Collections.singletonMap("b", "1")),
+                        new CatalogTableStatistics(6L, 1, 100L, 100L),
+                        false);
+        tEnv.getCatalog(tEnv.getCurrentCatalog())
+                .get()
+                .alterPartitionStatistics(
+                        new ObjectPath(tEnv.getCurrentDatabase(), "PartTable"),
+                        new CatalogPartitionSpec(Collections.singletonMap("b", "2")),
+                        new CatalogTableStatistics(3L, 1, 100L, 100L),
+                        false);
+
+        FlinkStatistic statistic = getStatisticsFromOptimizedPlan("select * from PartTable");
+        // TODO get partition statistics from catalog
+        assertThat(statistic.getTableStats()).isEqualTo(new TableStats(3));
+    }
+
+    @Test
+    public void testNoPartitionPushDownAndReportStatisticsDisabled() {
+        tEnv.getConfig()
+                .set(
+                        OptimizerConfigOptions.TABLE_OPTIMIZER_SOURCE_REPORT_STATISTICS_ENABLED,
+                        false);
+        FlinkStatistic statistic = getStatisticsFromOptimizedPlan("select * from PartTable");
+        // TODO get partition statistics from catalog
+        assertThat(statistic.getTableStats()).isEqualTo(TableStats.UNKNOWN);
+    }
+
+    @Test
+    public void testPartitionPushDownAndCatalogStatisticsExist() throws PartitionNotExistException {
+        tEnv.getCatalog(tEnv.getCurrentCatalog())
+                .get()
+                .alterPartitionStatistics(
+                        new ObjectPath(tEnv.getCurrentDatabase(), "PartTable"),
+                        new CatalogPartitionSpec(Collections.singletonMap("b", "1")),
+                        new CatalogTableStatistics(6L, 1, 100L, 100L),
+                        false);
+        tEnv.getCatalog(tEnv.getCurrentCatalog())
+                .get()
+                .alterPartitionStatistics(
+                        new ObjectPath(tEnv.getCurrentDatabase(), "PartTable"),
+                        new CatalogPartitionSpec(Collections.singletonMap("b", "2")),
+                        new CatalogTableStatistics(3L, 1, 100L, 100L),
+                        false);
+
+        FlinkStatistic statistic =
+                getStatisticsFromOptimizedPlan("select * from PartTable where b = 1");
+        assertThat(statistic.getTableStats()).isEqualTo(new TableStats(6));
+    }
+
+    @Test
+    public void testFilterPartitionPushDownPushDownAndCatalogStatisticsExist() throws Exception {
+        tEnv.getCatalog(tEnv.getCurrentCatalog())
+                .get()
+                .alterPartitionStatistics(
+                        new ObjectPath(tEnv.getCurrentDatabase(), "PartTable"),
+                        new CatalogPartitionSpec(Collections.singletonMap("b", "1")),
+                        new CatalogTableStatistics(6L, 1, 100L, 100L),
+                        false);
+        tEnv.getCatalog(tEnv.getCurrentCatalog())
+                .get()
+                .alterPartitionStatistics(
+                        new ObjectPath(tEnv.getCurrentDatabase(), "PartTable"),
+                        new CatalogPartitionSpec(Collections.singletonMap("b", "2")),
+                        new CatalogTableStatistics(3L, 1, 100L, 100L),
+                        false);
+
+        FlinkStatistic statistic =
+                getStatisticsFromOptimizedPlan("select * from PartTable where a > 10 and b = 1");
+        assertThat(statistic.getTableStats()).isEqualTo(new TableStats(6));
+    }
+
+    @Test
+    public void testFilterPartitionPushDownAndCatalogStatisticsDoNotExist() {
+        FlinkStatistic statistic =
+                getStatisticsFromOptimizedPlan("select * from PartTable where a > 10 and b = 1");
+        assertThat(statistic.getTableStats()).isEqualTo(new TableStats(2));
+    }
+
+    @Test
+    public void testFilterPartitionPushDownAndReportStatisticsDisabled() {
+        tEnv.getConfig()
+                .set(
+                        OptimizerConfigOptions.TABLE_OPTIMIZER_SOURCE_REPORT_STATISTICS_ENABLED,
+                        false);
+        FlinkStatistic statistic =
+                getStatisticsFromOptimizedPlan("select * from PartTable where a > 10 and b = 1");
+        assertThat(statistic.getTableStats()).isEqualTo(TableStats.UNKNOWN);
+    }
+
+    private FlinkStatistic getStatisticsFromOptimizedPlan(String sql) {
+        RelNode relNode = TableTestUtil.toRelNode(tEnv.sqlQuery(sql));
+        RelNode optimized = util.getPlanner().optimize(relNode);
+        FlinkStatisticVisitor visitor = new FlinkStatisticVisitor();
+        visitor.go(optimized);
+        return visitor.result;
+    }
+
+    private static class FlinkStatisticVisitor extends RelVisitor {
+        private FlinkStatistic result = null;
+
+        @Override
+        public void visit(RelNode node, int ordinal, RelNode parent) {
+            if (node instanceof TableScan) {
+                Preconditions.checkArgument(result == null);
+                TableSourceTable table = (TableSourceTable) node.getTable();
+                result = table.getStatistic();
+            }
+            super.visit(node, ordinal, parent);
+        }
+    }
+}


### PR DESCRIPTION


## What is the purpose of the change

*This pr aims to implement the basic logic for FLIP-231, including:
Introduce SupportsStatisticsReport and FileBasedStatisticsReportableDecodingFormat interface
Introduce FlinkRecomputeStatisticsProgram to compute statistics after filter push and partition pruning*


## Brief change log

  - *Introduce SupportsStatisticsReport interface*
  - *Introduce FileBasedStatisticsReportableDecodingFormat interface*
  - *Introduce FlinkRecomputeStatisticsProgram to compute statistics after filter push and partition pruning*


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing


This change added tests and can be verified as follows:

  - *Added FileSystemStatisticsReportTest to verify the change*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
