### PR TITLE
[FLINK-27667][yarn-tests] Stabilize flaky YARN integration tests

### DIFF
--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNHighAvailabilityITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNHighAvailabilityITCase.java
@@ -109,10 +109,10 @@ class YARNHighAvailabilityITCase extends YarnTestBase {
     private JobGraph job;
 
     @BeforeAll
-    static void setup(@TempDir File folder) throws Exception {
+    static void setup(@TempDir File tempDir) throws Exception {
         zkServer = new TestingServer();
 
-        storageDir = folder.getAbsolutePath();
+        storageDir = tempDir.getAbsolutePath();
 
         // startYARNWithConfig should be implemented by subclass
         YARN_CONFIGURATION.setClass(
@@ -124,15 +124,19 @@ class YARNHighAvailabilityITCase extends YarnTestBase {
 
     @AfterAll
     static void teardown() throws Exception {
-        if (zkServer != null) {
-            zkServer.stop();
-            zkServer = null;
+        try {
+            YarnTestBase.teardown();
+        } finally {
+            if (zkServer != null) {
+                zkServer.stop();
+                zkServer = null;
+            }
         }
     }
 
     @BeforeEach
-    void setUp(@TempDir File folder) {
-        stopJobSignal = YarnTestJob.StopJobSignal.usingMarkerFile(folder.toPath());
+    void setUp(@TempDir File tempDir) {
+        stopJobSignal = YarnTestJob.StopJobSignal.usingMarkerFile(tempDir.toPath());
         job = YarnTestJob.stoppableJob(stopJobSignal);
         final File testingJar =
                 TestUtils.findFile("..", new TestUtils.TestJarFinder("flink-yarn-tests"));

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNITCase.java
@@ -42,14 +42,13 @@ import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import static org.apache.flink.yarn.configuration.YarnConfigOptions.CLASSPATH_INCLUDE_USER_JAR;
@@ -90,13 +89,13 @@ class YARNITCase extends YarnTestBase {
     }
 
     @Test
-    void testPerJobModeWithDistributedCache() throws Exception {
+    void testPerJobModeWithDistributedCache(@TempDir File tempDir) throws Exception {
         runTest(
                 () ->
                         deployPerJob(
                                 createDefaultConfiguration(
                                         YarnConfigOptions.UserJarInclusion.DISABLED),
-                                YarnTestCacheJob.getDistributedCacheJobGraph(tmp),
+                                YarnTestCacheJob.getDistributedCacheJobGraph(tempDir),
                                 true));
     }
 
@@ -119,11 +118,9 @@ class YARNITCase extends YarnTestBase {
     }
 
     @Test
-    void testPerJobWithArchive() throws Exception {
+    void testPerJobWithArchive(@TempDir File tempDir) throws Exception {
         final Configuration flinkConfig =
                 createDefaultConfiguration(YarnConfigOptions.UserJarInclusion.DISABLED);
-        java.nio.file.Path tmpPath = tmp.toPath().resolve(UUID.randomUUID().toString());
-        File tempDir = Files.createDirectories(tmpPath).toFile();
         final JobGraph archiveJobGraph =
                 YarnTestArchiveJob.getArchiveJobGraph(tempDir, flinkConfig);
         runTest(() -> deployPerJob(flinkConfig, archiveJobGraph, true));


### PR DESCRIPTION
## What is the purpose of the change

Stabilizing YARN IT test cases. Currently, they tend to fail, because of a concurrent temp folder cleanup.

## Brief change log

Added separate JUnit temp dirs for test cases to avoid concurrent cleanup under the same root dir.

## Verifying this change

_in progress_

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
