### PR TITLE
[FLINK-28107][python][connector/elasticsearch] Support id of document is null

### DIFF
--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/sink/MapElasticsearchEmitter.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/sink/MapElasticsearchEmitter.java
@@ -31,7 +31,7 @@ import java.util.function.Function;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** A simple ElasticsearchEmitter which is currently used in PyFlink ES connector. */
-public class SimpleElasticsearchEmitter implements ElasticsearchEmitter<Map<String, Object>> {
+public class MapElasticsearchEmitter implements ElasticsearchEmitter<Map<String, Object>> {
 
     private static final long serialVersionUID = 1L;
 
@@ -41,7 +41,7 @@ public class SimpleElasticsearchEmitter implements ElasticsearchEmitter<Map<Stri
     private final boolean isDynamicIndex;
     private transient Function<Map<String, Object>, String> indexProvider;
 
-    public SimpleElasticsearchEmitter(
+    public MapElasticsearchEmitter(
             String index,
             @Nullable String documentType,
             @Nullable String idFieldName,

--- a/flink-python/pyflink/datastream/connectors/elasticsearch.py
+++ b/flink-python/pyflink/datastream/connectors/elasticsearch.py
@@ -75,9 +75,9 @@ class ElasticsearchEmitter(object):
         Creates an emitter with static index which is invoked on every record to convert it to
         Elasticsearch actions.
         """
-        JSimpleElasticsearchEmitter = get_gateway().jvm \
-            .org.apache.flink.connector.elasticsearch.sink.SimpleElasticsearchEmitter
-        j_emitter = JSimpleElasticsearchEmitter(index, doc_type, key_field, False)
+        JMapElasticsearchEmitter = get_gateway().jvm \
+            .org.apache.flink.connector.elasticsearch.sink.MapElasticsearchEmitter
+        j_emitter = JMapElasticsearchEmitter(index, doc_type, key_field, False)
         return ElasticsearchEmitter(j_emitter)
 
     @staticmethod
@@ -87,9 +87,9 @@ class ElasticsearchEmitter(object):
         Creates an emitter with dynamic index which is invoked on every record to convert it to
         Elasticsearch actions.
         """
-        JSimpleElasticsearchEmitter = get_gateway().jvm \
-            .org.apache.flink.connector.elasticsearch.sink.SimpleElasticsearchEmitter
-        j_emitter = JSimpleElasticsearchEmitter(index_field, doc_type, key_field, True)
+        JMapElasticsearchEmitter = get_gateway().jvm \
+            .org.apache.flink.connector.elasticsearch.sink.MapElasticsearchEmitter
+        j_emitter = JMapElasticsearchEmitter(index_field, doc_type, key_field, True)
         return ElasticsearchEmitter(j_emitter)
 
 

--- a/flink-python/pyflink/datastream/tests/test_connectors.py
+++ b/flink-python/pyflink/datastream/tests/test_connectors.py
@@ -142,6 +142,42 @@ class FlinkElasticsearch7Test(ConnectorTestBase):
 
         ds.sink_to(es_dynamic_index_sink).name('es dynamic index sink')
 
+    def test_es_sink_key_none(self):
+        ds = self.env.from_collection(
+            [{'name': 'ada', 'id': '1'}, {'name': 'luna', 'id': '2'}],
+            type_info=Types.MAP(Types.STRING(), Types.STRING()))
+
+        es_sink = Elasticsearch7SinkBuilder() \
+            .set_emitter(ElasticsearchEmitter.static_index('foo')) \
+            .set_hosts(['localhost:9200']) \
+            .build()
+
+        j_emitter = get_field_value(es_sink.get_java_function(), 'emitter')
+        self.assertTrue(
+            is_instance_of(
+                j_emitter,
+                'org.apache.flink.connector.elasticsearch.sink.SimpleElasticsearchEmitter'))
+
+        ds.sink_to(es_sink).name('es sink')
+
+    def test_es_sink_dynamic_key_none(self):
+        ds = self.env.from_collection(
+            [{'name': 'ada', 'id': '1'}, {'name': 'luna', 'id': '2'}],
+            type_info=Types.MAP(Types.STRING(), Types.STRING()))
+
+        es_dynamic_index_sink = Elasticsearch7SinkBuilder() \
+            .set_emitter(ElasticsearchEmitter.dynamic_index('name')) \
+            .set_hosts(['localhost:9200']) \
+            .build()
+
+        j_emitter = get_field_value(es_dynamic_index_sink.get_java_function(), 'emitter')
+        self.assertTrue(
+            is_instance_of(
+                j_emitter,
+                'org.apache.flink.connector.elasticsearch.sink.SimpleElasticsearchEmitter'))
+
+        ds.sink_to(es_dynamic_index_sink).name('es dynamic index sink')
+
 
 class FlinkKafkaTest(ConnectorTestBase):
 

--- a/flink-python/pyflink/datastream/tests/test_connectors.py
+++ b/flink-python/pyflink/datastream/tests/test_connectors.py
@@ -96,7 +96,7 @@ class FlinkElasticsearch7Test(ConnectorTestBase):
         self.assertTrue(
             is_instance_of(
                 j_emitter,
-                'org.apache.flink.connector.elasticsearch.sink.SimpleElasticsearchEmitter'))
+                'org.apache.flink.connector.elasticsearch.sink.MapElasticsearchEmitter'))
         self.assertEqual(
             get_field_value(
                 es_sink.get_java_function(), 'hosts')[0].toString(), 'http://localhost:9200')
@@ -138,7 +138,7 @@ class FlinkElasticsearch7Test(ConnectorTestBase):
         self.assertTrue(
             is_instance_of(
                 j_emitter,
-                'org.apache.flink.connector.elasticsearch.sink.SimpleElasticsearchEmitter'))
+                'org.apache.flink.connector.elasticsearch.sink.MapElasticsearchEmitter'))
 
         ds.sink_to(es_dynamic_index_sink).name('es dynamic index sink')
 
@@ -156,7 +156,7 @@ class FlinkElasticsearch7Test(ConnectorTestBase):
         self.assertTrue(
             is_instance_of(
                 j_emitter,
-                'org.apache.flink.connector.elasticsearch.sink.SimpleElasticsearchEmitter'))
+                'org.apache.flink.connector.elasticsearch.sink.MapElasticsearchEmitter'))
 
         ds.sink_to(es_sink).name('es sink')
 
@@ -174,7 +174,7 @@ class FlinkElasticsearch7Test(ConnectorTestBase):
         self.assertTrue(
             is_instance_of(
                 j_emitter,
-                'org.apache.flink.connector.elasticsearch.sink.SimpleElasticsearchEmitter'))
+                'org.apache.flink.connector.elasticsearch.sink.MapElasticsearchEmitter'))
 
         ds.sink_to(es_dynamic_index_sink).name('es dynamic index sink')
 


### PR DESCRIPTION
## What is the purpose of the change

Support id of document is null

## Brief change log

  - *Add IndexRequest in SimpleElasticsearchEmitter*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added integration tests for end-to-end deployment with large payloads (100MB)*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
