### PR TITLE
[FLINK-28065][Runtime/Configuration] Fix a never reached code in ProcessMemoryUtils Class

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/config/memory/ProcessMemoryUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/config/memory/ProcessMemoryUtils.java
@@ -181,8 +181,9 @@ public class ProcessMemoryUtils<FM extends FlinkMemory> {
                             getJvmOverheadRangeFraction(config));
             jvmMetaspaceAndOverhead =
                     new JvmMetaspaceAndOverhead(jvmMetaspaceSize, jvmOverheadSize);
-            sanityCheckTotalProcessMemory(config, totalFlinkMemorySize, jvmMetaspaceAndOverhead);
         }
+        sanityCheckTotalProcessMemory(config, totalFlinkMemorySize, jvmMetaspaceAndOverhead);
+
         return jvmMetaspaceAndOverhead;
     }
 


### PR DESCRIPTION
## What is the purpose of the change

Fix a never reached code in ProcessMemoryUtils Class


## Brief change log

Change the location of sanityCheckTotalProcessMemory method call, make sure when explicitly set taskmanager.memory.process.size, check the derived memory and the configured memory are equal

## Verifying this change

This change is already covered by existing tests, i ran TaskExecutorProcessUtilsTest Class and JobManagerProcessUtilsTest Class locally, they both passed the test

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no