### PR TITLE
[hotfix][docs] Fix the Intellij key nouns.

### DIFF
--- a/flink-examples/flink-examples-table/pom.xml
+++ b/flink-examples/flink-examples-table/pom.xml
@@ -57,7 +57,7 @@ under the License.
 
 		In particular, here we're forced to use flink-table-planner_${scala.binary.version} instead of
 		flink-table-planner-loader, because otherwise we hit this bug https://youtrack.jetbrains.com/issue/IDEA-93855
-		when trying to run the examples from within Intellij IDEA. This is only relevant to this specific
+		when trying to run the examples from within IntelliJ IDEA. This is only relevant to this specific
 		examples project, as it's in the same build tree of flink-parent.
 
 		In a real environment, you need flink-table-runtime and flink-table-planner-loader either

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@ under the License.
 		<slf4j.version>1.7.32</slf4j.version>
 		<log4j.version>2.17.1</log4j.version>
 		<!-- Overwrite default values from parent pom.
-			 Intellij is (sometimes?) using those values to choose target language level
+			 IntelliJ IDEA is (sometimes?) using those values to choose target language level
 			 and thus is changing back to java 1.6 on each maven re-import -->
 		<maven.compiler.source>${target.java.version}</maven.compiler.source>
 		<maven.compiler.target>${target.java.version}</maven.compiler.target>


### PR DESCRIPTION

## What is the purpose of the change

- I think the Intellij should be changed to IntelliJ IDEA. For details, please refer to the official website https://www.jetbrains.com/idea/ and https://en.wikipedia.org/wiki/IntelliJ_IDEA.

## Brief change log

- Modify Intellij to IntelliJ IDEA.


## Verifying this change

- This change is a trivial rework / code cleanup without any test coverage.
