### PR TITLE
 [FLINK-27933][coordination] OperationResult is serializable 

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/AkkaOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/AkkaOptions.java
@@ -35,7 +35,7 @@ public class AkkaOptions {
 
     @Internal
     @Documentation.ExcludeFromDocumentation("Internal use only")
-    private static final ConfigOption<Boolean> FORCE_RPC_INVOCATION_SERIALIZATION =
+    public static final ConfigOption<Boolean> FORCE_RPC_INVOCATION_SERIALIZATION =
             ConfigOptions.key("akka.rpc.force-invocation-serialization")
                     .booleanType()
                     .defaultValue(false)
@@ -49,8 +49,11 @@ public class AkkaOptions {
                                     .build());
 
     public static boolean isForceRpcInvocationSerializationEnabled(Configuration config) {
-        return config.get(FORCE_RPC_INVOCATION_SERIALIZATION)
-                || System.getProperties().containsKey(FORCE_RPC_INVOCATION_SERIALIZATION.key());
+        return config.getOptional(FORCE_RPC_INVOCATION_SERIALIZATION)
+                .orElse(
+                        FORCE_RPC_INVOCATION_SERIALIZATION.defaultValue()
+                                || System.getProperties()
+                                        .containsKey(FORCE_RPC_INVOCATION_SERIALIZATION.key()));
     }
 
     /** Flag whether to capture call stacks for RPC ask calls. */

--- a/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcService.java
+++ b/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcService.java
@@ -349,6 +349,7 @@ public class AkkaRpcService implements RpcService {
                                             actorTerminationFuture,
                                             getVersion(),
                                             configuration.getMaximumFramesize(),
+                                            configuration.isForceRpcInvocationSerialization(),
                                             flinkClassLoader),
                             rpcEndpoint.getEndpointId());
 

--- a/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/akka/FencedAkkaRpcActor.java
+++ b/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/akka/FencedAkkaRpcActor.java
@@ -45,8 +45,15 @@ public class FencedAkkaRpcActor<F extends Serializable, T extends FencedRpcEndpo
             CompletableFuture<Boolean> terminationFuture,
             int version,
             final long maximumFramesize,
+            final boolean forceSerialization,
             ClassLoader flinkClassLoader) {
-        super(rpcEndpoint, terminationFuture, version, maximumFramesize, flinkClassLoader);
+        super(
+                rpcEndpoint,
+                terminationFuture,
+                version,
+                maximumFramesize,
+                forceSerialization,
+                flinkClassLoader);
     }
 
     @Override

--- a/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActorOversizedResponseMessageTest.java
+++ b/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActorOversizedResponseMessageTest.java
@@ -57,6 +57,8 @@ class AkkaRpcActorOversizedResponseMessageTest {
     @BeforeAll
     static void setupClass() throws Exception {
         final Configuration configuration = new Configuration();
+        // some tests explicitly test local communication where no serialization should occur
+        configuration.set(AkkaOptions.FORCE_RPC_INVOCATION_SERIALIZATION, false);
         configuration.setString(AkkaOptions.FRAMESIZE, FRAMESIZE + " b");
 
         rpcService1 =

--- a/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/ContextClassLoadingSettingTest.java
+++ b/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/ContextClassLoadingSettingTest.java
@@ -19,6 +19,7 @@ package org.apache.flink.runtime.rpc.akka;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.concurrent.akka.AkkaFutureUtils;
+import org.apache.flink.runtime.rpc.Local;
 import org.apache.flink.runtime.rpc.RpcEndpoint;
 import org.apache.flink.runtime.rpc.RpcGateway;
 import org.apache.flink.runtime.rpc.RpcService;
@@ -439,6 +440,7 @@ class ContextClassLoadingSettingTest {
         }
 
         @Override
+        @Local
         public CompletableFuture<ClassLoader> getContextClassLoader() {
             return CompletableFuture.completedFuture(
                     Thread.currentThread().getContextClassLoader());

--- a/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/ContextClassLoadingSettingTest.java
+++ b/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/ContextClassLoadingSettingTest.java
@@ -359,10 +359,6 @@ class ContextClassLoadingSettingTest {
 
         CompletableFuture<Void> doSomethingAsync();
 
-        CompletableFuture<ClassLoader> doCallAsync();
-
-        CompletableFuture<ClassLoader> doRunAsync();
-
         void doSomethingWithoutReturningAnything();
 
         CompletableFuture<PickyObject> getPickyObject();
@@ -414,13 +410,11 @@ class ContextClassLoadingSettingTest {
             return rpcResponseFuture;
         }
 
-        @Override
         public CompletableFuture<ClassLoader> doCallAsync() {
             return callAsync(
                     () -> Thread.currentThread().getContextClassLoader(), Duration.ofSeconds(10));
         }
 
-        @Override
         public CompletableFuture<ClassLoader> doRunAsync() {
             final CompletableFuture<ClassLoader> contextClassLoader = new CompletableFuture<>();
             runAsync(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -60,6 +60,7 @@ import org.apache.flink.runtime.rest.messages.ThreadDumpInfo;
 import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerInfo;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.FencedRpcEndpoint;
+import org.apache.flink.runtime.rpc.Local;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.RpcServiceUtils;
 import org.apache.flink.runtime.security.token.DelegationTokenManager;
@@ -818,6 +819,7 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
     }
 
     @Override
+    @Local // Bug; see FLINK-27954
     public CompletableFuture<TaskExecutorThreadInfoGateway> requestTaskExecutorThreadInfoGateway(
             ResourceID taskManagerId, Time timeout) {
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/async/AbstractAsynchronousOperationHandlers.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/async/AbstractAsynchronousOperationHandlers.java
@@ -33,6 +33,7 @@ import org.apache.flink.util.concurrent.FutureUtils;
 
 import javax.annotation.Nonnull;
 
+import java.io.Serializable;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
@@ -87,7 +88,8 @@ import java.util.concurrent.CompletableFuture;
  * @param <K> type of the operation key under which the result future is stored
  * @param <R> type of the operation result
  */
-public abstract class AbstractAsynchronousOperationHandlers<K extends OperationKey, R> {
+public abstract class AbstractAsynchronousOperationHandlers<
+        K extends OperationKey, R extends Serializable> {
 
     private final CompletedOperationCache<K, R> completedOperationCache;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/async/CompletedOperationCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/async/CompletedOperationCache.java
@@ -36,6 +36,7 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
+import java.io.Serializable;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
@@ -56,7 +57,8 @@ import static org.apache.flink.util.Preconditions.checkState;
  * operations will be removed from the cache automatically after a fixed timeout.
  */
 @ThreadSafe
-public class CompletedOperationCache<K extends OperationKey, R> implements AutoCloseableAsync {
+public class CompletedOperationCache<K extends OperationKey, R extends Serializable>
+        implements AutoCloseableAsync {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CompletedOperationCache.class);
 
@@ -207,7 +209,7 @@ public class CompletedOperationCache<K extends OperationKey, R> implements AutoC
     }
 
     /** Stores the result of an asynchronous operation, and tracks accesses to it. */
-    private static class ResultAccessTracker<R> {
+    private static class ResultAccessTracker<R extends Serializable> {
 
         /** Result of an asynchronous operation. */
         private final OperationResult<R> operationResult;
@@ -215,7 +217,7 @@ public class CompletedOperationCache<K extends OperationKey, R> implements AutoC
         /** Future that completes if {@link #operationResult} is accessed after it finished. */
         private final CompletableFuture<Void> accessed;
 
-        private static <R> ResultAccessTracker<R> inProgress() {
+        private static <R extends Serializable> ResultAccessTracker<R> inProgress() {
             return new ResultAccessTracker<>();
         }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/async/OperationResult.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/async/OperationResult.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.rest.handler.async;
 
 import javax.annotation.Nullable;
 
+import java.io.Serializable;
 import java.util.Objects;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -29,7 +30,9 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * OperationResultStatus}, it contains either the actual result (if completed successfully), or the
  * cause of failure (if it failed), or none of the two (if still in progress).
  */
-public class OperationResult<R> {
+public class OperationResult<R> implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     private final OperationResultStatus status;
     @Nullable private final R result;
     @Nullable private final Throwable throwable;
@@ -58,17 +61,17 @@ public class OperationResult<R> {
         return throwable;
     }
 
-    public static <R> OperationResult<R> failure(Throwable throwable) {
+    public static <R extends Serializable> OperationResult<R> failure(Throwable throwable) {
         checkNotNull(throwable);
         return new OperationResult<>(OperationResultStatus.FAILURE, null, throwable);
     }
 
-    public static <R> OperationResult<R> success(R result) {
+    public static <R extends Serializable> OperationResult<R> success(R result) {
         checkNotNull(result);
         return new OperationResult<>(OperationResultStatus.SUCCESS, result, null);
     }
 
-    public static <R> OperationResult<R> inProgress() {
+    public static <R extends Serializable> OperationResult<R> inProgress() {
         return new OperationResult<>(OperationResultStatus.IN_PROGRESS, null, null);
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/dataset/ClusterDataSetDeleteHandlers.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/dataset/ClusterDataSetDeleteHandlers.java
@@ -38,13 +38,15 @@ import org.apache.flink.runtime.webmonitor.RestfulGateway;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
 import org.apache.flink.util.SerializedThrowable;
 
+import java.io.Serializable;
 import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 /** Handler for {@link ClusterDataSetDeleteTriggerHeaders}. */
 public class ClusterDataSetDeleteHandlers
-        extends AbstractAsynchronousOperationHandlers<OperationKey, Void> {
+        extends AbstractAsynchronousOperationHandlers<
+                OperationKey, ClusterDataSetDeleteHandlers.SerializableVoid> {
 
     public ClusterDataSetDeleteHandlers(Duration cacheDuration) {
         super(cacheDuration);
@@ -73,7 +75,7 @@ public class ClusterDataSetDeleteHandlers
         }
 
         @Override
-        protected CompletableFuture<Void> triggerOperation(
+        protected CompletableFuture<SerializableVoid> triggerOperation(
                 HandlerRequest<EmptyRequestBody> request, RestfulGateway gateway)
                 throws RestHandlerException {
             final IntermediateDataSetID clusterPartitionId =
@@ -81,7 +83,9 @@ public class ClusterDataSetDeleteHandlers
             ResourceManagerGateway resourceManagerGateway =
                     AbstractResourceManagerHandler.getResourceManagerGateway(
                             resourceManagerGatewayRetriever);
-            return resourceManagerGateway.releaseClusterPartitions(clusterPartitionId);
+            return resourceManagerGateway
+                    .releaseClusterPartitions(clusterPartitionId)
+                    .thenApply(ignored -> null);
         }
 
         @Override
@@ -122,8 +126,18 @@ public class ClusterDataSetDeleteHandlers
         }
 
         @Override
-        protected AsynchronousOperationInfo operationResultResponse(Void ignored) {
+        protected AsynchronousOperationInfo operationResultResponse(SerializableVoid ignored) {
             return AsynchronousOperationInfo.complete();
         }
+    }
+
+    /**
+     * A {@link Void} alternative that implements {@link Serializable}. Useful in cases where a type
+     * must be serializable but in practice is always null.
+     */
+    public static class SerializableVoid implements Serializable {
+        private static final long serialVersionUID = 1L;
+
+        private SerializableVoid() {}
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -557,7 +557,7 @@ public class DispatcherTest extends AbstractDispatcherTest {
                         .deserializeError(ClassLoader.getSystemClassLoader());
 
         // ensure correct exception type
-        assertThat(throwable, is(testFailure));
+        assertThat(throwable.getMessage(), equalTo(testFailure.getMessage()));
     }
 
     /** Test that {@link JobResult} is cached when the job finishes. */
@@ -590,9 +590,10 @@ public class DispatcherTest extends AbstractDispatcherTest {
         assertThat(
                 dispatcherGateway.requestJobStatus(failedJobId, TIMEOUT).get(),
                 equalTo(expectedState));
-        assertThat(
-                dispatcherGateway.requestExecutionGraphInfo(failedJobId, TIMEOUT).get(),
-                equalTo(failedExecutionGraphInfo));
+        final CompletableFuture<ExecutionGraphInfo> completableFutureCompletableFuture =
+                dispatcher.callAsyncInMainThread(
+                        () -> dispatcher.requestExecutionGraphInfo(failedJobId, TIMEOUT));
+        assertThat(completableFutureCompletableFuture.get(), is(failedExecutionGraphInfo));
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/TestingDispatcher.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/TestingDispatcher.java
@@ -44,6 +44,7 @@ import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.scheduler.ExecutionGraphInfo;
 import org.apache.flink.runtime.util.TestingFatalErrorHandler;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+import org.apache.flink.testutils.TestingUtils;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.TimeUtils;
 
@@ -52,6 +53,7 @@ import javax.annotation.Nullable;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
@@ -138,6 +140,10 @@ class TestingDispatcher extends Dispatcher {
                         throw new CompletionException(e);
                     }
                 });
+    }
+
+    <T> CompletableFuture<T> callAsyncInMainThread(Callable<CompletableFuture<T>> callable) {
+        return callAsync(callable, TestingUtils.TESTING_DURATION).thenCompose(Function.identity());
     }
 
     CompletableFuture<Void> getJobTerminationFuture(@Nonnull JobID jobId, @Nonnull Time timeout) {


### PR DESCRIPTION
Based on #19968 because this PR changes some timings that trigger FLINK-27972.

With this PR the OperationResult is serializable, as well as the contained result.
Additionally the switch to force serialization, introduced in FLINK-26780, now also applies to return values (and not just method arguments). Several problematic cases, mostly in tests, were also fixed.