### PR TITLE
[FLINK-28226][python] Limit grpcio<1.47

### DIFF
--- a/flink-end-to-end-tests/test-scripts/docker-hadoop-secure-cluster/Dockerfile
+++ b/flink-end-to-end-tests/test-scripts/docker-hadoop-secure-cluster/Dockerfile
@@ -36,7 +36,7 @@ RUN set -x \
 # install dev tools
 RUN set -x \
     && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    curl tar sudo openssh-server openssh-client rsync unzip krb5-user net-tools
+    curl tar sudo openssh-server openssh-client rsync unzip krb5-user net-tools build-essential
 
 # Kerberos client
 RUN set -x \

--- a/flink-end-to-end-tests/test-scripts/test_kubernetes_pyflink_application.sh
+++ b/flink-end-to-end-tests/test-scripts/test_kubernetes_pyflink_application.sh
@@ -82,6 +82,7 @@ cp "${FLINK_PYTHON_DIR}/dev/dev-requirements.txt" $PYFLINK_DOCKER_DIR/
 if [[ -d "dist" ]]; then rm -Rf dist; fi
 cd ${PYFLINK_DOCKER_DIR}
 echo "FROM ${PURE_FLINK_IMAGE_NAME}" >> Dockerfile
+echo "RUN apt-get update && apt-get install build-essential -y" >> Dockerfile
 echo "COPY lint-python.sh /tmp/lint-python.sh" >> Dockerfile
 echo "COPY dev-requirements.txt /tmp/dev-requirements.txt" >> Dockerfile
 echo "RUN bash /tmp/lint-python.sh -s basic" >> Dockerfile

--- a/flink-end-to-end-tests/test-scripts/test_kubernetes_pyflink_application.sh
+++ b/flink-end-to-end-tests/test-scripts/test_kubernetes_pyflink_application.sh
@@ -78,13 +78,16 @@ mkdir -p "$PYFLINK_DOCKER_DIR"
 cp "${FLINK_PYTHON_DIR}/dist/${PYFLINK_PACKAGE_FILE}" $PYFLINK_DOCKER_DIR/
 cp "${FLINK_PYTHON_DIR}/apache-flink-libraries/dist/${PYFLINK_LIBRARIES_PACKAGE_FILE}" $PYFLINK_DOCKER_DIR/
 cp "${FLINK_PYTHON_DIR}/dev/lint-python.sh" $PYFLINK_DOCKER_DIR/
+cp "${FLINK_PYTHON_DIR}/dev/dev-requirements.txt" $PYFLINK_DOCKER_DIR/
 if [[ -d "dist" ]]; then rm -Rf dist; fi
 cd ${PYFLINK_DOCKER_DIR}
 echo "FROM ${PURE_FLINK_IMAGE_NAME}" >> Dockerfile
 echo "COPY lint-python.sh /tmp/lint-python.sh" >> Dockerfile
+echo "COPY dev-requirements.txt /tmp/dev-requirements.txt" >> Dockerfile
 echo "RUN bash /tmp/lint-python.sh -s basic" >> Dockerfile
 echo "COPY ${PYFLINK_PACKAGE_FILE} ${PYFLINK_PACKAGE_FILE}" >> Dockerfile
 echo "COPY ${PYFLINK_LIBRARIES_PACKAGE_FILE} ${PYFLINK_LIBRARIES_PACKAGE_FILE}" >> Dockerfile
+echo "RUN /tmp/.conda/bin/python -m pip install -r /tmp/dev-requirements.txt"  >> Dockerfile
 echo "RUN /tmp/.conda/bin/python -m pip install ${PYFLINK_LIBRARIES_PACKAGE_FILE}" >> Dockerfile
 echo "RUN /tmp/.conda/bin/python -m pip install ${PYFLINK_PACKAGE_FILE}" >> Dockerfile
 echo "RUN rm ${PYFLINK_LIBRARIES_PACKAGE_FILE}" >> Dockerfile

--- a/flink-end-to-end-tests/test-scripts/test_pyflink.sh
+++ b/flink-end-to-end-tests/test-scripts/test_pyflink.sh
@@ -86,6 +86,8 @@ cd "${FLINK_PYTHON_DIR}"
 
 rm -rf dist
 
+pip install -r dev/dev-requirements.txt
+
 python setup.py sdist
 
 pushd apache-flink-libraries

--- a/flink-end-to-end-tests/test-scripts/test_pyflink_yarn.sh
+++ b/flink-end-to-end-tests/test-scripts/test_pyflink_yarn.sh
@@ -34,6 +34,7 @@ start_hadoop_cluster_and_prepare_flink
 
 # copy test files
 docker cp "${FLINK_PYTHON_DIR}/dev/lint-python.sh" master:/tmp/
+docker cp "${FLINK_PYTHON_DIR}/dev/dev-requirements.txt" master:/tmp/
 docker cp "${FLINK_PYTHON_TEST_DIR}/target/PythonUdfSqlJobExample.jar" master:/tmp/
 docker cp "${FLINK_PYTHON_TEST_DIR}/python/add_one.py" master:/tmp/
 docker cp "${REQUIREMENTS_PATH}" master:/tmp/
@@ -47,6 +48,7 @@ docker cp "${FLINK_PYTHON_DIR}/apache-flink-libraries/dist/${PYFLINK_LIBRARIES_P
 docker exec master bash -c "
 /tmp/lint-python.sh -s miniconda
 source /tmp/.conda/bin/activate
+pip install -r /tmp/dev-requirements.txt
 pip install /tmp/${PYFLINK_LIBRARIES_PACKAGE_FILE}
 pip install /tmp/${PYFLINK_PACKAGE_FILE}
 conda install -y -q zip=3.0

--- a/flink-python/dev/dev-requirements.txt
+++ b/flink-python/dev/dev-requirements.txt
@@ -29,7 +29,8 @@ pytz>=2018.3
 numpy>=1.21.4,<1.22.0; python_version >= '3.7'
 numpy>=1.14.3,<1.20; python_version < '3.7'
 fastavro>=1.1.0,<1.4.8
-grpcio>=1.29.0,<2
+grpcio>=1.29.0,<1.47
 grpcio-tools>=1.3.5,<=1.14.2
 pemja==0.1.5; python_version >= '3.7' and platform_system != 'Windows'
 httplib2>=0.19.0,<=0.20.4
+protobuf<3.18


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will limit grpcio<1.47*


## Verifying this change

This change added tests and can be verified as follows:

  - *Limit grpcio<1.47*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
