### PR TITLE
[FLINK-28060][Connector/Kafka] Updated Kafka Clients to 3.1.1 

### DIFF
--- a/flink-connectors/flink-connector-kafka/pom.xml
+++ b/flink-connectors/flink-connector-kafka/pom.xml
@@ -35,7 +35,7 @@ under the License.
 	<packaging>jar</packaging>
 
 	<properties>
-		<kafka.version>2.8.1</kafka.version>
+		<kafka.version>3.1.1</kafka.version>
 	</properties>
 
 	<dependencies>

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerTestBase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerTestBase.java
@@ -192,8 +192,8 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
 
             final TimeoutException timeoutException = optionalTimeoutException.get();
             if (useNewSource) {
-                assertThat(timeoutException.getCause().getMessage())
-                        .contains("Timed out waiting for a node assignment.");
+                assertThat(timeoutException)
+                        .hasMessageContaining("Timed out waiting for a node assignment.");
             } else {
                 assertThat(timeoutException)
                         .hasMessage("Timeout expired while fetching topic metadata");

--- a/flink-connectors/flink-sql-connector-kafka/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-kafka/src/main/resources/META-INF/NOTICE
@@ -6,4 +6,4 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- org.apache.kafka:kafka-clients:2.8.1
+- org.apache.kafka:kafka-clients:3.1.1

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/pom.xml
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/pom.xml
@@ -76,7 +76,7 @@ under the License.
 		<dependency>
 			<groupId>org.apache.kafka</groupId>
 			<artifactId>kafka-clients</artifactId>
-			<version>2.8.1</version>
+			<version>3.1.1</version>
 		</dependency>
 
 		<!-- The following dependencies are for connector/format sql-jars that
@@ -234,7 +234,7 @@ under the License.
 						<artifactItem>
 							<groupId>org.apache.kafka</groupId>
 							<artifactId>kafka-clients</artifactId>
-							<version>2.8.1</version>
+							<version>3.1.1</version>
 							<destFileName>kafka-clients.jar</destFileName>
 							<type>jar</type>
 							<outputDirectory>${project.build.directory}/dependencies</outputDirectory>

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SQLClientKafkaITCase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SQLClientKafkaITCase.java
@@ -74,7 +74,7 @@ public class SQLClientKafkaITCase extends TestLogger {
 
     @Parameterized.Parameters(name = "{index}: kafka-version:{0} kafka-sql-version:{1}")
     public static Collection<Object[]> data() {
-        return Arrays.asList(new Object[][] {{"2.8.1", "universal", "kafka", ".*kafka.jar"}});
+        return Arrays.asList(new Object[][] {{"3.1.1", "universal", "kafka", ".*kafka.jar"}});
     }
 
     private static Configuration getConfiguration() {

--- a/flink-end-to-end-tests/test-scripts/kafka-common.sh
+++ b/flink-end-to-end-tests/test-scripts/kafka-common.sh
@@ -140,7 +140,7 @@ function stop_kafka_cluster {
 }
 
 function create_kafka_topic {
-  $KAFKA_DIR/bin/kafka-topics.sh --create --zookeeper localhost:2181 --replication-factor $1 --partitions $2 --topic $3
+  $KAFKA_DIR/bin/kafka-topics.sh --create --bootstrap-server localhost:9092 --replication-factor $1 --partitions $2 --topic $3
 }
 
 function send_messages_to_kafka {
@@ -168,11 +168,11 @@ function read_messages_from_kafka_avro {
 }
 
 function modify_num_partitions {
-  $KAFKA_DIR/bin/kafka-topics.sh --alter --topic $1 --partitions $2 --zookeeper localhost:2181
+  $KAFKA_DIR/bin/kafka-topics.sh --alter --topic $1 --partitions $2 --bootstrap-server localhost:9092
 }
 
 function get_num_partitions {
-  $KAFKA_DIR/bin/kafka-topics.sh --describe --topic $1 --zookeeper localhost:2181 | grep -Eo "PartitionCount:[0-9]+" | cut -d ":" -f 2
+  $KAFKA_DIR/bin/kafka-topics.sh --describe --topic $1 --bootstrap-server localhost:9092 | grep -Eo "PartitionCount:[0-9]+" | cut -d ":" -f 2
 }
 
 function get_partition_end_offset {

--- a/flink-end-to-end-tests/test-scripts/test_confluent_schema_registry.sh
+++ b/flink-end-to-end-tests/test-scripts/test_confluent_schema_registry.sh
@@ -19,7 +19,7 @@
 
 set -Eeuo pipefail
 
-KAFKA_VERSION="2.8.1"
+KAFKA_VERSION="3.1.1"
 CONFLUENT_VERSION="6.2.2"
 CONFLUENT_MAJOR_VERSION="6.2"
 # Check the Confluent Platform <> Apache Kafka compatibility matrix when updating KAFKA_VERSION

--- a/flink-end-to-end-tests/test-scripts/test_pyflink.sh
+++ b/flink-end-to-end-tests/test-scripts/test_pyflink.sh
@@ -19,7 +19,7 @@
 
 set -Eeuo pipefail
 
-KAFKA_VERSION="2.8.1"
+KAFKA_VERSION="3.1.1"
 CONFLUENT_VERSION="6.2.2"
 CONFLUENT_MAJOR_VERSION="6.2"
 # Check the Confluent Platform <> Apache Kafka compatibility matrix when updating KAFKA_VERSION

--- a/flink-end-to-end-tests/test-scripts/test_sql_client.sh
+++ b/flink-end-to-end-tests/test-scripts/test_sql_client.sh
@@ -19,7 +19,7 @@
 
 set -Eeuo pipefail
 
-KAFKA_VERSION="2.8.1"
+KAFKA_VERSION="3.1.1"
 CONFLUENT_VERSION="6.2.2"
 CONFLUENT_MAJOR_VERSION="6.2"
 # Check the Confluent Platform <> Apache Kafka compatibility matrix when updating KAFKA_VERSION

--- a/flink-examples/flink-examples-build-helper/flink-examples-streaming-state-machine/src/main/resources/META-INF/NOTICE
+++ b/flink-examples/flink-examples-build-helper/flink-examples-streaming-state-machine/src/main/resources/META-INF/NOTICE
@@ -6,4 +6,4 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- org.apache.kafka:kafka-clients:2.8.1
+- org.apache.kafka:kafka-clients:3.1.1

--- a/flink-formats/flink-avro-confluent-registry/pom.xml
+++ b/flink-formats/flink-avro-confluent-registry/pom.xml
@@ -32,7 +32,7 @@ under the License.
 	<name>Flink : Formats : Avro confluent registry</name>
 
 	<properties>
-		<kafka.version>2.8.1</kafka.version>
+		<kafka.version>3.1.1</kafka.version>
 		<confluent.version>6.2.2</confluent.version>
 	</properties>
 


### PR DESCRIPTION
## What is the purpose of the change

Updated Kafka Clients to resolve the issue where Flink is unable to commit its offset back to Kafka in case of Kafka Broker becoming unavailable. This should be resolved when the broker comes back up, but due to KAFKA-13563 that doesn't work. Since that fix has only become available with Kafka Clients 3.1.1, this commit updates the Kafka Clients dependency from 2.8.4 to 3.1.1.

No interfaces needed to be adjusted.

It was necessary to change some of our Bash e2e tests since they still relied on the Zookeeper parameter which has been removed in this version.
The other necessary change was adjusting the `KafkaConsumerTestBase` class since the level of exception is changed in the new Kafka Clients so exception.getCause().getMessage()  throws an NPE in the test case.

## Brief change log

* Updated Kafka Clients dependency
* Adjusted Bash e2e tests to connect to the brokers instead of zookeeper
* Small change to `KafkaConsumerTestBase` due to change in level of exception


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
