### PR TITLE
[FLINK-27415][Connectors / FileSystem] Read empty csv file throws exception in FileSystem table connector

### DIFF
--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/impl/StreamFormatAdapter.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/impl/StreamFormatAdapter.java
@@ -261,7 +261,6 @@ public final class StreamFormatAdapter<T> implements BulkFormat<T, FileSourceSpl
         private int remainingInBatch;
 
         TrackingFsDataInputStream(FSDataInputStream stream, long fileLength, int batchSize) {
-            checkArgument(fileLength > 0L);
             checkArgument(batchSize > 0);
             this.stream = stream;
             this.fileLength = fileLength;

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/impl/StreamFormatAdapterTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/impl/StreamFormatAdapterTest.java
@@ -86,7 +86,7 @@ class StreamFormatAdapterTest extends AdapterTestBase<StreamFormat<Integer>> {
     }
 
     @Test
-    public void testReadEmptyFile() throws IOException {
+    void testReadEmptyFile() throws IOException {
         final StreamFormatAdapter<Integer> format =
                 new StreamFormatAdapter<>(new CheckpointedIntFormat());
 

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/impl/StreamFormatAdapterTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/impl/StreamFormatAdapterTest.java
@@ -27,9 +27,11 @@ import org.apache.flink.connector.file.src.reader.BulkFormat;
 import org.apache.flink.connector.file.src.reader.SimpleStreamFormat;
 import org.apache.flink.connector.file.src.reader.StreamFormat;
 import org.apache.flink.core.fs.FSDataInputStream;
+import org.apache.flink.core.fs.Path;
 
 import org.junit.jupiter.api.Test;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -81,6 +83,26 @@ class StreamFormatAdapterTest extends AdapterTestBase<StreamFormat<Integer>> {
     @Test
     void testBatchSizeIsRecordMultiple() throws IOException {
         simpleReadTest(20);
+    }
+
+    @Test
+    public void testReadEmptyFile() throws IOException {
+        final StreamFormatAdapter<Integer> format =
+                new StreamFormatAdapter<>(new CheckpointedIntFormat());
+
+        final File emptyFile = new File(tmpDir.toFile(), "testFile-empty");
+        emptyFile.createNewFile();
+        Path emptyFilePath = Path.fromLocalFile(emptyFile);
+
+        final BulkFormat.Reader<Integer> reader =
+                format.createReader(
+                        new Configuration(),
+                        new FileSourceSplit("test-id", emptyFilePath, 0L, 0, 0L, 0));
+
+        final List<Integer> result = new ArrayList<>();
+        readNumbers(reader, result, 0);
+
+        assertThat(result).hasSize(0);
     }
 
     private void simpleReadTest(int batchSize) throws IOException {

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/impl/StreamFormatAdapterTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/impl/StreamFormatAdapterTest.java
@@ -102,7 +102,7 @@ class StreamFormatAdapterTest extends AdapterTestBase<StreamFormat<Integer>> {
         final List<Integer> result = new ArrayList<>();
         readNumbers(reader, result, 0);
 
-        assertThat(result).hasSize(0);
+        assertThat(result).isEmpty();
     }
 
     private void simpleReadTest(int batchSize) throws IOException {

--- a/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvFilesystemBatchITCase.java
+++ b/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvFilesystemBatchITCase.java
@@ -30,6 +30,7 @@ import java.io.File;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 /** ITCase to test csv format for {@link CsvFileSystemFormatFactory} in batch mode. */
@@ -113,6 +114,16 @@ public class CsvFilesystemBatchITCase {
             check(
                     "select * from nonPartitionedTable",
                     Arrays.asList(Row.of("x5", 5, 1, 1), Row.of("x5", 5, 2, 2)));
+        }
+
+        @Test
+        public void testEmpty() throws Exception {
+            String path = new URI(resultPath()).getPath();
+            new File(path).mkdirs();
+            File file = new File(path, "test_file");
+            file.createNewFile();
+
+            check("select * from nonPartitionedTable", Collections.emptyList());
         }
     }
 }


### PR DESCRIPTION

## What is the purpose of the change

Read empty csv file throws exception in FileSystem table connector. 


## Brief change log

  - *Remove size check, so `StreamFormatAdapter` can read empty files *

## Verifying this change

This change added tests and can be verified as follows:

  - *Added integration tests for reading empty csv file*
  - *Added test that validates that `StreamFormatAdapter` read empty file*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
