### PR TITLE
[FLINK-28246][ci] Store classifier in Dependency 

### DIFF
--- a/tools/ci/flink-ci-tools/src/main/java/org/apache/flink/tools/ci/licensecheck/NoticeFileChecker.java
+++ b/tools/ci/flink-ci-tools/src/main/java/org/apache/flink/tools/ci/licensecheck/NoticeFileChecker.java
@@ -381,7 +381,7 @@ public class NoticeFileChecker {
                         String version = includeMatcher.group(3);
                         result.put(
                                 currentShadeModule,
-                                Dependency.create(groupId, artifactId, version));
+                                Dependency.create(groupId, artifactId, version, null));
                     }
                 }
                 if (line.contains("Replacing original artifact with shaded artifact")) {

--- a/tools/ci/flink-ci-tools/src/main/java/org/apache/flink/tools/ci/utils/dependency/DependencyParser.java
+++ b/tools/ci/flink-ci-tools/src/main/java/org/apache/flink/tools/ci/utils/dependency/DependencyParser.java
@@ -181,7 +181,8 @@ public class DependencyParser {
                 Dependency.create(
                         dependencyMatcher.group("groupId"),
                         dependencyMatcher.group("artifactId"),
-                        dependencyMatcher.group("version")));
+                        dependencyMatcher.group("version"),
+                        dependencyMatcher.group("classifier")));
     }
 
     @VisibleForTesting
@@ -196,6 +197,7 @@ public class DependencyParser {
                         dependencyMatcher.group("groupId"),
                         dependencyMatcher.group("artifactId"),
                         dependencyMatcher.group("version"),
+                        dependencyMatcher.group("classifier"),
                         dependencyMatcher.group("scope"),
                         dependencyMatcher.group("optional") != null));
     }

--- a/tools/ci/flink-ci-tools/src/main/java/org/apache/flink/tools/ci/utils/notice/NoticeParser.java
+++ b/tools/ci/flink-ci-tools/src/main/java/org/apache/flink/tools/ci/utils/notice/NoticeParser.java
@@ -75,7 +75,7 @@ public class NoticeParser {
             String groupId = matcher.group("groupId");
             String artifactId = matcher.group("artifactId");
             String version = matcher.group("version");
-            return Optional.of(Dependency.create(groupId, artifactId, version));
+            return Optional.of(Dependency.create(groupId, artifactId, version, null));
         }
         return Optional.empty();
     }

--- a/tools/ci/flink-ci-tools/src/main/java/org/apache/flink/tools/ci/utils/shared/Dependency.java
+++ b/tools/ci/flink-ci-tools/src/main/java/org/apache/flink/tools/ci/utils/shared/Dependency.java
@@ -34,6 +34,7 @@ public final class Dependency {
     private final String groupId;
     private final String artifactId;
     private final String version;
+    @Nullable private final String classifier;
     @Nullable private final String scope;
     @Nullable private final Boolean isOptional;
 
@@ -41,23 +42,36 @@ public final class Dependency {
             String groupId,
             String artifactId,
             String version,
+            @Nullable String classifier,
             @Nullable String scope,
             @Nullable Boolean isOptional) {
         this.groupId = Objects.requireNonNull(groupId);
         this.artifactId = Objects.requireNonNull(artifactId);
         this.version = Objects.requireNonNull(version);
+        this.classifier = classifier;
         this.scope = scope;
         this.isOptional = isOptional;
     }
 
     public static Dependency create(
-            String groupId, String artifactId, String version, String scope, boolean isOptional) {
+            String groupId,
+            String artifactId,
+            String version,
+            String classifier,
+            String scope,
+            boolean isOptional) {
         return new Dependency(
-                groupId, artifactId, version, Objects.requireNonNull(scope), isOptional);
+                groupId,
+                artifactId,
+                version,
+                classifier,
+                Objects.requireNonNull(scope),
+                isOptional);
     }
 
-    public static Dependency create(String groupId, String artifactId, String version) {
-        return new Dependency(groupId, artifactId, version, null, null);
+    public static Dependency create(
+            String groupId, String artifactId, String version, String classifier) {
+        return new Dependency(groupId, artifactId, version, classifier, null, null);
     }
 
     public String getGroupId() {
@@ -70,6 +84,10 @@ public final class Dependency {
 
     public String getVersion() {
         return version;
+    }
+
+    public Optional<String> getClassifier() {
+        return Optional.ofNullable(classifier);
     }
 
     public Optional<String> getScope() {

--- a/tools/ci/flink-ci-tools/src/test/java/org/apache/flink/tools/ci/licensecheck/NoticeFileCheckerTest.java
+++ b/tools/ci/flink-ci-tools/src/test/java/org/apache/flink/tools/ci/licensecheck/NoticeFileCheckerTest.java
@@ -39,7 +39,7 @@ class NoticeFileCheckerTest {
     @Test
     void testRunHappyPath() throws IOException {
         final String moduleName = "test";
-        final Dependency bundledDependency = Dependency.create("a", "b", "c");
+        final Dependency bundledDependency = Dependency.create("a", "b", "c", null);
         final ArrayListMultimap<String, Dependency> bundleDependencies = ArrayListMultimap.create();
         bundleDependencies.put(moduleName, bundledDependency);
         final Set<String> deployedModules = Collections.singleton(moduleName);
@@ -59,7 +59,7 @@ class NoticeFileCheckerTest {
     @Test
     void testRunRejectsMissingNotice() throws IOException {
         final String moduleName = "test";
-        final Dependency bundledDependency = Dependency.create("a", "b", "c");
+        final Dependency bundledDependency = Dependency.create("a", "b", "c", null);
         final ArrayListMultimap<String, Dependency> bundleDependencies = ArrayListMultimap.create();
         bundleDependencies.put(moduleName, bundledDependency);
         final Set<String> deployedModules = Collections.singleton(moduleName);
@@ -76,7 +76,7 @@ class NoticeFileCheckerTest {
     @Test
     void testRunRejectsIncorrectNotice() throws IOException {
         final String moduleName = "test";
-        final Dependency bundledDependency = Dependency.create("a", "b", "c");
+        final Dependency bundledDependency = Dependency.create("a", "b", "c", null);
         final ArrayListMultimap<String, Dependency> bundleDependencies = ArrayListMultimap.create();
         bundleDependencies.put(moduleName, bundledDependency);
         final Set<String> deployedModules = Collections.singleton(moduleName);
@@ -94,7 +94,7 @@ class NoticeFileCheckerTest {
     @Test
     void testRunSkipsNonDeployedModules() throws IOException {
         final String moduleName = "test";
-        final Dependency bundledDependency = Dependency.create("a", "b", "c");
+        final Dependency bundledDependency = Dependency.create("a", "b", "c", null);
         final ArrayListMultimap<String, Dependency> bundleDependencies = ArrayListMultimap.create();
         bundleDependencies.put(moduleName, bundledDependency);
         final Set<String> deployedModules = Collections.emptySet();
@@ -117,8 +117,9 @@ class NoticeFileCheckerTest {
 
         // a module that is not deployed but bundles another dependency with an empty NOTICE
         final String nonDeployedModuleName = "nonDeployed";
-        final Dependency nonDeployedDependency = Dependency.create("a", nonDeployedModuleName, "c");
-        final Dependency bundledDependency = Dependency.create("a", "b", "c");
+        final Dependency nonDeployedDependency =
+                Dependency.create("a", nonDeployedModuleName, "c", null);
+        final Dependency bundledDependency = Dependency.create("a", "b", "c", null);
         bundledDependencies.put(nonDeployedModuleName, bundledDependency);
         // this would usually not be a problem, but since the module is not bundled it's not OK!
         final Optional<NoticeContents> emptyNotice =
@@ -143,7 +144,7 @@ class NoticeFileCheckerTest {
     @Test
     void testCheckNoticeFileHappyPath() {
         final String moduleName = "test";
-        final Dependency bundledDependency = Dependency.create("a", "b", "c");
+        final Dependency bundledDependency = Dependency.create("a", "b", "c", null);
         final ArrayListMultimap<String, Dependency> bundleDependencies = ArrayListMultimap.create();
         bundleDependencies.put(moduleName, bundledDependency);
 
@@ -178,7 +179,7 @@ class NoticeFileCheckerTest {
     void testCheckNoticeFileRejectsDuplicateLine() {
         final String moduleName = "test";
         final ArrayListMultimap<String, Dependency> bundleDependencies = ArrayListMultimap.create();
-        bundleDependencies.put(moduleName, Dependency.create("a", "b", "c"));
+        bundleDependencies.put(moduleName, Dependency.create("a", "b", "c", null));
 
         assertThat(
                         NoticeFileChecker.checkNoticeFile(
@@ -187,8 +188,8 @@ class NoticeFileCheckerTest {
                                 new NoticeContents(
                                         moduleName,
                                         Arrays.asList(
-                                                Dependency.create("a", "b", "c"),
-                                                Dependency.create("a", "b", "c")))))
+                                                Dependency.create("a", "b", "c", null),
+                                                Dependency.create("a", "b", "c", null)))))
                 .containsOnlyKeys(NoticeFileChecker.Severity.CRITICAL);
     }
 
@@ -196,7 +197,7 @@ class NoticeFileCheckerTest {
     void testCheckNoticeFileRejectsMissingDependency() {
         final String moduleName = "test";
         final ArrayListMultimap<String, Dependency> bundleDependencies = ArrayListMultimap.create();
-        bundleDependencies.put(moduleName, Dependency.create("a", "b", "c"));
+        bundleDependencies.put(moduleName, Dependency.create("a", "b", "c", null));
 
         assertThat(
                         NoticeFileChecker.checkNoticeFile(

--- a/tools/ci/flink-ci-tools/src/test/java/org/apache/flink/tools/ci/utils/dependency/DependencyParserCopyTest.java
+++ b/tools/ci/flink-ci-tools/src/test/java/org/apache/flink/tools/ci/utils/dependency/DependencyParserCopyTest.java
@@ -34,7 +34,7 @@ class DependencyParserCopyTest {
         return Stream.of(
                 "[INFO] --- maven-dependency-plugin:3.2.0:copy (copy) @ m1 ---",
                 "[INFO] Configured Artifact: external:dependency1:2.1:jar",
-                "[INFO] Configured Artifact: external:dependency4:2.4:jar",
+                "[INFO] Configured Artifact: external:dependency4:classifier:2.4:jar",
                 "[INFO] Copying dependency1-2.1.jar to /some/path/dependency1-2.1.jar",
                 "[INFO] Copying dependency4-2.4.jar to /some/path/dependency4-2.4.jar",
                 "[INFO]",
@@ -51,10 +51,10 @@ class DependencyParserCopyTest {
         assertThat(dependenciesByModule).containsOnlyKeys("m1", "m2");
         assertThat(dependenciesByModule.get("m1"))
                 .containsExactlyInAnyOrder(
-                        Dependency.create("external", "dependency1", "2.1"),
-                        Dependency.create("external", "dependency4", "2.4"));
+                        Dependency.create("external", "dependency1", "2.1", null),
+                        Dependency.create("external", "dependency4", "2.4", "classifier"));
         assertThat(dependenciesByModule.get("m2"))
-                .containsExactlyInAnyOrder(Dependency.create("internal", "m1", "1.1"));
+                .containsExactlyInAnyOrder(Dependency.create("internal", "m1", "1.1", null));
     }
 
     @Test
@@ -106,6 +106,16 @@ class DependencyParserCopyTest {
         assertThat(
                         DependencyParser.parseCopyDependency(
                                 "[INFO] Configured Artifact: external:dependency1:1.0:pom"))
-                .hasValue(Dependency.create("external", "dependency1", "1.0"));
+                .hasValue(Dependency.create("external", "dependency1", "1.0", null));
+    }
+
+    @Test
+    void testCopyLineParsingClassifier() {
+        assertThat(
+                        DependencyParser.parseCopyDependency(
+                                "[INFO] Configured Artifact: external:dependency1:some_classifier:1.0:jar"))
+                .hasValueSatisfying(
+                        dependency ->
+                                assertThat(dependency.getClassifier()).hasValue("some_classifier"));
     }
 }

--- a/tools/ci/flink-ci-tools/src/test/java/org/apache/flink/tools/ci/utils/dependency/DependencyParserTreeTest.java
+++ b/tools/ci/flink-ci-tools/src/test/java/org/apache/flink/tools/ci/utils/dependency/DependencyParserTreeTest.java
@@ -37,7 +37,7 @@ class DependencyParserTreeTest {
                 "[INFO] +- external:dependency1:jar:2.1:compile",
                 "[INFO] |  +- external:dependency2:jar:2.2:compile (optional)",
                 "[INFO] |  |  \\- external:dependency3:jar:2.3:provided (optional)",
-                "[INFO] |  +- external:dependency4:jar:2.4:compile",
+                "[INFO] |  +- external:dependency4:classifier:jar:2.4:compile",
                 "[INFO]",
                 "[INFO] --- maven-dependency-plugin:3.2.0:tree (default-cli) @ m2 ---",
                 "[INFO] internal:m2:jar:1.2",
@@ -53,14 +53,16 @@ class DependencyParserTreeTest {
         assertThat(dependenciesByModule).containsOnlyKeys("m1", "m2");
         assertThat(dependenciesByModule.get("m1"))
                 .containsExactlyInAnyOrder(
-                        Dependency.create("external", "dependency1", "2.1", "compile", false),
-                        Dependency.create("external", "dependency2", "2.2", "compile", true),
-                        Dependency.create("external", "dependency3", "2.3", "provided", true),
-                        Dependency.create("external", "dependency4", "2.4", "compile", false));
+                        Dependency.create("external", "dependency1", "2.1", null, "compile", false),
+                        Dependency.create("external", "dependency2", "2.2", null, "compile", true),
+                        Dependency.create("external", "dependency3", "2.3", null, "provided", true),
+                        Dependency.create(
+                                "external", "dependency4", "2.4", "classifier", "compile", false));
         assertThat(dependenciesByModule.get("m2"))
                 .containsExactlyInAnyOrder(
-                        Dependency.create("internal", "m1", "1.1", "compile", false),
-                        Dependency.create("external", "dependency4", "2.4", "compile", false));
+                        Dependency.create("internal", "m1", "1.1", null, "compile", false),
+                        Dependency.create(
+                                "external", "dependency4", "2.4", null, "compile", false));
     }
 
     @Test
@@ -105,7 +107,9 @@ class DependencyParserTreeTest {
         assertThat(
                         DependencyParser.parseTreeDependency(
                                 "[INFO] +- external:dependency1:pom:1.0:compile"))
-                .hasValue(Dependency.create("external", "dependency1", "1.0", "compile", false));
+                .hasValue(
+                        Dependency.create(
+                                "external", "dependency1", "1.0", null, "compile", false));
     }
 
     @Test
@@ -113,7 +117,14 @@ class DependencyParserTreeTest {
         assertThat(
                         DependencyParser.parseTreeDependency(
                                 "[INFO] +- external:dependency1:jar:some_classifier:1.0:compile"))
-                .hasValue(Dependency.create("external", "dependency1", "1.0", "compile", false));
+                .hasValue(
+                        Dependency.create(
+                                "external",
+                                "dependency1",
+                                "1.0",
+                                "some_classifier",
+                                "compile",
+                                false));
     }
 
     @Test

--- a/tools/ci/flink-ci-tools/src/test/java/org/apache/flink/tools/ci/utils/notice/NoticeParserTest.java
+++ b/tools/ci/flink-ci-tools/src/test/java/org/apache/flink/tools/ci/utils/notice/NoticeParserTest.java
@@ -31,8 +31,10 @@ class NoticeParserTest {
     @Test
     void testParseNoticeFileCommonPath() {
         final String module = "some-module";
-        final Dependency dependency1 = Dependency.create("groupId1", "artifactId1", "version1");
-        final Dependency dependency2 = Dependency.create("groupId2", "artifactId2", "version2");
+        final Dependency dependency1 =
+                Dependency.create("groupId1", "artifactId1", "version1", null);
+        final Dependency dependency2 =
+                Dependency.create("groupId2", "artifactId2", "version2", null);
         final List<String> noticeContents =
                 Arrays.asList(
                         module,
@@ -55,7 +57,7 @@ class NoticeParserTest {
     @Test
     void testParseNoticeFileBundlesPath() {
         final String module = "some-module";
-        final Dependency dependency = Dependency.create("groupId", "artifactId", "version");
+        final Dependency dependency = Dependency.create("groupId", "artifactId", "version", null);
         final List<String> noticeContents =
                 Arrays.asList(module, "", "Something bundles \"" + dependency + "\"");
 
@@ -71,7 +73,7 @@ class NoticeParserTest {
     @Test
     void testParseNoticeFileMalformedDependencyIgnored() {
         final String module = "some-module";
-        final Dependency dependency = Dependency.create("groupId", "artifactId", "version");
+        final Dependency dependency = Dependency.create("groupId", "artifactId", "version", null);
         final List<String> noticeContents = Arrays.asList(module, "- " + dependency, "- a:b");
 
         assertThat(NoticeParser.parseNoticeFile(noticeContents))


### PR DESCRIPTION
~~Based on #20067.~~

Store the classifier (e.g., "test-jar") in the `Dependency`. This is required to properly distinguish between multiple artifacts with the same (groupId, artifactId, version) triplet.