### PR TITLE
[FLINK-28109][connector/elasticsearch] Delete useful code in the row emitter

### DIFF
--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/table/RowElasticsearchEmitter.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/table/RowElasticsearchEmitter.java
@@ -92,7 +92,6 @@ class RowElasticsearchEmitter implements ElasticsearchEmitter<RowData> {
         } else {
             final IndexRequest indexRequest =
                     new IndexRequest(indexGenerator.generate(row), documentType)
-                            .id(key)
                             .source(document, contentType);
             indexer.add(indexRequest);
         }


### PR DESCRIPTION
## Brief change log

  - *Delete id(key) in the RowElasticsearchEmitter class*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
