### PR TITLE
[FLINK-28077][checkpoint] Fix the bug that tasks get stuck during cancellation in ChannelStateWriteRequestExecutorImpl

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriteRequestExecutorImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriteRequestExecutorImplTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.runtime.checkpoint.channel;
 
+import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.function.BiConsumerWithException;
 
@@ -26,9 +27,11 @@ import javax.annotation.Nonnull;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.LinkedBlockingDeque;
 
 import static org.apache.flink.runtime.checkpoint.channel.ChannelStateWriteRequestDispatcher.NO_OP;
+import static org.apache.flink.runtime.state.ChannelPersistenceITCase.getStreamFactoryFactory;
 import static org.apache.flink.util.ExceptionUtils.findThrowable;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -129,11 +132,32 @@ public class ChannelStateWriteRequestExecutorImplTest {
     }
 
     @Test
-    public void testCanBeClosed() throws IOException {
-        TestRequestDispatcher requestProcessor = new TestRequestDispatcher();
+    public void testCanBeClosed() throws Exception {
+        long checkpointId = 1L;
+        ChannelStateWriteRequestDispatcher processor =
+                new ChannelStateWriteRequestDispatcherImpl(
+                        "dummy task",
+                        0,
+                        getStreamFactoryFactory(),
+                        new ChannelStateSerializerImpl());
         try (ChannelStateWriteRequestExecutorImpl worker =
-                new ChannelStateWriteRequestExecutorImpl(TASK_NAME, requestProcessor)) {
+                new ChannelStateWriteRequestExecutorImpl(TASK_NAME, processor)) {
             worker.start();
+            worker.submit(
+                    new CheckpointStartRequest(
+                            checkpointId,
+                            new ChannelStateWriter.ChannelStateWriteResult(),
+                            CheckpointStorageLocationReference.getDefault()));
+            worker.submit(
+                    ChannelStateWriteRequest.write(
+                            checkpointId,
+                            new ResultSubpartitionInfo(0, 0),
+                            new CompletableFuture<>()));
+            worker.submit(
+                    ChannelStateWriteRequest.write(
+                            checkpointId,
+                            new ResultSubpartitionInfo(0, 0),
+                            new CompletableFuture<>()));
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change

Fix the bug that tasks get stuck during cancellation in ChannelStateWriteRequestExecutorImpl

Currently, just call the `writer.fail(e);` and don't throw InterruptedException when caught the InterruptedException in ChannelStateWriterThread. So ChannelStateWriterThread cannot exit when meet InterruptedException. We should throw InterruptedException, and the ChannelStateWriterThread will be finished.

## Brief change log

Catch InterruptedException and throw it when caught the InterruptedException in ChannelStateWriterThread.


## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: yes
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: yes

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented?  not documented
