### PR TITLE
DO_NOT_MERGE_UNTIL_2.X [FLINK-28081][config] Remove deprecated Hadoop specific Flink configuration options

### DIFF
--- a/docs/content.zh/docs/deployment/filesystems/gcs.md
+++ b/docs/content.zh/docs/deployment/filesystems/gcs.md
@@ -96,7 +96,7 @@ You can use the following method for authentication
 
   ```yaml
   flinkConfiguration:
-    fs.hdfs.hadoopconf: <DIRECTORY PATH WHERE core-site.xml IS SAVED>
+    env.hadoop.conf.dir: <DIRECTORY PATH WHERE core-site.xml IS SAVED>
   ```
 
 * You can provide the necessary key via the `GOOGLE_APPLICATION_CREDENTIALS` environment variable.

--- a/docs/content.zh/docs/internals/filesystems.md
+++ b/docs/content.zh/docs/internals/filesystems.md
@@ -50,8 +50,7 @@ Other file system types are accessed by an implementation that bridges to the su
   - ...
 
 Flink loads Hadoop's file systems transparently if it finds the Hadoop File System classes in the class path and finds a valid
-Hadoop configuration. By default, it looks for the Hadoop configuration in the class path. Alternatively, one can specify a
-custom location via the configuration entry `fs.hdfs.hadoopconf`.
+Hadoop configuration. By default, it looks for the Hadoop configuration in the class path.
 
 
 # Persistence Guarantees

--- a/docs/content/docs/internals/filesystems.md
+++ b/docs/content/docs/internals/filesystems.md
@@ -50,8 +50,7 @@ Other file system types are accessed by an implementation that bridges to the su
   - ...
 
 Flink loads Hadoop's file systems transparently if it finds the Hadoop File System classes in the class path and finds a valid
-Hadoop configuration. By default, it looks for the Hadoop configuration in the class path. Alternatively, one can specify a
-custom location via the configuration entry `fs.hdfs.hadoopconf`.
+Hadoop configuration. By default, it looks for the Hadoop configuration in the class path.
 
 
 # Persistence Guarantees

--- a/flink-connectors/flink-hadoop-compatibility/src/main/java/org/apache/flink/api/java/hadoop/mapred/utils/HadoopUtils.java
+++ b/flink-connectors/flink-hadoop-compatibility/src/main/java/org/apache/flink/api/java/hadoop/mapred/utils/HadoopUtils.java
@@ -19,7 +19,6 @@
 package org.apache.flink.api.java.hadoop.mapred.utils;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.GlobalConfiguration;
 
 import org.apache.hadoop.conf.Configuration;
@@ -69,24 +68,7 @@ public final class HadoopUtils {
         // We need to load both core-site.xml and hdfs-site.xml to determine the default fs path and
         // the hdfs configuration
         // Try to load HDFS configuration from Hadoop's own configuration files
-        // 1. approach: Flink configuration
-        final String hdfsDefaultPath =
-                flinkConfiguration.getString(ConfigConstants.HDFS_DEFAULT_CONFIG, null);
-        if (hdfsDefaultPath != null) {
-            retConf.addResource(new org.apache.hadoop.fs.Path(hdfsDefaultPath));
-        } else {
-            LOG.debug("Cannot find hdfs-default configuration file");
-        }
-
-        final String hdfsSitePath =
-                flinkConfiguration.getString(ConfigConstants.HDFS_SITE_CONFIG, null);
-        if (hdfsSitePath != null) {
-            retConf.addResource(new org.apache.hadoop.fs.Path(hdfsSitePath));
-        } else {
-            LOG.debug("Cannot find hdfs-site configuration file");
-        }
-
-        // 2. Approach environment variables
+        // 1. Approach environment variables
         for (String possibleHadoopConfPath : possibleHadoopConfPaths(flinkConfiguration)) {
             if (new File(possibleHadoopConfPath).exists()) {
                 if (new File(possibleHadoopConfPath + "/core-site.xml").exists()) {
@@ -127,13 +109,12 @@ public final class HadoopUtils {
      */
     public static String[] possibleHadoopConfPaths(
             org.apache.flink.configuration.Configuration flinkConfiguration) {
-        String[] possiblePaths = new String[4];
-        possiblePaths[0] = flinkConfiguration.getString(ConfigConstants.PATH_HADOOP_CONFIG, null);
-        possiblePaths[1] = System.getenv("HADOOP_CONF_DIR");
+        String[] possiblePaths = new String[3];
+        possiblePaths[0] = System.getenv("HADOOP_CONF_DIR");
 
         if (System.getenv("HADOOP_HOME") != null) {
-            possiblePaths[2] = System.getenv("HADOOP_HOME") + "/conf";
-            possiblePaths[3] = System.getenv("HADOOP_HOME") + "/etc/hadoop"; // hadoop 2.2
+            possiblePaths[1] = System.getenv("HADOOP_HOME") + "/conf";
+            possiblePaths[2] = System.getenv("HADOOP_HOME") + "/etc/hadoop"; // hadoop 2.2
         }
         return Arrays.stream(possiblePaths).filter(Objects::nonNull).toArray(String[]::new);
     }

--- a/flink-core/pom.xml
+++ b/flink-core/pom.xml
@@ -144,6 +144,15 @@ under the License.
 			<plugin>
 				<groupId>com.github.siom79.japicmp</groupId>
 				<artifactId>japicmp-maven-plugin</artifactId>
+				<configuration>
+					<parameter>
+						<excludes>
+							<exclude>org.apache.flink.configuration.ConfigConstants#HDFS_DEFAULT_CONFIG</exclude>
+							<exclude>org.apache.flink.configuration.ConfigConstants#HDFS_SITE_CONFIG</exclude>
+							<exclude>org.apache.flink.configuration.ConfigConstants#PATH_HADOOP_CONFIG</exclude>
+						</excludes>
+					</parameter>
+				</configuration>
 			</plugin>
 
 			<!-- publish some test base classes -->

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -571,29 +571,6 @@ public final class ConfigConstants {
     public static final String MESOS_ARTIFACT_SERVER_SSL_ENABLED =
             "mesos.resourcemanager.artifactserver.ssl.enabled";
 
-    // ------------------------ Hadoop Configuration ------------------------
-
-    /**
-     * Path to hdfs-default.xml file.
-     *
-     * @deprecated Use environment variable HADOOP_CONF_DIR instead.
-     */
-    @Deprecated public static final String HDFS_DEFAULT_CONFIG = "fs.hdfs.hdfsdefault";
-
-    /**
-     * Path to hdfs-site.xml file.
-     *
-     * @deprecated Use environment variable HADOOP_CONF_DIR instead.
-     */
-    @Deprecated public static final String HDFS_SITE_CONFIG = "fs.hdfs.hdfssite";
-
-    /**
-     * Path to Hadoop configuration.
-     *
-     * @deprecated Use environment variable HADOOP_CONF_DIR instead.
-     */
-    @Deprecated public static final String PATH_HADOOP_CONFIG = "fs.hdfs.hadoopconf";
-
     // ------------------------ File System Behavior ------------------------
 
     /**

--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/util/HadoopUtils.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/util/HadoopUtils.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.util;
 
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.Preconditions;
 
@@ -49,7 +48,6 @@ public class HadoopUtils {
     /** The prefixes that Flink adds to the Hadoop config. */
     private static final String[] FLINK_CONFIG_PREFIXES = {"flink.hadoop."};
 
-    @SuppressWarnings("deprecation")
     public static Configuration getHadoopConfiguration(
             org.apache.flink.configuration.Configuration flinkConfiguration) {
 
@@ -77,47 +75,18 @@ public class HadoopUtils {
 
         for (String possibleHadoopConfPath : possibleHadoopConfPaths) {
             if (possibleHadoopConfPath != null) {
-                foundHadoopConfiguration = addHadoopConfIfFound(result, possibleHadoopConfPath);
+                foundHadoopConfiguration |= addHadoopConfIfFound(result, possibleHadoopConfPath);
             }
         }
 
-        // Approach 2: Flink configuration (deprecated)
-        final String hdfsDefaultPath =
-                flinkConfiguration.getString(ConfigConstants.HDFS_DEFAULT_CONFIG, null);
-        if (hdfsDefaultPath != null) {
-            result.addResource(new org.apache.hadoop.fs.Path(hdfsDefaultPath));
-            LOG.debug(
-                    "Using hdfs-default configuration-file path from Flink config: {}",
-                    hdfsDefaultPath);
-            foundHadoopConfiguration = true;
-        }
-
-        final String hdfsSitePath =
-                flinkConfiguration.getString(ConfigConstants.HDFS_SITE_CONFIG, null);
-        if (hdfsSitePath != null) {
-            result.addResource(new org.apache.hadoop.fs.Path(hdfsSitePath));
-            LOG.debug(
-                    "Using hdfs-site configuration-file path from Flink config: {}", hdfsSitePath);
-            foundHadoopConfiguration = true;
-        }
-
-        final String hadoopConfigPath =
-                flinkConfiguration.getString(ConfigConstants.PATH_HADOOP_CONFIG, null);
-        if (hadoopConfigPath != null) {
-            LOG.debug("Searching Hadoop configuration files in Flink config: {}", hadoopConfigPath);
-            foundHadoopConfiguration =
-                    addHadoopConfIfFound(result, hadoopConfigPath) || foundHadoopConfiguration;
-        }
-
-        // Approach 3: HADOOP_CONF_DIR environment variable
+        // Approach 2: HADOOP_CONF_DIR environment variable
         String hadoopConfDir = System.getenv("HADOOP_CONF_DIR");
         if (hadoopConfDir != null) {
             LOG.debug("Searching Hadoop configuration files in HADOOP_CONF_DIR: {}", hadoopConfDir);
-            foundHadoopConfiguration =
-                    addHadoopConfIfFound(result, hadoopConfDir) || foundHadoopConfiguration;
+            foundHadoopConfiguration |= addHadoopConfIfFound(result, hadoopConfDir);
         }
 
-        // Approach 4: Flink configuration
+        // Approach 3: Flink configuration
         // add all configuration key with prefix 'flink.hadoop.' in flink conf to hadoop conf
         for (String key : flinkConfiguration.keySet()) {
             for (String prefix : FLINK_CONFIG_PREFIXES) {

--- a/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HadoopConfigLoadingTest.java
+++ b/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HadoopConfigLoadingTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.fs.hdfs;
 
-import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.testutils.CommonTestUtils;
 import org.apache.flink.runtime.util.HadoopUtils;
@@ -54,63 +53,6 @@ public class HadoopConfigLoadingTest {
         org.apache.hadoop.conf.Configuration hadoopConf =
                 HadoopUtils.getHadoopConfiguration(new Configuration());
 
-        assertEquals(IN_CP_CONFIG_VALUE, hadoopConf.get(IN_CP_CONFIG_KEY, null));
-    }
-
-    @Test
-    public void loadFromLegacyConfigEntries() throws Exception {
-        final String k1 = "shipmate";
-        final String v1 = "smooth sailing";
-
-        final String k2 = "pirate";
-        final String v2 = "Arrg, yer scurvy dog!";
-
-        final File file1 = tempFolder.newFile("core-site.xml");
-        final File file2 = tempFolder.newFile("hdfs-site.xml");
-
-        printConfig(file1, k1, v1);
-        printConfig(file2, k2, v2);
-
-        final Configuration cfg = new Configuration();
-        cfg.setString(ConfigConstants.HDFS_DEFAULT_CONFIG, file1.getAbsolutePath());
-        cfg.setString(ConfigConstants.HDFS_SITE_CONFIG, file2.getAbsolutePath());
-
-        org.apache.hadoop.conf.Configuration hadoopConf = HadoopUtils.getHadoopConfiguration(cfg);
-
-        // contains extra entries
-        assertEquals(v1, hadoopConf.get(k1, null));
-        assertEquals(v2, hadoopConf.get(k2, null));
-
-        // also contains classpath defaults
-        assertEquals(IN_CP_CONFIG_VALUE, hadoopConf.get(IN_CP_CONFIG_KEY, null));
-    }
-
-    @Test
-    public void loadFromHadoopConfEntry() throws Exception {
-        final String k1 = "singing?";
-        final String v1 = "rain!";
-
-        final String k2 = "dancing?";
-        final String v2 = "shower!";
-
-        final File confDir = tempFolder.newFolder();
-
-        final File file1 = new File(confDir, "core-site.xml");
-        final File file2 = new File(confDir, "hdfs-site.xml");
-
-        printConfig(file1, k1, v1);
-        printConfig(file2, k2, v2);
-
-        final Configuration cfg = new Configuration();
-        cfg.setString(ConfigConstants.PATH_HADOOP_CONFIG, confDir.getAbsolutePath());
-
-        org.apache.hadoop.conf.Configuration hadoopConf = HadoopUtils.getHadoopConfiguration(cfg);
-
-        // contains extra entries
-        assertEquals(v1, hadoopConf.get(k1, null));
-        assertEquals(v2, hadoopConf.get(k2, null));
-
-        // also contains classpath defaults
         assertEquals(IN_CP_CONFIG_VALUE, hadoopConf.get(IN_CP_CONFIG_KEY, null));
     }
 
@@ -183,18 +125,12 @@ public class HadoopConfigLoadingTest {
         final String k1 = "key1";
         final String k2 = "key2";
         final String k3 = "key3";
-        final String k4 = "key4";
-        final String k5 = "key5";
 
         final String v1 = "from HADOOP_CONF_DIR";
-        final String v2 = "from Flink config `fs.hdfs.hadoopconf`";
-        final String v3 = "from Flink config `fs.hdfs.hdfsdefault`";
-        final String v4 = "from HADOOP_HOME/etc/hadoop";
-        final String v5 = "from HADOOP_HOME/conf";
+        final String v2 = "from HADOOP_HOME/etc/hadoop";
+        final String v3 = "from HADOOP_HOME/conf";
 
         final File hadoopConfDir = tempFolder.newFolder("hadoopConfDir");
-        final File hadoopConfEntryDir = tempFolder.newFolder("hadoopConfEntryDir");
-        final File legacyConfDir = tempFolder.newFolder("legacyConfDir");
         final File hadoopHome = tempFolder.newFolder("hadoopHome");
 
         final File hadoopHomeConf = new File(hadoopHome, "conf");
@@ -204,10 +140,8 @@ public class HadoopConfigLoadingTest {
         assertTrue(hadoopHomeEtc.mkdirs());
 
         final File file1 = new File(hadoopConfDir, "core-site.xml");
-        final File file2 = new File(hadoopConfEntryDir, "core-site.xml");
-        final File file3 = new File(legacyConfDir, "core-site.xml");
-        final File file4 = new File(hadoopHomeEtc, "core-site.xml");
-        final File file5 = new File(hadoopHomeConf, "core-site.xml");
+        final File file2 = new File(hadoopHomeEtc, "core-site.xml");
+        final File file3 = new File(hadoopHomeConf, "core-site.xml");
 
         printConfig(file1, k1, v1);
 
@@ -222,24 +156,7 @@ public class HadoopConfigLoadingTest {
         properties3.put(k3, v3);
         printConfigs(file3, properties3);
 
-        Map<String, String> properties4 = new HashMap<>();
-        properties4.put(k1, v4);
-        properties4.put(k2, v4);
-        properties4.put(k3, v4);
-        properties4.put(k4, v4);
-        printConfigs(file4, properties4);
-
-        Map<String, String> properties5 = new HashMap<>();
-        properties5.put(k1, v5);
-        properties5.put(k2, v5);
-        properties5.put(k3, v5);
-        properties5.put(k4, v5);
-        properties5.put(k5, v5);
-        printConfigs(file5, properties5);
-
         final Configuration cfg = new Configuration();
-        cfg.setString(ConfigConstants.PATH_HADOOP_CONFIG, hadoopConfEntryDir.getAbsolutePath());
-        cfg.setString(ConfigConstants.HDFS_DEFAULT_CONFIG, file3.getAbsolutePath());
 
         final org.apache.hadoop.conf.Configuration hadoopConf;
 
@@ -258,8 +175,6 @@ public class HadoopConfigLoadingTest {
         assertEquals(v1, hadoopConf.get(k1, null));
         assertEquals(v2, hadoopConf.get(k2, null));
         assertEquals(v3, hadoopConf.get(k3, null));
-        assertEquals(v4, hadoopConf.get(k4, null));
-        assertEquals(v5, hadoopConf.get(k5, null));
 
         // also contains classpath defaults
         assertEquals(IN_CP_CONFIG_VALUE, hadoopConf.get(IN_CP_CONFIG_KEY, null));

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnFileStageTestS3ITCase.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnFileStageTestS3ITCase.java
@@ -18,11 +18,11 @@
 
 package org.apache.flink.yarn;
 
-import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.core.testutils.CommonTestUtils;
 import org.apache.flink.runtime.fs.hdfs.HadoopFileSystem;
 import org.apache.flink.testutils.junit.RetryOnException;
 import org.apache.flink.testutils.junit.extensions.retry.RetryExtension;
@@ -133,10 +133,17 @@ class YarnFileStageTestS3ITCase {
         }
 
         final Configuration conf = new Configuration();
-        conf.setString(ConfigConstants.HDFS_SITE_CONFIG, hadoopConfig.getAbsolutePath());
         conf.set(CoreOptions.ALLOWED_FALLBACK_FILESYSTEMS, "s3;s3a;s3n");
 
-        FileSystem.initialize(conf, null);
+        final Map<String, String> originalEnv = System.getenv();
+        final Map<String, String> newEnv = new HashMap<>(originalEnv);
+        newEnv.put("HADOOP_CONF_DIR", hadoopConfig.getAbsolutePath());
+        try {
+            CommonTestUtils.setEnv(newEnv);
+            FileSystem.initialize(conf, null);
+        } finally {
+            CommonTestUtils.setEnv(originalEnv);
+        }
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -593,7 +593,7 @@ under the License.
 				<scope>import</scope>
 				<version>2.13.2.20220328</version>
 			</dependency>
-			
+
 			<dependency>
 				<groupId>com.squareup.okhttp3</groupId>
 				<artifactId>okhttp</artifactId>


### PR DESCRIPTION
## What is the purpose of the change

The following Flink configuration options are deprecated for quite some long time (10 minor releases) and it's time to remove them:
```
fs.hdfs.hdfsdefault
fs.hdfs.hdfssite
fs.hdfs.hadoopconf
```

The alternative is to use `HADOOP_CONF_DIR` or `HADOOP_HOME`.

## Brief change log

* Removed the mentioned  Flink configuration options
* Minor bugfixes

## Verifying this change

Existing unit tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
