### PR TITLE
[FLINK-28134][runtime] Introduce SpeculativeExecutionVertex

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorFactory.java
@@ -253,10 +253,10 @@ public class TaskDeploymentDescriptorFactory {
         }
     }
 
-    public static TaskDeploymentDescriptorFactory fromExecutionVertex(
-            ExecutionVertex executionVertex)
+    public static TaskDeploymentDescriptorFactory fromExecution(Execution execution)
             throws IOException, CachedIntermediateDataSetCorruptedException {
-        InternalExecutionGraphAccessor internalExecutionGraphAccessor =
+        final ExecutionVertex executionVertex = execution.getVertex();
+        final InternalExecutionGraphAccessor internalExecutionGraphAccessor =
                 executionVertex.getExecutionGraphAccessor();
         Map<IntermediateDataSetID, ShuffleDescriptor[]> clusterPartitionShuffleDescriptors;
         try {
@@ -272,7 +272,7 @@ public class TaskDeploymentDescriptorFactory {
         }
 
         return new TaskDeploymentDescriptorFactory(
-                executionVertex.getCurrentExecutionAttempt().getAttemptId(),
+                execution.getAttemptId(),
                 getSerializedJobInformation(internalExecutionGraphAccessor),
                 getSerializedTaskInformation(
                         executionVertex.getJobVertex().getTaskInformationOrBlobKey()),
@@ -338,7 +338,7 @@ public class TaskDeploymentDescriptorFactory {
     public static ShuffleDescriptor getConsumedPartitionShuffleDescriptor(
             IntermediateResultPartition consumedPartition,
             PartitionLocationConstraint partitionDeploymentConstraint) {
-        Execution producer = consumedPartition.getProducer().getCurrentExecutionAttempt();
+        Execution producer = consumedPartition.getProducer().getPartitionProducer();
 
         ExecutionState producerState = producer.getState();
         Optional<ResultPartitionDeploymentDescriptor> consumedPartitionDescriptor =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ArchivedSpeculativeExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ArchivedSpeculativeExecutionVertex.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph;
+
+/**
+ * {@link ArchivedSpeculativeExecutionVertex} is a readonly representation of {@link
+ * SpeculativeExecutionVertex}.
+ */
+public class ArchivedSpeculativeExecutionVertex extends ArchivedExecutionVertex {
+
+    private static final long serialVersionUID = 1L;
+
+    public ArchivedSpeculativeExecutionVertex(SpeculativeExecutionVertex vertex) {
+        super(
+                vertex.getParallelSubtaskIndex(),
+                vertex.getTaskNameWithSubtaskIndex(),
+                vertex.getCurrentExecutionAttempt().archive(),
+                getCopyOfExecutionHistory(vertex));
+    }
+
+    private static ExecutionHistory getCopyOfExecutionHistory(SpeculativeExecutionVertex vertex) {
+        final ExecutionHistory executionHistory =
+                ArchivedExecutionVertex.getCopyOfExecutionHistory(vertex);
+
+        // add all the executions to the execution history except for the only admitted current
+        // execution
+        final Execution currentAttempt = vertex.getCurrentExecutionAttempt();
+        for (Execution execution : vertex.getCurrentExecutions()) {
+            if (execution.getAttemptNumber() != currentAttempt.getAttemptNumber()) {
+                executionHistory.add(execution.archive());
+            }
+        }
+
+        return executionHistory;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraph.java
@@ -286,6 +286,8 @@ public class DefaultExecutionGraph implements ExecutionGraph, InternalExecutionG
 
     private final boolean isDynamic;
 
+    private final ExecutionJobVertex.Factory executionJobVertexFactory;
+
     // --------------------------------------------------------------------------------------------
     //   Constructors
     // --------------------------------------------------------------------------------------------
@@ -307,7 +309,8 @@ public class DefaultExecutionGraph implements ExecutionGraph, InternalExecutionG
             long initializationTimestamp,
             VertexAttemptNumberStore initialAttemptCounts,
             VertexParallelismStore vertexParallelismStore,
-            boolean isDynamic)
+            boolean isDynamic,
+            ExecutionJobVertex.Factory executionJobVertexFactory)
             throws IOException {
 
         this.executionGraphId = new ExecutionGraphID();
@@ -374,6 +377,8 @@ public class DefaultExecutionGraph implements ExecutionGraph, InternalExecutionG
         this.resultPartitionsById = new HashMap<>();
 
         this.isDynamic = isDynamic;
+
+        this.executionJobVertexFactory = checkNotNull(executionJobVertexFactory);
 
         LOG.info(
                 "Created execution graph {} for job {}.",
@@ -840,7 +845,9 @@ public class DefaultExecutionGraph implements ExecutionGraph, InternalExecutionG
                     parallelismStore.getParallelismInfo(jobVertex.getID());
 
             // create the execution job vertex and attach it to the graph
-            ExecutionJobVertex ejv = new ExecutionJobVertex(this, jobVertex, parallelismInfo);
+            ExecutionJobVertex ejv =
+                    executionJobVertexFactory.createExecutionJobVertex(
+                            this, jobVertex, parallelismInfo);
 
             ExecutionJobVertex previousTask = this.tasks.putIfAbsent(jobVertex.getID(), ejv);
             if (previousTask != null) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphBuilder.java
@@ -91,7 +91,8 @@ public class DefaultExecutionGraphBuilder {
             VertexAttemptNumberStore vertexAttemptNumberStore,
             VertexParallelismStore vertexParallelismStore,
             Supplier<CheckpointStatsTracker> checkpointStatsTrackerFactory,
-            boolean isDynamicGraph)
+            boolean isDynamicGraph,
+            ExecutionJobVertex.Factory executionJobVertexFactory)
             throws JobExecutionException, JobException {
 
         checkNotNull(jobGraph, "job graph cannot be null");
@@ -136,7 +137,8 @@ public class DefaultExecutionGraphBuilder {
                             initializationTimestamp,
                             vertexAttemptNumberStore,
                             vertexParallelismStore,
-                            isDynamicGraph);
+                            isDynamicGraph,
+                            executionJobVertexFactory);
         } catch (IOException e) {
             throw new JobException("Could not create the ExecutionGraph.", e);
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -564,13 +564,13 @@ public class Execution
                     "Deploying {} (attempt #{}) with attempt id {} and vertex id {} to {} with allocation id {}",
                     vertex.getTaskNameWithSubtaskIndex(),
                     getAttemptNumber(),
-                    vertex.getCurrentExecutionAttempt().getAttemptId(),
+                    attemptId,
                     vertex.getID(),
                     getAssignedResourceLocation(),
                     slot.getAllocationId());
 
             final TaskDeploymentDescriptor deployment =
-                    TaskDeploymentDescriptorFactory.fromExecutionVertex(vertex)
+                    TaskDeploymentDescriptorFactory.fromExecution(this)
                             .createDeploymentDescriptor(
                                     slot.getAllocationId(),
                                     taskRestore,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
@@ -188,7 +188,7 @@ public class ExecutionJobVertex
         // create all task vertices
         for (int i = 0; i < this.parallelismInfo.getParallelism(); i++) {
             ExecutionVertex vertex =
-                    new ExecutionVertex(
+                    createExecutionVertex(
                             this,
                             i,
                             producedDataSets,
@@ -258,6 +258,24 @@ public class ExecutionJobVertex
             throw new JobException(
                     "Creating the input splits caused an error: " + t.getMessage(), t);
         }
+    }
+
+    protected ExecutionVertex createExecutionVertex(
+            ExecutionJobVertex jobVertex,
+            int subTaskIndex,
+            IntermediateResult[] producedDataSets,
+            Time timeout,
+            long createTimestamp,
+            int executionHistorySizeLimit,
+            int initialAttemptCount) {
+        return new ExecutionVertex(
+                jobVertex,
+                subTaskIndex,
+                producedDataSets,
+                timeout,
+                createTimestamp,
+                executionHistorySizeLimit,
+                initialAttemptCount);
     }
 
     public boolean isInitialized() {
@@ -594,6 +612,17 @@ public class ExecutionJobVertex
         } else {
             // all else collapses under created
             return ExecutionState.CREATED;
+        }
+    }
+
+    /** Factory to create {@link ExecutionJobVertex}. */
+    public static class Factory {
+        ExecutionJobVertex createExecutionJobVertex(
+                InternalExecutionGraphAccessor graph,
+                JobVertex jobVertex,
+                VertexParallelismInformation parallelismInfo)
+                throws JobException {
+            return new ExecutionJobVertex(graph, jobVertex, parallelismInfo);
         }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -318,6 +318,10 @@ public class ExecutionVertex
         return resultPartitions;
     }
 
+    CompletableFuture<?> getTerminationFuture() {
+        return currentExecution.getTerminalStateFuture();
+    }
+
     // --------------------------------------------------------------------------------------------
     //  Graph building
     // --------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/SpeculativeExecutionJobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/SpeculativeExecutionJobVertex.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.JobException;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.scheduler.VertexParallelismInformation;
+
+/** The ExecutionJobVertex which supports speculative execution. */
+public class SpeculativeExecutionJobVertex extends ExecutionJobVertex {
+
+    public SpeculativeExecutionJobVertex(
+            InternalExecutionGraphAccessor graph,
+            JobVertex jobVertex,
+            VertexParallelismInformation parallelismInfo)
+            throws JobException {
+        super(graph, jobVertex, parallelismInfo);
+    }
+
+    @Override
+    protected ExecutionVertex createExecutionVertex(
+            ExecutionJobVertex jobVertex,
+            int subTaskIndex,
+            IntermediateResult[] producedDataSets,
+            Time timeout,
+            long createTimestamp,
+            int executionHistorySizeLimit,
+            int initialAttemptCount) {
+        return new SpeculativeExecutionVertex(
+                jobVertex,
+                subTaskIndex,
+                producedDataSets,
+                timeout,
+                createTimestamp,
+                executionHistorySizeLimit,
+                initialAttemptCount);
+    }
+
+    /** Factory to create {@link SpeculativeExecutionJobVertex}. */
+    public static class Factory extends ExecutionJobVertex.Factory {
+        @Override
+        ExecutionJobVertex createExecutionJobVertex(
+                InternalExecutionGraphAccessor graph,
+                JobVertex jobVertex,
+                VertexParallelismInformation parallelismInfo)
+                throws JobException {
+            return new SpeculativeExecutionJobVertex(graph, jobVertex, parallelismInfo);
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/SpeculativeExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/SpeculativeExecutionVertex.java
@@ -124,6 +124,15 @@ public class SpeculativeExecutionVertex extends ExecutionVertex {
     }
 
     @Override
+    CompletableFuture<?> getTerminationFuture() {
+        final List<CompletableFuture<?>> terminationFutures =
+                currentExecutions.values().stream()
+                        .map(Execution::getTerminalStateFuture)
+                        .collect(Collectors.toList());
+        return FutureUtils.waitForAll(terminationFutures);
+    }
+
+    @Override
     public void resetForNewExecution() {
         super.resetForNewExecution();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/SpeculativeExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/SpeculativeExecutionVertex.java
@@ -1,0 +1,276 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.jobmaster.LogicalSlot;
+import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+import org.apache.flink.util.concurrent.FutureUtils;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.runtime.execution.ExecutionState.FAILED;
+import static org.apache.flink.runtime.execution.ExecutionState.FINISHED;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/** The ExecutionVertex which supports speculative execution. */
+public class SpeculativeExecutionVertex extends ExecutionVertex {
+
+    private final Map<ExecutionAttemptID, Execution> currentExecutions;
+
+    public SpeculativeExecutionVertex(
+            ExecutionJobVertex jobVertex,
+            int subTaskIndex,
+            IntermediateResult[] producedDataSets,
+            Time timeout,
+            long createTimestamp,
+            int executionHistorySizeLimit,
+            int initialAttemptCount) {
+        super(
+                jobVertex,
+                subTaskIndex,
+                producedDataSets,
+                timeout,
+                createTimestamp,
+                executionHistorySizeLimit,
+                initialAttemptCount);
+
+        this.currentExecutions = new LinkedHashMap<>();
+        this.currentExecutions.put(currentExecution.getAttemptId(), currentExecution);
+    }
+
+    public boolean containsSources() {
+        return getJobVertex().getJobVertex().containsSources();
+    }
+
+    public boolean containsSinks() {
+        return getJobVertex().getJobVertex().containsSinks();
+    }
+
+    public Execution createNewSpeculativeExecution(final long timestamp) {
+        final Execution newExecution = createNewExecution(timestamp);
+        getExecutionGraphAccessor().registerExecution(newExecution);
+        currentExecutions.put(newExecution.getAttemptId(), newExecution);
+        return newExecution;
+    }
+
+    @Override
+    public Collection<Execution> getCurrentExecutions() {
+        return Collections.unmodifiableCollection(currentExecutions.values());
+    }
+
+    @Override
+    public Execution getPartitionProducer() {
+        final Execution finishedExecution = getCurrentExecutionAttempt();
+        checkState(
+                finishedExecution.getState() == FINISHED,
+                "It's not allowed to get the partition producer of an un-finished SpeculativeExecutionVertex");
+        return finishedExecution;
+    }
+
+    @Override
+    public CompletableFuture<?> cancel() {
+        final List<CompletableFuture<?>> cancelResultFutures =
+                new ArrayList<>(currentExecutions.size());
+        for (Execution execution : currentExecutions.values()) {
+            execution.cancel();
+            cancelResultFutures.add(execution.getReleaseFuture());
+        }
+        return FutureUtils.combineAll(cancelResultFutures);
+    }
+
+    @Override
+    public CompletableFuture<?> suspend() {
+        return FutureUtils.combineAll(
+                currentExecutions.values().stream()
+                        .map(Execution::suspend)
+                        .collect(Collectors.toList()));
+    }
+
+    @Override
+    public void fail(Throwable t) {
+        currentExecutions.values().forEach(e -> e.fail(t));
+    }
+
+    @Override
+    public void markFailed(Throwable t) {
+        currentExecutions.values().forEach(e -> e.markFailed(t));
+    }
+
+    @Override
+    public void resetForNewExecution() {
+        super.resetForNewExecution();
+
+        currentExecutions.clear();
+        currentExecutions.put(currentExecution.getAttemptId(), currentExecution);
+    }
+
+    @Override
+    void resetExecutionsInternal() {
+        for (Execution execution : currentExecutions.values()) {
+            resetExecution(execution);
+        }
+    }
+
+    /**
+     * Remove execution from currentExecutions if it is failed. It is needed to make room for
+     * possible future speculative executions.
+     *
+     * @param executionAttemptId attemptID of the execution to be removed
+     */
+    public void archiveFailedExecution(ExecutionAttemptID executionAttemptId) {
+        if (this.currentExecutions.size() <= 1) {
+            // Leave the last execution because currentExecutions should never be empty. This should
+            // happen only if all current executions have FAILED. A vertex reset will happen soon
+            // and will archive the remaining execution.
+            return;
+        }
+
+        final Execution removedExecution = this.currentExecutions.remove(executionAttemptId);
+        checkNotNull(
+                removedExecution,
+                "Cannot remove execution %s which does not exist.",
+                executionAttemptId);
+        checkState(
+                removedExecution.getState() == FAILED,
+                "Cannot remove execution %s which is not FAILED.",
+                executionAttemptId);
+
+        executionHistory.add(removedExecution.archive());
+        if (removedExecution == this.currentExecution) {
+            this.currentExecution = this.currentExecutions.values().iterator().next();
+        }
+    }
+
+    @Override
+    public Execution getCurrentExecutionAttempt() {
+        // returns the execution which is most likely to reach FINISHED state
+        Execution currentExecution = this.currentExecution;
+        for (Execution execution : currentExecutions.values()) {
+            if (getStatePriority(execution.getState())
+                    < getStatePriority(currentExecution.getState())) {
+                currentExecution = execution;
+            }
+        }
+        return currentExecution;
+    }
+
+    private int getStatePriority(ExecutionState state) {
+        // the more likely to reach FINISHED state, the higher priority, the smaller value
+        switch (state) {
+                // CREATED/SCHEDULED/INITIALIZING/RUNNING/FINISHED are healthy states with an
+                // increasing priority
+            case FINISHED:
+                return 0;
+            case RUNNING:
+                return 1;
+            case INITIALIZING:
+                return 2;
+            case DEPLOYING:
+                return 3;
+            case SCHEDULED:
+                return 4;
+            case CREATED:
+                return 5;
+                // if the vertex is not in a healthy state, shows its CANCELING state unless it is
+                // fully FAILED or CANCELED
+            case CANCELING:
+                return 6;
+            case FAILED:
+                return 7;
+            case CANCELED:
+                return 8;
+            default:
+                throw new IllegalStateException("Execution state " + state + " is not supported.");
+        }
+    }
+
+    @Override
+    void notifyPendingDeployment(Execution execution) {
+        getExecutionGraphAccessor()
+                .getExecutionDeploymentListener()
+                .onStartedDeployment(
+                        execution.getAttemptId(),
+                        execution.getAssignedResourceLocation().getResourceID());
+    }
+
+    @Override
+    void notifyCompletedDeployment(Execution execution) {
+        getExecutionGraphAccessor()
+                .getExecutionDeploymentListener()
+                .onCompletedDeployment(execution.getAttemptId());
+    }
+
+    @Override
+    void notifyStateTransition(
+            Execution execution, ExecutionState previousState, ExecutionState newState) {
+        getExecutionGraphAccessor().notifyExecutionChange(execution, previousState, newState);
+    }
+
+    @Override
+    public ArchivedSpeculativeExecutionVertex archive() {
+        return new ArchivedSpeculativeExecutionVertex(this);
+    }
+
+    @Override
+    void cachePartitionInfo(PartitionInfo partitionInfo) {
+        throw new UnsupportedOperationException(
+                "Method is not supported in SpeculativeExecutionVertex.");
+    }
+
+    @Override
+    public void tryAssignResource(LogicalSlot slot) {
+        throw new UnsupportedOperationException(
+                "Method is not supported in SpeculativeExecutionVertex.");
+    }
+
+    @Override
+    public void deploy() {
+        throw new UnsupportedOperationException(
+                "Method is not supported in SpeculativeExecutionVertex.");
+    }
+
+    @Override
+    public void deployToSlot(LogicalSlot slot) {
+        throw new UnsupportedOperationException(
+                "Method is not supported in SpeculativeExecutionVertex.");
+    }
+
+    @Override
+    public Optional<TaskManagerLocation> getPreferredLocationBasedOnState() {
+        throw new UnsupportedOperationException(
+                "Method is not supported in SpeculativeExecutionVertex.");
+    }
+
+    @Override
+    public CompletableFuture<TaskManagerLocation> getCurrentTaskManagerLocationFuture() {
+        throw new UnsupportedOperationException(
+                "Method is not supported in SpeculativeExecutionVertex.");
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchSchedulerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchSchedulerFactory.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.blob.BlobWriter;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
 import org.apache.flink.runtime.checkpoint.CheckpointsCleaner;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.JobStatusListener;
 import org.apache.flink.runtime.executiongraph.failover.flip1.FailoverStrategyFactoryLoader;
 import org.apache.flink.runtime.executiongraph.failover.flip1.RestartBackoffTimeStrategy;
@@ -145,7 +146,8 @@ public class AdaptiveBatchSchedulerFactory implements SchedulerNGFactory {
                         blobWriter,
                         shuffleMaster,
                         partitionTracker,
-                        true);
+                        true,
+                        new ExecutionJobVertex.Factory());
 
         return new AdaptiveBatchScheduler(
                 log,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/BlockingResultInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/BlockingResultInfo.java
@@ -68,8 +68,7 @@ public class BlockingResultInfo {
         for (IntermediateResultPartition partition : intermediateResult.getPartitions()) {
             checkState(partition.isConsumable());
 
-            IOMetrics ioMetrics =
-                    partition.getProducer().getCurrentExecutionAttempt().getIOMetrics();
+            IOMetrics ioMetrics = partition.getProducer().getPartitionProducer().getIOMetrics();
             checkNotNull(ioMetrics, "IOMetrics should not be null.");
 
             blockingPartitionSizes.add(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorFactoryTest.java
@@ -164,7 +164,7 @@ public class TaskDeploymentDescriptorFactoryTest extends TestLogger {
     private static TaskDeploymentDescriptor createTaskDeploymentDescriptor(ExecutionVertex ev)
             throws IOException, CachedIntermediateDataSetCorruptedException {
 
-        return TaskDeploymentDescriptorFactory.fromExecutionVertex(ev)
+        return TaskDeploymentDescriptorFactory.fromExecution(ev.getCurrentExecutionAttempt())
                 .createDeploymentDescriptor(new AllocationID(), null, Collections.emptyList());
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/SpeculativeExecutionVertexTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/SpeculativeExecutionVertexTest.java
@@ -1,0 +1,226 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph;
+
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobGraphTestUtils;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.scheduler.TestingInternalFailuresListener;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorExtension;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for the {@link SpeculativeExecutionVertex}. */
+class SpeculativeExecutionVertexTest {
+
+    @RegisterExtension
+    private static final TestExecutorExtension<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorExtension();
+
+    private TestingInternalFailuresListener internalFailuresListener;
+
+    @BeforeEach
+    void setUp() {
+        internalFailuresListener = new TestingInternalFailuresListener();
+    }
+
+    @Test
+    void testCreateSpeculativeExecution() throws Exception {
+        final SpeculativeExecutionVertex ev = createSpeculativeExecutionVertex();
+        assertThat(ev.getCurrentExecutions()).hasSize(1);
+
+        ev.createNewSpeculativeExecution(System.currentTimeMillis());
+        assertThat(ev.getCurrentExecutions()).hasSize(2);
+    }
+
+    @Test
+    void testResetExecutionVertex() throws Exception {
+        final SpeculativeExecutionVertex ev = createSpeculativeExecutionVertex();
+        final Execution e1 = ev.getCurrentExecutionAttempt();
+        final Execution e2 = ev.createNewSpeculativeExecution(System.currentTimeMillis());
+
+        e1.transitionState(ExecutionState.RUNNING);
+        e1.markFinished();
+        e2.cancel();
+        ev.resetForNewExecution();
+
+        assertThat(ev.getExecutionHistory().getHistoricalExecution(0).get().getAttemptId())
+                .isEqualTo(e1.getAttemptId());
+        assertThat(ev.getExecutionHistory().getHistoricalExecution(1).get().getAttemptId())
+                .isEqualTo(e2.getAttemptId());
+        assertThat(ev.getCurrentExecutions()).hasSize(1);
+        assertThat(ev.getCurrentExecutionAttempt().getAttemptNumber()).isEqualTo(2);
+    }
+
+    @Test
+    void testCancel() throws Exception {
+        final SpeculativeExecutionVertex ev = createSpeculativeExecutionVertex();
+        final Execution e1 = ev.getCurrentExecutionAttempt();
+        final Execution e2 = ev.createNewSpeculativeExecution(System.currentTimeMillis());
+
+        ev.cancel();
+        assertThat(e1.getState()).isSameAs(ExecutionState.CANCELED);
+        assertThat(e2.getState()).isSameAs(ExecutionState.CANCELED);
+    }
+
+    @Test
+    void testSuspend() throws Exception {
+        final SpeculativeExecutionVertex ev = createSpeculativeExecutionVertex();
+        final Execution e1 = ev.getCurrentExecutionAttempt();
+        final Execution e2 = ev.createNewSpeculativeExecution(System.currentTimeMillis());
+
+        ev.suspend();
+        assertThat(e1.getState()).isSameAs(ExecutionState.CANCELED);
+        assertThat(e2.getState()).isSameAs(ExecutionState.CANCELED);
+    }
+
+    @Test
+    void testFail() throws Exception {
+        final SpeculativeExecutionVertex ev = createSpeculativeExecutionVertex();
+        final Execution e1 = ev.getCurrentExecutionAttempt();
+        final Execution e2 = ev.createNewSpeculativeExecution(System.currentTimeMillis());
+
+        ev.fail(new Exception("Forced test failure."));
+        assertThat(internalFailuresListener.getFailedTasks())
+                .containsExactly(e1.getAttemptId(), e2.getAttemptId());
+    }
+
+    @Test
+    void testMarkFailed() throws Exception {
+        final SpeculativeExecutionVertex ev = createSpeculativeExecutionVertex();
+        final Execution e1 = ev.getCurrentExecutionAttempt();
+        final Execution e2 = ev.createNewSpeculativeExecution(System.currentTimeMillis());
+
+        ev.markFailed(new Exception("Forced test failure."));
+        assertThat(internalFailuresListener.getFailedTasks())
+                .containsExactly(e1.getAttemptId(), e2.getAttemptId());
+    }
+
+    @Test
+    void testArchiveFailedExecutions() throws Exception {
+        final SpeculativeExecutionVertex ev = createSpeculativeExecutionVertex();
+
+        final Execution e1 = ev.getCurrentExecutionAttempt();
+        e1.transitionState(ExecutionState.RUNNING);
+
+        final Execution e2 = ev.createNewSpeculativeExecution(0);
+        e2.transitionState(ExecutionState.FAILED);
+
+        ev.archiveFailedExecution(e2.getAttemptId());
+        assertThat(ev.getCurrentExecutions()).hasSize(1);
+        assertThat(ev.currentExecution).isSameAs(e1);
+
+        final Execution e3 = ev.createNewSpeculativeExecution(0);
+        e3.transitionState(ExecutionState.RUNNING);
+        e1.transitionState(ExecutionState.FAILED);
+
+        ev.archiveFailedExecution(e1.getAttemptId());
+        assertThat(ev.getCurrentExecutions()).hasSize(1);
+        assertThat(ev.currentExecution).isSameAs(e3);
+    }
+
+    @Test
+    void testArchiveTheOnlyCurrentExecution() throws Exception {
+        final SpeculativeExecutionVertex ev = createSpeculativeExecutionVertex();
+
+        final Execution e1 = ev.getCurrentExecutionAttempt();
+        e1.transitionState(ExecutionState.FAILED);
+
+        ev.archiveFailedExecution(e1.getAttemptId());
+
+        assertThat(ev.getCurrentExecutions()).hasSize(1);
+        assertThat(ev.currentExecution).isSameAs(e1);
+    }
+
+    @Test
+    void testArchiveNonFailedExecutionWithArchiveFailedExecutionMethod() {
+        Assertions.assertThrows(
+                IllegalStateException.class,
+                () -> {
+                    final SpeculativeExecutionVertex ev = createSpeculativeExecutionVertex();
+
+                    final Execution e1 = ev.getCurrentExecutionAttempt();
+                    e1.transitionState(ExecutionState.FAILED);
+
+                    final Execution e2 = ev.createNewSpeculativeExecution(0);
+                    e2.transitionState(ExecutionState.RUNNING);
+
+                    ev.archiveFailedExecution(e2.getAttemptId());
+                });
+    }
+
+    @Test
+    void testGetExecutionState() throws Exception {
+        final SpeculativeExecutionVertex ev = createSpeculativeExecutionVertex();
+
+        final Execution e1 = ev.getCurrentExecutionAttempt();
+        e1.transitionState(ExecutionState.CANCELED);
+        assertThat(ev.getExecutionState()).isSameAs(ExecutionState.CANCELED);
+
+        // the latter added state is more likely to reach FINISH state
+        final List<ExecutionState> statesSortedByPriority = new ArrayList<>();
+        statesSortedByPriority.add(ExecutionState.FAILED);
+        statesSortedByPriority.add(ExecutionState.CANCELING);
+        statesSortedByPriority.add(ExecutionState.CREATED);
+        statesSortedByPriority.add(ExecutionState.SCHEDULED);
+        statesSortedByPriority.add(ExecutionState.DEPLOYING);
+        statesSortedByPriority.add(ExecutionState.INITIALIZING);
+        statesSortedByPriority.add(ExecutionState.RUNNING);
+        statesSortedByPriority.add(ExecutionState.FINISHED);
+
+        for (ExecutionState state : statesSortedByPriority) {
+            final Execution execution = ev.createNewSpeculativeExecution(0);
+            execution.transitionState(state);
+            assertThat(ev.getExecutionState()).isSameAs(state);
+        }
+    }
+
+    private SpeculativeExecutionVertex createSpeculativeExecutionVertex() throws Exception {
+        final JobVertex jobVertex = ExecutionGraphTestUtils.createNoOpVertex(1);
+        final JobGraph jobGraph = JobGraphTestUtils.batchJobGraph(jobVertex);
+        final ExecutionGraph executionGraph = createExecutionGraph(jobGraph);
+        return (SpeculativeExecutionVertex)
+                executionGraph.getJobVertex(jobVertex.getID()).getTaskVertices()[0];
+    }
+
+    private ExecutionGraph createExecutionGraph(final JobGraph jobGraph) throws Exception {
+        final ExecutionGraph executionGraph =
+                TestingDefaultExecutionGraphBuilder.newBuilder()
+                        .setJobGraph(jobGraph)
+                        .setExecutionJobVertexFactory(new SpeculativeExecutionJobVertex.Factory())
+                        .build(EXECUTOR_RESOURCE.getExecutor());
+
+        executionGraph.setInternalTaskFailuresListener(internalFailuresListener);
+        executionGraph.start(ComponentMainThreadExecutorServiceAdapter.forMainThread());
+
+        return executionGraph;
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/TestingDefaultExecutionGraphBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/TestingDefaultExecutionGraphBuilder.java
@@ -73,6 +73,7 @@ public class TestingDefaultExecutionGraphBuilder {
     private ExecutionStateUpdateListener executionStateUpdateListener =
             (execution, previousState, newState) -> {};
     private VertexParallelismStore vertexParallelismStore;
+    private ExecutionJobVertex.Factory executionJobVertexFactory = new ExecutionJobVertex.Factory();
 
     private TestingDefaultExecutionGraphBuilder() {}
 
@@ -142,6 +143,12 @@ public class TestingDefaultExecutionGraphBuilder {
         return this;
     }
 
+    public TestingDefaultExecutionGraphBuilder setExecutionJobVertexFactory(
+            ExecutionJobVertex.Factory executionJobVertexFactory) {
+        this.executionJobVertexFactory = executionJobVertexFactory;
+        return this;
+    }
+
     private DefaultExecutionGraph build(
             boolean isDynamicGraph, ScheduledExecutorService executorService)
             throws JobException, JobExecutionException {
@@ -168,7 +175,8 @@ public class TestingDefaultExecutionGraphBuilder {
                 Optional.ofNullable(vertexParallelismStore)
                         .orElseGet(() -> SchedulerBase.computeVertexParallelismStore(jobGraph)),
                 () -> new CheckpointStatsTracker(0, new UnregisteredMetricsGroup()),
-                isDynamicGraph);
+                isDynamicGraph,
+                executionJobVertexFactory);
     }
 
     public DefaultExecutionGraph build(ScheduledExecutorService executorService)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultExecutionDeployerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultExecutionDeployerTest.java
@@ -333,18 +333,7 @@ class DefaultExecutionDeployerTest {
                         .setPartitionTracker(partitionTracker)
                         .build(executor);
 
-        executionGraph.setInternalTaskFailuresListener(
-                new InternalFailuresListener() {
-                    @Override
-                    public void notifyTaskFailure(
-                            ExecutionAttemptID attemptId,
-                            Throwable t,
-                            boolean cancelTask,
-                            boolean releasePartitions) {}
-
-                    @Override
-                    public void notifyGlobalFailure(Throwable t) {}
-                });
+        executionGraph.setInternalTaskFailuresListener(new TestingInternalFailuresListener());
         executionGraph.start(ComponentMainThreadExecutorServiceAdapter.forMainThread());
 
         return executionGraph;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/TestingInternalFailuresListener.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/TestingInternalFailuresListener.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler;
+
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/** An {@link InternalFailuresListener} implementation for testing purpose. */
+public class TestingInternalFailuresListener implements InternalFailuresListener {
+
+    private final List<ExecutionAttemptID> failedTasks = new ArrayList<>();
+
+    @Override
+    public void notifyTaskFailure(
+            ExecutionAttemptID attemptId,
+            Throwable t,
+            boolean cancelTask,
+            boolean releasePartitions) {
+        failedTasks.add(attemptId);
+    }
+
+    @Override
+    public void notifyGlobalFailure(Throwable t) {}
+
+    public List<ExecutionAttemptID> getFailedTasks() {
+        return Collections.unmodifiableList(failedTasks);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchSchedulerTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchSchedulerTestUtils.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.scheduler.adaptivebatch;
 
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmaster.DefaultExecutionDeploymentTracker;
 import org.apache.flink.runtime.scheduler.DefaultExecutionGraphFactory;
@@ -72,7 +73,8 @@ public class AdaptiveBatchSchedulerTestUtils {
                             blobWriter,
                             shuffleMaster,
                             partitionTracker,
-                            true);
+                            true,
+                            new ExecutionJobVertex.Factory());
 
             return new AdaptiveBatchScheduler(
                     log,


### PR DESCRIPTION
## What is the purpose of the change

SpeculativeExecutionVertex will be used if speculative execution is enabled, as a replacement of ExecutionVertex to form an ExecutionGraph. The core difference is that a SpeculativeExecutionVertex can have multiple current executions running at the same time.
This PR is based on #20080.

## Brief change log

  - *Introduce SpeculativeExecutionJobVertex and SpeculativeExecutionVertex*
  - *Rework TaskDeploymentDescriptorFactory to accept an execution to deploy*
  - *Wait for all the executions to be terminated before finishing a job*


## Verifying this change

  - *Added unit tests SpeculativeExecutionVertexTest*
  - *Changes are also covered by existing tests of scheduling*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
