### PR TITLE
[FLINK-28147][Python] Update httplib2 to at least 0.19.0

### DIFF
--- a/flink-python/dev/dev-requirements.txt
+++ b/flink-python/dev/dev-requirements.txt
@@ -32,4 +32,4 @@ fastavro>=1.1.0,<1.4.8
 grpcio>=1.29.0,<2
 grpcio-tools>=1.3.5,<=1.14.2
 pemja==0.1.5; python_version >= '3.7' and platform_system != 'Windows'
-httplib2>=0.8,<0.19.0
+httplib2>=0.19.0,<=0.20.4

--- a/flink-python/setup.py
+++ b/flink-python/setup.py
@@ -303,7 +303,7 @@ try:
                         'protobuf<3.18',
                         'pemja==0.1.5;'
                         'python_full_version >= "3.7" and platform_system != "Windows"',
-                        'httplib2>=0.8,<0.19.0', apache_flink_libraries_dependency]
+                        'httplib2>=0.19.0,<=0.20.4', apache_flink_libraries_dependency]
 
     if sys.version_info < (3, 7):
         # python 3.6 upper and lower limit


### PR DESCRIPTION
## What is the purpose of the change

* Updating httplib2 to at least 0.19.0 to address CVE-2021-21240 and avoid false flags about Flink being vulnerable.

## Brief change log

* Updated Python dev requirements for httplib2

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
