### PR TITLE
[FLINK-28043][Formats][Parquet] fix "Invalid lambda deserialization" in AvroParquetReaders

### DIFF
--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/avro/AvroParquetReaders.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/avro/AvroParquetReaders.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.java.typeutils.TypeExtractor;
 import org.apache.flink.connector.file.src.reader.StreamFormat;
 import org.apache.flink.formats.avro.typeutils.AvroTypeInfo;
 import org.apache.flink.formats.avro.typeutils.GenericRecordAvroTypeInfo;
+import org.apache.flink.util.function.SerializableSupplier;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
@@ -50,7 +51,13 @@ public class AvroParquetReaders {
     public static <T extends SpecificRecordBase> StreamFormat<T> forSpecificRecord(
             final Class<T> typeClass) {
         return new AvroParquetRecordFormat<>(
-                new AvroTypeInfo<>(typeClass), () -> SpecificData.get());
+                new AvroTypeInfo<>(typeClass),
+                new SerializableSupplier<GenericData>() {
+                    @Override
+                    public GenericData get() {
+                        return SpecificData.get();
+                    }
+                });
     }
 
     /**
@@ -83,7 +90,13 @@ public class AvroParquetReaders {
         // this is a PoJo that Avo will reader via reflect de-serialization
         // for Flink, this is just a plain PoJo type
         return new AvroParquetRecordFormat<>(
-                TypeExtractor.createTypeInfo(typeClass), () -> ReflectData.get());
+                TypeExtractor.createTypeInfo(typeClass),
+                new SerializableSupplier<GenericData>() {
+                    @Override
+                    public GenericData get() {
+                        return ReflectData.get();
+                    }
+                });
     }
 
     /**
@@ -98,7 +111,13 @@ public class AvroParquetReaders {
      */
     public static StreamFormat<GenericRecord> forGenericRecord(final Schema schema) {
         return new AvroParquetRecordFormat<>(
-                new GenericRecordAvroTypeInfo(schema), () -> GenericData.get());
+                new GenericRecordAvroTypeInfo(schema),
+                new SerializableSupplier<GenericData>() {
+                    @Override
+                    public GenericData get() {
+                        return GenericData.get();
+                    }
+                });
     }
 
     // ------------------------------------------------------------------------


### PR DESCRIPTION

## What is the purpose of the change

This PR fixes "Invalid lambda deserialization" error in AvroParquetReaders when avro classes are relocated in shading, by changing lambda to anonymous class. This is for packing a bundle jar to support parquet-avro format in PyFlink.
Related issue: [MSHADE-260](https://issues.apache.org/jira/browse/MSHADE-260)

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
