### PR TITLE
[FLINK-27965][table-planner] Fix EXPLAIN PLAN produces wrong query sc…

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/calcite/FlinkPlannerImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/calcite/FlinkPlannerImpl.scala
@@ -152,13 +152,7 @@ class FlinkPlannerImpl(
           val validatedStatement = richExplain.getStatement match {
             // only validate source here
             case insert: RichSqlInsert =>
-              if (insert.isUpsert) {
-                throw new ValidationException(
-                  "UPSERT INTO statement is not supported. Please use INSERT INTO instead.")
-              }
-              val validatedSource = validate(insert.getSource)
-              insert.setOperand(2, validatedSource)
-              insert
+              validateRichSqlInsert(insert)
             case others =>
               validate(others)
           }
@@ -173,16 +167,7 @@ class FlinkPlannerImpl(
           execute.setOperand(0, validate(execute.getStatement))
           execute
         case insert: RichSqlInsert =>
-          // We don't support UPSERT INTO semantics (see FLINK-24225).
-          if (insert.isUpsert) {
-            throw new ValidationException(
-              "UPSERT INTO statement is not supported. Please use INSERT INTO instead.")
-          }
-          // only validate source here.
-          // ignore row type which will be verified in table environment.
-          val validatedSource = validator.validate(insert.getSource)
-          insert.setOperand(2, validatedSource)
-          insert
+          validateRichSqlInsert(insert)
         case compile: SqlCompilePlan =>
           compile.setOperand(0, validate(compile.getOperandList.get(0)))
           compile
@@ -240,6 +225,19 @@ class FlinkPlannerImpl(
       sqlValidator.setExpectedOutputType(sqlNode, outputType)
     }
     sqlValidator.validateParameterizedExpression(sqlNode, nameToTypeMap)
+  }
+
+  private def validateRichSqlInsert(insert: RichSqlInsert): SqlNode = {
+    // We don't support UPSERT INTO semantics (see FLINK-24225).
+    if (insert.isUpsert) {
+      throw new ValidationException(
+        "UPSERT INTO statement is not supported. Please use INSERT INTO instead.")
+    }
+    // only validate source here.
+    // ignore row type which will be verified in table environment.
+    val validatedSource = validate(insert.getSource)
+    insert.setOperand(2, validatedSource)
+    insert
   }
 
   def rex(

--- a/flink-table/flink-table-planner/src/test/resources/explain/testExecuteSqlWithExplainInsertIntoStaticPartition.out
+++ b/flink-table/flink-table-planner/src/test/resources/explain/testExecuteSqlWithExplainInsertIntoStaticPartition.out
@@ -1,0 +1,14 @@
+== Abstract Syntax Tree ==
+LogicalSink(table=[default_catalog.default_database.MySink], fields=[f0, f1, EXPR$2])
++- LogicalProject(f0=[$0], f1=[$1], EXPR$2=[_UTF-16LE'123':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [CollectionTableSource(f0, f1, f2)]]])
+
+== Optimized Physical Plan ==
+Sink(table=[default_catalog.default_database.MySink], fields=[f0, f1, EXPR$2])
++- Calc(select=[f0, f1, '123' AS EXPR$2])
+   +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [CollectionTableSource(f0, f1, f2)]]], fields=[f0, f1, f2])
+
+== Optimized Execution Plan ==
+Sink(table=[default_catalog.default_database.MySink], fields=[f0, f1, EXPR$2])
++- Calc(select=[f0, f1, '123' AS EXPR$2])
+   +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [CollectionTableSource(f0, f1, f2)]]], fields=[f0, f1, f2])

--- a/flink-table/flink-table-planner/src/test/resources/explain/testExecuteSqlWithExplainInsertOverwriteStaticPartition.out
+++ b/flink-table/flink-table-planner/src/test/resources/explain/testExecuteSqlWithExplainInsertOverwriteStaticPartition.out
@@ -1,0 +1,14 @@
+== Abstract Syntax Tree ==
+LogicalSink(table=[default_catalog.default_database.MySink], fields=[f0, f1, EXPR$2])
++- LogicalProject(f0=[$0], f1=[$1], EXPR$2=[_UTF-16LE'123':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [CollectionTableSource(f0, f1, f2)]]])
+
+== Optimized Physical Plan ==
+Sink(table=[default_catalog.default_database.MySink], fields=[f0, f1, EXPR$2])
++- Calc(select=[f0, f1, '123' AS EXPR$2])
+   +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [CollectionTableSource(f0, f1, f2)]]], fields=[f0, f1, f2])
+
+== Optimized Execution Plan ==
+Sink(table=[default_catalog.default_database.MySink], fields=[f0, f1, EXPR$2])
++- Calc(select=[f0, f1, '123' AS EXPR$2])
+   +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [CollectionTableSource(f0, f1, f2)]]], fields=[f0, f1, f2])


### PR DESCRIPTION
## What is the purpose of the change

This pull request fixes the issue that the `EXPLAIN PLAN FOR INSERT` with static partition spec produces the wrong query schema.

During the conversion phase, the query will be validated and rewritten by `PreValidateReWriter`, and `PreValidateReWriter#appendPartitionAndNullsProjects` will perform the following rewrite(https://github.com/apache/flink/blob/master/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/calcite/PreValidateReWriter.scala#L89).
```sql
-- before rewrite
insert into A partition(a='11',
 c='22') select b from B

-- after rewrite
insert into A partition(a='11', c='22') select cast('11' as tpe1), b, cast('22' as tpe2) from B
```
However, the `SqlRichExplain` are first validated as a whole and then got its statement validated again, thus the insert query is rewritten twice, which causes the issue.

## Brief change log
  - For `SqlRichExplain`, let`FlinkPlannerImpl` validate the insert's source instead of insert.

## Verifying this change

This change added tests and can be verified as follows:

  - Add `TableEnvironmentTest#testExecuteSqlWithExplainInsertStaticPartition`
  - Add it case in `table.q`
 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
