### PR TITLE
[FLINK-28230][ci] Unify Dependency class 

### DIFF
--- a/tools/ci/java-ci-tools/src/main/java/org/apache/flink/tools/ci/suffixcheck/ScalaSuffixChecker.java
+++ b/tools/ci/java-ci-tools/src/main/java/org/apache/flink/tools/ci/suffixcheck/ScalaSuffixChecker.java
@@ -17,8 +17,8 @@
 
 package org.apache.flink.tools.ci.suffixcheck;
 
-import org.apache.flink.tools.ci.utils.dependency.Dependency;
 import org.apache.flink.tools.ci.utils.dependency.DependencyParser;
+import org.apache.flink.tools.ci.utils.shared.Dependency;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/tools/ci/java-ci-tools/src/main/java/org/apache/flink/tools/ci/utils/dependency/DependencyParser.java
+++ b/tools/ci/java-ci-tools/src/main/java/org/apache/flink/tools/ci/utils/dependency/DependencyParser.java
@@ -18,6 +18,7 @@
 package org.apache.flink.tools.ci.utils.dependency;
 
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.tools.ci.utils.shared.Dependency;
 
 import java.io.IOException;
 import java.nio.file.Files;

--- a/tools/ci/java-ci-tools/src/main/java/org/apache/flink/tools/ci/utils/shared/Dependency.java
+++ b/tools/ci/java-ci-tools/src/main/java/org/apache/flink/tools/ci/utils/shared/Dependency.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.tools.ci.utils.dependency;
+package org.apache.flink.tools.ci.utils.shared;
 
 import javax.annotation.Nullable;
 

--- a/tools/ci/java-ci-tools/src/test/java/org/apache/flink/tools/ci/utils/dependency/DependencyParserCopyTest.java
+++ b/tools/ci/java-ci-tools/src/test/java/org/apache/flink/tools/ci/utils/dependency/DependencyParserCopyTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.flink.tools.ci.utils.dependency;
 
+import org.apache.flink.tools.ci.utils.shared.Dependency;
+
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;

--- a/tools/ci/java-ci-tools/src/test/java/org/apache/flink/tools/ci/utils/dependency/DependencyParserTreeTest.java
+++ b/tools/ci/java-ci-tools/src/test/java/org/apache/flink/tools/ci/utils/dependency/DependencyParserTreeTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.flink.tools.ci.utils.dependency;
 
+import org.apache.flink.tools.ci.utils.shared.Dependency;
+
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;


### PR DESCRIPTION
Based on #20053.

Deduplicates the Dependency classes from the NoticeFileChecker and the one introduced in #20053. The goal is to ease interoperability between plugins/parser results, as most checks use 2 sources to parse dependencies.