### PR TITLE
[hotfix][checkpointing] Updated waiting for final checkpoint section

### DIFF
--- a/docs/content/docs/dev/datastream/fault-tolerance/checkpointing.md
+++ b/docs/content/docs/dev/datastream/fault-tolerance/checkpointing.md
@@ -278,7 +278,7 @@ task with the number of new subtasks equal to the number of running tasks.
 ### Waiting for the final checkpoint before task exit
 
 To ensure all the records could be committed for operators using the two-phase commit, 
-the tasks would wait for the final checkpoint completed successfully after all the operators finished. 
+the tasks would wait for the final checkpoint to be completed successfully after all the operators finished. 
 It needs to be noted that this behavior would prolong the execution time of tasks. 
 If the checkpoint interval is long, the execution time would also be prolonged largely. 
 For the worst case, if the checkpoint interval is set to `Long.MAX_VALUE`, 


### PR DESCRIPTION

## What is the purpose of the change

* The description indicates <code>...the tasks would wait for the final checkpoint **completed** successfully after all the operators finished</code>.  
Updated to <code>...the tasks would wait for the final checkpoint **to be completed** successfully after all the operators finished</code>.

## Brief change log

* Updated description

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
