### PR TITLE
[FLINK-28080][runtime] Introduce MutableURLClassLoader as parent class of FlinkUserClassLoader and SafetyNetWrapperClassLoader

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/FlinkUserCodeClassLoader.java
+++ b/flink-core/src/main/java/org/apache/flink/util/FlinkUserCodeClassLoader.java
@@ -19,14 +19,13 @@
 package org.apache.flink.util;
 
 import java.net.URL;
-import java.net.URLClassLoader;
 import java.util.function.Consumer;
 
 /**
  * This class loader accepts a custom handler if an exception occurs in {@link #loadClass(String,
  * boolean)}.
  */
-public abstract class FlinkUserCodeClassLoader extends URLClassLoader {
+public abstract class FlinkUserCodeClassLoader extends MutableURLClassLoader {
     public static final Consumer<Throwable> NOOP_EXCEPTION_HANDLER = classLoadingException -> {};
 
     static {
@@ -66,10 +65,5 @@ public abstract class FlinkUserCodeClassLoader extends URLClassLoader {
     protected Class<?> loadClassWithoutExceptionHandling(String name, boolean resolve)
             throws ClassNotFoundException {
         return super.loadClass(name, resolve);
-    }
-
-    @Override
-    protected void addURL(URL url) {
-        super.addURL(url);
     }
 }

--- a/flink-core/src/main/java/org/apache/flink/util/FlinkUserCodeClassLoaders.java
+++ b/flink-core/src/main/java/org/apache/flink/util/FlinkUserCodeClassLoaders.java
@@ -24,10 +24,8 @@ import org.apache.flink.configuration.CoreOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.net.URL;
-import java.net.URLClassLoader;
 import java.util.Enumeration;
 import java.util.function.Consumer;
 
@@ -37,7 +35,7 @@ public class FlinkUserCodeClassLoaders {
 
     private FlinkUserCodeClassLoaders() {}
 
-    public static URLClassLoader parentFirst(
+    public static MutableURLClassLoader parentFirst(
             URL[] urls,
             ClassLoader parent,
             Consumer<Throwable> classLoadingExceptionHandler,
@@ -47,7 +45,7 @@ public class FlinkUserCodeClassLoaders {
         return wrapWithSafetyNet(classLoader, checkClassLoaderLeak);
     }
 
-    public static URLClassLoader childFirst(
+    public static MutableURLClassLoader childFirst(
             URL[] urls,
             ClassLoader parent,
             String[] alwaysParentFirstPatterns,
@@ -59,7 +57,7 @@ public class FlinkUserCodeClassLoaders {
         return wrapWithSafetyNet(classLoader, checkClassLoaderLeak);
     }
 
-    public static URLClassLoader create(
+    public static MutableURLClassLoader create(
             ResolveOrder resolveOrder,
             URL[] urls,
             ClassLoader parent,
@@ -84,7 +82,7 @@ public class FlinkUserCodeClassLoaders {
         }
     }
 
-    private static URLClassLoader wrapWithSafetyNet(
+    private static MutableURLClassLoader wrapWithSafetyNet(
             FlinkUserCodeClassLoader classLoader, boolean check) {
         return check
                 ? new SafetyNetWrapperClassLoader(classLoader, classLoader.getParent())
@@ -131,8 +129,7 @@ public class FlinkUserCodeClassLoaders {
      * delegate is nulled and can be garbage collected. Additional class resolution will be resolved
      * solely through the bootstrap classloader and most likely result in ClassNotFound exceptions.
      */
-    @Internal
-    public static class SafetyNetWrapperClassLoader extends URLClassLoader implements Closeable {
+    private static class SafetyNetWrapperClassLoader extends MutableURLClassLoader {
         private static final Logger LOG =
                 LoggerFactory.getLogger(SafetyNetWrapperClassLoader.class);
 

--- a/flink-core/src/main/java/org/apache/flink/util/MutableURLClassLoader.java
+++ b/flink-core/src/main/java/org/apache/flink/util/MutableURLClassLoader.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.util;
+
+import org.apache.flink.annotation.Internal;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+
+/** URL class loader that exposes the `addURL` method in URLClassLoader. */
+@Internal
+public abstract class MutableURLClassLoader extends URLClassLoader {
+
+    static {
+        ClassLoader.registerAsParallelCapable();
+    }
+
+    public MutableURLClassLoader(URL[] urls, ClassLoader parent) {
+        super(urls, parent);
+    }
+
+    @Override
+    public void addURL(URL url) {
+        super.addURL(url);
+    }
+}

--- a/flink-core/src/test/java/org/apache/flink/util/FlinkUserCodeClassLoadersTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/FlinkUserCodeClassLoadersTest.java
@@ -211,13 +211,13 @@ public class FlinkUserCodeClassLoadersTest extends TestLogger {
                 startsWith("Cannot access classloader info due to an exception."));
     }
 
-    private static URLClassLoader createParentFirstClassLoader(
+    private static MutableURLClassLoader createParentFirstClassLoader(
             URL childCodePath, ClassLoader parentClassLoader) {
         return FlinkUserCodeClassLoaders.parentFirst(
                 new URL[] {childCodePath}, parentClassLoader, NOOP_EXCEPTION_HANDLER, true);
     }
 
-    private static URLClassLoader createChildFirstClassLoader(
+    private static MutableURLClassLoader createChildFirstClassLoader(
             URL childCodePath, ClassLoader parentClassLoader) {
         return FlinkUserCodeClassLoaders.childFirst(
                 new URL[] {childCodePath},
@@ -262,15 +262,12 @@ public class FlinkUserCodeClassLoadersTest extends TestLogger {
         // RocksDB itself
         final URL childCodePath = getClass().getProtectionDomain().getCodeSource().getLocation();
 
-        final FlinkUserCodeClassLoaders.SafetyNetWrapperClassLoader parentClassLoader =
-                (FlinkUserCodeClassLoaders.SafetyNetWrapperClassLoader)
-                        createChildFirstClassLoader(childCodePath, getClass().getClassLoader());
-        final FlinkUserCodeClassLoaders.SafetyNetWrapperClassLoader childClassLoader1 =
-                (FlinkUserCodeClassLoaders.SafetyNetWrapperClassLoader)
-                        createParentFirstClassLoader(childCodePath, parentClassLoader);
-        final FlinkUserCodeClassLoaders.SafetyNetWrapperClassLoader childClassLoader2 =
-                (FlinkUserCodeClassLoaders.SafetyNetWrapperClassLoader)
-                        createParentFirstClassLoader(childCodePath, parentClassLoader);
+        final MutableURLClassLoader parentClassLoader =
+                createChildFirstClassLoader(childCodePath, getClass().getClassLoader());
+        final MutableURLClassLoader childClassLoader1 =
+                createParentFirstClassLoader(childCodePath, parentClassLoader);
+        final MutableURLClassLoader childClassLoader2 =
+                createParentFirstClassLoader(childCodePath, parentClassLoader);
 
         // test class loader before add user jar ulr to ClassLoader
         assertClassNotFoundException(USER_CLASS, false, parentClassLoader);
@@ -300,15 +297,12 @@ public class FlinkUserCodeClassLoadersTest extends TestLogger {
         // RocksDB itself
         final URL childCodePath = getClass().getProtectionDomain().getCodeSource().getLocation();
 
-        final FlinkUserCodeClassLoaders.SafetyNetWrapperClassLoader parentClassLoader =
-                (FlinkUserCodeClassLoaders.SafetyNetWrapperClassLoader)
-                        createChildFirstClassLoader(childCodePath, getClass().getClassLoader());
-        final FlinkUserCodeClassLoaders.SafetyNetWrapperClassLoader childClassLoader1 =
-                (FlinkUserCodeClassLoaders.SafetyNetWrapperClassLoader)
-                        createChildFirstClassLoader(childCodePath, parentClassLoader);
-        final FlinkUserCodeClassLoaders.SafetyNetWrapperClassLoader childClassLoader2 =
-                (FlinkUserCodeClassLoaders.SafetyNetWrapperClassLoader)
-                        createChildFirstClassLoader(childCodePath, parentClassLoader);
+        final MutableURLClassLoader parentClassLoader =
+                createChildFirstClassLoader(childCodePath, getClass().getClassLoader());
+        final MutableURLClassLoader childClassLoader1 =
+                createChildFirstClassLoader(childCodePath, parentClassLoader);
+        final MutableURLClassLoader childClassLoader2 =
+                createChildFirstClassLoader(childCodePath, parentClassLoader);
 
         // test class loader before add user jar ulr to ClassLoader
         assertClassNotFoundException(USER_CLASS, false, parentClassLoader);

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/resource/ResourceManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/resource/ResourceManager.java
@@ -26,6 +26,7 @@ import org.apache.flink.core.fs.Path;
 import org.apache.flink.table.api.config.TableConfigOptions;
 import org.apache.flink.util.FileUtils;
 import org.apache.flink.util.JarUtils;
+import org.apache.flink.util.MutableURLClassLoader;
 
 import org.apache.flink.shaded.guava30.com.google.common.io.Files;
 
@@ -45,8 +46,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import static org.apache.flink.util.FlinkUserCodeClassLoaders.SafetyNetWrapperClassLoader;
-
 /** A manager for dealing with all user defined resource. */
 @Internal
 public class ResourceManager implements Closeable {
@@ -55,9 +54,9 @@ public class ResourceManager implements Closeable {
 
     private final Path localResourceDir;
     private final Map<ResourceUri, URL> resourceInfos;
-    private final SafetyNetWrapperClassLoader userClassLoader;
+    private final MutableURLClassLoader userClassLoader;
 
-    public ResourceManager(Configuration config, SafetyNetWrapperClassLoader userClassLoader) {
+    public ResourceManager(Configuration config, MutableURLClassLoader userClassLoader) {
         this.localResourceDir =
                 new Path(
                         config.get(TableConfigOptions.RESOURCE_DOWNLOAD_DIR),

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/resource/ResourceManagerTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/resource/ResourceManagerTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.testutils.CommonTestUtils;
 import org.apache.flink.util.FileUtils;
 import org.apache.flink.util.FlinkUserCodeClassLoaders;
+import org.apache.flink.util.MutableURLClassLoader;
 import org.apache.flink.util.UserClassLoaderJarTestUtils;
 
 import org.junit.BeforeClass;
@@ -153,12 +154,12 @@ public class ResourceManagerTest {
 
     private ResourceManager createResourceManager(URL[] urls) {
         Configuration configuration = new Configuration();
-        FlinkUserCodeClassLoaders.SafetyNetWrapperClassLoader mutableURLClassLoader =
+        MutableURLClassLoader mutableURLClassLoader =
                 createClassLoader(configuration, urls, getClass().getClassLoader());
         return new ResourceManager(configuration, mutableURLClassLoader);
     }
 
-    private FlinkUserCodeClassLoaders.SafetyNetWrapperClassLoader createClassLoader(
+    private MutableURLClassLoader createClassLoader(
             Configuration configuration, URL[] urls, ClassLoader parentClassLoader) {
         final String[] alwaysParentFirstLoaderPatterns =
                 CoreOptions.getParentFirstLoaderPatterns(configuration);
@@ -170,13 +171,12 @@ public class ResourceManagerTest {
                 configuration.getString(CoreOptions.CLASSLOADER_RESOLVE_ORDER);
         FlinkUserCodeClassLoaders.ResolveOrder resolveOrder =
                 FlinkUserCodeClassLoaders.ResolveOrder.fromString(classLoaderResolveOrder);
-        return (FlinkUserCodeClassLoaders.SafetyNetWrapperClassLoader)
-                FlinkUserCodeClassLoaders.create(
-                        resolveOrder,
-                        urls,
-                        parentClassLoader,
-                        alwaysParentFirstLoaderPatterns,
-                        NOOP_EXCEPTION_HANDLER,
-                        true);
+        return FlinkUserCodeClassLoaders.create(
+                resolveOrder,
+                urls,
+                parentClassLoader,
+                alwaysParentFirstLoaderPatterns,
+                NOOP_EXCEPTION_HANDLER,
+                true);
     }
 }


### PR DESCRIPTION

## What is the purpose of the change
In table module, we need an `URLClassLoader` which exposes the `addURL` method because we need to load jar dynamically in sql job. Although the SafetyNetWrapperClassLoader has exposed `addURL` method, but we can't ensure the  classloader created by `FlinkUserCodeClassLoaders` is `SafetyNetWrapperClassLoader`, because the returned classloader might not be `SafetyNetWrapperClassLoader` if checkClassLoaderLeak is false. So we need introduce a `MutableURLClassLoader` that exposes the `addURL`, and the `SafetyNetWrapperClassLoader` and `FlinkUserCodeClassLoader` both extends it, we only need refer to this class in table module.

## Brief change log
  - *Introduce MutableURLClassLoader as parent class of FlinkUserClassLoader and SafetyNetWrapperClassLoader*


## Verifying this change

This change is already covered by existing tests, such as *FlinkUserCodeClassLoadersTest*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
