### PR TITLE
[FLINK-27881][Connector/Pulsar] Never return null for PulsarMessageBuilder

### DIFF
--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/message/PulsarMessageBuilder.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/message/PulsarMessageBuilder.java
@@ -56,7 +56,7 @@ public class PulsarMessageBuilder<T> {
      */
     public PulsarMessageBuilder<T> key(String key) {
         this.key = checkNotNull(key);
-        return null;
+        return this;
     }
 
     /** Method wrapper of {@link TypedMessageBuilder#eventTime(long)}. */


### PR DESCRIPTION
## What is the purpose of the change

The PulsarMessageBuild.key(String) always return null, which cause NPE.

## Brief change log

`return this` instead of `return null`

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
