### PR TITLE
[FLINK-25454][runtime] Pause and resume time for throughput calculato…

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxProcessor.java
@@ -391,6 +391,7 @@ public class MailboxProcessor implements Closeable {
             suspendedDefaultAction = new DefaultActionSuspension(suspensionTimer);
         }
 
+        maybeRestartIdleTimer();
         return suspendedDefaultAction;
     }
 
@@ -468,6 +469,7 @@ public class MailboxProcessor implements Closeable {
         }
 
         private void resumeInternal() {
+            maybePauseIdleTimer();
             if (suspendedDefaultAction == this) {
                 suspendedDefaultAction = null;
             }


### PR DESCRIPTION
…r only from one thread.

## What is the purpose of the change

Backport of https://github.com/apache/flink/pull/18210

## Brief change log

Pausing and resuming idle metrics moved to mailbox thread.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
