### PR TITLE
[FLINK-28034] [StateBackends] Avoid classcastexception in creating a checkpoint with merge windows

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
@@ -341,18 +341,19 @@ public abstract class AbstractKeyedStateBackend<K>
         checkNotNull(namespace, "Namespace");
 
         if (lastName != null && lastName.equals(stateDescriptor.getName())) {
-        	if (namespace != VoidNamespace.INSTANCE || lastState.getNamespaceSerializer() == VoidNamespaceSerializer.INSTANCE) {
-        		lastState.setCurrentNamespace(namespace);
-        	}
+            if (namespace != VoidNamespace.INSTANCE || lastState.getNamespaceSerializer() == VoidNamespaceSerializer.INSTANCE) {
+                lastState.setCurrentNamespace(namespace);
+            }
             return (S) lastState;
         }
 
         InternalKvState<K, ?, ?> previous = keyValueStatesByName.get(stateDescriptor.getName());
         if (previous != null) {
             lastState = previous;
-        	if (namespace != VoidNamespace.INSTANCE || lastState.getNamespaceSerializer() == VoidNamespaceSerializer.INSTANCE) {
-        		lastState.setCurrentNamespace(namespace);
-        	}
+            if (namespace != VoidNamespace.INSTANCE
+                    || lastState.getNamespaceSerializer() == VoidNamespaceSerializer.INSTANCE) {
+                lastState.setCurrentNamespace(namespace);
+            }
             lastName = stateDescriptor.getName();
             return (S) previous;
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
@@ -341,7 +341,8 @@ public abstract class AbstractKeyedStateBackend<K>
         checkNotNull(namespace, "Namespace");
 
         if (lastName != null && lastName.equals(stateDescriptor.getName())) {
-            if (namespace != VoidNamespace.INSTANCE || lastState.getNamespaceSerializer() == VoidNamespaceSerializer.INSTANCE) {
+            if (namespace != VoidNamespace.INSTANCE
+                    || lastState.getNamespaceSerializer() == VoidNamespaceSerializer.INSTANCE) {
                 lastState.setCurrentNamespace(namespace);
             }
             return (S) lastState;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
@@ -341,14 +341,18 @@ public abstract class AbstractKeyedStateBackend<K>
         checkNotNull(namespace, "Namespace");
 
         if (lastName != null && lastName.equals(stateDescriptor.getName())) {
-            lastState.setCurrentNamespace(namespace);
+        	if (namespace != VoidNamespace.INSTANCE || lastState.getNamespaceSerializer() == VoidNamespaceSerializer.INSTANCE) {
+        		lastState.setCurrentNamespace(namespace);
+        	}
             return (S) lastState;
         }
 
         InternalKvState<K, ?, ?> previous = keyValueStatesByName.get(stateDescriptor.getName());
         if (previous != null) {
             lastState = previous;
-            lastState.setCurrentNamespace(namespace);
+        	if (namespace != VoidNamespace.INSTANCE || lastState.getNamespaceSerializer() == VoidNamespaceSerializer.INSTANCE) {
+        		lastState.setCurrentNamespace(namespace);
+        	}
             lastName = stateDescriptor.getName();
             return (S) previous;
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
@@ -5188,7 +5188,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
             state2.update("b");
 
             // draw a snapshot
-            KeyedStateHandle snapshot=
+            KeyedStateHandle snapshot =
                     runSnapshot(
                             backend.snapshot(
                                     682375462378L,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
@@ -5158,12 +5158,12 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
         }
     }
 
-	/**
-	 * This test verifies that the same descriptor can be used in different contexts
-	 * to refer to the same state and successfully create a snapshot.
-	 * @throws Exception
-	 */
-  	@Test
+    /**
+     * This test verifies that the same descriptor can be used in different contexts
+     * to refer to the same state and successfully create a snapshot.
+     * @throws Exception
+     */
+      @Test
     @SuppressWarnings("unused")
     public void testSameDescriptorInDifferentNamespace() throws Exception {
         CheckpointStreamFactory streamFactory = createStreamFactory();
@@ -5178,12 +5178,12 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
         final Integer namespace = 1;
 
         try {
-        	// Assume a state from trigger context (assigned to window).
+            // Assume a state from trigger context (assigned to window).
             ValueState<String> state1 = backend.getPartitionedState(namespace, IntSerializer.INSTANCE, desc);
             backend.setCurrentKey(1);
             state1.update("a");
 
-        	// Assume a global state on a window process function.
+            // Assume a global state on a window process function.
             ValueState<String> state2 = backend.getPartitionedState(VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, desc);
             state2.update("b");
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
@@ -5158,6 +5158,50 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
         }
     }
 
+	/**
+	 * This test verifies that the same descriptor can be used in different contexts
+	 * to refer to the same state and successfully create a snapshot.
+	 * @throws Exception
+	 */
+  	@Test
+    @SuppressWarnings("unused")
+    public void testSameDescriptorInDifferentNamespace() throws Exception {
+        CheckpointStreamFactory streamFactory = createStreamFactory();
+        SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
+
+        ValueStateDescriptor<String> desc =
+                new ValueStateDescriptor<>("a-string", StringSerializer.INSTANCE);
+
+        CheckpointableKeyedStateBackend<Integer> backend =
+                createKeyedBackend(IntSerializer.INSTANCE, 10, new KeyGroupRange(0, 9), env);
+
+        final Integer namespace = 1;
+
+        try {
+        	// Assume a state from trigger context (assigned to window).
+            ValueState<String> state1 = backend.getPartitionedState(namespace, IntSerializer.INSTANCE, desc);
+            backend.setCurrentKey(1);
+            state1.update("a");
+
+        	// Assume a global state on a window process function.
+            ValueState<String> state2 = backend.getPartitionedState(VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, desc);
+            state2.update("b");
+
+            // draw a snapshot
+            KeyedStateHandle snapshot=
+                    runSnapshot(
+                            backend.snapshot(
+                                    682375462378L,
+                                    2,
+                                    streamFactory,
+                                    CheckpointOptions.forCheckpointWithDefaultLocation()),
+                            sharedStateRegistry);
+        } finally {
+            IOUtils.closeQuietly(backend);
+            backend.dispose();
+        }
+    }
+
     protected Future<SnapshotResult<KeyedStateHandle>> runSnapshotAsync(
             ExecutorService executorService,
             RunnableFuture<SnapshotResult<KeyedStateHandle>> snapshotRunnableFuture)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
@@ -5159,11 +5159,11 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     }
 
     /**
-     * This test verifies that the same descriptor can be used in different contexts
-     * to refer to the same state and successfully create a snapshot.
+     * This test verifies that the same descriptor can be used in different contexts to refer to the
+     * same state and successfully create a snapshot.
      * @throws Exception
      */
-      @Test
+    @Test
     @SuppressWarnings("unused")
     public void testSameDescriptorInDifferentNamespace() throws Exception {
         CheckpointStreamFactory streamFactory = createStreamFactory();
@@ -5179,12 +5179,15 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 
         try {
             // Assume a state from trigger context (assigned to window).
-            ValueState<String> state1 = backend.getPartitionedState(namespace, IntSerializer.INSTANCE, desc);
+            ValueState<String> state1 =
+                    backend.getPartitionedState(namespace, IntSerializer.INSTANCE, desc);
             backend.setCurrentKey(1);
             state1.update("a");
 
             // Assume a global state on a window process function.
-            ValueState<String> state2 = backend.getPartitionedState(VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, desc);
+            ValueState<String> state2 =
+                    backend.getPartitionedState(
+                            VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, desc);
             state2.update("b");
 
             // draw a snapshot

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
@@ -5161,6 +5161,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     /**
      * This test verifies that the same descriptor can be used in different contexts to refer to the
      * same state and successfully create a snapshot.
+     *
      * @throws Exception
      */
     @Test


### PR DESCRIPTION
## What is the purpose of the change

To avoid ClassCastException in creating a checkpoint with merge windows.
Please see the description in [FLINK-28034](https://issues.apache.org/jira/browse/FLINK-28034).

## Brief change log

  - *VoidNamespace is assigned to currentNamespace only when namespaceSerializer is VoidNamespaceSerializer.*

## Verifying this change

This change added tests and can be verified as follows:

  - *Clone this repository `https://github.com/t-eimizu/flink-checkpoint-with-merging-window` and run the job.*
    - please change `KAFKA_BOOTSTRAP_SERVER` to your environment. 
  - *Added test that validates the same descriptor can be used in different contexts to refer to the same state and successfully create a snapshot.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes (StateBackends and Checkpointing)
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  