### PR TITLE
[FLINK-28019][table] fix error when retract a staled record if state ttl enabled in RetractableTopNFunction

### DIFF
--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/rank/RetractableTopNFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/rank/RetractableTopNFunction.java
@@ -191,16 +191,7 @@ public class RetractableTopNFunction extends AbstractTopNFunction {
                     sortedMap.put(sortKey, count);
                 }
             } else {
-                if (sortedMap.isEmpty()) {
-                    if (lenient) {
-                        LOG.warn(STATE_CLEARED_WARN_MSG);
-                    } else {
-                        throw new RuntimeException(STATE_CLEARED_WARN_MSG);
-                    }
-                } else {
-                    throw new RuntimeException(
-                            "Can not retract a non-existent record. This should never happen.");
-                }
+                stateStaledErrorHandle();
             }
 
             if (!stateRemoved) {
@@ -231,10 +222,16 @@ public class RetractableTopNFunction extends AbstractTopNFunction {
 
     private void processStateStaled(Iterator<Map.Entry<RowData, Long>> sortedMapIterator)
             throws RuntimeException {
+        if (lenient) {
+            // Sync with dataState first
+            sortedMapIterator.remove();
+        }
+        stateStaledErrorHandle();
+    }
+
+    private void stateStaledErrorHandle() {
         // Skip the data if it's state is cleared because of state ttl.
         if (lenient) {
-            // Sync with dataState
-            sortedMapIterator.remove();
             LOG.warn(STATE_CLEARED_WARN_MSG);
         } else {
             throw new RuntimeException(STATE_CLEARED_WARN_MSG);
@@ -395,8 +392,12 @@ public class RetractableTopNFunction extends AbstractTopNFunction {
             }
         }
         if (isInRankEnd(currentRank)) {
-            // there is no enough elements in Top-N, emit DELETE message for the retract record.
-            collectDelete(out, prevRow, currentRank);
+            if (!findsSortKey && null == prevRow) {
+                stateStaledErrorHandle();
+            } else {
+                // there is no enough elements in Top-N, emit DELETE message for the retract record.
+                collectDelete(out, prevRow, currentRank);
+            }
         }
 
         return findsSortKey;

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/rank/RetractableTopNFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/rank/RetractableTopNFunction.java
@@ -222,13 +222,16 @@ public class RetractableTopNFunction extends AbstractTopNFunction {
 
     private void processStateStaled(Iterator<Map.Entry<RowData, Long>> sortedMapIterator)
             throws RuntimeException {
-        if (lenient) {
-            // Sync with dataState first
-            sortedMapIterator.remove();
-        }
+        // Sync with dataState first
+        sortedMapIterator.remove();
+
         stateStaledErrorHandle();
     }
 
+    /**
+     * Handle state staled error by configured lenient option. If option is true, warning log only,
+     * otherwise a {@link RuntimeException} will be thrown.
+     */
     private void stateStaledErrorHandle() {
         // Skip the data if it's state is cleared because of state ttl.
         if (lenient) {


### PR DESCRIPTION
## What is the purpose of the change
We found an error occurred when retract a staled record when enable state ttl in RetractableTopNFunction, the reason is the uncomplete path when deal with staled records. This should be fixed.

## Brief change log
update the staled record error handling logic in retractRecordWithRowNumber and processElement of the RetractableTopNFunction.

## Verifying this change
add new tests for RetractableTopNFunctionTest

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation
  - Does this pull request introduce a new feature? (no)