### PR TITLE
[FLINK-27990][table-planner] Parquet format supports reporting statistics

### DIFF
--- a/flink-formats/flink-parquet/pom.xml
+++ b/flink-formats/flink-parquet/pom.xml
@@ -161,6 +161,13 @@ under the License.
 		<!-- Tests -->
 
 		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>${guava.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-test-utils</artifactId>
 			<version>${project.version}</version>

--- a/flink-formats/flink-parquet/pom.xml
+++ b/flink-formats/flink-parquet/pom.xml
@@ -160,6 +160,7 @@ under the License.
 
 		<!-- Tests -->
 
+		<!--Support ParquetFileSystemStatisticsReport using calcite verify plan methods, see FLINK-27990 -->
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/ParquetFileFormatFactory.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/ParquetFileFormatFactory.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.formats.parquet;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.serialization.BulkWriter;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ReadableConfig;
@@ -26,25 +27,59 @@ import org.apache.flink.connector.file.src.reader.BulkFormat;
 import org.apache.flink.connector.file.table.factories.BulkReaderFormatFactory;
 import org.apache.flink.connector.file.table.factories.BulkWriterFormatFactory;
 import org.apache.flink.connector.file.table.format.BulkDecodingFormat;
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.formats.parquet.row.ParquetRowDataBuilder;
+import org.apache.flink.formats.parquet.vector.reader.TimestampColumnReader;
 import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.connector.Projection;
 import org.apache.flink.table.connector.format.EncodingFormat;
+import org.apache.flink.table.connector.format.FileBasedStatisticsReportableInputFormat;
 import org.apache.flink.table.connector.format.ProjectableDecodingFormat;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.data.columnar.vector.VectorizedColumnBatch;
 import org.apache.flink.table.factories.DynamicTableFactory;
+import org.apache.flink.table.plan.stats.ColumnStats;
+import org.apache.flink.table.plan.stats.TableStats;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.utils.DateTimeUtils;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.Preconditions;
+import org.apache.parquet.column.statistics.BinaryStatistics;
+import org.apache.parquet.column.statistics.DoubleStatistics;
+import org.apache.parquet.column.statistics.FloatStatistics;
+import org.apache.parquet.column.statistics.IntStatistics;
+import org.apache.parquet.column.statistics.LongStatistics;
+import org.apache.parquet.column.statistics.Statistics;
+import org.apache.parquet.hadoop.ParquetFileReader;
+import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
+import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.Type;
 
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.configuration.ConfigOptions.key;
 
@@ -111,9 +146,14 @@ public class ParquetFileFormatFactory implements BulkReaderFormatFactory, BulkWr
         return new HashSet<>();
     }
 
-    private static class ParquetBulkDecodingFormat
+    /**
+     * ParquetBulkDecodingFormat which implements {@link FileBasedStatisticsReportableInputFormat}.
+     */
+    @VisibleForTesting
+    public static class ParquetBulkDecodingFormat
             implements ProjectableDecodingFormat<BulkFormat<RowData, FileSourceSplit>>,
-                    BulkDecodingFormat<RowData> {
+                    BulkDecodingFormat<RowData>,
+                    FileBasedStatisticsReportableInputFormat {
 
         private final ReadableConfig formatOptions;
 
@@ -141,6 +181,247 @@ public class ParquetFileFormatFactory implements BulkReaderFormatFactory, BulkWr
         @Override
         public ChangelogMode getChangelogMode() {
             return ChangelogMode.insertOnly();
+        }
+
+        @Override
+        public TableStats reportStatistics(List<Path> files, DataType producedDataType) {
+            try {
+                Configuration hadoopConfig = getParquetConfiguration(formatOptions);
+                Map<String, Statistics<?>> columnStatisticsMap = new HashMap<>();
+                RowType producedRowType = (RowType) producedDataType.getLogicalType();
+                long rowCount = 0;
+                for (Path file : files) {
+                    rowCount += updateStatistics(hadoopConfig, file, columnStatisticsMap);
+                }
+                Map<String, ColumnStats> columnStatsMap =
+                        convertToColumnStats(columnStatisticsMap, producedRowType);
+                return new TableStats(rowCount, columnStatsMap);
+            } catch (Exception e) {
+                return TableStats.UNKNOWN;
+            }
+        }
+
+        private Map<String, ColumnStats> convertToColumnStats(
+                Map<String, Statistics<?>> columnStatisticsMap, RowType producedRowType) {
+            Map<String, ColumnStats> columnStatMap = new HashMap<>();
+            for (String column : producedRowType.getFieldNames()) {
+                Statistics<?> statistics = columnStatisticsMap.get(column);
+                if (statistics == null) {
+                    continue;
+                }
+                ColumnStats columnStats =
+                        convertToColumnStats(
+                                producedRowType.getTypeAt(producedRowType.getFieldIndex(column)),
+                                statistics);
+                columnStatMap.put(column, columnStats);
+            }
+            return columnStatMap;
+        }
+
+        private ColumnStats convertToColumnStats(
+                LogicalType logicalType, Statistics<?> statistics) {
+            ColumnStats.Builder builder =
+                    new ColumnStats.Builder().setNullCount(statistics.getNumNulls());
+
+            switch (logicalType.getTypeRoot()) {
+                case BOOLEAN:
+                case BINARY:
+                case VARBINARY:
+                case ROW:
+                case ARRAY:
+                case MAP:
+                    break;
+                case TINYINT:
+                case SMALLINT:
+                case INTEGER:
+                case BIGINT:
+                    if (statistics instanceof IntStatistics) {
+                        builder.setMin(((IntStatistics) statistics).getMin())
+                                .setMax(((IntStatistics) statistics).getMax());
+                        break;
+                    } else if (statistics instanceof LongStatistics) {
+                        builder.setMin(((LongStatistics) statistics).getMin())
+                                .setMax(((LongStatistics) statistics).getMax());
+                        break;
+                    } else {
+                        return null;
+                    }
+                case DOUBLE:
+                    if (statistics instanceof DoubleStatistics) {
+                        builder.setMin(((DoubleStatistics) statistics).getMin())
+                                .setMax(((DoubleStatistics) statistics).getMax());
+                        break;
+                    } else {
+                        return null;
+                    }
+                case FLOAT:
+                    if (statistics instanceof FloatStatistics) {
+                        builder.setMin(((FloatStatistics) statistics).getMin())
+                                .setMax(((FloatStatistics) statistics).getMax());
+                        break;
+                    } else {
+                        return null;
+                    }
+                case DATE:
+                    if (statistics instanceof IntStatistics) {
+                        Date min =
+                                Date.valueOf(
+                                        DateTimeUtils.formatDate(
+                                                ((IntStatistics) statistics).getMin()));
+                        Date max =
+                                Date.valueOf(
+                                        DateTimeUtils.formatDate(
+                                                ((IntStatistics) statistics).getMax()));
+                        builder.setMin(min).setMax(max);
+                        break;
+                    } else {
+                        return null;
+                    }
+                case TIME_WITHOUT_TIME_ZONE:
+                    if (statistics instanceof IntStatistics) {
+                        Time min =
+                                Time.valueOf(
+                                        DateTimeUtils.toLocalTime(
+                                                ((IntStatistics) statistics).getMin()));
+                        Time max =
+                                Time.valueOf(
+                                        DateTimeUtils.toLocalTime(
+                                                ((IntStatistics) statistics).getMax()));
+                        builder.setMin(min).setMax(max);
+                        break;
+                    } else {
+                        return null;
+                    }
+                case CHAR:
+                case VARCHAR:
+                    if (statistics instanceof BinaryStatistics) {
+                        Binary min = ((BinaryStatistics) statistics).genericGetMin();
+                        Binary max = ((BinaryStatistics) statistics).genericGetMax();
+                        if (min != null) {
+                            builder.setMin(min.toStringUsingUTF8());
+                        } else {
+                            builder.setMin(null);
+                        }
+                        if (max != null) {
+                            builder.setMax(max.toStringUsingUTF8());
+                        } else {
+                            builder.setMax(null);
+                        }
+                        break;
+                    } else {
+                        return null;
+                    }
+                case TIMESTAMP_WITHOUT_TIME_ZONE:
+                case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+                case TIMESTAMP_WITH_TIME_ZONE:
+                    if (statistics instanceof LongStatistics) {
+                        builder.setMin(new Timestamp(((LongStatistics) statistics).getMin()))
+                                .setMax(new Timestamp(((LongStatistics) statistics).getMax()));
+                        break;
+                    } else if (statistics instanceof BinaryStatistics) {
+                        Binary min = ((BinaryStatistics) statistics).genericGetMin();
+                        Binary max = ((BinaryStatistics) statistics).genericGetMax();
+                        if (min != null) {
+                            builder.setMin(binaryToTimestamp(min, formatOptions.get(UTC_TIMEZONE)));
+                        } else {
+                            builder.setMin(null);
+                        }
+                        if (max != null) {
+                            builder.setMax(binaryToTimestamp(max, formatOptions.get(UTC_TIMEZONE)));
+                        } else {
+                            builder.setMax(null);
+                        }
+                        break;
+                    } else {
+                        return null;
+                    }
+                case DECIMAL:
+                    if (statistics instanceof IntStatistics) {
+                        builder.setMin(BigDecimal.valueOf(((IntStatistics) statistics).getMin()))
+                                .setMax(BigDecimal.valueOf(((IntStatistics) statistics).getMax()));
+                        break;
+                    } else if (statistics instanceof LongStatistics) {
+                        builder.setMin(BigDecimal.valueOf(((LongStatistics) statistics).getMin()))
+                                .setMax(BigDecimal.valueOf(((LongStatistics) statistics).getMax()));
+                        break;
+                    } else if (statistics instanceof BinaryStatistics) {
+                        Binary min = ((BinaryStatistics) statistics).genericGetMin();
+                        Binary max = ((BinaryStatistics) statistics).genericGetMax();
+                        if (min != null) {
+                            builder.setMin(
+                                    binaryToDecimal(min, ((DecimalType) logicalType).getScale()));
+                        } else {
+                            builder.setMin(null);
+                        }
+                        if (max != null) {
+                            builder.setMax(
+                                    binaryToDecimal(max, ((DecimalType) logicalType).getScale()));
+                        } else {
+                            builder.setMax(null);
+                        }
+                        break;
+                    } else {
+                        return null;
+                    }
+                default:
+                    return null;
+            }
+            return builder.build();
+        }
+
+        private long updateStatistics(
+                Configuration hadoopConfig,
+                Path file,
+                Map<String, Statistics<?>> columnStatisticsMap)
+                throws IOException {
+            org.apache.hadoop.fs.Path hadoopPath = new org.apache.hadoop.fs.Path(file.toUri());
+            ParquetMetadata metadata = ParquetFileReader.readFooter(hadoopConfig, hadoopPath);
+            MessageType schema = metadata.getFileMetaData().getSchema();
+            List<String> columns =
+                    schema.asGroupType().getFields().stream()
+                            .map(Type::getName)
+                            .collect(Collectors.toList());
+            List<BlockMetaData> blocks = metadata.getBlocks();
+            long rowCount = 0;
+            for (BlockMetaData block : blocks) {
+                rowCount += block.getRowCount();
+                for (int i = 0; i < columns.size(); ++i) {
+                    updateStatistics(
+                            block.getColumns().get(i).getStatistics(),
+                            columns.get(i),
+                            columnStatisticsMap);
+                }
+            }
+            return rowCount;
+        }
+
+        private void updateStatistics(
+                Statistics<?> statistics,
+                String column,
+                Map<String, Statistics<?>> columnStatisticsMap) {
+            Statistics<?> previousStatistics = columnStatisticsMap.get(column);
+            if (previousStatistics == null) {
+                columnStatisticsMap.put(column, statistics);
+            } else {
+                previousStatistics.mergeStatistics(statistics);
+            }
+        }
+
+        private static BigDecimal binaryToDecimal(Binary decimal, int scale) {
+            BigInteger bigInteger = new BigInteger(decimal.getBytesUnsafe());
+            return new BigDecimal(bigInteger, scale);
+        }
+
+        private static Timestamp binaryToTimestamp(Binary timestamp, boolean utcTimestamp) {
+            Preconditions.checkArgument(timestamp.length() == 12, "Must be 12 bytes");
+            ByteBuffer buf = timestamp.toByteBuffer();
+            buf.order(ByteOrder.LITTLE_ENDIAN);
+            long timeOfDayNanos = buf.getLong();
+            int julianDay = buf.getInt();
+
+            TimestampData timestampData =
+                    TimestampColumnReader.int96ToTimestamp(utcTimestamp, timeOfDayNanos, julianDay);
+            return timestampData.toTimestamp();
         }
     }
 }

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/ParquetFileFormatFactory.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/ParquetFileFormatFactory.java
@@ -223,13 +223,12 @@ public class ParquetFileFormatFactory implements BulkReaderFormatFactory, BulkWr
             ColumnStats.Builder builder =
                     new ColumnStats.Builder().setNullCount(statistics.getNumNulls());
 
+            // For complex types: ROW, ARRAY, MAP. The returned statistics have wrong null count
+            // value, so now complex types stats return null.
             switch (logicalType.getTypeRoot()) {
                 case BOOLEAN:
                 case BINARY:
                 case VARBINARY:
-                case ROW:
-                case ARRAY:
-                case MAP:
                     break;
                 case TINYINT:
                 case SMALLINT:

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/ParquetFileFormatFactory.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/ParquetFileFormatFactory.java
@@ -238,14 +238,13 @@ public class ParquetFileFormatFactory implements BulkReaderFormatFactory, BulkWr
                     if (statistics instanceof IntStatistics) {
                         builder.setMin(((IntStatistics) statistics).getMin())
                                 .setMax(((IntStatistics) statistics).getMax());
-                        break;
                     } else if (statistics instanceof LongStatistics) {
                         builder.setMin(((LongStatistics) statistics).getMin())
                                 .setMax(((LongStatistics) statistics).getMax());
-                        break;
                     } else {
                         return null;
                     }
+                    break;
                 case DOUBLE:
                     if (statistics instanceof DoubleStatistics) {
                         builder.setMin(((DoubleStatistics) statistics).getMin())
@@ -317,7 +316,6 @@ public class ParquetFileFormatFactory implements BulkReaderFormatFactory, BulkWr
                     if (statistics instanceof LongStatistics) {
                         builder.setMin(new Timestamp(((LongStatistics) statistics).getMin()))
                                 .setMax(new Timestamp(((LongStatistics) statistics).getMax()));
-                        break;
                     } else if (statistics instanceof BinaryStatistics) {
                         Binary min = ((BinaryStatistics) statistics).genericGetMin();
                         Binary max = ((BinaryStatistics) statistics).genericGetMax();
@@ -331,19 +329,17 @@ public class ParquetFileFormatFactory implements BulkReaderFormatFactory, BulkWr
                         } else {
                             builder.setMax(null);
                         }
-                        break;
                     } else {
                         return null;
                     }
+                    break;
                 case DECIMAL:
                     if (statistics instanceof IntStatistics) {
                         builder.setMin(BigDecimal.valueOf(((IntStatistics) statistics).getMin()))
                                 .setMax(BigDecimal.valueOf(((IntStatistics) statistics).getMax()));
-                        break;
                     } else if (statistics instanceof LongStatistics) {
                         builder.setMin(BigDecimal.valueOf(((LongStatistics) statistics).getMin()))
                                 .setMax(BigDecimal.valueOf(((LongStatistics) statistics).getMax()));
-                        break;
                     } else if (statistics instanceof BinaryStatistics) {
                         Binary min = ((BinaryStatistics) statistics).genericGetMin();
                         Binary max = ((BinaryStatistics) statistics).genericGetMax();
@@ -359,10 +355,10 @@ public class ParquetFileFormatFactory implements BulkReaderFormatFactory, BulkWr
                         } else {
                             builder.setMax(null);
                         }
-                        break;
                     } else {
                         return null;
                     }
+                    break;
                 default:
                     return null;
             }

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/vector/reader/TimestampColumnReader.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/vector/reader/TimestampColumnReader.java
@@ -95,7 +95,7 @@ public class TimestampColumnReader extends AbstractColumnReader<WritableTimestam
         return int96ToTimestamp(utcTimestamp, buffer.getLong(), buffer.getInt());
     }
 
-    private static TimestampData int96ToTimestamp(
+    public static TimestampData int96ToTimestamp(
             boolean utcTimestamp, long nanosOfDay, int julianDay) {
         long millisecond = julianDayToMillis(julianDay) + (nanosOfDay / NANOS_PER_MILLISECOND);
 

--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/ParquetFileSystemStatisticsReportTest.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/ParquetFileSystemStatisticsReportTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.parquet;
+
+import org.apache.flink.table.planner.plan.stats.FlinkStatistic;
+import org.apache.flink.table.types.DataType;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * Test for statistics functionality in {@link ParquetFileFormatFactory} in the case of file system
+ * source.
+ */
+public class ParquetFileSystemStatisticsReportTest extends ParquetFormatStatisticsReportTest {
+
+    @BeforeEach
+    public void setup(@TempDir File file) throws Exception {
+        super.setup(file);
+    }
+
+    @Test
+    public void testParquetFileSystemStatisticsReport()
+            throws ExecutionException, InterruptedException {
+        // insert data and get statistics by get plan.
+        DataType dataType = tEnv.from("sourceTable").getResolvedSchema().toPhysicalRowDataType();
+        tEnv.fromValues(dataType, getData()).executeInsert("sourceTable").await();
+        FlinkStatistic statistic = getStatisticsFromOptimizedPlan("select * from sourceTable");
+
+        int expectedRowCount = 3;
+        assertParquetFormatTableStatsEquals(statistic.getTableStats(), expectedRowCount, 1L);
+    }
+}

--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/ParquetFormatStatisticsReportTest.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/ParquetFormatStatisticsReportTest.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.parquet;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.table.plan.stats.ColumnStats;
+import org.apache.flink.table.plan.stats.TableStats;
+import org.apache.flink.table.planner.utils.StatisticsReportTestBase;
+import org.apache.flink.table.types.DataType;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.math.BigDecimal;
+import java.sql.Date;
+import java.sql.Time;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for statistics functionality in which storage format is parquet. */
+public class ParquetFormatStatisticsReportTest extends StatisticsReportTestBase {
+
+    private static ParquetFileFormatFactory.ParquetBulkDecodingFormat parquetBulkDecodingFormat;
+
+    @BeforeEach
+    public void setup(@TempDir File file) throws Exception {
+        super.setup(file);
+        createFileSystemSource();
+        Configuration configuration = new Configuration();
+        parquetBulkDecodingFormat =
+                new ParquetFileFormatFactory.ParquetBulkDecodingFormat(configuration);
+    }
+
+    @Override
+    protected String[] properties() {
+        List<String> ret = new ArrayList<>();
+        ret.add("'format'='parquet'");
+        ret.add("'parquet.utc-timezone'='true'");
+        ret.add("'parquet.compression'='gzip'");
+        return ret.toArray(new String[0]);
+    }
+
+    @Test
+    public void testParquetFormatStatsReportWithSingleFile() throws Exception {
+        // insert data and get statistics.
+        DataType dataType = tEnv.from("sourceTable").getResolvedSchema().toPhysicalRowDataType();
+        tEnv.fromValues(dataType, getData()).executeInsert("sourceTable").await();
+        assertThat(folder.listFiles()).isNotNull().hasSize(1);
+        File[] files = folder.listFiles();
+        assert files != null;
+        TableStats tableStats =
+                parquetBulkDecodingFormat.reportStatistics(
+                        Collections.singletonList(new Path(files[0].toURI().toString())), dataType);
+        assertParquetFormatTableStatsEquals(tableStats, 3, 1L);
+    }
+
+    @Test
+    public void testParquetFormatStatsReportWithMultiFile() throws Exception {
+        // insert data and get statistics.
+        DataType dataType = tEnv.from("sourceTable").getResolvedSchema().toPhysicalRowDataType();
+        tEnv.fromValues(dataType, getData()).executeInsert("sourceTable").await();
+        tEnv.fromValues(dataType, getData()).executeInsert("sourceTable").await();
+        assertThat(folder.listFiles()).isNotNull().hasSize(2);
+        File[] files = folder.listFiles();
+        List<Path> paths = new ArrayList<>();
+        assert files != null;
+        paths.add(new Path(files[0].toURI().toString()));
+        paths.add(new Path(files[1].toURI().toString()));
+        TableStats tableStats = parquetBulkDecodingFormat.reportStatistics(paths, dataType);
+        assertParquetFormatTableStatsEquals(tableStats, 6, 2L);
+    }
+
+    @Test
+    public void testParquetFormatStatsReportWithEmptyFile() {
+        TableStats tableStats = parquetBulkDecodingFormat.reportStatistics(null, null);
+        assertThat(tableStats).isEqualTo(TableStats.UNKNOWN);
+    }
+
+    protected static void assertParquetFormatTableStatsEquals(
+            TableStats tableStats, int expectedRowCount, long nullCount) {
+        Map<String, ColumnStats> expectedColumnStatsMap = new HashMap<>();
+        expectedColumnStatsMap.put(
+                "f_boolean", new ColumnStats.Builder().setNullCount(nullCount).build());
+        expectedColumnStatsMap.put(
+                "f_tinyint",
+                new ColumnStats.Builder().setMax(3).setMin(1).setNullCount(0L).build());
+        expectedColumnStatsMap.put(
+                "f_smallint",
+                new ColumnStats.Builder().setMax(128).setMin(100).setNullCount(0L).build());
+        expectedColumnStatsMap.put(
+                "f_int",
+                new ColumnStats.Builder()
+                        .setMax(45536)
+                        .setMin(31000)
+                        .setNullCount(nullCount)
+                        .build());
+        expectedColumnStatsMap.put(
+                "f_bigint",
+                new ColumnStats.Builder()
+                        .setMax(1238123899121L)
+                        .setMin(1238123899000L)
+                        .setNullCount(0L)
+                        .build());
+        expectedColumnStatsMap.put(
+                "f_float",
+                new ColumnStats.Builder()
+                        .setMax(33.333F)
+                        .setMin(33.311F)
+                        .setNullCount(nullCount)
+                        .build());
+        expectedColumnStatsMap.put(
+                "f_double",
+                new ColumnStats.Builder().setMax(10.1D).setMin(1.1D).setNullCount(0L).build());
+        expectedColumnStatsMap.put(
+                "f_string",
+                new ColumnStats.Builder().setMax("def").setMin("abcd").setNullCount(0L).build());
+        expectedColumnStatsMap.put(
+                "f_decimal5",
+                new ColumnStats.Builder()
+                        .setMax(new BigDecimal("223.45"))
+                        .setMin(new BigDecimal("123.45"))
+                        .setNullCount(0L)
+                        .build());
+        expectedColumnStatsMap.put(
+                "f_decimal14",
+                new ColumnStats.Builder()
+                        .setMax(new BigDecimal("123333333355.33"))
+                        .setMin(new BigDecimal("123333333333.33"))
+                        .setNullCount(0L)
+                        .build());
+        expectedColumnStatsMap.put(
+                "f_decimal38",
+                new ColumnStats.Builder()
+                        .setMax(new BigDecimal("123433343334333433343334333433343334.34"))
+                        .setMin(new BigDecimal("123433343334333433343334333433343334.33"))
+                        .setNullCount(nullCount)
+                        .build());
+        expectedColumnStatsMap.put(
+                "f_date",
+                new ColumnStats.Builder()
+                        .setMax(Date.valueOf("1990-10-16"))
+                        .setMin(Date.valueOf("1990-10-14"))
+                        .setNullCount(0L)
+                        .build());
+        // Now parquet store timestamp as type int96, and int96 now not support statistics, so
+        // timestamp not support statistics now.
+        expectedColumnStatsMap.put(
+                "f_timestamp3", new ColumnStats.Builder().setNullCount(0L).build());
+        expectedColumnStatsMap.put(
+                "f_timestamp9", new ColumnStats.Builder().setNullCount(0L).build());
+        expectedColumnStatsMap.put(
+                "f_timestamp_wtz", new ColumnStats.Builder().setNullCount(0L).build());
+        expectedColumnStatsMap.put(
+                "f_timestamp_ltz", new ColumnStats.Builder().setNullCount(nullCount).build());
+
+        // parquet writer support BINARY() and TIME() type.
+        expectedColumnStatsMap.put("f_binary", new ColumnStats.Builder().setNullCount(0L).build());
+        expectedColumnStatsMap.put(
+                "f_varbinary", new ColumnStats.Builder().setNullCount(nullCount).build());
+        expectedColumnStatsMap.put(
+                "f_time",
+                new ColumnStats.Builder()
+                        .setMax(Time.valueOf("12:12:45"))
+                        .setMin(Time.valueOf("12:12:43"))
+                        .setNullCount(0L)
+                        .build());
+        expectedColumnStatsMap.put(
+                "f_row", new ColumnStats.Builder().setNullCount(nullCount).build());
+        expectedColumnStatsMap.put(
+                "f_array", new ColumnStats.Builder().setNullCount(nullCount).build());
+        expectedColumnStatsMap.put(
+                "f_map", new ColumnStats.Builder().setNullCount(nullCount).build());
+        assertThat(tableStats).isEqualTo(new TableStats(expectedRowCount, expectedColumnStatsMap));
+    }
+}

--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/ParquetFormatStatisticsReportTest.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/ParquetFormatStatisticsReportTest.java
@@ -177,7 +177,6 @@ public class ParquetFormatStatisticsReportTest extends StatisticsReportTestBase 
         expectedColumnStatsMap.put(
                 "f_timestamp_ltz", new ColumnStats.Builder().setNullCount(nullCount).build());
 
-        // parquet writer support BINARY() and TIME() type.
         expectedColumnStatsMap.put("f_binary", new ColumnStats.Builder().setNullCount(0L).build());
         expectedColumnStatsMap.put(
                 "f_varbinary", new ColumnStats.Builder().setNullCount(nullCount).build());
@@ -188,12 +187,12 @@ public class ParquetFormatStatisticsReportTest extends StatisticsReportTestBase 
                         .setMin(Time.valueOf("12:12:43"))
                         .setNullCount(0L)
                         .build());
-        expectedColumnStatsMap.put(
-                "f_row", new ColumnStats.Builder().setNullCount(nullCount).build());
-        expectedColumnStatsMap.put(
-                "f_array", new ColumnStats.Builder().setNullCount(nullCount).build());
-        expectedColumnStatsMap.put(
-                "f_map", new ColumnStats.Builder().setNullCount(nullCount).build());
+
+        // For complex types: ROW, ARRAY, MAP. The returned statistics have wrong null count
+        // value, so now complex types stats return null.
+        expectedColumnStatsMap.put("f_row", null);
+        expectedColumnStatsMap.put("f_array", null);
+        expectedColumnStatsMap.put("f_map", null);
         assertThat(tableStats).isEqualTo(new TableStats(expectedRowCount, expectedColumnStatsMap));
     }
 }

--- a/flink-formats/pom.xml
+++ b/flink-formats/pom.xml
@@ -31,6 +31,7 @@ under the License.
 
 	<properties>
 		<flink.format.parquet.version>1.12.2</flink.format.parquet.version>
+		<guava.version>30.0-jre</guava.version>
 	</properties>
 
 	<artifactId>flink-formats</artifactId>

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/utils/CatalogTableStatisticsConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/utils/CatalogTableStatisticsConverter.java
@@ -31,8 +31,7 @@ import org.apache.flink.table.catalog.stats.CatalogColumnStatisticsDataString;
 import org.apache.flink.table.catalog.stats.CatalogTableStatistics;
 import org.apache.flink.table.plan.stats.ColumnStats;
 import org.apache.flink.table.plan.stats.TableStats;
-
-import org.apache.calcite.avatica.util.DateTimeUtils;
+import org.apache.flink.table.utils.DateTimeUtils;
 
 import java.sql.Date;
 import java.util.HashMap;
@@ -132,13 +131,13 @@ public class CatalogTableStatisticsConverter {
             if (dateData.getMax() != null) {
                 max =
                         Date.valueOf(
-                                DateTimeUtils.unixDateToString(
+                                DateTimeUtils.formatDate(
                                         (int) dateData.getMax().getDaysSinceEpoch()));
             }
             if (dateData.getMin() != null) {
                 min =
                         Date.valueOf(
-                                DateTimeUtils.unixDateToString(
+                                DateTimeUtils.formatDate(
                                         (int) dateData.getMin().getDaysSinceEpoch()));
             }
         } else {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/catalog/CatalogStatisticsTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/catalog/CatalogStatisticsTest.java
@@ -48,8 +48,8 @@ import org.apache.flink.table.planner.utils.TableTestUtil;
 import org.apache.flink.table.planner.utils.TestPartitionableSourceFactory;
 import org.apache.flink.table.planner.utils.TestTableSource;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.utils.DateTimeUtils;
 
-import org.apache.calcite.avatica.util.DateTimeUtils;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.junit.Before;
@@ -381,8 +381,8 @@ public class CatalogStatisticsTest {
         assertThat(mq.getColumnInterval(rel, 3))
                 .isEqualTo(
                         ValueInterval$.MODULE$.apply(
-                                java.sql.Date.valueOf(DateTimeUtils.unixDateToString(71)),
-                                java.sql.Date.valueOf(DateTimeUtils.unixDateToString(17923)),
+                                java.sql.Date.valueOf(DateTimeUtils.formatDate(71)),
+                                java.sql.Date.valueOf(DateTimeUtils.formatDate(17923)),
                                 true,
                                 true));
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/utils/StatisticsReportTestBase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/utils/StatisticsReportTestBase.java
@@ -1,0 +1,315 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.utils;
+
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.internal.TableEnvironmentImpl;
+import org.apache.flink.table.planner.delegation.PlannerBase;
+import org.apache.flink.table.planner.factories.TestValuesTableFactory;
+import org.apache.flink.table.planner.plan.schema.TableSourceTable;
+import org.apache.flink.table.planner.plan.stats.FlinkStatistic;
+import org.apache.flink.table.utils.DateTimeUtils;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.TestLogger;
+
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelVisitor;
+import org.apache.calcite.rel.core.TableScan;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toList;
+
+/** The base class for statistics report testing. */
+public abstract class StatisticsReportTestBase extends TestLogger {
+
+    protected TableEnvironment tEnv;
+    protected File folder;
+
+    @BeforeEach
+    public void setup(@TempDir File file) throws Exception {
+        folder = file;
+        tEnv = TableEnvironment.create(EnvironmentSettings.inBatchMode());
+    }
+
+    @AfterEach
+    public void after() {
+        TestValuesTableFactory.clearAllData();
+    }
+
+    protected void createFileSystemSource() {
+        String ddl1 =
+                String.format(
+                        "CREATE TABLE sourceTable (\n"
+                                + "%s"
+                                + ") with (\n"
+                                + " 'connector' = 'filesystem',"
+                                + " 'path' = '%s',"
+                                + "%s )",
+                        String.join(",\n", ddlTypesMapToStringList(ddlTypesMap())),
+                        folder,
+                        String.join(",\n", properties()));
+        tEnv.executeSql(ddl1);
+    }
+
+    protected abstract String[] properties();
+
+    private Map<String, String> ddlTypesMap() {
+        Map<String, String> ddlTypesMap = new LinkedHashMap<>();
+        ddlTypesMap.put("boolean", "f_boolean");
+        ddlTypesMap.put("tinyint", "f_tinyint");
+        ddlTypesMap.put("smallint", "f_smallint");
+        ddlTypesMap.put("int", "f_int");
+        ddlTypesMap.put("bigint", "f_bigint");
+        ddlTypesMap.put("float", "f_float");
+        ddlTypesMap.put("double", "f_double");
+        ddlTypesMap.put("string", "f_string");
+        ddlTypesMap.put("decimal(5,2)", "f_decimal5");
+        ddlTypesMap.put("decimal(14,2)", "f_decimal14");
+        ddlTypesMap.put("decimal(38,2)", "f_decimal38");
+        ddlTypesMap.put("date", "f_date");
+        ddlTypesMap.put("timestamp(3)", "f_timestamp3");
+        ddlTypesMap.put("timestamp(9)", "f_timestamp9");
+        ddlTypesMap.put("timestamp without time zone", "f_timestamp_wtz");
+        ddlTypesMap.put("timestamp with local time zone", "f_timestamp_ltz");
+        ddlTypesMap.put("binary(1)", "f_binary");
+        ddlTypesMap.put("varbinary(1)", "f_varbinary");
+        ddlTypesMap.put("time", "f_time");
+        ddlTypesMap.put("row<col1 string, col2 int>", "f_row");
+        ddlTypesMap.put("array<int>", "f_array");
+        ddlTypesMap.put("map<string, int>", "f_map");
+
+        return ddlTypesMap;
+    }
+
+    private Map<String, List<Object>> getDataMap() {
+        Map<String, List<Object>> dataMap = new LinkedHashMap<>();
+        dataMap.put("boolean", Stream.of(null, true, false).collect(toList()));
+        dataMap.put("tinyint", Stream.of((byte) 1, (byte) 2, (byte) 3).collect(toList()));
+        dataMap.put("smallint", Stream.of(128, 111, 100).collect(toList()));
+        dataMap.put("int", Stream.of(45536, null, 31000).collect(toList()));
+        dataMap.put(
+                "bigint",
+                Stream.of(1238123899121L, 1238123899100L, 1238123899000L).collect(toList()));
+        dataMap.put("float", Stream.of(33.333F, 33.311F, null).collect(toList()));
+        dataMap.put("double", Stream.of(1.1D, 1.5D, 10.1D).collect(toList()));
+        dataMap.put("string", Stream.of("abcd", "abcd", "def").collect(toList()));
+        dataMap.put(
+                "decimal(5,2)",
+                Stream.of(
+                                new BigDecimal("123.45"),
+                                new BigDecimal("223.45"),
+                                new BigDecimal("127.45"))
+                        .collect(toList()));
+        dataMap.put(
+                "decimal(14,2)",
+                Stream.of(
+                                new BigDecimal("123333333333.33"),
+                                new BigDecimal("123333333355.33"),
+                                new BigDecimal("123333333344.33"))
+                        .collect(toList()));
+        dataMap.put(
+                "decimal(38,2)",
+                Stream.of(
+                                new BigDecimal("123433343334333433343334333433343334.34"),
+                                new BigDecimal("123433343334333433343334333433343334.33"),
+                                null)
+                        .collect(toList()));
+        dataMap.put(
+                "date",
+                Stream.of(
+                                LocalDate.parse("1990-10-14"),
+                                LocalDate.parse("1990-10-15"),
+                                LocalDate.parse("1990-10-16"))
+                        .collect(toList()));
+        dataMap.put(
+                "timestamp(3)",
+                Stream.of(
+                                localDateTime("1990-10-14 12:12:43.123", 3),
+                                localDateTime("1990-10-15 12:12:43.123", 3),
+                                localDateTime("1990-10-16 12:12:43.123", 3))
+                        .collect(toList()));
+        dataMap.put(
+                "timestamp(9)",
+                Stream.of(
+                                localDateTime("1990-10-14 12:12:43.123456789", 9),
+                                localDateTime("1990-10-15 12:12:43.123456789", 9),
+                                localDateTime("1990-10-16 12:12:43.123456789", 9))
+                        .collect(toList()));
+        dataMap.put(
+                "timestamp without time zone",
+                Stream.of(
+                                localDateTime("1990-10-14 12:12:43.123", 3),
+                                localDateTime("1990-10-15 12:12:43.123", 3),
+                                localDateTime("1990-10-16 12:12:43.123", 3))
+                        .collect(toList()));
+        dataMap.put(
+                "timestamp with local time zone",
+                Stream.of(
+                                localDateTime("1990-10-14 12:12:43.123", 3),
+                                null,
+                                localDateTime("1990-10-16 12:12:43.123", 3))
+                        .collect(toList()));
+        dataMap.put(
+                "binary(1)",
+                Stream.of(new byte[] {1}, new byte[] {2}, new byte[] {3}).collect(toList()));
+        dataMap.put(
+                "varbinary(1)", Stream.of(new byte[] {1}, null, new byte[] {3}).collect(toList()));
+        dataMap.put(
+                "time",
+                Stream.of(
+                                LocalTime.parse("12:12:43"),
+                                LocalTime.parse("12:12:44"),
+                                LocalTime.parse("12:12:45"))
+                        .collect(toList()));
+        dataMap.put(
+                "row<col1 string, col2 int>",
+                Stream.of(
+                                new Object[] {"abc", 10},
+                                new Object[] {"ef", 11},
+                                new Object[] {"gh", 12})
+                        .collect(toList()));
+        dataMap.put(
+                "array<int>",
+                Stream.of(new Object[] {1, 2, 3}, new Object[] {2, 3, 4}, new Object[] {3, 4, 5})
+                        .collect(toList()));
+        dataMap.put(
+                "map<string, int>",
+                Stream.of(
+                                new Object[] {"abc", 10},
+                                new Object[] {"ef", 11},
+                                new Object[] {"gh", 12})
+                        .collect(toList()));
+        return dataMap;
+    }
+
+    protected List<Row> getData() {
+        Map<String, List<Object>> dataMap = getDataMap();
+        Row row1 = new Row(dataMap.size());
+        Row row2 = new Row(dataMap.size());
+        Row row3 = new Row(dataMap.size());
+        int i = 0;
+        for (Map.Entry<String, List<Object>> entry : dataMap.entrySet()) {
+            List<Object> value = entry.getValue();
+            switch (entry.getKey()) {
+                case "row<col1 string, col2 int>":
+                    row1.setField(i, getTypeRowData(value.get(0)));
+                    row2.setField(i, getTypeRowData(value.get(1)));
+                    row2.setField(i++, getTypeRowData(value.get(2)));
+                    break;
+                case "array<int>":
+                    row1.setField(i, getTypeArrayData(value.get(0)));
+                    row2.setField(i, getTypeArrayData(value.get(1)));
+                    row2.setField(i++, getTypeArrayData(value.get(2)));
+                    break;
+                case "map<string, int>":
+                    row1.setField(i, getTypeMapData(value.get(0)));
+                    row2.setField(i, getTypeMapData(value.get(1)));
+                    row2.setField(i++, getTypeMapData(value.get(2)));
+                    break;
+                default:
+                    row1.setField(i, value.get(0));
+                    row2.setField(i, value.get(1));
+                    row3.setField(i++, value.get(2));
+                    break;
+            }
+        }
+        return Stream.of(row1, row2, row3).collect(toList());
+    }
+
+    private Row getTypeRowData(Object object) {
+        Object[] objectList = (Object[]) object;
+        Row row = new Row(objectList.length);
+        row.setField(0, objectList[0]);
+        row.setField(1, objectList[1]);
+        return row;
+    }
+
+    private Map<String, Integer> getTypeMapData(Object object) {
+        Object[] objectList = (Object[]) object;
+        Map<String, Integer> map = new HashMap<>();
+        map.put((String) objectList[0], (int) objectList[1]);
+        return map;
+    }
+
+    private List<Integer> getTypeArrayData(Object object) {
+        Object[] objectList = (Object[]) object;
+        List<Integer> list = new ArrayList<>();
+        for (Object obj : objectList) {
+            list.add((int) obj);
+        }
+        return list;
+    }
+
+    protected FlinkStatistic getStatisticsFromOptimizedPlan(String sql) {
+        RelNode relNode = TableTestUtil.toRelNode(tEnv.sqlQuery(sql));
+        RelNode optimized = getPlanner(tEnv).optimize(relNode);
+        FlinkStatisticVisitor visitor = new FlinkStatisticVisitor();
+        visitor.go(optimized);
+        return visitor.result;
+    }
+
+    private static class FlinkStatisticVisitor extends RelVisitor {
+        private FlinkStatistic result = null;
+
+        @Override
+        public void visit(RelNode node, int ordinal, RelNode parent) {
+            if (node instanceof TableScan) {
+                Preconditions.checkArgument(result == null);
+                TableSourceTable table = (TableSourceTable) node.getTable();
+                result = table.getStatistic();
+            }
+            super.visit(node, ordinal, parent);
+        }
+    }
+
+    private static String[] ddlTypesMapToStringList(Map<String, String> ddlTypesMap) {
+        String[] types = new String[ddlTypesMap.size()];
+        int i = 0;
+        for (Map.Entry<String, String> entry : ddlTypesMap.entrySet()) {
+            String str = entry.getValue() + " " + entry.getKey();
+            types[i++] = str;
+        }
+        return types;
+    }
+
+    private static PlannerBase getPlanner(TableEnvironment tEnv) {
+        TableEnvironmentImpl tEnvImpl = (TableEnvironmentImpl) tEnv;
+        return (PlannerBase) tEnvImpl.getPlanner();
+    }
+
+    protected LocalDateTime localDateTime(String dateTime, int precision) {
+        return DateTimeUtils.parseTimestampData(dateTime, precision).toLocalDateTime();
+    }
+}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

In FLIP-231, [https://cwiki.apache.org/confluence/display/FLINK/FLIP-231%3A+Introduce+SupportsStatisticReport+to+support+reporting+statistics+from+source+connectors](https://github.com/apache/flink/pull/url), we aims to support csv, parquet, orc format for reporting statistics. This pr is a part of it to support Parquet format. The details are as follows:

- In `ParquetFileFormatFactory`, for class `ParquetBulkDecodingFormat`, we implements `FileBasedStatisticsReportableInputFormat` interface, and implements `reportStatistics()` method. In this method, we cover  all types stats of Parquet, including complex types.
- Adding a base UT test `StatisticsReportTestBase`, which is a base test for stats report, and every stats report tests need to extends it. 
- Adding two UT tests, `ParquetFormatStatisticsReportTest` and `ParquetFileSystemStatisticsReportTest`, they all extends from `StatisticsReportTestBase` and cover the logical of parquet stats report.
- Fix some wrong using of Timestamp conversion method.


## Brief change log

- In `ParquetFileFormatFactory`, for class `ParquetBulkDecodingFormat`, we implements `FileBasedStatisticsReportableInputFormat` interface, and implements `reportStatistics()` method. In this method, we cover  all types stats of Parquet, including complex types.
- Adding a base UT test `StatisticsReportTestBase`
- Adding two UT tests, `ParquetFormatStatisticsReportTest` and `ParquetFileSystemStatisticsReportTest`.
- Fix some wrong using of Timestamp conversion method.



## Verifying this change

Using two UT tests, `ParquetFormatStatisticsReportTest` and `ParquetFileSystemStatisticsReportTest` to verify change, including single parquet file and multi parquet files.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? no docs.
