### PR TITLE
[FLINK-27964][python] Support Cassandra connector in Python DataStream API

### DIFF
--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/SimpleMapperOptions.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/SimpleMapperOptions.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.cassandra;
+
+import com.datastax.driver.core.ConsistencyLevel;
+import com.datastax.driver.core.ProtocolVersion;
+import com.datastax.driver.mapping.Mapper;
+
+import java.util.ArrayList;
+
+/** A simple MapperOptions implement which is currently used in PyFlink Cassandra connector. */
+public class SimpleMapperOptions implements MapperOptions {
+
+    private static final long serialVersionUID = 1L;
+    ArrayList<Mapper.Option> options;
+
+    public SimpleMapperOptions() {
+        options = new ArrayList<>();
+    }
+
+    /**
+     * Creates a new SimpleMapperOptions object to add time-to-live to a mapper operation. This is
+     * only valid for save operations.
+     *
+     * <p>Note that this option is only available if using {@link ProtocolVersion#V2} or above.
+     *
+     * @param ttl the TTL (in seconds).
+     * @return the SimpleMapperOptions.
+     */
+    public SimpleMapperOptions ttl(int ttl) {
+        options.add(Mapper.Option.ttl(ttl));
+        return this;
+    }
+
+    /**
+     * Creates a new SimpleMapperOptions object to add a timestamp to a mapper operation. This is
+     * only valid for save and delete operations.
+     *
+     * <p>Note that this option is only available if using {@link ProtocolVersion#V2} or above.
+     *
+     * @param timestamp the timestamp (in microseconds).
+     * @return the SimpleMapperOptions.
+     */
+    public SimpleMapperOptions timestamp(long timestamp) {
+        options.add(Mapper.Option.timestamp(timestamp));
+        return this;
+    }
+
+    /**
+     * Creates a new SimpleMapperOptions object to add a consistency level value to a mapper
+     * operation. This is valid for save, delete and get operations.
+     *
+     * <p>Note that the consistency level can also be defined at the mapper level, as a parameter of
+     * the {@link com.datastax.driver.mapping.annotations.Table} annotation (this is redundant for
+     * backward compatibility). This option, whether defined on a specific call or as the default,
+     * will always take precedence over the annotation.
+     *
+     * @param cl the {@link com.datastax.driver.core.ConsistencyLevel} to use for the operation.
+     * @return the SimpleMapperOptions.
+     */
+    public SimpleMapperOptions consistencyLevel(ConsistencyLevel cl) {
+        options.add(Mapper.Option.consistencyLevel(cl));
+        return this;
+    }
+
+    /**
+     * Creates a new SimpleMapperOptions object to enable query tracing for a mapper operation. This
+     * is valid for save, delete and get operations.
+     *
+     * @param enabled whether to enable tracing.
+     * @return the SimpleMapperOptions.
+     */
+    public SimpleMapperOptions tracing(boolean enabled) {
+        options.add(Mapper.Option.tracing(enabled));
+        return this;
+    }
+
+    /**
+     * Creates a new SimpleMapperOptions object to specify whether null entity fields should be
+     * included in insert queries. This option is valid only for save operations.
+     *
+     * <p>If this option is not specified, it defaults to {@code true} (null fields are saved).
+     *
+     * @param enabled whether to include null fields in queries.
+     * @return the SimpleMapperOptions.
+     */
+    public SimpleMapperOptions saveNullFields(boolean enabled) {
+        options.add(Mapper.Option.saveNullFields(enabled));
+        return this;
+    }
+
+    /**
+     * Creates a new SimpleMapperOptions object to specify whether an IF NOT EXISTS clause should be
+     * included in insert queries. This option is valid only for save operations.
+     *
+     * <p>If this option is not specified, it defaults to {@code false} (IF NOT EXISTS statements
+     * are not used).
+     *
+     * @param enabled whether to include an IF NOT EXISTS clause in queries.
+     * @return the SimpleMapperOptions.
+     */
+    public SimpleMapperOptions ifNotExists(boolean enabled) {
+        options.add(Mapper.Option.ifNotExists(enabled));
+        return this;
+    }
+
+    /**
+     * Returns an array of {@link com.datastax.driver.mapping.Mapper.Option} that are used configure
+     * the mapper.
+     *
+     * @return array of options used to configure the mapper.
+     */
+    @Override
+    public Mapper.Option[] getMapperOptions() {
+        return new Mapper.Option[options.size()];
+    }
+}

--- a/flink-python/pyflink/datastream/connectors/__init__.py
+++ b/flink-python/pyflink/datastream/connectors/__init__.py
@@ -32,6 +32,7 @@ from pyflink.datastream.connectors.pulsar import PulsarDeserializationSchema, Pu
 from pyflink.datastream.connectors.rabbitmq import RMQConnectionConfig, RMQSource, RMQSink
 from pyflink.datastream.connectors.kinesis import (FlinkKinesisConsumer, KinesisStreamsSink,
                                                    KinesisFirehoseSink)
+from pyflink.datastream.connectors.cassandra import CassandraSink
 
 
 __all__ = [
@@ -73,5 +74,6 @@ __all__ = [
     'KinesisStreamsSink',
     'KinesisFirehoseSink',
     'Elasticsearch6SinkBuilder',
-    'Elasticsearch7SinkBuilder'
+    'Elasticsearch7SinkBuilder',
+    'CassandraSink'
 ]

--- a/flink-python/pyflink/datastream/connectors/cassandra.py
+++ b/flink-python/pyflink/datastream/connectors/cassandra.py
@@ -1,0 +1,370 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+from enum import Enum
+
+from pyflink.common import Duration
+from pyflink.java_gateway import get_gateway
+
+
+# ---- Classes introduced to construct the MapperOptions ----
+
+
+class ConsistencyLevel(Enum):
+    """
+    The consistency level
+    """
+    ANY = 0
+    ONE = 1
+    TWO = 2
+    THREE = 3
+    QUORUM = 4
+    ALL = 5
+    LOCAL_QUORUM = 6
+    EACH_QUORUM = 7
+    SERIAL = 8
+    LOCAL_SERIAL = 9
+    LOCAL_ONE = 10
+
+    def _to_j_consistency_level(self):
+        JConsistencyLevel = get_gateway().jvm.com.datastax.driver.core.ConsistencyLevel
+        return getattr(JConsistencyLevel, self.name)
+
+
+# ---- Classes introduced to construct the CassandraSink ----
+
+
+class MapperOptions(object):
+    """
+    This class is used to configure a Mapper after deployment.
+    """
+
+    def __init__(self, j_mapper_options):
+        self._j_mapper_options = j_mapper_options
+
+    @staticmethod
+    def simple_mapper_options() -> 'MapperOptions':
+        """
+        A simple method to construct MapperOptions.
+
+        Example:
+        ::
+
+        >>> mapper_option = MapperOptions.simple_mapper_options() \\
+        ...    .ttl(1800) \\
+        ...    .timestamp(3600) \\
+        ...    .consistency_level(ConsistencyLevel.ANY) \\
+        ...    .tracing(True) \\
+        ...    .save_null_fields(True)
+        """
+        JSimpleMapperOptions = get_gateway().jvm.org.apache.flink.streaming.connectors. \
+            cassandra.SimpleMapperOptions
+        return MapperOptions(JSimpleMapperOptions())
+
+    def ttl(self, ttl: int) -> 'MapperOptions':
+        """
+        Creates a new Option object to add time-to-live to a mapper operation. This is only
+        valid for save operations.
+        """
+        self._j_mapper_options.ttl = ttl
+        return self
+
+    def timestamp(self, timestamp: int) -> 'MapperOptions':
+        """
+        Creates a new Option object to add a timestamp to a mapper operation. This is only
+        valid for save and delete operations.
+        """
+        self._j_mapper_options.timestamp = timestamp
+        return self
+
+    def consistency_level(self, cl: ConsistencyLevel) -> 'MapperOptions':
+        """
+        Creates a new Option object to add a consistency level value to a mapper operation.
+        This is valid for save, delete and get operations.
+        """
+        self._j_mapper_options.consistencyLevel(cl._to_j_consistency_level())
+        return self
+
+    def tracing(self, enabled: bool) -> 'MapperOptions':
+        """
+        Creates a new Option object to enable query tracing for a mapper operation. This is
+        valid for save, delete and get operations.
+        """
+        self._j_mapper_options.tracing(enabled)
+        return self
+
+    def save_null_fields(self, enabled: bool) -> 'MapperOptions':
+        """
+        Creates a new Option object to specify whether null entity fields should be included in
+        insert queries. This option is valid only for save operations.
+        """
+        self._j_mapper_options.saveNullFields(enabled)
+        return self
+
+    def if_not_exists(self, enabled: bool) -> 'MapperOptions':
+        """
+        Creates a new Option object to specify whether an IF NOT EXISTS clause should be included in
+        insert queries. This option is valid only for save operations.
+
+        If this option is not specified, it defaults to false (IF NOT EXISTS statements are not
+        used).
+        """
+        self._j_mapper_options.ifNotExists(enabled)
+        return self
+
+
+class ClusterBuilder(object):
+    """
+    This class is used to configure a Cluster after deployment. The cluster represents the
+    connection that will be established to Cassandra.
+    """
+
+    def __init__(self, j_cluster_builder):
+        self._j_cluster_builder = j_cluster_builder
+
+
+class CassandraCommitter(object):
+    """
+    CheckpointCommitter that saves information about completed checkpoints within a separate table
+    in a cassandra database.
+    """
+
+    def __init__(self, j_checkpoint_committer):
+        self._j_checkpoint_committer = j_checkpoint_committer
+
+    @staticmethod
+    def default_checkpoint_committer(builder: ClusterBuilder, key_space: str = None) \
+            -> 'CassandraCommitter':
+        """
+        CheckpointCommitter that saves information about completed checkpoints within a separate
+        table in a cassandra database.
+        """
+        JCassandraCommitter = get_gateway().jvm.org.apache.flink.streaming.connectors.\
+            cassandra.CassandraCommitter
+        if key_space is None:
+            j_checkpoint_committer = JCassandraCommitter(builder._j_cluster_builder)
+        else:
+            j_checkpoint_committer = JCassandraCommitter(builder._j_cluster_builder, key_space)
+        return CassandraCommitter(j_checkpoint_committer)
+
+
+class CassandraFailureHandler(object):
+    """
+    Handle a failed Throwable.
+    """
+
+    def __init__(self, j_cassandra_failure_handler):
+        self._j_cassandra_failure_handler = j_cassandra_failure_handler
+
+    @staticmethod
+    def default_failure_handler() -> 'CassandraFailureHandler':
+        """
+        A CassandraFailureHandler that simply fails the sink on any failures.
+        """
+        return CassandraFailureHandler(get_gateway().jvm.org.apache.flink.streaming.connectors.
+                                       cassandra.NoOpCassandraFailureHandler())
+
+
+# ---- CassandraSink ----
+
+
+class CassandraSink(object):
+    """
+    Sets the ClusterBuilder for this sink. A ClusterBuilder is used to configure the connection to
+    cassandra.
+    """
+
+    def __init__(self, j_cassandra_sink):
+        self._j_cassandra_sink = j_cassandra_sink
+
+    def name(self, name: str) -> 'CassandraSink':
+        """
+        Set the name of this sink. This name is used by the visualization and logging during
+        runtime.
+        """
+        self._j_cassandra_sink.name(name)
+        return self
+
+    def uid(self, uid: str) -> 'CassandraSink':
+        """
+        Sets an ID for this operator. The specified ID is used to assign the same operator ID
+        across job submissions (for example when starting a job from a savepoint).
+        Note that this ID needs to be unique per transformation and job. Otherwise, job submission
+        will fail.
+        """
+        self._j_cassandra_sink.uid(uid)
+        return self
+
+    def set_uid_hash(self, uid_hash: str) -> 'CassandraSink':
+        """
+        Sets an user provided hash for this operator. This will be used AS IS the create the
+        JobVertexID.
+
+        The user provided hash is an alternative to the generated hashes, that is considered when
+        identifying an operator through the default hash mechanics fails (e.g. because of changes
+        between Flink versions).
+
+        Note that this should be used as a workaround or for trouble shooting. The provided hash
+        needs to be unique per transformation and job. Otherwise, job submission will fail.
+        Furthermore, you cannot assign user-specified hash to intermediate nodes in an operator
+        chain and trying so will let your job fail.
+
+        A use case for this is in migration between Flink versions or changing the jobs in a way
+        that changes the automatically generated hashes. In this case, providing the previous hashes
+        directly through this method (e.g. obtained from old logs) can help to reestablish a lost
+        mapping from states to their target operator.
+        """
+        self._j_cassandra_sink.setUidHash(uid_hash)
+        return self
+
+    def set_parallelism(self, parallelism: int) -> 'CassandraSink':
+        """
+        Sets the parallelism for this sink. The degree must be higher than zero.
+        """
+        self._j_cassandra_sink.setParallelism(parallelism)
+        return self
+
+    def disable_chaining(self) -> 'CassandraSink':
+        """
+        Turns off chaining for this operator so thread co-location will not be used as an
+        optimization.
+        """
+        self._j_cassandra_sink.disableChaining()
+        return self
+
+    def slot_sharing_group(self, slot_sharing_group: str) -> 'CassandraSink':
+        """
+        Sets the slot sharing group of this operation. Parallel instances of operations that are in
+        the same slot sharing group will be co-located in the same TaskManager slot, if possible.
+
+        Operations inherit the slot sharing group of input operations if all input operations are in
+        the same slot sharing group and no slot sharing group was explicitly specified.
+
+        Initially an operation is in the default slot sharing group. An operation can be put into
+        the default group explicitly by setting the slot sharing group to {@code "default"}.
+        """
+        self._j_cassandra_sink.slotSharingGroup(slot_sharing_group)
+        return self
+
+    @staticmethod
+    def add_sink(input) -> 'CassandraSinkBuilder':
+        """
+        Writes a DataStream into a Cassandra database.
+        """
+        JCassandraSink = get_gateway().jvm \
+            .org.apache.flink.streaming.connectors.cassandra.CassandraSink
+        j_cassandra_sink_builder = JCassandraSink.addSink(input._j_data_stream)
+        return CassandraSink.CassandraSinkBuilder(j_cassandra_sink_builder)
+
+    class CassandraSinkBuilder(object):
+        """
+        Builder for a CassandraSink.
+        """
+
+        def __init__(self, j_cassandra_sink_builder):
+            self._j_cassandra_sink_builder = j_cassandra_sink_builder
+
+        def set_query(self, query: str) -> 'CassandraSink.CassandraSinkBuilder':
+            """
+            Sets the query that is to be executed for every record.
+            """
+            self._j_cassandra_sink_builder.setQuery(query)
+            return self
+
+        def set_default_key_space(self, key_space: str) -> 'CassandraSink.CassandraSinkBuilder':
+            """
+            Sets the keyspace to be used.
+            """
+            self._j_cassandra_sink_builder.setDefaultKeyspace(key_space)
+            return self
+
+        def set_host(self, host: str, port: int = 9042) -> 'CassandraSink.CassandraSinkBuilder':
+            """
+            Sets the cassandra host/port to connect to.
+            """
+            self._j_cassandra_sink_builder.setHost(host, port)
+            return self
+
+        def set_cluster_builder(self, builder: ClusterBuilder) \
+                -> 'CassandraSink.CassandraSinkBuilder':
+            """
+            Sets the ClusterBuilder for this sink. A ClusterBuilder is used to configure the
+            connection to cassandra.
+            """
+            self._j_cassandra_sink_builder.setClusterBuilder(builder._j_cluster_builder)
+            return self
+
+        def enable_write_ahead_log(self, committer: CassandraCommitter = None) \
+                -> 'CassandraSink.CassandraSinkBuilder':
+            """
+            Enables the write-ahead log, which allows exactly-once processing for non-deterministic
+            algorithms that use idempotent updates.
+            """
+            if committer is None:
+                self._j_cassandra_sink_builder.enableWriteAheadLog()
+            else:
+                self._j_cassandra_sink_builder.enableWriteAheadLog(
+                    committer._j_checkpoint_committer)
+            return self
+
+        def set_mapper_options(self, options: MapperOptions) \
+                -> 'CassandraSink.CassandraSinkBuilder':
+            """
+            Sets the mapper options for this sink. The mapper options are used to configure the
+            DataStax com.datastax.driver.mapping.Mapper when writing POJOs.
+            This call has no effect if the input DataStream for this sink does not contain POJOs.
+            """
+            self._j_cassandra_sink_builder.setMapperOptions(options._j_mapper_options)
+            return self
+
+        def set_failure_handler(self, failure_handler: CassandraFailureHandler) \
+                -> 'CassandraSink.CassandraSinkBuilder':
+            """
+            Sets the failure handler for this sink. The failure handler is used to provide custom
+            error handling.
+            """
+            self._j_cassandra_sink_builder.setFailureHandler(
+                failure_handler._j_cassandra_failure_handler)
+            return self
+
+        def set_max_concurrent_requests(self, max_concurrent_requests: int,
+                                        duration: Duration = None) \
+                -> 'CassandraSink.CassandraSinkBuilder':
+            """
+            Sets the maximum allowed number of concurrent requests for this sink.
+            """
+            if duration is None:
+                self._j_cassandra_sink_builder.setMaxConcurrentRequests(max_concurrent_requests)
+            else:
+                self._j_cassandra_sink_builder.setMaxConcurrentRequests(
+                    max_concurrent_requests, duration._j_duration)
+            return self
+
+        def enable_ignore_null_fields(self) -> 'CassandraSink.CassandraSinkBuilder':
+            """
+            Enables ignoring null values, treats null values as unset and avoids writing null fields
+            and creating tombstones.
+            This call has no effect if CassandraSinkBuilder.enableWriteAheadLog() is called.
+            """
+            self._j_cassandra_sink_builder.enableIgnoreNullFields()
+            return self
+
+        def build(self) -> 'CassandraSink':
+            """
+            Finalizes the configuration of this sink.
+            """
+            return CassandraSink(self._j_cassandra_sink_builder.build())

--- a/flink-python/pyflink/datastream/tests/test_connectors.py
+++ b/flink-python/pyflink/datastream/tests/test_connectors.py
@@ -32,6 +32,7 @@ from pyflink.datastream.connectors import FlinkKafkaConsumer, FlinkKafkaProducer
     RMQConnectionConfig, PulsarSource, StartCursor, PulsarDeserializationSchema, StopCursor, \
     SubscriptionType, PulsarSink, PulsarSerializationSchema, DeliveryGuarantee, TopicRoutingMode, \
     MessageDelayer, FlinkKinesisConsumer, KinesisStreamsSink, KinesisFirehoseSink
+from pyflink.datastream.connectors.cassandra import CassandraSink
 from pyflink.datastream.connectors.kinesis import PartitionKeyGenerator
 from pyflink.datastream.tests.test_util import DataStreamTestSinkFunction
 from pyflink.java_gateway import get_gateway
@@ -726,3 +727,28 @@ class FlinkKinesisTest(ConnectorTestBase):
         self.assertEqual(
             get_field_value(kinesis_firehose_sink.get_java_function(), 'deliveryStreamName'),
             'stream-1')
+
+
+class CassandraSinkTest(ConnectorTestBase):
+    @classmethod
+    def _get_jars_relative_path(cls):
+        return '/flink-connectors/flink-connector-cassandra'
+
+    def test_cassandra_sink(self):
+        type_info = Types.ROW([Types.STRING(), Types.INT()])
+        ds = self.env.from_collection([('ab', 1), ('bdc', 2), ('cfgs', 3), ('deeefg', 4)],
+                                      type_info=type_info)
+        cassandra_sink_builder = CassandraSink.add_sink(ds)
+
+        cassandra_sink = cassandra_sink_builder\
+            .set_host('localhost', 9876) \
+            .set_query('query') \
+            .enable_ignore_null_fields() \
+            .set_max_concurrent_requests(1000) \
+            .build()
+
+        cassandra_sink.name('cassandra_sink').set_parallelism(3)
+
+        plan = eval(self.env.get_execution_plan())
+        self.assertEqual("Sink: cassandra_sink", plan['nodes'][1]['type'])
+        self.assertEqual(3, plan['nodes'][1]['parallelism'])


### PR DESCRIPTION
## What is the purpose of the change

Support Cassandra connector in Python DataStream API.

## Brief change log

  - Introduces the `CassandraSink` to support sink of Cassandra connector in PyFlink.
  
## Verifying this change

  - Adds the CassandraSinkTest to verify the CassandraSink.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)