### PR TITLE
[FLINK-28263][TPCDS][Tests] Clean-up generated data folder by TPCDS test

### DIFF
--- a/flink-end-to-end-tests/test-scripts/test_tpcds.sh
+++ b/flink-end-to-end-tests/test-scripts/test_tpcds.sh
@@ -96,3 +96,10 @@ mkdir -p "$QUALIFIED_ANSWER_DIR"
 java -cp "$TARGET_DIR/TpcdsTestProgram.jar:$TARGET_DIR/lib/*" org.apache.flink.table.tpcds.utils.AnswerFormatter -originDir "$ORGIN_ANSWER_DIR" -destDir "$QUALIFIED_ANSWER_DIR"
 
 java -cp "$TARGET_DIR/TpcdsTestProgram.jar:$TARGET_DIR/lib/*" org.apache.flink.table.tpcds.utils.TpcdsResultComparator -expectedDir "$QUALIFIED_ANSWER_DIR" -actualDir "$RESULT_DIR"
+
+################################################################################
+# Clean-up generated data folder
+################################################################################
+
+rm -rf "${TPCDS_DATA_DIR}"
+echo "Deleted all files under $TPCDS_DATA_DIR"


### PR DESCRIPTION
## What is the purpose of the change

* The TPCDS tests generated folders/files, but doesn't clean them up afterwards. This causes out of diskspace errors further downstream. This change cleans up those files/folders

## Brief change log

* Remove the folders/files that are generated by TPCDS tests

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
