### PR TITLE
[FLINK-19358][runtime] Make the job id distinct in application mode w…

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/application/ApplicationDispatcherBootstrap.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/application/ApplicationDispatcherBootstrap.java
@@ -29,6 +29,7 @@ import org.apache.flink.client.deployment.application.executors.EmbeddedExecutor
 import org.apache.flink.client.program.PackagedProgram;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.DeploymentOptions;
+import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.PipelineOptionsInternal;
 import org.apache.flink.core.execution.PipelineExecutorServiceLoader;
 import org.apache.flink.runtime.client.DuplicateJobSubmissionException;
@@ -42,6 +43,7 @@ import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.messages.FlinkJobNotFoundException;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.concurrent.FutureUtils;
 import org.apache.flink.util.concurrent.ScheduledExecutor;
 
@@ -79,8 +81,6 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  */
 @Internal
 public class ApplicationDispatcherBootstrap implements DispatcherBootstrap {
-
-    public static final JobID ZERO_JOB_ID = new JobID(0, 0);
 
     @VisibleForTesting static final String FAILED_JOB_NAME = "(application driver)";
 
@@ -216,8 +216,18 @@ public class ApplicationDispatcherBootstrap implements DispatcherBootstrap {
                     dispatcherGateway, scheduledExecutor, false, submitFailedJobOnApplicationError);
         }
         if (!configuredJobId.isPresent()) {
+            // In HA mode, we only support single-execute jobs at the moment. Here, we manually
+            // generate the job id, if not configured, from the cluster id to keep it consistent
+            // across failover.
             configuration.set(
-                    PipelineOptionsInternal.PIPELINE_FIXED_JOB_ID, ZERO_JOB_ID.toHexString());
+                    PipelineOptionsInternal.PIPELINE_FIXED_JOB_ID,
+                    new JobID(
+                                    Preconditions.checkNotNull(
+                                                    configuration.get(
+                                                            HighAvailabilityOptions.HA_CLUSTER_ID))
+                                            .hashCode(),
+                                    0)
+                            .toHexString());
         }
         return runApplicationAsync(
                 dispatcherGateway, scheduledExecutor, true, submitFailedJobOnApplicationError);

--- a/flink-clients/src/test/java/org/apache/flink/client/deployment/application/ApplicationDispatcherBootstrapITCase.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/deployment/application/ApplicationDispatcherBootstrapITCase.java
@@ -102,9 +102,11 @@ public class ApplicationDispatcherBootstrapITCase {
     public void testDispatcherRecoversAfterLosingAndRegainingLeadership() throws Exception {
         final String blockId = UUID.randomUUID().toString();
         final Configuration configuration = new Configuration();
+        final JobID jobId = new JobID();
         configuration.set(HighAvailabilityOptions.HA_MODE, HighAvailabilityMode.ZOOKEEPER.name());
         configuration.set(DeploymentOptions.TARGET, EmbeddedExecutor.NAME);
         configuration.set(ClientOptions.CLIENT_RETRY_PERIOD, Duration.ofMillis(100));
+        configuration.set(PipelineOptionsInternal.PIPELINE_FIXED_JOB_ID, jobId.toHexString());
         final TestingMiniClusterConfiguration clusterConfiguration =
                 TestingMiniClusterConfiguration.newBuilder()
                         .setConfiguration(configuration)
@@ -124,13 +126,12 @@ public class ApplicationDispatcherBootstrapITCase {
             cluster.start();
 
             // wait until job is running
-            awaitJobStatus(cluster, ApplicationDispatcherBootstrap.ZERO_JOB_ID, JobStatus.RUNNING);
+            awaitJobStatus(cluster, jobId, JobStatus.RUNNING);
 
             // make sure the operator is actually running
             BlockingJob.awaitRunning(blockId);
 
-            final CompletableFuture<JobResult> firstJobResult =
-                    cluster.requestJobResult(ApplicationDispatcherBootstrap.ZERO_JOB_ID);
+            final CompletableFuture<JobResult> firstJobResult = cluster.requestJobResult(jobId);
             haServices.revokeDispatcherLeadership();
             // make sure the leadership is revoked to avoid race conditions
             assertThat(firstJobResult.get())
@@ -139,14 +140,13 @@ public class ApplicationDispatcherBootstrapITCase {
             haServices.grantDispatcherLeadership();
 
             // job is suspended, wait until it's running
-            awaitJobStatus(cluster, ApplicationDispatcherBootstrap.ZERO_JOB_ID, JobStatus.RUNNING);
+            awaitJobStatus(cluster, jobId, JobStatus.RUNNING);
 
             // unblock processing so the job can finish
             BlockingJob.unblock(blockId);
 
             // and wait for it to actually finish
-            final JobResult secondJobResult =
-                    cluster.requestJobResult(ApplicationDispatcherBootstrap.ZERO_JOB_ID).get();
+            final JobResult secondJobResult = cluster.requestJobResult(jobId).get();
             assertThat(secondJobResult.isSuccess()).isTrue();
             assertThat(secondJobResult.getApplicationStatus())
                     .isEqualTo(ApplicationStatus.SUCCEEDED);
@@ -161,9 +161,11 @@ public class ApplicationDispatcherBootstrapITCase {
     @Test
     public void testDirtyJobResultRecoveryInApplicationMode() throws Exception {
         final Configuration configuration = new Configuration();
+        final JobID jobId = new JobID();
         configuration.set(HighAvailabilityOptions.HA_MODE, HighAvailabilityMode.ZOOKEEPER.name());
         configuration.set(DeploymentOptions.TARGET, EmbeddedExecutor.NAME);
         configuration.set(ClientOptions.CLIENT_RETRY_PERIOD, Duration.ofMillis(100));
+        configuration.set(PipelineOptionsInternal.PIPELINE_FIXED_JOB_ID, jobId.toHexString());
         final TestingMiniClusterConfiguration clusterConfiguration =
                 TestingMiniClusterConfiguration.newBuilder()
                         .setConfiguration(configuration)
@@ -173,9 +175,7 @@ public class ApplicationDispatcherBootstrapITCase {
         // implementation fail to submit the job
         final JobResultStore jobResultStore = new EmbeddedJobResultStore();
         jobResultStore.createDirtyResult(
-                new JobResultEntry(
-                        TestingJobResultStore.createSuccessfulJobResult(
-                                ApplicationDispatcherBootstrap.ZERO_JOB_ID)));
+                new JobResultEntry(TestingJobResultStore.createSuccessfulJobResult(jobId)));
         final EmbeddedHaServicesWithLeadershipControl haServices =
                 new EmbeddedHaServicesWithLeadershipControl(EXECUTOR_EXTENSION.getExecutor()) {
 
@@ -205,14 +205,8 @@ public class ApplicationDispatcherBootstrapITCase {
                         "The job's main method shouldn't have been succeeded due to a DuplicateJobSubmissionException.")
                 .hasAtLeastOneElementOfType(DuplicateJobSubmissionException.class);
 
-        assertThat(
-                        jobResultStore.hasDirtyJobResultEntry(
-                                ApplicationDispatcherBootstrap.ZERO_JOB_ID))
-                .isFalse();
-        assertThat(
-                        jobResultStore.hasCleanJobResultEntry(
-                                ApplicationDispatcherBootstrap.ZERO_JOB_ID))
-                .isTrue();
+        assertThat(jobResultStore.hasDirtyJobResultEntry(jobId)).isFalse();
+        assertThat(jobResultStore.hasCleanJobResultEntry(jobId)).isTrue();
     }
 
     @Test

--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -715,7 +715,7 @@ function wait_num_of_occurence_in_logs {
     echo "Waiting for text ${text} to appear ${number} of times in logs..."
 
     while : ; do
-      N=$(grep -o "${text}" $FLINK_LOG_DIR/*${logs}*.log* | wc -l)
+      N=$(grep -E -o "${text}" $FLINK_LOG_DIR/*${logs}*.log* | wc -l)
 
       if [ -z $N ]; then
         N=0

--- a/flink-end-to-end-tests/test-scripts/test_ha_per_job_cluster_datastream.sh
+++ b/flink-end-to-end-tests/test-scripts/test_ha_per_job_cluster_datastream.sh
@@ -23,7 +23,6 @@ source "$(dirname "$0")"/common_ha.sh
 TEST_PROGRAM_JAR_NAME=DataStreamAllroundTestProgram.jar
 TEST_PROGRAM_JAR=${END_TO_END_DIR}/flink-datastream-allround-test/target/${TEST_PROGRAM_JAR_NAME}
 FLINK_LIB_DIR=${FLINK_DIR}/lib
-JOB_ID="00000000000000000000000000000000"
 
 #
 # NOTE: This script requires at least Bash version >= 4. Mac OS in 2020 still ships 3.x
@@ -126,6 +125,8 @@ function run_ha_test() {
     local neededTaskmanagers=$(( (${PARALLELISM} + ${TASK_SLOTS_PER_TM_HA} - 1)  / ${TASK_SLOTS_PER_TM_HA} ))
     start_taskmanagers ${neededTaskmanagers}
 
+    wait_num_of_occurence_in_logs "Job [a-z0-9]+ is submitted." 1 "standalonejob"
+    JOB_ID=$(grep -E -o 'Job [a-z0-9]+ is submitted' $FLINK_LOG_DIR/*standalonejob*.log* | awk '{print $2}')
     wait_job_running ${JOB_ID}
 
     # start the watchdog that keeps the number of JMs stable


### PR DESCRIPTION
…hen HA is enabled.

Previously, the job id will be set to zero in application mode when HA is enabled and the job id is not configured by user.
This commit make the job id distinct across different jobs in such case, which allow HistoryServer to distinguish it.

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Previously, the job id will be set to zero in application mode when HA is enabled and the job id is not configured by user.
This commit makes the job id distinct across different jobs in such case, which allows HistoryServer to distinguish it.

## Brief change log

Generate a random jobId for the application job in HA mode if not configured by user.

## Verifying this change

This change is already covered by existing tests, such as ApplicationDispatcherBootstrapTest.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable 
