### PR TITLE
[FLINK-27971][tests][JUnit5 migration] flink-orc

### DIFF
--- a/flink-formats/flink-orc-nohive/src/test/java/org/apache/flink/architecture/TestCodeArchitectureTest.java
+++ b/flink-formats/flink-orc-nohive/src/test/java/org/apache/flink/architecture/TestCodeArchitectureTest.java
@@ -33,7 +33,7 @@ import com.tngtech.archunit.junit.ArchTests;
             ImportOptions.ExcludeScalaImportOption.class,
             ImportOptions.ExcludeShadedImportOption.class
         })
-public class TestCodeArchitectureTest {
+class TestCodeArchitectureTest {
 
     @ArchTest
     public static final ArchTests COMMON_TESTS = ArchTests.in(TestCodeArchitectureTestBase.class);

--- a/flink-formats/flink-orc-nohive/src/test/java/org/apache/flink/orc/nohive/OrcColumnarRowSplitReaderNoHiveTest.java
+++ b/flink-formats/flink-orc-nohive/src/test/java/org/apache/flink/orc/nohive/OrcColumnarRowSplitReaderNoHiveTest.java
@@ -39,7 +39,7 @@ import java.util.Map;
 import java.util.stream.IntStream;
 
 /** Test for {@link OrcColumnarRowSplitReader}. */
-public class OrcColumnarRowSplitReaderNoHiveTest extends OrcColumnarRowSplitReaderTest {
+class OrcColumnarRowSplitReaderNoHiveTest extends OrcColumnarRowSplitReaderTest {
 
     @Override
     protected void prepareReadFileWithTypes(String file, int rowSize) throws IOException {

--- a/flink-formats/flink-orc-nohive/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/flink-formats/flink-orc-nohive/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.util.TestLoggerExtension

--- a/flink-formats/flink-orc/src/test/java/org/apache/flink/architecture/TestCodeArchitectureTest.java
+++ b/flink-formats/flink-orc/src/test/java/org/apache/flink/architecture/TestCodeArchitectureTest.java
@@ -33,7 +33,7 @@ import com.tngtech.archunit.junit.ArchTests;
             ImportOptions.ExcludeScalaImportOption.class,
             ImportOptions.ExcludeShadedImportOption.class
         })
-public class TestCodeArchitectureTest {
+class TestCodeArchitectureTest {
 
     @ArchTest
     public static final ArchTests COMMON_TESTS = ArchTests.in(TestCodeArchitectureTestBase.class);

--- a/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/OrcColumnarRowSplitReaderTest.java
+++ b/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/OrcColumnarRowSplitReaderTest.java
@@ -27,7 +27,6 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.types.Row;
-import org.apache.flink.util.IOUtils;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.ql.exec.vector.DoubleColumnVector;
@@ -37,12 +36,11 @@ import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.orc.OrcFile;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.Writer;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.sql.Date;
@@ -53,15 +51,15 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.IntStream;
 
+import static org.apache.flink.orc.OrcColumnarRowInputFormatTest.copyFileFromResource;
 import static org.apache.flink.table.utils.DateTimeUtils.toSQLDate;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link OrcColumnarRowSplitReader}. */
-public class OrcColumnarRowSplitReaderTest {
+class OrcColumnarRowSplitReaderTest {
 
     protected static final int BATCH_SIZE = 10;
 
-    private final Path testFileFlat = new Path(getPath("test-data-flat.orc"));
     private final DataType[] testSchemaFlat =
             new DataType[] {
                 DataTypes.INT(),
@@ -75,13 +73,22 @@ public class OrcColumnarRowSplitReaderTest {
                 DataTypes.INT()
             };
 
-    private final Path testFileDecimal = new Path(getPath("test-data-decimal.orc"));
     private final DataType[] testSchemaDecimal = new DataType[] {DataTypes.DECIMAL(10, 5)};
 
-    @ClassRule public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+    private static Path testFileFlat;
+    private static Path testFileDecimal;
+
+    @BeforeAll
+    static void setupFiles(@TempDir java.nio.file.Path tmpDir) {
+        testFileFlat =
+                copyFileFromResource("test-data-flat.orc", tmpDir.resolve("test-data-flat.orc"));
+        testFileDecimal =
+                copyFileFromResource(
+                        "test-data-decimal.orc", tmpDir.resolve("test-data-decimal.orc"));
+    }
 
     @Test
-    public void testReadFileInSplits() throws IOException {
+    void testReadFileInSplits() throws IOException {
         FileInputSplit[] splits = createSplits(testFileFlat, 4);
 
         long cnt = 0;
@@ -108,7 +115,7 @@ public class OrcColumnarRowSplitReaderTest {
     }
 
     @Test
-    public void testReadDecimalTypeFile() throws IOException {
+    void testReadDecimalTypeFile() throws IOException {
         FileInputSplit[] splits = createSplits(testFileDecimal, 1);
 
         try (OrcColumnarRowSplitReader reader =
@@ -140,7 +147,7 @@ public class OrcColumnarRowSplitReaderTest {
     }
 
     @Test
-    public void testReadFileWithSelectFields() throws IOException {
+    void testReadFileWithSelectFields() throws IOException {
         FileInputSplit[] splits = createSplits(testFileFlat, 4);
 
         long cnt = 0;
@@ -206,7 +213,7 @@ public class OrcColumnarRowSplitReaderTest {
     }
 
     @Test
-    public void testReadFileWithPartitionValues() throws IOException {
+    void testReadFileWithPartitionValues() throws IOException {
         FileInputSplit[] splits = createSplits(testFileFlat, 4);
 
         long cnt = 0;
@@ -289,8 +296,7 @@ public class OrcColumnarRowSplitReaderTest {
     }
 
     @Test
-    public void testReadFileWithTypes() throws IOException {
-        File folder = TEMPORARY_FOLDER.newFolder();
+    void testReadFileWithTypes(@TempDir File folder) throws IOException {
         String file = new File(folder, "testOrc").getPath();
         int rowSize = 1024;
 
@@ -375,7 +381,7 @@ public class OrcColumnarRowSplitReaderTest {
     }
 
     @Test
-    public void testReachEnd() throws Exception {
+    void testReachEnd() throws Exception {
         FileInputSplit[] splits = createSplits(testFileFlat, 1);
         try (OrcColumnarRowSplitReader reader =
                 createReader(new int[] {0, 1}, testSchemaFlat, new HashMap<>(), splits[0])) {
@@ -409,19 +415,6 @@ public class OrcColumnarRowSplitReaderTest {
                 split.getPath(),
                 split.getStart(),
                 split.getLength());
-    }
-
-    private String getPath(String fileName) {
-        try {
-            File file = TEMPORARY_FOLDER.newFile();
-            IOUtils.copyBytes(
-                    getClass().getClassLoader().getResource(fileName).openStream(),
-                    new FileOutputStream(file),
-                    true);
-            return file.getPath();
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
     }
 
     private static FileInputSplit[] createSplits(Path path, int minNumSplits) throws IOException {

--- a/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/OrcColumnarRowSplitReaderTest.java
+++ b/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/OrcColumnarRowSplitReaderTest.java
@@ -56,7 +56,7 @@ import static org.apache.flink.table.utils.DateTimeUtils.toSQLDate;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link OrcColumnarRowSplitReader}. */
-class OrcColumnarRowSplitReaderTest {
+public class OrcColumnarRowSplitReaderTest {
 
     protected static final int BATCH_SIZE = 10;
 

--- a/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/OrcFileSystemFilterTest.java
+++ b/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/OrcFileSystemFilterTest.java
@@ -26,7 +26,7 @@ import org.apache.flink.table.expressions.ValueLiteralExpression;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 
 import org.apache.hadoop.hive.ql.io.sarg.PredicateLeaf;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -34,7 +34,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Unit Tests for {@link OrcFileFormatFactory}. */
-public class OrcFileSystemFilterTest {
+class OrcFileSystemFilterTest {
 
     @Test
     @SuppressWarnings("unchecked")
@@ -54,7 +54,7 @@ public class OrcFileSystemFilterTest {
         OrcFilters.Predicate predicate1 = OrcFilters.toOrcPredicate(equalExpression);
         OrcFilters.Predicate predicate2 =
                 new OrcFilters.Equals("long1", PredicateLeaf.Type.LONG, 10);
-        assertThat(predicate1.toString()).isEqualTo(predicate2.toString());
+        assertThat(predicate1).hasToString(predicate2.toString());
 
         // greater than
         CallExpression greaterExpression =
@@ -64,7 +64,7 @@ public class OrcFileSystemFilterTest {
         OrcFilters.Predicate predicate4 =
                 new OrcFilters.Not(
                         new OrcFilters.LessThanEquals("long1", PredicateLeaf.Type.LONG, 10));
-        assertThat(predicate3.toString()).isEqualTo(predicate4.toString());
+        assertThat(predicate3).hasToString(predicate4.toString());
 
         // less than
         CallExpression lessExpression =
@@ -73,6 +73,6 @@ public class OrcFileSystemFilterTest {
         OrcFilters.Predicate predicate5 = OrcFilters.toOrcPredicate(lessExpression);
         OrcFilters.Predicate predicate6 =
                 new OrcFilters.LessThan("long1", PredicateLeaf.Type.LONG, 10);
-        assertThat(predicate5.toString()).isEqualTo(predicate6.toString());
+        assertThat(predicate5).hasToString(predicate6.toString());
     }
 }

--- a/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/OrcSplitReaderUtilTest.java
+++ b/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/OrcSplitReaderUtilTest.java
@@ -21,16 +21,16 @@ package org.apache.flink.orc;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.types.DataType;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.flink.orc.OrcSplitReaderUtil.logicalTypeToOrcType;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link OrcSplitReaderUtil}. */
-public class OrcSplitReaderUtilTest {
+class OrcSplitReaderUtilTest {
 
     @Test
-    public void testLogicalTypeToOrcType() {
+    void testLogicalTypeToOrcType() {
         test("boolean", DataTypes.BOOLEAN());
         test("char(123)", DataTypes.CHAR(123));
         test("varchar(123)", DataTypes.VARCHAR(123));
@@ -61,6 +61,6 @@ public class OrcSplitReaderUtilTest {
     }
 
     private void test(String expected, DataType type) {
-        assertThat(logicalTypeToOrcType(type.getLogicalType()).toString()).isEqualTo(expected);
+        assertThat(logicalTypeToOrcType(type.getLogicalType())).hasToString(expected);
     }
 }

--- a/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/util/OrcBulkWriterTestUtil.java
+++ b/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/util/OrcBulkWriterTestUtil.java
@@ -67,8 +67,7 @@ public class OrcBulkWriterTestUtil {
 
             List<Record> results = getResults(reader);
 
-            assertThat(results).hasSize(3);
-            assertThat(results).isEqualTo(expected);
+            assertThat(results).hasSize(3).isEqualTo(expected);
         }
     }
 

--- a/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/writer/OrcBulkRowDataWriterTest.java
+++ b/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/writer/OrcBulkRowDataWriterTest.java
@@ -53,10 +53,9 @@ import org.apache.orc.CompressionKind;
 import org.apache.orc.OrcFile;
 import org.apache.orc.Reader;
 import org.apache.orc.RecordReader;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
@@ -72,12 +71,10 @@ import java.util.Properties;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Unit test for the ORC BulkWriter write RowData with nested type. */
-public class OrcBulkRowDataWriterTest {
-
-    @ClassRule public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+class OrcBulkRowDataWriterTest {
 
     @SuppressWarnings("FieldCanBeLocal")
-    private String schema =
+    private final String schema =
             "struct<_col0:string,_col1:int,_col2:array<struct<_col2_col0:string>>,"
                     + "_col3:map<string,struct<_col3_col0:string,_col3_col1:timestamp>>>";
 
@@ -85,8 +82,7 @@ public class OrcBulkRowDataWriterTest {
     private List<RowData> input;
 
     @Test
-    public void testOrcBulkWriterWithRowData() throws Exception {
-        final File outDir = TEMPORARY_FOLDER.newFolder();
+    void testOrcBulkWriterWithRowData(@TempDir File outDir) throws Exception {
         final Properties writerProps = new Properties();
         writerProps.setProperty("orc.compress", "LZ4");
 
@@ -120,8 +116,8 @@ public class OrcBulkRowDataWriterTest {
         }
     }
 
-    @Before
-    public void initInput() {
+    @BeforeEach
+    void initInput() {
         input = new ArrayList<>();
         fieldTypes = new LogicalType[4];
         fieldTypes[0] = new VarCharType();
@@ -189,7 +185,6 @@ public class OrcBulkRowDataWriterTest {
 
     private void validate(File files, List<RowData> expected) throws IOException {
         final File[] buckets = files.listFiles();
-        assertThat(buckets).isNotNull();
         assertThat(buckets).hasSize(1);
 
         final File[] partFiles = buckets[0].listFiles();
@@ -209,8 +204,7 @@ public class OrcBulkRowDataWriterTest {
 
             List<RowData> results = getResults(reader);
 
-            assertThat(results).hasSize(2);
-            assertThat(results).isEqualTo(expected);
+            assertThat(results).hasSize(2).isEqualTo(expected);
         }
     }
 

--- a/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/writer/OrcBulkWriterFactoryTest.java
+++ b/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/writer/OrcBulkWriterFactoryTest.java
@@ -26,9 +26,8 @@ import org.apache.flink.orc.vector.Vectorizer;
 import org.apache.hadoop.fs.Path;
 import org.apache.orc.MemoryManager;
 import org.apache.orc.OrcFile;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -38,18 +37,16 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests the behavior of {@link OrcBulkWriterFactory}. */
-public class OrcBulkWriterFactoryTest {
-
-    @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
+class OrcBulkWriterFactoryTest {
 
     @Test
-    public void testNotOverrideInMemoryManager() throws IOException {
+    void testNotOverrideInMemoryManager(@TempDir java.nio.file.Path tmpDir) throws IOException {
         TestMemoryManager memoryManager = new TestMemoryManager();
         OrcBulkWriterFactory<Record> factory =
                 new TestOrcBulkWriterFactory<>(
                         new RecordVectorizer("struct<_col0:string,_col1:int>"), memoryManager);
-        factory.create(new LocalDataOutputStream(temporaryFolder.newFile()));
-        factory.create(new LocalDataOutputStream(temporaryFolder.newFile()));
+        factory.create(new LocalDataOutputStream(tmpDir.resolve("file1").toFile()));
+        factory.create(new LocalDataOutputStream(tmpDir.resolve("file2").toFile()));
 
         List<Path> addedWriterPath = memoryManager.getAddedWriterPath();
         assertThat(addedWriterPath).hasSize(2);

--- a/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/writer/OrcBulkWriterITCase.java
+++ b/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/writer/OrcBulkWriterITCase.java
@@ -28,12 +28,10 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink;
 import org.apache.flink.streaming.api.functions.sink.filesystem.bucketassigners.UniqueBucketAssigner;
 import org.apache.flink.streaming.util.FiniteTestSource;
-import org.apache.flink.util.TestLogger;
 
 import org.apache.hadoop.conf.Configuration;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.util.Arrays;
@@ -41,17 +39,14 @@ import java.util.List;
 import java.util.Properties;
 
 /** Integration test for writing data in ORC bulk format using StreamingFileSink. */
-public class OrcBulkWriterITCase extends TestLogger {
-
-    @ClassRule public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+class OrcBulkWriterITCase {
 
     private final String schema = "struct<_col0:string,_col1:int>";
     private final List<Record> testData =
             Arrays.asList(new Record("Sourav", 41), new Record("Saul", 35), new Record("Kim", 31));
 
     @Test
-    public void testOrcBulkWriter() throws Exception {
-        final File outDir = TEMPORARY_FOLDER.newFolder();
+    void testOrcBulkWriter(@TempDir File outDir) throws Exception {
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         final Properties writerProps = new Properties();
         writerProps.setProperty("orc.compress", "LZ4");

--- a/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/writer/OrcBulkWriterTest.java
+++ b/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/writer/OrcBulkWriterTest.java
@@ -28,9 +28,8 @@ import org.apache.flink.streaming.api.operators.StreamSink;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 
 import org.apache.hadoop.conf.Configuration;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.util.Arrays;
@@ -38,17 +37,14 @@ import java.util.List;
 import java.util.Properties;
 
 /** Unit test for the ORC BulkWriter implementation. */
-public class OrcBulkWriterTest {
-
-    @ClassRule public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+class OrcBulkWriterTest {
 
     private final String schema = "struct<_col0:string,_col1:int>";
     private final List<Record> input =
             Arrays.asList(new Record("Shiv", 44), new Record("Jesse", 23), new Record("Walt", 50));
 
     @Test
-    public void testOrcBulkWriter() throws Exception {
-        final File outDir = TEMPORARY_FOLDER.newFolder();
+    void testOrcBulkWriter(@TempDir File outDir) throws Exception {
         final Properties writerProps = new Properties();
         writerProps.setProperty("orc.compress", "LZ4");
 

--- a/flink-formats/flink-orc/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/flink-formats/flink-orc/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.util.TestLoggerExtension


### PR DESCRIPTION
## What is the purpose of the change

Update the `flink-formats/flink-orc` module to AssertJ and JUnit 5 following the [JUnit 5 Migration Guide](https://docs.google.com/document/d/1514Wa_aNB9bJUen4xm5uiuXOooOJTtXqS_Jqk9KJitU/edit)

## Brief change log

* Removed dependences on JUnit 4, JUnit 5 Assertions and Hamcrest where possible.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

I've verified that there are 62 tests run in this module before and after the refactoring.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive):no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no