### PR TITLE
[FLINK-28034] [StateBackends] Avoid classcastexception in creating a checkpoint with merge windows

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
@@ -341,14 +341,20 @@ public abstract class AbstractKeyedStateBackend<K>
         checkNotNull(namespace, "Namespace");
 
         if (lastName != null && lastName.equals(stateDescriptor.getName())) {
-            lastState.setCurrentNamespace(namespace);
+            if (namespace != VoidNamespace.INSTANCE
+                    || lastState.getNamespaceSerializer() == VoidNamespaceSerializer.INSTANCE) {
+                lastState.setCurrentNamespace(namespace);
+            }
             return (S) lastState;
         }
 
         InternalKvState<K, ?, ?> previous = keyValueStatesByName.get(stateDescriptor.getName());
         if (previous != null) {
             lastState = previous;
-            lastState.setCurrentNamespace(namespace);
+            if (namespace != VoidNamespace.INSTANCE
+                    || lastState.getNamespaceSerializer() == VoidNamespaceSerializer.INSTANCE) {
+                lastState.setCurrentNamespace(namespace);
+            }
             lastName = stateDescriptor.getName();
             return (S) previous;
         }

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
@@ -49,6 +49,8 @@ import org.apache.flink.runtime.state.SnapshotResult;
 import org.apache.flink.runtime.state.StateSnapshotTransformer;
 import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.TestableKeyedStateBackend;
+import org.apache.flink.runtime.state.VoidNamespace;
+import org.apache.flink.runtime.state.VoidNamespaceSerializer;
 import org.apache.flink.runtime.state.changelog.ChangelogStateBackendHandle;
 import org.apache.flink.runtime.state.changelog.ChangelogStateBackendHandle.ChangelogStateBackendHandleImpl;
 import org.apache.flink.runtime.state.changelog.ChangelogStateHandle;

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
@@ -335,7 +335,10 @@ public class ChangelogKeyedStateBackend<K>
         checkNotNull(namespace, "Namespace");
 
         if (lastName != null && lastName.equals(stateDescriptor.getName())) {
-            lastState.setCurrentNamespace(namespace);
+            if (namespace != VoidNamespace.INSTANCE
+                    || lastState.getNamespaceSerializer() == VoidNamespaceSerializer.INSTANCE) {
+                lastState.setCurrentNamespace(namespace);
+            }
             return (S) lastState;
         }
 
@@ -343,7 +346,10 @@ public class ChangelogKeyedStateBackend<K>
                 keyValueStatesByName.get(stateDescriptor.getName());
         if (previous != null) {
             lastState = previous;
-            lastState.setCurrentNamespace(namespace);
+            if (namespace != VoidNamespace.INSTANCE
+                    || lastState.getNamespaceSerializer() == VoidNamespaceSerializer.INSTANCE) {
+                lastState.setCurrentNamespace(namespace);
+            }
             lastName = stateDescriptor.getName();
             functionDelegationHelper.addOrUpdate(stateDescriptor);
             return (S) previous;


### PR DESCRIPTION
## What is the purpose of the change

To avoid ClassCastException in creating a checkpoint with merge windows.
Please see the description in [FLINK-28034](https://issues.apache.org/jira/browse/FLINK-28034).

## Brief change log

  - *VoidNamespace is assigned to currentNamespace only when namespaceSerializer is VoidNamespaceSerializer.*

## Verifying this change

This change added tests and can be verified as follows:

  - *Clone this repository `https://github.com/t-eimizu/flink-checkpoint-with-merging-window` and run the job.*
    - please change `KAFKA_BOOTSTRAP_SERVER` to your environment. 
  - *Added test that validates the same descriptor can be used in different contexts to refer to the same state and successfully create a snapshot.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes (StateBackends and Checkpointing)
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  
