### PR TITLE
[FLINK-28135][runtime] Introduce SlowTaskDetector

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/slowtaskdetector/SlowTaskDetector.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/slowtaskdetector/SlowTaskDetector.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.slowtaskdetector;
+
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+
+/** Component responsible for detecting slow tasks. */
+public interface SlowTaskDetector {
+
+    /** Start detecting slow tasks periodically. */
+    void start(
+            ExecutionGraph executionGraph,
+            SlowTaskDetectorListener listener,
+            ComponentMainThreadExecutor mainThreadExecutor);
+
+    /** Stop detecting slow tasks. */
+    void stop();
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/slowtaskdetector/SlowTaskDetectorListener.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/slowtaskdetector/SlowTaskDetectorListener.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.slowtaskdetector;
+
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+
+import java.util.Collection;
+import java.util.Map;
+
+/** Component responsible for listening on slow tasks. */
+public interface SlowTaskDetectorListener {
+
+    /**
+     * Notify detected slow tasks.
+     *
+     * @param slowTasks the map of execution vertices and their execution attempts which are
+     *     detected as slow.
+     */
+    void notifySlowTasks(Map<ExecutionVertexID, Collection<ExecutionAttemptID>> slowTasks);
+}


### PR DESCRIPTION
A SlowTaskDetector will periodically check all the current tasks/executions and notify the SlowTaskDetectorListener about the detected slow tasks. SpeculativeScheduler will register itself as the SlowTaskDetectorListener.

## What is the purpose of the change
Add two interface to find slow tasks. Another pr will implement them.

## Brief change log
Add two interface.
(1) SlowTaskDetector. The component responsible for detecting slow tasks.
(2)SlowTaskDetectorListener. The component responsible for listening on slow tasks. 

## Verifying this change
This pr mainly add two interfaces. UT will implement in another pr.

## Does this pull request potentially affect one of the following parts:
Dependencies (does it add or upgrade a dependency): no
The public API, i.e., is any changed class annotated with @Public(Evolving):no
The serializers: no
The runtime per-record code paths (performance sensitive): no
Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
The S3 file system connector: no

## Documentation
Does this pull request introduce a new feature? no
If yes, how is the feature documented? not applicable
