### PR TITLE
[FLINK-19869][connectors/jdbc] Add support for postgres UUID type

### DIFF
--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/converter/AbstractJdbcRowConverter.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/converter/AbstractJdbcRowConverter.java
@@ -173,7 +173,7 @@ public abstract class AbstractJdbcRowConverter implements JdbcRowConverter {
                                 : TimestampData.fromTimestamp((Timestamp) val);
             case CHAR:
             case VARCHAR:
-                return val -> StringData.fromString((String) val);
+                return val -> StringData.fromString(val.toString());
             case BINARY:
             case VARBINARY:
                 return val -> val;

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/internal/converter/PostgresRowConverterTest.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/internal/converter/PostgresRowConverterTest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.internal.converter;
+
+import org.apache.flink.connector.jdbc.converter.JdbcRowConverter;
+import org.apache.flink.connector.jdbc.statement.FieldNamedPreparedStatement;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.VarCharType;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.sql.ResultSet;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+/** Test for {@link PostgresRowConverter}. */
+public class PostgresRowConverterTest {
+    @Test
+    public void testInternalConverterHandlesUUIDs() throws Exception {
+        // arrange
+        RowType rowType = RowType.of(new VarCharType(), new VarCharType());
+        JdbcRowConverter rowConverter =
+                new PostgresRowConverter(rowType) {
+
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public String converterName() {
+                        return "test";
+                    }
+                };
+
+        UUID uuid = UUID.randomUUID();
+        String notUUID = "not-a-uuid";
+
+        ResultSet resultSet = Mockito.mock(ResultSet.class);
+        Mockito.when(resultSet.getObject(1)).thenReturn(uuid);
+        Mockito.when(resultSet.getObject(2)).thenReturn(notUUID);
+
+        // act
+        RowData res = rowConverter.toInternal(resultSet);
+
+        // assert
+        assertThat(res.getString(0).toString()).isEqualTo(uuid.toString());
+        assertThat(res.getString(1).toString()).isEqualTo(notUUID);
+    }
+
+    @Test
+    public void testExternalConverterHandlesUUIDs() throws Exception {
+        // arrange
+        RowType rowType = RowType.of(new VarCharType(), new VarCharType());
+        JdbcRowConverter rowConverter = new PostgresRowConverter(rowType);
+
+        UUID uuid = UUID.randomUUID();
+        String notUUID = "not-a-uuid";
+
+        RowData rowData =
+                GenericRowData.of(
+                        StringData.fromString(uuid.toString()), StringData.fromString(notUUID));
+
+        FieldNamedPreparedStatement ps = Mockito.mock(FieldNamedPreparedStatement.class);
+
+        // act
+        rowConverter.toExternal(rowData, ps);
+
+        // assert
+        verify(ps).setObject(0, uuid);
+        verify(ps).setString(1, notUUID);
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Add support for reading and writing postgres UUID types via Flink SQL STRING type


## Brief change log

- modified AbstractJdbcRowConverter.createInternalConverter to use toString() for CHAR and VARCHAR types instead of casting to string. Previously the cast would fail for postgres UUIDs
- add createExternalConverter override to PostgresRowConverter for CHAR and VARCHAR types. It will check if the string is a UUID and pass the UUID to the PreparedSatement via setObject if so


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable 
