### PR TITLE
[FLINK-28104][planner] drop the unused order parameter in FirstValueFunction/LastValueFunction

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueAggFunctionNew.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueAggFunctionNew.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.functions.aggfunctions;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.expressions.Expression;
+import org.apache.flink.table.expressions.UnresolvedReferenceExpression;
+import org.apache.flink.table.types.DataType;
+
+import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedRef;
+import static org.apache.flink.table.planner.expressions.ExpressionBuilder.ifThenElse;
+import static org.apache.flink.table.planner.expressions.ExpressionBuilder.isNull;
+import static org.apache.flink.table.planner.expressions.ExpressionBuilder.literal;
+import static org.apache.flink.table.planner.expressions.ExpressionBuilder.not;
+import static org.apache.flink.table.planner.expressions.ExpressionBuilder.nullOf;
+import static org.apache.flink.table.planner.expressions.ExpressionBuilder.or;
+
+/** first_value function. */
+public class FirstValueAggFunctionNew extends DeclarativeAggregateFunction {
+
+    private final DataType argDataType;
+    private final UnresolvedReferenceExpression firstValue = unresolvedRef("firstValue");
+    private final UnresolvedReferenceExpression valueSet = unresolvedRef("valueSet");
+
+    public FirstValueAggFunctionNew(DataType argDataType) {
+        this.argDataType = argDataType;
+    }
+
+    @Override
+    public int operandCount() {
+        return 1;
+    }
+
+    @Override
+    public UnresolvedReferenceExpression[] aggBufferAttributes() {
+        return new UnresolvedReferenceExpression[] {firstValue, valueSet};
+    }
+
+    @Override
+    public DataType[] getAggBufferTypes() {
+        return new DataType[] {argDataType, DataTypes.BOOLEAN().notNull()};
+    }
+
+    @Override
+    public DataType getResultType() {
+        return argDataType;
+    }
+
+    @Override
+    public Expression[] initialValuesExpressions() {
+        return new Expression[] {nullOf(argDataType), literal(false)};
+    }
+
+    @Override
+    public Expression[] accumulateExpressions() {
+        return new Expression[] {
+            ifThenElse(or(valueSet, isNull(operand(0))), firstValue, operand(0)),
+            or(valueSet, not(isNull(operand(0))))
+        };
+    }
+
+    @Override
+    public Expression[] retractExpressions() {
+        throw new TableException("This function does not support retraction.");
+    }
+
+    @Override
+    public Expression[] mergeExpressions() {
+        return new Expression[] {
+            ifThenElse(valueSet, firstValue, mergeOperand(firstValue)),
+            or(valueSet, mergeOperand(valueSet))
+        };
+    }
+
+    @Override
+    public Expression getValueExpression() {
+        return firstValue;
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueAggFunctionNew.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueAggFunctionNew.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.functions.aggfunctions;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.expressions.Expression;
+import org.apache.flink.table.expressions.UnresolvedReferenceExpression;
+import org.apache.flink.table.types.DataType;
+
+import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedRef;
+import static org.apache.flink.table.planner.expressions.ExpressionBuilder.ifThenElse;
+import static org.apache.flink.table.planner.expressions.ExpressionBuilder.isNull;
+import static org.apache.flink.table.planner.expressions.ExpressionBuilder.literal;
+import static org.apache.flink.table.planner.expressions.ExpressionBuilder.not;
+import static org.apache.flink.table.planner.expressions.ExpressionBuilder.nullOf;
+import static org.apache.flink.table.planner.expressions.ExpressionBuilder.or;
+
+/** last_value function. */
+public class LastValueAggFunctionNew extends DeclarativeAggregateFunction {
+
+    private final DataType argDataType;
+    private final UnresolvedReferenceExpression lastValue = unresolvedRef("lastValue");
+    private final UnresolvedReferenceExpression valueSet = unresolvedRef("valueSet");
+
+    public LastValueAggFunctionNew(DataType argDataType) {
+        this.argDataType = argDataType;
+    }
+
+    @Override
+    public int operandCount() {
+        return 1;
+    }
+
+    @Override
+    public UnresolvedReferenceExpression[] aggBufferAttributes() {
+        return new UnresolvedReferenceExpression[] {lastValue, valueSet};
+    }
+
+    @Override
+    public DataType[] getAggBufferTypes() {
+        return new DataType[] {argDataType, DataTypes.BOOLEAN().notNull()};
+    }
+
+    @Override
+    public DataType getResultType() {
+        return argDataType;
+    }
+
+    @Override
+    public Expression[] initialValuesExpressions() {
+        return new Expression[] {nullOf(argDataType), literal(false)};
+    }
+
+    @Override
+    public Expression[] accumulateExpressions() {
+        return new Expression[] {
+            ifThenElse(isNull(operand(0)), lastValue, operand(0)),
+            or(valueSet, not(isNull(operand(0))))
+        };
+    }
+
+    @Override
+    public Expression[] retractExpressions() {
+        throw new TableException("This function does not support retraction.");
+    }
+
+    @Override
+    public Expression[] mergeExpressions() {
+        return new Expression[] {
+            ifThenElse(mergeOperand(valueSet), mergeOperand(lastValue), lastValue),
+            or(mergeOperand(valueSet), valueSet)
+        };
+    }
+
+    @Override
+    public Expression getValueExpression() {
+        return lastValue;
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/utils/CommonPythonUtil.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/utils/CommonPythonUtil.java
@@ -36,6 +36,8 @@ import org.apache.flink.table.functions.python.PythonFunctionInfo;
 import org.apache.flink.table.planner.functions.aggfunctions.AvgAggFunction;
 import org.apache.flink.table.planner.functions.aggfunctions.Count1AggFunction;
 import org.apache.flink.table.planner.functions.aggfunctions.CountAggFunction;
+import org.apache.flink.table.planner.functions.aggfunctions.FirstValueAggFunctionNew;
+import org.apache.flink.table.planner.functions.aggfunctions.LastValueAggFunctionNew;
 import org.apache.flink.table.planner.functions.aggfunctions.ListAggFunction;
 import org.apache.flink.table.planner.functions.aggfunctions.MaxAggFunction;
 import org.apache.flink.table.planner.functions.aggfunctions.MinAggFunction;
@@ -53,9 +55,7 @@ import org.apache.flink.table.planner.utils.DummyStreamExecutionEnvironment;
 import org.apache.flink.table.runtime.dataview.DataViewSpec;
 import org.apache.flink.table.runtime.dataview.ListViewSpec;
 import org.apache.flink.table.runtime.dataview.MapViewSpec;
-import org.apache.flink.table.runtime.functions.aggregate.FirstValueAggFunction;
 import org.apache.flink.table.runtime.functions.aggregate.FirstValueWithRetractAggFunction;
-import org.apache.flink.table.runtime.functions.aggregate.LastValueAggFunction;
 import org.apache.flink.table.runtime.functions.aggregate.LastValueWithRetractAggFunction;
 import org.apache.flink.table.runtime.functions.aggregate.ListAggWithRetractAggFunction;
 import org.apache.flink.table.runtime.functions.aggregate.ListAggWsWithRetractAggFunction;
@@ -466,13 +466,13 @@ public class CommonPythonUtil {
         if (javaBuiltInAggregateFunction instanceof CountAggFunction) {
             return BuiltInPythonAggregateFunction.COUNT;
         }
-        if (javaBuiltInAggregateFunction instanceof FirstValueAggFunction) {
+        if (javaBuiltInAggregateFunction instanceof FirstValueAggFunctionNew) {
             return BuiltInPythonAggregateFunction.FIRST_VALUE;
         }
         if (javaBuiltInAggregateFunction instanceof FirstValueWithRetractAggFunction) {
             return BuiltInPythonAggregateFunction.FIRST_VALUE_RETRACT;
         }
-        if (javaBuiltInAggregateFunction instanceof LastValueAggFunction) {
+        if (javaBuiltInAggregateFunction instanceof LastValueAggFunctionNew) {
             return BuiltInPythonAggregateFunction.LAST_VALUE;
         }
         if (javaBuiltInAggregateFunction instanceof LastValueWithRetractAggFunction) {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/AggFunctionFactory.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/AggFunctionFactory.scala
@@ -25,9 +25,10 @@ import org.apache.flink.table.planner.functions.aggfunctions.SumWithRetractAggFu
 import org.apache.flink.table.planner.functions.bridging.BridgingSqlAggFunction
 import org.apache.flink.table.planner.functions.sql.{SqlFirstLastValueAggFunction, SqlListAggFunction}
 import org.apache.flink.table.planner.functions.utils.AggSqlFunction
-import org.apache.flink.table.runtime.functions.aggregate.{BuiltInAggregateFunction, CollectAggFunction, FirstValueAggFunction, FirstValueWithRetractAggFunction, JsonArrayAggFunction, JsonObjectAggFunction, LagAggFunction, LastValueAggFunction, LastValueWithRetractAggFunction, ListAggWithRetractAggFunction, ListAggWsWithRetractAggFunction, MaxWithRetractAggFunction, MinWithRetractAggFunction}
+import org.apache.flink.table.runtime.functions.aggregate.{BuiltInAggregateFunction, CollectAggFunction, FirstValueAggOldFunction, FirstValueWithRetractAggFunction, JsonArrayAggFunction, JsonObjectAggFunction, LagAggFunction, LastValueAggOldFunction, LastValueWithRetractAggFunction, ListAggWithRetractAggFunction, ListAggWsWithRetractAggFunction, MaxWithRetractAggFunction, MinWithRetractAggFunction}
 import org.apache.flink.table.types.logical._
 import org.apache.flink.table.types.logical.LogicalTypeRoot._
+import org.apache.flink.table.types.utils.DataTypeUtils
 
 import org.apache.calcite.rel.core.AggregateCall
 import org.apache.calcite.sql.{SqlAggFunction, SqlJsonConstructorNullClause, SqlKind, SqlRankFunction}
@@ -477,14 +478,7 @@ class AggFunctionFactory(
               s"support type: ''$t''.\nPlease re-check the data type.")
       }
     } else {
-      valueType.getTypeRoot match {
-        case TINYINT | SMALLINT | INTEGER | BIGINT | FLOAT | DOUBLE | BOOLEAN | VARCHAR | DECIMAL =>
-          new FirstValueAggFunction(valueType)
-        case t =>
-          throw new TableException(
-            s"FIRST_VALUE aggregate function does not support " +
-              s"type: ''$t''.\nPlease re-check the data type.")
-      }
+      new FirstValueAggFunctionNew(DataTypeUtils.toInternalDataType(valueType));
     }
   }
 
@@ -502,14 +496,7 @@ class AggFunctionFactory(
               s"support type: ''$t''.\nPlease re-check the data type.")
       }
     } else {
-      valueType.getTypeRoot match {
-        case TINYINT | SMALLINT | INTEGER | BIGINT | FLOAT | DOUBLE | BOOLEAN | VARCHAR | DECIMAL =>
-          new LastValueAggFunction(valueType)
-        case t =>
-          throw new TableException(
-            s"LAST_VALUE aggregate function does not support " +
-              s"type: ''$t''.\nPlease re-check the data type.")
-      }
+      new LastValueAggFunctionNew(DataTypeUtils.toInternalDataType(valueType))
     }
   }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstLastValueAggOldFunctionWithOrderTestBase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstLastValueAggOldFunctionWithOrderTestBase.java
@@ -33,7 +33,7 @@ import java.util.List;
  * Base test case for built-in FIRST_VALUE and LAST_VALUE (with retract) aggregate function. This
  * class tests `accumulate` method with order argument.
  */
-public abstract class FirstLastValueAggFunctionWithOrderTestBase<T, ACC>
+public abstract class FirstLastValueAggOldFunctionWithOrderTestBase<T, ACC>
         extends AggFunctionTestBase<T, ACC> {
 
     protected Method getAccumulateFunc() throws NoSuchMethodException {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueAggOldFunctionWithOrderTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueAggOldFunctionWithOrderTest.java
@@ -24,7 +24,7 @@ import org.apache.flink.table.data.DecimalDataUtils;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.functions.AggregateFunction;
-import org.apache.flink.table.runtime.functions.aggregate.FirstValueAggFunction;
+import org.apache.flink.table.runtime.functions.aggregate.FirstValueAggOldFunction;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.BooleanType;
 import org.apache.flink.table.types.logical.DecimalType;
@@ -42,22 +42,23 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * Test case for built-in FIRST_VALUE aggregate function. This class tests `accumulate` method
- * without order argument.
+ * Test case for built-in FIRST_VALUE aggregate function. This class tests `accumulate` method with
+ * order argument.
  */
 @RunWith(Enclosed.class)
-public final class FirstValueAggFunctionWithoutOrderTest {
+public final class FirstValueAggOldFunctionWithOrderTest {
 
     // --------------------------------------------------------------------------------------------
     // Test sets for a particular type being aggregated
     //
     // Actual tests are implemented in:
-    //  - AggFunctionTestBase
+    //  - FirstLastValueAggFunctionWithOrderTestBase -> tests specific for FirstValue and LastValue
+    //  - AggFunctionTestBase -> tests that apply to all aggregate functions
     // --------------------------------------------------------------------------------------------
 
     /** Test for {@link TinyIntType}. */
-    public static final class ByteFirstValueAggFunctionWithoutOrderTest
-            extends NumberFirstValueAggFunctionWithoutOrderTest<Byte> {
+    public static final class ByteFirstValueAggOldFunctionWithOrderTest
+            extends NumberFirstValueAggOldFunctionWithOrderTestBase<Byte> {
 
         @Override
         protected Byte getValue(String v) {
@@ -66,13 +67,13 @@ public final class FirstValueAggFunctionWithoutOrderTest {
 
         @Override
         protected AggregateFunction<Byte, RowData> getAggregator() {
-            return new FirstValueAggFunction<>(DataTypes.TINYINT().getLogicalType());
+            return new FirstValueAggOldFunction<>(DataTypes.TINYINT().getLogicalType());
         }
     }
 
     /** Test for {@link ShortType}. */
-    public static final class ShortFirstValueAggFunctionWithoutOrderTest
-            extends NumberFirstValueAggFunctionWithoutOrderTest<Short> {
+    public static final class ShortFirstValueAggOldFunctionWithOrderTest
+            extends NumberFirstValueAggOldFunctionWithOrderTestBase<Short> {
 
         @Override
         protected Short getValue(String v) {
@@ -81,13 +82,13 @@ public final class FirstValueAggFunctionWithoutOrderTest {
 
         @Override
         protected AggregateFunction<Short, RowData> getAggregator() {
-            return new FirstValueAggFunction<>(DataTypes.SMALLINT().getLogicalType());
+            return new FirstValueAggOldFunction<>(DataTypes.SMALLINT().getLogicalType());
         }
     }
 
     /** Test for {@link IntType}. */
-    public static final class IntFirstValueAggFunctionWithoutOrderTest
-            extends NumberFirstValueAggFunctionWithoutOrderTest<Integer> {
+    public static final class IntFirstValueAggOldFunctionWithOrderTest
+            extends NumberFirstValueAggOldFunctionWithOrderTestBase<Integer> {
 
         @Override
         protected Integer getValue(String v) {
@@ -96,13 +97,13 @@ public final class FirstValueAggFunctionWithoutOrderTest {
 
         @Override
         protected AggregateFunction<Integer, RowData> getAggregator() {
-            return new FirstValueAggFunction<>(DataTypes.INT().getLogicalType());
+            return new FirstValueAggOldFunction<>(DataTypes.INT().getLogicalType());
         }
     }
 
     /** Test for {@link BigIntType}. */
-    public static final class LongFirstValueAggFunctionWithoutOrderTest
-            extends NumberFirstValueAggFunctionWithoutOrderTest<Long> {
+    public static final class LongFirstValueAggOldFunctionWithOrderTest
+            extends NumberFirstValueAggOldFunctionWithOrderTestBase<Long> {
 
         @Override
         protected Long getValue(String v) {
@@ -111,13 +112,13 @@ public final class FirstValueAggFunctionWithoutOrderTest {
 
         @Override
         protected AggregateFunction<Long, RowData> getAggregator() {
-            return new FirstValueAggFunction<>(DataTypes.BIGINT().getLogicalType());
+            return new FirstValueAggOldFunction<>(DataTypes.BIGINT().getLogicalType());
         }
     }
 
     /** Test for {@link FloatType}. */
-    public static final class FloatFirstValueAggFunctionWithoutOrderTest
-            extends NumberFirstValueAggFunctionWithoutOrderTest<Float> {
+    public static final class FloatFirstValueAggOldFunctionWithOrderTest
+            extends NumberFirstValueAggOldFunctionWithOrderTestBase<Float> {
 
         @Override
         protected Float getValue(String v) {
@@ -126,13 +127,13 @@ public final class FirstValueAggFunctionWithoutOrderTest {
 
         @Override
         protected AggregateFunction<Float, RowData> getAggregator() {
-            return new FirstValueAggFunction<>(DataTypes.FLOAT().getLogicalType());
+            return new FirstValueAggOldFunction<>(DataTypes.FLOAT().getLogicalType());
         }
     }
 
     /** Test for {@link DoubleType}. */
-    public static final class DoubleFirstValueAggFunctionWithoutOrderTest
-            extends NumberFirstValueAggFunctionWithoutOrderTest<Double> {
+    public static final class DoubleFirstValueAggOldFunctionWithOrderTest
+            extends NumberFirstValueAggOldFunctionWithOrderTestBase<Double> {
 
         @Override
         protected Double getValue(String v) {
@@ -141,13 +142,13 @@ public final class FirstValueAggFunctionWithoutOrderTest {
 
         @Override
         protected AggregateFunction<Double, RowData> getAggregator() {
-            return new FirstValueAggFunction<>(DataTypes.DOUBLE().getLogicalType());
+            return new FirstValueAggOldFunction<>(DataTypes.DOUBLE().getLogicalType());
         }
     }
 
     /** Test for {@link BooleanType}. */
-    public static final class BooleanFirstValueAggFunctionWithoutOrderTest
-            extends FirstValueAggFunctionWithoutOrderTestBase<Boolean> {
+    public static final class BooleanFirstValueAggOldFunctionWithOrderTest
+            extends FirstValueAggOldFunctionWithOrderTestBase<Boolean> {
 
         @Override
         protected List<List<Boolean>> getInputValueSets() {
@@ -160,19 +161,29 @@ public final class FirstValueAggFunctionWithoutOrderTest {
         }
 
         @Override
+        protected List<List<Long>> getInputOrderSets() {
+            return Arrays.asList(
+                    Arrays.asList(6L, 2L, 3L),
+                    Arrays.asList(1L, 2L, 3L),
+                    Arrays.asList(10L, 2L, 5L, 11L, 3L, 7L, 5L),
+                    Arrays.asList(6L, 9L, 5L),
+                    Arrays.asList(4L, 3L));
+        }
+
+        @Override
         protected List<Boolean> getExpectedResults() {
-            return Arrays.asList(false, true, true, null, true);
+            return Arrays.asList(false, true, false, null, true);
         }
 
         @Override
         protected AggregateFunction<Boolean, RowData> getAggregator() {
-            return new FirstValueAggFunction<>(DataTypes.BOOLEAN().getLogicalType());
+            return new FirstValueAggOldFunction<>(DataTypes.BOOLEAN().getLogicalType());
         }
     }
 
     /** Test for {@link DecimalType}. */
-    public static final class DecimalFirstValueAggFunctionWithoutOrderTest
-            extends FirstValueAggFunctionWithoutOrderTestBase<DecimalData> {
+    public static final class DecimalFirstValueAggOldFunctionWithOrderTest
+            extends FirstValueAggOldFunctionWithOrderTestBase<DecimalData> {
 
         private int precision = 20;
         private int scale = 6;
@@ -195,23 +206,31 @@ public final class FirstValueAggFunctionWithoutOrderTest {
         }
 
         @Override
+        protected List<List<Long>> getInputOrderSets() {
+            return Arrays.asList(
+                    Arrays.asList(10L, 2L, 1L, 5L, null, 3L, 1L, 5L, 2L),
+                    Arrays.asList(6L, 5L, null, 8L, null),
+                    Arrays.asList(8L, 6L));
+        }
+
+        @Override
         protected List<DecimalData> getExpectedResults() {
             return Arrays.asList(
-                    DecimalDataUtils.castFrom("1", precision, scale),
+                    DecimalDataUtils.castFrom("-1", precision, scale),
                     null,
                     DecimalDataUtils.castFrom("0", precision, scale));
         }
 
         @Override
         protected AggregateFunction<DecimalData, RowData> getAggregator() {
-            return new FirstValueAggFunction<>(
+            return new FirstValueAggOldFunction<>(
                     DataTypes.DECIMAL(precision, scale).getLogicalType());
         }
     }
 
     /** Test for {@link VarCharType}. */
-    public static final class StringFirstValueAggFunctionWithoutOrderTest
-            extends FirstValueAggFunctionWithoutOrderTestBase<StringData> {
+    public static final class StringFirstValueAggOldFunctionWithOrderTest
+            extends FirstValueAggOldFunctionWithOrderTestBase<StringData> {
 
         @Override
         protected List<List<StringData>> getInputValueSets() {
@@ -230,30 +249,38 @@ public final class FirstValueAggFunctionWithoutOrderTest {
         }
 
         @Override
+        protected List<List<Long>> getInputOrderSets() {
+            return Arrays.asList(
+                    Arrays.asList(10L, 2L, 5L, null, 3L, 1L, 5L),
+                    Arrays.asList(6L, 5L),
+                    Arrays.asList(8L, 6L),
+                    Arrays.asList(6L, 4L, 3L));
+        }
+
+        @Override
         protected List<StringData> getExpectedResults() {
             return Arrays.asList(
-                    StringData.fromString("abc"),
+                    StringData.fromString("def"),
                     null,
                     StringData.fromString("a"),
-                    StringData.fromString("x"));
+                    StringData.fromString("e"));
         }
 
         @Override
         protected AggregateFunction<StringData, RowData> getAggregator() {
-            return new FirstValueAggFunction<>(DataTypes.STRING().getLogicalType());
+            return new FirstValueAggOldFunction<>(DataTypes.STRING().getLogicalType());
         }
     }
 
     // --------------------------------------------------------------------------------------------
     // This section contain base classes that provide:
     //  - common inputs
-    //  - accumulator class
     // for tests declared above.
     // --------------------------------------------------------------------------------------------
 
-    /** Test base for {@link FirstValueAggFunction} without order. */
-    public abstract static class FirstValueAggFunctionWithoutOrderTestBase<T>
-            extends AggFunctionTestBase<T, RowData> {
+    /** Test base for {@link FirstValueAggOldFunction}. */
+    public abstract static class FirstValueAggOldFunctionWithOrderTestBase<T>
+            extends FirstLastValueAggOldFunctionWithOrderTestBase<T, RowData> {
 
         @Override
         protected Class<?> getAccClass() {
@@ -261,23 +288,39 @@ public final class FirstValueAggFunctionWithoutOrderTest {
         }
     }
 
-    /** Test base for {@link FirstValueAggFunction} with number types. */
-    public abstract static class NumberFirstValueAggFunctionWithoutOrderTest<T>
-            extends FirstValueAggFunctionWithoutOrderTestBase<T> {
+    /** Test base for {@link FirstValueAggOldFunction} with number types. */
+    public abstract static class NumberFirstValueAggOldFunctionWithOrderTestBase<T>
+            extends FirstValueAggOldFunctionWithOrderTestBase<T> {
 
         protected abstract T getValue(String v);
 
         @Override
         protected List<List<T>> getInputValueSets() {
             return Arrays.asList(
-                    Arrays.asList(getValue("1"), null, getValue("-99"), getValue("3"), null),
+                    Arrays.asList(
+                            getValue("1"),
+                            null,
+                            getValue("-99"),
+                            getValue("3"),
+                            null,
+                            getValue("3"),
+                            getValue("2"),
+                            getValue("-99")),
                     Arrays.asList(null, null, null, null),
-                    Arrays.asList(null, getValue("10"), null, getValue("3")));
+                    Arrays.asList(null, getValue("10"), null, getValue("5")));
+        }
+
+        @Override
+        protected List<List<Long>> getInputOrderSets() {
+            return Arrays.asList(
+                    Arrays.asList(10L, 2L, 5L, 6L, 11L, 3L, 7L, 5L),
+                    Arrays.asList(8L, 6L, 9L, 5L),
+                    Arrays.asList(null, 6L, 4L, 3L));
         }
 
         @Override
         protected List<T> getExpectedResults() {
-            return Arrays.asList(getValue("1"), null, getValue("10"));
+            return Arrays.asList(getValue("3"), null, getValue("5"));
         }
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueAggOldFunctionWithoutOrderTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueAggOldFunctionWithoutOrderTest.java
@@ -24,7 +24,7 @@ import org.apache.flink.table.data.DecimalDataUtils;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.functions.AggregateFunction;
-import org.apache.flink.table.runtime.functions.aggregate.FirstValueAggFunction;
+import org.apache.flink.table.runtime.functions.aggregate.FirstValueAggOldFunction;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.BooleanType;
 import org.apache.flink.table.types.logical.DecimalType;
@@ -42,23 +42,22 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * Test case for built-in FIRST_VALUE aggregate function. This class tests `accumulate` method with
- * order argument.
+ * Test case for built-in FIRST_VALUE aggregate function. This class tests `accumulate` method
+ * without order argument.
  */
 @RunWith(Enclosed.class)
-public final class FirstValueAggFunctionWithOrderTest {
+public final class FirstValueAggOldFunctionWithoutOrderTest {
 
     // --------------------------------------------------------------------------------------------
     // Test sets for a particular type being aggregated
     //
     // Actual tests are implemented in:
-    //  - FirstLastValueAggFunctionWithOrderTestBase -> tests specific for FirstValue and LastValue
-    //  - AggFunctionTestBase -> tests that apply to all aggregate functions
+    //  - AggFunctionTestBase
     // --------------------------------------------------------------------------------------------
 
     /** Test for {@link TinyIntType}. */
-    public static final class ByteFirstValueAggFunctionWithOrderTest
-            extends NumberFirstValueAggFunctionWithOrderTestBase<Byte> {
+    public static final class ByteFirstValueAggOldFunctionWithoutOrderTest
+            extends NumberFirstValueAggOldFunctionWithoutOrderTest<Byte> {
 
         @Override
         protected Byte getValue(String v) {
@@ -67,13 +66,13 @@ public final class FirstValueAggFunctionWithOrderTest {
 
         @Override
         protected AggregateFunction<Byte, RowData> getAggregator() {
-            return new FirstValueAggFunction<>(DataTypes.TINYINT().getLogicalType());
+            return new FirstValueAggOldFunction<>(DataTypes.TINYINT().getLogicalType());
         }
     }
 
     /** Test for {@link ShortType}. */
-    public static final class ShortFirstValueAggFunctionWithOrderTest
-            extends NumberFirstValueAggFunctionWithOrderTestBase<Short> {
+    public static final class ShortFirstValueAggOldFunctionWithoutOrderTest
+            extends NumberFirstValueAggOldFunctionWithoutOrderTest<Short> {
 
         @Override
         protected Short getValue(String v) {
@@ -82,13 +81,13 @@ public final class FirstValueAggFunctionWithOrderTest {
 
         @Override
         protected AggregateFunction<Short, RowData> getAggregator() {
-            return new FirstValueAggFunction<>(DataTypes.SMALLINT().getLogicalType());
+            return new FirstValueAggOldFunction<>(DataTypes.SMALLINT().getLogicalType());
         }
     }
 
     /** Test for {@link IntType}. */
-    public static final class IntFirstValueAggFunctionWithOrderTest
-            extends NumberFirstValueAggFunctionWithOrderTestBase<Integer> {
+    public static final class IntFirstValueAggOldFunctionWithoutOrderTest
+            extends NumberFirstValueAggOldFunctionWithoutOrderTest<Integer> {
 
         @Override
         protected Integer getValue(String v) {
@@ -97,13 +96,13 @@ public final class FirstValueAggFunctionWithOrderTest {
 
         @Override
         protected AggregateFunction<Integer, RowData> getAggregator() {
-            return new FirstValueAggFunction<>(DataTypes.INT().getLogicalType());
+            return new FirstValueAggOldFunction<>(DataTypes.INT().getLogicalType());
         }
     }
 
     /** Test for {@link BigIntType}. */
-    public static final class LongFirstValueAggFunctionWithOrderTest
-            extends NumberFirstValueAggFunctionWithOrderTestBase<Long> {
+    public static final class LongFirstValueAggOldFunctionWithoutOrderTest
+            extends NumberFirstValueAggOldFunctionWithoutOrderTest<Long> {
 
         @Override
         protected Long getValue(String v) {
@@ -112,13 +111,13 @@ public final class FirstValueAggFunctionWithOrderTest {
 
         @Override
         protected AggregateFunction<Long, RowData> getAggregator() {
-            return new FirstValueAggFunction<>(DataTypes.BIGINT().getLogicalType());
+            return new FirstValueAggOldFunction<>(DataTypes.BIGINT().getLogicalType());
         }
     }
 
     /** Test for {@link FloatType}. */
-    public static final class FloatFirstValueAggFunctionWithOrderTest
-            extends NumberFirstValueAggFunctionWithOrderTestBase<Float> {
+    public static final class FloatFirstValueAggOldFunctionWithoutOrderTest
+            extends NumberFirstValueAggOldFunctionWithoutOrderTest<Float> {
 
         @Override
         protected Float getValue(String v) {
@@ -127,13 +126,13 @@ public final class FirstValueAggFunctionWithOrderTest {
 
         @Override
         protected AggregateFunction<Float, RowData> getAggregator() {
-            return new FirstValueAggFunction<>(DataTypes.FLOAT().getLogicalType());
+            return new FirstValueAggOldFunction<>(DataTypes.FLOAT().getLogicalType());
         }
     }
 
     /** Test for {@link DoubleType}. */
-    public static final class DoubleFirstValueAggFunctionWithOrderTest
-            extends NumberFirstValueAggFunctionWithOrderTestBase<Double> {
+    public static final class DoubleFirstValueAggOldFunctionWithoutOrderTest
+            extends NumberFirstValueAggOldFunctionWithoutOrderTest<Double> {
 
         @Override
         protected Double getValue(String v) {
@@ -142,13 +141,13 @@ public final class FirstValueAggFunctionWithOrderTest {
 
         @Override
         protected AggregateFunction<Double, RowData> getAggregator() {
-            return new FirstValueAggFunction<>(DataTypes.DOUBLE().getLogicalType());
+            return new FirstValueAggOldFunction<>(DataTypes.DOUBLE().getLogicalType());
         }
     }
 
     /** Test for {@link BooleanType}. */
-    public static final class BooleanFirstValueAggFunctionWithOrderTest
-            extends FirstValueAggFunctionWithOrderTestBase<Boolean> {
+    public static final class BooleanFirstValueAggOldFunctionWithoutOrderTest
+            extends FirstValueAggOldFunctionWithoutOrderTestBase<Boolean> {
 
         @Override
         protected List<List<Boolean>> getInputValueSets() {
@@ -161,29 +160,19 @@ public final class FirstValueAggFunctionWithOrderTest {
         }
 
         @Override
-        protected List<List<Long>> getInputOrderSets() {
-            return Arrays.asList(
-                    Arrays.asList(6L, 2L, 3L),
-                    Arrays.asList(1L, 2L, 3L),
-                    Arrays.asList(10L, 2L, 5L, 11L, 3L, 7L, 5L),
-                    Arrays.asList(6L, 9L, 5L),
-                    Arrays.asList(4L, 3L));
-        }
-
-        @Override
         protected List<Boolean> getExpectedResults() {
-            return Arrays.asList(false, true, false, null, true);
+            return Arrays.asList(false, true, true, null, true);
         }
 
         @Override
         protected AggregateFunction<Boolean, RowData> getAggregator() {
-            return new FirstValueAggFunction<>(DataTypes.BOOLEAN().getLogicalType());
+            return new FirstValueAggOldFunction<>(DataTypes.BOOLEAN().getLogicalType());
         }
     }
 
     /** Test for {@link DecimalType}. */
-    public static final class DecimalFirstValueAggFunctionWithOrderTest
-            extends FirstValueAggFunctionWithOrderTestBase<DecimalData> {
+    public static final class DecimalFirstValueAggOldFunctionWithoutOrderTest
+            extends FirstValueAggOldFunctionWithoutOrderTestBase<DecimalData> {
 
         private int precision = 20;
         private int scale = 6;
@@ -206,31 +195,23 @@ public final class FirstValueAggFunctionWithOrderTest {
         }
 
         @Override
-        protected List<List<Long>> getInputOrderSets() {
-            return Arrays.asList(
-                    Arrays.asList(10L, 2L, 1L, 5L, null, 3L, 1L, 5L, 2L),
-                    Arrays.asList(6L, 5L, null, 8L, null),
-                    Arrays.asList(8L, 6L));
-        }
-
-        @Override
         protected List<DecimalData> getExpectedResults() {
             return Arrays.asList(
-                    DecimalDataUtils.castFrom("-1", precision, scale),
+                    DecimalDataUtils.castFrom("1", precision, scale),
                     null,
                     DecimalDataUtils.castFrom("0", precision, scale));
         }
 
         @Override
         protected AggregateFunction<DecimalData, RowData> getAggregator() {
-            return new FirstValueAggFunction<>(
+            return new FirstValueAggOldFunction<>(
                     DataTypes.DECIMAL(precision, scale).getLogicalType());
         }
     }
 
     /** Test for {@link VarCharType}. */
-    public static final class StringFirstValueAggFunctionWithOrderTest
-            extends FirstValueAggFunctionWithOrderTestBase<StringData> {
+    public static final class StringFirstValueAggOldFunctionWithoutOrderTest
+            extends FirstValueAggOldFunctionWithoutOrderTestBase<StringData> {
 
         @Override
         protected List<List<StringData>> getInputValueSets() {
@@ -249,38 +230,30 @@ public final class FirstValueAggFunctionWithOrderTest {
         }
 
         @Override
-        protected List<List<Long>> getInputOrderSets() {
-            return Arrays.asList(
-                    Arrays.asList(10L, 2L, 5L, null, 3L, 1L, 5L),
-                    Arrays.asList(6L, 5L),
-                    Arrays.asList(8L, 6L),
-                    Arrays.asList(6L, 4L, 3L));
-        }
-
-        @Override
         protected List<StringData> getExpectedResults() {
             return Arrays.asList(
-                    StringData.fromString("def"),
+                    StringData.fromString("abc"),
                     null,
                     StringData.fromString("a"),
-                    StringData.fromString("e"));
+                    StringData.fromString("x"));
         }
 
         @Override
         protected AggregateFunction<StringData, RowData> getAggregator() {
-            return new FirstValueAggFunction<>(DataTypes.STRING().getLogicalType());
+            return new FirstValueAggOldFunction<>(DataTypes.STRING().getLogicalType());
         }
     }
 
     // --------------------------------------------------------------------------------------------
     // This section contain base classes that provide:
     //  - common inputs
+    //  - accumulator class
     // for tests declared above.
     // --------------------------------------------------------------------------------------------
 
-    /** Test base for {@link FirstValueAggFunction}. */
-    public abstract static class FirstValueAggFunctionWithOrderTestBase<T>
-            extends FirstLastValueAggFunctionWithOrderTestBase<T, RowData> {
+    /** Test base for {@link FirstValueAggOldFunction} without order. */
+    public abstract static class FirstValueAggOldFunctionWithoutOrderTestBase<T>
+            extends AggFunctionTestBase<T, RowData> {
 
         @Override
         protected Class<?> getAccClass() {
@@ -288,39 +261,23 @@ public final class FirstValueAggFunctionWithOrderTest {
         }
     }
 
-    /** Test base for {@link FirstValueAggFunction} with number types. */
-    public abstract static class NumberFirstValueAggFunctionWithOrderTestBase<T>
-            extends FirstValueAggFunctionWithOrderTestBase<T> {
+    /** Test base for {@link FirstValueAggOldFunction} with number types. */
+    public abstract static class NumberFirstValueAggOldFunctionWithoutOrderTest<T>
+            extends FirstValueAggOldFunctionWithoutOrderTestBase<T> {
 
         protected abstract T getValue(String v);
 
         @Override
         protected List<List<T>> getInputValueSets() {
             return Arrays.asList(
-                    Arrays.asList(
-                            getValue("1"),
-                            null,
-                            getValue("-99"),
-                            getValue("3"),
-                            null,
-                            getValue("3"),
-                            getValue("2"),
-                            getValue("-99")),
+                    Arrays.asList(getValue("1"), null, getValue("-99"), getValue("3"), null),
                     Arrays.asList(null, null, null, null),
-                    Arrays.asList(null, getValue("10"), null, getValue("5")));
-        }
-
-        @Override
-        protected List<List<Long>> getInputOrderSets() {
-            return Arrays.asList(
-                    Arrays.asList(10L, 2L, 5L, 6L, 11L, 3L, 7L, 5L),
-                    Arrays.asList(8L, 6L, 9L, 5L),
-                    Arrays.asList(null, 6L, 4L, 3L));
+                    Arrays.asList(null, getValue("10"), null, getValue("3")));
         }
 
         @Override
         protected List<T> getExpectedResults() {
-            return Arrays.asList(getValue("3"), null, getValue("5"));
+            return Arrays.asList(getValue("1"), null, getValue("10"));
         }
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueWithRetractAggFunctionWithOrderTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueWithRetractAggFunctionWithOrderTest.java
@@ -286,7 +286,7 @@ public final class FirstValueWithRetractAggFunctionWithOrderTest {
 
     /** Test base for {@link FirstValueWithRetractAggFunction} with order. */
     public abstract static class FirstValueWithRetractAggFunctionWithOrderTestBase<T>
-            extends FirstLastValueAggFunctionWithOrderTestBase<
+            extends FirstLastValueAggOldFunctionWithOrderTestBase<
                     T, FirstValueWithRetractAccumulator<T>> {
 
         @Override

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueAggOldFunctionWithOrderTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueAggOldFunctionWithOrderTest.java
@@ -24,7 +24,7 @@ import org.apache.flink.table.data.DecimalDataUtils;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.functions.AggregateFunction;
-import org.apache.flink.table.runtime.functions.aggregate.LastValueAggFunction;
+import org.apache.flink.table.runtime.functions.aggregate.LastValueAggOldFunction;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.BooleanType;
 import org.apache.flink.table.types.logical.DecimalType;
@@ -42,22 +42,23 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * Test case for built-in LAST_VALUE aggregate function. This class tests `accumulate` method
- * without order argument.
+ * Test case for built-in LastValue aggregate function. This class tests `accumulate` method with
+ * order argument.
  */
 @RunWith(Enclosed.class)
-public final class LastValueAggFunctionWithoutOrderTest {
+public final class LastValueAggOldFunctionWithOrderTest {
 
     // --------------------------------------------------------------------------------------------
     // Test sets for a particular type being aggregated
     //
     // Actual tests are implemented in:
-    //  - AggFunctionTestBase
+    //  - FirstLastValueAggFunctionWithOrderTestBase -> tests specific for FirstValue and LastValue
+    //  - AggFunctionTestBase -> tests that apply to all aggregate functions
     // --------------------------------------------------------------------------------------------
 
     /** Test for {@link TinyIntType}. */
-    public static final class ByteLastValueAggFunctionWithoutOrderTest
-            extends NumberLastValueAggFunctionWithoutOrderTestBase<Byte> {
+    public static final class ByteLastValueAggOldFunctionWithOrderTest
+            extends NumberLastValueAggOldFunctionWithOrderTestBase<Byte> {
 
         @Override
         protected Byte getValue(String v) {
@@ -66,13 +67,13 @@ public final class LastValueAggFunctionWithoutOrderTest {
 
         @Override
         protected AggregateFunction<Byte, RowData> getAggregator() {
-            return new LastValueAggFunction<>(DataTypes.TINYINT().getLogicalType());
+            return new LastValueAggOldFunction<>(DataTypes.TINYINT().getLogicalType());
         }
     }
 
     /** Test for {@link ShortType}. */
-    public static final class ShortLastValueAggFunctionWithoutOrderTest
-            extends NumberLastValueAggFunctionWithoutOrderTestBase<Short> {
+    public static final class ShortLastValueAggOldFunctionWithOrderTest
+            extends NumberLastValueAggOldFunctionWithOrderTestBase<Short> {
 
         @Override
         protected Short getValue(String v) {
@@ -81,13 +82,13 @@ public final class LastValueAggFunctionWithoutOrderTest {
 
         @Override
         protected AggregateFunction<Short, RowData> getAggregator() {
-            return new LastValueAggFunction<>(DataTypes.SMALLINT().getLogicalType());
+            return new LastValueAggOldFunction<>(DataTypes.SMALLINT().getLogicalType());
         }
     }
 
     /** Test for {@link IntType}. */
-    public static final class IntLastValueAggFunctionWithoutOrderTest
-            extends NumberLastValueAggFunctionWithoutOrderTestBase<Integer> {
+    public static final class IntLastValueAggOldFunctionWithOrderTest
+            extends NumberLastValueAggOldFunctionWithOrderTestBase<Integer> {
 
         @Override
         protected Integer getValue(String v) {
@@ -96,13 +97,13 @@ public final class LastValueAggFunctionWithoutOrderTest {
 
         @Override
         protected AggregateFunction<Integer, RowData> getAggregator() {
-            return new LastValueAggFunction<>(DataTypes.INT().getLogicalType());
+            return new LastValueAggOldFunction<>(DataTypes.INT().getLogicalType());
         }
     }
 
     /** Test for {@link BigIntType}. */
-    public static final class LongLastValueAggFunctionWithoutOrderTest
-            extends NumberLastValueAggFunctionWithoutOrderTestBase<Long> {
+    public static final class LongLastValueAggOldFunctionWithOrderTest
+            extends NumberLastValueAggOldFunctionWithOrderTestBase<Long> {
 
         @Override
         protected Long getValue(String v) {
@@ -111,13 +112,13 @@ public final class LastValueAggFunctionWithoutOrderTest {
 
         @Override
         protected AggregateFunction<Long, RowData> getAggregator() {
-            return new LastValueAggFunction<>(DataTypes.BIGINT().getLogicalType());
+            return new LastValueAggOldFunction<>(DataTypes.BIGINT().getLogicalType());
         }
     }
 
     /** Test for {@link FloatType}. */
-    public static final class FloatLastValueAggFunctionWithoutOrderTest
-            extends NumberLastValueAggFunctionWithoutOrderTestBase<Float> {
+    public static final class FloatLastValueAggOldFunctionWithOrderTest
+            extends NumberLastValueAggOldFunctionWithOrderTestBase<Float> {
 
         @Override
         protected Float getValue(String v) {
@@ -126,13 +127,13 @@ public final class LastValueAggFunctionWithoutOrderTest {
 
         @Override
         protected AggregateFunction<Float, RowData> getAggregator() {
-            return new LastValueAggFunction<>(DataTypes.FLOAT().getLogicalType());
+            return new LastValueAggOldFunction<>(DataTypes.FLOAT().getLogicalType());
         }
     }
 
     /** Test for {@link DoubleType}. */
-    public static final class DoubleLastValueAggFunctionWithoutOrderTest
-            extends NumberLastValueAggFunctionWithoutOrderTestBase<Double> {
+    public static final class DoubleLastValueAggOldFunctionWithOrderTest
+            extends NumberLastValueAggOldFunctionWithOrderTestBase<Double> {
 
         @Override
         protected Double getValue(String v) {
@@ -141,13 +142,13 @@ public final class LastValueAggFunctionWithoutOrderTest {
 
         @Override
         protected AggregateFunction<Double, RowData> getAggregator() {
-            return new LastValueAggFunction<>(DataTypes.DOUBLE().getLogicalType());
+            return new LastValueAggOldFunction<>(DataTypes.DOUBLE().getLogicalType());
         }
     }
 
     /** Test for {@link BooleanType}. */
-    public static final class BooleanLastValueAggFunctionWithoutOrderTest
-            extends LastValueAggFunctionWithoutOrderTestBase<Boolean> {
+    public static final class BooleanLastValueAggOldFunctionWithOrderTest
+            extends LastValueAggOldFunctionWithOrderTestBase<Boolean> {
 
         @Override
         protected List<List<Boolean>> getInputValueSets() {
@@ -160,19 +161,29 @@ public final class LastValueAggFunctionWithoutOrderTest {
         }
 
         @Override
+        protected List<List<Long>> getInputOrderSets() {
+            return Arrays.asList(
+                    Arrays.asList(6L, 2L, 3L),
+                    Arrays.asList(1L, 2L, 3L),
+                    Arrays.asList(10L, 2L, 5L, 3L, 11L, 7L, 5L),
+                    Arrays.asList(6L, 9L, 5L),
+                    Arrays.asList(4L, 3L));
+        }
+
+        @Override
         protected List<Boolean> getExpectedResults() {
-            return Arrays.asList(false, true, true, null, true);
+            return Arrays.asList(false, true, false, null, true);
         }
 
         @Override
         protected AggregateFunction<Boolean, RowData> getAggregator() {
-            return new LastValueAggFunction<>(DataTypes.BOOLEAN().getLogicalType());
+            return new LastValueAggOldFunction<>(DataTypes.BOOLEAN().getLogicalType());
         }
     }
 
     /** Test for {@link DecimalType}. */
-    public static final class DecimalLastValueAggFunctionWithoutOrderTest
-            extends LastValueAggFunctionWithoutOrderTestBase<DecimalData> {
+    public static final class DecimalLastValueAggOldFunctionWithOrderTest
+            extends LastValueAggOldFunctionWithOrderTestBase<DecimalData> {
 
         private int precision = 20;
         private int scale = 6;
@@ -195,22 +206,31 @@ public final class LastValueAggFunctionWithoutOrderTest {
         }
 
         @Override
+        protected List<List<Long>> getInputOrderSets() {
+            return Arrays.asList(
+                    Arrays.asList(10L, 2L, 1L, 5L, null, 3L, 1L, 5L, 2L),
+                    Arrays.asList(6L, 5L, null, 8L, null),
+                    Arrays.asList(8L, 6L));
+        }
+
+        @Override
         protected List<DecimalData> getExpectedResults() {
             return Arrays.asList(
-                    DecimalDataUtils.castFrom("999.999", precision, scale),
+                    DecimalDataUtils.castFrom("1", precision, scale),
                     null,
                     DecimalDataUtils.castFrom("0", precision, scale));
         }
 
         @Override
         protected AggregateFunction<DecimalData, RowData> getAggregator() {
-            return new LastValueAggFunction<>(DataTypes.DECIMAL(precision, scale).getLogicalType());
+            return new LastValueAggOldFunction<>(
+                    DataTypes.DECIMAL(precision, scale).getLogicalType());
         }
     }
 
     /** Test for {@link VarCharType}. */
-    public static final class StringLastValueAggFunctionWithoutOrderTest
-            extends LastValueAggFunctionWithoutOrderTestBase<StringData> {
+    public static final class StringLastValueAggOldFunctionWithOrderTest
+            extends LastValueAggOldFunctionWithOrderTestBase<StringData> {
 
         @Override
         protected List<List<StringData>> getInputValueSets() {
@@ -224,8 +244,17 @@ public final class LastValueAggFunctionWithoutOrderTest {
                             null,
                             StringData.fromString("zzz")),
                     Arrays.asList(null, null),
-                    Arrays.asList(null, StringData.fromString("a"), null),
+                    Arrays.asList(null, StringData.fromString("a")),
                     Arrays.asList(StringData.fromString("x"), null, StringData.fromString("e")));
+        }
+
+        @Override
+        protected List<List<Long>> getInputOrderSets() {
+            return Arrays.asList(
+                    Arrays.asList(10L, 2L, 5L, null, 3L, 1L, 15L),
+                    Arrays.asList(6L, 5L),
+                    Arrays.asList(8L, 6L),
+                    Arrays.asList(6L, 4L, 3L));
         }
 
         @Override
@@ -234,23 +263,22 @@ public final class LastValueAggFunctionWithoutOrderTest {
                     StringData.fromString("zzz"),
                     null,
                     StringData.fromString("a"),
-                    StringData.fromString("e"));
+                    StringData.fromString("x"));
         }
 
         @Override
         protected AggregateFunction<StringData, RowData> getAggregator() {
-            return new LastValueAggFunction<>(DataTypes.STRING().getLogicalType());
+            return new LastValueAggOldFunction<>(DataTypes.STRING().getLogicalType());
         }
     }
 
     // --------------------------------------------------------------------------------------------
-    // This section contain base classes that provide common inputs and declare the accumulator
-    // class type for tests declared above.
+    // This section contain base classes that provide common inputs for tests declared above.
     // --------------------------------------------------------------------------------------------
 
-    /** Test base for {@link LastValueAggFunction} without order. */
-    public abstract static class LastValueAggFunctionWithoutOrderTestBase<T>
-            extends AggFunctionTestBase<T, RowData> {
+    /** Test base for {@link LastValueAggOldFunction}. */
+    public abstract static class LastValueAggOldFunctionWithOrderTestBase<T>
+            extends FirstLastValueAggOldFunctionWithOrderTestBase<T, RowData> {
 
         @Override
         protected Class<?> getAccClass() {
@@ -258,23 +286,39 @@ public final class LastValueAggFunctionWithoutOrderTest {
         }
     }
 
-    /** Test base for {@link LastValueAggFunction} with number types. */
-    public abstract static class NumberLastValueAggFunctionWithoutOrderTestBase<T>
-            extends LastValueAggFunctionWithoutOrderTestBase<T> {
+    /** Test base for {@link LastValueAggOldFunction} with number types. */
+    public abstract static class NumberLastValueAggOldFunctionWithOrderTestBase<T>
+            extends LastValueAggOldFunctionWithOrderTestBase<T> {
 
         protected abstract T getValue(String v);
 
         @Override
         protected List<List<T>> getInputValueSets() {
             return Arrays.asList(
-                    Arrays.asList(getValue("1"), null, getValue("-99"), getValue("3"), null),
+                    Arrays.asList(
+                            getValue("1"),
+                            null,
+                            getValue("-99"),
+                            getValue("3"),
+                            null,
+                            getValue("3"),
+                            getValue("2"),
+                            getValue("-99")),
                     Arrays.asList(null, null, null, null),
-                    Arrays.asList(null, getValue("10"), null, getValue("3")));
+                    Arrays.asList(null, getValue("10"), null, getValue("5")));
+        }
+
+        @Override
+        protected List<List<Long>> getInputOrderSets() {
+            return Arrays.asList(
+                    Arrays.asList(10L, 2L, 5L, 6L, 11L, 3L, 17L, 5L),
+                    Arrays.asList(8L, 6L, 9L, 5L),
+                    Arrays.asList(null, 6L, 4L, 3L));
         }
 
         @Override
         protected List<T> getExpectedResults() {
-            return Arrays.asList(getValue("3"), null, getValue("3"));
+            return Arrays.asList(getValue("2"), null, getValue("10"));
         }
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueAggOldFunctionWithoutOrderTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueAggOldFunctionWithoutOrderTest.java
@@ -24,7 +24,7 @@ import org.apache.flink.table.data.DecimalDataUtils;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.functions.AggregateFunction;
-import org.apache.flink.table.runtime.functions.aggregate.LastValueAggFunction;
+import org.apache.flink.table.runtime.functions.aggregate.LastValueAggOldFunction;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.BooleanType;
 import org.apache.flink.table.types.logical.DecimalType;
@@ -42,23 +42,22 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * Test case for built-in LastValue aggregate function. This class tests `accumulate` method with
- * order argument.
+ * Test case for built-in LAST_VALUE aggregate function. This class tests `accumulate` method
+ * without order argument.
  */
 @RunWith(Enclosed.class)
-public final class LastValueAggFunctionWithOrderTest {
+public final class LastValueAggOldFunctionWithoutOrderTest {
 
     // --------------------------------------------------------------------------------------------
     // Test sets for a particular type being aggregated
     //
     // Actual tests are implemented in:
-    //  - FirstLastValueAggFunctionWithOrderTestBase -> tests specific for FirstValue and LastValue
-    //  - AggFunctionTestBase -> tests that apply to all aggregate functions
+    //  - AggFunctionTestBase
     // --------------------------------------------------------------------------------------------
 
     /** Test for {@link TinyIntType}. */
-    public static final class ByteLastValueAggFunctionWithOrderTest
-            extends NumberLastValueAggFunctionWithOrderTestBase<Byte> {
+    public static final class ByteLastValueAggOldFunctionWithoutOrderTest
+            extends NumberLastValueAggOldFunctionWithoutOrderTestBase<Byte> {
 
         @Override
         protected Byte getValue(String v) {
@@ -67,13 +66,13 @@ public final class LastValueAggFunctionWithOrderTest {
 
         @Override
         protected AggregateFunction<Byte, RowData> getAggregator() {
-            return new LastValueAggFunction<>(DataTypes.TINYINT().getLogicalType());
+            return new LastValueAggOldFunction<>(DataTypes.TINYINT().getLogicalType());
         }
     }
 
     /** Test for {@link ShortType}. */
-    public static final class ShortLastValueAggFunctionWithOrderTest
-            extends NumberLastValueAggFunctionWithOrderTestBase<Short> {
+    public static final class ShortLastValueAggOldFunctionWithoutOrderTest
+            extends NumberLastValueAggOldFunctionWithoutOrderTestBase<Short> {
 
         @Override
         protected Short getValue(String v) {
@@ -82,13 +81,13 @@ public final class LastValueAggFunctionWithOrderTest {
 
         @Override
         protected AggregateFunction<Short, RowData> getAggregator() {
-            return new LastValueAggFunction<>(DataTypes.SMALLINT().getLogicalType());
+            return new LastValueAggOldFunction<>(DataTypes.SMALLINT().getLogicalType());
         }
     }
 
     /** Test for {@link IntType}. */
-    public static final class IntLastValueAggFunctionWithOrderTest
-            extends NumberLastValueAggFunctionWithOrderTestBase<Integer> {
+    public static final class IntLastValueAggOldFunctionWithoutOrderTest
+            extends NumberLastValueAggOldFunctionWithoutOrderTestBase<Integer> {
 
         @Override
         protected Integer getValue(String v) {
@@ -97,13 +96,13 @@ public final class LastValueAggFunctionWithOrderTest {
 
         @Override
         protected AggregateFunction<Integer, RowData> getAggregator() {
-            return new LastValueAggFunction<>(DataTypes.INT().getLogicalType());
+            return new LastValueAggOldFunction<>(DataTypes.INT().getLogicalType());
         }
     }
 
     /** Test for {@link BigIntType}. */
-    public static final class LongLastValueAggFunctionWithOrderTest
-            extends NumberLastValueAggFunctionWithOrderTestBase<Long> {
+    public static final class LongLastValueAggOldFunctionWithoutOrderTest
+            extends NumberLastValueAggOldFunctionWithoutOrderTestBase<Long> {
 
         @Override
         protected Long getValue(String v) {
@@ -112,13 +111,13 @@ public final class LastValueAggFunctionWithOrderTest {
 
         @Override
         protected AggregateFunction<Long, RowData> getAggregator() {
-            return new LastValueAggFunction<>(DataTypes.BIGINT().getLogicalType());
+            return new LastValueAggOldFunction<>(DataTypes.BIGINT().getLogicalType());
         }
     }
 
     /** Test for {@link FloatType}. */
-    public static final class FloatLastValueAggFunctionWithOrderTest
-            extends NumberLastValueAggFunctionWithOrderTestBase<Float> {
+    public static final class FloatLastValueAggOldFunctionWithoutOrderTest
+            extends NumberLastValueAggOldFunctionWithoutOrderTestBase<Float> {
 
         @Override
         protected Float getValue(String v) {
@@ -127,13 +126,13 @@ public final class LastValueAggFunctionWithOrderTest {
 
         @Override
         protected AggregateFunction<Float, RowData> getAggregator() {
-            return new LastValueAggFunction<>(DataTypes.FLOAT().getLogicalType());
+            return new LastValueAggOldFunction<>(DataTypes.FLOAT().getLogicalType());
         }
     }
 
     /** Test for {@link DoubleType}. */
-    public static final class DoubleLastValueAggFunctionWithOrderTest
-            extends NumberLastValueAggFunctionWithOrderTestBase<Double> {
+    public static final class DoubleLastValueAggOldFunctionWithoutOrderTest
+            extends NumberLastValueAggOldFunctionWithoutOrderTestBase<Double> {
 
         @Override
         protected Double getValue(String v) {
@@ -142,13 +141,13 @@ public final class LastValueAggFunctionWithOrderTest {
 
         @Override
         protected AggregateFunction<Double, RowData> getAggregator() {
-            return new LastValueAggFunction<>(DataTypes.DOUBLE().getLogicalType());
+            return new LastValueAggOldFunction<>(DataTypes.DOUBLE().getLogicalType());
         }
     }
 
     /** Test for {@link BooleanType}. */
-    public static final class BooleanLastValueAggFunctionWithOrderTest
-            extends LastValueAggFunctionWithOrderTestBase<Boolean> {
+    public static final class BooleanLastValueAggOldFunctionWithoutOrderTest
+            extends LastValueAggOldFunctionWithoutOrderTestBase<Boolean> {
 
         @Override
         protected List<List<Boolean>> getInputValueSets() {
@@ -161,29 +160,19 @@ public final class LastValueAggFunctionWithOrderTest {
         }
 
         @Override
-        protected List<List<Long>> getInputOrderSets() {
-            return Arrays.asList(
-                    Arrays.asList(6L, 2L, 3L),
-                    Arrays.asList(1L, 2L, 3L),
-                    Arrays.asList(10L, 2L, 5L, 3L, 11L, 7L, 5L),
-                    Arrays.asList(6L, 9L, 5L),
-                    Arrays.asList(4L, 3L));
-        }
-
-        @Override
         protected List<Boolean> getExpectedResults() {
-            return Arrays.asList(false, true, false, null, true);
+            return Arrays.asList(false, true, true, null, true);
         }
 
         @Override
         protected AggregateFunction<Boolean, RowData> getAggregator() {
-            return new LastValueAggFunction<>(DataTypes.BOOLEAN().getLogicalType());
+            return new LastValueAggOldFunction<>(DataTypes.BOOLEAN().getLogicalType());
         }
     }
 
     /** Test for {@link DecimalType}. */
-    public static final class DecimalLastValueAggFunctionWithOrderTest
-            extends LastValueAggFunctionWithOrderTestBase<DecimalData> {
+    public static final class DecimalLastValueAggOldFunctionWithoutOrderTest
+            extends LastValueAggOldFunctionWithoutOrderTestBase<DecimalData> {
 
         private int precision = 20;
         private int scale = 6;
@@ -206,30 +195,23 @@ public final class LastValueAggFunctionWithOrderTest {
         }
 
         @Override
-        protected List<List<Long>> getInputOrderSets() {
-            return Arrays.asList(
-                    Arrays.asList(10L, 2L, 1L, 5L, null, 3L, 1L, 5L, 2L),
-                    Arrays.asList(6L, 5L, null, 8L, null),
-                    Arrays.asList(8L, 6L));
-        }
-
-        @Override
         protected List<DecimalData> getExpectedResults() {
             return Arrays.asList(
-                    DecimalDataUtils.castFrom("1", precision, scale),
+                    DecimalDataUtils.castFrom("999.999", precision, scale),
                     null,
                     DecimalDataUtils.castFrom("0", precision, scale));
         }
 
         @Override
         protected AggregateFunction<DecimalData, RowData> getAggregator() {
-            return new LastValueAggFunction<>(DataTypes.DECIMAL(precision, scale).getLogicalType());
+            return new LastValueAggOldFunction<>(
+                    DataTypes.DECIMAL(precision, scale).getLogicalType());
         }
     }
 
     /** Test for {@link VarCharType}. */
-    public static final class StringLastValueAggFunctionWithOrderTest
-            extends LastValueAggFunctionWithOrderTestBase<StringData> {
+    public static final class StringLastValueAggOldFunctionWithoutOrderTest
+            extends LastValueAggOldFunctionWithoutOrderTestBase<StringData> {
 
         @Override
         protected List<List<StringData>> getInputValueSets() {
@@ -243,17 +225,8 @@ public final class LastValueAggFunctionWithOrderTest {
                             null,
                             StringData.fromString("zzz")),
                     Arrays.asList(null, null),
-                    Arrays.asList(null, StringData.fromString("a")),
+                    Arrays.asList(null, StringData.fromString("a"), null),
                     Arrays.asList(StringData.fromString("x"), null, StringData.fromString("e")));
-        }
-
-        @Override
-        protected List<List<Long>> getInputOrderSets() {
-            return Arrays.asList(
-                    Arrays.asList(10L, 2L, 5L, null, 3L, 1L, 15L),
-                    Arrays.asList(6L, 5L),
-                    Arrays.asList(8L, 6L),
-                    Arrays.asList(6L, 4L, 3L));
         }
 
         @Override
@@ -262,22 +235,23 @@ public final class LastValueAggFunctionWithOrderTest {
                     StringData.fromString("zzz"),
                     null,
                     StringData.fromString("a"),
-                    StringData.fromString("x"));
+                    StringData.fromString("e"));
         }
 
         @Override
         protected AggregateFunction<StringData, RowData> getAggregator() {
-            return new LastValueAggFunction<>(DataTypes.STRING().getLogicalType());
+            return new LastValueAggOldFunction<>(DataTypes.STRING().getLogicalType());
         }
     }
 
     // --------------------------------------------------------------------------------------------
-    // This section contain base classes that provide common inputs for tests declared above.
+    // This section contain base classes that provide common inputs and declare the accumulator
+    // class type for tests declared above.
     // --------------------------------------------------------------------------------------------
 
-    /** Test base for {@link LastValueAggFunction}. */
-    public abstract static class LastValueAggFunctionWithOrderTestBase<T>
-            extends FirstLastValueAggFunctionWithOrderTestBase<T, RowData> {
+    /** Test base for {@link LastValueAggOldFunction} without order. */
+    public abstract static class LastValueAggOldFunctionWithoutOrderTestBase<T>
+            extends AggFunctionTestBase<T, RowData> {
 
         @Override
         protected Class<?> getAccClass() {
@@ -285,39 +259,23 @@ public final class LastValueAggFunctionWithOrderTest {
         }
     }
 
-    /** Test base for {@link LastValueAggFunction} with number types. */
-    public abstract static class NumberLastValueAggFunctionWithOrderTestBase<T>
-            extends LastValueAggFunctionWithOrderTestBase<T> {
+    /** Test base for {@link LastValueAggOldFunction} with number types. */
+    public abstract static class NumberLastValueAggOldFunctionWithoutOrderTestBase<T>
+            extends LastValueAggOldFunctionWithoutOrderTestBase<T> {
 
         protected abstract T getValue(String v);
 
         @Override
         protected List<List<T>> getInputValueSets() {
             return Arrays.asList(
-                    Arrays.asList(
-                            getValue("1"),
-                            null,
-                            getValue("-99"),
-                            getValue("3"),
-                            null,
-                            getValue("3"),
-                            getValue("2"),
-                            getValue("-99")),
+                    Arrays.asList(getValue("1"), null, getValue("-99"), getValue("3"), null),
                     Arrays.asList(null, null, null, null),
-                    Arrays.asList(null, getValue("10"), null, getValue("5")));
-        }
-
-        @Override
-        protected List<List<Long>> getInputOrderSets() {
-            return Arrays.asList(
-                    Arrays.asList(10L, 2L, 5L, 6L, 11L, 3L, 17L, 5L),
-                    Arrays.asList(8L, 6L, 9L, 5L),
-                    Arrays.asList(null, 6L, 4L, 3L));
+                    Arrays.asList(null, getValue("10"), null, getValue("3")));
         }
 
         @Override
         protected List<T> getExpectedResults() {
-            return Arrays.asList(getValue("2"), null, getValue("10"));
+            return Arrays.asList(getValue("3"), null, getValue("3"));
         }
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueWithRetractAggFunctionWithOrderTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueWithRetractAggFunctionWithOrderTest.java
@@ -289,7 +289,7 @@ public final class LastValueWithRetractAggFunctionWithOrderTest {
 
     /** Test base for {@link LastValueWithRetractAggFunction} with order. */
     public abstract static class LastValueWithRetractAggFunctionWithOrderTestBase<T>
-            extends FirstLastValueAggFunctionWithOrderTestBase<
+            extends FirstLastValueAggOldFunctionWithOrderTestBase<
                     T, LastValueWithRetractAccumulator<T>> {
 
         @Override

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/operator/BatchOperatorNameTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/operator/BatchOperatorNameTest.java
@@ -70,9 +70,9 @@ public class BatchOperatorNameTest extends OperatorNameTestBase {
         verifyQuery("SELECT a, " + "count(distinct b) as b " + "FROM MyTable GROUP BY a");
     }
 
-    /** Verify SortWindowAggregate. */
+    /** Verify HashWindowAggregate. */
     @Test
-    public void testSortWindowAggregate() {
+    public void testHashWindowAggregate() {
         createSourceWithTimeAttribute();
         verifyQuery(
                 "SELECT\n"

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/operator/BatchOperatorNameTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/operator/BatchOperatorNameTest.xml
@@ -1906,7 +1906,7 @@ SortMergeJoin(joinType=[InnerJoin], where=[(a = d0)], select=[a, b, c, d, a0, b0
 }]]>
     </Resource>
   </TestCase>
-  <TestCase name="testSortWindowAggregate[isNameSimplifyEnabled=true]">
+  <TestCase name="testHashWindowAggregate[isNameSimplifyEnabled=true]">
     <Resource name="explain">
       <![CDATA[== Abstract Syntax Tree ==
 LogicalProject(b=[$0], window_end=[TUMBLE_END($1)], EXPR$2=[$2])
@@ -1916,16 +1916,16 @@ LogicalProject(b=[$0], window_end=[TUMBLE_END($1)], EXPR$2=[$2])
 
 == Optimized Physical Plan ==
 Calc(select=[b, w$end AS window_end, EXPR$2])
-+- SortWindowAggregate(groupBy=[b], window=[TumblingGroupWindow('w$, rowtime, 900000)], properties=[w$start, w$end, w$rowtime], select=[b, FIRST_VALUE(a) AS EXPR$2])
-   +- Sort(orderBy=[b ASC, rowtime ASC])
-      +- Exchange(distribution=[hash[b]])
++- HashWindowAggregate(groupBy=[b], window=[TumblingGroupWindow('w$, rowtime, 900000)], properties=[w$start, w$end, w$rowtime], select=[b, Final_FIRST_VALUE(firstValue$0, valueSet$1) AS EXPR$2])
+   +- Exchange(distribution=[hash[b]])
+      +- LocalHashWindowAggregate(groupBy=[b], window=[TumblingGroupWindow('w$, rowtime, 900000)], properties=[w$start, w$end, w$rowtime], select=[b, Partial_FIRST_VALUE(a) AS (firstValue$0, valueSet$1)])
          +- TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[b, rowtime, a], metadata=[]]], fields=[b, rowtime, a])
 
 == Optimized Execution Plan ==
 Calc(select=[b, w$end AS window_end, EXPR$2])
-+- SortWindowAggregate(groupBy=[b], window=[TumblingGroupWindow('w$, rowtime, 900000)], properties=[w$start, w$end, w$rowtime], select=[b, FIRST_VALUE(a) AS EXPR$2])
-   +- Sort(orderBy=[b ASC, rowtime ASC])
-      +- Exchange(distribution=[hash[b]])
++- HashWindowAggregate(groupBy=[b], window=[TumblingGroupWindow('w$, rowtime, 900000)], properties=[w$start, w$end, w$rowtime], select=[b, Final_FIRST_VALUE(firstValue$0, valueSet$1) AS EXPR$2])
+   +- Exchange(distribution=[hash[b]])
+      +- LocalHashWindowAggregate(groupBy=[b], window=[TumblingGroupWindow('w$, rowtime, 900000)], properties=[w$start, w$end, w$rowtime], select=[b, Partial_FIRST_VALUE(a) AS (firstValue$0, valueSet$1)])
          +- TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[b, rowtime, a], metadata=[]]], fields=[b, rowtime, a])
 
 == Physical Execution Plan ==
@@ -1938,24 +1938,24 @@ Calc(select=[b, w$end AS window_end, EXPR$2])
     "parallelism" : 1
   }, {
     "id" : ,
-    "type" : "Sort[]",
+    "type" : "HashWindowAggregate[]",
     "pact" : "Operator",
-    "contents" : "[]:Sort(orderBy=[b ASC, rowtime ASC])",
-    "parallelism" : 2,
+    "contents" : "[]:LocalHashWindowAggregate(groupBy=[b], window=[TumblingGroupWindow('w$, rowtime, 900000)], properties=[w$start, w$end, w$rowtime], select=[b, Partial_FIRST_VALUE(a) AS (firstValue$0, valueSet$1)])",
+    "parallelism" : 1,
     "predecessors" : [ {
       "id" : ,
-      "ship_strategy" : "HASH[b]",
+      "ship_strategy" : "FORWARD",
       "side" : "second"
     } ]
   }, {
     "id" : ,
-    "type" : "SortWindowAggregate[]",
+    "type" : "HashWindowAggregate[]",
     "pact" : "Operator",
-    "contents" : "[]:SortWindowAggregate(groupBy=[b], window=[TumblingGroupWindow('w$, rowtime, 900000)], properties=[w$start, w$end, w$rowtime], select=[b, FIRST_VALUE(a) AS EXPR$2])",
+    "contents" : "[]:HashWindowAggregate(groupBy=[b], window=[TumblingGroupWindow('w$, rowtime, 900000)], properties=[w$start, w$end, w$rowtime], select=[b, Final_FIRST_VALUE(firstValue$0, valueSet$1) AS EXPR$2])",
     "parallelism" : 2,
     "predecessors" : [ {
       "id" : ,
-      "ship_strategy" : "FORWARD",
+      "ship_strategy" : "HASH[b]",
       "side" : "second"
     } ]
   }, {
@@ -2029,7 +2029,7 @@ SortMergeJoin(joinType=[InnerJoin], where=[(a = d0)], select=[a, b, c, d, a0, b0
 }]]>
     </Resource>
   </TestCase>
-  <TestCase name="testSortWindowAggregate[isNameSimplifyEnabled=false]">
+  <TestCase name="testHashWindowAggregate[isNameSimplifyEnabled=false]">
     <Resource name="explain">
       <![CDATA[== Abstract Syntax Tree ==
 LogicalProject(b=[$0], window_end=[TUMBLE_END($1)], EXPR$2=[$2])
@@ -2039,16 +2039,16 @@ LogicalProject(b=[$0], window_end=[TUMBLE_END($1)], EXPR$2=[$2])
 
 == Optimized Physical Plan ==
 Calc(select=[b, w$end AS window_end, EXPR$2])
-+- SortWindowAggregate(groupBy=[b], window=[TumblingGroupWindow('w$, rowtime, 900000)], properties=[w$start, w$end, w$rowtime], select=[b, FIRST_VALUE(a) AS EXPR$2])
-   +- Sort(orderBy=[b ASC, rowtime ASC])
-      +- Exchange(distribution=[hash[b]])
++- HashWindowAggregate(groupBy=[b], window=[TumblingGroupWindow('w$, rowtime, 900000)], properties=[w$start, w$end, w$rowtime], select=[b, Final_FIRST_VALUE(firstValue$0, valueSet$1) AS EXPR$2])
+   +- Exchange(distribution=[hash[b]])
+      +- LocalHashWindowAggregate(groupBy=[b], window=[TumblingGroupWindow('w$, rowtime, 900000)], properties=[w$start, w$end, w$rowtime], select=[b, Partial_FIRST_VALUE(a) AS (firstValue$0, valueSet$1)])
          +- TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[b, rowtime, a], metadata=[]]], fields=[b, rowtime, a])
 
 == Optimized Execution Plan ==
 Calc(select=[b, w$end AS window_end, EXPR$2])
-+- SortWindowAggregate(groupBy=[b], window=[TumblingGroupWindow('w$, rowtime, 900000)], properties=[w$start, w$end, w$rowtime], select=[b, FIRST_VALUE(a) AS EXPR$2])
-   +- Sort(orderBy=[b ASC, rowtime ASC])
-      +- Exchange(distribution=[hash[b]])
++- HashWindowAggregate(groupBy=[b], window=[TumblingGroupWindow('w$, rowtime, 900000)], properties=[w$start, w$end, w$rowtime], select=[b, Final_FIRST_VALUE(firstValue$0, valueSet$1) AS EXPR$2])
+   +- Exchange(distribution=[hash[b]])
+      +- LocalHashWindowAggregate(groupBy=[b], window=[TumblingGroupWindow('w$, rowtime, 900000)], properties=[w$start, w$end, w$rowtime], select=[b, Partial_FIRST_VALUE(a) AS (firstValue$0, valueSet$1)])
          +- TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[b, rowtime, a], metadata=[]]], fields=[b, rowtime, a])
 
 == Physical Execution Plan ==
@@ -2061,9 +2061,20 @@ Calc(select=[b, w$end AS window_end, EXPR$2])
     "parallelism" : 1
   }, {
     "id" : ,
-    "type" : "Sort(orderBy=[b ASC, rowtime ASC])",
+    "type" : "LocalHashWindowAggregate(groupBy=[b], window=[TumblingGroupWindow('w$, rowtime, 900000)], properties=[w$start, w$end, w$rowtime], select=[b, Partial_FIRST_VALUE(a) AS (firstValue$0, valueSet$1)])",
     "pact" : "Operator",
-    "contents" : "Sort(orderBy=[b ASC, rowtime ASC])",
+    "contents" : "LocalHashWindowAggregate(groupBy=[b], window=[TumblingGroupWindow('w$, rowtime, 900000)], properties=[w$start, w$end, w$rowtime], select=[b, Partial_FIRST_VALUE(a) AS (firstValue$0, valueSet$1)])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "HashWindowAggregate(groupBy=[b], window=[TumblingGroupWindow('w$, rowtime, 900000)], properties=[w$start, w$end, w$rowtime], select=[b, Final_FIRST_VALUE(firstValue$0, valueSet$1) AS EXPR$2])",
+    "pact" : "Operator",
+    "contents" : "HashWindowAggregate(groupBy=[b], window=[TumblingGroupWindow('w$, rowtime, 900000)], properties=[w$start, w$end, w$rowtime], select=[b, Final_FIRST_VALUE(firstValue$0, valueSet$1) AS EXPR$2])",
     "parallelism" : 2,
     "predecessors" : [ {
       "id" : ,
@@ -2072,75 +2083,10 @@ Calc(select=[b, w$end AS window_end, EXPR$2])
     } ]
   }, {
     "id" : ,
-    "type" : "SortWindowAggregate(groupBy=[b], window=[TumblingGroupWindow('w$, rowtime, 900000)], properties=[w$start, w$end, w$rowtime], select=[b, FIRST_VALUE(a) AS EXPR$2])",
-    "pact" : "Operator",
-    "contents" : "SortWindowAggregate(groupBy=[b], window=[TumblingGroupWindow('w$, rowtime, 900000)], properties=[w$start, w$end, w$rowtime], select=[b, FIRST_VALUE(a) AS EXPR$2])",
-    "parallelism" : 2,
-    "predecessors" : [ {
-      "id" : ,
-      "ship_strategy" : "FORWARD",
-      "side" : "second"
-    } ]
-  }, {
-    "id" : ,
     "type" : "Calc(select=[b, w$end AS window_end, EXPR$2])",
     "pact" : "Operator",
     "contents" : "Calc(select=[b, w$end AS window_end, EXPR$2])",
     "parallelism" : 2,
-    "predecessors" : [ {
-      "id" : ,
-      "ship_strategy" : "FORWARD",
-      "side" : "second"
-    } ]
-  } ]
-}]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testMatch[isNameSimplifyEnabled=false]">
-    <Resource name="explain">
-      <![CDATA[== Abstract Syntax Tree ==
-LogicalProject(aid=[$0], bid=[$1], cid=[$2])
-+- LogicalMatch(partition=[[]], order=[[5 ASC-nulls-first]], outputFields=[[aid, bid, cid]], allRows=[false], after=[FLAG(SKIP TO NEXT ROW)], pattern=[((_UTF-16LE'A"', _UTF-16LE'l'), _UTF-16LE'C')], isStrictStarts=[false], isStrictEnds=[false], subsets=[[]], patternDefinitions=[[=(LAST(*.$0, 0), 1), =(LAST(*.$1, 0), 2), =(LAST(*.$2, 0), _UTF-16LE'c')]], inputFields=[[a, b, c, d, rowtime, proctime]])
-   +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], rowtime=[$4], proctime=[PROCTIME()])
-      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
-
-== Optimized Physical Plan ==
-Match(orderBy=[proctime ASC], measures=[FINAL(A".a) AS aid, FINAL(l.a) AS bid, FINAL(C.a) AS cid], rowsPerMatch=[ONE ROW PER MATCH], after=[SKIP TO NEXT ROW], pattern=[((_UTF-16LE'A"', _UTF-16LE'l'), _UTF-16LE'C')], define=[{A"==(LAST(*.$0, 0), 1), l==(LAST(*.$1, 0), 2), C==(LAST(*.$2, 0), _UTF-16LE'c')}])
-+- Calc(select=[a, b, c, d, rowtime, PROCTIME() AS proctime])
-   +- Exchange(distribution=[single])
-      +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d, rowtime])
-
-== Optimized Execution Plan ==
-Match(orderBy=[proctime ASC], measures=[FINAL(A".a) AS aid, FINAL(l.a) AS bid, FINAL(C.a) AS cid], rowsPerMatch=[ONE ROW PER MATCH], after=[SKIP TO NEXT ROW], pattern=[((_UTF-16LE'A"', _UTF-16LE'l'), _UTF-16LE'C')], define=[{A"==(LAST(*.$0, 0), 1), l==(LAST(*.$1, 0), 2), C==(LAST(*.$2, 0), _UTF-16LE'c')}])
-+- Calc(select=[a, b, c, d, rowtime, PROCTIME() AS proctime])
-   +- Exchange(distribution=[single])
-      +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d, rowtime])
-
-== Physical Execution Plan ==
-{
-  "nodes" : [ {
-    "id" : ,
-    "type" : "Source: TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d, rowtime])",
-    "pact" : "Data Source",
-    "contents" : "TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d, rowtime])",
-    "parallelism" : 1
-  }, {
-    "id" : ,
-    "type" : "Calc(select=[a, b, c, d, rowtime, PROCTIME() AS proctime])",
-    "pact" : "Operator",
-    "contents" : "Calc(select=[a, b, c, d, rowtime, PROCTIME() AS proctime])",
-    "parallelism" : 1,
-    "predecessors" : [ {
-      "id" : ,
-      "ship_strategy" : "GLOBAL",
-      "side" : "second"
-    } ]
-  }, {
-    "id" : ,
-    "type" : "Match(orderBy=[proctime ASC], measures=[FINAL(A\".a) AS aid, FINAL(l.a) AS bid, FINAL(C.a) AS cid], rowsPerMatch=[ONE ROW PER MATCH], after=[SKIP TO NEXT ROW], pattern=[((_UTF-16LE'A\"', _UTF-16LE'l'), _UTF-16LE'C')], define=[{A\"==(LAST(*.$0, 0), 1), l==(LAST(*.$1, 0), 2), C==(LAST(*.$2, 0), _UTF-16LE'c')}])",
-    "pact" : "Operator",
-    "contents" : "Match(orderBy=[proctime ASC], measures=[FINAL(A\".a) AS aid, FINAL(l.a) AS bid, FINAL(C.a) AS cid], rowsPerMatch=[ONE ROW PER MATCH], after=[SKIP TO NEXT ROW], pattern=[((_UTF-16LE'A\"', _UTF-16LE'l'), _UTF-16LE'C')], define=[{A\"==(LAST(*.$0, 0), 1), l==(LAST(*.$1, 0), 2), C==(LAST(*.$2, 0), _UTF-16LE'c')}])",
-    "parallelism" : 1,
     "predecessors" : [ {
       "id" : ,
       "ship_strategy" : "FORWARD",

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/agg/DistinctAggregateTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/agg/DistinctAggregateTest.xml
@@ -1229,10 +1229,11 @@ LogicalAggregate(group=[{0}], EXPR$1=[FIRST_VALUE($1)], EXPR$2=[COUNT(DISTINCT $
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-GroupAggregate(groupBy=[a], select=[a, FIRST_VALUE(c) AS EXPR$1, COUNT(DISTINCT b) AS EXPR$2])
+GlobalGroupAggregate(groupBy=[a], select=[a, FIRST_VALUE((firstValue$0, valueSet$1)) AS EXPR$1, COUNT(distinct$0 count$2) AS EXPR$2])
 +- Exchange(distribution=[hash[a]])
-   +- MiniBatchAssigner(interval=[1000ms], mode=[ProcTime])
-      +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+   +- LocalGroupAggregate(groupBy=[a], select=[a, FIRST_VALUE(c) AS (firstValue$0, valueSet$1), COUNT(distinct$0 b) AS count$2, DISTINCT(b) AS distinct$0])
+      +- MiniBatchAssigner(interval=[1000ms], mode=[ProcTime])
+         +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>
@@ -1276,13 +1277,14 @@ LogicalAggregate(group=[{0}], EXPR$1=[FIRST_VALUE($1)], EXPR$2=[COUNT(DISTINCT $
       <![CDATA[
 GroupAggregate(groupBy=[a], partialFinalType=[FINAL], select=[a, FIRST_VALUE_RETRACT($f3_0) AS $f1, $SUM0_RETRACT($f4_0) AS $f2])
 +- Exchange(distribution=[hash[a]])
-   +- GroupAggregate(groupBy=[a, $f3, $f4], partialFinalType=[PARTIAL], select=[a, $f3, $f4, FIRST_VALUE(c) FILTER $g_2 AS $f3_0, COUNT(DISTINCT b) FILTER $g_1 AS $f4_0])
+   +- GlobalGroupAggregate(groupBy=[a, $f3, $f4], partialFinalType=[PARTIAL], select=[a, $f3, $f4, FIRST_VALUE((firstValue$0, valueSet$1)) AS $f3_0, COUNT(distinct$0 count$2) AS $f4_0])
       +- Exchange(distribution=[hash[a, $f3, $f4]])
-         +- Calc(select=[a, b, c, $f3, $f4, ($e = 2) AS $g_2, ($e = 1) AS $g_1])
-            +- Expand(projects=[{a, b, c, $f3, null AS $f4, 1 AS $e}, {a, b, c, null AS $f3, $f4, 2 AS $e}])
-               +- Calc(select=[a, b, c, MOD(HASH_CODE(b), 1024) AS $f3, MOD(HASH_CODE(c), 1024) AS $f4])
-                  +- MiniBatchAssigner(interval=[1000ms], mode=[ProcTime])
-                     +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+         +- LocalGroupAggregate(groupBy=[a, $f3, $f4], partialFinalType=[PARTIAL], select=[a, $f3, $f4, FIRST_VALUE(c) FILTER $g_2 AS (firstValue$0, valueSet$1), COUNT(distinct$0 b) FILTER $g_1 AS count$2, DISTINCT(b) AS distinct$0])
+            +- Calc(select=[a, b, c, $f3, $f4, ($e = 2) AS $g_2, ($e = 1) AS $g_1])
+               +- Expand(projects=[{a, b, c, $f3, null AS $f4, 1 AS $e}, {a, b, c, null AS $f3, $f4, 2 AS $e}])
+                  +- Calc(select=[a, b, c, MOD(HASH_CODE(b), 1024) AS $f3, MOD(HASH_CODE(c), 1024) AS $f4])
+                     +- MiniBatchAssigner(interval=[1000ms], mode=[ProcTime])
+                        +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>
@@ -1319,10 +1321,11 @@ LogicalAggregate(group=[{0}], EXPR$1=[LAST_VALUE($1)], EXPR$2=[COUNT(DISTINCT $2
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-GroupAggregate(groupBy=[a], select=[a, LAST_VALUE(c) AS EXPR$1, COUNT(DISTINCT b) AS EXPR$2])
+GlobalGroupAggregate(groupBy=[a], select=[a, LAST_VALUE((lastValue$0, valueSet$1)) AS EXPR$1, COUNT(distinct$0 count$2) AS EXPR$2])
 +- Exchange(distribution=[hash[a]])
-   +- MiniBatchAssigner(interval=[1000ms], mode=[ProcTime])
-      +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+   +- LocalGroupAggregate(groupBy=[a], select=[a, LAST_VALUE(c) AS (lastValue$0, valueSet$1), COUNT(distinct$0 b) AS count$2, DISTINCT(b) AS distinct$0])
+      +- MiniBatchAssigner(interval=[1000ms], mode=[ProcTime])
+         +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>
@@ -1366,13 +1369,14 @@ LogicalAggregate(group=[{0}], EXPR$1=[LAST_VALUE($1)], EXPR$2=[COUNT(DISTINCT $2
       <![CDATA[
 GroupAggregate(groupBy=[a], partialFinalType=[FINAL], select=[a, LAST_VALUE_RETRACT($f3_0) AS $f1, $SUM0_RETRACT($f4_0) AS $f2])
 +- Exchange(distribution=[hash[a]])
-   +- GroupAggregate(groupBy=[a, $f3, $f4], partialFinalType=[PARTIAL], select=[a, $f3, $f4, LAST_VALUE(c) FILTER $g_2 AS $f3_0, COUNT(DISTINCT b) FILTER $g_1 AS $f4_0])
+   +- GlobalGroupAggregate(groupBy=[a, $f3, $f4], partialFinalType=[PARTIAL], select=[a, $f3, $f4, LAST_VALUE((lastValue$0, valueSet$1)) AS $f3_0, COUNT(distinct$0 count$2) AS $f4_0])
       +- Exchange(distribution=[hash[a, $f3, $f4]])
-         +- Calc(select=[a, b, c, $f3, $f4, ($e = 2) AS $g_2, ($e = 1) AS $g_1])
-            +- Expand(projects=[{a, b, c, $f3, null AS $f4, 1 AS $e}, {a, b, c, null AS $f3, $f4, 2 AS $e}])
-               +- Calc(select=[a, b, c, MOD(HASH_CODE(b), 1024) AS $f3, MOD(HASH_CODE(c), 1024) AS $f4])
-                  +- MiniBatchAssigner(interval=[1000ms], mode=[ProcTime])
-                     +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+         +- LocalGroupAggregate(groupBy=[a, $f3, $f4], partialFinalType=[PARTIAL], select=[a, $f3, $f4, LAST_VALUE(c) FILTER $g_2 AS (lastValue$0, valueSet$1), COUNT(distinct$0 b) FILTER $g_1 AS count$2, DISTINCT(b) AS distinct$0])
+            +- Calc(select=[a, b, c, $f3, $f4, ($e = 2) AS $g_2, ($e = 1) AS $g_1])
+               +- Expand(projects=[{a, b, c, $f3, null AS $f4, 1 AS $e}, {a, b, c, null AS $f3, $f4, 2 AS $e}])
+                  +- Calc(select=[a, b, c, MOD(HASH_CODE(b), 1024) AS $f3, MOD(HASH_CODE(c), 1024) AS $f4])
+                     +- MiniBatchAssigner(interval=[1000ms], mode=[ProcTime])
+                        +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/SubplanReuseTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/SubplanReuseTest.scala
@@ -20,13 +20,14 @@ package org.apache.flink.table.planner.plan.batch.sql
 import org.apache.flink.api.scala._
 import org.apache.flink.table.api._
 import org.apache.flink.table.api.config.{ExecutionConfigOptions, OptimizerConfigOptions}
+import org.apache.flink.table.planner.functions.aggfunctions.FirstValueAggFunctionNew
 import org.apache.flink.table.planner.plan.rules.physical.batch.BatchPhysicalSortMergeJoinRule
 import org.apache.flink.table.planner.plan.rules.physical.batch.BatchPhysicalSortRule.TABLE_EXEC_RANGE_SORT_ENABLED
 import org.apache.flink.table.planner.plan.utils.OperatorType
 import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedScalarFunctions.NonDeterministicUdf
 import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedTableFunctions.{NonDeterministicTableFunc, StringSplit}
 import org.apache.flink.table.planner.utils.TableTestBase
-import org.apache.flink.table.runtime.functions.aggregate.FirstValueAggFunction
+import org.apache.flink.table.runtime.functions.aggregate.{FirstValueAggOldFunction, FirstValueWithRetractAggFunction}
 
 import org.junit.{Before, Test}
 
@@ -206,10 +207,10 @@ class SubplanReuseTest extends TableTestBase {
     // FirstValueAggFunction and LastValueAggFunction are not deterministic
     util.addTemporarySystemFunction(
       "MyFirst",
-      new FirstValueAggFunction(DataTypes.INT().getLogicalType))
+      new FirstValueWithRetractAggFunction(DataTypes.INT.getLogicalType))
     util.addTemporarySystemFunction(
       "MyLast",
-      new FirstValueAggFunction(DataTypes.BIGINT().getLogicalType))
+      new FirstValueWithRetractAggFunction(DataTypes.BIGINT.getLogicalType))
 
     val sqlQuery =
       """
@@ -339,7 +340,7 @@ class SubplanReuseTest extends TableTestBase {
     // FirstValueAggFunction is not deterministic
     util.addTemporarySystemFunction(
       "MyFirst",
-      new FirstValueAggFunction(DataTypes.STRING().getLogicalType))
+      new FirstValueWithRetractAggFunction(DataTypes.STRING.getLogicalType))
 
     val sqlQuery =
       """

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/SubplanReuseTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/SubplanReuseTest.scala
@@ -23,7 +23,7 @@ import org.apache.flink.table.api.config.{ExecutionConfigOptions, OptimizerConfi
 import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedScalarFunctions.NonDeterministicUdf
 import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedTableFunctions.{NonDeterministicTableFunc, StringSplit}
 import org.apache.flink.table.planner.utils.TableTestBase
-import org.apache.flink.table.runtime.functions.aggregate.FirstValueAggFunction
+import org.apache.flink.table.runtime.functions.aggregate.{FirstValueAggOldFunction, FirstValueWithRetractAggFunction}
 
 import org.junit.{Before, Test}
 
@@ -158,10 +158,10 @@ class SubplanReuseTest extends TableTestBase {
     // FirstValueAggFunction and LastValueAggFunction are not deterministic
     util.addTemporarySystemFunction(
       "MyFirst",
-      new FirstValueAggFunction(DataTypes.INT().getLogicalType))
+      new FirstValueWithRetractAggFunction(DataTypes.INT().getLogicalType))
     util.addTemporarySystemFunction(
       "MyLast",
-      new FirstValueAggFunction(DataTypes.BIGINT().getLogicalType))
+      new FirstValueWithRetractAggFunction(DataTypes.BIGINT().getLogicalType))
 
     val sqlQuery =
       """
@@ -253,7 +253,7 @@ class SubplanReuseTest extends TableTestBase {
     // FirstValueAggFunction is not deterministic
     util.addTemporarySystemFunction(
       "MyFirst",
-      new FirstValueAggFunction(DataTypes.STRING().getLogicalType))
+      new FirstValueWithRetractAggFunction(DataTypes.STRING().getLogicalType))
     val sqlQuery =
       """
         |WITH r AS (SELECT a, b, MyFirst(c) OVER (PARTITION BY c ORDER BY c DESC) FROM x)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/agg/DistinctAggregateTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/agg/DistinctAggregateTest.scala
@@ -76,13 +76,11 @@ class DistinctAggregateTest(
 
   @Test
   def testSingleFirstValueWithDistinctAgg(): Unit = {
-    // FIRST_VALUE is not mergeable, so the final plan does not contain local agg
     util.verifyExecPlan("SELECT a, FIRST_VALUE(c), COUNT(DISTINCT b) FROM MyTable GROUP BY a")
   }
 
   @Test
   def testSingleLastValueWithDistinctAgg(): Unit = {
-    // LAST_VALUE is not mergeable, so the final plan does not contain local agg
     util.verifyExecPlan("SELECT a, LAST_VALUE(c), COUNT(DISTINCT b) FROM MyTable GROUP BY a")
   }
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/aggregate/FirstValueAggOldFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/aggregate/FirstValueAggOldFunction.java
@@ -34,11 +34,11 @@ import static org.apache.flink.table.types.utils.DataTypeUtils.toInternalDataTyp
 
 /** Built-in FIRST_VALUE aggregate function. */
 @Internal
-public final class FirstValueAggFunction<T> extends BuiltInAggregateFunction<T, RowData> {
+public final class FirstValueAggOldFunction<T> extends BuiltInAggregateFunction<T, RowData> {
 
     private final transient DataType valueDataType;
 
-    public FirstValueAggFunction(LogicalType valueType) {
+    public FirstValueAggOldFunction(LogicalType valueType) {
         this.valueDataType = toInternalDataType(valueType);
     }
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/aggregate/LastValueAggOldFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/aggregate/LastValueAggOldFunction.java
@@ -34,11 +34,11 @@ import static org.apache.flink.table.types.utils.DataTypeUtils.toInternalDataTyp
 
 /** Built-in LAST_VALUE aggregate function. */
 @Internal
-public final class LastValueAggFunction<T> extends BuiltInAggregateFunction<T, RowData> {
+public final class LastValueAggOldFunction<T> extends BuiltInAggregateFunction<T, RowData> {
 
     private final transient DataType valueDataType;
 
-    public LastValueAggFunction(LogicalType valueType) {
+    public LastValueAggOldFunction(LogicalType valueType) {
         this.valueDataType = toInternalDataType(valueType);
     }
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
