### PR TITLE
[FLINK-28193][runtime] Enable to identify whether a job vertex contains source/sink operators

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobVertex.java
@@ -147,6 +147,12 @@ public class JobVertex implements java.io.Serializable {
      */
     private final List<IntermediateDataSetID> intermediateDataSetIdsToConsume = new ArrayList<>();
 
+    /** Indicates whether this job vertex contains source operators. */
+    private boolean containsSourceOperators = false;
+
+    /** Indicates whether this job vertex contains sink operators. */
+    private boolean containsSinkOperators = false;
+
     // --------------------------------------------------------------------------------------------
 
     /**
@@ -523,6 +529,22 @@ public class JobVertex implements java.io.Serializable {
         }
 
         return true;
+    }
+
+    public void markContainsSources() {
+        this.containsSourceOperators = true;
+    }
+
+    public boolean containsSources() {
+        return containsSourceOperators;
+    }
+
+    public void markContainsSinks() {
+        this.containsSinkOperators = true;
+    }
+
+    public boolean containsSinks() {
+        return containsSinkOperators;
     }
 
     // --------------------------------------------------------------------------------------------

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -116,6 +116,7 @@ public class StreamGraph implements Pipeline {
     private Map<Integer, StreamNode> streamNodes;
     private Set<Integer> sources;
     private Set<Integer> sinks;
+    private Set<Integer> expandedSinks;
     private Map<Integer, Tuple2<Integer, OutputTag>> virtualSideOutputNodes;
     private Map<Integer, Tuple3<Integer, StreamPartitioner<?>, StreamExchangeMode>>
             virtualPartitionNodes;
@@ -156,6 +157,7 @@ public class StreamGraph implements Pipeline {
         iterationSourceSinkPairs = new HashSet<>();
         sources = new HashSet<>();
         sinks = new HashSet<>();
+        expandedSinks = new HashSet<>();
         slotSharingGroupResources = new HashMap<>();
     }
 
@@ -365,6 +367,16 @@ public class StreamGraph implements Pipeline {
                     vertexID, ((OutputFormatOperatorFactory) operatorFactory).getOutputFormat());
         }
         sinks.add(vertexID);
+    }
+
+    /**
+     * Register expanded sink nodes. These nodes should also be treated as sinks. But we do not add
+     * them into {@link #sinks} to avoid messing up the json plan.
+     *
+     * @param nodeIds sink nodes to register
+     */
+    public void registerExpandedSinks(Collection<Integer> nodeIds) {
+        expandedSinks.addAll(nodeIds);
     }
 
     public <IN, OUT> void addOperator(
@@ -874,6 +886,10 @@ public class StreamGraph implements Pipeline {
 
     public Collection<Integer> getSinkIDs() {
         return sinks;
+    }
+
+    public Collection<Integer> getExpandedSinkIds() {
+        return expandedSinks;
     }
 
     public Collection<StreamNode> getStreamNodes() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -186,6 +186,8 @@ public class StreamingJobGraphGenerator {
 
         setPhysicalEdges();
 
+        markContainsSourcesOrSinks();
+
         setSlotSharingAndCoLocation();
 
         setManagedMemoryFraction(
@@ -1176,6 +1178,27 @@ public class StreamingJobGraphGenerator {
                     streamGraph.getSourceVertex(upStreamVertex.getInEdges().get(0)), streamGraph);
         }
         return upStreamVertex.getOperatorFactory();
+    }
+
+    private void markContainsSourcesOrSinks() {
+        for (Map.Entry<Integer, JobVertex> entry : jobVertices.entrySet()) {
+            final JobVertex jobVertex = entry.getValue();
+            final Set<Integer> vertexOperators = new HashSet<>();
+            vertexOperators.add(entry.getKey());
+            if (chainedConfigs.containsKey(entry.getKey())) {
+                vertexOperators.addAll(chainedConfigs.get(entry.getKey()).keySet());
+            }
+
+            for (int nodeId : vertexOperators) {
+                if (streamGraph.getSourceIDs().contains(nodeId)) {
+                    jobVertex.markContainsSources();
+                }
+                if (streamGraph.getSinkIDs().contains(nodeId)
+                        || streamGraph.getExpandedSinkIds().contains(nodeId)) {
+                    jobVertex.markContainsSinks();
+                }
+            }
+        }
     }
 
     private void setSlotSharingAndCoLocation() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/SinkTransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/SinkTransformationTranslator.java
@@ -47,8 +47,10 @@ import javax.annotation.Nullable;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
@@ -150,11 +152,13 @@ public class SinkTransformationTranslator<Input, Output>
                         false);
             }
 
+            final Set<Integer> expandedSinks = new HashSet<>();
             final List<Transformation<?>> sinkTransformations =
                     executionEnvironment
                             .getTransformations()
                             .subList(sizeBefore, executionEnvironment.getTransformations().size());
-            sinkTransformations.forEach(context::transform);
+            sinkTransformations.forEach(t -> expandedSinks.addAll(context.transform(t)));
+            context.getStreamGraph().registerExpandedSinks(expandedSinks);
 
             // Remove all added sink subtransformations to avoid duplications and allow additional
             // expansions

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorSourceSinkTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorSourceSinkTest.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.graph;
+
+import org.apache.flink.api.common.RuntimeExecutionMode;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.SinkFunction;
+import org.apache.flink.streaming.api.operators.ChainingStrategy;
+import org.apache.flink.streaming.api.transformations.MultipleInputTransformation;
+import org.apache.flink.streaming.util.TestExpandingSink;
+import org.apache.flink.util.TestLoggerExtension;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests whether a generated job vertex is correctly marked as a source/sink by {@link
+ * StreamingJobGraphGenerator}.
+ */
+@ExtendWith(TestLoggerExtension.class)
+class StreamingJobGraphGeneratorSourceSinkTest {
+
+    private StreamExecutionEnvironment env;
+
+    @BeforeEach
+    void setUp() {
+        env = StreamExecutionEnvironment.getExecutionEnvironment();
+    }
+
+    @Test
+    void testLegacySource() {
+        env.fromElements(0, 1).map(i -> i);
+
+        final List<JobVertex> verticesSorted = getJobVertices();
+
+        final JobVertex sourceVertex = verticesSorted.get(0);
+        assertThat(sourceVertex.containsSources()).isTrue();
+        assertThat(sourceVertex.containsSinks()).isFalse();
+    }
+
+    @Test
+    void testNewSource() {
+        env.fromSequence(0, 1).map(i -> i);
+
+        final List<JobVertex> verticesSorted = getJobVertices();
+
+        final JobVertex sourceVertex = verticesSorted.get(0);
+        assertThat(sourceVertex.containsSources()).isTrue();
+        assertThat(sourceVertex.containsSinks()).isFalse();
+    }
+
+    @Test
+    void testMultiInputSource() {
+        final DataStream<Long> source1 = env.fromSequence(0, 1);
+        final DataStream<Long> source2 = env.fromSequence(0, 1);
+        final MultipleInputTransformation<Long> multiInputTransform =
+                new MultipleInputTransformation<>(
+                        "multi-input-operator",
+                        new StreamingJobGraphGeneratorTest.UnusedOperatorFactory(),
+                        Types.LONG,
+                        env.getParallelism());
+        multiInputTransform.addInput(source1.map(i -> i).getTransformation());
+        multiInputTransform.addInput(source2.getTransformation());
+        multiInputTransform.setChainingStrategy(ChainingStrategy.HEAD_WITH_SOURCES);
+        env.addOperator(multiInputTransform);
+
+        final List<JobVertex> verticesSorted = getJobVertices();
+
+        final JobVertex source1Vertex = verticesSorted.get(0);
+        assertThat(source1Vertex.containsSources()).isTrue();
+        assertThat(source1Vertex.containsSinks()).isFalse();
+
+        // source-2 is chained with the multi-input vertex
+        final JobVertex multiInputVertex = verticesSorted.get(1);
+        assertThat(multiInputVertex.containsSources()).isTrue();
+        assertThat(multiInputVertex.containsSinks()).isFalse();
+    }
+
+    @Test
+    void testLegacySink() {
+        env.fromElements(0, 1).map(i -> i).startNewChain().addSink(new SinkFunction<Integer>() {});
+
+        final List<JobVertex> verticesSorted = getJobVertices();
+
+        final JobVertex sinkVertex = verticesSorted.get(1);
+        assertThat(sinkVertex.containsSources()).isFalse();
+        assertThat(sinkVertex.containsSinks()).isTrue();
+    }
+
+    @Test
+    void testNewSink() {
+        env.fromElements(0, 1).disableChaining().sinkTo(new TestExpandingSink());
+
+        final List<JobVertex> verticesSorted = getJobVertices();
+
+        final JobVertex sinkVertex = verticesSorted.get(1);
+        assertThat(sinkVertex.containsSources()).isFalse();
+        assertThat(sinkVertex.containsSinks()).isTrue();
+    }
+
+    @Test
+    void testNewSinkWithSinkTopology() {
+        env.setRuntimeMode(RuntimeExecutionMode.BATCH);
+        env.fromElements(0, 1).disableChaining().sinkTo(new TestExpandingSink());
+
+        final List<JobVertex> verticesSorted = getJobVertices();
+
+        final JobVertex sinkWriterVertex = verticesSorted.get(1);
+        assertThat(sinkWriterVertex.containsSources()).isFalse();
+        assertThat(sinkWriterVertex.containsSinks()).isTrue();
+
+        final JobVertex sinkCommitterVertex = verticesSorted.get(2);
+        assertThat(sinkCommitterVertex.containsSources()).isFalse();
+        assertThat(sinkCommitterVertex.containsSinks()).isTrue();
+
+        final JobVertex sinkPostCommitterVertex = verticesSorted.get(3);
+        assertThat(sinkPostCommitterVertex.containsSources()).isFalse();
+        assertThat(sinkPostCommitterVertex.containsSinks()).isTrue();
+    }
+
+    @Test
+    void testChainedSourceSink() {
+        env.setParallelism(1);
+        env.fromElements(0, 1).sinkTo(new TestExpandingSink());
+
+        final List<JobVertex> verticesSorted = getJobVertices();
+
+        final JobVertex sourceSinkVertex = verticesSorted.get(0);
+        assertThat(sourceSinkVertex.containsSources()).isTrue();
+        assertThat(sourceSinkVertex.containsSinks()).isTrue();
+    }
+
+    private List<JobVertex> getJobVertices() {
+        final StreamGraph streamGraph = env.getStreamGraph();
+        final JobGraph jobGraph = streamGraph.getJobGraph();
+        return jobGraph.getVerticesSortedTopologicallyFromSources();
+    }
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
@@ -1552,7 +1552,7 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
         return StreamingJobGraphGenerator.createJobGraph(env.getStreamGraph());
     }
 
-    private static final class UnusedOperatorFactory extends AbstractStreamOperatorFactory<Long> {
+    static final class UnusedOperatorFactory extends AbstractStreamOperatorFactory<Long> {
 
         @Override
         public <T extends StreamOperator<Long>> T createStreamOperator(


### PR DESCRIPTION
## What is the purpose of the change

Speculative execution does not support sources/sinks in the first version. Therefore, it will not create speculation instances for vertices which contains source/sink operators.
Note that a job vertex with no input/output does not mean it is a true source/sink vertex:
- Multi-input sources can have input
- It's possible that the vertex with no output edge does not contain any sink operator
- A new sink with topology can spread the sink logic into multiple job vertices connected with job edges.


In this pr, we introduce methods to check whether a job vertex contains source/sink operators.

## Verifying this change

  - *Added unit test StreamingJobGraphGeneratorSourceSinkTest*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
