### PR TITLE
[FLINK-28234][hive] fix Infinite or NaN exception in ExpressionReducer

### DIFF
--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
@@ -1576,12 +1576,11 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
       "NULL"
     )
 
-    // invalid log
-    val infiniteOrNaNException = "Infinite or NaN"
+    // test Infinite or NaN
     // Infinity
-    testExpectedSqlException("LOG(1, 100)", infiniteOrNaNException, classOf[NumberFormatException])
+    testSqlApi("LOG(1, 100)", "Infinity")
     // NaN
-    testExpectedSqlException("LOG(-1)", infiniteOrNaNException, classOf[NumberFormatException])
+    testSqlApi("LOG(-1)", "NaN")
   }
 
   @Test

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/SqlExpressionTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/SqlExpressionTest.scala
@@ -97,6 +97,7 @@ class SqlExpressionTest extends ExpressionTestBase {
     testSqlApi("5/5", "1")
     testSqlApi("5%2", "1");
     testSqlApi("POWER(5, 5)", "3125.0")
+    testSqlApi("POWER(-1, 0.5)", "NaN")
     testSqlApi("ABS(-5)", "5")
     testSqlApi("MOD(-26, 5)", "-1")
     testSqlApi("SQRT(4)", "2.0")


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
To fix the "Infinite or NaN exception" thrown by ExpressionReducer when the reduced value is `NaN`.


## Brief change log
  -  When the reduced value is `NaN`, skip the reduce for we can't make the literal for the `NaN`.


## Verifying this change
Added test `POWER(-1, 0.5) ` in [SqlExpressionTest.scala](https://github.com/apache/flink/compare/master...luoyuxia:FLINK-28234?expand=1#diff-9eeebd8f435753f895d83c2754556b028cf917fcf4d02a15306aca2aa7e34725)


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive):  no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature?  no
  - If yes, how is the feature documented? N/A
