### PR TITLE
[FLINK-28213][runtime] StreamExecutionEnvironment configure method support override pipeline.jars option

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigUtils.java
@@ -155,5 +155,33 @@ public class ConfigUtils {
         return options;
     }
 
+    /**
+     * Merge a {@link Collection} of values of type {@code T} and option {@link ConfigOption} value
+     * of type {@link List} of type {@code T} from current {@link Configuration}, then put it to
+     * {@link Configuration}.
+     *
+     * @param configuration the configuration object to get the value out and write
+     * @param key the {@link ConfigOption option} to serve as the key for the list in the
+     *     configuration
+     * @param values the collection of values to merge as value for the {@code key}
+     * @param decodeMapper the decode transformation function.
+     * @param encodeMapper the encode transformation function.
+     */
+    public static <T, E extends Throwable> void mergeCollectionsToConfig(
+            final Configuration configuration,
+            final ConfigOption<List<T>> key,
+            final Collection<T> values,
+            final FunctionWithException<T, T, E> decodeMapper,
+            final Function<T, T> encodeMapper)
+            throws E {
+        // decode option value from current configuration
+        Set<T> valueInConfig =
+                new HashSet<>(decodeListFromConfig(configuration, key, decodeMapper));
+        // merge provided option value
+        valueInConfig.addAll(values);
+        // encode the merged value to current WritableConfig
+        encodeCollectionToConfig(configuration, key, valueInConfig, encodeMapper);
+    }
+
     private ConfigUtils() {}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -52,6 +52,7 @@ import org.apache.flink.api.java.typeutils.PojoTypeInfo;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
 import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigUtils;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.DeploymentOptions;
@@ -116,6 +117,7 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -1022,6 +1024,19 @@ public class StreamExecutionEnvironment {
                                         ExecutionCheckpointingOptions
                                                 .ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH,
                                         flag));
+
+        // merge PipelineOptions.JARS, user maybe set this option in high level such as table
+        // module, so here need to merge the jars from both configuration object
+        configuration
+                .getOptional(PipelineOptions.JARS)
+                .ifPresent(
+                        jars ->
+                                ConfigUtils.mergeCollectionsToConfig(
+                                        this.configuration,
+                                        PipelineOptions.JARS,
+                                        Collections.unmodifiableCollection(jars),
+                                        String::toString,
+                                        String::toString));
 
         config.configure(configuration, classLoader);
         checkpointCfg.configure(configuration);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironmentComplexConfigurationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironmentComplexConfigurationTest.java
@@ -240,6 +240,27 @@ public class StreamExecutionEnvironmentComplexConfigurationTest {
         assertThat(env.getStateBackend(), instanceOf(MemoryStateBackend.class));
     }
 
+    @Test
+    public void testMergePipelineJarsWithConfiguration() {
+        Configuration configuration = new Configuration();
+        configuration.set(PipelineOptions.JARS, Arrays.asList("/tmp/test1.jar", "/tmp/test2.jar"));
+        StreamExecutionEnvironment envFromConfiguration =
+                StreamExecutionEnvironment.getExecutionEnvironment(configuration);
+
+        // user configuration with different jars
+        Configuration userConfiguration = new Configuration();
+        userConfiguration.set(
+                PipelineOptions.JARS, Arrays.asList("/tmp/test2.jar", "/tmp/test3.jar"));
+
+        // test pipeline.jars merge
+        envFromConfiguration.configure(
+                userConfiguration, Thread.currentThread().getContextClassLoader());
+
+        assertEquals(
+                envFromConfiguration.getConfiguration().get(PipelineOptions.JARS),
+                Arrays.asList("/tmp/test1.jar", "/tmp/test2.jar", "/tmp/test3.jar"));
+    }
+
     /** JobSubmitted counter listener for unit test. */
     public static class BasicJobSubmittedCounter implements JobListener {
         private int count = 0;


### PR DESCRIPTION
## What is the purpose of the change

StreamExecutionEnvironment configure method support override pipeline.jars option. The background is that table module introduce `create function using jar` which allow user register jar dynamically after StreamExecutionEnvironment created,  Therefore, when compile and submit SQL job, if refer the user jar, these jar should be passed to JobGraph, we need to merge user jars and existing jars.


## Brief change log

  - *StreamExecutionEnvironment configure method support override pipeline.jars option*


## Verifying this change

This change added tests and can be verified as follows:

  - *Added integration tests `testMergePipelineJarsWithConfiguration`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? ( not documented)
