### PR TITLE
[FLINK-28238][sql-gateway] Fix unstable testCancelOperationAndFetchResultInParallel

### DIFF
--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/SqlGatewayServiceITCase.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/SqlGatewayServiceITCase.java
@@ -37,12 +37,14 @@ import org.apache.flink.table.gateway.api.utils.SqlGatewayException;
 import org.apache.flink.table.gateway.service.operation.Operation;
 import org.apache.flink.table.gateway.service.operation.OperationManager;
 import org.apache.flink.table.gateway.service.session.SessionManager;
+import org.apache.flink.table.gateway.service.utils.IgnoreErrorThreadFactory;
 import org.apache.flink.table.gateway.service.utils.SqlExecutionException;
 import org.apache.flink.table.gateway.service.utils.SqlGatewayServiceExtension;
 import org.apache.flink.test.util.AbstractTestBase;
 import org.apache.flink.util.function.RunnableWithException;
 
 import org.assertj.core.api.Assertions;
+import org.assertj.core.api.Condition;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -58,6 +60,7 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 
 import static org.apache.flink.core.testutils.FlinkAssertions.anyCauseMatches;
+import static org.apache.flink.core.testutils.FlinkAssertions.assertThatChainOfCauses;
 import static org.apache.flink.types.RowKind.DELETE;
 import static org.apache.flink.types.RowKind.INSERT;
 import static org.apache.flink.types.RowKind.UPDATE_AFTER;
@@ -244,7 +247,7 @@ public class SqlGatewayServiceITCase extends AbstractTestBase {
     // --------------------------------------------------------------------------------------------
 
     @Test
-    public void testCancelOperationAndFetchResultInParallel() throws Exception {
+    public void testCancelOperationAndFetchResultInParallel() {
         SessionHandle sessionHandle = service.openSession(defaultSessionEnvironment);
         CountDownLatch latch = new CountDownLatch(1);
         // Make sure cancel the Operation before finish.
@@ -253,9 +256,13 @@ public class SqlGatewayServiceITCase extends AbstractTestBase {
                 sessionHandle,
                 operationHandle,
                 () -> service.cancelOperation(sessionHandle, operationHandle),
-                String.format(
-                        "Can not fetch results from the %s in %s status.",
-                        operationHandle, OperationStatus.CANCELED));
+                new Condition<>(
+                        msg ->
+                                msg.contains(
+                                        String.format(
+                                                "Can not fetch results from the %s in %s status.",
+                                                operationHandle, OperationStatus.CANCELED)),
+                        "Fetch results with expected error message."));
         latch.countDown();
     }
 
@@ -273,9 +280,19 @@ public class SqlGatewayServiceITCase extends AbstractTestBase {
                 sessionHandle,
                 operationHandle,
                 () -> service.closeOperation(sessionHandle, operationHandle),
-                String.format(
-                        "Can not find the submitted operation in the OperationManager with the %s.",
-                        operationHandle));
+                // It's possible the fetcher fetch the result from a closed operation or fetcher
+                // can't find the operation.
+                new Condition<>(
+                        msg ->
+                                msg.contains(
+                                                String.format(
+                                                        "Can not find the submitted operation in the OperationManager with the %s.",
+                                                        operationHandle))
+                                        || msg.contains(
+                                                String.format(
+                                                        "Can not fetch results from the %s in %s status.",
+                                                        operationHandle, OperationStatus.CLOSED)),
+                        "Fetch results with expected error message."));
     }
 
     @Test
@@ -300,8 +317,12 @@ public class SqlGatewayServiceITCase extends AbstractTestBase {
                     service.getSession(sessionHandle)
                             .getOperationManager()
                             .getOperation(operationHandle));
-            new Thread(() -> service.cancelOperation(sessionHandle, operationHandle)).start();
-            new Thread(() -> service.closeOperation(sessionHandle, operationHandle)).start();
+            IgnoreErrorThreadFactory.INSTANCE
+                    .newThread(() -> service.cancelOperation(sessionHandle, operationHandle))
+                    .start();
+            IgnoreErrorThreadFactory.INSTANCE
+                    .newThread(() -> service.closeOperation(sessionHandle, operationHandle))
+                    .start();
         }
 
         CommonTestUtils.waitUtil(
@@ -323,7 +344,8 @@ public class SqlGatewayServiceITCase extends AbstractTestBase {
         int submitThreadsNum = 100;
         CountDownLatch latch = new CountDownLatch(submitThreadsNum);
         for (int i = 0; i < submitThreadsNum; i++) {
-            new Thread(
+            IgnoreErrorThreadFactory.INSTANCE
+                    .newThread(
                             () -> {
                                 try {
                                     submitDefaultOperation(sessionHandle, () -> {});
@@ -419,10 +441,11 @@ public class SqlGatewayServiceITCase extends AbstractTestBase {
             SessionHandle sessionHandle,
             OperationHandle operationHandle,
             RunnableWithException cancelOrClose,
-            String errorMsg) {
+            Condition<String> condition) {
 
         List<RowData> actual = new ArrayList<>();
-        new Thread(
+        IgnoreErrorThreadFactory.INSTANCE
+                .newThread(
                         () -> {
                             try {
                                 cancelOrClose.run();
@@ -448,7 +471,10 @@ public class SqlGatewayServiceITCase extends AbstractTestBase {
                                 }
                             }
                         })
-                .satisfies(anyCauseMatches(errorMsg));
+                .satisfies(
+                        t ->
+                                assertThatChainOfCauses(t)
+                                        .anySatisfy(t1 -> condition.matches(t1.getMessage())));
 
         assertTrue(new HashSet<>(getDefaultResultSet().getData()).containsAll(actual));
     }

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/result/ResultFetcherTest.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/result/ResultFetcherTest.java
@@ -28,6 +28,7 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.gateway.api.operation.OperationHandle;
 import org.apache.flink.table.gateway.api.results.ResultSet;
 import org.apache.flink.table.gateway.api.utils.SqlGatewayException;
+import org.apache.flink.table.gateway.service.utils.IgnoreErrorThreadFactory;
 import org.apache.flink.types.RowKind;
 import org.apache.flink.util.CloseableIterator;
 import org.apache.flink.util.TestLogger;
@@ -180,7 +181,8 @@ public class ResultFetcherTest extends TestLogger {
                 "Failed to wait the buffer has data.");
         List<RowData> firstFetch = fetcher.fetchResults(0, Integer.MAX_VALUE).getData();
         for (int i = 0; i < fetchThreadNum; i++) {
-            new Thread(
+            IgnoreErrorThreadFactory.INSTANCE
+                    .newThread(
                             () -> {
                                 ResultSet resultSet = fetcher.fetchResults(0, Integer.MAX_VALUE);
 

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/result/ResultFetcherTest.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/result/ResultFetcherTest.java
@@ -28,10 +28,11 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.gateway.api.operation.OperationHandle;
 import org.apache.flink.table.gateway.api.results.ResultSet;
 import org.apache.flink.table.gateway.api.utils.SqlGatewayException;
-import org.apache.flink.table.gateway.service.utils.IgnoreErrorThreadFactory;
+import org.apache.flink.table.gateway.service.utils.IgnoreExceptionHandler;
 import org.apache.flink.types.RowKind;
 import org.apache.flink.util.CloseableIterator;
 import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.concurrent.ExecutorThreadFactory;
 
 import org.apache.commons.collections.iterators.IteratorChain;
 import org.junit.jupiter.api.BeforeAll;
@@ -46,6 +47,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -58,6 +60,9 @@ public class ResultFetcherTest extends TestLogger {
 
     private static ResolvedSchema schema;
     private static List<RowData> data;
+
+    private final ThreadFactory threadFactory =
+            new ExecutorThreadFactory("Result Fetcher Test Pool", IgnoreExceptionHandler.INSTANCE);
 
     @BeforeAll
     public static void setUp() {
@@ -181,7 +186,7 @@ public class ResultFetcherTest extends TestLogger {
                 "Failed to wait the buffer has data.");
         List<RowData> firstFetch = fetcher.fetchResults(0, Integer.MAX_VALUE).getData();
         for (int i = 0; i < fetchThreadNum; i++) {
-            IgnoreErrorThreadFactory.INSTANCE
+            threadFactory
                     .newThread(
                             () -> {
                                 ResultSet resultSet = fetcher.fetchResults(0, Integer.MAX_VALUE);

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/utils/IgnoreErrorThreadFactory.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/utils/IgnoreErrorThreadFactory.java
@@ -1,0 +1,44 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.flink.table.gateway.service.utils;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.ThreadFactory;
+
+/** Factory to create the thread that ignores error message. */
+public class IgnoreErrorThreadFactory implements ThreadFactory {
+
+    public static final IgnoreErrorThreadFactory INSTANCE = new IgnoreErrorThreadFactory();
+
+    private IgnoreErrorThreadFactory() {}
+
+    @Override
+    public Thread newThread(@NotNull Runnable r) {
+        Thread thread = new Thread(r);
+        thread.setUncaughtExceptionHandler(
+                new Thread.UncaughtExceptionHandler() {
+                    @Override
+                    public void uncaughtException(Thread t, Throwable e) {
+                        // ignore error
+                    }
+                });
+        return thread;
+    }
+}

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/utils/IgnoreExceptionHandler.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/utils/IgnoreExceptionHandler.java
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
 /** Handler to log the exception and exits. */
 public class IgnoreExceptionHandler implements Thread.UncaughtExceptionHandler {
 
-    public static IgnoreExceptionHandler INSTANCE = new IgnoreExceptionHandler();
+    public static final IgnoreExceptionHandler INSTANCE = new IgnoreExceptionHandler();
 
     private static final Logger LOG = LoggerFactory.getLogger(IgnoreExceptionHandler.class);
 

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/utils/IgnoreExceptionHandler.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/utils/IgnoreExceptionHandler.java
@@ -18,27 +18,19 @@
 
 package org.apache.flink.table.gateway.service.utils;
 
-import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.util.concurrent.ThreadFactory;
+/** Handler to log the exception and exits. */
+public class IgnoreExceptionHandler implements Thread.UncaughtExceptionHandler {
 
-/** Factory to create the thread that ignores error message. */
-public class IgnoreErrorThreadFactory implements ThreadFactory {
+    public static IgnoreExceptionHandler INSTANCE = new IgnoreExceptionHandler();
 
-    public static final IgnoreErrorThreadFactory INSTANCE = new IgnoreErrorThreadFactory();
-
-    private IgnoreErrorThreadFactory() {}
+    private static final Logger LOG = LoggerFactory.getLogger(IgnoreExceptionHandler.class);
 
     @Override
-    public Thread newThread(@NotNull Runnable r) {
-        Thread thread = new Thread(r);
-        thread.setUncaughtExceptionHandler(
-                new Thread.UncaughtExceptionHandler() {
-                    @Override
-                    public void uncaughtException(Thread t, Throwable e) {
-                        // ignore error
-                    }
-                });
-        return thread;
+    public void uncaughtException(Thread t, Throwable e) {
+        // ignore error
+        LOG.error("Thread '{}' produced an uncaught exception. Ignore...", t.getName(), e);
     }
 }


### PR DESCRIPTION
…sultInParallel

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*Fix the unstable test case.  The root cause is the fetcher thread and another thread is in parallel. There are two cases:*
*1. The fetcher gets the Operation and then another thread closes the Operation. Then the fetcher gets the error message "Can not fetch results in closed operation."*
*2. The closing thread closes the Operation and removes the Operation from the Operation Manager, then the fetcher tries to fetch the results. In this case, the fetcher will get the message "Can not find the operation".*


## Brief change log

  - *Matches the expected error message in the test.*
  - *In the concurrent test, the thread print the error msg to the terminal when getting exceptions. Introduce an `IgnoreErrorThreadFactory` to swallow the useless message.*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
