### PR TITLE
[FLINK-26762][docs] Document overdraft buffers

### DIFF
--- a/docs/content.zh/docs/deployment/memory/network_mem_tuning.md
+++ b/docs/content.zh/docs/deployment/memory/network_mem_tuning.md
@@ -122,8 +122,8 @@ Flink 有多个本地缓冲区池 —— 每个输出和输入流对应一个。
 
 For each output subtask can also request up to `taskmanager.network.memory.max-overdraft-buffers-per-gate`
 (by default 5) extra overdraft buffers. Those buffers are only used, if the subtask is backpressured
-by downstream subtasks but the subtask can not gracefully pause its current process. This can happen
-in situations like:
+by downstream subtasks and the subtask requires more than a single network buffer to finish what its
+currently doing. This can happen in situations like:
 - Serializing very large records, that do not fit into a single network buffer.
 - Flat Map like operator, that produces many output records per single input record.
 - Operators that output many records either periodically or on a reaction to some events (for

--- a/docs/content/docs/deployment/memory/network_mem_tuning.md
+++ b/docs/content/docs/deployment/memory/network_mem_tuning.md
@@ -124,8 +124,8 @@ Unlike the input buffer pool, the configured amount of exclusive buffers and flo
 
 For each output subtask can also request up to `taskmanager.network.memory.max-overdraft-buffers-per-gate`
 (by default 5) extra overdraft buffers. Those buffers are only used, if the subtask is backpressured
-by downstream subtasks but the subtask can not gracefully pause its current process. This can happen
-in situations like:
+by downstream subtasks and the subtask requires more than a single network buffer to finish what its
+currently doing. This can happen in situations like:
 - Serializing very large records, that do not fit into a single network buffer.
 - Flat Map like operator, that produces many output records per single input record.
 - Operators that output many records either periodically or on a reaction to some events (for

--- a/docs/content/docs/deployment/memory/network_mem_tuning.md
+++ b/docs/content/docs/deployment/memory/network_mem_tuning.md
@@ -122,16 +122,20 @@ Unlike the input buffer pool, the configured amount of exclusive buffers and flo
 
 #### Overdraft buffers
 
-For each output subtask can also request up to `taskmanager.network.memory.max-overdraft-buffers-per-gate` (by default 5) extra overdraft buffers.
-Those buffers are only used, if despite presence of a backpressure, Flink can not stop producing more records to the output.
-This can happen in situations like:
+For each output subtask can also request up to `taskmanager.network.memory.max-overdraft-buffers-per-gate`
+(by default 5) extra overdraft buffers. Those buffers are only used, if the subtask is backpressured
+by downstream subtasks but the subtask can not gracefully pause its current process. This can happen
+in situations like:
 - Serializing very large records, that do not fit into a single network buffer.
 - Flat Map like operator, that produces many output records per single input record.
-- Operators that output many records either periodically or on a reaction to some event (for example `WindowOperator`).
+- Operators that output many records either periodically or on a reaction to some events (for
+example `WindowOperator`'s triggers).
 
-Without overdraft buffers in such situations Flink subtask thread would block on the backpressure, preventing for example unaligned checkpoints
-from being triggered. To mitigate this, the overdraft buffers concept has been added. Those buffers are strictly optional and Flink can
-make progress even if the Task Manager doesn't have any spare buffers in the global pool to be used as overdraft buffers.
+Without overdraft buffers in such situations Flink subtask thread would block on the backpressure,
+preventing for example unaligned checkpoints from completing. To mitigate this, the overdraft
+buffers concept has been added. Those overdraft buffers are strictly optional and Flink can
+gradually make progress using only regular buffers, which means `0` is an acceptable configuration
+for the `taskmanager.network.memory.max-overdraft-buffers-per-gate`.
 
 ## The number of in-flight buffers 
 


### PR DESCRIPTION
This documents a change added by https://github.com/apache/flink/pull/19499 . No testing coverage is necessary.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / no ****/ don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
