### PR TITLE
[FLINK-28036][hive] HiveInspectors should use correct writable type to create ConstantObjectInspector

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/conversion/HiveInspectors.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/conversion/HiveInspectors.java
@@ -37,6 +37,7 @@ import org.apache.flink.types.Row;
 import org.apache.hadoop.hive.common.type.HiveChar;
 import org.apache.hadoop.hive.common.type.HiveDecimal;
 import org.apache.hadoop.hive.common.type.HiveVarchar;
+import org.apache.hadoop.hive.serde2.io.ByteWritable;
 import org.apache.hadoop.hive.serde2.io.DoubleWritable;
 import org.apache.hadoop.hive.serde2.io.HiveCharWritable;
 import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
@@ -90,7 +91,7 @@ import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
 import org.apache.hadoop.hive.serde2.typeinfo.VarcharTypeInfo;
 import org.apache.hadoop.io.BooleanWritable;
-import org.apache.hadoop.io.ByteWritable;
+import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.FloatWritable;
 import org.apache.hadoop.io.IntWritable;
 import org.apache.hadoop.io.LongWritable;
@@ -442,7 +443,7 @@ public class HiveInspectors {
             case BYTE:
                 className = WritableConstantByteObjectInspector.class.getName();
                 return HiveReflectionUtils.createConstantObjectInspector(
-                        className, org.apache.hadoop.hive.serde2.io.ByteWritable.class, value);
+                        className, ByteWritable.class, value);
             case SHORT:
                 className = WritableConstantShortObjectInspector.class.getName();
                 return HiveReflectionUtils.createConstantObjectInspector(
@@ -511,7 +512,7 @@ public class HiveInspectors {
             case BINARY:
                 className = WritableConstantBinaryObjectInspector.class.getName();
                 return HiveReflectionUtils.createConstantObjectInspector(
-                        className, ByteWritable.class, value);
+                        className, BytesWritable.class, value);
             case UNKNOWN:
             case VOID:
                 // If type is null, we use the Constant String to replace

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/conversion/HiveInspectors.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/conversion/HiveInspectors.java
@@ -37,9 +37,11 @@ import org.apache.flink.types.Row;
 import org.apache.hadoop.hive.common.type.HiveChar;
 import org.apache.hadoop.hive.common.type.HiveDecimal;
 import org.apache.hadoop.hive.common.type.HiveVarchar;
+import org.apache.hadoop.hive.serde2.io.DoubleWritable;
 import org.apache.hadoop.hive.serde2.io.HiveCharWritable;
 import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
 import org.apache.hadoop.hive.serde2.io.HiveVarcharWritable;
+import org.apache.hadoop.hive.serde2.io.ShortWritable;
 import org.apache.hadoop.hive.serde2.objectinspector.ListObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.MapObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
@@ -89,11 +91,9 @@ import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
 import org.apache.hadoop.hive.serde2.typeinfo.VarcharTypeInfo;
 import org.apache.hadoop.io.BooleanWritable;
 import org.apache.hadoop.io.ByteWritable;
-import org.apache.hadoop.io.DoubleWritable;
 import org.apache.hadoop.io.FloatWritable;
 import org.apache.hadoop.io.IntWritable;
 import org.apache.hadoop.io.LongWritable;
-import org.apache.hadoop.io.ShortWritable;
 import org.apache.hadoop.io.Text;
 
 import javax.annotation.Nullable;
@@ -442,7 +442,7 @@ public class HiveInspectors {
             case BYTE:
                 className = WritableConstantByteObjectInspector.class.getName();
                 return HiveReflectionUtils.createConstantObjectInspector(
-                        className, ByteWritable.class, value);
+                        className, org.apache.hadoop.hive.serde2.io.ByteWritable.class, value);
             case SHORT:
                 className = WritableConstantShortObjectInspector.class.getName();
                 return HiveReflectionUtils.createConstantObjectInspector(

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/functions/hive/HiveGenericUDFTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/functions/hive/HiveGenericUDFTest.java
@@ -286,6 +286,53 @@ public class HiveGenericUDFTest {
         assertThat(udf.eval(result)).isEqualTo(3);
     }
 
+    @Test
+    public void testInitUDFWithConstantArguments() {
+        // test init udf with different type of constants as arguments to
+        // make sure we can get the ConstantObjectInspector normally
+
+        // test with byte type as constant argument
+        init(GenericUDFCoalesce.class, new Object[] {1}, new DataType[] {DataTypes.TINYINT()});
+        // test with short type as constant argument
+        init(GenericUDFCoalesce.class, new Object[] {1}, new DataType[] {DataTypes.SMALLINT()});
+        // test with int type as constant argument
+        init(GenericUDFCoalesce.class, new Object[] {1}, new DataType[] {DataTypes.INT()});
+        // test with long type as constant argument
+        init(GenericUDFCoalesce.class, new Object[] {1}, new DataType[] {DataTypes.BIGINT()});
+        // test with float type as constant argument
+        init(GenericUDFCoalesce.class, new Object[] {1}, new DataType[] {DataTypes.FLOAT()});
+        // test with double type as constant argument
+        init(GenericUDFCoalesce.class, new Object[] {1}, new DataType[] {DataTypes.DOUBLE()});
+        // test with string type as constant argument
+        init(GenericUDFCoalesce.class, new Object[] {"test"}, new DataType[] {DataTypes.STRING()});
+        // test with char type as constant argument
+        init(GenericUDFCoalesce.class, new Object[] {"tes"}, new DataType[] {DataTypes.CHAR(7)});
+        // test with varchar type as constant argument
+        init(GenericUDFCoalesce.class, new Object[] {"tes"}, new DataType[] {DataTypes.VARCHAR(7)});
+        // test with date type as constant argument
+        init(
+                GenericUDFCoalesce.class,
+                new Object[] {new Date(10000)},
+                new DataType[] {DataTypes.DATE()});
+        // test with timestamp type as constant argument
+        init(
+                GenericUDFCoalesce.class,
+                new Object[] {new Timestamp(10000)},
+                new DataType[] {DataTypes.TIMESTAMP()});
+
+        // test with decimal type as constant argument
+        init(
+                GenericUDFCoalesce.class,
+                new Object[] {new BigDecimal("23.45")},
+                new DataType[] {DataTypes.DECIMAL(10, 3)});
+
+        // test with binary type as constant argument
+        init(
+                GenericUDFCoalesce.class,
+                new Object[] {new byte[] {1, 2}},
+                new DataType[] {DataTypes.BYTES()});
+    }
+
     private static HiveGenericUDF init(
             Class hiveUdfClass, Object[] constantArgs, DataType[] argTypes) {
         HiveGenericUDF udf =


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
To make `HiveInspectors` use correct writable type to create ConstantObjectInspector


## Brief change log
Replace `org.apache.hadoop.io.ByteWritable`, `org.apache.hadoop.io.ShortWritable`, `org.apache.hadoop.io.DoubleWritable`  with `org.apache.hadoop.hive.serde2.io.ByteWritable`, `org.apache.hadoop.hive.serde2.io.ShortWritable`, `org.apache.hadoop.hive.serde2.io.DoubleWritable` when create `WritableConstantByteObjectInspector`, `WritableConstantShortObjectInspector`, `WritableConstantDoubleObjectInspector`.


## Verifying this change
Existing test and verification manually. 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers:  no
  - The runtime per-record code paths (performance sensitive):  no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper:  no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature?  no
  - If yes, how is the feature documented?  N/A
