### PR TITLE
[FLINK-27878][datastream] Add Retry Support For Async I/O In DataStream API

### DIFF
--- a/docs/content.zh/docs/dev/datastream/operators/asyncio.md
+++ b/docs/content.zh/docs/dev/datastream/operators/asyncio.md
@@ -30,7 +30,7 @@ under the License.
 对于不熟悉异步或者事件驱动编程的用户，建议先储备一些关于 Future 和事件驱动编程的知识。
 
 提示：这篇文档 [FLIP-12: 异步 I/O 的设计和实现](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=65870673)介绍了关于设计和实现异步 I/O 功能的细节。
-对于新增的重试支持涉及和实现细节可以参考[FLIP-232: 为 DataStream API 异步 I/O 操作增加重试支持](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=211883963)
+对于新增的重试支持的实现细节可以参考[FLIP-232: 为 DataStream API 异步 I/O 操作增加重试支持](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=211883963)。
 
 
 ## 对于异步 I/O 操作的需求

--- a/docs/content.zh/docs/dev/datastream/operators/asyncio.md
+++ b/docs/content.zh/docs/dev/datastream/operators/asyncio.md
@@ -30,6 +30,8 @@ under the License.
 对于不熟悉异步或者事件驱动编程的用户，建议先储备一些关于 Future 和事件驱动编程的知识。
 
 提示：这篇文档 [FLIP-12: 异步 I/O 的设计和实现](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=65870673)介绍了关于设计和实现异步 I/O 功能的细节。
+对于新增的重试支持涉及和实现细节可以参考[FLIP-232: 为 DataStream API 异步 I/O 操作增加重试支持](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=211883963)
+
 
 ## 对于异步 I/O 操作的需求
 
@@ -60,7 +62,7 @@ Flink 的异步 I/O API 允许用户在流处理中使用异步请求客户端�
 
 - 实现分发请求的 `AsyncFunction`
 - 获取数据库交互的结果并发送给 `ResultFuture` 的 *回调* 函数
-- 将异步 I/O 操作应用于 `DataStream` 作为 `DataStream` 的一次转换操作。
+- 将异步 I/O 操作应用于 `DataStream` 作为 `DataStream` 的一次转换操作, 启用或者不启用重试。
 
 下面是基本的代码模板：
 
@@ -115,10 +117,21 @@ class AsyncDatabaseRequest extends RichAsyncFunction<String, Tuple2<String, Stri
 // 创建初始 DataStream
 DataStream<String> stream = ...;
 
-// 应用异步 I/O 转换操作
+// 应用异步 I/O 转换操作，不启用重试
 DataStream<Tuple2<String, String>> resultStream =
     AsyncDataStream.unorderedWait(stream, new AsyncDatabaseRequest(), 1000, TimeUnit.MILLISECONDS, 100);
 
+// 或 应用异步 I/O 转换操作并启用重试
+// 通过工具类创建一个异步重试策略, 或用户实现自定义的策略
+AsyncRetryStrategy asyncRetryStrategy =
+	new AsyncRetryStrategies.FixedDelayRetryStrategyBuilder(3, 100L) // maxAttempts=3, fixedDelay=100ms
+		.retryIfResult(RetryPredicates.EMPTY_RESULT_PREDICATE)
+		.retryIfException(RetryPredicates.HAS_EXCEPTION_PREDICATE)
+		.build();
+
+// 应用异步 I/O 转换操作并启用重试
+DataStream<Tuple2<String, String>> resultStream =
+	AsyncDataStream.unorderedWaitWithRetry(stream, new AsyncDatabaseRequest(), 1000, TimeUnit.MILLISECONDS, 100, asyncRetryStrategy);
 ```
 {{< /tab >}}
 {{< tab "Scala" >}}
@@ -151,10 +164,17 @@ class AsyncDatabaseRequest extends AsyncFunction[String, (String, String)] {
 // 创建初始 DataStream
 val stream: DataStream[String] = ...
 
-// 应用异步 I/O 转换操作
+// 应用异步 I/O 转换操作，不启用重试
 val resultStream: DataStream[(String, String)] =
     AsyncDataStream.unorderedWait(stream, new AsyncDatabaseRequest(), 1000, TimeUnit.MILLISECONDS, 100)
 
+// 或 应用异步 I/O 转换操作并启用重试
+// 创建一个异步重试策略
+val asyncRetryStrategy: AsyncRetryStrategy[OUT] = ...
+
+// 应用异步 I/O 转换操作并启用重试
+val resultStream: DataStream[(String, String)] =
+  AsyncDataStream.unorderedWaitWithRetry(stream, new AsyncDatabaseRequest(), 1000, TimeUnit.MILLISECONDS, 100, asyncRetryStrategy)
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -164,11 +184,12 @@ val resultStream: DataStream[(String, String)] =
 
 下面两个参数控制异步操作：
 
-  - **Timeout**： 超时参数定义了异步请求发出多久后未得到响应即被认定为失败。 它可以防止一直等待得不到响应的请求。
+  - **Timeout**： 超时参数定义了异步操作执行多久未完成、最终认定为失败的时长，如果启用重试，则可能包括多个重试请求。 它可以防止一直等待得不到响应的请求。
 
   - **Capacity**： 容量参数定义了可以同时进行的异步请求数。
     即使异步 I/O 通常带来更高的吞吐量，执行异步 I/O 操作的算子仍然可能成为流处理的瓶颈。 限制并发请求的数量可以确保算子不会持续累积待处理的请求进而造成积压，而是在容量耗尽时触发反压。
 
+  - **AsyncRetryStrategy**: 重试策略参数定义了什么条件会触发延迟重试以及延迟的策略，例如，固定延迟、指数后退延迟、自定义实现等。
 
 ### 超时处理
 
@@ -211,6 +232,16 @@ Flink 提供两种模式控制结果记录以何种顺序发出。
 异步 I/O 算子提供了完全的精确一次容错保证。它将在途的异步请求的记录保存在 checkpoint 中，在故障恢复时重新触发请求。
 
 
+### 重试支持
+
+重试支持为异步 I/O 操作引入了一个内置重试机制，它对用户的异步函数实现逻辑是透明的。
+
+  - **AsyncRetryStrategy**: 异步重试策略包含了触发重试条件 `AsyncRetryPredicate` 定义，以及根据当前已尝试次数判断是否继续重试、下次重试间隔时长的接口方法。
+    需要注意，在满足触发重试条件后，有可能因为当前重试次数超过预设的上限放弃重试，或是在任务结束时被强制终止重试（这种情况下，系统以最后一次执行的结果或异常作为最终状态）。
+
+  - **AsyncRetryPredicate**: 触发重试条件可以选择基于返回结果、 执行异常来定义条件，两种条件是或的关系，满足其一即会触发。
+
+
 ### 实现提示
 
 在实现使用 *Executor*（或者 Scala 中的 *ExecutionContext*）和回调的 *Futures* 时，建议使用 `DirectExecutor`，因为通常回调的工作量很小，`DirectExecutor` 避免了额外的线程切换开销。回调通常只是把结果发送给 `ResultFuture`，也就是把它添加进输出缓冲。从这里开始，包括发送记录和与 chenkpoint 交互在内的繁重逻辑都将在专有的线程池中进行处理。
@@ -232,5 +263,25 @@ Flink 提供两种模式控制结果记录以何种顺序发出。
   - 在 `asyncInvoke(...)` 方法内阻塞等待异步客户端返回的 future 类型对象
 
 **默认情况下，AsyncFunction 的算子（异步等待算子）可以在作业图的任意处使用，但它不能与`SourceFunction`/`SourceStreamTask`组成算子链**
+
+**启用重试后可能需要更大的缓冲队列容量**
+
+新的重试功能可能会导致更大的队列容量要求，最大数量可以近似地评估如下。
+
+```
+inputRate * retryRate * avgRetryDuration
+```
+
+例如，对于一个输入率=100条记录/秒的任务，其中1%的元素将平均触发1次重试，平均重试时间为60秒，额外的队列容量要求为:
+
+```
+100条记录/秒 * 1% * 60s = 60
+```
+
+也就是说，在无序输出模式下，给工作队列增加 60 个容量可能不会影响吞吐量； 而在有序模式下，头部元素是关键点，它未完成的时间越长，算子提供的处理延迟就越长,
+在相同的超时约束下，如果头元素事实上获得了更多的重试, 那重试功能可能会增加头部元素的处理时间即未完成时间，也就是说在有序模式下，增大队列容量并不是总能提升吞吐。
+
+当队列容量增长时（ 这是缓解背压的常用方法），OOM 的风险会随之增加。对于 `ListState` 存储来说，理论的上限是 `Integer.MAX_VALUE`，
+所以, 虽然事实上队列容量的限制是一样的，但我们在生产中不能把队列容量增加到太大，这种情况下增加任务的并行性也许更可行。
 
 {{< top >}}

--- a/docs/content/docs/dev/datastream/operators/asyncio.md
+++ b/docs/content/docs/dev/datastream/operators/asyncio.md
@@ -32,7 +32,8 @@ event-driven programming may be useful preparation.
 
 Note: Details about the design and implementation of the asynchronous I/O utility can be found in the proposal and design document
 [FLIP-12: Asynchronous I/O Design and Implementation](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=65870673).
-
+Details about the new retry support can be found in document
+[FLIP-232: Add Retry Support For Async I/O In DataStream API](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=211883963)。
 
 ## The need for Asynchronous I/O Operations
 
@@ -68,14 +69,14 @@ efficient than a proper asynchronous client.
 ## Async I/O API
 
 Flink's Async I/O API allows users to use asynchronous request clients with data streams. The API handles the integration with
-data streams, well as handling order, event time, fault tolerance, etc.
+data streams, well as handling order, event time, fault tolerance, retry support, etc.
 
 Assuming one has an asynchronous client for the target database, three parts are needed to implement a stream transformation
 with asynchronous I/O against the database:
 
   - An implementation of `AsyncFunction` that dispatches the requests
   - A *callback* that takes the result of the operation and hands it to the `ResultFuture`
-  - Applying the async I/O operation on a DataStream as a transformation
+  - Applying the async I/O operation on a DataStream as a transformation with or without retry
 
 The following code example illustrates the basic pattern:
 
@@ -131,10 +132,21 @@ class AsyncDatabaseRequest extends RichAsyncFunction<String, Tuple2<String, Stri
 // create the original stream
 DataStream<String> stream = ...;
 
-// apply the async I/O transformation
+// apply the async I/O transformation without retry
 DataStream<Tuple2<String, String>> resultStream =
     AsyncDataStream.unorderedWait(stream, new AsyncDatabaseRequest(), 1000, TimeUnit.MILLISECONDS, 100);
 
+// or apply the async I/O transformation with retry
+// create an async retry strategy via utility class or a user defined strategy
+AsyncRetryStrategy asyncRetryStrategy =
+	new AsyncRetryStrategies.FixedDelayRetryStrategyBuilder(3, 100L) // maxAttempts=3, fixedDelay=100ms
+		.retryIfResult(RetryPredicates.EMPTY_RESULT_PREDICATE)
+		.retryIfException(RetryPredicates.HAS_EXCEPTION_PREDICATE)
+		.build();
+
+// apply the async I/O transformation with retry
+DataStream<Tuple2<String, String>> resultStream =
+	AsyncDataStream.unorderedWaitWithRetry(stream, new AsyncDatabaseRequest(), 1000, TimeUnit.MILLISECONDS, 100, asyncRetryStrategy);
 ```
 {{< /tab >}}
 {{< tab "Scala" >}}
@@ -167,9 +179,17 @@ class AsyncDatabaseRequest extends AsyncFunction[String, (String, String)] {
 // create the original stream
 val stream: DataStream[String] = ...
 
-// apply the async I/O transformation
+// apply the async I/O transformation without retry
 val resultStream: DataStream[(String, String)] =
     AsyncDataStream.unorderedWait(stream, new AsyncDatabaseRequest(), 1000, TimeUnit.MILLISECONDS, 100)
+
+// apply the async I/O transformation with retry
+// create an AsyncRetryStrategy
+val asyncRetryStrategy: AsyncRetryStrategy[OUT] = ...
+
+// apply the async I/O transformation with retry
+val resultStream: DataStream[(String, String)] =
+  AsyncDataStream.unorderedWaitWithRetry(stream, new AsyncDatabaseRequest(), 1000, TimeUnit.MILLISECONDS, 100, asyncRetryStrategy)
 
 ```
 {{< /tab >}}
@@ -178,10 +198,10 @@ val resultStream: DataStream[(String, String)] =
 **Important note**: The `ResultFuture` is completed with the first call of `ResultFuture.complete`.
 All subsequent `complete` calls will be ignored.
 
-The following two parameters control the asynchronous operations:
+The following three parameters control the asynchronous operations:
 
-  - **Timeout**: The timeout defines how long an asynchronous request may take before it is considered failed. This parameter
-    guards against dead/failed requests.
+  - **Timeout**: The timeout defines how long an asynchronous operation take before it is finally considered failed,
+    may include multiple retry requests if retry enabled. This parameter guards against dead/failed requests.
 
   - **Capacity**: This parameter defines how many asynchronous requests may be in progress at the same time.
     Even though the async I/O approach leads typically to much better throughput, the operator can still be the bottleneck in
@@ -189,6 +209,8 @@ The following two parameters control the asynchronous operations:
     accumulate an ever-growing backlog of pending requests, but that it will trigger backpressure once the capacity
     is exhausted.
 
+  - **AsyncRetryStrategy**: The asyncRetryStrategy defines what conditions will trigger a delayed retry and the delay strategy,
+    e.g., fixed-delay, exponential-backoff-delay, custom implementation, etc.
 
 ### Timeout Handling
 
@@ -243,6 +265,18 @@ The asynchronous I/O operator offers full exactly-once fault tolerance guarantee
 asynchronous requests in checkpoints and restores/re-triggers the requests when recovering from a failure.
 
 
+### Retry Support
+
+The retry support introduces a built-in mechanism for async operator which being transparently to the user's AsyncFunction.
+
+  - **AsyncRetryStrategy**: The `AsyncRetryStrategy` contains the definition of the retry condition `AsyncRetryPredicate` and the interfaces
+    to determine whether to continue retry and the retry interval based on the current attempt number.
+    Note that after the trigger retry condition is met, it is possible to abandon the retry because the current attempt number exceeds the preset limit,
+    or to be forced to terminate the retry at the end of the task (in this case, the system takes the last execution result or exception as the final state).
+
+  - **AsyncRetryPredicate**: The retry condition can be triggered based on the return result or the execution exception.
+
+
 ### Implementation Tips
 
 For implementations with *Futures* that have an *Executor* (or *ExecutionContext* in Scala) for callbacks, we suggests to use a `DirectExecutor`, because the
@@ -270,5 +304,27 @@ For example, the following patterns result in a blocking `asyncInvoke(...)` func
   - Blocking/waiting on the future-type objects returned by an asynchronous client inside the `asyncInvoke(...)` method
   
 **An AsyncFunction(AsyncWaitOperator) can be used anywhere in the job graph, except that it cannot be chained to a `SourceFunction`/`SourceStreamTask`.**
+
+**May Need Larger Queue Capacity If Retry Enabled**
+
+The new retry feature may result in larger queue capacity requirements, the maximum number can be approximately evaluated as below:
+
+```
+inputRate * retryRate * avgRetryDuration
+```
+
+For example, for a task with inputRate = 100 records/sec, where 1% of the elements will trigger 1 retry on average, and the average retry time is 60s,
+the additional queue capacity requirement will be:
+
+```
+100 records/sec * 1% * 60s = 60
+```
+
+That is, adding more 60 capacity to the work queue may not affect the throughput in unordered output mode , in case of ordered mode, the head element is the key point,
+and the longer it stays uncompleted, the longer the processing delay provided by the operator, the retry feature may increase the incomplete time of the head element,
+if in fact more retries are obtained with the same timeout constraint.
+
+When the queue capacity grows(common way to ease the backpressure), the risk of OOM increases. Though in fact, for `ListState` storage, the theoretical upper limit is `Integer.MAX_VALUE`,
+so the queue capacity's limit is the same, but we can't increase the queue capacity too big in production, increase the task parallelism maybe a more viable way.
 
 {{< top >}}

--- a/docs/content/docs/dev/datastream/operators/asyncio.md
+++ b/docs/content/docs/dev/datastream/operators/asyncio.md
@@ -33,7 +33,7 @@ event-driven programming may be useful preparation.
 Note: Details about the design and implementation of the asynchronous I/O utility can be found in the proposal and design document
 [FLIP-12: Asynchronous I/O Design and Implementation](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=65870673).
 Details about the new retry support can be found in document
-[FLIP-232: Add Retry Support For Async I/O In DataStream API](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=211883963)。
+[FLIP-232: Add Retry Support For Async I/O In DataStream API](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=211883963).
 
 ## The need for Asynchronous I/O Operations
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/AsyncDataStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/AsyncDataStream.java
@@ -22,10 +22,14 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.Utils;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
 import org.apache.flink.streaming.api.functions.async.AsyncFunction;
+import org.apache.flink.streaming.api.functions.async.AsyncRetryStrategy;
 import org.apache.flink.streaming.api.operators.async.AsyncWaitOperator;
 import org.apache.flink.streaming.api.operators.async.AsyncWaitOperatorFactory;
+import org.apache.flink.util.Preconditions;
 
 import java.util.concurrent.TimeUnit;
+
+import static org.apache.flink.streaming.util.retryable.AsyncRetryStrategies.NO_RETRY_STRATEGY;
 
 /**
  * A helper class to apply {@link AsyncFunction} to a data stream.
@@ -66,7 +70,29 @@ public class AsyncDataStream {
             long timeout,
             int bufSize,
             OutputMode mode) {
+        return addOperator(in, func, timeout, bufSize, mode, NO_RETRY_STRATEGY);
+    }
 
+    /**
+     * Add an AsyncWaitOperator.
+     *
+     * @param in The {@link DataStream} where the {@link AsyncWaitOperator} will be added.
+     * @param func {@link AsyncFunction} wrapped inside {@link AsyncWaitOperator}.
+     * @param timeout for the asynchronous operation to complete
+     * @param bufSize The max number of inputs the {@link AsyncWaitOperator} can hold inside.
+     * @param mode Processing mode for {@link AsyncWaitOperator}.
+     * @param asyncRetryStrategy AsyncRetryStrategy for {@link AsyncFunction}.
+     * @param <IN> Input type.
+     * @param <OUT> Output type.
+     * @return A new {@link SingleOutputStreamOperator}
+     */
+    private static <IN, OUT> SingleOutputStreamOperator<OUT> addOperator(
+            DataStream<IN> in,
+            AsyncFunction<IN, OUT> func,
+            long timeout,
+            int bufSize,
+            OutputMode mode,
+            AsyncRetryStrategy<OUT> asyncRetryStrategy) {
         TypeInformation<OUT> outTypeInfo =
                 TypeExtractor.getUnaryOperatorReturnType(
                         func,
@@ -81,7 +107,11 @@ public class AsyncDataStream {
         // create transform
         AsyncWaitOperatorFactory<IN, OUT> operatorFactory =
                 new AsyncWaitOperatorFactory<>(
-                        in.getExecutionEnvironment().clean(func), timeout, bufSize, mode);
+                        in.getExecutionEnvironment().clean(func),
+                        timeout,
+                        bufSize,
+                        mode,
+                        asyncRetryStrategy);
 
         return in.transform("async wait operator", outTypeInfo, operatorFactory);
     }
@@ -162,5 +192,135 @@ public class AsyncDataStream {
             DataStream<IN> in, AsyncFunction<IN, OUT> func, long timeout, TimeUnit timeUnit) {
         return addOperator(
                 in, func, timeUnit.toMillis(timeout), DEFAULT_QUEUE_CAPACITY, OutputMode.ORDERED);
+    }
+
+    // ======= retryable ========
+
+    /**
+     * Add an AsyncWaitOperator with an AsyncRetryStrategy to support retry of AsyncFunction. The
+     * order of output stream records may be reordered.
+     *
+     * @param in Input {@link DataStream}
+     * @param func {@link AsyncFunction}
+     * @param timeout from first invoke to final completion of asynchronous operation, may include
+     *     multiple retries, and will be reset in case of restart
+     * @param timeUnit of the given timeout
+     * @param asyncRetryStrategy The strategy of reattempt async i/o operation that can be triggered
+     * @param <IN> Type of input record
+     * @param <OUT> Type of output record
+     * @return A new {@link SingleOutputStreamOperator}.
+     */
+    public static <IN, OUT> SingleOutputStreamOperator<OUT> unorderedWaitWithRetry(
+            DataStream<IN> in,
+            AsyncFunction<IN, OUT> func,
+            long timeout,
+            TimeUnit timeUnit,
+            AsyncRetryStrategy asyncRetryStrategy) {
+        Preconditions.checkArgument(
+                timeout > 0, "Timeout should be configured when do async with retry.");
+        return addOperator(
+                in,
+                func,
+                timeUnit.toMillis(timeout),
+                DEFAULT_QUEUE_CAPACITY,
+                OutputMode.UNORDERED,
+                asyncRetryStrategy);
+    }
+
+    /**
+     * Add an AsyncWaitOperator with an AsyncRetryStrategy to support retry of AsyncFunction. The
+     * order of output stream records may be reordered.
+     *
+     * @param in Input {@link DataStream}
+     * @param func {@link AsyncFunction}
+     * @param timeout from first invoke to final completion of asynchronous operation, may include
+     *     multiple retries, and will be reset in case of restart
+     * @param timeUnit of the given timeout
+     * @param capacity The max number of async i/o operation that can be triggered
+     * @param asyncRetryStrategy The strategy of reattempt async i/o operation that can be triggered
+     * @param <IN> Type of input record
+     * @param <OUT> Type of output record
+     * @return A new {@link SingleOutputStreamOperator}.
+     */
+    public static <IN, OUT> SingleOutputStreamOperator<OUT> unorderedWaitWithRetry(
+            DataStream<IN> in,
+            AsyncFunction<IN, OUT> func,
+            long timeout,
+            TimeUnit timeUnit,
+            int capacity,
+            AsyncRetryStrategy asyncRetryStrategy) {
+        Preconditions.checkArgument(
+                timeout > 0, "Timeout should be configured when do async with retry.");
+        return addOperator(
+                in,
+                func,
+                timeUnit.toMillis(timeout),
+                capacity,
+                OutputMode.UNORDERED,
+                asyncRetryStrategy);
+    }
+
+    /**
+     * Add an AsyncWaitOperator with an AsyncRetryStrategy to support retry of AsyncFunction. The
+     * order to process input records is guaranteed to be the same as * input ones.
+     *
+     * @param in Input {@link DataStream}
+     * @param func {@link AsyncFunction}
+     * @param timeout from first invoke to final completion of asynchronous operation, may include
+     *     multiple retries, and will be reset in case of restart
+     * @param timeUnit of the given timeout
+     * @param asyncRetryStrategy The strategy of reattempt async i/o operation that can be triggered
+     * @param <IN> Type of input record
+     * @param <OUT> Type of output record
+     * @return A new {@link SingleOutputStreamOperator}.
+     */
+    public static <IN, OUT> SingleOutputStreamOperator<OUT> orderedWaitWithRetry(
+            DataStream<IN> in,
+            AsyncFunction<IN, OUT> func,
+            long timeout,
+            TimeUnit timeUnit,
+            AsyncRetryStrategy asyncRetryStrategy) {
+        Preconditions.checkArgument(
+                timeout > 0, "Timeout should be configured when do async with retry.");
+        return addOperator(
+                in,
+                func,
+                timeUnit.toMillis(timeout),
+                DEFAULT_QUEUE_CAPACITY,
+                OutputMode.ORDERED,
+                asyncRetryStrategy);
+    }
+
+    /**
+     * Add an AsyncWaitOperator with an AsyncRetryStrategy to support retry of AsyncFunction. The
+     * order to process input records is guaranteed to be the same as * input ones.
+     *
+     * @param in Input {@link DataStream}
+     * @param func {@link AsyncFunction}
+     * @param timeout from first invoke to final completion of asynchronous operation, may include
+     *     multiple retries, and will be reset in case of restart
+     * @param timeUnit of the given timeout
+     * @param capacity The max number of async i/o operation that can be triggered
+     * @param asyncRetryStrategy The strategy of reattempt async i/o operation that can be triggered
+     * @param <IN> Type of input record
+     * @param <OUT> Type of output record
+     * @return A new {@link SingleOutputStreamOperator}.
+     */
+    public static <IN, OUT> SingleOutputStreamOperator<OUT> orderedWaitWithRetry(
+            DataStream<IN> in,
+            AsyncFunction<IN, OUT> func,
+            long timeout,
+            TimeUnit timeUnit,
+            int capacity,
+            AsyncRetryStrategy asyncRetryStrategy) {
+        Preconditions.checkArgument(
+                timeout > 0, "Timeout should be configured when do async with retry.");
+        return addOperator(
+                in,
+                func,
+                timeUnit.toMillis(timeout),
+                capacity,
+                OutputMode.ORDERED,
+                asyncRetryStrategy);
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/async/AsyncRetryPredicate.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/async/AsyncRetryPredicate.java
@@ -29,7 +29,7 @@ public interface AsyncRetryPredicate<OUT> {
      * An Optional Java {@Predicate} that defines a condition on asyncFunction's future result which
      * will trigger a later reattempt operation, will be called before user's ResultFuture#complete.
      *
-     * @return predicate on result of {@link Collection<OUT>}
+     * @return predicate on result of {@link Collection}
      */
     Optional<Predicate<Collection<OUT>>> resultPredicate();
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/async/AsyncRetryPredicate.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/async/AsyncRetryPredicate.java
@@ -18,11 +18,14 @@
 
 package org.apache.flink.streaming.api.functions.async;
 
+import org.apache.flink.annotation.PublicEvolving;
+
 import java.util.Collection;
 import java.util.Optional;
 import java.util.function.Predicate;
 
 /** Interface encapsulates an asynchronous retry predicate. */
+@PublicEvolving
 public interface AsyncRetryPredicate<OUT> {
 
     /**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/async/AsyncRetryPredicate.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/async/AsyncRetryPredicate.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.functions.async;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+/** Interface encapsulates an asynchronous retry predicate. */
+public interface AsyncRetryPredicate<OUT> {
+
+    /**
+     * An Optional Java {@Predicate} that defines a condition on asyncFunction's future result which
+     * will trigger a later reattempt operation, will be called before user's ResultFuture#complete.
+     *
+     * @return predicate on result of {@link Collection<OUT>}
+     */
+    Optional<Predicate<Collection<OUT>>> resultPredicate();
+
+    /**
+     * An Optional Java {@Predicate} that defines a condition on asyncFunction's exception which
+     * will trigger a later reattempt operation, will be called before user's
+     * ResultFuture#completeExceptionally.
+     *
+     * @return predicate on {@link Throwable} exception
+     */
+    Optional<Predicate<Throwable>> exceptionPredicate();
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/async/AsyncRetryStrategy.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/async/AsyncRetryStrategy.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.functions.async;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import java.io.Serializable;
+
+/** Interface encapsulates an asynchronous retry strategy. */
+@PublicEvolving
+public interface AsyncRetryStrategy<OUT> extends Serializable {
+
+    /** @return whether the next attempt can happen */
+    boolean canRetry(int currentAttempts);
+
+    /** @return the delay time of next attempt */
+    long getBackoffTimeMillis(int currentAttempts);
+
+    /** @return the defined retry predicate {@link AsyncRetryPredicate} */
+    AsyncRetryPredicate<OUT> getRetryPredicate();
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperator.java
@@ -193,14 +193,12 @@ public class AsyncWaitOperator<IN, OUT>
             default:
                 throw new IllegalStateException("Unknown async mode: " + outputMode + '.');
         }
-        if (asyncRetryStrategy.getRetryPredicate().resultPredicate().isPresent()) {
+        if (retryEnabled) {
             this.retryResultPredicate =
                     asyncRetryStrategy
                             .getRetryPredicate()
                             .resultPredicate()
                             .orElse(ignore -> false);
-        }
-        if (asyncRetryStrategy.getRetryPredicate().exceptionPredicate().isPresent()) {
             this.retryExceptionPredicate =
                     asyncRetryStrategy
                             .getRetryPredicate()

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperator.java
@@ -162,11 +162,8 @@ public class AsyncWaitOperator<IN, OUT>
                 // construct from utility class
                 asyncRetryStrategy != NO_RETRY_STRATEGY
                         // construct from api
-                        || (asyncRetryStrategy.getRetryPredicate().resultPredicate().isPresent()
-                                && asyncRetryStrategy
-                                        .getRetryPredicate()
-                                        .exceptionPredicate()
-                                        .isPresent());
+                        || asyncRetryStrategy.getRetryPredicate().resultPredicate().isPresent()
+                        || asyncRetryStrategy.getRetryPredicate().exceptionPredicate().isPresent();
 
         this.processingTimeService = Preconditions.checkNotNull(processingTimeService);
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperator.java
@@ -431,8 +431,8 @@ public class AsyncWaitOperator<IN, OUT>
 
         /**
          * A guard similar to ResultHandler#complete to prevent repeated complete calls from
-         * ill-written AsyncFunction. This flag indicates a retry is in-flight, will reject new
-         * retry request if true. And wil be reset to false after the retry fired.
+         * ill-written AsyncFunction. This flag indicates a retry is in-flight, new retry will be
+         * rejected if it is ture, and it will be reset to false after the retry fired.
          */
         private final AtomicBoolean retryAwaiting = new AtomicBoolean(false);
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperator.java
@@ -326,7 +326,8 @@ public class AsyncWaitOperator<IN, OUT>
      * @return a handle that allows to set the result of the async computation for the given
      *     element.
      */
-    private ResultFuture<OUT> addToWorkQueue(StreamElement streamElement) throws Exception {
+    private ResultFuture<OUT> addToWorkQueue(StreamElement streamElement)
+            throws InterruptedException {
 
         Optional<ResultFuture<OUT>> queueEntry;
         while (!(queueEntry = queue.tryPut(streamElement)).isPresent()) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperator.java
@@ -408,7 +408,7 @@ public class AsyncWaitOperator<IN, OUT>
 
         private ScheduledFuture<?> delayedRetryTimer;
 
-        /** start from 1, when this entry created, the first attempt will happen */
+        /** start from 1, when this entry created, the first attempt will happen. */
         private int currentAttempts = 1;
 
         private long backoffTimeMillis;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorFactory.java
@@ -19,12 +19,15 @@ package org.apache.flink.streaming.api.operators.async;
 
 import org.apache.flink.streaming.api.datastream.AsyncDataStream;
 import org.apache.flink.streaming.api.functions.async.AsyncFunction;
+import org.apache.flink.streaming.api.functions.async.AsyncRetryStrategy;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperatorFactory;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperatorFactory;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
 import org.apache.flink.streaming.api.operators.YieldingOperatorFactory;
+
+import static org.apache.flink.streaming.util.retryable.AsyncRetryStrategies.NO_RETRY_STRATEGY;
 
 /**
  * The factory of {@link AsyncWaitOperator}.
@@ -38,17 +41,28 @@ public class AsyncWaitOperatorFactory<IN, OUT> extends AbstractStreamOperatorFac
     private final long timeout;
     private final int capacity;
     private final AsyncDataStream.OutputMode outputMode;
+    private final AsyncRetryStrategy<OUT> asyncRetryStrategy;
 
     public AsyncWaitOperatorFactory(
             AsyncFunction<IN, OUT> asyncFunction,
             long timeout,
             int capacity,
             AsyncDataStream.OutputMode outputMode) {
+        this(asyncFunction, timeout, capacity, outputMode, NO_RETRY_STRATEGY);
+    }
+
+    public AsyncWaitOperatorFactory(
+            AsyncFunction<IN, OUT> asyncFunction,
+            long timeout,
+            int capacity,
+            AsyncDataStream.OutputMode outputMode,
+            AsyncRetryStrategy<OUT> asyncRetryStrategy) {
         this.asyncFunction = asyncFunction;
         this.timeout = timeout;
         this.capacity = capacity;
         this.outputMode = outputMode;
         this.chainingStrategy = ChainingStrategy.ALWAYS;
+        this.asyncRetryStrategy = asyncRetryStrategy;
     }
 
     @Override
@@ -60,6 +74,7 @@ public class AsyncWaitOperatorFactory<IN, OUT> extends AbstractStreamOperatorFac
                         timeout,
                         capacity,
                         outputMode,
+                        asyncRetryStrategy,
                         processingTimeService,
                         getMailboxExecutor());
         asyncWaitOperator.setup(

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/queue/StreamRecordQueueEntry.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/queue/StreamRecordQueueEntry.java
@@ -37,7 +37,7 @@ import java.util.Collection;
  * @param <OUT> Type of the asynchronous collection result.
  */
 @Internal
-class StreamRecordQueueEntry<OUT> implements StreamElementQueueEntry<OUT> {
+public class StreamRecordQueueEntry<OUT> implements StreamElementQueueEntry<OUT> {
     @Nonnull private final StreamRecord<?> inputRecord;
 
     private Collection<OUT> completedElements;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/queue/StreamRecordQueueEntry.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/queue/StreamRecordQueueEntry.java
@@ -37,7 +37,7 @@ import java.util.Collection;
  * @param <OUT> Type of the asynchronous collection result.
  */
 @Internal
-public class StreamRecordQueueEntry<OUT> implements StreamElementQueueEntry<OUT> {
+class StreamRecordQueueEntry<OUT> implements StreamElementQueueEntry<OUT> {
     @Nonnull private final StreamRecord<?> inputRecord;
 
     private Collection<OUT> completedElements;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/retryable/AsyncRetryStrategies.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/retryable/AsyncRetryStrategies.java
@@ -33,7 +33,7 @@ public class AsyncRetryStrategies {
     public static final NoRetryStrategy NO_RETRY_STRATEGY = new NoRetryStrategy();
 
     /** NoRetryStrategy. */
-    public static class NoRetryStrategy implements AsyncRetryStrategy {
+    private static class NoRetryStrategy implements AsyncRetryStrategy {
         private static final long serialVersionUID = 1L;
 
         private NoRetryStrategy() {}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/retryable/AsyncRetryStrategies.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/retryable/AsyncRetryStrategies.java
@@ -1,0 +1,260 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.util.retryable;
+
+import org.apache.flink.streaming.api.functions.async.AsyncRetryPredicate;
+import org.apache.flink.streaming.api.functions.async.AsyncRetryStrategy;
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nonnull;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+/** Utility class to create concrete {@link AsyncRetryStrategy}. */
+public class AsyncRetryStrategies {
+    public static final NoRetryStrategy NO_RETRY_STRATEGY = new NoRetryStrategy();
+
+    /** NoRetryStrategy. */
+    public static class NoRetryStrategy implements AsyncRetryStrategy {
+        private static final long serialVersionUID = 1L;
+
+        private NoRetryStrategy() {}
+
+        @Override
+        public boolean canRetry(int currentAttempts) {
+            return false;
+        }
+
+        @Override
+        public long getBackoffTimeMillis(int currentAttempts) {
+            return -1;
+        }
+
+        @Override
+        public AsyncRetryPredicate getRetryPredicate() {
+            return new AsyncRetryPredicate() {
+                @Override
+                public Optional<Predicate<Collection>> resultPredicate() {
+                    return Optional.empty();
+                }
+
+                @Override
+                public Optional<Predicate<Throwable>> exceptionPredicate() {
+                    return Optional.empty();
+                }
+            };
+        }
+    }
+
+    /** FixedDelayRetryStrategy. */
+    public static class FixedDelayRetryStrategy<OUT> implements AsyncRetryStrategy<OUT> {
+        private static final long serialVersionUID = 1L;
+        private final int maxAttempts;
+        private final long backoffTimeMillis;
+        private final Predicate<Collection<OUT>> resultPredicate;
+        private final Predicate<Throwable> exceptionPredicate;
+
+        private FixedDelayRetryStrategy(
+                int maxAttempts,
+                long backoffTimeMillis,
+                Predicate<Collection<OUT>> resultPredicate,
+                Predicate<Throwable> exceptionPredicate) {
+            this.maxAttempts = maxAttempts;
+            this.backoffTimeMillis = backoffTimeMillis;
+            this.resultPredicate = resultPredicate;
+            this.exceptionPredicate = exceptionPredicate;
+        }
+
+        @Override
+        public boolean canRetry(int currentAttempts) {
+            return currentAttempts <= maxAttempts;
+        }
+
+        @Override
+        public AsyncRetryPredicate<OUT> getRetryPredicate() {
+            return new AsyncRetryPredicate<OUT>() {
+                @Override
+                public Optional<Predicate<Collection<OUT>>> resultPredicate() {
+                    if (null == resultPredicate) {
+                        return Optional.empty();
+                    }
+                    return Optional.of(resultPredicate);
+                }
+
+                @Override
+                public Optional<Predicate<Throwable>> exceptionPredicate() {
+                    if (null == exceptionPredicate) {
+                        return Optional.empty();
+                    }
+                    return Optional.of(exceptionPredicate);
+                }
+            };
+        }
+
+        @Override
+        public long getBackoffTimeMillis(int currentAttempts) {
+            return backoffTimeMillis;
+        }
+    }
+
+    /** FixedDelayRetryStrategyBuilder for building a FixedDelayRetryStrategy. */
+    public static class FixedDelayRetryStrategyBuilder<OUT> {
+        private int maxAttempts;
+        private long backoffTimeMillis;
+        private Predicate<Collection<OUT>> resultPredicate;
+        private Predicate<Throwable> exceptionPredicate;
+
+        public FixedDelayRetryStrategyBuilder(int maxAttempts, long backoffTimeMillis) {
+            Preconditions.checkArgument(
+                    maxAttempts > 0, "maxAttempts should be greater than zero.");
+            Preconditions.checkArgument(
+                    backoffTimeMillis > 0, "backoffTimeMillis should be greater than zero.");
+            this.maxAttempts = maxAttempts;
+            this.backoffTimeMillis = backoffTimeMillis;
+        }
+
+        public FixedDelayRetryStrategyBuilder ifResult(
+                @Nonnull Predicate<Collection<OUT>> resultRetryPredicate) {
+            this.resultPredicate = resultRetryPredicate;
+            return this;
+        }
+
+        public FixedDelayRetryStrategyBuilder ifException(
+                @Nonnull Predicate<Throwable> exceptionRetryPredicate) {
+            this.exceptionPredicate = exceptionRetryPredicate;
+            return this;
+        }
+
+        public FixedDelayRetryStrategy build() {
+            return new FixedDelayRetryStrategy(
+                    maxAttempts, backoffTimeMillis, resultPredicate, exceptionPredicate);
+        }
+    }
+
+    /** ExponentialBackoffDelayRetryStrategy. */
+    public static class ExponentialBackoffDelayRetryStrategy<OUT>
+            implements AsyncRetryStrategy<OUT> {
+        private static final long serialVersionUID = 1L;
+        private final int maxAttempts;
+
+        private final long initialDelay;
+        private final long maxRetryDelay;
+
+        private final double multiplier;
+        private final Predicate<Collection<OUT>> resultPredicate;
+        private final Predicate<Throwable> exceptionPredicate;
+
+        private long lastRetryDelay;
+
+        public ExponentialBackoffDelayRetryStrategy(
+                int maxAttempts,
+                long initialDelay,
+                long maxRetryDelay,
+                double multiplier,
+                Predicate<Collection<OUT>> resultPredicate,
+                Predicate<Throwable> exceptionPredicate) {
+            this.maxAttempts = maxAttempts;
+            this.initialDelay = initialDelay;
+            this.maxRetryDelay = maxRetryDelay;
+            this.multiplier = multiplier;
+            this.resultPredicate = resultPredicate;
+            this.exceptionPredicate = exceptionPredicate;
+            this.lastRetryDelay = initialDelay;
+        }
+
+        @Override
+        public boolean canRetry(int currentAttempts) {
+            return currentAttempts <= maxAttempts;
+        }
+
+        @Override
+        public long getBackoffTimeMillis(int currentAttempts) {
+            long backoff = Math.min((long) (lastRetryDelay * multiplier), maxRetryDelay);
+            this.lastRetryDelay = backoff;
+            return backoff;
+        }
+
+        @Override
+        public AsyncRetryPredicate<OUT> getRetryPredicate() {
+            return new AsyncRetryPredicate<OUT>() {
+                @Override
+                public Optional<Predicate<Collection<OUT>>> resultPredicate() {
+                    if (null == resultPredicate) {
+                        return Optional.empty();
+                    }
+                    return Optional.of(resultPredicate);
+                }
+
+                @Override
+                public Optional<Predicate<Throwable>> exceptionPredicate() {
+                    if (null == exceptionPredicate) {
+                        return Optional.empty();
+                    }
+                    return Optional.of(exceptionPredicate);
+                }
+            };
+        }
+    }
+
+    /**
+     * ExponentialBackoffDelayRetryStrategyBuilder for building a
+     * ExponentialBackoffDelayRetryStrategy.
+     */
+    public static class ExponentialBackoffDelayRetryStrategyBuilder<OUT> {
+        private final int maxAttempts;
+        private final long initialDelay;
+        private final long maxRetryDelay;
+        private final double multiplier;
+
+        private Predicate<Collection<OUT>> resultPredicate;
+        private Predicate<Throwable> exceptionPredicate;
+
+        public ExponentialBackoffDelayRetryStrategyBuilder(
+                int maxAttempts, long initialDelay, long maxRetryDelay, double multiplier) {
+            this.maxAttempts = maxAttempts;
+            this.initialDelay = initialDelay;
+            this.maxRetryDelay = maxRetryDelay;
+            this.multiplier = multiplier;
+        }
+
+        public ExponentialBackoffDelayRetryStrategyBuilder ifResult(
+                @Nonnull Predicate<Collection<OUT>> resultRetryPredicate) {
+            this.resultPredicate = resultRetryPredicate;
+            return this;
+        }
+
+        public ExponentialBackoffDelayRetryStrategyBuilder ifException(
+                @Nonnull Predicate<Throwable> exceptionRetryPredicate) {
+            this.exceptionPredicate = exceptionRetryPredicate;
+            return this;
+        }
+
+        public ExponentialBackoffDelayRetryStrategy build() {
+            return new ExponentialBackoffDelayRetryStrategy(
+                    maxAttempts,
+                    initialDelay,
+                    maxRetryDelay,
+                    multiplier,
+                    resultPredicate,
+                    exceptionPredicate);
+        }
+    }
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/retryable/RetryPredicates.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/retryable/RetryPredicates.java
@@ -34,7 +34,7 @@ public class RetryPredicates {
     public static final HasExceptionPredicate HAS_EXCEPTION_PREDICATE = new HasExceptionPredicate();
 
     /**
-     * Create a predicate on given exception type.
+     * Creates a predicate on given exception type.
      *
      * @param exceptionClass
      * @return predicate on exception type.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/retryable/RetryPredicates.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/retryable/RetryPredicates.java
@@ -27,10 +27,10 @@ import java.util.function.Predicate;
 /** Utility class to create concrete retry predicates. */
 public class RetryPredicates {
 
-    /** A predicate matches empty result which means an empty {@link Collection} */
+    /** A predicate matches empty result which means an empty {@link Collection}. */
     public static final EmptyResultPredicate EMPTY_RESULT_PREDICATE = new EmptyResultPredicate();
 
-    /** A predicate matches any exception which means a non-null{@link Throwable} */
+    /** A predicate matches any exception which means a non-null{@link Throwable}. */
     public static final HasExceptionPredicate HAS_EXCEPTION_PREDICATE = new HasExceptionPredicate();
 
     /**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/retryable/RetryPredicates.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/retryable/RetryPredicates.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.util.retryable;
+
+import javax.annotation.Nonnull;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.function.Predicate;
+
+/** Utility class to create concrete retry predicates. */
+public class RetryPredicates {
+
+    /** A predicate matches empty result which means an empty {@link Collection} */
+    public static final EmptyResultPredicate EMPTY_RESULT_PREDICATE = new EmptyResultPredicate();
+
+    /** A predicate matches any exception which means a non-null{@link Throwable} */
+    public static final HasExceptionPredicate HAS_EXCEPTION_PREDICATE = new HasExceptionPredicate();
+
+    /**
+     * Create a predicate on given exception type.
+     *
+     * @param exceptionClass
+     * @return predicate on exception type.
+     */
+    public static ExceptionTypePredicate createExceptionTypePredicate(
+            @Nonnull Class<? extends Throwable> exceptionClass) {
+        return new ExceptionTypePredicate(exceptionClass);
+    }
+
+    public static ExceptionTypePredicate exceptionTypePredicate(
+            @Nonnull Class<? extends Throwable> exceptionClass) {
+        return new ExceptionTypePredicate(exceptionClass);
+    }
+
+    private static final class EmptyResultPredicate<T>
+            implements Predicate<Collection<T>>, Serializable {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public boolean test(Collection<T> ts) {
+            if (null == ts || ts.isEmpty()) {
+                return true;
+            }
+            return false;
+        }
+    }
+
+    private static final class HasExceptionPredicate implements Predicate<Throwable>, Serializable {
+        private static final long serialVersionUID = 1L;
+
+        private HasExceptionPredicate() {}
+
+        @Override
+        public boolean test(Throwable throwable) {
+            return null != throwable;
+        }
+    }
+
+    private static final class ExceptionTypePredicate
+            implements Predicate<Throwable>, Serializable {
+        private static final long serialVersionUID = 1L;
+        private final Class<? extends Throwable> exceptionClass;
+
+        public ExceptionTypePredicate(@Nonnull Class<? extends Throwable> exceptionClass) {
+            this.exceptionClass = exceptionClass;
+        }
+
+        @Override
+        public boolean test(@Nonnull Throwable throwable) {
+            return exceptionClass.isAssignableFrom(throwable.getClass());
+        }
+    }
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/retryable/RetryPredicates.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/retryable/RetryPredicates.java
@@ -44,11 +44,6 @@ public class RetryPredicates {
         return new ExceptionTypePredicate(exceptionClass);
     }
 
-    public static ExceptionTypePredicate exceptionTypePredicate(
-            @Nonnull Class<? extends Throwable> exceptionClass) {
-        return new ExceptionTypePredicate(exceptionClass);
-    }
-
     private static final class EmptyResultPredicate<T>
             implements Predicate<Collection<T>>, Serializable {
         private static final long serialVersionUID = 1L;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorTest.java
@@ -40,6 +40,7 @@ import org.apache.flink.streaming.api.datastream.AsyncDataStream;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.async.AsyncFunction;
+import org.apache.flink.streaming.api.functions.async.AsyncRetryStrategy;
 import org.apache.flink.streaming.api.functions.async.ResultFuture;
 import org.apache.flink.streaming.api.functions.async.RichAsyncFunction;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
@@ -54,6 +55,8 @@ import org.apache.flink.streaming.runtime.tasks.StreamTaskMailboxTestHarness;
 import org.apache.flink.streaming.runtime.tasks.StreamTaskMailboxTestHarnessBuilder;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.TestHarnessUtil;
+import org.apache.flink.streaming.util.retryable.AsyncRetryStrategies;
+import org.apache.flink.streaming.util.retryable.RetryPredicates;
 import org.apache.flink.testutils.junit.SharedObjects;
 import org.apache.flink.testutils.junit.SharedReference;
 import org.apache.flink.util.ExceptionUtils;
@@ -101,6 +104,7 @@ import static org.junit.Assert.assertTrue;
  * <ul>
  *   <li>Process StreamRecords and Watermarks in ORDERED mode
  *   <li>Process StreamRecords and Watermarks in UNORDERED mode
+ *   <li>Process StreamRecords with retry
  *   <li>AsyncWaitOperator in operator chain
  *   <li>Snapshot state and restore state
  * </ul>
@@ -110,6 +114,16 @@ public class AsyncWaitOperatorTest extends TestLogger {
 
     @Rule public Timeout timeoutRule = new Timeout(100, TimeUnit.SECONDS);
     @Rule public final SharedObjects sharedObjects = SharedObjects.create();
+
+    private static AsyncRetryStrategy emptyResultFixedDelayRetryStrategy =
+            new AsyncRetryStrategies.FixedDelayRetryStrategyBuilder(2, 10L)
+                    .ifResult(RetryPredicates.EMPTY_RESULT_PREDICATE)
+                    .build();
+
+    private static AsyncRetryStrategy exceptionRetryStrategy =
+            new AsyncRetryStrategies.FixedDelayRetryStrategyBuilder(2, 10L)
+                    .ifException(RetryPredicates.HAS_EXCEPTION_PREDICATE)
+                    .build();
 
     private abstract static class MyAbstractAsyncFunction<IN>
             extends RichAsyncFunction<IN, Integer> {
@@ -267,6 +281,31 @@ public class AsyncWaitOperatorTest extends TestLogger {
         @Override
         public void timeout(Integer input, ResultFuture<Integer> resultFuture) {
             TIMED_OUT.set(true);
+        }
+    }
+
+    private static class OddInputEmptyResultAsyncFunction extends MyAbstractAsyncFunction<Integer> {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public void asyncInvoke(final Integer input, final ResultFuture<Integer> resultFuture)
+                throws Exception {
+            executorService.submit(
+                    new Runnable() {
+                        @Override
+                        public void run() {
+                            try {
+                                Thread.sleep(3);
+                            } catch (InterruptedException e) {
+                                throw new RuntimeException(e);
+                            }
+                            if (input % 2 == 1) {
+                                resultFuture.complete(Collections.EMPTY_LIST);
+                            } else {
+                                resultFuture.complete(Collections.singletonList(input * 2));
+                            }
+                        }
+                    });
         }
     }
 
@@ -859,7 +898,13 @@ public class AsyncWaitOperatorTest extends TestLogger {
      */
     @Test
     public void testOrderedWaitUserExceptionHandling() throws Exception {
-        testUserExceptionHandling(AsyncDataStream.OutputMode.ORDERED);
+        testUserExceptionHandling(
+                AsyncDataStream.OutputMode.ORDERED, AsyncRetryStrategies.NO_RETRY_STRATEGY);
+    }
+
+    @Test
+    public void testOrderedWaitUserExceptionHandlingWithRetry() throws Exception {
+        testUserExceptionHandling(AsyncDataStream.OutputMode.ORDERED, exceptionRetryStrategy);
     }
 
     /**
@@ -871,10 +916,18 @@ public class AsyncWaitOperatorTest extends TestLogger {
      */
     @Test
     public void testUnorderedWaitUserExceptionHandling() throws Exception {
-        testUserExceptionHandling(AsyncDataStream.OutputMode.UNORDERED);
+        testUserExceptionHandling(
+                AsyncDataStream.OutputMode.UNORDERED, AsyncRetryStrategies.NO_RETRY_STRATEGY);
     }
 
-    private void testUserExceptionHandling(AsyncDataStream.OutputMode outputMode) throws Exception {
+    @Test
+    public void testUnorderedWaitUserExceptionHandlingWithRetry() throws Exception {
+        testUserExceptionHandling(AsyncDataStream.OutputMode.UNORDERED, exceptionRetryStrategy);
+    }
+
+    private void testUserExceptionHandling(
+            AsyncDataStream.OutputMode outputMode, AsyncRetryStrategy asyncRetryStrategy)
+            throws Exception {
         OneInputStreamOperatorTestHarness<Integer, Integer> harness =
                 createTestHarness(new UserExceptionAsyncFunction(), TIMEOUT, 2, outputMode);
 
@@ -912,7 +965,14 @@ public class AsyncWaitOperatorTest extends TestLogger {
      */
     @Test
     public void testOrderedWaitTimeoutHandling() throws Exception {
-        testTimeoutExceptionHandling(AsyncDataStream.OutputMode.ORDERED);
+        testTimeoutExceptionHandling(
+                AsyncDataStream.OutputMode.ORDERED, AsyncRetryStrategies.NO_RETRY_STRATEGY);
+    }
+
+    @Test
+    public void testOrderedWaitTimeoutHandlingWithRetry() throws Exception {
+        testTimeoutExceptionHandling(
+                AsyncDataStream.OutputMode.ORDERED, emptyResultFixedDelayRetryStrategy);
     }
 
     /**
@@ -923,13 +983,22 @@ public class AsyncWaitOperatorTest extends TestLogger {
      */
     @Test
     public void testUnorderedWaitTimeoutHandling() throws Exception {
-        testTimeoutExceptionHandling(AsyncDataStream.OutputMode.UNORDERED);
+        testTimeoutExceptionHandling(
+                AsyncDataStream.OutputMode.UNORDERED, AsyncRetryStrategies.NO_RETRY_STRATEGY);
     }
 
-    private void testTimeoutExceptionHandling(AsyncDataStream.OutputMode outputMode)
+    @Test
+    public void testUnorderedWaitTimeoutHandlingWithRetry() throws Exception {
+        testTimeoutExceptionHandling(
+                AsyncDataStream.OutputMode.UNORDERED, emptyResultFixedDelayRetryStrategy);
+    }
+
+    private void testTimeoutExceptionHandling(
+            AsyncDataStream.OutputMode outputMode, AsyncRetryStrategy asyncRetryStrategy)
             throws Exception {
         OneInputStreamOperatorTestHarness<Integer, Integer> harness =
-                createTestHarness(new NoOpAsyncFunction<>(), 10L, 2, outputMode);
+                createTestHarnessWithRetry(
+                        new NoOpAsyncFunction<>(), 10L, 2, outputMode, asyncRetryStrategy);
 
         harness.getEnvironment().setExpectedExternalFailureCause(Throwable.class);
         harness.open();
@@ -1024,6 +1093,16 @@ public class AsyncWaitOperatorTest extends TestLogger {
 
     @Test
     public void testIgnoreAsyncOperatorRecordsOnDrain() throws Exception {
+        testIgnoreAsyncOperatorRecordsOnDrain(AsyncRetryStrategies.NO_RETRY_STRATEGY);
+    }
+
+    @Test
+    public void testIgnoreAsyncOperatorRecordsOnDrainWithRetry() throws Exception {
+        testIgnoreAsyncOperatorRecordsOnDrain(emptyResultFixedDelayRetryStrategy);
+    }
+
+    private void testIgnoreAsyncOperatorRecordsOnDrain(AsyncRetryStrategy asyncRetryStrategy)
+            throws Exception {
         // given: Async wait operator which are able to collect result futures.
         StreamTaskMailboxTestHarnessBuilder<Integer> builder =
                 new StreamTaskMailboxTestHarnessBuilder<>(
@@ -1036,7 +1115,8 @@ public class AsyncWaitOperatorTest extends TestLogger {
                                         new CollectableFuturesAsyncFunction<>(resultFutures),
                                         TIMEOUT,
                                         5,
-                                        AsyncDataStream.OutputMode.ORDERED))
+                                        AsyncDataStream.OutputMode.ORDERED,
+                                        asyncRetryStrategy))
                         .build()) {
             // when: Processing at least two elements in reverse order to keep completed queue not
             // empty.
@@ -1051,6 +1131,98 @@ public class AsyncWaitOperatorTest extends TestLogger {
             // be processed on recovery.
             harness.finishProcessing();
             assertTrue(harness.getOutput().isEmpty());
+        }
+    }
+
+    /** Test the AsyncWaitOperator with ordered mode and processing time. */
+    @Test
+    public void testProcessingTimeOrderedWithRetry() throws Exception {
+        testProcessingTimeWithRetry(AsyncDataStream.OutputMode.ORDERED);
+    }
+
+    /** Test the AsyncWaitOperator with unordered mode and processing time. */
+    @Test
+    public void testProcessingUnorderedWithRetry() throws Exception {
+        testProcessingTimeWithRetry(AsyncDataStream.OutputMode.UNORDERED);
+    }
+
+    private void testProcessingTimeWithRetry(AsyncDataStream.OutputMode mode) throws Exception {
+
+        final OneInputStreamOperatorTestHarness<Integer, Integer> testHarness =
+                createTestHarnessWithRetry(
+                        new OddInputEmptyResultAsyncFunction(),
+                        TIMEOUT,
+                        6,
+                        mode,
+                        emptyResultFixedDelayRetryStrategy);
+
+        final long initialTime = 0L;
+        final Queue<Object> expectedOutput = new ArrayDeque<>();
+        final long startTime = 1;
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+
+        testHarness.open();
+        testHarness.setProcessingTime(startTime);
+        synchronized (testHarness.getCheckpointLock()) {
+            testHarness.processElement(new StreamRecord<>(1, initialTime + 1));
+            testHarness.processElement(new StreamRecord<>(2, initialTime + 2));
+            testHarness.processElement(new StreamRecord<>(3, initialTime + 3));
+            testHarness.processElement(new StreamRecord<>(4, initialTime + 4));
+            testHarness.processElement(new StreamRecord<>(5, initialTime + 5));
+            testHarness.processElement(new StreamRecord<>(6, initialTime + 6));
+            // for first retry
+            asyncDelayedSettingProcessingTime(executor, testHarness, startTime + 10, 10);
+            // for second retry and some elements can be complete
+            asyncDelayedSettingProcessingTime(executor, testHarness, startTime + 20, 10);
+            testHarness.processElement(new StreamRecord<>(7, initialTime + 7));
+            asyncDelayedSettingProcessingTime(executor, testHarness, startTime + 30, 10);
+            testHarness.processElement(new StreamRecord<>(8, initialTime + 8));
+            asyncDelayedSettingProcessingTime(executor, testHarness, startTime + 40, 10);
+        }
+
+        expectedOutput.add(new StreamRecord<>(4, initialTime + 2));
+        expectedOutput.add(new StreamRecord<>(8, initialTime + 4));
+        expectedOutput.add(new StreamRecord<>(12, initialTime + 6));
+        expectedOutput.add(new StreamRecord<>(16, initialTime + 8));
+
+        synchronized (testHarness.getCheckpointLock()) {
+            asyncDelayedSettingProcessingTime(executor, testHarness, startTime + 90, 50);
+            testHarness.endInput();
+            testHarness.close();
+        }
+
+        if (mode == AsyncDataStream.OutputMode.ORDERED) {
+            TestHarnessUtil.assertOutputEquals(
+                    "ORDERED Output was not correct.", expectedOutput, testHarness.getOutput());
+        } else {
+            TestHarnessUtil.assertOutputEqualsSorted(
+                    "UNORDERED Output was not correct.",
+                    expectedOutput,
+                    testHarness.getOutput(),
+                    new StreamRecordComparator());
+        }
+        assertEquals(0, testHarness.getProcessingTimeService().getNumActiveTimers());
+
+        executor.shutdown();
+    }
+
+    /** simulate a threaded processing time service. */
+    private void asyncDelayedSettingProcessingTime(
+            ExecutorService executor,
+            OneInputStreamOperatorTestHarness testHarness,
+            long proctime,
+            long delay) {
+        executor.submit(() -> delayedSettingProcessingTime(testHarness, proctime, delay));
+    }
+
+    private void delayedSettingProcessingTime(
+            OneInputStreamOperatorTestHarness testHarness, long proctime, long delay) {
+        try {
+            Thread.sleep(delay);
+            testHarness.setProcessingTime(proctime);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
         }
     }
 
@@ -1105,6 +1277,20 @@ public class AsyncWaitOperatorTest extends TestLogger {
 
         return new OneInputStreamOperatorTestHarness<>(
                 new AsyncWaitOperatorFactory<>(function, timeout, capacity, outputMode),
+                IntSerializer.INSTANCE);
+    }
+
+    private static <OUT> OneInputStreamOperatorTestHarness<Integer, OUT> createTestHarnessWithRetry(
+            AsyncFunction<Integer, OUT> function,
+            long timeout,
+            int capacity,
+            AsyncDataStream.OutputMode outputMode,
+            AsyncRetryStrategy<OUT> asyncRetryStrategy)
+            throws Exception {
+
+        return new OneInputStreamOperatorTestHarness<>(
+                new AsyncWaitOperatorFactory<>(
+                        function, timeout, capacity, outputMode, asyncRetryStrategy),
                 IntSerializer.INSTANCE);
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorTest.java
@@ -958,7 +958,12 @@ public class AsyncWaitOperatorTest extends TestLogger {
             AsyncDataStream.OutputMode outputMode, AsyncRetryStrategy asyncRetryStrategy)
             throws Exception {
         OneInputStreamOperatorTestHarness<Integer, Integer> harness =
-                createTestHarness(new UserExceptionAsyncFunction(), TIMEOUT, 2, outputMode);
+                createTestHarnessWithRetry(
+                        new UserExceptionAsyncFunction(),
+                        TIMEOUT,
+                        2,
+                        outputMode,
+                        asyncRetryStrategy);
 
         harness.getEnvironment().setExpectedExternalFailureCause(Throwable.class);
         harness.open();
@@ -968,6 +973,7 @@ public class AsyncWaitOperatorTest extends TestLogger {
         }
 
         synchronized (harness.getCheckpointLock()) {
+            harness.endInput();
             harness.close();
         }
 

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/AsyncDataStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/AsyncDataStream.scala
@@ -325,10 +325,8 @@ object AsyncDataStream {
     orderedWait(input, timeout, timeUnit, DEFAULT_QUEUE_CAPACITY)(asyncFunction)
   }
 
-  // ======= retryable ========
-
   /**
-   * Add an AsyncWaitOperator with an AsyncRetryStrategy to support retry of AsyncFunction. The
+   * Adds an AsyncWaitOperator with an AsyncRetryStrategy to support retry of AsyncFunction. The
    * order of output stream records may be reordered.
    *
    * @param input
@@ -380,7 +378,7 @@ object AsyncDataStream {
   }
 
   /**
-   * Add an AsyncWaitOperator with an AsyncRetryStrategy to support retry of AsyncFunction. The
+   * Adds an AsyncWaitOperator with an AsyncRetryStrategy to support retry of AsyncFunction. The
    * order of output stream records may be reordered.
    *
    * @param input
@@ -508,7 +506,7 @@ object AsyncDataStream {
   }
 
   /**
-   * Add an AsyncWaitOperator with an AsyncRetryStrategy to support retry of AsyncFunction. The
+   * Adds an AsyncWaitOperator with an AsyncRetryStrategy to support retry of AsyncFunction. The
    * output order is the same as the input order of the elements.
    *
    * @param input
@@ -560,7 +558,7 @@ object AsyncDataStream {
   }
 
   /**
-   * Add an AsyncWaitOperator with an AsyncRetryStrategy to support retry of AsyncFunction. The
+   * Adds an AsyncWaitOperator with an AsyncRetryStrategy to support retry of AsyncFunction. The
    * output order is the same as the input order of the elements.
    *
    * @param input

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/AsyncDataStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/AsyncDataStream.scala
@@ -20,9 +20,13 @@ package org.apache.flink.streaming.api.scala
 import org.apache.flink.annotation.PublicEvolving
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.streaming.api.datastream.{AsyncDataStream => JavaAsyncDataStream}
-import org.apache.flink.streaming.api.functions.async.{AsyncFunction => JavaAsyncFunction, ResultFuture => JavaResultFuture}
+import org.apache.flink.streaming.api.functions.async.{AsyncFunction => JavaAsyncFunction, AsyncRetryPredicate => JavaAsyncRetryPredicate, AsyncRetryStrategy => JavaAsyncRetryStrategy, ResultFuture => JavaResultFuture}
 import org.apache.flink.streaming.api.scala.async._
 import org.apache.flink.util.Preconditions
+
+import java.util
+import java.util.Optional
+import java.util.function.Predicate
 
 import scala.concurrent.duration.TimeUnit
 
@@ -321,6 +325,365 @@ object AsyncDataStream {
     orderedWait(input, timeout, timeUnit, DEFAULT_QUEUE_CAPACITY)(asyncFunction)
   }
 
+  // ======= retryable ========
+
+  /**
+   * Add an AsyncWaitOperator with an AsyncRetryStrategy to support retry of AsyncFunction. The
+   * order of output stream records may be reordered.
+   *
+   * @param input
+   *   Input {@link DataStream}
+   * @param asyncFunction
+   *   {@link AsyncFunction}
+   * @param timeout
+   *   from first invoke to final completion of asynchronous operation, may include multiple
+   *   retries, and will be reset in case of restart
+   * @param timeUnit
+   *   of the given timeout
+   * @param capacity
+   *   The max number of async i/o operation that can be triggered
+   * @param asyncRetryStrategy
+   *   The strategy of reattempt async i/o operation that can be triggered
+   * @tparam IN
+   *   Type of input record
+   * @tparam OUT
+   *   Type of output record
+   * @return
+   *   the resulting stream containing the asynchronous results
+   */
+  def unorderedWaitWithRetry[IN, OUT: TypeInformation](
+      input: DataStream[IN],
+      asyncFunction: AsyncFunction[IN, OUT],
+      timeout: Long,
+      timeUnit: TimeUnit,
+      capacity: Int,
+      asyncRetryStrategy: AsyncRetryStrategy[OUT]): DataStream[OUT] = {
+
+    Preconditions.checkArgument(timeout > 0)
+    Preconditions.checkNotNull(asyncFunction)
+
+    val javaAsyncFunction = wrapAsJavaAsyncFunction(asyncFunction)
+    val javaAsyncRetryStrategy = wrapAsJavaAsyncRetryStrategy(asyncRetryStrategy)
+
+    val outType: TypeInformation[OUT] = implicitly[TypeInformation[OUT]]
+
+    asScalaStream(
+      JavaAsyncDataStream
+        .unorderedWaitWithRetry[IN, OUT](
+          input.javaStream,
+          javaAsyncFunction,
+          timeout,
+          timeUnit,
+          capacity,
+          javaAsyncRetryStrategy)
+        .returns(outType))
+  }
+
+  /**
+   * Add an AsyncWaitOperator with an AsyncRetryStrategy to support retry of AsyncFunction. The
+   * order of output stream records may be reordered.
+   *
+   * @param input
+   *   Input {@link DataStream}
+   * @param asyncFunction
+   *   {@link AsyncFunction}
+   * @param timeout
+   *   from first invoke to final completion of asynchronous operation, may include multiple
+   *   retries, and will be reset in case of restart
+   * @param timeUnit
+   *   of the given timeout
+   * @param asyncRetryStrategy
+   *   The strategy of reattempt async i/o operation that can be triggered
+   * @tparam IN
+   *   Type of input record
+   * @tparam OUT
+   *   Type of output record
+   * @return
+   *   the resulting stream containing the asynchronous results
+   */
+  def unorderedWaitWithRetry[IN, OUT: TypeInformation](
+      input: DataStream[IN],
+      asyncFunction: AsyncFunction[IN, OUT],
+      timeout: Long,
+      timeUnit: TimeUnit,
+      asyncRetryStrategy: AsyncRetryStrategy[OUT]): DataStream[OUT] = {
+
+    unorderedWaitWithRetry(
+      input,
+      asyncFunction,
+      timeout,
+      timeUnit,
+      DEFAULT_QUEUE_CAPACITY,
+      asyncRetryStrategy)
+  }
+
+  /**
+   * Apply an asynchronous function on the input data stream with an AsyncRetryStrategy to support
+   * retry. The output order is only maintained with respect to watermarks. Stream records which lie
+   * between the same two watermarks, can be re-ordered.
+   *
+   * @param input
+   *   to apply the async function on
+   * @param timeout
+   *   from first invoke to final completion of asynchronous operation, may include multiple
+   *   retries, and will be reset in case of restart
+   * @param timeUnit
+   *   of the timeout
+   * @param capacity
+   *   of the operator which is equivalent to the number of concurrent asynchronous operations
+   * @param asyncFunction
+   *   to use
+   * @tparam IN
+   *   Type of the input record
+   * @tparam OUT
+   *   Type of the output record
+   * @return
+   *   the resulting stream containing the asynchronous results
+   */
+  def unorderedWaitWithRetry[IN, OUT: TypeInformation](
+      input: DataStream[IN],
+      timeout: Long,
+      timeUnit: TimeUnit,
+      capacity: Int,
+      asyncRetryStrategy: AsyncRetryStrategy[OUT])(
+      asyncFunction: (IN, ResultFuture[OUT]) => Unit): DataStream[OUT] = {
+
+    Preconditions.checkNotNull(asyncFunction)
+    Preconditions.checkArgument(timeout > 0)
+
+    val cleanAsyncFunction = input.executionEnvironment.scalaClean(asyncFunction)
+
+    val func = new JavaAsyncFunction[IN, OUT] {
+      override def asyncInvoke(input: IN, resultFuture: JavaResultFuture[OUT]): Unit = {
+
+        cleanAsyncFunction(input, new JavaResultFutureWrapper[OUT](resultFuture))
+      }
+    }
+    val javaAsyncRetryStrategy = wrapAsJavaAsyncRetryStrategy(asyncRetryStrategy)
+
+    val outType: TypeInformation[OUT] = implicitly[TypeInformation[OUT]]
+
+    asScalaStream(
+      JavaAsyncDataStream
+        .unorderedWaitWithRetry[IN, OUT](
+          input.javaStream,
+          func,
+          timeout,
+          timeUnit,
+          capacity,
+          javaAsyncRetryStrategy)
+        .returns(outType))
+  }
+
+  /**
+   * Apply an asynchronous function on the input data stream with an AsyncRetryStrategy to support
+   * retry. The output order is only maintained with respect to watermarks. Stream records which lie
+   * between the same two watermarks, can be re-ordered.
+   *
+   * @param input
+   *   to apply the async function on
+   * @param timeout
+   *   from first invoke to final completion of asynchronous operation, may include multiple
+   *   retries, and will be reset in case of restart
+   * @param timeUnit
+   *   of the timeout
+   * @param asyncFunction
+   *   to use
+   * @tparam IN
+   *   Type of the input record
+   * @tparam OUT
+   *   Type of the output record
+   * @return
+   *   the resulting stream containing the asynchronous results
+   */
+  def unorderedWaitWithRetry[IN, OUT: TypeInformation](
+      input: DataStream[IN],
+      timeout: Long,
+      timeUnit: TimeUnit,
+      asyncRetryStrategy: AsyncRetryStrategy[OUT])(
+      asyncFunction: (IN, ResultFuture[OUT]) => Unit): DataStream[OUT] = {
+
+    unorderedWaitWithRetry(input, timeout, timeUnit, DEFAULT_QUEUE_CAPACITY, asyncRetryStrategy)(
+      asyncFunction)
+  }
+
+  /**
+   * Add an AsyncWaitOperator with an AsyncRetryStrategy to support retry of AsyncFunction. The
+   * output order is the same as the input order of the elements.
+   *
+   * @param input
+   *   Input {@link DataStream}
+   * @param asyncFunction
+   *   {@link AsyncFunction}
+   * @param timeout
+   *   from first invoke to final completion of asynchronous operation, may include multiple
+   *   retries, and will be reset in case of restart
+   * @param timeUnit
+   *   of the given timeout
+   * @param capacity
+   *   The max number of async i/o operation that can be triggered
+   * @param asyncRetryStrategy
+   *   The strategy of reattempt async i/o operation that can be triggered
+   * @tparam IN
+   *   Type of input record
+   * @tparam OUT
+   *   Type of output record
+   * @return
+   *   the resulting stream containing the asynchronous results
+   */
+  def orderedWaitWithRetry[IN, OUT: TypeInformation](
+      input: DataStream[IN],
+      asyncFunction: AsyncFunction[IN, OUT],
+      timeout: Long,
+      timeUnit: TimeUnit,
+      capacity: Int,
+      asyncRetryStrategy: AsyncRetryStrategy[OUT]): DataStream[OUT] = {
+
+    Preconditions.checkArgument(timeout > 0)
+    Preconditions.checkNotNull(asyncFunction)
+
+    val javaAsyncFunction = wrapAsJavaAsyncFunction(asyncFunction)
+    val javaAsyncRetryStrategy = wrapAsJavaAsyncRetryStrategy(asyncRetryStrategy)
+
+    val outType: TypeInformation[OUT] = implicitly[TypeInformation[OUT]]
+
+    asScalaStream(
+      JavaAsyncDataStream
+        .orderedWaitWithRetry[IN, OUT](
+          input.javaStream,
+          javaAsyncFunction,
+          timeout,
+          timeUnit,
+          capacity,
+          javaAsyncRetryStrategy)
+        .returns(outType))
+  }
+
+  /**
+   * Add an AsyncWaitOperator with an AsyncRetryStrategy to support retry of AsyncFunction. The
+   * output order is the same as the input order of the elements.
+   *
+   * @param input
+   *   Input {@link DataStream}
+   * @param asyncFunction
+   *   {@link AsyncFunction}
+   * @param timeout
+   *   from first invoke to final completion of asynchronous operation, may include multiple
+   *   retries, and will be reset in case of restart
+   * @param timeUnit
+   *   of the given timeout
+   * @param asyncRetryStrategy
+   *   The strategy of reattempt async i/o operation that can be triggered
+   * @tparam IN
+   *   Type of input record
+   * @tparam OUT
+   *   Type of output record
+   * @return
+   *   the resulting stream containing the asynchronous results
+   */
+  def orderedWaitWithRetry[IN, OUT: TypeInformation](
+      input: DataStream[IN],
+      asyncFunction: AsyncFunction[IN, OUT],
+      timeout: Long,
+      timeUnit: TimeUnit,
+      asyncRetryStrategy: AsyncRetryStrategy[OUT]): DataStream[OUT] = {
+
+    orderedWaitWithRetry(
+      input,
+      asyncFunction,
+      timeout,
+      timeUnit,
+      DEFAULT_QUEUE_CAPACITY,
+      asyncRetryStrategy)
+  }
+
+  /**
+   * Apply an asynchronous function on the input data stream with an AsyncRetryStrategy to support
+   * retry. The output order is the same as the input order of the elements.
+   *
+   * @param input
+   *   to apply the async function on
+   * @param timeout
+   *   from first invoke to final completion of asynchronous operation, may include multiple
+   *   retries, and will be reset in case of restart
+   * @param timeUnit
+   *   of the timeout
+   * @param capacity
+   *   of the operator which is equivalent to the number of concurrent asynchronous operations
+   * @param asyncFunction
+   *   to use
+   * @tparam IN
+   *   Type of the input record
+   * @tparam OUT
+   *   Type of the output record
+   * @return
+   *   the resulting stream containing the asynchronous results
+   */
+  def orderedWaitWithRetry[IN, OUT: TypeInformation](
+      input: DataStream[IN],
+      timeout: Long,
+      timeUnit: TimeUnit,
+      capacity: Int,
+      asyncRetryStrategy: AsyncRetryStrategy[OUT])(
+      asyncFunction: (IN, ResultFuture[OUT]) => Unit): DataStream[OUT] = {
+
+    Preconditions.checkArgument(timeout > 0)
+    Preconditions.checkNotNull(asyncFunction)
+
+    val cleanAsyncFunction = input.executionEnvironment.scalaClean(asyncFunction)
+
+    val func = new JavaAsyncFunction[IN, OUT] {
+      override def asyncInvoke(input: IN, resultFuture: JavaResultFuture[OUT]): Unit = {
+        cleanAsyncFunction(input, new JavaResultFutureWrapper[OUT](resultFuture))
+      }
+    }
+    val javaAsyncRetryStrategy = wrapAsJavaAsyncRetryStrategy(asyncRetryStrategy)
+
+    val outType: TypeInformation[OUT] = implicitly[TypeInformation[OUT]]
+
+    asScalaStream(
+      JavaAsyncDataStream
+        .orderedWaitWithRetry[IN, OUT](
+          input.javaStream,
+          func,
+          timeout,
+          timeUnit,
+          capacity,
+          javaAsyncRetryStrategy)
+        .returns(outType))
+  }
+
+  /**
+   * Apply an asynchronous function on the input data stream with an AsyncRetryStrategy to support
+   * retry. The output order is the same as the input order of the elements.
+   *
+   * @param input
+   *   to apply the async function on
+   * @param timeout
+   *   from first invoke to final completion of asynchronous operation, may include multiple
+   *   retries, and will be reset in case of restart
+   * @param timeUnit
+   *   of the timeout
+   * @param asyncFunction
+   *   to use
+   * @tparam IN
+   *   Type of the input record
+   * @tparam OUT
+   *   Type of the output record
+   * @return
+   *   the resulting stream containing the asynchronous results
+   */
+  def orderedWaitWithRetry[IN, OUT: TypeInformation](
+      input: DataStream[IN],
+      timeout: Long,
+      timeUnit: TimeUnit,
+      asyncRetryStrategy: AsyncRetryStrategy[OUT])(
+      asyncFunction: (IN, ResultFuture[OUT]) => Unit): DataStream[OUT] = {
+
+    orderedWaitWithRetry(input, timeout, timeUnit, DEFAULT_QUEUE_CAPACITY, asyncRetryStrategy)(
+      asyncFunction)
+  }
+
   private def wrapAsJavaAsyncFunction[IN, OUT: TypeInformation](
       asyncFunction: AsyncFunction[IN, OUT]): JavaAsyncFunction[IN, OUT] = asyncFunction match {
     case richAsyncFunction: RichAsyncFunction[IN, OUT] =>
@@ -335,5 +698,39 @@ object AsyncDataStream {
           asyncFunction.timeout(input, new JavaResultFutureWrapper[OUT](resultFuture))
         }
       }
+  }
+
+  private def wrapAsJavaAsyncRetryStrategy[OUT](
+      asyncRetryStrategy: AsyncRetryStrategy[OUT]): JavaAsyncRetryStrategy[OUT] = {
+    new JavaAsyncRetryStrategy[OUT] {
+
+      override def canRetry(currentAttempts: Int): Boolean =
+        asyncRetryStrategy.canRetry(currentAttempts)
+
+      override def getBackoffTimeMillis(currentAttempts: Int): Long =
+        asyncRetryStrategy.getBackoffTimeMillis(currentAttempts)
+
+      override def getRetryPredicate: JavaAsyncRetryPredicate[OUT] = {
+        new JavaAsyncRetryPredicate[OUT] {
+          override def resultPredicate(): Optional[Predicate[util.Collection[OUT]]] = {
+            asyncRetryStrategy.getRetryPredicate().resultPredicate match {
+              case Some(_) =>
+                Optional.of(asyncRetryStrategy.getRetryPredicate().resultPredicate.get)
+              case None =>
+                Optional.empty()
+            }
+          }
+
+          override def exceptionPredicate(): Optional[Predicate[Throwable]] = {
+            asyncRetryStrategy.getRetryPredicate().exceptionPredicate match {
+              case Some(_) =>
+                Optional.of(asyncRetryStrategy.getRetryPredicate().exceptionPredicate.get)
+              case None =>
+                Optional.empty()
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/async/AsyncRetryPredicate.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/async/AsyncRetryPredicate.scala
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.scala.async
+
+import java.util
+import java.util.function.Predicate
+
+/** Interface encapsulates an asynchronous retry predicate. */
+trait AsyncRetryPredicate[OUT] {
+
+  /**
+   * An Optional Java {@Predicate } that defines a condition on asyncFunction's future result which
+   * will trigger a later reattempt operation, will be called before user's ResultFuture#complete.
+   *
+   * @return
+   *   predicate on result of {@link util.Collection}
+   */
+  def resultPredicate: Option[Predicate[util.Collection[OUT]]]
+
+  /**
+   * An Optional Java {@Predicate } that defines a condition on asyncFunction's exception which will
+   * trigger a later reattempt operation, will be called before user's
+   * ResultFuture#completeExceptionally.
+   *
+   * @return
+   *   predicate on {@link Throwable} exception
+   */
+  def exceptionPredicate: Option[Predicate[Throwable]]
+}

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/async/AsyncRetryPredicate.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/async/AsyncRetryPredicate.scala
@@ -15,13 +15,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.flink.streaming.api.scala.async
+
+import org.apache.flink.annotation.PublicEvolving
 
 import java.util
 import java.util.function.Predicate
 
 /** Interface encapsulates an asynchronous retry predicate. */
+@PublicEvolving
 trait AsyncRetryPredicate[OUT] {
 
   /**

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/async/AsyncRetryStrategy.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/async/AsyncRetryStrategy.scala
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.scala.async
+
+/** Interface encapsulates an asynchronous retry strategy. */
+trait AsyncRetryStrategy[OUT] extends Serializable {
+
+  /** @return whether the next attempt can happen */
+  def canRetry(currentAttempts: Int): Boolean
+
+  /** @return the delay time of next attempt */
+  def getBackoffTimeMillis(currentAttempts: Int): Long
+
+  /** @return the defined retry predicate {@link AsyncRetryPredicate} */
+  def getRetryPredicate(): AsyncRetryPredicate[OUT]
+}

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/async/AsyncRetryStrategy.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/async/AsyncRetryStrategy.scala
@@ -15,10 +15,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.flink.streaming.api.scala.async
 
+import org.apache.flink.annotation.PublicEvolving
+
 /** Interface encapsulates an asynchronous retry strategy. */
+@PublicEvolving
 trait AsyncRetryStrategy[OUT] extends Serializable {
 
   /** @return whether the next attempt can happen */


### PR DESCRIPTION
## What is the purpose of the change
This is the implementation of [FLIP-232](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=211883963)

## Brief change log
* add new interface and api proposed in the flip to support retry
* add a RetryableResultHandlerDelegator to  AsyncWaitOperator to support retry, if retry disabled, all the behaviors keep the same as previous version which does not support retry
* add tests to ensure retry logic is covered under both ordered and unordered mode

## Verifying this change
AsyncWaitOperatorTest &  AsyncDataStreamITCase

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation
  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)