### PR TITLE
[FLINK-28125] Promote leadership changing logs to INFO level

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/DefaultDispatcherRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/DefaultDispatcherRunner.java
@@ -102,15 +102,7 @@ public final class DefaultDispatcherRunner implements DispatcherRunner, LeaderCo
 
     @Override
     public void grantLeadership(UUID leaderSessionID) {
-        runActionIfRunning(
-                () -> {
-                    LOG.info(
-                            "{} was granted leadership with leader id {}. Creating new {}.",
-                            getClass().getSimpleName(),
-                            leaderSessionID,
-                            DispatcherLeaderProcess.class.getSimpleName());
-                    startNewDispatcherLeaderProcess(leaderSessionID);
-                });
+        runActionIfRunning(() -> startNewDispatcherLeaderProcess(leaderSessionID));
     }
 
     private void startNewDispatcherLeaderProcess(UUID leaderSessionID) {
@@ -180,15 +172,7 @@ public final class DefaultDispatcherRunner implements DispatcherRunner, LeaderCo
 
     @Override
     public void revokeLeadership() {
-        runActionIfRunning(
-                () -> {
-                    LOG.info(
-                            "{} was revoked the leadership with leader id {}. Stopping the {}.",
-                            getClass().getSimpleName(),
-                            dispatcherLeaderProcess.getLeaderSessionId(),
-                            DispatcherLeaderProcess.class.getSimpleName());
-                    this.stopDispatcherLeaderProcess();
-                });
+        runActionIfRunning(() -> this.stopDispatcherLeaderProcess());
     }
 
     private void runActionIfRunning(Runnable runnable) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionService.java
@@ -193,13 +193,10 @@ public class DefaultLeaderElectionService
             if (running) {
                 issuedLeaderSessionID = newLeaderSessionId;
                 clearConfirmedLeaderInformation();
-
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug(
-                            "Grant leadership to contender {} with session ID {}.",
-                            leaderContender.getDescription(),
-                            issuedLeaderSessionID);
-                }
+                LOG.info(
+                        "Grant leadership to contender {} with session ID {}.",
+                        leaderContender.getDescription(),
+                        issuedLeaderSessionID);
 
                 leaderContender.grantLeadership(issuedLeaderSessionID);
             } else {
@@ -218,13 +215,11 @@ public class DefaultLeaderElectionService
     public void onRevokeLeadership() {
         synchronized (lock) {
             if (running) {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug(
-                            "Revoke leadership of {} ({}@{}).",
-                            leaderContender.getDescription(),
-                            confirmedLeaderInformation.getLeaderSessionID(),
-                            confirmedLeaderInformation.getLeaderAddress());
-                }
+                LOG.info(
+                        "Revoke leadership of {} ({}@{}).",
+                        leaderContender.getDescription(),
+                        confirmedLeaderInformation.getLeaderSessionID(),
+                        confirmedLeaderInformation.getLeaderAddress());
 
                 issuedLeaderSessionID = null;
                 clearConfirmedLeaderInformation();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerServiceImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerServiceImpl.java
@@ -196,10 +196,6 @@ public class ResourceManagerServiceImpl implements ResourceManagerService, Leade
                             return;
                         }
 
-                        LOG.info(
-                                "Resource manager service is granted leadership with session id {}.",
-                                newLeaderSessionID);
-
                         try {
                             startNewLeaderResourceManager(newLeaderSessionID);
                         } catch (Throwable t) {
@@ -220,11 +216,6 @@ public class ResourceManagerServiceImpl implements ResourceManagerService, Leade
                                     "Resource manager service is not running. Ignore revoking leadership.");
                             return;
                         }
-
-                        LOG.info(
-                                "Resource manager service is revoked leadership with session id {}.",
-                                leaderSessionID);
-
                         stopLeaderResourceManager();
 
                         if (!resourceManagerFactory.supportMultiLeaderSession()) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
@@ -1010,17 +1010,11 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
 
     @Override
     public void grantLeadership(final UUID leaderSessionID) {
-        log.info(
-                "{} was granted leadership with leaderSessionID={}",
-                getRestBaseUrl(),
-                leaderSessionID);
         leaderElectionService.confirmLeadership(leaderSessionID, getRestBaseUrl());
     }
 
     @Override
-    public void revokeLeadership() {
-        log.info("{} lost leadership", getRestBaseUrl());
-    }
+    public void revokeLeadership() {}
 
     @Override
     public String getDescription() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingContender.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingContender.java
@@ -43,8 +43,6 @@ public class TestingContender extends TestingLeaderBase implements LeaderContend
 
     @Override
     public void grantLeadership(UUID leaderSessionID) {
-        LOG.debug("Was granted leadership with session ID {}.", leaderSessionID);
-
         this.leaderSessionID = leaderSessionID;
 
         leaderElectionService.confirmLeadership(leaderSessionID, address);
@@ -54,8 +52,6 @@ public class TestingContender extends TestingLeaderBase implements LeaderContend
 
     @Override
     public void revokeLeadership() {
-        LOG.debug("Was revoked leadership. Old session ID {}.", leaderSessionID);
-
         leaderSessionID = null;
         leaderEventQueue.offer(LeaderInformation.empty());
     }


### PR DESCRIPTION
## What is the purpose of the change

Promote leadership changing logs to INFO level.



## Brief change log
  - *Printing the INFO logs from DeafaultLeaderElectionService*
  - *Removing the contender side logs to avoid redundancy*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
