### PR TITLE
[FLINK-27907][runtime] implement disk read and write logic for hybrid shuffle

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/BufferWithIdentity.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/BufferWithIdentity.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid;
+
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+
+/** Integrate the buffer with index and the channel information to which it belongs. */
+public class BufferWithIdentity {
+    private final Buffer buffer;
+
+    private final int bufferIndex;
+
+    private final int channelIndex;
+
+    public BufferWithIdentity(Buffer buffer, int bufferIndex, int channelIndex) {
+        this.buffer = buffer;
+        this.bufferIndex = bufferIndex;
+        this.channelIndex = channelIndex;
+    }
+
+    public Buffer getBuffer() {
+        return buffer;
+    }
+
+    public int getBufferIndex() {
+        return bufferIndex;
+    }
+
+    public int getChannelIndex() {
+        return channelIndex;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsMemoryDataSpiller.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsMemoryDataSpiller.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid;
+
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.partition.BufferReaderWriterUtil;
+import org.apache.flink.runtime.io.network.partition.hybrid.HsFileDataIndex.SpilledBuffer;
+
+import org.apache.flink.shaded.guava30.com.google.common.util.concurrent.ThreadFactoryBuilder;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * This component is responsible for asynchronously writing in-memory data to disk. Each spilling
+ * operation will write the disk file sequentially.
+ */
+public class HsMemoryDataSpiller implements AutoCloseable {
+    /** One thread to perform spill operation. */
+    private final ExecutorService ioExecutor =
+            Executors.newSingleThreadScheduledExecutor(
+                    new ThreadFactoryBuilder().setNameFormat("hybrid spiller thread").build());
+
+    /** File channel to write data. */
+    private final FileChannel dataFileChannel;
+
+    /** Records the current writing location. */
+    private long totalBytesWritten;
+
+    public HsMemoryDataSpiller(FileChannel dataFileChannel) {
+        this.dataFileChannel = dataFileChannel;
+    }
+
+    /**
+     * Spilling buffers to disk asynchronously.
+     *
+     * @param bufferToSpill buffers need to be spilled, must ensure that it is sorted by
+     *     (subpartitionId, bufferIndex).
+     * @return the completable future contains spilled buffers information.
+     */
+    public CompletableFuture<List<SpilledBuffer>> spillAsync(
+            List<BufferWithIdentity> bufferToSpill) {
+        CompletableFuture<List<SpilledBuffer>> spilledFuture = new CompletableFuture<>();
+        ioExecutor.execute(() -> spill(bufferToSpill, spilledFuture));
+        return spilledFuture;
+    }
+
+    /** Called in single-threaded ioExecutor. Order is guaranteed. */
+    private void spill(
+            List<BufferWithIdentity> toWrite,
+            CompletableFuture<List<SpilledBuffer>> spilledFuture) {
+        try {
+            List<SpilledBuffer> spilledBuffers = new ArrayList<>();
+            long expectedBytes = createSpilledBuffersAndGetTotalBytes(toWrite, spilledBuffers);
+            // write all buffers to file
+            writeBuffers(toWrite, expectedBytes);
+            // complete spill future when buffers are written to disk successfully.
+            // note that the ownership of these buffers is transferred to the MemoryDataManager,
+            // which controls data's life cycle.
+            // TODO update file data index and handle buffers release in future ticket.
+            spilledFuture.complete(spilledBuffers);
+        } catch (Throwable t) {
+            spilledFuture.completeExceptionally(t);
+        }
+    }
+
+    /**
+     * Compute buffer's file offset and create spilled buffers.
+     *
+     * @param toWrite for create {@link SpilledBuffer}.
+     * @param spilledBuffers receive the created {@link SpilledBuffer} by this method.
+     * @return total bytes(header size + buffer size) of all buffers to write.
+     */
+    private long createSpilledBuffersAndGetTotalBytes(
+            List<BufferWithIdentity> toWrite, List<SpilledBuffer> spilledBuffers) {
+        long expectedBytes = 0;
+        for (BufferWithIdentity bufferWithIdentity : toWrite) {
+            Buffer buffer = bufferWithIdentity.getBuffer();
+            int numBytes = buffer.readableBytes() + BufferReaderWriterUtil.HEADER_LENGTH;
+            spilledBuffers.add(
+                    new SpilledBuffer(
+                            bufferWithIdentity.getChannelIndex(),
+                            bufferWithIdentity.getBufferIndex(),
+                            totalBytesWritten + expectedBytes));
+            expectedBytes += numBytes;
+        }
+        return expectedBytes;
+    }
+
+    /** Write all buffers to disk. */
+    private void writeBuffers(List<BufferWithIdentity> bufferWithIdentities, long expectedBytes)
+            throws IOException {
+        if (bufferWithIdentities.isEmpty()) {
+            return;
+        }
+
+        ByteBuffer[] bufferWithHeaders = new ByteBuffer[2 * bufferWithIdentities.size()];
+
+        for (int i = 0; i < bufferWithIdentities.size(); i++) {
+            Buffer buffer = bufferWithIdentities.get(i).getBuffer();
+            setBufferWithHeader(buffer, bufferWithHeaders, 2 * i);
+        }
+
+        BufferReaderWriterUtil.writeBuffers(dataFileChannel, expectedBytes, bufferWithHeaders);
+        totalBytesWritten += expectedBytes;
+    }
+
+    private void setBufferWithHeader(Buffer buffer, ByteBuffer[] bufferWithHeaders, int index) {
+        ByteBuffer header = BufferReaderWriterUtil.allocatedHeaderBuffer();
+        BufferReaderWriterUtil.setByteChannelBufferHeader(buffer, header);
+
+        bufferWithHeaders[index] = header;
+        bufferWithHeaders[index + 1] = buffer.getNioBufferReadable();
+    }
+
+    @Override
+    public void close() throws Exception {
+        ioExecutor.shutdown();
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsResultPartitionReadScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsResultPartitionReadScheduler.java
@@ -1,0 +1,402 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid;
+
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.runtime.io.disk.BatchShuffleReadBufferPool;
+import org.apache.flink.runtime.io.network.buffer.BufferRecycler;
+import org.apache.flink.util.FatalExitExceptionHandler;
+import org.apache.flink.util.IOUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.concurrent.GuardedBy;
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.time.Duration;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.PriorityQueue;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeoutException;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * IO scheduler for HsResultPartition, which schedules {@link HsSubpartitionFileReaderImpl} for
+ * loading data w.r.t. their offset in the file.
+ */
+@ThreadSafe
+public class HsResultPartitionReadScheduler implements Runnable, BufferRecycler {
+    private static final Logger LOG = LoggerFactory.getLogger(HsResultPartitionReadScheduler.class);
+
+    /** Executor to run the shuffle data reading task. */
+    private final Executor ioExecutor;
+
+    /** Maximum number of buffers can be allocated by this partition reader. */
+    private final int maxRequestedBuffers;
+
+    /**
+     * Maximum time to wait when requesting read buffers from the buffer pool before throwing an
+     * exception.
+     */
+    private final Duration bufferRequestTimeout;
+
+    /** Lock used to synchronize multi-thread access to thread-unsafe fields. */
+    private final Object lock = new Object();
+
+    /**
+     * A {@link CompletableFuture} to be completed when this read scheduler including all resources
+     * is released.
+     */
+    @GuardedBy("lock")
+    private final CompletableFuture<?> releaseFuture = new CompletableFuture<>();
+
+    /** Buffer pool from which to allocate buffers for shuffle data reading. */
+    private final BatchShuffleReadBufferPool bufferPool;
+
+    private final Path dataFilePath;
+
+    private final HsFileDataIndex dataIndex;
+
+    private final HsSubpartitionFileReader.Factory fileReaderFactory;
+
+    private final HybridShuffleConfiguration hybridShuffleConfiguration;
+
+    /** All failed subpartition readers to be released. */
+    @GuardedBy("lock")
+    private final Set<HsSubpartitionFileReader> failedReaders = new HashSet<>();
+
+    /** All readers waiting to read data of different subpartitions. */
+    @GuardedBy("lock")
+    private final Set<HsSubpartitionFileReader> allReaders = new HashSet<>();
+
+    /**
+     * Whether the data reading task is currently running or not. This flag is used when trying to
+     * submit the data reading task.
+     */
+    @GuardedBy("lock")
+    private boolean isRunning;
+
+    /** Number of buffers already allocated and still not recycled by this partition reader. */
+    @GuardedBy("lock")
+    private volatile int numRequestedBuffers;
+
+    /** Whether this read scheduler has been released or not. */
+    @GuardedBy("lock")
+    private volatile boolean isReleased;
+
+    @GuardedBy("lock")
+    private FileChannel dataFileChannel;
+
+    public HsResultPartitionReadScheduler(
+            BatchShuffleReadBufferPool bufferPool,
+            Executor ioExecutor,
+            HsFileDataIndex dataIndex,
+            Path dataFilePath,
+            HsSubpartitionFileReader.Factory fileReaderFactory,
+            HybridShuffleConfiguration hybridShuffleConfiguration) {
+        this.fileReaderFactory = fileReaderFactory;
+        this.hybridShuffleConfiguration = checkNotNull(hybridShuffleConfiguration);
+        this.dataIndex = checkNotNull(dataIndex);
+        this.dataFilePath = checkNotNull(dataFilePath);
+        this.bufferPool = checkNotNull(bufferPool);
+        this.ioExecutor = checkNotNull(ioExecutor);
+        this.maxRequestedBuffers = hybridShuffleConfiguration.getMaxRequestedBuffers();
+        this.bufferRequestTimeout =
+                checkNotNull(hybridShuffleConfiguration.getBufferRequestTimeout());
+    }
+
+    @Override
+    // Note, this method is synchronized on `this`, not `lock`. The purpose here is to prevent
+    // concurrent `run()` executions. Concurrent calls to other methods are allowed.
+    public synchronized void run() {
+        int numBuffersRead = tryRead();
+        endCurrentRoundOfReading(numBuffersRead);
+    }
+
+    /** This method only called by result partition to create subpartitionFileReader. */
+    public HsSubpartitionFileReader registerNewSubpartition(
+            int subpartitionId, HsSubpartitionViewInternalOperations operation) throws IOException {
+        synchronized (lock) {
+            checkState(!isReleased, "HsResultPartitionReadScheduler is already released.");
+            lazyInitialize();
+
+            HsSubpartitionFileReader subpartitionReader =
+                    fileReaderFactory.createFileReader(
+                            subpartitionId,
+                            dataFileChannel,
+                            operation,
+                            dataIndex,
+                            hybridShuffleConfiguration.getMaxBuffersReadAhead());
+
+            allReaders.add(subpartitionReader);
+
+            mayTriggerReading();
+            return subpartitionReader;
+        }
+    }
+
+    /**
+     * Releases this read scheduler and returns a {@link CompletableFuture} which will be completed
+     * when all resources are released.
+     */
+    public CompletableFuture<?> release() {
+        synchronized (lock) {
+            if (isReleased) {
+                return releaseFuture;
+            }
+            isReleased = true;
+
+            failedReaders.addAll(allReaders);
+            List<HsSubpartitionFileReader> pendingReaders = new ArrayList<>(allReaders);
+            mayNotifyReleased();
+            failSubpartitionReaders(
+                    pendingReaders,
+                    new IllegalStateException("Result partition has been already released."));
+            return releaseFuture;
+        }
+    }
+
+    // ------------------------------------------------------------------------
+    //  Internal Methods
+    // ------------------------------------------------------------------------
+
+    /** @return number of buffers read. */
+    private int tryRead() {
+        Queue<HsSubpartitionFileReader> availableReaders = prepareAndGetAvailableReaders();
+        if (availableReaders.isEmpty()) {
+            return 0;
+        }
+
+        Queue<MemorySegment> buffers;
+        try {
+            buffers = allocateBuffers();
+        } catch (Exception exception) {
+            // fail all pending subpartition readers immediately if any exception occurs
+            failSubpartitionReaders(availableReaders, exception);
+            LOG.error("Failed to request buffers for data reading.", exception);
+            return 0;
+        }
+
+        int numBuffersAllocated = buffers.size();
+        if (numBuffersAllocated <= 0) {
+            return 0;
+        }
+
+        readData(availableReaders, buffers);
+        int numBuffersRead = numBuffersAllocated - buffers.size();
+
+        releaseBuffers(buffers);
+
+        return numBuffersRead;
+    }
+
+    @SuppressWarnings("FieldAccessNotGuarded")
+    // read-only access to volatile isReleased and numRequestedBuffers
+    private Queue<MemorySegment> allocateBuffers() throws Exception {
+        long timeoutTime = getBufferRequestTimeoutTime();
+        do {
+            List<MemorySegment> buffers = bufferPool.requestBuffers();
+            if (!buffers.isEmpty()) {
+                return new ArrayDeque<>(buffers);
+            }
+            checkState(!isReleased, "Result partition has been already released.");
+        } while (System.nanoTime() < timeoutTime
+                || System.nanoTime() < (timeoutTime = getBufferRequestTimeoutTime()));
+
+        if (numRequestedBuffers <= 0) {
+            // This is a safe net against potential deadlocks.
+            //
+            // A deadlock can happen when the downstream task needs to consume multiple result
+            // partitions (e.g., A and B) in specific order (cannot consume B before finishing
+            // consuming A). Since the reading buffer pool is shared across the TM, if B happens to
+            // take all the buffers, A cannot be consumed due to lack of buffers, which also blocks
+            // B from being consumed and releasing the buffers.
+            //
+            // The imperfect solution here is to fail all the subpartitionReaders (A), which
+            // consequently fail all the downstream tasks, unregister their other
+            // subpartitionReaders (B) and release the read buffers.
+            throw new TimeoutException(
+                    String.format(
+                            "Buffer request timeout, this means there is a fierce contention of"
+                                    + " the batch shuffle read memory, please increase '%s'.",
+                            TaskManagerOptions.NETWORK_BATCH_SHUFFLE_READ_MEMORY.key()));
+        }
+        return new ArrayDeque<>();
+    }
+
+    @GuardedBy("lock")
+    private void mayTriggerReading() {
+        assert Thread.holdsLock(lock);
+
+        if (!isRunning
+                && !allReaders.isEmpty()
+                && numRequestedBuffers + bufferPool.getNumBuffersPerRequest() <= maxRequestedBuffers
+                && numRequestedBuffers < bufferPool.getAverageBuffersPerRequester()) {
+            isRunning = true;
+            ioExecutor.execute(this);
+        }
+    }
+
+    @GuardedBy("lock")
+    private void mayNotifyReleased() {
+        assert Thread.holdsLock(lock);
+
+        if (isReleased && allReaders.isEmpty()) {
+            releaseFuture.complete(null);
+        }
+    }
+
+    private long getBufferRequestTimeoutTime() {
+        return bufferPool.getLastBufferOperationTimestamp() + bufferRequestTimeout.toNanos();
+    }
+
+    private void releaseBuffers(Queue<MemorySegment> buffers) {
+        if (!buffers.isEmpty()) {
+            try {
+                bufferPool.recycle(buffers);
+                buffers.clear();
+            } catch (Throwable throwable) {
+                // this should never happen so just trigger fatal error
+                FatalExitExceptionHandler.INSTANCE.uncaughtException(
+                        Thread.currentThread(), throwable);
+            }
+        }
+    }
+
+    private Queue<HsSubpartitionFileReader> prepareAndGetAvailableReaders() {
+        synchronized (lock) {
+            if (isReleased) {
+                return new ArrayDeque<>();
+            }
+
+            for (HsSubpartitionFileReader reader : allReaders) {
+                reader.prepareForScheduling();
+            }
+            return new PriorityQueue<>(allReaders);
+        }
+    }
+
+    private void readData(
+            Queue<HsSubpartitionFileReader> availableReaders, Queue<MemorySegment> buffers) {
+        while (!availableReaders.isEmpty() && !buffers.isEmpty()) {
+            HsSubpartitionFileReader subpartitionReader = availableReaders.poll();
+            try {
+                subpartitionReader.readBuffers(buffers, this);
+            } catch (IOException throwable) {
+                failSubpartitionReaders(Collections.singletonList(subpartitionReader), throwable);
+                LOG.debug("Failed to read shuffle data.", throwable);
+            }
+        }
+    }
+
+    private void failSubpartitionReaders(
+            Collection<HsSubpartitionFileReader> readers, Throwable failureCause) {
+        synchronized (lock) {
+            failedReaders.addAll(readers);
+        }
+
+        for (HsSubpartitionFileReader reader : readers) {
+            reader.fail(failureCause);
+        }
+    }
+
+    private void endCurrentRoundOfReading(int numBuffersRead) {
+        synchronized (lock) {
+            removeFailedReaders();
+            numRequestedBuffers += numBuffersRead;
+            isRunning = false;
+            mayTriggerReading();
+            mayNotifyReleased();
+        }
+    }
+
+    @GuardedBy("lock")
+    private void removeFailedReaders() {
+        assert Thread.holdsLock(lock);
+
+        for (HsSubpartitionFileReader reader : failedReaders) {
+            allReaders.remove(reader);
+        }
+        failedReaders.clear();
+
+        if (allReaders.isEmpty()) {
+            bufferPool.unregisterRequester(this);
+            closeFileChannel();
+        }
+    }
+
+    @GuardedBy("lock")
+    private void lazyInitialize() throws IOException {
+        assert Thread.holdsLock(lock);
+        try {
+            if (allReaders.isEmpty()) {
+                dataFileChannel = openFileChannel(dataFilePath);
+                bufferPool.registerRequester(this);
+            }
+        } catch (IOException exception) {
+            if (allReaders.isEmpty()) {
+                bufferPool.unregisterRequester(this);
+                closeFileChannel();
+            }
+            throw exception;
+        }
+    }
+
+    private FileChannel openFileChannel(Path path) throws IOException {
+        return FileChannel.open(path, StandardOpenOption.READ);
+    }
+
+    @GuardedBy("lock")
+    private void closeFileChannel() {
+        assert Thread.holdsLock(lock);
+
+        IOUtils.closeQuietly(dataFileChannel);
+        dataFileChannel = null;
+    }
+
+    // ------------------------------------------------------------------------
+    //  Implementation Methods of BufferRecycler
+    // ------------------------------------------------------------------------
+
+    @Override
+    public void recycle(MemorySegment segment) {
+        synchronized (lock) {
+            bufferPool.recycle(segment);
+            --numRequestedBuffers;
+
+            mayTriggerReading();
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionFileReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionFileReader.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid;
+
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.runtime.io.network.buffer.BufferRecycler;
+
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.util.Queue;
+
+/**
+ * This component is responsible for reading data from disk for a specific subpartition.
+ *
+ * <p>In order to access the disk as sequentially as possible {@link HsSubpartitionFileReader} need
+ * to be able to compare priorities.
+ */
+public interface HsSubpartitionFileReader extends Comparable<HsSubpartitionFileReader> {
+    /** Do prep work before this {@link HsSubpartitionFileReader} is scheduled to read data. */
+    void prepareForScheduling();
+
+    /**
+     * Read data from disk.
+     *
+     * @param buffers for reading, note that the ownership of the buffer taken out from the queue is
+     *     transferred to this class, and the unused buffer must be returned.
+     * @param recycler to return buffer to read buffer pool.
+     */
+    void readBuffers(Queue<MemorySegment> buffers, BufferRecycler recycler) throws IOException;
+
+    /**
+     * Fail this {@link HsSubpartitionFileReader} caused by failureCause.
+     *
+     * @param failureCause represents the reason why it failed.
+     */
+    void fail(Throwable failureCause);
+
+    /** Factory to create {@link HsSubpartitionFileReader} */
+    interface Factory {
+        HsSubpartitionFileReader createFileReader(
+                int subpartitionId,
+                FileChannel dataFileChannel,
+                HsSubpartitionViewInternalOperations operation,
+                HsFileDataIndex dataIndex,
+                int maxBuffersReadAhead);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionFileReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionFileReader.java
@@ -51,7 +51,7 @@ public interface HsSubpartitionFileReader extends Comparable<HsSubpartitionFileR
      */
     void fail(Throwable failureCause);
 
-    /** Factory to create {@link HsSubpartitionFileReader} */
+    /** Factory to create {@link HsSubpartitionFileReader}. */
     interface Factory {
         HsSubpartitionFileReader createFileReader(
                 int subpartitionId,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionFileReaderImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionFileReaderImpl.java
@@ -1,0 +1,410 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.BufferRecycler;
+import org.apache.flink.runtime.io.network.partition.BufferReaderWriterUtil;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.util.Deque;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.concurrent.LinkedBlockingDeque;
+
+import static org.apache.flink.runtime.io.network.partition.BufferReaderWriterUtil.positionToNextBuffer;
+import static org.apache.flink.runtime.io.network.partition.BufferReaderWriterUtil.readFromByteChannel;
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * Default implementation of {@link HsSubpartitionFileReader}.
+ *
+ * <p>Note: This class is not thread safe.
+ */
+public class HsSubpartitionFileReaderImpl implements HsSubpartitionFileReader {
+
+    private final ByteBuffer headerBuf = BufferReaderWriterUtil.allocatedHeaderBuffer();
+
+    private final int subpartitionId;
+
+    private final FileChannel dataFileChannel;
+
+    private final HsSubpartitionViewInternalOperations operations;
+
+    private final CachedRegionManager cachedRegionManager;
+
+    private final BufferIndexManager bufferIndexManager;
+
+    private final Deque<BufferIndexOrError> loadedBuffers = new LinkedBlockingDeque<>();
+
+    private volatile boolean isFailed;
+
+    public HsSubpartitionFileReaderImpl(
+            int subpartitionId,
+            FileChannel dataFileChannel,
+            HsSubpartitionViewInternalOperations operations,
+            HsFileDataIndex dataIndex,
+            int maxBufferReadAhead) {
+        this.subpartitionId = subpartitionId;
+        this.dataFileChannel = dataFileChannel;
+        this.operations = operations;
+        this.bufferIndexManager = new BufferIndexManager(maxBufferReadAhead);
+        this.cachedRegionManager = new CachedRegionManager(subpartitionId, dataIndex);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        HsSubpartitionFileReaderImpl that = (HsSubpartitionFileReaderImpl) o;
+        return subpartitionId == that.subpartitionId;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(subpartitionId);
+    }
+
+    /**
+     * Read subpartition data into buffers.
+     *
+     * <p>This transfers the ownership of used buffers to this class. It's this class'
+     * responsibility to release the buffers using the recycler when no longer needed.
+     *
+     * <p>Calling this method does not always use up all the provided buffers. It's this class'
+     * decision when to stop reading. Currently, it stops reading when: 1) buffers are used up, or
+     * 2) reaches the end of the subpartition data within the region, or 3) enough data have been
+     * read ahead the downstream consuming offset.
+     */
+    @Override
+    public synchronized void readBuffers(Queue<MemorySegment> buffers, BufferRecycler recycler)
+            throws IOException {
+        if (isFailed) {
+            throw new IOException("subpartition reader has already failed.");
+        }
+        int firstBufferToLoad = bufferIndexManager.getNextToLoad();
+        if (firstBufferToLoad < 0) {
+            return;
+        }
+
+        // If lookup result is empty, it means that one the following things have happened:
+        // 1) The target buffer has not been spilled into disk.
+        // 2) The target buffer has not been released from memory.
+        // So, just skip this round reading.
+        int numRemainingBuffer = cachedRegionManager.getRemainingBuffersInRegion(firstBufferToLoad);
+        if (numRemainingBuffer == 0) {
+            return;
+        }
+        moveFileOffsetToBuffer(firstBufferToLoad);
+
+        int indexToLoad;
+        int numLoaded = 0;
+        while (!buffers.isEmpty()
+                && (indexToLoad = bufferIndexManager.getNextToLoad()) >= 0
+                && numRemainingBuffer-- > 0) {
+            MemorySegment segment = buffers.poll();
+            Buffer buffer;
+            try {
+                if ((buffer = readFromByteChannel(dataFileChannel, headerBuf, segment, recycler))
+                        == null) {
+                    buffers.add(segment);
+                    break;
+                }
+            } catch (Throwable throwable) {
+                buffers.add(segment);
+                throw throwable;
+            }
+
+            loadedBuffers.add(BufferIndexOrError.newBuffer(buffer, indexToLoad));
+            bufferIndexManager.updateLastLoaded(indexToLoad);
+            cachedRegionManager.advance(
+                    buffer.readableBytes() + BufferReaderWriterUtil.HEADER_LENGTH);
+            ++numLoaded;
+        }
+
+        if (loadedBuffers.size() <= numLoaded) {
+            operations.notifyDataAvailableFromDisk();
+        }
+    }
+
+    @Override
+    public synchronized void fail(Throwable failureCause) {
+        if (isFailed) {
+            return;
+        }
+        isFailed = true;
+        BufferIndexOrError bufferIndexOrError;
+        // empty from tail, in-case subpartition view consumes concurrently and gets the wrong order
+        while ((bufferIndexOrError = loadedBuffers.pollLast()) != null) {
+            if (bufferIndexOrError.getBuffer().isPresent()) {
+                checkNotNull(bufferIndexOrError.buffer).recycleBuffer();
+            }
+        }
+
+        loadedBuffers.add(BufferIndexOrError.newError(failureCause));
+        operations.notifyDataAvailableFromDisk();
+    }
+
+    /** Refresh downstream consumption progress for another round scheduling of reading. */
+    @Override
+    public void prepareForScheduling() {
+        bufferIndexManager.updateLastConsumed(operations.getConsumingOffset());
+    }
+
+    /** Provides priority calculation logic for io scheduler. */
+    @Override
+    public int compareTo(HsSubpartitionFileReader that) {
+        checkArgument(that instanceof HsSubpartitionFileReaderImpl);
+        return Long.compare(
+                getNextOffsetToLoad(), ((HsSubpartitionFileReaderImpl) that).getNextOffsetToLoad());
+    }
+
+    public Deque<BufferIndexOrError> getLoadedBuffers() {
+        return loadedBuffers;
+    }
+
+    // ------------------------------------------------------------------------
+    //  Internal Methods
+    // ------------------------------------------------------------------------
+
+    private void moveFileOffsetToBuffer(int bufferIndex) throws IOException {
+        Tuple2<Integer, Long> indexAndOffset =
+                cachedRegionManager.getNumSkipAndFileOffset(bufferIndex);
+        dataFileChannel.position(indexAndOffset.f1);
+        for (int i = 0; i < indexAndOffset.f0; ++i) {
+            positionToNextBuffer(dataFileChannel, headerBuf);
+        }
+        cachedRegionManager.skipAll(dataFileChannel.position());
+    }
+
+    /** Returns Long.MAX_VALUE if it shouldn't load. */
+    private long getNextOffsetToLoad() {
+        int bufferIndex = bufferIndexManager.getNextToLoad();
+        if (bufferIndex < 0) {
+            return Long.MAX_VALUE;
+        } else {
+            return cachedRegionManager.getFileOffset(bufferIndex);
+        }
+    }
+
+    /** Indicates a buffer with index or an error. */
+    public static class BufferIndexOrError {
+        @Nullable private final Buffer buffer;
+        private final int index;
+        @Nullable private final Throwable throwable;
+
+        private BufferIndexOrError(
+                @Nullable Buffer buffer, int index, @Nullable Throwable throwable) {
+            this.buffer = buffer;
+            this.index = index;
+            this.throwable = throwable;
+        }
+
+        public Buffer.DataType getDataType() {
+            return buffer == null ? Buffer.DataType.NONE : buffer.getDataType();
+        }
+
+        private static BufferIndexOrError newError(Throwable throwable) {
+            return new BufferIndexOrError(null, -1, checkNotNull(throwable));
+        }
+
+        private static BufferIndexOrError newBuffer(Buffer buffer, int index) {
+            return new BufferIndexOrError(checkNotNull(buffer), index, null);
+        }
+
+        public Optional<Buffer> getBuffer() {
+            return Optional.ofNullable(buffer);
+        }
+
+        public Optional<Throwable> getThrowable() {
+            return Optional.ofNullable(throwable);
+        }
+
+        public int getIndex() {
+            checkNotNull(buffer);
+            return index;
+        }
+    }
+
+    /** Take care of buffer index consumed by the file reader. */
+    static class BufferIndexManager {
+        private final int maxBuffersReadAhead;
+
+        /** Index of the last buffer that has ever been loaded from file. */
+        private int lastLoaded = -1;
+        /** Index of the last buffer that has been consumed by downstream, to the best knowledge. */
+        private int lastConsumed = -1;
+
+        BufferIndexManager(int maxBuffersReadAhead) {
+            this.maxBuffersReadAhead = maxBuffersReadAhead;
+        }
+
+        private void updateLastLoaded(int lastLoaded) {
+            checkState(this.lastLoaded <= lastLoaded);
+            this.lastLoaded = lastLoaded;
+        }
+
+        private void updateLastConsumed(int lastConsumed) {
+            this.lastConsumed = lastConsumed;
+        }
+
+        /** Returns a negative value if shouldn't load. */
+        private int getNextToLoad() {
+            int nextToLoad = Math.max(lastLoaded, lastConsumed) + 1;
+            int maxToLoad = lastConsumed + maxBuffersReadAhead;
+            return nextToLoad <= maxToLoad ? nextToLoad : -1;
+        }
+    }
+
+    /**
+     * Maintains a set of cursors on the last fetched readable region.
+     *
+     * <p>The semantics are:
+     *
+     * <ol>
+     *   <li>The offset of the buffer with {@code currentBufferIndex} in file can be derived by
+     *       starting from {@code offset} and skipping {@code numSkip} buffers.
+     *   <li>The {@code numReadable} continuous buffers starting from the offset of the buffer with
+     *       {@code currentBufferIndex} belongs to the same readable region.
+     * </ol>
+     */
+    private static class CachedRegionManager {
+        private final int subpartitionId;
+        private final HsFileDataIndex dataIndex;
+
+        private int currentBufferIndex;
+        private int numSkip;
+        private int numReadable;
+        private long offset;
+
+        private CachedRegionManager(int subpartitionId, HsFileDataIndex dataIndex) {
+            this.subpartitionId = subpartitionId;
+            this.dataIndex = dataIndex;
+        }
+
+        // ------------------------------------------------------------------------
+        //  Called by HsSubpartitionFileReader
+        // ------------------------------------------------------------------------
+
+        /** Return Long.MAX_VALUE if region does not exist to giving the lowest priority. */
+        private long getFileOffset(int bufferIndex) {
+            updateCachedRegionIfNeeded(bufferIndex);
+            return currentBufferIndex == -1 ? Long.MAX_VALUE : offset;
+        }
+
+        private int getRemainingBuffersInRegion(int bufferIndex) {
+            updateCachedRegionIfNeeded(bufferIndex);
+
+            return numReadable;
+        }
+
+        private void skipAll(long newOffset) {
+            this.offset = newOffset;
+            this.numSkip = 0;
+        }
+
+        /**
+         * Maps the given buffer index to the offset in file.
+         *
+         * @return a tuple of {@code <numSkip,offset>}. The offset of the given buffer index can be
+         *     derived by starting from the {@code offset} and skipping {@code numSkip} buffers.
+         */
+        private Tuple2<Integer, Long> getNumSkipAndFileOffset(int bufferIndex) {
+            updateCachedRegionIfNeeded(bufferIndex);
+
+            checkState(numSkip >= 0, "num skip must be greater than or equal to 0");
+            // Assumption: buffer index is always requested / updated increasingly
+            checkState(currentBufferIndex <= bufferIndex);
+            return new Tuple2<>(numSkip, offset);
+        }
+
+        private void advance(long bufferSize) {
+            if (isInCachedRegion(currentBufferIndex + 1)) {
+                currentBufferIndex++;
+                numReadable--;
+                offset += bufferSize;
+            }
+        }
+
+        // ------------------------------------------------------------------------
+        //  Internal Methods
+        // ------------------------------------------------------------------------
+
+        /** Points the cursors to the given buffer index, if possible. */
+        private void updateCachedRegionIfNeeded(int bufferIndex) {
+            if (isInCachedRegion(bufferIndex)) {
+                int numAdvance = bufferIndex - currentBufferIndex;
+                numSkip += numAdvance;
+                numReadable -= numAdvance;
+                currentBufferIndex = bufferIndex;
+                return;
+            }
+
+            Optional<HsFileDataIndex.ReadableRegion> lookupResultOpt =
+                    dataIndex.getReadableRegion(subpartitionId, bufferIndex);
+            if (!lookupResultOpt.isPresent()) {
+                currentBufferIndex = -1;
+                numReadable = 0;
+                numSkip = 0;
+                offset = -1L;
+            } else {
+                HsFileDataIndex.ReadableRegion cachedRegion = lookupResultOpt.get();
+                currentBufferIndex = bufferIndex;
+                numSkip = cachedRegion.numSkip;
+                numReadable = cachedRegion.numReadable;
+                offset = cachedRegion.offset;
+            }
+        }
+
+        private boolean isInCachedRegion(int bufferIndex) {
+            return bufferIndex < currentBufferIndex + numReadable
+                    && bufferIndex >= currentBufferIndex;
+        }
+    }
+
+    public static class Factory implements HsSubpartitionFileReader.Factory {
+        public static final Factory INSTANCE = new Factory();
+
+        private Factory() {}
+
+        @Override
+        public HsSubpartitionFileReader createFileReader(
+                int subpartitionId,
+                FileChannel dataFileChannel,
+                HsSubpartitionViewInternalOperations operation,
+                HsFileDataIndex dataIndex,
+                int maxBuffersReadAhead) {
+            return new HsSubpartitionFileReaderImpl(
+                    subpartitionId, dataFileChannel, operation, dataIndex, maxBuffersReadAhead);
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionFileReaderImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionFileReaderImpl.java
@@ -250,7 +250,7 @@ public class HsSubpartitionFileReaderImpl implements HsSubpartitionFileReader {
         }
 
         public int getIndex() {
-            checkNotNull(buffer);
+            checkNotNull(buffer, "Is error, cannot get index.");
             return index;
         }
     }
@@ -391,6 +391,7 @@ public class HsSubpartitionFileReaderImpl implements HsSubpartitionFileReader {
         }
     }
 
+    /** Factory of {@link HsSubpartitionFileReader}. */
     public static class Factory implements HsSubpartitionFileReader.Factory {
         public static final Factory INSTANCE = new Factory();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionViewInternalOperations.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionViewInternalOperations.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid;
+
+/**
+ * Operations provided by HsSubpartitionView that are used by other internal components of hybrid
+ * result partition.
+ */
+public interface HsSubpartitionViewInternalOperations {
+
+    /** Callback for new data become available from disk. */
+    void notifyDataAvailableFromDisk();
+
+    /** Get the latest consuming offset of the subpartition. */
+    int getConsumingOffset();
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HybridShuffleConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HybridShuffleConfiguration.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid;
+
+import java.time.Duration;
+
+/** Configuration for hybrid shuffle mode. */
+public class HybridShuffleConfiguration {
+    private static final int MAX_BUFFERS_READ_AHEAD = 5;
+    private static final Duration DEFAULT_BUFFER_REQUEST_TIMEOUT = Duration.ofMillis(5);
+
+    private final int maxBuffersReadAhead;
+
+    private final Duration bufferRequestTimeout;
+
+    private final int maxRequestedBuffers;
+
+    public HybridShuffleConfiguration(
+            int maxBuffersReadAhead, Duration bufferRequestTimeout, int maxRequestedBuffers) {
+        this.maxBuffersReadAhead = maxBuffersReadAhead;
+        this.bufferRequestTimeout = bufferRequestTimeout;
+        this.maxRequestedBuffers = maxRequestedBuffers;
+    }
+
+    /**
+     * Temporarily adopt a fixed value, and then adjust the default value according to the
+     * experiment, and introduce configuration options.
+     */
+    public static HybridShuffleConfiguration createConfiguration(
+            int numSubpartitions, int numBuffersPerRequest, Duration bufferRequestTimeout) {
+        final int maxRequestedBuffers = Math.max(2 * numBuffersPerRequest, numSubpartitions);
+        return new HybridShuffleConfiguration(
+                MAX_BUFFERS_READ_AHEAD, bufferRequestTimeout, maxRequestedBuffers);
+    }
+
+    public static HybridShuffleConfiguration createConfiguration(
+            int numSubpartitions, int numBuffersPerRequest) {
+        return createConfiguration(
+                numSubpartitions, numBuffersPerRequest, DEFAULT_BUFFER_REQUEST_TIMEOUT);
+    }
+
+    public int getMaxRequestedBuffers() {
+        return maxRequestedBuffers;
+    }
+
+    /**
+     * Determine how many buffers to read ahead at most for each subpartition to prevent other
+     * consumers from starving.
+     */
+    public int getMaxBuffersReadAhead() {
+        return maxBuffersReadAhead;
+    }
+
+    /**
+     * Maximum time to wait when requesting read buffers from the buffer pool before throwing an
+     * exception.
+     */
+    public Duration getBufferRequestTimeout() {
+        return bufferRequestTimeout;
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/BufferReaderWriterUtilTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/BufferReaderWriterUtilTest.java
@@ -23,34 +23,35 @@ import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferBuilderTestUtils;
 import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
+import org.apache.flink.util.TestLoggerExtension;
 
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileChannel.MapMode;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.util.UUID;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for the {@link BufferReaderWriterUtil}. */
-public class BufferReaderWriterUtilTest {
-
-    @ClassRule public static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();
+@ExtendWith(TestLoggerExtension.class)
+class BufferReaderWriterUtilTest {
 
     // ------------------------------------------------------------------------
     // Byte Buffer
     // ------------------------------------------------------------------------
 
     @Test
-    public void writeReadByteBuffer() {
+    void writeReadByteBuffer() {
         final ByteBuffer memory = ByteBuffer.allocateDirect(1200);
         final Buffer buffer = createTestBuffer();
 
@@ -59,34 +60,34 @@ public class BufferReaderWriterUtilTest {
         memory.flip();
         Buffer result = BufferReaderWriterUtil.sliceNextBuffer(memory);
 
-        assertEquals(pos, memory.position());
+        assertThat(memory.position()).isEqualTo(pos);
         validateTestBuffer(result);
     }
 
     @Test
-    public void writeByteBufferNotEnoughSpace() {
+    void writeByteBufferNotEnoughSpace() {
         final ByteBuffer memory = ByteBuffer.allocateDirect(10);
         final Buffer buffer = createTestBuffer();
 
         final boolean written = BufferReaderWriterUtil.writeBuffer(buffer, memory);
 
-        assertFalse(written);
-        assertEquals(0, memory.position());
-        assertEquals(memory.capacity(), memory.limit());
+        assertThat(written).isFalse();
+        assertThat(memory.position()).isZero();
+        assertThat(memory.limit()).isEqualTo(memory.capacity());
     }
 
     @Test
-    public void readFromEmptyByteBuffer() {
+    void readFromEmptyByteBuffer() {
         final ByteBuffer memory = ByteBuffer.allocateDirect(100);
         memory.position(memory.limit());
 
         final Buffer result = BufferReaderWriterUtil.sliceNextBuffer(memory);
 
-        assertNull(result);
+        assertThat(result).isNull();
     }
 
     @Test
-    public void testReadFromByteBufferNotEnoughData() {
+    void testReadFromByteBufferNotEnoughData() {
         final ByteBuffer memory = ByteBuffer.allocateDirect(1200);
         final Buffer buffer = createTestBuffer();
         BufferReaderWriterUtil.writeBuffer(buffer, memory);
@@ -94,12 +95,8 @@ public class BufferReaderWriterUtilTest {
         memory.flip().limit(memory.limit() - 1);
         ByteBuffer tooSmall = memory.slice();
 
-        try {
-            BufferReaderWriterUtil.sliceNextBuffer(tooSmall);
-            fail();
-        } catch (Exception e) {
-            // expected
-        }
+        assertThatThrownBy(() -> BufferReaderWriterUtil.sliceNextBuffer(tooSmall))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     // ------------------------------------------------------------------------
@@ -107,8 +104,8 @@ public class BufferReaderWriterUtilTest {
     // ------------------------------------------------------------------------
 
     @Test
-    public void writeReadFileChannel() throws Exception {
-        final FileChannel fc = tmpFileChannel();
+    void writeReadFileChannel(@TempDir Path tempPath) throws Exception {
+        final FileChannel fc = tmpFileChannel(tempPath);
         final Buffer buffer = createTestBuffer();
         final MemorySegment readBuffer =
                 MemorySegmentFactory.allocateUnpooledOffHeapMemory(buffer.getSize(), null);
@@ -128,8 +125,8 @@ public class BufferReaderWriterUtilTest {
     }
 
     @Test
-    public void readPrematureEndOfFile1() throws Exception {
-        final FileChannel fc = tmpFileChannel();
+    void readPrematureEndOfFile1(@TempDir Path tempPath) throws Exception {
+        final FileChannel fc = tmpFileChannel(tempPath);
         final Buffer buffer = createTestBuffer();
         final MemorySegment readBuffer =
                 MemorySegmentFactory.allocateUnpooledOffHeapMemory(buffer.getSize(), null);
@@ -139,21 +136,19 @@ public class BufferReaderWriterUtilTest {
         fc.truncate(fc.position() - 1);
         fc.position(0);
 
-        try {
-            BufferReaderWriterUtil.readFromByteChannel(
-                    fc,
-                    BufferReaderWriterUtil.allocatedHeaderBuffer(),
-                    readBuffer,
-                    FreeingBufferRecycler.INSTANCE);
-            fail();
-        } catch (IOException e) {
-            // expected
-        }
+        assertThatThrownBy(
+                        () ->
+                                BufferReaderWriterUtil.readFromByteChannel(
+                                        fc,
+                                        BufferReaderWriterUtil.allocatedHeaderBuffer(),
+                                        readBuffer,
+                                        FreeingBufferRecycler.INSTANCE))
+                .isInstanceOf(IOException.class);
     }
 
     @Test
-    public void readPrematureEndOfFile2() throws Exception {
-        final FileChannel fc = tmpFileChannel();
+    void readPrematureEndOfFile2(@TempDir Path tempPath) throws Exception {
+        final FileChannel fc = tmpFileChannel(tempPath);
         final Buffer buffer = createTestBuffer();
         final MemorySegment readBuffer =
                 MemorySegmentFactory.allocateUnpooledOffHeapMemory(buffer.getSize(), null);
@@ -163,30 +158,28 @@ public class BufferReaderWriterUtilTest {
         fc.truncate(2); // less than a header size
         fc.position(0);
 
-        try {
-            BufferReaderWriterUtil.readFromByteChannel(
-                    fc,
-                    BufferReaderWriterUtil.allocatedHeaderBuffer(),
-                    readBuffer,
-                    FreeingBufferRecycler.INSTANCE);
-            fail();
-        } catch (IOException e) {
-            // expected
-        }
+        assertThatThrownBy(
+                        () ->
+                                BufferReaderWriterUtil.readFromByteChannel(
+                                        fc,
+                                        BufferReaderWriterUtil.allocatedHeaderBuffer(),
+                                        readBuffer,
+                                        FreeingBufferRecycler.INSTANCE))
+                .isInstanceOf(IOException.class);
     }
 
     @Test
-    public void testBulkWritingLargeNumberOfBuffers() throws Exception {
+    void testBulkWritingLargeNumberOfBuffers(@TempDir Path tempPath) throws Exception {
         int bufferSize = 1024;
         int numBuffers = 1025;
-        try (FileChannel fileChannel = tmpFileChannel()) {
+        try (FileChannel fileChannel = tmpFileChannel(tempPath)) {
             ByteBuffer[] data = new ByteBuffer[numBuffers];
             for (int i = 0; i < numBuffers; ++i) {
                 data[i] = ByteBuffer.allocateDirect(bufferSize);
             }
             int bytesExpected = bufferSize * numBuffers;
             BufferReaderWriterUtil.writeBuffers(fileChannel, bytesExpected, data);
-            assertEquals(bytesExpected, fileChannel.size());
+            assertThat(fileChannel.size()).isEqualTo(bytesExpected);
         }
     }
 
@@ -195,8 +188,8 @@ public class BufferReaderWriterUtilTest {
     // ------------------------------------------------------------------------
 
     @Test
-    public void writeFileReadMemoryBuffer() throws Exception {
-        final FileChannel fc = tmpFileChannel();
+    void writeFileReadMemoryBuffer(@TempDir Path tempPath) throws Exception {
+        final FileChannel fc = tmpFileChannel(tempPath);
         final Buffer buffer = createTestBuffer();
         BufferReaderWriterUtil.writeToByteChannel(
                 fc, buffer, BufferReaderWriterUtil.allocatedWriteBufferArray());
@@ -215,9 +208,9 @@ public class BufferReaderWriterUtilTest {
     //  Util
     // ------------------------------------------------------------------------
 
-    private static FileChannel tmpFileChannel() throws IOException {
+    private static FileChannel tmpFileChannel(Path tempPath) throws IOException {
         return FileChannel.open(
-                TMP_FOLDER.newFile().toPath(),
+                Files.createFile(tempPath.resolve(UUID.randomUUID().toString())),
                 StandardOpenOption.CREATE,
                 StandardOpenOption.READ,
                 StandardOpenOption.WRITE);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/BufferReaderWriterUtilTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/BufferReaderWriterUtilTest.java
@@ -194,7 +194,7 @@ class BufferReaderWriterUtilTest {
         // reset the channel's position to read.
         fc.position(0);
         BufferReaderWriterUtil.positionToNextBuffer(fc, byteBuffersWithHeader[0]);
-        long expectedPosition = BufferReaderWriterUtil.HEADER_LENGTH + 1024;
+        long expectedPosition = totalBytes / 2;
         assertThat(fc.position()).isEqualTo(expectedPosition);
     }
 
@@ -240,7 +240,7 @@ class BufferReaderWriterUtilTest {
         for (int i = 0; i < numBuffers; i++) {
             buffers[2 * i] = BufferReaderWriterUtil.allocatedHeaderBuffer();
             Buffer buffer = createTestBuffer();
-            BufferReaderWriterUtil.setByteChannelBufferHeader(buffer, buffers[i]);
+            BufferReaderWriterUtil.setByteChannelBufferHeader(buffer, buffers[2 * i]);
             buffers[2 * i + 1] = buffer.getNioBufferReadable();
         }
         return buffers;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/BufferReaderWriterUtilTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/BufferReaderWriterUtilTest.java
@@ -37,6 +37,7 @@ import java.nio.channels.FileChannel.MapMode;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -183,6 +184,20 @@ class BufferReaderWriterUtilTest {
         }
     }
 
+    @Test
+    void testPositionToNextBuffer(@TempDir Path tempPath) throws Exception {
+        final FileChannel fc = tmpFileChannel(tempPath);
+        ByteBuffer[] byteBuffersWithHeader = createByteBuffersWithHeader(2);
+        long totalBytes =
+                Arrays.stream(byteBuffersWithHeader).mapToLong(ByteBuffer::remaining).sum();
+        BufferReaderWriterUtil.writeBuffers(fc, totalBytes, byteBuffersWithHeader);
+        // reset the channel's position to read.
+        fc.position(0);
+        BufferReaderWriterUtil.positionToNextBuffer(fc, byteBuffersWithHeader[0]);
+        long expectedPosition = BufferReaderWriterUtil.HEADER_LENGTH + 1024;
+        assertThat(fc.position()).isEqualTo(expectedPosition);
+    }
+
     // ------------------------------------------------------------------------
     //  Mixed
     // ------------------------------------------------------------------------
@@ -214,6 +229,21 @@ class BufferReaderWriterUtilTest {
                 StandardOpenOption.CREATE,
                 StandardOpenOption.READ,
                 StandardOpenOption.WRITE);
+    }
+
+    /**
+     * Create an array of ByteBuffer, the odd-numbered position in the array is header buffer, and
+     * the even-numbered position is the corresponding data buffer.
+     */
+    private static ByteBuffer[] createByteBuffersWithHeader(int numBuffers) {
+        ByteBuffer[] buffers = new ByteBuffer[numBuffers * 2];
+        for (int i = 0; i < numBuffers; i++) {
+            buffers[2 * i] = BufferReaderWriterUtil.allocatedHeaderBuffer();
+            Buffer buffer = createTestBuffer();
+            BufferReaderWriterUtil.setByteChannelBufferHeader(buffer, buffers[i]);
+            buffers[2 * i + 1] = buffer.getNioBufferReadable();
+        }
+        return buffers;
     }
 
     private static Buffer createTestBuffer() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsMemoryDataSpillerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsMemoryDataSpillerTest.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.core.memory.MemorySegmentFactory;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
+import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
+import org.apache.flink.runtime.io.network.partition.BufferReaderWriterUtil;
+import org.apache.flink.runtime.io.network.partition.hybrid.HsFileDataIndex.SpilledBuffer;
+import org.apache.flink.util.TestLoggerExtension;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.ClosedChannelException;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link HsMemoryDataSpiller}. */
+@ExtendWith(TestLoggerExtension.class)
+class HsMemoryDataSpillerTest {
+
+    private static final int BUFFER_SIZE = Integer.BYTES;
+
+    private static final long BUFFER_WITH_HEADER_SIZE =
+            BUFFER_SIZE + BufferReaderWriterUtil.HEADER_LENGTH;
+
+    private FileChannel dataFileChannel;
+
+    private HsMemoryDataSpiller memoryDataSpiller;
+
+    @BeforeEach
+    void before(@TempDir Path tempDir) throws Exception {
+        dataFileChannel =
+                FileChannel.open(
+                        Files.createFile(tempDir.resolve(".data")),
+                        StandardOpenOption.WRITE,
+                        StandardOpenOption.READ);
+        this.memoryDataSpiller = new HsMemoryDataSpiller(dataFileChannel);
+    }
+
+    @Test
+    void testSpillExceptionally() throws IOException {
+        int targetChannel = 0;
+        List<BufferWithIdentity> bufferWithIdentityList =
+                createBufferWithIdentityList(
+                        targetChannel,
+                        Arrays.asList(Tuple2.of(0, 0), Tuple2.of(1, 1), Tuple2.of(2, 2)));
+        // close data file channel to trigger exception when spill data into disk.
+        dataFileChannel.close();
+
+        CompletableFuture<List<SpilledBuffer>> future =
+                memoryDataSpiller.spillAsync(bufferWithIdentityList);
+        assertThat(future)
+                .failsWithin(60, TimeUnit.SECONDS)
+                .withThrowableOfType(ExecutionException.class)
+                .withCauseInstanceOf(ClosedChannelException.class);
+    }
+
+    @Test
+    void testSpillSuccessfully() throws Exception {
+        List<BufferWithIdentity> bufferWithIdentityList = new ArrayList<>();
+        bufferWithIdentityList.addAll(
+                createBufferWithIdentityList(
+                        0, Arrays.asList(Tuple2.of(0, 0), Tuple2.of(1, 1), Tuple2.of(2, 2))));
+        bufferWithIdentityList.addAll(
+                createBufferWithIdentityList(
+                        0, Arrays.asList(Tuple2.of(4, 0), Tuple2.of(5, 1), Tuple2.of(6, 2))));
+        CompletableFuture<List<SpilledBuffer>> future =
+                memoryDataSpiller.spillAsync(bufferWithIdentityList);
+        List<SpilledBuffer> expectedSpilledBuffers =
+                getExpectedSpilledBuffers(bufferWithIdentityList);
+        assertThat(future)
+                .succeedsWithin(60, TimeUnit.SECONDS)
+                .satisfies(
+                        spilledBuffers ->
+                                assertThat(spilledBuffers)
+                                        .zipSatisfy(
+                                                expectedSpilledBuffers,
+                                                (spilledBuffer, expectedSpilledBuffer) -> {
+                                                    assertThat(spilledBuffer.bufferIndex)
+                                                            .isEqualTo(
+                                                                    expectedSpilledBuffer
+                                                                            .bufferIndex);
+                                                    assertThat(spilledBuffer.subpartitionId)
+                                                            .isEqualTo(
+                                                                    expectedSpilledBuffer
+                                                                            .subpartitionId);
+                                                    assertThat(spilledBuffer.fileOffset)
+                                                            .isEqualTo(
+                                                                    expectedSpilledBuffer
+                                                                            .fileOffset);
+                                                }));
+        checkData(
+                Arrays.asList(
+                        Tuple2.of(0, 0),
+                        Tuple2.of(1, 1),
+                        Tuple2.of(2, 2),
+                        Tuple2.of(4, 0),
+                        Tuple2.of(5, 1),
+                        Tuple2.of(6, 2)));
+    }
+
+    /**
+     * create buffer with identity list.
+     *
+     * @param subpartitionId the buffers belong to.
+     * @param dataAndIndexes is the list contains pair of (bufferData, bufferIndex).
+     */
+    private static List<BufferWithIdentity> createBufferWithIdentityList(
+            int subpartitionId, List<Tuple2<Integer, Integer>> dataAndIndexes) {
+        List<BufferWithIdentity> bufferWithIdentityList = new ArrayList<>();
+        for (Tuple2<Integer, Integer> dataAndIndex : dataAndIndexes) {
+            Buffer.DataType dataType =
+                    dataAndIndex.f1 % 2 == 0
+                            ? Buffer.DataType.EVENT_BUFFER
+                            : Buffer.DataType.DATA_BUFFER;
+
+            MemorySegment segment = MemorySegmentFactory.allocateUnpooledSegment(BUFFER_SIZE);
+            segment.putInt(0, dataAndIndex.f0);
+            Buffer buffer =
+                    new NetworkBuffer(
+                            segment, FreeingBufferRecycler.INSTANCE, dataType, BUFFER_SIZE);
+            bufferWithIdentityList.add(
+                    new BufferWithIdentity(buffer, dataAndIndex.f1, subpartitionId));
+        }
+        return Collections.unmodifiableList(bufferWithIdentityList);
+    }
+
+    /** get SpilledBuffers from BufferWithIdentities. */
+    private static List<SpilledBuffer> getExpectedSpilledBuffers(
+            List<BufferWithIdentity> bufferWithIdentityList) {
+        long totalBytes = 0;
+        List<SpilledBuffer> spilledBuffers = new ArrayList<>();
+        for (BufferWithIdentity bufferWithIdentity : bufferWithIdentityList) {
+            spilledBuffers.add(
+                    new SpilledBuffer(
+                            bufferWithIdentity.getChannelIndex(),
+                            bufferWithIdentity.getBufferIndex(),
+                            totalBytes));
+            totalBytes += BUFFER_WITH_HEADER_SIZE;
+        }
+        return Collections.unmodifiableList(spilledBuffers);
+    }
+
+    private void checkData(List<Tuple2<Integer, Integer>> dataAndIndexes) throws Exception {
+        // reset channel position for read.
+        dataFileChannel.position(0);
+        ByteBuffer headerBuf = BufferReaderWriterUtil.allocatedHeaderBuffer();
+        MemorySegment segment = MemorySegmentFactory.allocateUnpooledSegment(BUFFER_SIZE);
+        for (Tuple2<Integer, Integer> dataAndIndex : dataAndIndexes) {
+            Buffer buffer =
+                    BufferReaderWriterUtil.readFromByteChannel(
+                            dataFileChannel, headerBuf, segment, (ignore) -> {});
+
+            assertThat(buffer.readableBytes()).isEqualTo(BUFFER_SIZE);
+            assertThat(buffer.getNioBufferReadable().order(ByteOrder.nativeOrder()).getInt())
+                    .isEqualTo(dataAndIndex.f0);
+            assertThat(buffer.getDataType().isEvent()).isEqualTo(dataAndIndex.f1 % 2 == 0);
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsResultPartitionReadSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsResultPartitionReadSchedulerTest.java
@@ -141,14 +141,13 @@ class HsResultPartitionReadSchedulerTest {
 
         assertThat(reader.readBuffers).hasSize(BUFFER_POOL_SIZE);
         assertThat(bufferPool.getAvailableBuffers()).isZero();
-        CompletableFuture<Void> triggerRun = new CompletableFuture<>();
 
         readScheduler.recycle(reader.readBuffers.poll());
-        reader.setPrepareForSchedulingRunnable(() -> triggerRun.complete(null));
+        readScheduler.recycle(reader.readBuffers.poll());
 
         // recycle buffer will push new runnable to ioExecutor.
         ioExecutor.trigger();
-        assertThat(triggerRun).isCompleted();
+        assertThat(reader.readBuffers).hasSize(BUFFER_POOL_SIZE);
     }
 
     /** Test all not used buffers will be released after run method finish. */
@@ -352,7 +351,7 @@ class HsResultPartitionReadSchedulerTest {
 
         private int priority;
 
-        public TestingHsSubpartitionFileReader() {
+        private TestingHsSubpartitionFileReader() {
             this.readBuffers = new ArrayDeque<>();
         }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsResultPartitionReadSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsResultPartitionReadSchedulerTest.java
@@ -1,0 +1,414 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid;
+
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.core.testutils.CheckedThread;
+import org.apache.flink.runtime.io.disk.BatchShuffleReadBufferPool;
+import org.apache.flink.runtime.io.network.buffer.BufferRecycler;
+import org.apache.flink.util.TestLoggerExtension;
+import org.apache.flink.util.concurrent.ManuallyTriggeredScheduledExecutor;
+import org.apache.flink.util.function.BiConsumerWithException;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.time.Duration;
+import java.util.ArrayDeque;
+import java.util.Queue;
+import java.util.Random;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link HsResultPartitionReadScheduler}. */
+@ExtendWith(TestLoggerExtension.class)
+class HsResultPartitionReadSchedulerTest {
+    private static final int BUFFER_SIZE = 1024;
+
+    private static final int NUM_SUBPARTITIONS = 10;
+
+    private static final int BUFFER_POOL_SIZE = 2;
+
+    private final byte[] dataBytes = new byte[BUFFER_SIZE];
+
+    private ManuallyTriggeredScheduledExecutor ioExecutor;
+
+    private BatchShuffleReadBufferPool bufferPool;
+
+    private FileChannel dataFileChannel;
+
+    private Path dataFilePath;
+
+    private HsResultPartitionReadScheduler readScheduler;
+
+    private TestingSubpartitionViewInternalOperation subpartitionViewOperation;
+
+    private TestingHsSubpartitionFileReader.Factory factory;
+
+    @BeforeEach
+    void before(@TempDir Path tempDir) throws IOException {
+        Random random = new Random();
+        random.nextBytes(dataBytes);
+        bufferPool = new BatchShuffleReadBufferPool(BUFFER_POOL_SIZE * BUFFER_SIZE, BUFFER_SIZE);
+        ioExecutor = new ManuallyTriggeredScheduledExecutor();
+        dataFilePath = Files.createFile(tempDir.resolve(".data"));
+        dataFileChannel = openFileChannel(dataFilePath);
+        factory = new TestingHsSubpartitionFileReader.Factory();
+        readScheduler =
+                new HsResultPartitionReadScheduler(
+                        bufferPool,
+                        ioExecutor,
+                        new HsFileDataIndexImpl(NUM_SUBPARTITIONS),
+                        dataFilePath,
+                        factory,
+                        HybridShuffleConfiguration.createConfiguration(
+                                bufferPool.getNumBuffersPerRequest(), NUM_SUBPARTITIONS));
+        subpartitionViewOperation = new TestingSubpartitionViewInternalOperation();
+    }
+
+    @AfterEach
+    void after() throws Exception {
+        bufferPool.destroy();
+        if (dataFileChannel != null) {
+            dataFileChannel.close();
+        }
+    }
+
+    // ----------------------- test run and register ---------------------------------------
+
+    @Test
+    void testRegisterReaderTriggerRun() throws Exception {
+        TestingHsSubpartitionFileReader reader = new TestingHsSubpartitionFileReader();
+        reader.setReadBuffersConsumer(
+                (requestedBuffers, readBuffers) -> readBuffers.addAll(requestedBuffers));
+        factory.allReaders.add(reader);
+
+        assertThat(reader.readBuffers).isEmpty();
+
+        readScheduler.registerNewSubpartition(0, subpartitionViewOperation);
+
+        ioExecutor.trigger();
+
+        assertThat(reader.readBuffers).hasSize(BUFFER_POOL_SIZE);
+    }
+
+    @Test
+    void testBufferReleasedTriggerRun() throws Exception {
+        TestingHsSubpartitionFileReader reader = new TestingHsSubpartitionFileReader();
+        reader.setReadBuffersConsumer(
+                (requestedBuffer, readBuffers) -> {
+                    while (!requestedBuffer.isEmpty()) {
+                        readBuffers.add(requestedBuffer.poll());
+                    }
+                });
+
+        factory.allReaders.add(reader);
+
+        readScheduler.registerNewSubpartition(0, subpartitionViewOperation);
+
+        ioExecutor.trigger();
+
+        assertThat(reader.readBuffers).hasSize(BUFFER_POOL_SIZE);
+        assertThat(bufferPool.getAvailableBuffers()).isZero();
+        CompletableFuture<Void> triggerRun = new CompletableFuture<>();
+
+        readScheduler.recycle(reader.readBuffers.poll());
+        reader.setPrepareForSchedulingRunnable(() -> triggerRun.complete(null));
+
+        // recycle buffer will push new runnable to ioExecutor.
+        ioExecutor.trigger();
+        assertThat(triggerRun).isCompleted();
+    }
+
+    /** Test all not used buffers will be released after run method finish. */
+    @Test
+    void testRunReleaseUnusedBuffers() throws Exception {
+        TestingHsSubpartitionFileReader reader = new TestingHsSubpartitionFileReader();
+
+        CompletableFuture<Void> prepareForSchedulingFinished = new CompletableFuture<>();
+        reader.setPrepareForSchedulingRunnable(() -> prepareForSchedulingFinished.complete(null));
+        reader.setReadBuffersConsumer(
+                (requestedBuffers, readBuffers) -> {
+                    assertThat(prepareForSchedulingFinished).isCompleted();
+                    assertThat(requestedBuffers).hasSize(BUFFER_POOL_SIZE);
+                    assertThat(bufferPool.getAvailableBuffers()).isEqualTo(0);
+                    // read one buffer, return another buffer to scheduler.
+                    readBuffers.add(requestedBuffers.poll());
+                });
+        factory.allReaders.add(reader);
+
+        readScheduler.registerNewSubpartition(0, subpartitionViewOperation);
+
+        ioExecutor.trigger();
+
+        // not used buffer should be recycled.
+        assertThat(bufferPool.getAvailableBuffers()).isEqualTo(1);
+    }
+
+    /** Test scheduler will schedule readers in order. */
+    @Test
+    void testScheduleReadersOrdered() throws Exception {
+        TestingHsSubpartitionFileReader reader1 = new TestingHsSubpartitionFileReader();
+        TestingHsSubpartitionFileReader reader2 = new TestingHsSubpartitionFileReader();
+
+        CompletableFuture<Void> readBuffersFinished1 = new CompletableFuture<>();
+        CompletableFuture<Void> readBuffersFinished2 = new CompletableFuture<>();
+        reader1.setReadBuffersConsumer(
+                (requestedBuffers, readBuffers) -> {
+                    assertThat(readBuffersFinished2).isNotDone();
+                    readBuffersFinished1.complete(null);
+                });
+        reader2.setReadBuffersConsumer(
+                (requestedBuffers, readBuffers) -> {
+                    assertThat(readBuffersFinished1).isDone();
+                    readBuffersFinished2.complete(null);
+                });
+
+        reader1.setPriority(1);
+        reader2.setPriority(2);
+
+        factory.allReaders.add(reader1);
+        factory.allReaders.add(reader2);
+
+        readScheduler.registerNewSubpartition(0, subpartitionViewOperation);
+        readScheduler.registerNewSubpartition(1, subpartitionViewOperation);
+
+        // trigger run.
+        ioExecutor.trigger();
+
+        assertThat(readBuffersFinished2).isCompleted();
+    }
+
+    @Test
+    void testRunRequestBufferTimeout() throws Exception {
+        Duration bufferRequestTimeout = Duration.ofSeconds(3);
+
+        // request all buffer first.
+        bufferPool.requestBuffers();
+        assertThat(bufferPool.getAvailableBuffers()).isZero();
+
+        readScheduler =
+                new HsResultPartitionReadScheduler(
+                        bufferPool,
+                        ioExecutor,
+                        new HsFileDataIndexImpl(NUM_SUBPARTITIONS),
+                        dataFilePath,
+                        factory,
+                        HybridShuffleConfiguration.createConfiguration(
+                                bufferPool.getNumBuffersPerRequest(),
+                                NUM_SUBPARTITIONS,
+                                bufferRequestTimeout));
+
+        TestingHsSubpartitionFileReader reader = new TestingHsSubpartitionFileReader();
+        CompletableFuture<Void> prepareForSchedulingFinished = new CompletableFuture<>();
+        CompletableFuture<Throwable> cause = new CompletableFuture<>();
+        reader.setPrepareForSchedulingRunnable(() -> prepareForSchedulingFinished.complete(null));
+        reader.setFailConsumer((cause::complete));
+        factory.allReaders.add(reader);
+
+        readScheduler.registerNewSubpartition(0, subpartitionViewOperation);
+
+        ioExecutor.trigger();
+
+        assertThat(prepareForSchedulingFinished).isCompleted();
+        assertThat(cause).isCompleted();
+        assertThat(cause.get())
+                .isInstanceOf(TimeoutException.class)
+                .hasMessageContaining("Buffer request timeout");
+    }
+
+    /**
+     * When {@link HsSubpartitionFileReader#readBuffers(Queue, BufferRecycler)} throw IOException,
+     * subpartition reader should fail.
+     */
+    @Test
+    void testRunReadBuffersThrowException() throws Exception {
+        TestingHsSubpartitionFileReader reader = new TestingHsSubpartitionFileReader();
+        CompletableFuture<Throwable> cause = new CompletableFuture<>();
+        reader.setFailConsumer((cause::complete));
+        reader.setReadBuffersConsumer(
+                (requestedBuffers, readBuffers) -> {
+                    throw new IOException("expected exception.");
+                });
+        factory.allReaders.add(reader);
+
+        readScheduler.registerNewSubpartition(0, subpartitionViewOperation);
+
+        ioExecutor.trigger();
+
+        assertThat(cause).isCompleted();
+        assertThat(cause.get())
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("expected exception.");
+    }
+
+    // ----------------------- test release ---------------------------------------
+
+    /** Test scheduler release when reader is reading buffers. */
+    @Test
+    @Timeout(10)
+    void testReleasedWhenReading() throws Exception {
+        TestingHsSubpartitionFileReader reader = new TestingHsSubpartitionFileReader();
+
+        CompletableFuture<Throwable> cause = new CompletableFuture<>();
+        reader.setFailConsumer((cause::complete));
+        CompletableFuture<Void> readBufferStart = new CompletableFuture<>();
+        CompletableFuture<Void> schedulerReleasedFinish = new CompletableFuture<>();
+        reader.setReadBuffersConsumer(
+                (requestedBuffers, readBuffers) -> {
+                    try {
+                        readBufferStart.complete(null);
+                        schedulerReleasedFinish.get();
+                    } catch (Exception e) {
+                        // re-throw all exception to IOException caught by read scheduler.
+                        throw new IOException(e);
+                    }
+                });
+        factory.allReaders.add(reader);
+
+        CheckedThread releaseThread =
+                new CheckedThread() {
+                    @Override
+                    public void go() throws Exception {
+                        readBufferStart.get();
+                        readScheduler.release();
+                        schedulerReleasedFinish.complete(null);
+                    }
+                };
+        releaseThread.start();
+
+        readScheduler.registerNewSubpartition(0, subpartitionViewOperation);
+
+        ioExecutor.trigger();
+
+        releaseThread.sync();
+
+        assertThat(cause).isCompleted();
+        assertThat(cause.get())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Result partition has been already released.");
+    }
+
+    /** Test scheduler was released, but receive new subpartition reader registration. */
+    @Test
+    void testRegisterSubpartitionReaderAfterSchedulerReleased() {
+        TestingHsSubpartitionFileReader reader = new TestingHsSubpartitionFileReader();
+        factory.allReaders.add(reader);
+
+        readScheduler.release();
+        assertThatThrownBy(
+                        () -> {
+                            readScheduler.registerNewSubpartition(0, subpartitionViewOperation);
+                            ioExecutor.trigger();
+                        })
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("HsResultPartitionReadScheduler is already released.");
+    }
+
+    private static FileChannel openFileChannel(Path path) throws IOException {
+        return FileChannel.open(path, StandardOpenOption.READ);
+    }
+
+    private static class TestingHsSubpartitionFileReader implements HsSubpartitionFileReader {
+        private Runnable prepareForSchedulingRunnable = () -> {};
+
+        private BiConsumerWithException<Queue<MemorySegment>, Queue<MemorySegment>, IOException>
+                readBuffersConsumer = (ignore1, ignore2) -> {};
+
+        private Consumer<Throwable> failConsumer = (ignore) -> {};
+
+        private final Queue<MemorySegment> readBuffers;
+
+        private int priority;
+
+        public TestingHsSubpartitionFileReader() {
+            this.readBuffers = new ArrayDeque<>();
+        }
+
+        @Override
+        public void prepareForScheduling() {
+            prepareForSchedulingRunnable.run();
+        }
+
+        @Override
+        public void readBuffers(Queue<MemorySegment> buffers, BufferRecycler recycler)
+                throws IOException {
+            readBuffersConsumer.accept(buffers, readBuffers);
+        }
+
+        @Override
+        public void fail(Throwable failureCause) {
+            failConsumer.accept(failureCause);
+        }
+
+        @Override
+        public int compareTo(HsSubpartitionFileReader that) {
+            checkArgument(that instanceof TestingHsSubpartitionFileReader);
+            return Integer.compare(priority, ((TestingHsSubpartitionFileReader) that).priority);
+        }
+
+        public void setPriority(int priority) {
+            this.priority = priority;
+        }
+
+        public void setPrepareForSchedulingRunnable(Runnable prepareForSchedulingRunnable) {
+            this.prepareForSchedulingRunnable = prepareForSchedulingRunnable;
+        }
+
+        public void setReadBuffersConsumer(
+                BiConsumerWithException<Queue<MemorySegment>, Queue<MemorySegment>, IOException>
+                        readBuffersConsumer) {
+            this.readBuffersConsumer = readBuffersConsumer;
+        }
+
+        public void setFailConsumer(Consumer<Throwable> failConsumer) {
+            this.failConsumer = failConsumer;
+        }
+
+        /** Factory for {@link TestingHsSubpartitionFileReader}. */
+        private static class Factory implements HsSubpartitionFileReader.Factory {
+            private final Queue<HsSubpartitionFileReader> allReaders = new ArrayDeque<>();
+
+            @Override
+            public HsSubpartitionFileReader createFileReader(
+                    int subpartitionId,
+                    FileChannel dataFileChannel,
+                    HsSubpartitionViewInternalOperations operation,
+                    HsFileDataIndex dataIndex,
+                    int maxBuffersReadAhead) {
+                return checkNotNull(allReaders.poll());
+            }
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionFileReaderImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionFileReaderImplTest.java
@@ -1,0 +1,449 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid;
+
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.core.memory.MemorySegmentFactory;
+import org.apache.flink.core.testutils.CheckedThread;
+import org.apache.flink.core.testutils.OneShotLatch;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
+import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
+import org.apache.flink.runtime.io.network.partition.BufferReaderWriterUtil;
+import org.apache.flink.runtime.io.network.partition.hybrid.HsFileDataIndex.SpilledBuffer;
+import org.apache.flink.runtime.io.network.partition.hybrid.HsSubpartitionFileReaderImpl.BufferIndexOrError;
+import org.apache.flink.util.IOUtils;
+import org.apache.flink.util.TestLoggerExtension;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.Queue;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.BlockingDeque;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link HsSubpartitionFileReaderImpl}. */
+@ExtendWith(TestLoggerExtension.class)
+class HsSubpartitionFileReaderImplTest {
+    private static final int bufferSize = Integer.BYTES;
+
+    private static final int targetChannel = 0;
+
+    private static final int MAX_BUFFERS_READ_AHEAD = 5;
+
+    private Random random;
+
+    private HsFileDataIndex diskIndex;
+
+    private TestingSubpartitionViewInternalOperation subpartitionOperation;
+
+    private FileChannel dataFileChannel;
+
+    private long currentFileOffset;
+
+    @BeforeEach
+    void before(@TempDir Path tempPath) throws Exception {
+        random = new Random();
+        Path dataFilePath = Files.createFile(tempPath.resolve(UUID.randomUUID().toString()));
+        dataFileChannel = openFileChannel(dataFilePath);
+        diskIndex = new HsFileDataIndexImpl(1);
+        subpartitionOperation = new TestingSubpartitionViewInternalOperation();
+        currentFileOffset = 0L;
+    }
+
+    @AfterEach
+    void after() {
+        IOUtils.closeQuietly(dataFileChannel);
+    }
+
+    @Test
+    void testReadBuffer() throws Exception {
+        diskIndex = new HsFileDataIndexImpl(2);
+        TestingSubpartitionViewInternalOperation viewNotifier1 =
+                new TestingSubpartitionViewInternalOperation();
+        TestingSubpartitionViewInternalOperation viewNotifier2 =
+                new TestingSubpartitionViewInternalOperation();
+        HsSubpartitionFileReaderImpl fileReader1 = createSubpartitionFileReader(0, viewNotifier1);
+        HsSubpartitionFileReaderImpl fileReader2 = createSubpartitionFileReader(1, viewNotifier2);
+
+        writeDataToFile(0, 0, 10, 2);
+        writeDataToFile(1, 0, 20, 2);
+
+        writeDataToFile(0, 2, 15, 1);
+        writeDataToFile(1, 2, 25, 1);
+
+        Queue<MemorySegment> memorySegments = createsMemorySegments(6);
+
+        fileReader1.readBuffers(memorySegments, FreeingBufferRecycler.INSTANCE);
+        assertThat(memorySegments).hasSize(4);
+        checkData(fileReader1, 10, 11);
+
+        fileReader2.readBuffers(memorySegments, FreeingBufferRecycler.INSTANCE);
+        assertThat(memorySegments).hasSize(2);
+        checkData(fileReader2, 20, 21);
+
+        fileReader1.readBuffers(memorySegments, FreeingBufferRecycler.INSTANCE);
+        assertThat(memorySegments).hasSize(1);
+        checkData(fileReader1, 15);
+
+        fileReader2.readBuffers(memorySegments, FreeingBufferRecycler.INSTANCE);
+        assertThat(memorySegments).isEmpty();
+        checkData(fileReader2, 25);
+    }
+
+    @Test
+    void testReadEmptyRegion() throws Exception {
+        HsSubpartitionFileReaderImpl subpartitionFileReader = createSubpartitionFileReader();
+        Deque<BufferIndexOrError> loadedBuffers = subpartitionFileReader.getLoadedBuffers();
+        Queue<MemorySegment> memorySegments = createsMemorySegments(2);
+        subpartitionFileReader.readBuffers(memorySegments, FreeingBufferRecycler.INSTANCE);
+
+        assertThat(memorySegments).hasSize(2);
+        assertThat(loadedBuffers).isEmpty();
+    }
+
+    /**
+     * If target buffer is not the first buffer in the region, file reader will skip the buffers not
+     * needed.
+     */
+    @Test
+    void testReadBufferSkip() throws Exception {
+        HsSubpartitionFileReaderImpl subpartitionFileReader = createSubpartitionFileReader();
+        Deque<BufferIndexOrError> loadedBuffers = subpartitionFileReader.getLoadedBuffers();
+        // write buffer with index: 0, 1, 2, 3, 4, 5
+        writeDataToFile(targetChannel, 0, 6);
+
+        subpartitionOperation.advanceConsumptionProgress();
+        subpartitionOperation.advanceConsumptionProgress();
+        assertThat(subpartitionOperation.getConsumingOffset()).isEqualTo(1);
+        // update consumptionProgress
+        subpartitionFileReader.prepareForScheduling();
+        // read buffer, expected buffer with index: 2
+        Queue<MemorySegment> segments = createsMemorySegments(1);
+        subpartitionFileReader.readBuffers(segments, FreeingBufferRecycler.INSTANCE);
+
+        assertThat(segments).isEmpty();
+        assertThat(loadedBuffers).hasSize(1);
+
+        BufferIndexOrError bufferIndexOrError = loadedBuffers.poll();
+        assertThat(bufferIndexOrError).isNotNull();
+        assertThat(bufferIndexOrError.getBuffer()).isPresent();
+        assertThat(bufferIndexOrError.getThrowable()).isNotPresent();
+        assertThat(bufferIndexOrError.getIndex()).isEqualTo(2);
+
+        subpartitionOperation.advanceConsumptionProgress();
+        subpartitionOperation.advanceConsumptionProgress();
+        subpartitionFileReader.prepareForScheduling();
+        segments = createsMemorySegments(1);
+        // trigger next round read, cached region will not update, but numSkip, numReadable and
+        // currentBufferIndex should be updated.
+        subpartitionFileReader.readBuffers(segments, FreeingBufferRecycler.INSTANCE);
+        assertThat(segments).isEmpty();
+        assertThat(loadedBuffers).hasSize(1);
+
+        bufferIndexOrError = loadedBuffers.poll();
+        assertThat(bufferIndexOrError).isNotNull();
+        assertThat(bufferIndexOrError.getBuffer()).isPresent();
+        assertThat(bufferIndexOrError.getThrowable()).isNotPresent();
+        assertThat(bufferIndexOrError.getIndex()).isEqualTo(4);
+    }
+
+    @Test
+    void testReadBufferNotBeyondRegionBoundary() throws Exception {
+        HsSubpartitionFileReaderImpl subpartitionFileReader = createSubpartitionFileReader();
+        Deque<BufferIndexOrError> loadedBuffers = subpartitionFileReader.getLoadedBuffers();
+
+        // create two region: (0-0, 0-1) (0-2, 0-3)
+        writeDataToFile(targetChannel, 0, 0, 2);
+        writeDataToFile(targetChannel, 2, 2, 2);
+
+        subpartitionFileReader.prepareForScheduling();
+
+        // create enough buffers for read all two regions.
+        Queue<MemorySegment> memorySegments = createsMemorySegments(4);
+        // trigger reading
+        subpartitionFileReader.readBuffers(memorySegments, FreeingBufferRecycler.INSTANCE);
+
+        assertThat(loadedBuffers).hasSize(2);
+        checkData(subpartitionFileReader, 0, 1);
+        assertThat(memorySegments).hasSize(2);
+    }
+
+    @Test
+    void testReadBufferNotExceedThreshold() throws Exception {
+        HsSubpartitionFileReaderImpl subpartitionFileReader = createSubpartitionFileReader();
+        Deque<BufferIndexOrError> loadedBuffers = subpartitionFileReader.getLoadedBuffers();
+
+        writeDataToFile(targetChannel, 0, MAX_BUFFERS_READ_AHEAD + 1);
+
+        subpartitionFileReader.prepareForScheduling();
+        // allocate maxBuffersReadAhead + 1 read buffers for reading
+        Queue<MemorySegment> memorySegments = createsMemorySegments(MAX_BUFFERS_READ_AHEAD + 1);
+        // trigger reading
+        subpartitionFileReader.readBuffers(memorySegments, FreeingBufferRecycler.INSTANCE);
+
+        // preload by fileReader will not exceed threshold
+        assertThat(loadedBuffers).hasSize(MAX_BUFFERS_READ_AHEAD);
+        assertThat(memorySegments).hasSize(1);
+    }
+
+    @Test
+    void testReadBufferNotifyDataAvailable() throws Exception {
+        OneShotLatch notifyLatch = new OneShotLatch();
+        subpartitionOperation.setNotifyDataAvailableRunnable(notifyLatch::trigger);
+
+        HsSubpartitionFileReaderImpl subpartitionFileReader = createSubpartitionFileReader();
+        BlockingDeque<BufferIndexOrError> loadedBuffers =
+                (BlockingDeque<BufferIndexOrError>) subpartitionFileReader.getLoadedBuffers();
+
+        // trigger next round reading.
+        final int numBuffers = MAX_BUFFERS_READ_AHEAD;
+        Queue<MemorySegment> memorySegments = createsMemorySegments(numBuffers);
+        writeDataToFile(targetChannel, 0, numBuffers);
+        subpartitionFileReader.prepareForScheduling();
+        CheckedThread checkedThread =
+                new CheckedThread() {
+                    @Override
+                    public void go() throws Exception {
+                        int numConsumedBuffer = 0;
+                        while (numConsumedBuffer < numBuffers) {
+                            BufferIndexOrError bufferIndexOrError = loadedBuffers.poll();
+                            if (bufferIndexOrError != null) {
+                                assertThat(bufferIndexOrError.getBuffer()).isPresent();
+                                numConsumedBuffer++;
+                            } else {
+                                notifyLatch.await();
+                                notifyLatch.reset();
+                            }
+                        }
+                    }
+                };
+        checkedThread.start();
+
+        // read data from disk then add it to buffer queue.
+        subpartitionFileReader.readBuffers(memorySegments, FreeingBufferRecycler.INSTANCE);
+
+        checkedThread.sync();
+
+        assertThat(loadedBuffers).isEmpty();
+    }
+
+    @Test
+    void testReadWillReturnBufferAfterError() throws Exception {
+        HsSubpartitionFileReaderImpl subpartitionFileReader = createSubpartitionFileReader();
+        writeDataToFile(targetChannel, 0, 2);
+
+        subpartitionFileReader.prepareForScheduling();
+
+        Queue<MemorySegment> memorySegments = createsMemorySegments(2);
+        // close data channel to trigger a error during read buffer.
+        dataFileChannel.close();
+
+        assertThatThrownBy(
+                        () ->
+                                subpartitionFileReader.readBuffers(
+                                        memorySegments, FreeingBufferRecycler.INSTANCE))
+                .isInstanceOf(IOException.class);
+
+        assertThat(memorySegments).hasSize(2);
+    }
+
+    @Test
+    void testReadBufferAfterFail() {
+        HsSubpartitionFileReaderImpl subpartitionFileReader = createSubpartitionFileReader();
+        subpartitionFileReader.fail(new RuntimeException("expected exception."));
+        assertThatThrownBy(
+                        () ->
+                                subpartitionFileReader.readBuffers(
+                                        createsMemorySegments(2), FreeingBufferRecycler.INSTANCE))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("subpartition reader has already failed.");
+    }
+
+    @Test
+    void testFail() throws Exception {
+        AtomicInteger numOfNotify = new AtomicInteger(0);
+        subpartitionOperation.setNotifyDataAvailableRunnable(numOfNotify::incrementAndGet);
+        HsSubpartitionFileReaderImpl subpartitionFileReader = createSubpartitionFileReader();
+        Deque<BufferIndexOrError> loadedBuffers = subpartitionFileReader.getLoadedBuffers();
+        writeDataToFile(targetChannel, 0, 2);
+
+        subpartitionFileReader.prepareForScheduling();
+        Queue<MemorySegment> memorySegments = createsMemorySegments(2);
+        // trigger reading, add buffer to queue.
+        AtomicInteger numReleased = new AtomicInteger(0);
+        subpartitionFileReader.readBuffers(
+                memorySegments, (buffer) -> numReleased.incrementAndGet());
+
+        assertThat(memorySegments).isEmpty();
+        assertThat(loadedBuffers).hasSize(2);
+        assertThat(numOfNotify).hasValue(1);
+
+        subpartitionFileReader.fail(new RuntimeException("expected exception."));
+        // all buffers in file reader queue should recycle during fail.
+        assertThat(numReleased).hasValue(2);
+        BufferIndexOrError error = loadedBuffers.poll();
+        assertThat(loadedBuffers).isEmpty();
+        assertThat(error).isNotNull();
+        assertThat(error.getThrowable())
+                .hasValueSatisfying(
+                        throwable ->
+                                assertThat(throwable)
+                                        .isInstanceOf(RuntimeException.class)
+                                        .hasMessage("expected exception."));
+
+        // subpartitionReader fail should notify downstream.
+        assertThat(numOfNotify).hasValue(2);
+    }
+
+    @Test
+    void testCompareTo() throws Exception {
+        diskIndex = new HsFileDataIndexImpl(2);
+        TestingSubpartitionViewInternalOperation viewNotifier1 =
+                new TestingSubpartitionViewInternalOperation();
+        TestingSubpartitionViewInternalOperation viewNotifier2 =
+                new TestingSubpartitionViewInternalOperation();
+        HsSubpartitionFileReaderImpl fileReader1 = createSubpartitionFileReader(0, viewNotifier1);
+        HsSubpartitionFileReaderImpl fileReader2 = createSubpartitionFileReader(1, viewNotifier2);
+        assertThat(fileReader1).isEqualByComparingTo(fileReader2);
+
+        // buffers in file: (0-0, 0-1, 1-0, 0-2)
+        writeDataToFile(0, 0, 2);
+        writeDataToFile(1, 0, 1);
+        writeDataToFile(0, 2, 1);
+        // fileReader1 -> (0-0) fileReader2 -> (1-0)
+        assertThat(fileReader1).isLessThan(fileReader2);
+
+        viewNotifier1.advanceConsumptionProgress();
+        fileReader1.prepareForScheduling();
+        // fileReader1 -> (0-1) fileReader2 -> (1-0)
+        assertThat(fileReader1).isLessThan(fileReader2);
+
+        viewNotifier1.advanceConsumptionProgress();
+        fileReader1.prepareForScheduling();
+        // fileReader1 -> (0-2) fileReader2 -> (1-0)
+        assertThat(fileReader1).isGreaterThan(fileReader2);
+    }
+
+    private static void checkData(HsSubpartitionFileReaderImpl fileReader, int... expectedData) {
+        assertThat(fileReader.getLoadedBuffers()).hasSameSizeAs(expectedData);
+        for (int data : expectedData) {
+            BufferIndexOrError bufferIndexOrError = fileReader.getLoadedBuffers().poll();
+            assertThat(bufferIndexOrError).isNotNull();
+            assertThat(bufferIndexOrError.getBuffer())
+                    .hasValueSatisfying(
+                            buffer ->
+                                    assertThat(
+                                                    buffer.getNioBufferReadable()
+                                                            .order(ByteOrder.nativeOrder())
+                                                            .getInt())
+                                            .isEqualTo(data));
+        }
+    }
+
+    private HsSubpartitionFileReaderImpl createSubpartitionFileReader() {
+        return createSubpartitionFileReader(targetChannel, subpartitionOperation);
+    }
+
+    private HsSubpartitionFileReaderImpl createSubpartitionFileReader(
+            int targetChannel, HsSubpartitionViewInternalOperations operations) {
+        return new HsSubpartitionFileReaderImpl(
+                targetChannel, dataFileChannel, operations, diskIndex, MAX_BUFFERS_READ_AHEAD);
+    }
+
+    private static FileChannel openFileChannel(Path path) throws IOException {
+        return FileChannel.open(path, StandardOpenOption.READ, StandardOpenOption.WRITE);
+    }
+
+    private static Queue<MemorySegment> createsMemorySegments(int numSegments) {
+        Queue<MemorySegment> segments = new ArrayDeque<>();
+        for (int i = 0; i < numSegments; ++i) {
+            segments.add(MemorySegmentFactory.allocateUnpooledSegment(bufferSize));
+        }
+        return segments;
+    }
+
+    private void writeDataToFile(
+            int subpartitionId, int firstBufferIndex, int firstBufferData, int numBuffers)
+            throws Exception {
+        List<SpilledBuffer> spilledBuffers = new ArrayList<>(numBuffers);
+        ByteBuffer[] bufferWithHeaders = new ByteBuffer[2 * numBuffers];
+        int totalBytes = 0;
+
+        for (int i = 0; i < numBuffers; i++) {
+            Buffer.DataType dataType =
+                    i == numBuffers - 1
+                            ? Buffer.DataType.EVENT_BUFFER
+                            : Buffer.DataType.DATA_BUFFER;
+
+            MemorySegment segment = MemorySegmentFactory.allocateUnpooledSegment(bufferSize);
+            segment.putInt(0, firstBufferData + i);
+            Buffer buffer =
+                    new NetworkBuffer(
+                            segment, FreeingBufferRecycler.INSTANCE, dataType, bufferSize);
+            setBufferWithHeader(buffer, bufferWithHeaders, 2 * i);
+            spilledBuffers.add(
+                    new SpilledBuffer(
+                            subpartitionId, firstBufferIndex + i, currentFileOffset + totalBytes));
+            totalBytes += bufferSize + BufferReaderWriterUtil.HEADER_LENGTH;
+        }
+
+        BufferReaderWriterUtil.writeBuffers(dataFileChannel, totalBytes, bufferWithHeaders);
+        currentFileOffset += totalBytes;
+
+        diskIndex.addBuffers(spilledBuffers);
+        // mark all buffers status to release.
+        spilledBuffers.forEach(
+                spilledBuffer ->
+                        diskIndex.markBufferReadable(subpartitionId, spilledBuffer.bufferIndex));
+    }
+
+    private void writeDataToFile(int subpartitionId, int firstBufferIndex, int numBuffers)
+            throws Exception {
+        writeDataToFile(subpartitionId, firstBufferIndex, random.nextInt(), numBuffers);
+    }
+
+    private static void setBufferWithHeader(
+            Buffer buffer, ByteBuffer[] bufferWithHeaders, int index) {
+        ByteBuffer header = BufferReaderWriterUtil.allocatedHeaderBuffer();
+        BufferReaderWriterUtil.setByteChannelBufferHeader(buffer, header);
+
+        bufferWithHeaders[index] = header;
+        bufferWithHeaders[index + 1] = buffer.getNioBufferReadable();
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/TestingSubpartitionViewInternalOperation.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/TestingSubpartitionViewInternalOperation.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid;
+
+/** Mock {@link HsSubpartitionViewInternalOperations} for test. */
+public class TestingSubpartitionViewInternalOperation
+        implements HsSubpartitionViewInternalOperations {
+    // -1 indicates downstream just start consuming offset.
+    private int consumingOffset = -1;
+
+    private Runnable notifyDataAvailableRunnable = () -> {};
+
+    @Override
+    public void notifyDataAvailableFromDisk() {
+        notifyDataAvailableRunnable.run();
+    }
+
+    @Override
+    public int getConsumingOffset() {
+        return consumingOffset;
+    }
+
+    public void advanceConsumptionProgress() {
+        consumingOffset++;
+    }
+
+    public void setNotifyDataAvailableRunnable(Runnable notifyDataAvailableRunnable) {
+        this.notifyDataAvailableRunnable = notifyDataAvailableRunnable;
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

*Implement disk read and write logic for hybrid shuffle*


## Brief change log
  -  *Migrate BufferReaderWriterUtilTest to junit5 and assertJ.*
  -  *Introduce HsSubpartitionFileReader and HsResultPartitionReadScheduler.*
  -  *Introduce HsMemoryDataSpiller.*

## Verifying this change

This change added unit tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector:  no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
