### PR TITLE
[FLINK-27473] Capture Time That Job Spends In Initialization 

### DIFF
--- a/docs/content.zh/docs/ops/metrics.md
+++ b/docs/content.zh/docs/ops/metrics.md
@@ -1137,12 +1137,32 @@ Whether these metrics are reported depends on the [metrics.job.status.enable]({{
       <td>Return how much time (in milliseconds) the job has spent deploying* tasks in total.</td>
       <td>Gauge</td>
     </tr>
+    <tr>
+      <th rowspan="3"><strong>Job (only available on JobManager)</strong></th>
+      <td>initializingState</td>
+      <td>Return 1 if the job is currently initializing** tasks, otherwise return 0.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>initializingTime</td>
+      <td>Return the time (in milliseconds) since the job has started initializing** tasks, otherwise return 0.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>initializingTimeTotal</td>
+      <td>Return how much time (in milliseconds) the job has spent initializing** tasks in total.</td>
+      <td>Gauge</td>
+    </tr>
   </tbody>
 </table>
 
 *A job is considered to be deploying tasks when:
 * for streaming jobs, any task is in the DEPLOYING state
 * for batch jobs, if at least 1 task is in the DEPLOYING state, and there are no INITIALIZING/RUNNING tasks
+
+**A job is considered to be initializing tasks when:
+* for streaming jobs, any task is in the INITIALIZING state
+* for batch jobs, if at least 1 task is in the INITIALIZING state, and there are no RUNNING tasks
 {{< /hint >}}
 
 <table class="table table-bordered">

--- a/docs/content/docs/ops/metrics.md
+++ b/docs/content/docs/ops/metrics.md
@@ -1137,12 +1137,37 @@ Whether these metrics are reported depends on the [metrics.job.status.enable]({{
       <td>Return how much time (in milliseconds) the job has spent deploying* tasks in total.</td>
       <td>Gauge</td>
     </tr>
+    <tr>
+      <td>deployingTimeTotal</td>
+      <td>Return how much time (in milliseconds) the job has spent deploying* tasks in total.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <th rowspan="3"><strong>Job (only available on JobManager)</strong></th>
+      <td>initializingState</td>
+      <td>Return 1 if the job is currently initializing** tasks, otherwise return 0.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>initializingTime</td>
+      <td>Return the time (in milliseconds) since the job has started initializing** tasks, otherwise return 0.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>initializingTimeTotal</td>
+      <td>Return how much time (in milliseconds) the job has spent initializing** tasks in total.</td>
+      <td>Gauge</td>
+    </tr>
   </tbody>
 </table>
 
 *A job is considered to be deploying tasks when:
 * for streaming jobs, any task is in the DEPLOYING state
 * for batch jobs, if at least 1 task is in the DEPLOYING state, and there are no INITIALIZING/RUNNING tasks
+
+**A job is considered to be initializing tasks when:
+* for streaming jobs, any task is in the INITIALIZING state
+* for batch jobs, if at least 1 task is in the INITIALIZING state, and there are no RUNNING tasks
 {{< /hint >}}
 
 <table class="table table-bordered">

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultExecutionGraphFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultExecutionGraphFactory.java
@@ -18,8 +18,6 @@
 
 package org.apache.flink.runtime.scheduler;
 
-import java.util.List;
-
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.WebOptions;
@@ -47,6 +45,7 @@ import org.apache.flink.util.function.CachingSupplier;
 import org.slf4j.Logger;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Supplier;
@@ -141,10 +140,10 @@ public class DefaultExecutionGraphFactory implements ExecutionGraphFactory {
                 new ExecutionDeploymentTrackerDeploymentListenerAdapter(executionDeploymentTracker);
         ExecutionStateUpdateListener combinedExecutionStateUpdateListener =
                 (execution, previousState, newState) -> {
-                    for (ExecutionStateUpdateListener executionStateUpdateListener : executionStateUpdateListenerList) {
-                        executionStateUpdateListener.onStateUpdate(execution,
-                                previousState,
-                                newState);
+                    for (ExecutionStateUpdateListener executionStateUpdateListener :
+                            executionStateUpdateListenerList) {
+                        executionStateUpdateListener.onStateUpdate(
+                                execution, previousState, newState);
                     }
                     if (newState.isTerminal()) {
                         executionDeploymentTracker.stopTrackingDeploymentOf(execution);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultExecutionGraphFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultExecutionGraphFactory.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.scheduler;
 
+import java.util.List;
+
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.WebOptions;
@@ -132,14 +134,18 @@ public class DefaultExecutionGraphFactory implements ExecutionGraphFactory {
             long initializationTimestamp,
             VertexAttemptNumberStore vertexAttemptNumberStore,
             VertexParallelismStore vertexParallelismStore,
-            ExecutionStateUpdateListener executionStateUpdateListener,
+            List<ExecutionStateUpdateListener> executionStateUpdateListenerList,
             Logger log)
             throws Exception {
         ExecutionDeploymentListener executionDeploymentListener =
                 new ExecutionDeploymentTrackerDeploymentListenerAdapter(executionDeploymentTracker);
         ExecutionStateUpdateListener combinedExecutionStateUpdateListener =
                 (execution, previousState, newState) -> {
-                    executionStateUpdateListener.onStateUpdate(execution, previousState, newState);
+                    for (ExecutionStateUpdateListener executionStateUpdateListener : executionStateUpdateListenerList) {
+                        executionStateUpdateListener.onStateUpdate(execution,
+                                previousState,
+                                newState);
+                    }
                     if (newState.isTerminal()) {
                         executionDeploymentTracker.stopTrackingDeploymentOf(execution);
                     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionGraphFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionGraphFactory.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.scheduler;
 
+import java.util.List;
+
 import org.apache.flink.runtime.checkpoint.CheckpointIDCounter;
 import org.apache.flink.runtime.checkpoint.CheckpointsCleaner;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpointStore;
@@ -60,7 +62,7 @@ public interface ExecutionGraphFactory {
             long initializationTimestamp,
             VertexAttemptNumberStore vertexAttemptNumberStore,
             VertexParallelismStore vertexParallelismStore,
-            ExecutionStateUpdateListener executionStateUpdateListener,
+            List<ExecutionStateUpdateListener> executionStateUpdateListenerList,
             Logger log)
             throws Exception;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionGraphFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionGraphFactory.java
@@ -47,7 +47,7 @@ public interface ExecutionGraphFactory {
      *     attempts of previous runs
      * @param vertexParallelismStore vertexMaxParallelismStore keeping information about the vertex
      *     max parallelism settings
-     * @param executionStateUpdateListener listener for state transitions of the individual
+     * @param executionStateUpdateListenerList listeners for state transitions of the individual
      *     executions
      * @param log log to use for logging
      * @return restored {@link ExecutionGraph}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionGraphFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionGraphFactory.java
@@ -18,8 +18,6 @@
 
 package org.apache.flink.runtime.scheduler;
 
-import java.util.List;
-
 import org.apache.flink.runtime.checkpoint.CheckpointIDCounter;
 import org.apache.flink.runtime.checkpoint.CheckpointsCleaner;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpointStore;
@@ -30,6 +28,8 @@ import org.apache.flink.runtime.executiongraph.VertexAttemptNumberStore;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 
 import org.slf4j.Logger;
+
+import java.util.List;
 
 /** Factory for creating an {@link ExecutionGraph}. */
 public interface ExecutionGraphFactory {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -19,8 +19,6 @@
 
 package org.apache.flink.runtime.scheduler;
 
-import java.util.Arrays;
-
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
@@ -53,7 +51,6 @@ import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
-import org.apache.flink.runtime.executiongraph.ExecutionStateUpdateListener;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.executiongraph.JobStatusListener;
 import org.apache.flink.runtime.executiongraph.JobStatusProvider;
@@ -106,6 +103,7 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
@@ -18,8 +18,6 @@
 
 package org.apache.flink.runtime.scheduler.adaptive;
 
-import java.util.Arrays;
-
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
@@ -125,6 +123,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/metrics/DeploymentStateTimeMetrics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/metrics/DeploymentStateTimeMetrics.java
@@ -17,8 +17,6 @@
 
 package org.apache.flink.runtime.scheduler.metrics;
 
-import org.apache.commons.lang3.tuple.Pair;
-
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.MetricOptions;
 import org.apache.flink.metrics.MetricGroup;
@@ -29,21 +27,22 @@ import org.apache.flink.runtime.jobgraph.JobType;
 import org.apache.flink.util.clock.Clock;
 import org.apache.flink.util.clock.SystemClock;
 
+import org.apache.commons.lang3.tuple.Pair;
+
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Predicate;
-
 
 /**
  * Metrics that capture how long a job was deploying tasks.
  *
  * <p>These metrics differentiate between batch & streaming use-cases:
  *
- * <p>Batch: Measures from the start of the first deployment until the first task has been
- * deployed. From that point the job is making progress.
+ * <p>Batch: Measures from the start of the first deployment until the first task has been deployed.
+ * From that point the job is making progress.
  *
- * <p>Streaming: Measures from the start of the first deployment until all tasks have been
- * deployed. From that point on checkpoints can be triggered, and thus progress be made.
+ * <p>Streaming: Measures from the start of the first deployment until all tasks have been deployed.
+ * From that point on checkpoints can be triggered, and thus progress be made.
  */
 public class DeploymentStateTimeMetrics
         implements ExecutionStateUpdateListener, StateTimeMetric, MetricsRegistrar {
@@ -84,8 +83,9 @@ public class DeploymentStateTimeMetrics
             // is either
             // initializing or running.
             // Deployment is completed iff any task is in either initializing or deploying state
-            deploymentStartPredicate = deploymentPair -> deploymentPair.getLeft() == 0
-                    && deploymentPair.getRight() == 0;
+            deploymentStartPredicate =
+                    deploymentPair ->
+                            deploymentPair.getLeft() == 0 && deploymentPair.getRight() == 0;
             deploymentEndPredicate =
                     deploymentPair -> deploymentPair.getLeft() > 0 || deploymentPair.getRight() > 0;
         } else {
@@ -94,14 +94,16 @@ public class DeploymentStateTimeMetrics
             // Deployment is completed if all tasks are either initializing or running
             deploymentStartPredicate = deploymentPair -> true;
             deploymentEndPredicate =
-                    deploymentPair -> (deploymentPair.getLeft() + deploymentPair.getRight())
-                            == expectedDeployments.size();
+                    deploymentPair ->
+                            (deploymentPair.getLeft() + deploymentPair.getRight())
+                                    == expectedDeployments.size();
         }
     }
 
     @Override
     public long getCurrentTime() {
-        return deploymentStart == NOT_STARTED ? 0L
+        return deploymentStart == NOT_STARTED
+                ? 0L
                 : Math.max(0, clock.absoluteTimeMillis() - deploymentStart);
     }
 
@@ -153,8 +155,9 @@ public class DeploymentStateTimeMetrics
         }
 
         if (deploymentStart == NOT_STARTED) {
-            if (pendingDeployments > 0 && deploymentStartPredicate.test(Pair.of(initializingDeployments,
-                    completedDeployments))) {
+            if (pendingDeployments > 0
+                    && deploymentStartPredicate.test(
+                            Pair.of(initializingDeployments, completedDeployments))) {
                 markDeploymentStart();
             }
         } else {
@@ -176,7 +179,10 @@ public class DeploymentStateTimeMetrics
 
     @VisibleForTesting
     boolean hasCleanState() {
-        return expectedDeployments.isEmpty() && pendingDeployments == 0 && completedDeployments == 0
-                && initializingDeployments == 0 && deploymentStart == NOT_STARTED;
+        return expectedDeployments.isEmpty()
+                && pendingDeployments == 0
+                && completedDeployments == 0
+                && initializingDeployments == 0
+                && deploymentStart == NOT_STARTED;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/metrics/InitializationStateTimeMetrics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/metrics/InitializationStateTimeMetrics.java
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.flink.runtime.scheduler.metrics;
 
 import org.apache.flink.annotation.VisibleForTesting;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/metrics/InitializationStateTimeMetrics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/metrics/InitializationStateTimeMetrics.java
@@ -38,10 +38,10 @@ import org.apache.flink.util.clock.SystemClock;
  *
  * <p>These metrics differentiate between batch & streaming use-cases:
  *
- * <p>Batch: Measures from the start of the first initialization until the first task has been deployed.
+ * <p>Batch: Measures from the start of the first initialization until the first task is running.
  * From that point the job is making progress.
  *
- * <p>Streaming: Measures from the start of the first initialization until all tasks have been deployed.
+ * <p>Streaming: Measures from the start of the first initialization until all tasks are running.
  * From that point on checkpoints can be triggered, and thus progress be made.
  */
 public class InitializationStateTimeMetrics

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/metrics/InitializationStateTimeMetrics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/metrics/InitializationStateTimeMetrics.java
@@ -16,12 +16,6 @@
  */
 package org.apache.flink.runtime.scheduler.metrics;
 
-import java.util.HashSet;
-import java.util.Set;
-import java.util.function.Predicate;
-
-import org.apache.commons.lang3.tuple.Pair;
-
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.MetricOptions;
 import org.apache.flink.metrics.MetricGroup;
@@ -32,6 +26,11 @@ import org.apache.flink.runtime.jobgraph.JobType;
 import org.apache.flink.util.clock.Clock;
 import org.apache.flink.util.clock.SystemClock;
 
+import org.apache.commons.lang3.tuple.Pair;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Predicate;
 
 /**
  * Metrics that capture how long a job took in initialization
@@ -92,7 +91,8 @@ public class InitializationStateTimeMetrics
 
     @Override
     public long getCurrentTime() {
-        return initializationStart == NOT_STARTED ? 0L
+        return initializationStart == NOT_STARTED
+                ? 0L
                 : Math.max(0, clock.absoluteTimeMillis() - initializationStart);
     }
 
@@ -144,8 +144,9 @@ public class InitializationStateTimeMetrics
         }
 
         if (initializationStart == NOT_STARTED) {
-            if (initializingDeployments > 0 && initializationStartPredicate.test(Pair.of(completedDeployments,
-                    pendingDeployments))) {
+            if (initializingDeployments > 0
+                    && initializationStartPredicate.test(
+                            Pair.of(completedDeployments, pendingDeployments))) {
                 markInitializationStart();
             }
         } else {
@@ -167,7 +168,10 @@ public class InitializationStateTimeMetrics
 
     @VisibleForTesting
     boolean hasCleanState() {
-        return expectedDeployments.isEmpty() && pendingDeployments == 0 && completedDeployments == 0
-                && initializingDeployments == 0 && initializationStart == NOT_STARTED;
+        return expectedDeployments.isEmpty()
+                && pendingDeployments == 0
+                && completedDeployments == 0
+                && initializingDeployments == 0
+                && initializationStart == NOT_STARTED;
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultExecutionGraphFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultExecutionGraphFactoryTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.scheduler;
 
+import java.util.Arrays;
+
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.testutils.FlinkMatchers;
@@ -83,7 +85,7 @@ public class DefaultExecutionGraphFactoryTest extends TestLogger {
                     0L,
                     new DefaultVertexAttemptNumberStore(),
                     SchedulerBase.computeVertexParallelismStore(jobGraphWithNewOperator),
-                    (execution, previousState, newState) -> {},
+                    Arrays.asList((execution, previousState, newState) -> {}),
                     log);
             fail("Expected ExecutionGraph creation to fail because of non restored state.");
         } catch (Exception e) {
@@ -112,7 +114,7 @@ public class DefaultExecutionGraphFactoryTest extends TestLogger {
                 0L,
                 new DefaultVertexAttemptNumberStore(),
                 SchedulerBase.computeVertexParallelismStore(jobGraphWithNewOperator),
-                (execution, previousState, newState) -> {},
+                Arrays.asList((execution, previousState, newState) -> {}),
                 log);
 
         final CompletedCheckpoint savepoint = completedCheckpointStore.getLatestCheckpoint();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultExecutionGraphFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultExecutionGraphFactoryTest.java
@@ -18,8 +18,6 @@
 
 package org.apache.flink.runtime.scheduler;
 
-import java.util.Arrays;
-
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.testutils.FlinkMatchers;
@@ -54,6 +52,7 @@ import javax.annotation.Nonnull;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.concurrent.ScheduledExecutorService;
 
 import static org.hamcrest.Matchers.notNullValue;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/metrics/CombinedMetricsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/metrics/CombinedMetricsTest.java
@@ -17,7 +17,6 @@
 package org.apache.flink.runtime.scheduler.metrics;
 
 import org.apache.flink.configuration.MetricOptions;
-
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.jobgraph.JobType;
@@ -28,12 +27,12 @@ import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.cr
 import static org.apache.flink.runtime.scheduler.metrics.StateTimeMetricTest.enable;
 import static org.assertj.core.api.Assertions.assertThat;
 
-
 public class CombinedMetricsTest {
-    private static final MetricOptions.JobStatusMetricsSettings settings = enable(
-            MetricOptions.JobStatusMetrics.STATE,
-            MetricOptions.JobStatusMetrics.CURRENT_TIME,
-            MetricOptions.JobStatusMetrics.TOTAL_TIME);
+    private static final MetricOptions.JobStatusMetricsSettings settings =
+            enable(
+                    MetricOptions.JobStatusMetrics.STATE,
+                    MetricOptions.JobStatusMetrics.CURRENT_TIME,
+                    MetricOptions.JobStatusMetrics.TOTAL_TIME);
 
     @Test
     public void testCombined_batch() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/metrics/CombinedMetricsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/metrics/CombinedMetricsTest.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.scheduler.metrics;
+
+import org.apache.flink.configuration.MetricOptions;
+
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.jobgraph.JobType;
+
+import org.junit.Test;
+
+import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.createExecutionAttemptId;
+import static org.apache.flink.runtime.scheduler.metrics.StateTimeMetricTest.enable;
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+public class CombinedMetricsTest {
+    private static final MetricOptions.JobStatusMetricsSettings settings = enable(
+            MetricOptions.JobStatusMetrics.STATE,
+            MetricOptions.JobStatusMetrics.CURRENT_TIME,
+            MetricOptions.JobStatusMetrics.TOTAL_TIME);
+
+    @Test
+    public void testCombined_batch() {
+        final InitializationStateTimeMetrics initializationStateTimeMetrics =
+                new InitializationStateTimeMetrics(JobType.BATCH, settings);
+        final DeploymentStateTimeMetrics deploymentStateTimeMetrics =
+                new DeploymentStateTimeMetrics(JobType.BATCH, settings);
+
+        final ExecutionAttemptID id1 = createExecutionAttemptId();
+        final ExecutionAttemptID id2 = createExecutionAttemptId();
+
+        updateMetrics(
+                id1,
+                initializationStateTimeMetrics,
+                deploymentStateTimeMetrics,
+                ExecutionState.CREATED,
+                ExecutionState.SCHEDULED);
+
+        updateMetrics(
+                id2,
+                initializationStateTimeMetrics,
+                deploymentStateTimeMetrics,
+                ExecutionState.CREATED,
+                ExecutionState.SCHEDULED);
+
+        updateMetrics(
+                id1,
+                initializationStateTimeMetrics,
+                deploymentStateTimeMetrics,
+                ExecutionState.SCHEDULED,
+                ExecutionState.DEPLOYING);
+
+        assertThat(deploymentStateTimeMetrics.getBinary()).isEqualTo(1L);
+        assertThat(initializationStateTimeMetrics.getBinary()).isEqualTo(0L);
+
+        updateMetrics(
+                id1,
+                initializationStateTimeMetrics,
+                deploymentStateTimeMetrics,
+                ExecutionState.DEPLOYING,
+                ExecutionState.INITIALIZING);
+
+        assertThat(deploymentStateTimeMetrics.getBinary()).isEqualTo(0L);
+        assertThat(initializationStateTimeMetrics.getBinary()).isEqualTo(1L);
+
+        updateMetrics(
+                id2,
+                initializationStateTimeMetrics,
+                deploymentStateTimeMetrics,
+                ExecutionState.DEPLOYING,
+                ExecutionState.INITIALIZING);
+
+        assertThat(deploymentStateTimeMetrics.getBinary()).isEqualTo(0L);
+        assertThat(initializationStateTimeMetrics.getBinary()).isEqualTo(1L);
+
+        updateMetrics(
+                id2,
+                initializationStateTimeMetrics,
+                deploymentStateTimeMetrics,
+                ExecutionState.INITIALIZING,
+                ExecutionState.RUNNING);
+
+        assertThat(deploymentStateTimeMetrics.getBinary()).isEqualTo(0L);
+        assertThat(initializationStateTimeMetrics.getBinary()).isEqualTo(0L);
+    }
+
+    @Test
+    public void testCombined_streaming() {
+        final InitializationStateTimeMetrics initializationStateTimeMetrics =
+                new InitializationStateTimeMetrics(JobType.STREAMING, settings);
+        final DeploymentStateTimeMetrics deploymentStateTimeMetrics =
+                new DeploymentStateTimeMetrics(JobType.STREAMING, settings);
+
+        final ExecutionAttemptID id1 = createExecutionAttemptId();
+        final ExecutionAttemptID id2 = createExecutionAttemptId();
+
+        updateMetrics(
+                id1,
+                initializationStateTimeMetrics,
+                deploymentStateTimeMetrics,
+                ExecutionState.CREATED,
+                ExecutionState.SCHEDULED);
+
+        updateMetrics(
+                id2,
+                initializationStateTimeMetrics,
+                deploymentStateTimeMetrics,
+                ExecutionState.CREATED,
+                ExecutionState.SCHEDULED);
+
+        updateMetrics(
+                id1,
+                initializationStateTimeMetrics,
+                deploymentStateTimeMetrics,
+                ExecutionState.SCHEDULED,
+                ExecutionState.DEPLOYING);
+
+        assertThat(deploymentStateTimeMetrics.getBinary()).isEqualTo(1L);
+        assertThat(initializationStateTimeMetrics.getBinary()).isEqualTo(0L);
+
+        updateMetrics(
+                id1,
+                initializationStateTimeMetrics,
+                deploymentStateTimeMetrics,
+                ExecutionState.DEPLOYING,
+                ExecutionState.INITIALIZING);
+
+        assertThat(deploymentStateTimeMetrics.getBinary()).isEqualTo(1L);
+        assertThat(initializationStateTimeMetrics.getBinary()).isEqualTo(1L);
+
+        updateMetrics(
+                id2,
+                initializationStateTimeMetrics,
+                deploymentStateTimeMetrics,
+                ExecutionState.DEPLOYING,
+                ExecutionState.INITIALIZING);
+
+        assertThat(deploymentStateTimeMetrics.getBinary()).isEqualTo(0L);
+        assertThat(initializationStateTimeMetrics.getBinary()).isEqualTo(1L);
+
+        updateMetrics(
+                id2,
+                initializationStateTimeMetrics,
+                deploymentStateTimeMetrics,
+                ExecutionState.INITIALIZING,
+                ExecutionState.RUNNING);
+
+        assertThat(deploymentStateTimeMetrics.getBinary()).isEqualTo(0L);
+        assertThat(initializationStateTimeMetrics.getBinary()).isEqualTo(1L);
+
+        updateMetrics(
+                id2,
+                initializationStateTimeMetrics,
+                deploymentStateTimeMetrics,
+                ExecutionState.INITIALIZING,
+                ExecutionState.RUNNING);
+
+        assertThat(deploymentStateTimeMetrics.getBinary()).isEqualTo(0L);
+        assertThat(initializationStateTimeMetrics.getBinary()).isEqualTo(0L);
+    }
+
+    private static void updateMetrics(
+            ExecutionAttemptID id,
+            InitializationStateTimeMetrics initializationStateTimeMetrics,
+            DeploymentStateTimeMetrics deploymentStateTimeMetrics,
+            ExecutionState previousState,
+            ExecutionState currentState) {
+        initializationStateTimeMetrics.onStateUpdate(id, previousState, currentState);
+        deploymentStateTimeMetrics.onStateUpdate(id, previousState, currentState);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/metrics/CombinedMetricsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/metrics/CombinedMetricsTest.java
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.flink.runtime.scheduler.metrics;
 
 import org.apache.flink.configuration.MetricOptions;
@@ -27,6 +28,11 @@ import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.cr
 import static org.apache.flink.runtime.scheduler.metrics.StateTimeMetricTest.enable;
 import static org.assertj.core.api.Assertions.assertThat;
 
+
+/**
+ * Tests combining DeploymentStateMetricsTest and
+ * InitializationStateTimeMetricsTest
+ */
 public class CombinedMetricsTest {
     private static final MetricOptions.JobStatusMetricsSettings settings =
             enable(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/metrics/DeploymentStateTimeMetricsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/metrics/DeploymentStateTimeMetricsTest.java
@@ -31,13 +31,13 @@ import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.cr
 import static org.apache.flink.runtime.scheduler.metrics.StateTimeMetricTest.enable;
 import static org.assertj.core.api.Assertions.assertThat;
 
+
 class DeploymentStateTimeMetricsTest {
 
-    private static final MetricOptions.JobStatusMetricsSettings settings =
-            enable(
-                    MetricOptions.JobStatusMetrics.STATE,
-                    MetricOptions.JobStatusMetrics.CURRENT_TIME,
-                    MetricOptions.JobStatusMetrics.TOTAL_TIME);
+    private static final MetricOptions.JobStatusMetricsSettings settings = enable(
+            MetricOptions.JobStatusMetrics.STATE,
+            MetricOptions.JobStatusMetrics.CURRENT_TIME,
+            MetricOptions.JobStatusMetrics.TOTAL_TIME);
 
     @Test
     void testInitialValues() {
@@ -76,6 +76,25 @@ class DeploymentStateTimeMetricsTest {
         metrics.onStateUpdate(id1, ExecutionState.SCHEDULED, ExecutionState.DEPLOYING);
         metrics.onStateUpdate(id1, ExecutionState.DEPLOYING, ExecutionState.INITIALIZING);
         metrics.onStateUpdate(id1, ExecutionState.INITIALIZING, ExecutionState.RUNNING);
+
+        final ExecutionAttemptID id2 = createExecutionAttemptId();
+
+        metrics.onStateUpdate(id2, ExecutionState.CREATED, ExecutionState.SCHEDULED);
+        metrics.onStateUpdate(id2, ExecutionState.SCHEDULED, ExecutionState.DEPLOYING);
+
+        assertThat(metrics.getBinary()).isEqualTo(0L);
+    }
+
+    @Test
+    void testDeploymentStart_batch_notTriggeredIfOneDeploymentIsInitializing() {
+        final DeploymentStateTimeMetrics metrics =
+                new DeploymentStateTimeMetrics(JobType.BATCH, settings);
+
+        final ExecutionAttemptID id1 = createExecutionAttemptId();
+
+        metrics.onStateUpdate(id1, ExecutionState.CREATED, ExecutionState.SCHEDULED);
+        metrics.onStateUpdate(id1, ExecutionState.SCHEDULED, ExecutionState.DEPLOYING);
+        metrics.onStateUpdate(id1, ExecutionState.DEPLOYING, ExecutionState.INITIALIZING);
 
         final ExecutionAttemptID id2 = createExecutionAttemptId();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/metrics/DeploymentStateTimeMetricsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/metrics/DeploymentStateTimeMetricsTest.java
@@ -31,13 +31,13 @@ import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.cr
 import static org.apache.flink.runtime.scheduler.metrics.StateTimeMetricTest.enable;
 import static org.assertj.core.api.Assertions.assertThat;
 
-
 class DeploymentStateTimeMetricsTest {
 
-    private static final MetricOptions.JobStatusMetricsSettings settings = enable(
-            MetricOptions.JobStatusMetrics.STATE,
-            MetricOptions.JobStatusMetrics.CURRENT_TIME,
-            MetricOptions.JobStatusMetrics.TOTAL_TIME);
+    private static final MetricOptions.JobStatusMetricsSettings settings =
+            enable(
+                    MetricOptions.JobStatusMetrics.STATE,
+                    MetricOptions.JobStatusMetrics.CURRENT_TIME,
+                    MetricOptions.JobStatusMetrics.TOTAL_TIME);
 
     @Test
     void testInitialValues() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/metrics/InitializationStateTimeMetricsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/metrics/InitializationStateTimeMetricsTest.java
@@ -16,8 +16,6 @@
  */
 package org.apache.flink.runtime.scheduler.metrics;
 
-import java.time.Duration;
-
 import org.apache.flink.configuration.MetricOptions;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
@@ -26,16 +24,18 @@ import org.apache.flink.util.clock.ManualClock;
 
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
+
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.createExecutionAttemptId;
 import static org.apache.flink.runtime.scheduler.metrics.StateTimeMetricTest.enable;
 import static org.assertj.core.api.Assertions.assertThat;
 
-
 public class InitializationStateTimeMetricsTest {
-    private static final MetricOptions.JobStatusMetricsSettings settings = enable(
-            MetricOptions.JobStatusMetrics.STATE,
-            MetricOptions.JobStatusMetrics.CURRENT_TIME,
-            MetricOptions.JobStatusMetrics.TOTAL_TIME);
+    private static final MetricOptions.JobStatusMetricsSettings settings =
+            enable(
+                    MetricOptions.JobStatusMetrics.STATE,
+                    MetricOptions.JobStatusMetrics.CURRENT_TIME,
+                    MetricOptions.JobStatusMetrics.TOTAL_TIME);
 
     @Test
     void testInitialValues() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/metrics/InitializationStateTimeMetricsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/metrics/InitializationStateTimeMetricsTest.java
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.flink.runtime.scheduler.metrics;
 
 import org.apache.flink.configuration.MetricOptions;
@@ -30,6 +31,10 @@ import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.cr
 import static org.apache.flink.runtime.scheduler.metrics.StateTimeMetricTest.enable;
 import static org.assertj.core.api.Assertions.assertThat;
 
+
+/**
+ * Tests for InitializationStateTimeMetrics
+ */
 public class InitializationStateTimeMetricsTest {
     private static final MetricOptions.JobStatusMetricsSettings settings =
             enable(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/metrics/InitializationStateTimeMetricsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/metrics/InitializationStateTimeMetricsTest.java
@@ -32,11 +32,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 
 public class InitializationStateTimeMetricsTest {
-    private static final MetricOptions.JobStatusMetricsSettings settings =
-            enable(
-                    MetricOptions.JobStatusMetrics.STATE,
-                    MetricOptions.JobStatusMetrics.CURRENT_TIME,
-                    MetricOptions.JobStatusMetrics.TOTAL_TIME);
+    private static final MetricOptions.JobStatusMetricsSettings settings = enable(
+            MetricOptions.JobStatusMetrics.STATE,
+            MetricOptions.JobStatusMetrics.CURRENT_TIME,
+            MetricOptions.JobStatusMetrics.TOTAL_TIME);
 
     @Test
     void testInitialValues() {


### PR DESCRIPTION
This commit introduces a new metric to track the time that a job spends in initializing. Existing deployment state time metrics are modified to identify this new state.

ExecutionGraphFactory API is expanded a bit to allow future state time metrics to be added a bit more easily.