### PR TITLE
[FLINK-28195][python] Annotate Python3.6 as deprecated in PyFlink 1.16

### DIFF
--- a/flink-python/dev/lint-python.sh
+++ b/flink-python/dev/lint-python.sh
@@ -228,7 +228,7 @@ function install_py_env() {
     if [[ ${BUILD_REASON} = 'IndividualCI' ]]; then
         py_env=("3.9")
     else
-        py_env=("3.6" "3.7" "3.8" "3.9")
+        py_env=("3.7" "3.8" "3.9")
     fi
     for ((i=0;i<${#py_env[@]};i++)) do
         if [ -d "$CURRENT_DIR/.conda/envs/${py_env[i]}" ]; then
@@ -403,7 +403,7 @@ function install_environment() {
     fi
 
     # step-3 install python environment which includes
-    # 3.6 3.7 3.8 3.9
+    # 3.7 3.8 3.9
     if [ $STEP -lt 3 ] && [ `need_install_component "py_env"` = true ]; then
         print_function "STEP" "installing python environment..."
         install_py_env
@@ -778,7 +778,7 @@ usage: $0 [options]
 -l          list all checks supported.
 Examples:
   ./lint-python -s basic        =>  install environment with basic components.
-  ./lint-python -s py_env       =>  install environment with python env(3.6,3.7,3.8,3.9).
+  ./lint-python -s py_env       =>  install environment with python env(3.7,3.8,3.9).
   ./lint-python -s all          =>  install environment with all components such as python env,tox,flake8,sphinx,mypy etc.
   ./lint-python -s tox,flake8   =>  install environment with tox,flake8.
   ./lint-python -s tox -f       =>  reinstall environment with tox.

--- a/flink-python/setup.py
+++ b/flink-python/setup.py
@@ -21,6 +21,7 @@ import io
 import os
 import platform
 import sys
+import warnings
 from distutils.command.build_ext import build_ext
 from shutil import copytree, copy, rmtree
 
@@ -30,6 +31,8 @@ if sys.version_info < (3, 6):
     print("Python versions prior to 3.6 are not supported for PyFlink.",
           file=sys.stderr)
     sys.exit(-1)
+elif sys.version_info.minor == 6:
+    warnings.warn("Python version 3.6 won't be supported for PyFlink after 1.16.")
 
 
 def remove_if_exists(file_path):


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will annotate Python3.6 as deprecated in PyFlink 1.16*

## Verifying this change

This change added tests and can be verified as follows:

  - *original tests*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
