### PR TITLE
[FLINK-24666][table-runtime] Add job level table.exec.state-stale.error-handling option and apply to related stateful stream operators

### DIFF
--- a/docs/layouts/shortcodes/generated/execution_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/execution_config_configuration.html
@@ -149,6 +149,12 @@ By default no operator is disabled.</td>
             <td>Whether to compress spilled data. Currently we only support compress spilled data for sort and hash-agg and hash-join operators.</td>
         </tr>
         <tr>
+            <td><h5>table.exec.state-stale.error-handling</h5><br> <span class="label label-primary">Streaming</span></td>
+            <td style="word-wrap: break-word;">CONTINUE_WITHOUT_LOGGING</td>
+            <td><p>Enum</p></td>
+            <td>A unified error handling strategy to handle the situation that operators can not be able to handle the updates normally when the corresponding record was expired which exceeds state ttl.<br />By default, expired records are simply discarded from the system and there's no logging. If you want to reserve the log then choose CONTINUE_WITH_LOGGING, or choose ERROR in order to raise an error to fail the processing immediately.<br /><br />Possible values:<ul><li>"ERROR"</li><li>"CONTINUE_WITH_LOGGING"</li><li>"CONTINUE_WITHOUT_LOGGING"</li></ul></td>
+        </tr>
+        <tr>
             <td><h5>table.exec.state.ttl</h5><br> <span class="label label-primary">Streaming</span></td>
             <td style="word-wrap: break-word;">0 ms</td>
             <td>Duration</td>

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
@@ -64,11 +64,11 @@ public class ExecutionConfigOptions {
     //  Error Handling Options
     // ------------------------------------------------------------------------
     @Documentation.TableOption(execMode = Documentation.ExecMode.STREAMING)
-    public static final ConfigOption<StateStaledErrorHandling>
-            TABLE_EXEC_STATE_STALED_ERROR_HANDLING =
-                    key("table.exec.state-staled.error-handling")
-                            .enumType(StateStaledErrorHandling.class)
-                            .defaultValue(StateStaledErrorHandling.CONTINUE_WITHOUT_LOGGING)
+    public static final ConfigOption<StateStaleErrorHandling>
+            TABLE_EXEC_STATE_STALE_ERROR_HANDLING =
+                    key("table.exec.state-stale.error-handling")
+                            .enumType(StateStaleErrorHandling.class)
+                            .defaultValue(StateStaleErrorHandling.CONTINUE_WITHOUT_LOGGING)
                             .withDescription(
                                     Description.builder()
                                             .text(
@@ -595,14 +595,14 @@ public class ExecutionConfigOptions {
         FORCE
     }
 
-    /** The error handling strategy when operator encounter state staled error. */
+    /** The error handling strategy when operator encounter state stale error. */
     @PublicEvolving
-    public enum StateStaledErrorHandling {
+    public enum StateStaleErrorHandling {
 
-        /** Raise an error when operators encounter state staled error. */
+        /** Raise an error when operators encounter state stale error. */
         ERROR,
 
-        /** Continue processing with logging when operators encounter state staled error. */
+        /** Continue processing with logging when operators encounter state stale error. */
         CONTINUE_WITH_LOGGING,
 
         /**

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
@@ -61,6 +61,28 @@ public class ExecutionConfigOptions {
                                     + "Default value is 0, which means that it will never clean up state.");
 
     // ------------------------------------------------------------------------
+    //  Error Handling Options
+    // ------------------------------------------------------------------------
+    @Documentation.TableOption(execMode = Documentation.ExecMode.STREAMING)
+    public static final ConfigOption<StateStaledErrorHandling>
+            TABLE_EXEC_STATE_STALED_ERROR_HANDLING =
+                    key("table.exec.state-staled.error-handling")
+                            .enumType(StateStaledErrorHandling.class)
+                            .defaultValue(StateStaledErrorHandling.CONTINUE_WITHOUT_LOGGING)
+                            .withDescription(
+                                    Description.builder()
+                                            .text(
+                                                    "A unified error handling strategy to handle the situation that operators can not "
+                                                            + "be able to handle the updates normally when the corresponding record was "
+                                                            + "expired which exceeds state ttl.")
+                                            .linebreak()
+                                            .text(
+                                                    "By default, expired records are simply discarded from the system and there's no logging. "
+                                                            + "If you want to reserve the log then choose CONTINUE_WITH_LOGGING, "
+                                                            + "or choose ERROR in order to raise an error to fail the processing immediately.")
+                                            .build());
+
+    // ------------------------------------------------------------------------
     //  Source Options
     // ------------------------------------------------------------------------
 
@@ -571,6 +593,23 @@ public class ExecutionConfigOptions {
 
         /** Add keyed shuffle in any case except single parallelism. */
         FORCE
+    }
+
+    /** The error handling strategy when operator encounter state staled error. */
+    @PublicEvolving
+    public enum StateStaledErrorHandling {
+
+        /** Raise an error when operators encounter state staled error. */
+        ERROR,
+
+        /** Continue processing with logging when operators encounter state staled error. */
+        CONTINUE_WITH_LOGGING,
+
+        /**
+         * Continue processing silently (without any logging) when operator encounter state staled
+         * error.
+         */
+        CONTINUE_WITHOUT_LOGGING
     }
 
     /** Determine if CAST operates using the legacy behaviour or the new one. */

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecSink.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecSink.java
@@ -410,7 +410,8 @@ public abstract class CommonExecSink extends ExecNodeBase<Object>
                         StateConfigUtil.createTtlConfig(
                                 config.get(ExecutionConfigOptions.IDLE_STATE_RETENTION).toMillis()),
                         InternalSerializers.create(physicalRowType),
-                        equaliser);
+                        equaliser,
+                        config.get(ExecutionConfigOptions.TABLE_EXEC_STATE_STALED_ERROR_HANDLING));
         final String[] fieldNames = physicalRowType.getFieldNames().toArray(new String[0]);
         final List<String> pkFieldNames =
                 Arrays.stream(primaryKeys)

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecSink.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecSink.java
@@ -411,7 +411,7 @@ public abstract class CommonExecSink extends ExecNodeBase<Object>
                                 config.get(ExecutionConfigOptions.IDLE_STATE_RETENTION).toMillis()),
                         InternalSerializers.create(physicalRowType),
                         equaliser,
-                        config.get(ExecutionConfigOptions.TABLE_EXEC_STATE_STALED_ERROR_HANDLING));
+                        config.get(ExecutionConfigOptions.TABLE_EXEC_STATE_STALE_ERROR_HANDLING));
         final String[] fieldNames = physicalRowType.getFieldNames().toArray(new String[0]);
         final List<String> pkFieldNames =
                 Arrays.stream(primaryKeys)

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecJoin.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecJoin.java
@@ -53,7 +53,7 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonPro
 
 import java.util.List;
 
-import static org.apache.flink.table.api.config.ExecutionConfigOptions.TABLE_EXEC_STATE_STALED_ERROR_HANDLING;
+import static org.apache.flink.table.api.config.ExecutionConfigOptions.TABLE_EXEC_STATE_STALE_ERROR_HANDLING;
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -171,8 +171,8 @@ public class StreamExecJoin extends ExecNodeBase<RowData>
 
         long minRetentionTime = config.getStateRetentionTime();
 
-        ExecutionConfigOptions.StateStaledErrorHandling stateStaledErrorHandling =
-                config.get(TABLE_EXEC_STATE_STALED_ERROR_HANDLING);
+        ExecutionConfigOptions.StateStaleErrorHandling stateStaleErrorHandling =
+                config.get(TABLE_EXEC_STATE_STALE_ERROR_HANDLING);
         AbstractStreamingJoinOperator operator;
         FlinkJoinType joinType = joinSpec.getJoinType();
         if (joinType == FlinkJoinType.ANTI || joinType == FlinkJoinType.SEMI) {
@@ -186,7 +186,7 @@ public class StreamExecJoin extends ExecNodeBase<RowData>
                             rightInputSpec,
                             joinSpec.getFilterNulls(),
                             minRetentionTime,
-                            stateStaledErrorHandling);
+                            stateStaleErrorHandling);
         } else {
             boolean leftIsOuter = joinType == FlinkJoinType.LEFT || joinType == FlinkJoinType.FULL;
             boolean rightIsOuter =
@@ -202,7 +202,7 @@ public class StreamExecJoin extends ExecNodeBase<RowData>
                             rightIsOuter,
                             joinSpec.getFilterNulls(),
                             minRetentionTime,
-                            stateStaledErrorHandling);
+                            stateStaleErrorHandling);
         }
 
         final RowType returnType = (RowType) getOutputType();

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecJoin.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecJoin.java
@@ -23,6 +23,7 @@ import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.streaming.api.transformations.TwoInputTransformation;
+import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.planner.delegation.PlannerBase;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
@@ -52,6 +53,7 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonPro
 
 import java.util.List;
 
+import static org.apache.flink.table.api.config.ExecutionConfigOptions.TABLE_EXEC_STATE_STALED_ERROR_HANDLING;
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -169,6 +171,8 @@ public class StreamExecJoin extends ExecNodeBase<RowData>
 
         long minRetentionTime = config.getStateRetentionTime();
 
+        ExecutionConfigOptions.StateStaledErrorHandling stateStaledErrorHandling =
+                config.get(TABLE_EXEC_STATE_STALED_ERROR_HANDLING);
         AbstractStreamingJoinOperator operator;
         FlinkJoinType joinType = joinSpec.getJoinType();
         if (joinType == FlinkJoinType.ANTI || joinType == FlinkJoinType.SEMI) {
@@ -181,7 +185,8 @@ public class StreamExecJoin extends ExecNodeBase<RowData>
                             leftInputSpec,
                             rightInputSpec,
                             joinSpec.getFilterNulls(),
-                            minRetentionTime);
+                            minRetentionTime,
+                            stateStaledErrorHandling);
         } else {
             boolean leftIsOuter = joinType == FlinkJoinType.LEFT || joinType == FlinkJoinType.FULL;
             boolean rightIsOuter =
@@ -196,7 +201,8 @@ public class StreamExecJoin extends ExecNodeBase<RowData>
                             leftIsOuter,
                             rightIsOuter,
                             joinSpec.getFilterNulls(),
-                            minRetentionTime);
+                            minRetentionTime,
+                            stateStaledErrorHandling);
         }
 
         final RowType returnType = (RowType) getOutputType();

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecRank.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecRank.java
@@ -70,7 +70,7 @@ import java.util.List;
 import java.util.stream.IntStream;
 
 import static org.apache.flink.table.api.config.ExecutionConfigOptions.TABLE_EXEC_RANK_TOPN_CACHE_SIZE;
-import static org.apache.flink.table.api.config.ExecutionConfigOptions.TABLE_EXEC_STATE_STALED_ERROR_HANDLING;
+import static org.apache.flink.table.api.config.ExecutionConfigOptions.TABLE_EXEC_STATE_STALE_ERROR_HANDLING;
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -219,8 +219,8 @@ public class StreamExecRank extends ExecNodeBase<RowData>
         long cacheSize = config.get(TABLE_EXEC_RANK_TOPN_CACHE_SIZE);
         StateTtlConfig ttlConfig = StateConfigUtil.createTtlConfig(config.getStateRetentionTime());
 
-        ExecutionConfigOptions.StateStaledErrorHandling stateStaledErrorHandling =
-                config.get(TABLE_EXEC_STATE_STALED_ERROR_HANDLING);
+        ExecutionConfigOptions.StateStaleErrorHandling stateStaleErrorHandling =
+                config.get(TABLE_EXEC_STATE_STALE_ERROR_HANDLING);
         AbstractTopNFunction processFunction;
         if (rankStrategy instanceof RankProcessStrategy.AppendFastStrategy) {
             if (sortFields.length == 1
@@ -295,7 +295,7 @@ public class StreamExecRank extends ExecNodeBase<RowData>
                                 generateUpdateBefore,
                                 outputRankNumber,
                                 cacheSize,
-                                stateStaledErrorHandling);
+                                stateStaleErrorHandling);
             }
             // TODO Use UnaryUpdateTopNFunction after SortedMapState is merged
         } else if (rankStrategy instanceof RankProcessStrategy.RetractStrategy) {
@@ -325,7 +325,7 @@ public class StreamExecRank extends ExecNodeBase<RowData>
                             generatedEqualiser,
                             generateUpdateBefore,
                             outputRankNumber,
-                            stateStaledErrorHandling);
+                            stateStaleErrorHandling);
         } else {
             throw new TableException(
                     String.format("rank strategy:%s is not supported.", rankStrategy));

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/AbstractStreamingJoinOperator.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/AbstractStreamingJoinOperator.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.TimestampedCollector;
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
+import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.generated.GeneratedJoinCondition;
 import org.apache.flink.table.runtime.generated.JoinCondition;
@@ -62,6 +63,8 @@ public abstract class AbstractStreamingJoinOperator extends AbstractStreamOperat
 
     protected final long stateRetentionTime;
 
+    protected final ExecutionConfigOptions.StateStaledErrorHandling stateStaledErrorHandling;
+
     protected transient JoinConditionWithNullFilters joinCondition;
     protected transient TimestampedCollector<RowData> collector;
 
@@ -72,7 +75,8 @@ public abstract class AbstractStreamingJoinOperator extends AbstractStreamOperat
             JoinInputSideSpec leftInputSideSpec,
             JoinInputSideSpec rightInputSideSpec,
             boolean[] filterNullKeys,
-            long stateRetentionTime) {
+            long stateRetentionTime,
+            ExecutionConfigOptions.StateStaledErrorHandling stateStaledErrorHandling) {
         this.leftType = leftType;
         this.rightType = rightType;
         this.generatedJoinCondition = generatedJoinCondition;
@@ -80,6 +84,7 @@ public abstract class AbstractStreamingJoinOperator extends AbstractStreamOperat
         this.rightInputSideSpec = rightInputSideSpec;
         this.stateRetentionTime = stateRetentionTime;
         this.filterNullKeys = filterNullKeys;
+        this.stateStaledErrorHandling = stateStaledErrorHandling;
     }
 
     @Override

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/AbstractStreamingJoinOperator.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/AbstractStreamingJoinOperator.java
@@ -63,7 +63,7 @@ public abstract class AbstractStreamingJoinOperator extends AbstractStreamOperat
 
     protected final long stateRetentionTime;
 
-    protected final ExecutionConfigOptions.StateStaledErrorHandling stateStaledErrorHandling;
+    protected final ExecutionConfigOptions.StateStaleErrorHandling stateStaleErrorHandling;
 
     protected transient JoinConditionWithNullFilters joinCondition;
     protected transient TimestampedCollector<RowData> collector;
@@ -76,7 +76,7 @@ public abstract class AbstractStreamingJoinOperator extends AbstractStreamOperat
             JoinInputSideSpec rightInputSideSpec,
             boolean[] filterNullKeys,
             long stateRetentionTime,
-            ExecutionConfigOptions.StateStaledErrorHandling stateStaledErrorHandling) {
+            ExecutionConfigOptions.StateStaleErrorHandling stateStaleErrorHandling) {
         this.leftType = leftType;
         this.rightType = rightType;
         this.generatedJoinCondition = generatedJoinCondition;
@@ -84,7 +84,7 @@ public abstract class AbstractStreamingJoinOperator extends AbstractStreamOperat
         this.rightInputSideSpec = rightInputSideSpec;
         this.stateRetentionTime = stateRetentionTime;
         this.filterNullKeys = filterNullKeys;
-        this.stateStaledErrorHandling = stateStaledErrorHandling;
+        this.stateStaleErrorHandling = stateStaleErrorHandling;
     }
 
     @Override

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/StreamingJoinOperator.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/StreamingJoinOperator.java
@@ -62,7 +62,7 @@ public class StreamingJoinOperator extends AbstractStreamingJoinOperator {
             boolean rightIsOuter,
             boolean[] filterNullKeys,
             long stateRetentionTime,
-            ExecutionConfigOptions.StateStaledErrorHandling stateStaledErrorHandling) {
+            ExecutionConfigOptions.StateStaleErrorHandling stateStaleErrorHandling) {
         super(
                 leftType,
                 rightType,
@@ -71,7 +71,7 @@ public class StreamingJoinOperator extends AbstractStreamingJoinOperator {
                 rightInputSideSpec,
                 filterNullKeys,
                 stateRetentionTime,
-                stateStaledErrorHandling);
+                stateStaleErrorHandling);
         this.leftIsOuter = leftIsOuter;
         this.rightIsOuter = rightIsOuter;
     }
@@ -92,7 +92,8 @@ public class StreamingJoinOperator extends AbstractStreamingJoinOperator {
                             "left-records",
                             leftInputSideSpec,
                             leftType,
-                            stateRetentionTime);
+                            stateRetentionTime,
+                            stateStaleErrorHandling);
         } else {
             this.leftRecordStateView =
                     JoinRecordStateViews.create(
@@ -100,7 +101,8 @@ public class StreamingJoinOperator extends AbstractStreamingJoinOperator {
                             "left-records",
                             leftInputSideSpec,
                             leftType,
-                            stateRetentionTime);
+                            stateRetentionTime,
+                            stateStaleErrorHandling);
         }
 
         if (rightIsOuter) {
@@ -110,7 +112,8 @@ public class StreamingJoinOperator extends AbstractStreamingJoinOperator {
                             "right-records",
                             rightInputSideSpec,
                             rightType,
-                            stateRetentionTime);
+                            stateRetentionTime,
+                            stateStaleErrorHandling);
         } else {
             this.rightRecordStateView =
                     JoinRecordStateViews.create(
@@ -118,7 +121,8 @@ public class StreamingJoinOperator extends AbstractStreamingJoinOperator {
                             "right-records",
                             rightInputSideSpec,
                             rightType,
-                            stateRetentionTime);
+                            stateRetentionTime,
+                            stateStaleErrorHandling);
         }
     }
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/StreamingJoinOperator.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/StreamingJoinOperator.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.runtime.operators.join.stream;
 
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.util.RowDataUtil;
@@ -60,7 +61,8 @@ public class StreamingJoinOperator extends AbstractStreamingJoinOperator {
             boolean leftIsOuter,
             boolean rightIsOuter,
             boolean[] filterNullKeys,
-            long stateRetentionTime) {
+            long stateRetentionTime,
+            ExecutionConfigOptions.StateStaledErrorHandling stateStaledErrorHandling) {
         super(
                 leftType,
                 rightType,
@@ -68,7 +70,8 @@ public class StreamingJoinOperator extends AbstractStreamingJoinOperator {
                 leftInputSideSpec,
                 rightInputSideSpec,
                 filterNullKeys,
-                stateRetentionTime);
+                stateRetentionTime,
+                stateStaledErrorHandling);
         this.leftIsOuter = leftIsOuter;
         this.rightIsOuter = rightIsOuter;
     }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/StreamingSemiAntiJoinOperator.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/StreamingSemiAntiJoinOperator.java
@@ -53,7 +53,7 @@ public class StreamingSemiAntiJoinOperator extends AbstractStreamingJoinOperator
             JoinInputSideSpec rightInputSideSpec,
             boolean[] filterNullKeys,
             long stateRetentionTime,
-            ExecutionConfigOptions.StateStaledErrorHandling stateStaledErrorHandling) {
+            ExecutionConfigOptions.StateStaleErrorHandling stateStaleErrorHandling) {
         super(
                 leftType,
                 rightType,
@@ -62,7 +62,7 @@ public class StreamingSemiAntiJoinOperator extends AbstractStreamingJoinOperator
                 rightInputSideSpec,
                 filterNullKeys,
                 stateRetentionTime,
-                stateStaledErrorHandling);
+                stateStaleErrorHandling);
         this.isAntiJoin = isAntiJoin;
     }
 
@@ -77,7 +77,7 @@ public class StreamingSemiAntiJoinOperator extends AbstractStreamingJoinOperator
                         leftInputSideSpec,
                         leftType,
                         stateRetentionTime,
-                        stateStaledErrorHandling);
+                        stateStaleErrorHandling);
 
         this.rightRecordStateView =
                 JoinRecordStateViews.create(
@@ -86,7 +86,7 @@ public class StreamingSemiAntiJoinOperator extends AbstractStreamingJoinOperator
                         rightInputSideSpec,
                         rightType,
                         stateRetentionTime,
-                        stateStaledErrorHandling);
+                        stateStaleErrorHandling);
     }
 
     /**

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/StreamingSemiAntiJoinOperator.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/StreamingSemiAntiJoinOperator.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.runtime.operators.join.stream;
 
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.util.RowDataUtil;
 import org.apache.flink.table.runtime.generated.GeneratedJoinCondition;
@@ -51,7 +52,8 @@ public class StreamingSemiAntiJoinOperator extends AbstractStreamingJoinOperator
             JoinInputSideSpec leftInputSideSpec,
             JoinInputSideSpec rightInputSideSpec,
             boolean[] filterNullKeys,
-            long stateRetentionTime) {
+            long stateRetentionTime,
+            ExecutionConfigOptions.StateStaledErrorHandling stateStaledErrorHandling) {
         super(
                 leftType,
                 rightType,
@@ -59,7 +61,8 @@ public class StreamingSemiAntiJoinOperator extends AbstractStreamingJoinOperator
                 leftInputSideSpec,
                 rightInputSideSpec,
                 filterNullKeys,
-                stateRetentionTime);
+                stateRetentionTime,
+                stateStaledErrorHandling);
         this.isAntiJoin = isAntiJoin;
     }
 
@@ -73,7 +76,8 @@ public class StreamingSemiAntiJoinOperator extends AbstractStreamingJoinOperator
                         LEFT_RECORDS_STATE_NAME,
                         leftInputSideSpec,
                         leftType,
-                        stateRetentionTime);
+                        stateRetentionTime,
+                        stateStaledErrorHandling);
 
         this.rightRecordStateView =
                 JoinRecordStateViews.create(
@@ -81,7 +85,8 @@ public class StreamingSemiAntiJoinOperator extends AbstractStreamingJoinOperator
                         RIGHT_RECORDS_STATE_NAME,
                         rightInputSideSpec,
                         rightType,
-                        stateRetentionTime);
+                        stateRetentionTime,
+                        stateStaledErrorHandling);
     }
 
     /**

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/state/JoinRecordStateViews.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/state/JoinRecordStateViews.java
@@ -50,12 +50,12 @@ public final class JoinRecordStateViews {
             JoinInputSideSpec inputSideSpec,
             InternalTypeInfo<RowData> recordType,
             long retentionTime,
-            ExecutionConfigOptions.StateStaledErrorHandling stateStaledErrorHandling) {
+            ExecutionConfigOptions.StateStaleErrorHandling stateStaleErrorHandling) {
         StateTtlConfig ttlConfig = createTtlConfig(retentionTime);
         if (inputSideSpec.hasUniqueKey()) {
             if (inputSideSpec.joinKeyContainsUniqueKey()) {
                 return new JoinKeyContainsUniqueKey(
-                        ctx, stateName, recordType, ttlConfig, stateStaledErrorHandling);
+                        ctx, stateName, recordType, ttlConfig, stateStaleErrorHandling);
             } else {
                 return new InputSideHasUniqueKey(
                         ctx,
@@ -64,11 +64,11 @@ public final class JoinRecordStateViews {
                         inputSideSpec.getUniqueKeyType(),
                         inputSideSpec.getUniqueKeySelector(),
                         ttlConfig,
-                        stateStaledErrorHandling);
+                        stateStaleErrorHandling);
             }
         } else {
             return new InputSideHasNoUniqueKey(
-                    ctx, stateName, recordType, ttlConfig, stateStaledErrorHandling);
+                    ctx, stateName, recordType, ttlConfig, stateStaleErrorHandling);
         }
     }
 
@@ -78,13 +78,13 @@ public final class JoinRecordStateViews {
 
         protected final StateTtlConfig ttlConfig;
 
-        protected final ExecutionConfigOptions.StateStaledErrorHandling stateStaledErrorHandling;
+        protected final ExecutionConfigOptions.StateStaleErrorHandling stateStaleErrorHandling;
 
         public AbstractJoinRecordStateView(
                 StateTtlConfig ttlConfig,
-                ExecutionConfigOptions.StateStaledErrorHandling stateStaledErrorHandling) {
+                ExecutionConfigOptions.StateStaleErrorHandling stateStaleErrorHandling) {
             this.ttlConfig = ttlConfig;
-            this.stateStaledErrorHandling = stateStaledErrorHandling;
+            this.stateStaleErrorHandling = stateStaleErrorHandling;
         }
     }
 
@@ -98,8 +98,8 @@ public final class JoinRecordStateViews {
                 String stateName,
                 InternalTypeInfo<RowData> recordType,
                 StateTtlConfig ttlConfig,
-                ExecutionConfigOptions.StateStaledErrorHandling stateStaledErrorHandling) {
-            super(ttlConfig, stateStaledErrorHandling);
+                ExecutionConfigOptions.StateStaleErrorHandling stateStaleErrorHandling) {
+            super(ttlConfig, stateStaleErrorHandling);
             ValueStateDescriptor<RowData> recordStateDesc =
                     new ValueStateDescriptor<>(stateName, recordType);
             if (ttlConfig.isEnabled()) {
@@ -146,8 +146,8 @@ public final class JoinRecordStateViews {
                 InternalTypeInfo<RowData> uniqueKeyType,
                 KeySelector<RowData, RowData> uniqueKeySelector,
                 StateTtlConfig ttlConfig,
-                ExecutionConfigOptions.StateStaledErrorHandling stateStaledErrorHandling) {
-            super(ttlConfig, stateStaledErrorHandling);
+                ExecutionConfigOptions.StateStaleErrorHandling stateStaleErrorHandling) {
+            super(ttlConfig, stateStaleErrorHandling);
             checkNotNull(uniqueKeyType);
             checkNotNull(uniqueKeySelector);
             MapStateDescriptor<RowData, RowData> recordStateDesc =
@@ -188,8 +188,8 @@ public final class JoinRecordStateViews {
                 String stateName,
                 InternalTypeInfo<RowData> recordType,
                 StateTtlConfig ttlConfig,
-                ExecutionConfigOptions.StateStaledErrorHandling stateStaledErrorHandling) {
-            super(ttlConfig, stateStaledErrorHandling);
+                ExecutionConfigOptions.StateStaleErrorHandling stateStaleErrorHandling) {
+            super(ttlConfig, stateStaleErrorHandling);
             MapStateDescriptor<RowData, Integer> recordStateDesc =
                     new MapStateDescriptor<>(stateName, recordType, Types.INT);
             if (ttlConfig.isEnabled()) {
@@ -220,7 +220,7 @@ public final class JoinRecordStateViews {
                 }
             }
             // cnt == null means state may be expired
-            ErrorHandlingUtil.handleStateStaledError(ttlConfig, stateStaledErrorHandling, null);
+            ErrorHandlingUtil.handleStateStaleError(ttlConfig, stateStaleErrorHandling, null);
         }
 
         @Override

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/state/JoinRecordStateViews.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/state/JoinRecordStateViews.java
@@ -218,9 +218,10 @@ public final class JoinRecordStateViews {
                 } else {
                     recordState.remove(record);
                 }
+            } else {
+                // cnt == null means state may be expired
+                ErrorHandlingUtil.handleStateStaleError(ttlConfig, stateStaleErrorHandling, null);
             }
-            // cnt == null means state may be expired
-            ErrorHandlingUtil.handleStateStaleError(ttlConfig, stateStaleErrorHandling, null);
         }
 
         @Override

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/state/OuterJoinRecordStateViews.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/state/OuterJoinRecordStateViews.java
@@ -52,12 +52,12 @@ public final class OuterJoinRecordStateViews {
             JoinInputSideSpec inputSideSpec,
             InternalTypeInfo<RowData> recordType,
             long retentionTime,
-            ExecutionConfigOptions.StateStaledErrorHandling stateStaledErrorHandling) {
+            ExecutionConfigOptions.StateStaleErrorHandling stateStaleErrorHandling) {
         StateTtlConfig ttlConfig = createTtlConfig(retentionTime);
         if (inputSideSpec.hasUniqueKey()) {
             if (inputSideSpec.joinKeyContainsUniqueKey()) {
                 return new OuterJoinRecordStateViews.JoinKeyContainsUniqueKey(
-                        ctx, stateName, recordType, ttlConfig, stateStaledErrorHandling);
+                        ctx, stateName, recordType, ttlConfig, stateStaleErrorHandling);
             } else {
                 return new OuterJoinRecordStateViews.InputSideHasUniqueKey(
                         ctx,
@@ -66,11 +66,11 @@ public final class OuterJoinRecordStateViews {
                         inputSideSpec.getUniqueKeyType(),
                         inputSideSpec.getUniqueKeySelector(),
                         ttlConfig,
-                        stateStaledErrorHandling);
+                        stateStaleErrorHandling);
             }
         } else {
             return new OuterJoinRecordStateViews.InputSideHasNoUniqueKey(
-                    ctx, stateName, recordType, ttlConfig, stateStaledErrorHandling);
+                    ctx, stateName, recordType, ttlConfig, stateStaleErrorHandling);
         }
     }
 
@@ -81,13 +81,13 @@ public final class OuterJoinRecordStateViews {
 
         protected final StateTtlConfig ttlConfig;
 
-        protected final ExecutionConfigOptions.StateStaledErrorHandling stateStaledErrorHandling;
+        protected final ExecutionConfigOptions.StateStaleErrorHandling stateStaleErrorHandling;
 
         public AbstractOuterJoinRecordStateView(
                 StateTtlConfig ttlConfig,
-                ExecutionConfigOptions.StateStaledErrorHandling stateStaledErrorHandling) {
+                ExecutionConfigOptions.StateStaleErrorHandling stateStaleErrorHandling) {
             this.ttlConfig = ttlConfig;
-            this.stateStaledErrorHandling = stateStaledErrorHandling;
+            this.stateStaleErrorHandling = stateStaleErrorHandling;
         }
     }
 
@@ -102,8 +102,8 @@ public final class OuterJoinRecordStateViews {
                 String stateName,
                 InternalTypeInfo<RowData> recordType,
                 StateTtlConfig ttlConfig,
-                ExecutionConfigOptions.StateStaledErrorHandling stateStaledErrorHandling) {
-            super(ttlConfig, stateStaledErrorHandling);
+                ExecutionConfigOptions.StateStaleErrorHandling stateStaleErrorHandling) {
+            super(ttlConfig, stateStaleErrorHandling);
             TupleTypeInfo<Tuple2<RowData, Integer>> valueTypeInfo =
                     new TupleTypeInfo<>(recordType, Types.INT);
             ValueStateDescriptor<Tuple2<RowData, Integer>> recordStateDesc =
@@ -176,8 +176,8 @@ public final class OuterJoinRecordStateViews {
                 InternalTypeInfo<RowData> uniqueKeyType,
                 KeySelector<RowData, RowData> uniqueKeySelector,
                 StateTtlConfig ttlConfig,
-                ExecutionConfigOptions.StateStaledErrorHandling stateStaledErrorHandling) {
-            super(ttlConfig, stateStaledErrorHandling);
+                ExecutionConfigOptions.StateStaleErrorHandling stateStaleErrorHandling) {
+            super(ttlConfig, stateStaleErrorHandling);
             checkNotNull(uniqueKeyType);
             checkNotNull(uniqueKeySelector);
             TupleTypeInfo<Tuple2<RowData, Integer>> valueTypeInfo =
@@ -241,8 +241,8 @@ public final class OuterJoinRecordStateViews {
                 String stateName,
                 InternalTypeInfo<RowData> recordType,
                 StateTtlConfig ttlConfig,
-                ExecutionConfigOptions.StateStaledErrorHandling stateStaledErrorHandling) {
-            super(ttlConfig, stateStaledErrorHandling);
+                ExecutionConfigOptions.StateStaleErrorHandling stateStaleErrorHandling) {
+            super(ttlConfig, stateStaleErrorHandling);
             TupleTypeInfo<Tuple2<Integer, Integer>> tupleTypeInfo =
                     new TupleTypeInfo<>(Types.INT, Types.INT);
             MapStateDescriptor<RowData, Tuple2<Integer, Integer>> recordStateDesc =
@@ -295,7 +295,7 @@ public final class OuterJoinRecordStateViews {
                     recordState.remove(record);
                 }
             } else {
-                ErrorHandlingUtil.handleStateStaledError(ttlConfig, stateStaledErrorHandling, null);
+                ErrorHandlingUtil.handleStateStaleError(ttlConfig, stateStaleErrorHandling, null);
             }
         }
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/sink/SinkUpsertMaterializer.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/sink/SinkUpsertMaterializer.java
@@ -66,7 +66,7 @@ public class SinkUpsertMaterializer extends TableStreamOperator<RowData>
     private final StateTtlConfig ttlConfig;
     private final TypeSerializer<RowData> serializer;
     private final GeneratedRecordEqualiser generatedEqualiser;
-    private final ExecutionConfigOptions.StateStaledErrorHandling stateStaledErrorHandling;
+    private final ExecutionConfigOptions.StateStaleErrorHandling stateStaleErrorHandling;
 
     private transient RecordEqualiser equaliser;
     // Buffer of emitted insertions on which deletions will be applied first.
@@ -78,11 +78,11 @@ public class SinkUpsertMaterializer extends TableStreamOperator<RowData>
             StateTtlConfig ttlConfig,
             TypeSerializer<RowData> serializer,
             GeneratedRecordEqualiser generatedEqualiser,
-            ExecutionConfigOptions.StateStaledErrorHandling stateStaledErrorHandling) {
+            ExecutionConfigOptions.StateStaleErrorHandling stateStaleErrorHandling) {
         this.ttlConfig = ttlConfig;
         this.serializer = serializer;
         this.generatedEqualiser = generatedEqualiser;
-        this.stateStaledErrorHandling = stateStaledErrorHandling;
+        this.stateStaleErrorHandling = stateStaleErrorHandling;
     }
 
     @Override
@@ -120,8 +120,8 @@ public class SinkUpsertMaterializer extends TableStreamOperator<RowData>
                 final int lastIndex = values.size() - 1;
                 final int index = removeFirst(values, row);
                 if (index == -1) {
-                    ErrorHandlingUtil.handleStateStaledError(
-                            ttlConfig, stateStaledErrorHandling, LOG);
+                    ErrorHandlingUtil.handleStateStaleError(
+                            ttlConfig, stateStaleErrorHandling, LOG);
                     return;
                 }
                 if (values.isEmpty()) {

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/util/ErrorHandlingUtil.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/util/ErrorHandlingUtil.java
@@ -27,7 +27,7 @@ import org.slf4j.Logger;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-/** Utility to handle processing errors. */
+/** Utility to handle state stale errors. */
 @Internal
 public class ErrorHandlingUtil {
 
@@ -35,7 +35,7 @@ public class ErrorHandlingUtil {
      * Message to indicate the state is expired because exceeds the state ttl. The message could be
      * used to output to log.
      */
-    public static final String STATE_EXPIRED_WARN_MSG =
+    public static final String STATE_STALE_WARN_MSG =
             "The state is cleared because of state ttl. "
                     + "This will result in incorrect result. You can increase the state ttl to avoid this.";
 
@@ -43,41 +43,63 @@ public class ErrorHandlingUtil {
      * Message to indicate an unexpected state error when state ttl is disabled. The message could
      * be used to raise an error.
      */
-    public static final String STATE_ERROR_MSG =
+    public static final String UNEXPECTED_STATE_ERROR =
             "The state is unexpectedly cleared while state ttl is not enabled, this is a bug, please fire an issue.";
 
-    /** Utility method to handle state staled error. */
-    public static void handleStateStaledError(
-            @Nonnull StateTtlConfig stateTtlConfig,
-            @Nonnull ExecutionConfigOptions.StateStaledErrorHandling errorHandling,
-            @Nullable Logger logger) {
-        handleStateStaledError(stateTtlConfig, errorHandling, STATE_EXPIRED_WARN_MSG, logger);
-    }
-
     /**
-     * Handle the state staled error by state ttl and error handling configuration. If
-     * stateTtlConfig is enabled and errorHandling is not set to ERROR otherwise a {@link
-     * RuntimeException} will be thrown.
+     * Handle the state stale error by given {@link StateTtlConfig} and {@link
+     * ExecutionConfigOptions.StateStaleErrorHandling}.
+     *
+     * <p>The action mapping to the StateTtlConfig and StateStaleErrorHandling:
+     *
+     * <table border="1" align="left">
+     *   <tr>
+     *     <td> Action </td> <td> StateTtlConfig </td> <td> StateStaleErrorHandling </td>
+     *   </tr>
+     *   <tr>
+     *     <td> Raise Error </td> <td> Disabled </td> <td> Any </td>
+     *   </tr>
+     *   <tr>
+     *     <td> Raise Error </td> <td> Enabled </td> <td> ERROR </td>
+     *   </tr>
+     *   <tr>
+     *     <td> Log Only </td> <td> Enabled </td> <td> CONTINUE_WITH_LOGGING </td>
+     *   </tr>
+     *   <tr>
+     *     <td> Do Nothing </td> <td> Enabled </td> <td> CONTINUE_WITHOUT_LOGGING </td>
+     *   </tr>
+     * </table>
+     *
+     * <p>Note: StateTtlConfig enabled means state will be expired after configured duration which
+     * should be greater than zero.
      */
-    public static void handleStateStaledError(
+    public static void handleStateStaleError(
             @Nonnull StateTtlConfig stateTtlConfig,
-            @Nonnull ExecutionConfigOptions.StateStaledErrorHandling errorHandling,
-            @Nonnull String errorMessage,
+            @Nonnull ExecutionConfigOptions.StateStaleErrorHandling errorHandling,
+            @Nonnull String stateStaleErrorMessage,
             @Nullable Logger logger) {
-        if (stateTtlConfig.isEnabled()) {
+        if (stateTtlConfig.isEnabled() && stateTtlConfig.getTtl().toMilliseconds() > 0) {
             switch (errorHandling) {
                 case ERROR:
-                    throw new RuntimeException(errorMessage);
+                    throw new RuntimeException(stateStaleErrorMessage);
                 case CONTINUE_WITH_LOGGING:
                     if (null != logger) {
-                        logger.warn(errorMessage);
+                        logger.warn(stateStaleErrorMessage);
                     }
                     break;
                 case CONTINUE_WITHOUT_LOGGING:
                     break;
             }
         } else {
-            throw new RuntimeException(STATE_ERROR_MSG);
+            throw new RuntimeException(UNEXPECTED_STATE_ERROR);
         }
+    }
+
+    /** HandleStateStaleError using default STATE_EXPIRED_WARN_MSG. */
+    public static void handleStateStaleError(
+            @Nonnull StateTtlConfig stateTtlConfig,
+            @Nonnull ExecutionConfigOptions.StateStaleErrorHandling errorHandling,
+            @Nullable Logger logger) {
+        handleStateStaleError(stateTtlConfig, errorHandling, STATE_STALE_WARN_MSG, logger);
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/util/ErrorHandlingUtil.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/util/ErrorHandlingUtil.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.util;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.state.StateTtlConfig;
+import org.apache.flink.table.api.config.ExecutionConfigOptions;
+
+import org.slf4j.Logger;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/** Utility to handle processing errors. */
+@Internal
+public class ErrorHandlingUtil {
+
+    /**
+     * Message to indicate the state is expired because exceeds the state ttl. The message could be
+     * used to output to log.
+     */
+    public static final String STATE_EXPIRED_WARN_MSG =
+            "The state is cleared because of state ttl. "
+                    + "This will result in incorrect result. You can increase the state ttl to avoid this.";
+
+    /**
+     * Message to indicate an unexpected state error when state ttl is disabled. The message could
+     * be used to raise an error.
+     */
+    public static final String STATE_ERROR_MSG =
+            "The state is unexpectedly cleared while state ttl is not enabled, this is a bug, please fire an issue.";
+
+    /** Utility method to handle state staled error. */
+    public static void handleStateStaledError(
+            @Nonnull StateTtlConfig stateTtlConfig,
+            @Nonnull ExecutionConfigOptions.StateStaledErrorHandling errorHandling,
+            @Nullable Logger logger) {
+        handleStateStaledError(stateTtlConfig, errorHandling, STATE_EXPIRED_WARN_MSG, logger);
+    }
+
+    /**
+     * Handle the state staled error by state ttl and error handling configuration. If
+     * stateTtlConfig is enabled and errorHandling is not set to ERROR otherwise a {@link
+     * RuntimeException} will be thrown.
+     */
+    public static void handleStateStaledError(
+            @Nonnull StateTtlConfig stateTtlConfig,
+            @Nonnull ExecutionConfigOptions.StateStaledErrorHandling errorHandling,
+            @Nonnull String errorMessage,
+            @Nullable Logger logger) {
+        if (stateTtlConfig.isEnabled()) {
+            switch (errorHandling) {
+                case ERROR:
+                    throw new RuntimeException(errorMessage);
+                case CONTINUE_WITH_LOGGING:
+                    if (null != logger) {
+                        logger.warn(errorMessage);
+                    }
+                    break;
+                case CONTINUE_WITHOUT_LOGGING:
+                    break;
+            }
+        } else {
+            throw new RuntimeException(STATE_ERROR_MSG);
+        }
+    }
+}

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/rank/RetractableTopNFunctionTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/rank/RetractableTopNFunctionTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.runtime.operators.rank;
 import org.apache.flink.api.common.state.StateTtlConfig;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.runtime.util.StateConfigUtil;
@@ -56,7 +57,8 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
                 rankRange,
                 generatedEqualiser,
                 generateUpdateBefore,
-                outputRankNumber);
+                outputRankNumber,
+                ExecutionConfigOptions.StateStaledErrorHandling.CONTINUE_WITHOUT_LOGGING);
     }
 
     @Test
@@ -532,7 +534,8 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
                         new ConstantRankRange(1, 1),
                         generatedEqualiser,
                         true,
-                        false);
+                        false,
+                        ExecutionConfigOptions.StateStaledErrorHandling.CONTINUE_WITHOUT_LOGGING);
 
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
         testHarness.open();
@@ -571,7 +574,8 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
                         new ConstantRankRange(1, 2),
                         generatedEqualiser,
                         true,
-                        true);
+                        true,
+                        ExecutionConfigOptions.StateStaledErrorHandling.CONTINUE_WITHOUT_LOGGING);
 
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
         testHarness.open();

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/rank/UpdatableTopNFunctionTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/rank/UpdatableTopNFunctionTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.runtime.operators.rank;
 
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.flink.table.data.RowData;
 
 import org.junit.Test;
@@ -50,7 +51,8 @@ public class UpdatableTopNFunctionTest extends TopNFunctionTestBase {
                 rankRange,
                 generateUpdateBefore,
                 outputRankNumber,
-                cacheSize);
+                cacheSize,
+                ExecutionConfigOptions.StateStaledErrorHandling.CONTINUE_WITHOUT_LOGGING);
     }
 
     @Test

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/rank/UpdatableTopNFunctionTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/rank/UpdatableTopNFunctionTest.java
@@ -52,7 +52,7 @@ public class UpdatableTopNFunctionTest extends TopNFunctionTestBase {
                 generateUpdateBefore,
                 outputRankNumber,
                 cacheSize,
-                ExecutionConfigOptions.StateStaledErrorHandling.CONTINUE_WITHOUT_LOGGING);
+                ExecutionConfigOptions.StateStaleErrorHandling.CONTINUE_WITHOUT_LOGGING);
     }
 
     @Test

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/sink/SinkUpsertMaterializerTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/sink/SinkUpsertMaterializerTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.state.StateTtlConfig;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.generated.GeneratedRecordEqualiser;
@@ -65,7 +66,11 @@ public class SinkUpsertMaterializerTest {
     @Test
     public void test() throws Exception {
         SinkUpsertMaterializer materializer =
-                new SinkUpsertMaterializer(ttlConfig, serializer, equaliser);
+                new SinkUpsertMaterializer(
+                        ttlConfig,
+                        serializer,
+                        equaliser,
+                        ExecutionConfigOptions.StateStaledErrorHandling.CONTINUE_WITHOUT_LOGGING);
         KeyedOneInputStreamOperatorTestHarness<RowData, RowData, RowData> testHarness =
                 new KeyedOneInputStreamOperatorTestHarness<>(
                         materializer, keySelector, keySelector.getProducedType());

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/sink/SinkUpsertMaterializerTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/sink/SinkUpsertMaterializerTest.java
@@ -70,7 +70,7 @@ public class SinkUpsertMaterializerTest {
                         ttlConfig,
                         serializer,
                         equaliser,
-                        ExecutionConfigOptions.StateStaledErrorHandling.CONTINUE_WITHOUT_LOGGING);
+                        ExecutionConfigOptions.StateStaleErrorHandling.CONTINUE_WITHOUT_LOGGING);
         KeyedOneInputStreamOperatorTestHarness<RowData, RowData, RowData> testHarness =
                 new KeyedOneInputStreamOperatorTestHarness<>(
                         materializer, keySelector, keySelector.getProducedType());


### PR DESCRIPTION
## What is the purpose of the change
In stream processing, records will be deleted when exceed state ttl (if configured), and when the corresponding record's update arrives again, the operator may not be able to handle it properly, we need a unified error handling mechanism to 
handle this situation, instead of each stateful operator currently handling its own.

## Brief change log
* add 'table.exec.state-stale.error-handling' to ExecutionConfigOptions
* add utility class `ErrorHandlingUtil` for unified state stale error handling
* apply the state stale error handling logic to related stateful streaming operators
* update existing tests to ensure error handling is covered

## Verifying this change
updated existing tests

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation
  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)