### PR TITLE
[FLINK-27988][table-planner] Let HiveTableSource extend from SupportStatisticsReport

### DIFF
--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemTableSource.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemTableSource.java
@@ -387,9 +387,8 @@ public class FileSystemTableSource extends AbstractFileSystemTable
                 return TableStats.UNKNOWN;
             }
         } catch (Exception e) {
-            LOG.info(
-                    String.format(
-                            "Reporting statistics failed for file system table source: %s", e));
+            LOG.warn(
+                    "Reporting statistics failed for file system table source: {}", e.getMessage());
             return TableStats.UNKNOWN;
         }
     }

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemTableSource.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemTableSource.java
@@ -55,6 +55,9 @@ import org.apache.flink.table.plan.stats.TableStats;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.utils.PartitionPathUtils;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.annotation.Nullable;
 
 import java.io.Serializable;
@@ -85,6 +88,8 @@ public class FileSystemTableSource extends AbstractFileSystemTable
                 SupportsFilterPushDown,
                 SupportsReadingMetadata,
                 SupportsStatisticReport {
+
+    private static final Logger LOG = LoggerFactory.getLogger(FileSystemTableSource.class);
 
     @Nullable private final DecodingFormat<BulkFormat<RowData, FileSourceSplit>> bulkReaderFormat;
     @Nullable private final DecodingFormat<DeserializationSchema<RowData>> deserializationFormat;
@@ -362,6 +367,9 @@ public class FileSystemTableSource extends AbstractFileSystemTable
                 TableStats tableStats =
                         ((FileBasedStatisticsReportableInputFormat) bulkReaderFormat)
                                 .reportStatistics(files, producedDataType);
+                if (tableStats.equals(TableStats.UNKNOWN)) {
+                    return tableStats;
+                }
                 return limit == null
                         ? tableStats
                         : new TableStats(Math.min(limit, tableStats.getRowCount()));
@@ -369,6 +377,9 @@ public class FileSystemTableSource extends AbstractFileSystemTable
                 TableStats tableStats =
                         ((FileBasedStatisticsReportableInputFormat) deserializationFormat)
                                 .reportStatistics(files, producedDataType);
+                if (tableStats.equals(TableStats.UNKNOWN)) {
+                    return tableStats;
+                }
                 return limit == null
                         ? tableStats
                         : new TableStats(Math.min(limit, tableStats.getRowCount()));
@@ -376,6 +387,9 @@ public class FileSystemTableSource extends AbstractFileSystemTable
                 return TableStats.UNKNOWN;
             }
         } catch (Exception e) {
+            LOG.info(
+                    String.format(
+                            "Reporting statistics failed for file system table source: %s", e));
             return TableStats.UNKNOWN;
         }
     }

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemTableSource.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemTableSource.java
@@ -359,11 +359,19 @@ public class FileSystemTableSource extends AbstractFileSystemTable
                     splits.stream().map(FileSourceSplit::path).collect(Collectors.toList());
 
             if (bulkReaderFormat instanceof FileBasedStatisticsReportableInputFormat) {
-                return ((FileBasedStatisticsReportableInputFormat) bulkReaderFormat)
-                        .reportStatistics(files, producedDataType);
+                TableStats tableStats =
+                        ((FileBasedStatisticsReportableInputFormat) bulkReaderFormat)
+                                .reportStatistics(files, producedDataType);
+                return limit == null
+                        ? tableStats
+                        : new TableStats(Math.min(limit, tableStats.getRowCount()));
             } else if (deserializationFormat instanceof FileBasedStatisticsReportableInputFormat) {
-                return ((FileBasedStatisticsReportableInputFormat) deserializationFormat)
-                        .reportStatistics(files, producedDataType);
+                TableStats tableStats =
+                        ((FileBasedStatisticsReportableInputFormat) deserializationFormat)
+                                .reportStatistics(files, producedDataType);
+                return limit == null
+                        ? tableStats
+                        : new TableStats(Math.min(limit, tableStats.getRowCount()));
             } else {
                 return TableStats.UNKNOWN;
             }

--- a/flink-connectors/flink-connector-hive/pom.xml
+++ b/flink-connectors/flink-connector-hive/pom.xml
@@ -210,12 +210,6 @@ under the License.
 			<version>${project.version}</version>
 		</dependency>
 
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-csv</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-
 		<!-- File systems -->
 
 		<dependency>
@@ -848,6 +842,13 @@ under the License.
 			</exclusions>
 		</dependency>
 
+		<!-- TODO: move to flink-connector-hive-test end-to-end test module once it's setup -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-csv</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
@@ -965,7 +966,6 @@ under the License.
 									<include>org.apache.flink:flink-orc-nohive</include>
 									<include>org.apache.flink:flink-hadoop-compatibility_${scala.binary.version}</include>
 									<include>org.apache.flink:flink-parquet</include>
-									<include>org.apache.flink:flink-csv</include>
 									<include>org.apache.flink:flink-hadoop-bulk</include>
 									<include>org.apache.parquet:parquet-hadoop</include>
 									<include>org.apache.parquet:parquet-format</include>

--- a/flink-connectors/flink-connector-hive/pom.xml
+++ b/flink-connectors/flink-connector-hive/pom.xml
@@ -210,6 +210,12 @@ under the License.
 			<version>${project.version}</version>
 		</dependency>
 
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-csv</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
 		<!-- File systems -->
 
 		<dependency>
@@ -842,13 +848,7 @@ under the License.
 			</exclusions>
 		</dependency>
 
-		<!-- TODO: move to flink-connector-hive-test end-to-end test module once it's setup -->
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-csv</artifactId>
-			<version>${project.version}</version>
-			<scope>test</scope>
-		</dependency>
+
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>

--- a/flink-connectors/flink-connector-hive/pom.xml
+++ b/flink-connectors/flink-connector-hive/pom.xml
@@ -849,7 +849,6 @@ under the License.
 		</dependency>
 
 
-
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-test-utils</artifactId>
@@ -966,6 +965,7 @@ under the License.
 									<include>org.apache.flink:flink-orc-nohive</include>
 									<include>org.apache.flink:flink-hadoop-compatibility_${scala.binary.version}</include>
 									<include>org.apache.flink:flink-parquet</include>
+									<include>org.apache.flink:flink-csv</include>
 									<include>org.apache.flink:flink-hadoop-bulk</include>
 									<include>org.apache.parquet:parquet-hadoop</include>
 									<include>org.apache.parquet:parquet-format</include>

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveSourceBuilder.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveSourceBuilder.java
@@ -315,7 +315,7 @@ public class HiveSourceBuilder {
         return (RowType) producedSchema.toRowDataType().bridgedTo(RowData.class).getLogicalType();
     }
 
-    private BulkFormat<RowData, HiveSourceSplit> createDefaultBulkFormat() {
+    public BulkFormat<RowData, HiveSourceSplit> createDefaultBulkFormat() {
         return LimitableBulkFormat.create(
                 new HiveInputFormat(
                         new JobConfWrapper(jobConf),

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveSourceBuilder.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveSourceBuilder.java
@@ -315,7 +315,7 @@ public class HiveSourceBuilder {
         return (RowType) producedSchema.toRowDataType().bridgedTo(RowData.class).getLogicalType();
     }
 
-    public BulkFormat<RowData, HiveSourceSplit> createDefaultBulkFormat() {
+    protected BulkFormat<RowData, HiveSourceSplit> createDefaultBulkFormat() {
         return LimitableBulkFormat.create(
                 new HiveInputFormat(
                         new JobConfWrapper(jobConf),

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
@@ -66,6 +66,8 @@ import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.thrift.TException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
@@ -89,6 +91,7 @@ public class HiveTableSource
                 SupportsLimitPushDown,
                 SupportsStatisticReport {
 
+    private static final Logger LOG = LoggerFactory.getLogger(HiveTableSource.class);
     private static final String HIVE_TRANSFORMATION = "hive";
 
     protected final JobConf jobConf;
@@ -287,8 +290,7 @@ public class HiveTableSource
 
             HiveSourceBuilder sourceBuilder =
                     new HiveSourceBuilder(jobConf, flinkConf, tablePath, hiveVersion, catalogTable)
-                            .setProjectedFields(projectedFields)
-                            .setLimit(limit);
+                            .setProjectedFields(projectedFields);
             int threadNum =
                     flinkConf.get(HiveOptions.TABLE_EXEC_HIVE_LOAD_PARTITION_SPLITS_THREAD_NUM);
             List<HiveTablePartition> hivePartitionsToRead =
@@ -336,6 +338,7 @@ public class HiveTableSource
             }
 
         } catch (Exception e) {
+            LOG.info(String.format("Reporting statistics failed for hive table source: %s", e));
             return TableStats.UNKNOWN;
         }
     }
@@ -362,6 +365,8 @@ public class HiveTableSource
                     files, producedDataType, jobConf);
         } else {
             // Now, only support Orc and Parquet Formats.
+            LOG.info(
+                    "Now for hive table source, reporting statistics only support Orc and Parquet formats.");
             return TableStats.UNKNOWN;
         }
     }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
@@ -338,7 +338,7 @@ public class HiveTableSource
             }
 
         } catch (Exception e) {
-            LOG.info(String.format("Reporting statistics failed for hive table source: %s", e));
+            LOG.warn("Reporting statistics failed for hive table source: {}", e.getMessage());
             return TableStats.UNKNOWN;
         }
     }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
@@ -332,7 +332,7 @@ public class HiveTableSource
                     return new TableStats(newRowCount);
                 }
             } else {
-                return TableStats.UNKNOWN;
+                return new TableStats(0);
             }
 
         } catch (Exception e) {
@@ -353,7 +353,7 @@ public class HiveTableSource
                         .toLowerCase();
         List<Path> files =
                 inputSplits.stream().map(FileSourceSplit::path).collect(Collectors.toList());
-        // Now we only support Csv, Parquet, Orc formats.
+        // Now we only support Parquet, Orc formats.
         if (serializationLib.contains("parquet")) {
             return ParquetFormatStatisticsReportUtil.getTableStatistics(
                     files, producedDataType, jobConf, hiveVersion.startsWith("3"));

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
@@ -35,7 +35,6 @@ import org.apache.flink.connectors.hive.read.HivePartitionFetcherContextBase;
 import org.apache.flink.connectors.hive.read.HiveSourceSplit;
 import org.apache.flink.connectors.hive.util.HivePartitionUtils;
 import org.apache.flink.core.fs.Path;
-import org.apache.flink.formats.csv.util.CsvFormatStatisticsReportUtil;
 import org.apache.flink.formats.parquet.utils.ParquetFormatStatisticsReportUtil;
 import org.apache.flink.orc.util.OrcFormatStatisticsReportUtil;
 import org.apache.flink.streaming.api.datastream.DataStream;
@@ -362,7 +361,8 @@ public class HiveTableSource
             return OrcFormatStatisticsReportUtil.getTableStatistics(
                     files, producedDataType, jobConf);
         } else {
-            return CsvFormatStatisticsReportUtil.getTableStatistics(files);
+            // Now, only support Orc and Parquet Formats.
+            return TableStats.UNKNOWN;
         }
     }
 

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
@@ -306,8 +306,8 @@ public class HiveTableSource
             if (inputSplits.size() != 0) {
                 TableStats tableStats;
                 if (defaultBulkFormat instanceof FileBasedStatisticsReportableInputFormat) {
-                    // If HiveInputFormat's variable useMapRedReader is false, Hive using Flink's
-                    // InputFormat to read data.
+                    // If HiveInputFormat's variable useMapRedReader is false, Flink will use hadoop
+                    // mapRed record to read data.
                     tableStats =
                             ((FileBasedStatisticsReportableInputFormat) defaultBulkFormat)
                                     .reportStatistics(

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveInputFormat.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveInputFormat.java
@@ -135,7 +135,7 @@ public class HiveInputFormat implements BulkFormat<RowData, HiveSourceSplit> {
     private BulkFormat<RowData, ? super HiveSourceSplit> createBulkFormatForSplit(
             HiveSourceSplit split) {
         if (!useMapRedReader && useParquetVectorizedRead(split.getHiveTablePartition())) {
-            LOG.debug(String.format("Use native parquet reader for %s.", split.toString()));
+            LOG.debug(String.format("Use native parquet reader for %s.", split));
             return ParquetColumnarRowInputFormat.createPartitionedFormat(
                     jobConfWrapper.conf(),
                     producedRowType,
@@ -146,7 +146,7 @@ public class HiveInputFormat implements BulkFormat<RowData, HiveSourceSplit> {
                     hiveVersion.startsWith("3"),
                     false);
         } else if (!useMapRedReader && useOrcVectorizedRead(split.getHiveTablePartition())) {
-            LOG.debug(String.format("Use native orc reader for %s.", split.toString()));
+            LOG.debug(String.format("Use native orc reader for %s.", split));
             return createOrcFormat();
         } else {
             if (useMapRedReader) {
@@ -157,7 +157,7 @@ public class HiveInputFormat implements BulkFormat<RowData, HiveSourceSplit> {
                 LOG.debug(
                         String.format(
                                 "Use MapReduce RecordReader reader because the conditions of vectorized read are not met for %s.",
-                                split.toString()));
+                                split));
             }
             return new HiveMapRedBulkFormat();
         }

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceStatisticsReportTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceStatisticsReportTest.java
@@ -201,9 +201,10 @@ public class HiveTableSourceStatisticsReportTest extends StatisticsReportTestBas
         String binaryTypeName = ddlTypesMap.remove("binary(1)");
         ddlTypesMap.remove("varbinary(1)");
         ddlTypesMap.remove("time");
-        ddlTypesMap.remove("row<col1 string, col2 int>");
+        String rowName = ddlTypesMap.remove("row<col1 string, col2 int>");
         ddlTypesMap.put("timestamp", timestampTypeName);
         ddlTypesMap.put("binary", binaryTypeName);
+        ddlTypesMap.put("STRUCT<col1 : string, col2 : int>", rowName);
 
         return ddlTypesMap;
     }
@@ -213,16 +214,17 @@ public class HiveTableSourceStatisticsReportTest extends StatisticsReportTestBas
         // hive table ddl now don't support type: TIMESTAMP(3), TIMESTAMP(9), TIMESTAMP WITHOUT TIME
         // ZONE, TIMESTAMP WITH LOCAL TIME ZONE AND ROW. So we remove these types related data.
         Map<String, List<Object>> dataMap = super.getDataMap();
-        List<Object> timestampDate = dataMap.remove("timestamp(3)");
+        List<Object> timestampData = dataMap.remove("timestamp(3)");
         dataMap.remove("timestamp(9)");
         dataMap.remove("timestamp without time zone");
         dataMap.remove("timestamp with local time zone");
-        List<Object> binaryDate = dataMap.remove("binary(1)");
+        List<Object> binaryData = dataMap.remove("binary(1)");
         dataMap.remove("varbinary(1)");
         dataMap.remove("time");
-        dataMap.remove("row<col1 string, col2 int>");
-        dataMap.put("timestamp", timestampDate);
-        dataMap.put("binary", binaryDate);
+        List<Object> rowData = dataMap.remove("row<col1 string, col2 int>");
+        dataMap.put("timestamp", timestampData);
+        dataMap.put("binary", binaryData);
+        dataMap.put("row<col1 string, col2 int>", rowData);
 
         return dataMap;
     }
@@ -307,6 +309,7 @@ public class HiveTableSourceStatisticsReportTest extends StatisticsReportTestBas
         expectedColumnStatsMap.put("f_binary", null);
         expectedColumnStatsMap.put("f_array", null);
         expectedColumnStatsMap.put("f_map", null);
+        expectedColumnStatsMap.put("f_row", null);
 
         assertThat(tableStats).isEqualTo(new TableStats(expectedRowCount, expectedColumnStatsMap));
     }
@@ -384,6 +387,7 @@ public class HiveTableSourceStatisticsReportTest extends StatisticsReportTestBas
         expectedColumnStatsMap.put("f_binary", new ColumnStats.Builder().setNullCount(0L).build());
         expectedColumnStatsMap.put("f_array", null);
         expectedColumnStatsMap.put("f_map", null);
+        expectedColumnStatsMap.put("f_row", null);
         assertThat(tableStats).isEqualTo(new TableStats(expectedRowCount, expectedColumnStatsMap));
     }
 }

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceStatisticsReportTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceStatisticsReportTest.java
@@ -189,6 +189,31 @@ public class HiveTableSourceStatisticsReportTest extends StatisticsReportTestBas
         assertThat(statistic.getTableStats()).isEqualTo(new TableStats(1));
     }
 
+    @Test
+    public void testHiveTableSourceWithoutData() {
+        tEnv.executeSql(
+                String.format(
+                        "create table hive.db1.orcTable ( %s ) stored as orc",
+                        String.join(", ", ddlTypesMapToStringList(ddlTypesMap()))));
+        FlinkStatistic statistic =
+                getStatisticsFromOptimizedPlan(
+                        String.format("select * from %s.%s.%s", catalogName, dbName, "orcTable"));
+        assertThat(statistic.getTableStats()).isEqualTo(new TableStats(0));
+    }
+
+    @Test
+    public void testHiveTableSourceWithoutDataWithLimitPushDown() {
+        tEnv.executeSql(
+                String.format(
+                        "create table hive.db1.orcTable ( %s ) stored as orc",
+                        String.join(", ", ddlTypesMapToStringList(ddlTypesMap()))));
+        FlinkStatistic statistic =
+                getStatisticsFromOptimizedPlan(
+                        String.format(
+                                "select * from %s.%s.%s limit 1", catalogName, dbName, "orcTable"));
+        assertThat(statistic.getTableStats()).isEqualTo(new TableStats(0));
+    }
+
     @Override
     protected Map<String, String> ddlTypesMap() {
         // hive table ddl now don't support type: TIMESTAMP(3), TIMESTAMP(9), TIMESTAMP WITHOUT TIME

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceStatisticsReportTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceStatisticsReportTest.java
@@ -120,7 +120,8 @@ public class HiveTableSourceStatisticsReportTest extends StatisticsReportTestBas
 
         // Hive to read Orc file
         FlinkStatistic statistic =
-                getStatisticsFromOptimizedPlan("select * from hive.db1.orcTable");
+                getStatisticsFromOptimizedPlan(
+                        "select * from hive.db1.orcTable where f_smallint > 100");
         assertHiveTableOrcFormatTableStatsEquals(statistic.getTableStats(), 3, 1L);
     }
 
@@ -142,7 +143,8 @@ public class HiveTableSourceStatisticsReportTest extends StatisticsReportTestBas
 
         // Hive to read Parquet file
         FlinkStatistic statistic =
-                getStatisticsFromOptimizedPlan("select * from hive.db1.parquetTable");
+                getStatisticsFromOptimizedPlan(
+                        "select * from hive.db1.parquetTable where f_smallint > 100");
         assertHiveTableParquetFormatTableStatsEquals(statistic.getTableStats(), 3, 1L);
     }
 
@@ -166,7 +168,8 @@ public class HiveTableSourceStatisticsReportTest extends StatisticsReportTestBas
 
         // Hive to read Orc file
         FlinkStatistic statistic =
-                getStatisticsFromOptimizedPlan("select * from hive.db1.orcTable");
+                getStatisticsFromOptimizedPlan(
+                        "select * from hive.db1.orcTable where f_smallint > 100");
         assertHiveTableOrcFormatTableStatsEquals(statistic.getTableStats(), 3, 1L);
     }
 
@@ -190,8 +193,23 @@ public class HiveTableSourceStatisticsReportTest extends StatisticsReportTestBas
 
         // Hive to read Parquet file.
         FlinkStatistic statistic =
-                getStatisticsFromOptimizedPlan("select * from hive.db1.parquetTable");
+                getStatisticsFromOptimizedPlan(
+                        "select * from hive.db1.parquetTable where f_smallint > 100");
         assertHiveTableParquetFormatTableStatsEquals(statistic.getTableStats(), 3, 1L);
+    }
+
+    @Test
+    public void testHiveTableSourceWithLimitPushDown() {
+        FlinkStatistic statistic =
+                getStatisticsFromOptimizedPlan(
+                        "select * from "
+                                + catalogName
+                                + "."
+                                + dbName
+                                + "."
+                                + sourceTable
+                                + " limit 1");
+        assertThat(statistic.getTableStats()).isEqualTo(new TableStats(1));
     }
 
     @Override

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceStatisticsReportTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceStatisticsReportTest.java
@@ -1,0 +1,371 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connectors.hive;
+
+import org.apache.flink.table.api.SqlDialect;
+import org.apache.flink.table.catalog.hive.HiveCatalog;
+import org.apache.flink.table.catalog.hive.HiveTestUtils;
+import org.apache.flink.table.plan.stats.ColumnStats;
+import org.apache.flink.table.plan.stats.TableStats;
+import org.apache.flink.table.planner.plan.stats.FlinkStatistic;
+import org.apache.flink.table.planner.utils.StatisticsReportTestBase;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.utils.DateTimeUtils;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.math.BigDecimal;
+import java.sql.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for statistics functionality in {@link HiveTableSource}. */
+public class HiveTableSourceStatisticsReportTest extends StatisticsReportTestBase {
+
+    private static HiveCatalog hiveCatalog;
+    private static final String catalogName = "hive";
+    private static final String dbName = "db1";
+    private static final String sourceTable = "sourceTable";
+
+    @BeforeEach
+    public void setup(@TempDir File file) throws Exception {
+        super.setup(file);
+        hiveCatalog = HiveTestUtils.createHiveCatalog();
+        hiveCatalog.open();
+
+        tEnv.getConfig().setSqlDialect(SqlDialect.HIVE);
+        tEnv.registerCatalog(catalogName, hiveCatalog);
+        tEnv.useCatalog(catalogName);
+        tEnv.executeSql("create database " + dbName);
+
+        tEnv.executeSql(
+                "create table "
+                        + catalogName
+                        + "."
+                        + dbName
+                        + "."
+                        + sourceTable
+                        + "("
+                        + String.join(", ", ddlTypesMapToStringList(ddlTypesMap()))
+                        + ")");
+
+        DataType dataType =
+                tEnv.from(catalogName + "." + dbName + "." + sourceTable)
+                        .getResolvedSchema()
+                        .toPhysicalRowDataType();
+        tEnv.fromValues(dataType, getData())
+                .executeInsert(catalogName + "." + dbName + "." + sourceTable)
+                .await();
+    }
+
+    @AfterEach
+    public void after() {
+        super.after();
+        if (null != hiveCatalog) {
+            hiveCatalog.close();
+        }
+    }
+
+    @Test
+    public void testMapRedCsvFormatHiveTableSourceStatisticsReport() {
+        FlinkStatistic statistic =
+                getStatisticsFromOptimizedPlan(
+                        "select * from " + catalogName + "." + dbName + "." + sourceTable);
+        assertThat(statistic.getTableStats()).isEqualTo(new TableStats(3));
+    }
+
+    @Test
+    public void testFlinkOrcFormatHiveTableSourceStatisticsReport() throws Exception {
+        tEnv.executeSql(
+                "create table hive.db1.orcTable "
+                        + " ("
+                        + String.join(", ", ddlTypesMapToStringList(ddlTypesMap()))
+                        + ") stored as orc");
+        tEnv.executeSql(
+                        "insert into hive.db1.orcTable select * from "
+                                + catalogName
+                                + "."
+                                + dbName
+                                + "."
+                                + sourceTable)
+                .await();
+
+        // Hive to read Orc file
+        FlinkStatistic statistic =
+                getStatisticsFromOptimizedPlan("select * from hive.db1.orcTable");
+        assertHiveTableOrcFormatTableStatsEquals(statistic.getTableStats(), 3, 1L);
+    }
+
+    @Test
+    public void testFlinkParquetFormatHiveTableSourceStatisticsReport() throws Exception {
+        tEnv.executeSql(
+                "create table hive.db1.parquetTable"
+                        + " ("
+                        + String.join(", ", ddlTypesMapToStringList(ddlTypesMap()))
+                        + ") stored as parquet");
+        tEnv.executeSql(
+                        "insert into hive.db1.parquetTable select * from "
+                                + catalogName
+                                + "."
+                                + dbName
+                                + "."
+                                + sourceTable)
+                .await();
+
+        // Hive to read Parquet file
+        FlinkStatistic statistic =
+                getStatisticsFromOptimizedPlan("select * from hive.db1.parquetTable");
+        assertHiveTableParquetFormatTableStatsEquals(statistic.getTableStats(), 3, 1L);
+    }
+
+    @Test
+    public void testMapRedOrcFormatHiveTableSourceStatisticsReport() throws Exception {
+        // Use mapRed parquet format.
+        tEnv.getConfig().set(HiveOptions.TABLE_EXEC_HIVE_FALLBACK_MAPRED_READER, true);
+        tEnv.executeSql(
+                "create table hive.db1.orcTable"
+                        + " ("
+                        + String.join(", ", ddlTypesMapToStringList(ddlTypesMap()))
+                        + ") stored as orc");
+        tEnv.executeSql(
+                        "insert into hive.db1.orcTable select * from "
+                                + catalogName
+                                + "."
+                                + dbName
+                                + "."
+                                + sourceTable)
+                .await();
+
+        // Hive to read Orc file
+        FlinkStatistic statistic =
+                getStatisticsFromOptimizedPlan("select * from hive.db1.orcTable");
+        assertHiveTableOrcFormatTableStatsEquals(statistic.getTableStats(), 3, 1L);
+    }
+
+    @Test
+    public void testMapRedParquetFormatHiveTableSourceStatisticsReport() throws Exception {
+        // Use mapRed parquet format.
+        tEnv.getConfig().set(HiveOptions.TABLE_EXEC_HIVE_FALLBACK_MAPRED_READER, true);
+        tEnv.executeSql(
+                "create table hive.db1.parquetTable"
+                        + " ("
+                        + String.join(", ", ddlTypesMapToStringList(ddlTypesMap()))
+                        + ") stored as parquet");
+        tEnv.executeSql(
+                        "insert into hive.db1.parquetTable select * from "
+                                + catalogName
+                                + "."
+                                + dbName
+                                + "."
+                                + sourceTable)
+                .await();
+
+        // Hive to read Parquet file.
+        FlinkStatistic statistic =
+                getStatisticsFromOptimizedPlan("select * from hive.db1.parquetTable");
+        assertHiveTableParquetFormatTableStatsEquals(statistic.getTableStats(), 3, 1L);
+    }
+
+    @Override
+    protected Map<String, String> ddlTypesMap() {
+        // hive table ddl
+        Map<String, String> ddlTypesMap = super.ddlTypesMap();
+        String timestampTypeName = ddlTypesMap.remove("timestamp(3)");
+        ddlTypesMap.remove("timestamp(9)");
+        String binaryTypeName = ddlTypesMap.remove("binary(1)");
+        ddlTypesMap.remove("varbinary(1)");
+        ddlTypesMap.remove("time");
+        ddlTypesMap.put("timestamp", timestampTypeName);
+        ddlTypesMap.put("binary", binaryTypeName);
+
+        return ddlTypesMap;
+    }
+
+    @Override
+    protected Map<String, List<Object>> getDataMap() {
+        // now hive table source don't support TIME(), and VARBINARY() types, so we remove these
+        // types.
+        Map<String, List<Object>> dataMap = super.getDataMap();
+        List<Object> timestampDate = dataMap.remove("timestamp(3)");
+        dataMap.remove("timestamp(9)");
+        List<Object> binaryDate = dataMap.remove("binary(1)");
+        dataMap.remove("varbinary(1)");
+        dataMap.remove("time");
+        dataMap.put("timestamp", timestampDate);
+        dataMap.put("binary", binaryDate);
+
+        return dataMap;
+    }
+
+    private static void assertHiveTableOrcFormatTableStatsEquals(
+            TableStats tableStats, int expectedRowCount, long nullCount) {
+        Map<String, ColumnStats> expectedColumnStatsMap = new HashMap<>();
+        expectedColumnStatsMap.put("a", new ColumnStats.Builder().setNullCount(nullCount).build());
+        expectedColumnStatsMap.put(
+                "b", new ColumnStats.Builder().setMax(3L).setMin(1L).setNullCount(0L).build());
+        expectedColumnStatsMap.put(
+                "c", new ColumnStats.Builder().setMax(128L).setMin(100L).setNullCount(0L).build());
+        expectedColumnStatsMap.put(
+                "d",
+                new ColumnStats.Builder()
+                        .setMax(45536L)
+                        .setMin(31000L)
+                        .setNullCount(nullCount)
+                        .build());
+        expectedColumnStatsMap.put(
+                "e",
+                new ColumnStats.Builder()
+                        .setMax(1238123899121L)
+                        .setMin(1238123899000L)
+                        .setNullCount(0L)
+                        .build());
+        expectedColumnStatsMap.put(
+                "f",
+                new ColumnStats.Builder()
+                        .setMax(33.33300018310547D)
+                        .setMin(33.31100082397461D)
+                        .setNullCount(nullCount)
+                        .build());
+        expectedColumnStatsMap.put(
+                "g", new ColumnStats.Builder().setMax(10.1D).setMin(1.1D).setNullCount(0L).build());
+        expectedColumnStatsMap.put(
+                "h",
+                new ColumnStats.Builder().setMax("def").setMin("abcd").setNullCount(0L).build());
+        expectedColumnStatsMap.put(
+                "i",
+                new ColumnStats.Builder()
+                        .setMax(new BigDecimal("223.45"))
+                        .setMin(new BigDecimal("123.45"))
+                        .setNullCount(0L)
+                        .build());
+        expectedColumnStatsMap.put(
+                "j",
+                new ColumnStats.Builder()
+                        .setMax(new BigDecimal("123333333355.33"))
+                        .setMin(new BigDecimal("123333333333.33"))
+                        .setNullCount(0L)
+                        .build());
+        expectedColumnStatsMap.put(
+                "k",
+                new ColumnStats.Builder()
+                        .setMax(new BigDecimal("123433343334333433343334333433343334.34"))
+                        .setMin(new BigDecimal("123433343334333433343334333433343334.33"))
+                        .setNullCount(nullCount)
+                        .build());
+        expectedColumnStatsMap.put(
+                "l",
+                new ColumnStats.Builder()
+                        .setMax(Date.valueOf("1990-10-16"))
+                        .setMin(Date.valueOf("1990-10-14"))
+                        .setNullCount(0L)
+                        .build());
+        expectedColumnStatsMap.put(
+                "m",
+                new ColumnStats.Builder()
+                        .setMax(
+                                DateTimeUtils.parseTimestampData("1990-10-16 12:12:43.123", 3)
+                                        .toTimestamp())
+                        .setMin(
+                                DateTimeUtils.parseTimestampData("1990-10-14 12:12:43.123", 3)
+                                        .toTimestamp())
+                        .setNullCount(0L)
+                        .build());
+        expectedColumnStatsMap.put("o", null);
+
+        assertThat(tableStats).isEqualTo(new TableStats(expectedRowCount, expectedColumnStatsMap));
+    }
+
+    private static void assertHiveTableParquetFormatTableStatsEquals(
+            TableStats tableStats, int expectedRowCount, long nullCount) {
+        Map<String, ColumnStats> expectedColumnStatsMap = new HashMap<>();
+        expectedColumnStatsMap.put("a", new ColumnStats.Builder().setNullCount(nullCount).build());
+        expectedColumnStatsMap.put(
+                "b", new ColumnStats.Builder().setMax(3).setMin(1).setNullCount(0L).build());
+        expectedColumnStatsMap.put(
+                "c", new ColumnStats.Builder().setMax(128).setMin(100).setNullCount(0L).build());
+        expectedColumnStatsMap.put(
+                "d",
+                new ColumnStats.Builder()
+                        .setMax(45536)
+                        .setMin(31000)
+                        .setNullCount(nullCount)
+                        .build());
+        expectedColumnStatsMap.put(
+                "e",
+                new ColumnStats.Builder()
+                        .setMax(1238123899121L)
+                        .setMin(1238123899000L)
+                        .setNullCount(0L)
+                        .build());
+        expectedColumnStatsMap.put(
+                "f",
+                new ColumnStats.Builder()
+                        .setMax(33.333F)
+                        .setMin(33.311F)
+                        .setNullCount(nullCount)
+                        .build());
+        expectedColumnStatsMap.put(
+                "g", new ColumnStats.Builder().setMax(10.1D).setMin(1.1D).setNullCount(0L).build());
+        expectedColumnStatsMap.put(
+                "h",
+                new ColumnStats.Builder().setMax("def").setMin("abcd").setNullCount(0L).build());
+        expectedColumnStatsMap.put(
+                "i",
+                new ColumnStats.Builder()
+                        .setMax(new BigDecimal("223.45"))
+                        .setMin(new BigDecimal("123.45"))
+                        .setNullCount(0L)
+                        .build());
+        expectedColumnStatsMap.put(
+                "j",
+                new ColumnStats.Builder()
+                        .setMax(new BigDecimal("123333333355.33"))
+                        .setMin(new BigDecimal("123333333333.33"))
+                        .setNullCount(0L)
+                        .build());
+        expectedColumnStatsMap.put(
+                "k",
+                new ColumnStats.Builder()
+                        .setMax(new BigDecimal("123433343334333433343334333433343334.34"))
+                        .setMin(new BigDecimal("123433343334333433343334333433343334.33"))
+                        .setNullCount(nullCount)
+                        .build());
+        expectedColumnStatsMap.put(
+                "l",
+                new ColumnStats.Builder()
+                        .setMax(Date.valueOf("1990-10-16"))
+                        .setMin(Date.valueOf("1990-10-14"))
+                        .setNullCount(0L)
+                        .build());
+        // Now parquet store timestamp as type int96, and int96 now not support statistics, so
+        // timestamp not support statistics now.
+        expectedColumnStatsMap.put("m", new ColumnStats.Builder().setNullCount(0L).build());
+
+        // parquet writer support BINARY() type.
+        expectedColumnStatsMap.put("o", new ColumnStats.Builder().setNullCount(0L).build());
+        assertThat(tableStats).isEqualTo(new TableStats(expectedRowCount, expectedColumnStatsMap));
+    }
+}

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceStatisticsReportTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceStatisticsReportTest.java
@@ -59,25 +59,22 @@ public class HiveTableSourceStatisticsReportTest extends StatisticsReportTestBas
         tEnv.getConfig().setSqlDialect(SqlDialect.HIVE);
         tEnv.registerCatalog(catalogName, hiveCatalog);
         tEnv.useCatalog(catalogName);
-        tEnv.executeSql("create database " + dbName);
+        tEnv.executeSql(String.format("create database %s", dbName));
 
         tEnv.executeSql(
-                "create table "
-                        + catalogName
-                        + "."
-                        + dbName
-                        + "."
-                        + sourceTable
-                        + "("
-                        + String.join(", ", ddlTypesMapToStringList(ddlTypesMap()))
-                        + ")");
+                String.format(
+                        "create table %s.%s.%s ( %s )",
+                        catalogName,
+                        dbName,
+                        sourceTable,
+                        String.join(", ", ddlTypesMapToStringList(ddlTypesMap()))));
 
         DataType dataType =
-                tEnv.from(catalogName + "." + dbName + "." + sourceTable)
+                tEnv.from(String.format("%s.%s.%s", catalogName, dbName, sourceTable))
                         .getResolvedSchema()
                         .toPhysicalRowDataType();
         tEnv.fromValues(dataType, getData())
-                .executeInsert(catalogName + "." + dbName + "." + sourceTable)
+                .executeInsert(String.format("%s.%s.%s", catalogName, dbName, sourceTable))
                 .await();
     }
 
@@ -98,24 +95,20 @@ public class HiveTableSourceStatisticsReportTest extends StatisticsReportTestBas
     public void testMapRedCsvFormatHiveTableSourceStatisticsReport() {
         FlinkStatistic statistic =
                 getStatisticsFromOptimizedPlan(
-                        "select * from " + catalogName + "." + dbName + "." + sourceTable);
+                        String.format("select * from %s.%s.%s", catalogName, dbName, sourceTable));
         assertThat(statistic.getTableStats()).isEqualTo(TableStats.UNKNOWN);
     }
 
     @Test
     public void testFlinkOrcFormatHiveTableSourceStatisticsReport() throws Exception {
         tEnv.executeSql(
-                "create table hive.db1.orcTable "
-                        + " ("
-                        + String.join(", ", ddlTypesMapToStringList(ddlTypesMap()))
-                        + ") stored as orc");
+                String.format(
+                        "create table hive.db1.orcTable ( %s ) stored as orc",
+                        String.join(", ", ddlTypesMapToStringList(ddlTypesMap()))));
         tEnv.executeSql(
-                        "insert into hive.db1.orcTable select * from "
-                                + catalogName
-                                + "."
-                                + dbName
-                                + "."
-                                + sourceTable)
+                        String.format(
+                                "insert into hive.db1.orcTable select * from %s.%s.%s",
+                                catalogName, dbName, sourceTable))
                 .await();
 
         // Hive to read Orc file
@@ -128,17 +121,13 @@ public class HiveTableSourceStatisticsReportTest extends StatisticsReportTestBas
     @Test
     public void testFlinkParquetFormatHiveTableSourceStatisticsReport() throws Exception {
         tEnv.executeSql(
-                "create table hive.db1.parquetTable"
-                        + " ("
-                        + String.join(", ", ddlTypesMapToStringList(ddlTypesMap()))
-                        + ") stored as parquet");
+                String.format(
+                        "create table hive.db1.parquetTable ( %s ) stored as parquet",
+                        String.join(", ", ddlTypesMapToStringList(ddlTypesMap()))));
         tEnv.executeSql(
-                        "insert into hive.db1.parquetTable select * from "
-                                + catalogName
-                                + "."
-                                + dbName
-                                + "."
-                                + sourceTable)
+                        String.format(
+                                "insert into hive.db1.parquetTable select * from %s.%s.%s",
+                                catalogName, dbName, sourceTable))
                 .await();
 
         // Hive to read Parquet file
@@ -153,17 +142,13 @@ public class HiveTableSourceStatisticsReportTest extends StatisticsReportTestBas
         // Use mapRed parquet format.
         tEnv.getConfig().set(HiveOptions.TABLE_EXEC_HIVE_FALLBACK_MAPRED_READER, true);
         tEnv.executeSql(
-                "create table hive.db1.orcTable"
-                        + " ("
-                        + String.join(", ", ddlTypesMapToStringList(ddlTypesMap()))
-                        + ") stored as orc");
+                String.format(
+                        "create table hive.db1.orcTable ( %s ) stored as orc",
+                        String.join(", ", ddlTypesMapToStringList(ddlTypesMap()))));
         tEnv.executeSql(
-                        "insert into hive.db1.orcTable select * from "
-                                + catalogName
-                                + "."
-                                + dbName
-                                + "."
-                                + sourceTable)
+                        String.format(
+                                "insert into hive.db1.orcTable select * from %s.%s.%s",
+                                catalogName, dbName, sourceTable))
                 .await();
 
         // Hive to read Orc file
@@ -178,17 +163,13 @@ public class HiveTableSourceStatisticsReportTest extends StatisticsReportTestBas
         // Use mapRed parquet format.
         tEnv.getConfig().set(HiveOptions.TABLE_EXEC_HIVE_FALLBACK_MAPRED_READER, true);
         tEnv.executeSql(
-                "create table hive.db1.parquetTable"
-                        + " ("
-                        + String.join(", ", ddlTypesMapToStringList(ddlTypesMap()))
-                        + ") stored as parquet");
+                String.format(
+                        "create table hive.db1.parquetTable ( %s ) stored as parquet",
+                        String.join(", ", ddlTypesMapToStringList(ddlTypesMap()))));
         tEnv.executeSql(
-                        "insert into hive.db1.parquetTable select * from "
-                                + catalogName
-                                + "."
-                                + dbName
-                                + "."
-                                + sourceTable)
+                        String.format(
+                                "insert into hive.db1.parquetTable select * from %s.%s.%s",
+                                catalogName, dbName, sourceTable))
                 .await();
 
         // Hive to read Parquet file.
@@ -202,13 +183,9 @@ public class HiveTableSourceStatisticsReportTest extends StatisticsReportTestBas
     public void testHiveTableSourceWithLimitPushDown() {
         FlinkStatistic statistic =
                 getStatisticsFromOptimizedPlan(
-                        "select * from "
-                                + catalogName
-                                + "."
-                                + dbName
-                                + "."
-                                + sourceTable
-                                + " limit 1");
+                        String.format(
+                                "select * from %s.%s.%s limit 1",
+                                catalogName, dbName, sourceTable));
         assertThat(statistic.getTableStats()).isEqualTo(new TableStats(1));
     }
 

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceStatisticsReportTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceStatisticsReportTest.java
@@ -99,7 +99,7 @@ public class HiveTableSourceStatisticsReportTest extends StatisticsReportTestBas
         FlinkStatistic statistic =
                 getStatisticsFromOptimizedPlan(
                         "select * from " + catalogName + "." + dbName + "." + sourceTable);
-        assertThat(statistic.getTableStats()).isEqualTo(new TableStats(3));
+        assertThat(statistic.getTableStats()).isEqualTo(TableStats.UNKNOWN);
     }
 
     @Test

--- a/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/util/CsvFormatStatisticsReportUtil.java
+++ b/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/util/CsvFormatStatisticsReportUtil.java
@@ -23,6 +23,9 @@ import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.table.plan.stats.TableStats;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.InputStreamReader;
@@ -32,6 +35,9 @@ import java.util.List;
 
 /** Utils for Csv format statistics report. */
 public class CsvFormatStatisticsReportUtil {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CsvFormatStatisticsReportUtil.class);
+
     public static TableStats getTableStatistics(List<Path> files) {
         // For Csv format, it's a heavy operation to obtain accurate statistics by scanning all
         // files. So, We obtain the estimated statistics by sampling, the specific way is to
@@ -76,6 +82,7 @@ public class CsvFormatStatisticsReportUtil {
             long estimatedRowCount = totalFileSize * realSampledLineCnt / sampledRowSize;
             return new TableStats(estimatedRowCount);
         } catch (Exception e) {
+            LOG.info(String.format("Reporting statistics failed for Csv format: %s", e));
             return TableStats.UNKNOWN;
         }
     }

--- a/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/util/CsvFormatStatisticsReportUtil.java
+++ b/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/util/CsvFormatStatisticsReportUtil.java
@@ -82,7 +82,7 @@ public class CsvFormatStatisticsReportUtil {
             long estimatedRowCount = totalFileSize * realSampledLineCnt / sampledRowSize;
             return new TableStats(estimatedRowCount);
         } catch (Exception e) {
-            LOG.info(String.format("Reporting statistics failed for Csv format: %s", e));
+            LOG.warn("Reporting statistics failed for Csv format: {}", e.getMessage());
             return TableStats.UNKNOWN;
         }
     }

--- a/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/util/CsvFormatStatisticsReportUtil.java
+++ b/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/util/CsvFormatStatisticsReportUtil.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.csv.util;
+
+import org.apache.flink.core.fs.FileStatus;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.table.plan.stats.TableStats;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.List;
+
+/** Utils for Csv format statistics report. */
+public class CsvFormatStatisticsReportUtil {
+    public static TableStats getTableStatistics(List<Path> files) {
+        // For Csv format, it's a heavy operation to obtain accurate statistics by scanning all
+        // files. So, We obtain the estimated statistics by sampling, the specific way is to
+        // sample the first 100 lines and calculate their row size, then compare row size with
+        // total file size to get the estimated row count.
+        final int totalSampleLineCnt = 100;
+        try {
+            long totalFileSize = 0;
+            int sampledRowCnt = 0;
+            long sampledRowSize = 0;
+            for (Path file : files) {
+                FileSystem fs = FileSystem.get(file.toUri());
+                FileStatus status = fs.getFileStatus(file);
+                totalFileSize += status.getLen();
+
+                // sample the line size
+                if (sampledRowCnt < totalSampleLineCnt) {
+                    try (InputStreamReader isr =
+                                    new InputStreamReader(
+                                            Files.newInputStream(new File(file.toUri()).toPath()));
+                            BufferedReader br = new BufferedReader(isr)) {
+                        String line;
+                        while (sampledRowCnt < totalSampleLineCnt
+                                && (line = br.readLine()) != null) {
+                            sampledRowCnt += 1;
+                            sampledRowSize += (line.getBytes(StandardCharsets.UTF_8).length + 1);
+                        }
+                    }
+                }
+            }
+
+            // If line break is "\r\n", br.readLine() will ignore '\n' which make sampledRowSize
+            // smaller than totalFileSize. This will influence test result.
+            if (sampledRowCnt < totalSampleLineCnt) {
+                sampledRowSize = totalFileSize;
+            }
+            if (sampledRowSize == 0) {
+                return TableStats.UNKNOWN;
+            }
+
+            int realSampledLineCnt = Math.min(totalSampleLineCnt, sampledRowCnt);
+            long estimatedRowCount = totalFileSize * realSampledLineCnt / sampledRowSize;
+            return new TableStats(estimatedRowCount);
+        } catch (Exception e) {
+            return TableStats.UNKNOWN;
+        }
+    }
+}

--- a/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvFormatFilesystemStatisticsReportTest.java
+++ b/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvFormatFilesystemStatisticsReportTest.java
@@ -18,90 +18,36 @@
 
 package org.apache.flink.formats.csv;
 
-import org.apache.flink.table.api.TableConfig;
-import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.plan.stats.TableStats;
-import org.apache.flink.table.planner.plan.schema.TableSourceTable;
 import org.apache.flink.table.planner.plan.stats.FlinkStatistic;
-import org.apache.flink.table.planner.utils.BatchTableTestUtil;
-import org.apache.flink.table.planner.utils.TableTestBase;
-import org.apache.flink.table.planner.utils.TableTestUtil;
-import org.apache.flink.util.Preconditions;
+import org.apache.flink.table.types.DataType;
 
-import org.apache.calcite.rel.RelNode;
-import org.apache.calcite.rel.RelVisitor;
-import org.apache.calcite.rel.core.TableScan;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.util.Arrays;
-import java.util.List;
+import java.util.concurrent.ExecutionException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Test for statistics functionality in {@link CsvFormatFactory} in the case of file system source.
  */
-public class CsvFormatFilesystemStatisticsReportTest extends TableTestBase {
-    private BatchTableTestUtil util;
-    private TableEnvironment tEnv;
-    @TempDir private static File path;
+public class CsvFormatFilesystemStatisticsReportTest extends CsvFormatStatisticsReportTest {
 
     @BeforeEach
-    public void setup() throws IOException {
-        util = batchTestUtil(TableConfig.getDefault());
-        tEnv = util.getTableEnv();
-        String pathName = writeData(path, Arrays.asList("1,1,hi", "2,1,hello", "3,2,hello world"));
-
-        String ddl =
-                String.format(
-                        "CREATE TABLE sourceTable (\n"
-                                + "  a bigint,\n"
-                                + "  b int,\n"
-                                + "  c varchar\n"
-                                + ") with (\n"
-                                + " 'connector' = 'filesystem',"
-                                + " 'format' = 'csv',"
-                                + " 'path' = '%s')",
-                        pathName);
-        tEnv.executeSql(ddl);
+    public void setup(@TempDir File file) throws Exception {
+        super.setup(file);
     }
 
     @Test
-    public void testCsvFileSystemStatisticsReport() {
+    public void testCsvFileSystemStatisticsReport()
+            throws ExecutionException, InterruptedException {
+        // insert data and get statistics by get plan.
+        DataType dataType = tEnv.from("sourceTable").getResolvedSchema().toPhysicalRowDataType();
+        tEnv.fromValues(dataType, getData()).executeInsert("sourceTable").await();
         FlinkStatistic statistic = getStatisticsFromOptimizedPlan("select * from sourceTable");
         assertThat(statistic.getTableStats()).isEqualTo(new TableStats(3));
-    }
-
-    private String writeData(File path, List<String> data) throws IOException {
-        String file = path.getAbsolutePath() + "/00-00.tmp";
-        Files.write(new File(file).toPath(), String.join("\n", data).getBytes());
-        return file;
-    }
-
-    private FlinkStatistic getStatisticsFromOptimizedPlan(String sql) {
-        RelNode relNode = TableTestUtil.toRelNode(tEnv.sqlQuery(sql));
-        RelNode optimized = util.getPlanner().optimize(relNode);
-        FlinkStatisticVisitor visitor = new FlinkStatisticVisitor();
-        visitor.go(optimized);
-        return visitor.result;
-    }
-
-    private static class FlinkStatisticVisitor extends RelVisitor {
-        private FlinkStatistic result = null;
-
-        @Override
-        public void visit(RelNode node, int ordinal, RelNode parent) {
-            if (node instanceof TableScan) {
-                Preconditions.checkArgument(result == null);
-                TableSourceTable table = (TableSourceTable) node.getTable();
-                result = table.getStatistic();
-            }
-            super.visit(node, ordinal, parent);
-        }
     }
 }

--- a/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvFormatStatisticsReportTest.java
+++ b/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvFormatStatisticsReportTest.java
@@ -36,6 +36,7 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -47,9 +48,16 @@ public class CsvFormatStatisticsReportTest extends StatisticsReportTestBase {
     @BeforeEach
     public void setup(@TempDir File file) throws Exception {
         super.setup(file);
-        createFileSystemSource("csv");
+        createFileSystemSource();
         Configuration configuration = new Configuration();
         csvBulkDecodingFormat = new CsvFileFormatFactory.CsvBulkDecodingFormat(configuration);
+    }
+
+    @Override
+    protected String[] properties() {
+        List<String> ret = new ArrayList<>();
+        ret.add("'format' = 'csv'");
+        return ret.toArray(new String[0]);
     }
 
     @Test
@@ -99,6 +107,22 @@ public class CsvFormatStatisticsReportTest extends StatisticsReportTestBase {
     public void testCsvFormatStatsReportWithEmptyFile() {
         TableStats tableStats = csvBulkDecodingFormat.reportStatistics(null, null);
         assertThat(tableStats).isEqualTo(TableStats.UNKNOWN);
+    }
+
+    @Override
+    protected Map<String, String> ddlTypesMap() {
+        // now Csv format don't support type MAP, so we remove this type.
+        Map<String, String> ddlTypes = super.ddlTypesMap();
+        ddlTypes.remove("map<string, int>");
+        return ddlTypes;
+    }
+
+    @Override
+    protected Map<String, List<Object>> getDataMap() {
+        // now Csv format don't support type MAP, so we remove data belong to this type.
+        Map<String, List<Object>> dataMap = super.getDataMap();
+        dataMap.remove("map<string, int>");
+        return dataMap;
     }
 
     private static Path createTempFile(String content) throws IOException {

--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/OrcColumnarRowInputFormat.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/OrcColumnarRowInputFormat.java
@@ -23,13 +23,18 @@ import org.apache.flink.connector.file.src.FileSourceSplit;
 import org.apache.flink.connector.file.src.util.Pool;
 import org.apache.flink.connector.file.table.ColumnarRowIterator;
 import org.apache.flink.connector.file.table.PartitionFieldExtractor;
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.orc.shim.OrcShim;
+import org.apache.flink.orc.util.OrcFormatStatisticsReportUtil;
 import org.apache.flink.orc.vector.ColumnBatchFactory;
 import org.apache.flink.orc.vector.OrcVectorizedBatchWrapper;
+import org.apache.flink.table.connector.format.FileBasedStatisticsReportableInputFormat;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.columnar.ColumnarRowData;
 import org.apache.flink.table.data.columnar.vector.ColumnVector;
 import org.apache.flink.table.data.columnar.vector.VectorizedColumnBatch;
+import org.apache.flink.table.plan.stats.TableStats;
+import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 
@@ -56,7 +61,8 @@ import static org.apache.flink.orc.vector.AbstractOrcColumnVector.createFlinkVec
  * different and types of extra fields need to be added.
  */
 public class OrcColumnarRowInputFormat<BatchT, SplitT extends FileSourceSplit>
-        extends AbstractOrcFileInputFormat<RowData, BatchT, SplitT> {
+        extends AbstractOrcFileInputFormat<RowData, BatchT, SplitT>
+        implements FileBasedStatisticsReportableInputFormat {
 
     private static final long serialVersionUID = 1L;
 
@@ -92,6 +98,12 @@ public class OrcColumnarRowInputFormat<BatchT, SplitT extends FileSourceSplit>
     @Override
     public TypeInformation<RowData> getProducedType() {
         return this.producedTypeInfo;
+    }
+
+    @Override
+    public TableStats reportStatistics(List<Path> files, DataType producedDataType) {
+        return OrcFormatStatisticsReportUtil.getTableStatistics(
+                files, producedDataType, hadoopConfigWrapper.getHadoopConfig());
     }
 
     // ------------------------------------------------------------------------

--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/OrcFileFormatFactory.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/OrcFileFormatFactory.java
@@ -29,6 +29,7 @@ import org.apache.flink.connector.file.table.factories.BulkWriterFormatFactory;
 import org.apache.flink.connector.file.table.format.BulkDecodingFormat;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.orc.shim.OrcShim;
+import org.apache.flink.orc.util.OrcFormatStatisticsReportUtil;
 import org.apache.flink.orc.vector.RowDataVectorizer;
 import org.apache.flink.orc.writer.OrcBulkWriterFactory;
 import org.apache.flink.table.connector.ChangelogMode;
@@ -43,34 +44,18 @@ import org.apache.flink.table.data.columnar.vector.VectorizedColumnBatch;
 import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.expressions.ResolvedExpression;
 import org.apache.flink.table.factories.DynamicTableFactory;
-import org.apache.flink.table.plan.stats.ColumnStats;
 import org.apache.flink.table.plan.stats.TableStats;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.orc.ColumnStatistics;
-import org.apache.orc.DateColumnStatistics;
-import org.apache.orc.DecimalColumnStatistics;
-import org.apache.orc.DoubleColumnStatistics;
-import org.apache.orc.IntegerColumnStatistics;
-import org.apache.orc.OrcConf;
-import org.apache.orc.OrcFile;
-import org.apache.orc.Reader;
-import org.apache.orc.StringColumnStatistics;
-import org.apache.orc.TimestampColumnStatistics;
 import org.apache.orc.TypeDescription;
-import org.apache.orc.impl.ColumnStatisticsImpl;
 
-import java.io.IOException;
-import java.sql.Date;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
@@ -101,6 +86,13 @@ public class OrcFileFormatFactory implements BulkReaderFormatFactory, BulkWriter
         ((org.apache.flink.configuration.Configuration) options).addAllToProperties(properties);
         properties.forEach((k, v) -> orcProperties.put(IDENTIFIER + "." + k, v));
         return orcProperties;
+    }
+
+    private static Configuration getOrcConfiguration(ReadableConfig formatOptions) {
+        Properties properties = getOrcProperties(formatOptions);
+        Configuration hadoopConf = new Configuration();
+        properties.forEach((k, v) -> hadoopConf.set(k.toString(), v.toString()));
+        return hadoopConf;
     }
 
     @Override
@@ -165,13 +157,9 @@ public class OrcFileFormatFactory implements BulkReaderFormatFactory, BulkWriter
                 }
             }
 
-            Properties properties = getOrcProperties(formatOptions);
-            Configuration conf = new Configuration();
-            properties.forEach((k, v) -> conf.set(k.toString(), v.toString()));
-
             return OrcColumnarRowInputFormat.createPartitionedFormat(
                     OrcShim.defaultShim(),
-                    conf,
+                    getOrcConfiguration(formatOptions),
                     (RowType) producedDataType.getLogicalType(),
                     Collections.emptyList(),
                     null,
@@ -193,177 +181,8 @@ public class OrcFileFormatFactory implements BulkReaderFormatFactory, BulkWriter
 
         @Override
         public TableStats reportStatistics(List<Path> files, DataType producedDataType) {
-            try {
-                Properties properties = getOrcProperties(formatOptions);
-                Configuration hadoopConfig = new Configuration();
-                properties.forEach((k, v) -> hadoopConfig.set(k.toString(), v.toString()));
-
-                long rowCount = 0;
-                Map<String, ColumnStatistics> columnStatisticsMap = new HashMap<>();
-                RowType producedRowType = (RowType) producedDataType.getLogicalType();
-                for (Path file : files) {
-                    rowCount +=
-                            updateStatistics(
-                                    hadoopConfig, file, columnStatisticsMap, producedRowType);
-                }
-
-                Map<String, ColumnStats> columnStatsMap =
-                        convertToColumnStats(rowCount, columnStatisticsMap, producedRowType);
-
-                return new TableStats(rowCount, columnStatsMap);
-            } catch (Exception e) {
-                return TableStats.UNKNOWN;
-            }
-        }
-
-        private long updateStatistics(
-                Configuration hadoopConf,
-                Path file,
-                Map<String, ColumnStatistics> columnStatisticsMap,
-                RowType producedRowType)
-                throws IOException {
-            org.apache.hadoop.fs.Path path = new org.apache.hadoop.fs.Path(file.toUri());
-            Reader reader =
-                    OrcFile.createReader(
-                            path,
-                            OrcFile.readerOptions(hadoopConf)
-                                    .maxLength(OrcConf.MAX_FILE_LENGTH.getLong(hadoopConf)));
-            ColumnStatistics[] statistics = reader.getStatistics();
-            TypeDescription schema = reader.getSchema();
-            List<String> fieldNames = schema.getFieldNames();
-            List<TypeDescription> columnTypes = schema.getChildren();
-            for (String column : producedRowType.getFieldNames()) {
-                int fieldIdx = fieldNames.indexOf(column);
-                if (fieldIdx >= 0) {
-                    int colId = columnTypes.get(fieldIdx).getId();
-                    ColumnStatistics statistic = statistics[colId];
-                    updateStatistics(statistic, column, columnStatisticsMap);
-                }
-            }
-
-            return reader.getNumberOfRows();
-        }
-
-        private void updateStatistics(
-                ColumnStatistics statistic,
-                String column,
-                Map<String, ColumnStatistics> columnStatisticsMap) {
-            ColumnStatistics previousStatistics = columnStatisticsMap.get(column);
-            if (previousStatistics == null) {
-                columnStatisticsMap.put(column, statistic);
-            } else {
-                if (previousStatistics instanceof ColumnStatisticsImpl) {
-                    ((ColumnStatisticsImpl) previousStatistics)
-                            .merge((ColumnStatisticsImpl) statistic);
-                }
-            }
-        }
-
-        private Map<String, ColumnStats> convertToColumnStats(
-                long totalRowCount,
-                Map<String, ColumnStatistics> columnStatisticsMap,
-                RowType logicalType) {
-            Map<String, ColumnStats> columnStatsMap = new HashMap<>();
-            for (String column : logicalType.getFieldNames()) {
-                ColumnStatistics columnStatistics = columnStatisticsMap.get(column);
-                if (columnStatistics == null) {
-                    continue;
-                }
-                ColumnStats columnStats =
-                        convertToColumnStats(
-                                totalRowCount,
-                                logicalType.getTypeAt(logicalType.getFieldIndex(column)),
-                                columnStatistics);
-                columnStatsMap.put(column, columnStats);
-            }
-
-            return columnStatsMap;
-        }
-
-        private ColumnStats convertToColumnStats(
-                long totalRowCount, LogicalType logicalType, ColumnStatistics columnStatistics) {
-            ColumnStats.Builder builder =
-                    new ColumnStats.Builder().setNdv(null).setAvgLen(null).setMaxLen(null);
-            if (!columnStatistics.hasNull()) {
-                builder.setNullCount(0L);
-            } else {
-                builder.setNullCount(totalRowCount - columnStatistics.getNumberOfValues());
-            }
-
-            // For complex types: ROW, ARRAY, MAP. The returned statistics have wrong null count
-            // value, so now complex types stats return null.
-            switch (logicalType.getTypeRoot()) {
-                case BOOLEAN:
-                    break;
-                case TINYINT:
-                case SMALLINT:
-                case INTEGER:
-                case BIGINT:
-                    if (columnStatistics instanceof IntegerColumnStatistics) {
-                        builder.setMax(((IntegerColumnStatistics) columnStatistics).getMaximum())
-                                .setMin(((IntegerColumnStatistics) columnStatistics).getMinimum());
-                        break;
-                    } else {
-                        return null;
-                    }
-                case FLOAT:
-                case DOUBLE:
-                    if (columnStatistics instanceof DoubleColumnStatistics) {
-                        builder.setMax(((DoubleColumnStatistics) columnStatistics).getMaximum())
-                                .setMin(((DoubleColumnStatistics) columnStatistics).getMinimum());
-                        break;
-                    } else {
-                        return null;
-                    }
-                case CHAR:
-                case VARCHAR:
-                    if (columnStatistics instanceof StringColumnStatistics) {
-                        builder.setMax(((StringColumnStatistics) columnStatistics).getMaximum())
-                                .setMin(((StringColumnStatistics) columnStatistics).getMinimum());
-                        break;
-                    } else {
-                        return null;
-                    }
-                case DATE:
-                    if (columnStatistics instanceof DateColumnStatistics) {
-                        Date maximum =
-                                (Date) ((DateColumnStatistics) columnStatistics).getMaximum();
-                        Date minimum =
-                                (Date) ((DateColumnStatistics) columnStatistics).getMinimum();
-                        builder.setMax(maximum).setMin(minimum);
-                        break;
-                    } else {
-                        return null;
-                    }
-                case TIMESTAMP_WITHOUT_TIME_ZONE:
-                case TIMESTAMP_WITH_TIME_ZONE:
-                    if (columnStatistics instanceof TimestampColumnStatistics) {
-                        builder.setMax(((TimestampColumnStatistics) columnStatistics).getMaximum())
-                                .setMin(
-                                        ((TimestampColumnStatistics) columnStatistics)
-                                                .getMinimum());
-                        break;
-                    } else {
-                        return null;
-                    }
-                case DECIMAL:
-                    if (columnStatistics instanceof DecimalColumnStatistics) {
-                        builder.setMax(
-                                        ((DecimalColumnStatistics) columnStatistics)
-                                                .getMaximum()
-                                                .bigDecimalValue())
-                                .setMin(
-                                        ((DecimalColumnStatistics) columnStatistics)
-                                                .getMinimum()
-                                                .bigDecimalValue());
-                        break;
-                    } else {
-                        return null;
-                    }
-                default:
-                    return null;
-            }
-            return builder.build();
+            return OrcFormatStatisticsReportUtil.getTableStatistics(
+                    files, producedDataType, getOrcConfiguration(formatOptions));
         }
     }
 }

--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/util/OrcFormatStatisticsReportUtil.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/util/OrcFormatStatisticsReportUtil.java
@@ -38,6 +38,8 @@ import org.apache.orc.StringColumnStatistics;
 import org.apache.orc.TimestampColumnStatistics;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.impl.ColumnStatisticsImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.sql.Date;
@@ -47,6 +49,9 @@ import java.util.Map;
 
 /** Utils for Orc format statistics report. */
 public class OrcFormatStatisticsReportUtil {
+
+    private static final Logger LOG = LoggerFactory.getLogger(OrcFormatStatisticsReportUtil.class);
+
     public static TableStats getTableStatistics(
             List<Path> files, DataType producedDataType, Configuration hadoopConfig) {
         try {
@@ -63,6 +68,7 @@ public class OrcFormatStatisticsReportUtil {
 
             return new TableStats(rowCount, columnStatsMap);
         } catch (Exception e) {
+            LOG.info(String.format("Reporting statistics failed for Orc format: %s", e));
             return TableStats.UNKNOWN;
         }
     }

--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/util/OrcFormatStatisticsReportUtil.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/util/OrcFormatStatisticsReportUtil.java
@@ -68,7 +68,7 @@ public class OrcFormatStatisticsReportUtil {
 
             return new TableStats(rowCount, columnStatsMap);
         } catch (Exception e) {
-            LOG.info(String.format("Reporting statistics failed for Orc format: %s", e));
+            LOG.warn("Reporting statistics failed for Orc format: {}", e.getMessage());
             return TableStats.UNKNOWN;
         }
     }

--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/util/OrcFormatStatisticsReportUtil.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/util/OrcFormatStatisticsReportUtil.java
@@ -1,0 +1,214 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.orc.util;
+
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.table.plan.stats.ColumnStats;
+import org.apache.flink.table.plan.stats.TableStats;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.orc.ColumnStatistics;
+import org.apache.orc.DateColumnStatistics;
+import org.apache.orc.DecimalColumnStatistics;
+import org.apache.orc.DoubleColumnStatistics;
+import org.apache.orc.IntegerColumnStatistics;
+import org.apache.orc.OrcConf;
+import org.apache.orc.OrcFile;
+import org.apache.orc.Reader;
+import org.apache.orc.StringColumnStatistics;
+import org.apache.orc.TimestampColumnStatistics;
+import org.apache.orc.TypeDescription;
+import org.apache.orc.impl.ColumnStatisticsImpl;
+
+import java.io.IOException;
+import java.sql.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Utils for Orc format statistics report. */
+public class OrcFormatStatisticsReportUtil {
+    public static TableStats getTableStatistics(
+            List<Path> files, DataType producedDataType, Configuration hadoopConfig) {
+        try {
+            long rowCount = 0;
+            Map<String, ColumnStatistics> columnStatisticsMap = new HashMap<>();
+            RowType producedRowType = (RowType) producedDataType.getLogicalType();
+            for (Path file : files) {
+                rowCount +=
+                        updateStatistics(hadoopConfig, file, columnStatisticsMap, producedRowType);
+            }
+
+            Map<String, ColumnStats> columnStatsMap =
+                    convertToColumnStats(rowCount, columnStatisticsMap, producedRowType);
+
+            return new TableStats(rowCount, columnStatsMap);
+        } catch (Exception e) {
+            return TableStats.UNKNOWN;
+        }
+    }
+
+    private static long updateStatistics(
+            Configuration hadoopConf,
+            Path file,
+            Map<String, ColumnStatistics> columnStatisticsMap,
+            RowType producedRowType)
+            throws IOException {
+        org.apache.hadoop.fs.Path path = new org.apache.hadoop.fs.Path(file.toUri());
+        Reader reader =
+                OrcFile.createReader(
+                        path,
+                        OrcFile.readerOptions(hadoopConf)
+                                .maxLength(OrcConf.MAX_FILE_LENGTH.getLong(hadoopConf)));
+        ColumnStatistics[] statistics = reader.getStatistics();
+        TypeDescription schema = reader.getSchema();
+        List<String> fieldNames = schema.getFieldNames();
+        List<TypeDescription> columnTypes = schema.getChildren();
+        for (String column : producedRowType.getFieldNames()) {
+            int fieldIdx = fieldNames.indexOf(column);
+            if (fieldIdx >= 0) {
+                int colId = columnTypes.get(fieldIdx).getId();
+                ColumnStatistics statistic = statistics[colId];
+                updateStatistics(statistic, column, columnStatisticsMap);
+            }
+        }
+
+        return reader.getNumberOfRows();
+    }
+
+    private static void updateStatistics(
+            ColumnStatistics statistic,
+            String column,
+            Map<String, ColumnStatistics> columnStatisticsMap) {
+        ColumnStatistics previousStatistics = columnStatisticsMap.get(column);
+        if (previousStatistics == null) {
+            columnStatisticsMap.put(column, statistic);
+        } else {
+            if (previousStatistics instanceof ColumnStatisticsImpl) {
+                ((ColumnStatisticsImpl) previousStatistics).merge((ColumnStatisticsImpl) statistic);
+            }
+        }
+    }
+
+    private static Map<String, ColumnStats> convertToColumnStats(
+            long totalRowCount,
+            Map<String, ColumnStatistics> columnStatisticsMap,
+            RowType logicalType) {
+        Map<String, ColumnStats> columnStatsMap = new HashMap<>();
+        for (String column : logicalType.getFieldNames()) {
+            ColumnStatistics columnStatistics = columnStatisticsMap.get(column);
+            if (columnStatistics == null) {
+                continue;
+            }
+            ColumnStats columnStats =
+                    convertToColumnStats(
+                            totalRowCount,
+                            logicalType.getTypeAt(logicalType.getFieldIndex(column)),
+                            columnStatistics);
+            columnStatsMap.put(column, columnStats);
+        }
+
+        return columnStatsMap;
+    }
+
+    private static ColumnStats convertToColumnStats(
+            long totalRowCount, LogicalType logicalType, ColumnStatistics columnStatistics) {
+        ColumnStats.Builder builder =
+                new ColumnStats.Builder().setNdv(null).setAvgLen(null).setMaxLen(null);
+        if (!columnStatistics.hasNull()) {
+            builder.setNullCount(0L);
+        } else {
+            builder.setNullCount(totalRowCount - columnStatistics.getNumberOfValues());
+        }
+
+        // For complex types: ROW, ARRAY, MAP. The returned statistics have wrong null count
+        // value, so now complex types stats return null.
+        switch (logicalType.getTypeRoot()) {
+            case BOOLEAN:
+                break;
+            case TINYINT:
+            case SMALLINT:
+            case INTEGER:
+            case BIGINT:
+                if (columnStatistics instanceof IntegerColumnStatistics) {
+                    builder.setMax(((IntegerColumnStatistics) columnStatistics).getMaximum())
+                            .setMin(((IntegerColumnStatistics) columnStatistics).getMinimum());
+                    break;
+                } else {
+                    return null;
+                }
+            case FLOAT:
+            case DOUBLE:
+                if (columnStatistics instanceof DoubleColumnStatistics) {
+                    builder.setMax(((DoubleColumnStatistics) columnStatistics).getMaximum())
+                            .setMin(((DoubleColumnStatistics) columnStatistics).getMinimum());
+                    break;
+                } else {
+                    return null;
+                }
+            case CHAR:
+            case VARCHAR:
+                if (columnStatistics instanceof StringColumnStatistics) {
+                    builder.setMax(((StringColumnStatistics) columnStatistics).getMaximum())
+                            .setMin(((StringColumnStatistics) columnStatistics).getMinimum());
+                    break;
+                } else {
+                    return null;
+                }
+            case DATE:
+                if (columnStatistics instanceof DateColumnStatistics) {
+                    Date maximum = (Date) ((DateColumnStatistics) columnStatistics).getMaximum();
+                    Date minimum = (Date) ((DateColumnStatistics) columnStatistics).getMinimum();
+                    builder.setMax(maximum).setMin(minimum);
+                    break;
+                } else {
+                    return null;
+                }
+            case TIMESTAMP_WITHOUT_TIME_ZONE:
+            case TIMESTAMP_WITH_TIME_ZONE:
+                if (columnStatistics instanceof TimestampColumnStatistics) {
+                    builder.setMax(((TimestampColumnStatistics) columnStatistics).getMaximum())
+                            .setMin(((TimestampColumnStatistics) columnStatistics).getMinimum());
+                    break;
+                } else {
+                    return null;
+                }
+            case DECIMAL:
+                if (columnStatistics instanceof DecimalColumnStatistics) {
+                    builder.setMax(
+                                    ((DecimalColumnStatistics) columnStatistics)
+                                            .getMaximum()
+                                            .bigDecimalValue())
+                            .setMin(
+                                    ((DecimalColumnStatistics) columnStatistics)
+                                            .getMinimum()
+                                            .bigDecimalValue());
+                    break;
+                } else {
+                    return null;
+                }
+            default:
+                return null;
+        }
+        return builder.build();
+    }
+}

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/ParquetFileFormatFactory.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/ParquetFileFormatFactory.java
@@ -29,7 +29,7 @@ import org.apache.flink.connector.file.table.factories.BulkWriterFormatFactory;
 import org.apache.flink.connector.file.table.format.BulkDecodingFormat;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.formats.parquet.row.ParquetRowDataBuilder;
-import org.apache.flink.formats.parquet.vector.reader.TimestampColumnReader;
+import org.apache.flink.formats.parquet.utils.ParquetFormatStatisticsReportUtil;
 import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.connector.Projection;
 import org.apache.flink.table.connector.format.EncodingFormat;
@@ -38,48 +38,19 @@ import org.apache.flink.table.connector.format.ProjectableDecodingFormat;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.data.columnar.vector.VectorizedColumnBatch;
 import org.apache.flink.table.factories.DynamicTableFactory;
-import org.apache.flink.table.plan.stats.ColumnStats;
 import org.apache.flink.table.plan.stats.TableStats;
 import org.apache.flink.table.types.DataType;
-import org.apache.flink.table.types.logical.DecimalType;
-import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
-import org.apache.flink.table.utils.DateTimeUtils;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.parquet.Preconditions;
-import org.apache.parquet.column.statistics.BinaryStatistics;
-import org.apache.parquet.column.statistics.DoubleStatistics;
-import org.apache.parquet.column.statistics.FloatStatistics;
-import org.apache.parquet.column.statistics.IntStatistics;
-import org.apache.parquet.column.statistics.LongStatistics;
-import org.apache.parquet.column.statistics.Statistics;
-import org.apache.parquet.hadoop.ParquetFileReader;
-import org.apache.parquet.hadoop.metadata.BlockMetaData;
-import org.apache.parquet.hadoop.metadata.ParquetMetadata;
-import org.apache.parquet.io.api.Binary;
-import org.apache.parquet.schema.MessageType;
-import org.apache.parquet.schema.Type;
 
-import java.io.IOException;
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.sql.Date;
-import java.sql.Time;
-import java.sql.Timestamp;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static org.apache.flink.configuration.ConfigOptions.key;
 
@@ -185,238 +156,11 @@ public class ParquetFileFormatFactory implements BulkReaderFormatFactory, BulkWr
 
         @Override
         public TableStats reportStatistics(List<Path> files, DataType producedDataType) {
-            try {
-                Configuration hadoopConfig = getParquetConfiguration(formatOptions);
-                Map<String, Statistics<?>> columnStatisticsMap = new HashMap<>();
-                RowType producedRowType = (RowType) producedDataType.getLogicalType();
-                long rowCount = 0;
-                for (Path file : files) {
-                    rowCount += updateStatistics(hadoopConfig, file, columnStatisticsMap);
-                }
-                Map<String, ColumnStats> columnStatsMap =
-                        convertToColumnStats(columnStatisticsMap, producedRowType);
-                return new TableStats(rowCount, columnStatsMap);
-            } catch (Exception e) {
-                return TableStats.UNKNOWN;
-            }
-        }
-
-        private Map<String, ColumnStats> convertToColumnStats(
-                Map<String, Statistics<?>> columnStatisticsMap, RowType producedRowType) {
-            Map<String, ColumnStats> columnStatMap = new HashMap<>();
-            for (String column : producedRowType.getFieldNames()) {
-                Statistics<?> statistics = columnStatisticsMap.get(column);
-                if (statistics == null) {
-                    continue;
-                }
-                ColumnStats columnStats =
-                        convertToColumnStats(
-                                producedRowType.getTypeAt(producedRowType.getFieldIndex(column)),
-                                statistics);
-                columnStatMap.put(column, columnStats);
-            }
-            return columnStatMap;
-        }
-
-        private ColumnStats convertToColumnStats(
-                LogicalType logicalType, Statistics<?> statistics) {
-            ColumnStats.Builder builder =
-                    new ColumnStats.Builder().setNullCount(statistics.getNumNulls());
-
-            // For complex types: ROW, ARRAY, MAP. The returned statistics have wrong null count
-            // value, so now complex types stats return null.
-            switch (logicalType.getTypeRoot()) {
-                case BOOLEAN:
-                case BINARY:
-                case VARBINARY:
-                    break;
-                case TINYINT:
-                case SMALLINT:
-                case INTEGER:
-                case BIGINT:
-                    if (statistics instanceof IntStatistics) {
-                        builder.setMin(((IntStatistics) statistics).getMin())
-                                .setMax(((IntStatistics) statistics).getMax());
-                    } else if (statistics instanceof LongStatistics) {
-                        builder.setMin(((LongStatistics) statistics).getMin())
-                                .setMax(((LongStatistics) statistics).getMax());
-                    } else {
-                        return null;
-                    }
-                    break;
-                case DOUBLE:
-                    if (statistics instanceof DoubleStatistics) {
-                        builder.setMin(((DoubleStatistics) statistics).getMin())
-                                .setMax(((DoubleStatistics) statistics).getMax());
-                        break;
-                    } else {
-                        return null;
-                    }
-                case FLOAT:
-                    if (statistics instanceof FloatStatistics) {
-                        builder.setMin(((FloatStatistics) statistics).getMin())
-                                .setMax(((FloatStatistics) statistics).getMax());
-                        break;
-                    } else {
-                        return null;
-                    }
-                case DATE:
-                    if (statistics instanceof IntStatistics) {
-                        Date min =
-                                Date.valueOf(
-                                        DateTimeUtils.formatDate(
-                                                ((IntStatistics) statistics).getMin()));
-                        Date max =
-                                Date.valueOf(
-                                        DateTimeUtils.formatDate(
-                                                ((IntStatistics) statistics).getMax()));
-                        builder.setMin(min).setMax(max);
-                        break;
-                    } else {
-                        return null;
-                    }
-                case TIME_WITHOUT_TIME_ZONE:
-                    if (statistics instanceof IntStatistics) {
-                        Time min =
-                                Time.valueOf(
-                                        DateTimeUtils.toLocalTime(
-                                                ((IntStatistics) statistics).getMin()));
-                        Time max =
-                                Time.valueOf(
-                                        DateTimeUtils.toLocalTime(
-                                                ((IntStatistics) statistics).getMax()));
-                        builder.setMin(min).setMax(max);
-                        break;
-                    } else {
-                        return null;
-                    }
-                case CHAR:
-                case VARCHAR:
-                    if (statistics instanceof BinaryStatistics) {
-                        Binary min = ((BinaryStatistics) statistics).genericGetMin();
-                        Binary max = ((BinaryStatistics) statistics).genericGetMax();
-                        if (min != null) {
-                            builder.setMin(min.toStringUsingUTF8());
-                        } else {
-                            builder.setMin(null);
-                        }
-                        if (max != null) {
-                            builder.setMax(max.toStringUsingUTF8());
-                        } else {
-                            builder.setMax(null);
-                        }
-                        break;
-                    } else {
-                        return null;
-                    }
-                case TIMESTAMP_WITHOUT_TIME_ZONE:
-                case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
-                case TIMESTAMP_WITH_TIME_ZONE:
-                    if (statistics instanceof LongStatistics) {
-                        builder.setMin(new Timestamp(((LongStatistics) statistics).getMin()))
-                                .setMax(new Timestamp(((LongStatistics) statistics).getMax()));
-                    } else if (statistics instanceof BinaryStatistics) {
-                        Binary min = ((BinaryStatistics) statistics).genericGetMin();
-                        Binary max = ((BinaryStatistics) statistics).genericGetMax();
-                        if (min != null) {
-                            builder.setMin(binaryToTimestamp(min, formatOptions.get(UTC_TIMEZONE)));
-                        } else {
-                            builder.setMin(null);
-                        }
-                        if (max != null) {
-                            builder.setMax(binaryToTimestamp(max, formatOptions.get(UTC_TIMEZONE)));
-                        } else {
-                            builder.setMax(null);
-                        }
-                    } else {
-                        return null;
-                    }
-                    break;
-                case DECIMAL:
-                    if (statistics instanceof IntStatistics) {
-                        builder.setMin(BigDecimal.valueOf(((IntStatistics) statistics).getMin()))
-                                .setMax(BigDecimal.valueOf(((IntStatistics) statistics).getMax()));
-                    } else if (statistics instanceof LongStatistics) {
-                        builder.setMin(BigDecimal.valueOf(((LongStatistics) statistics).getMin()))
-                                .setMax(BigDecimal.valueOf(((LongStatistics) statistics).getMax()));
-                    } else if (statistics instanceof BinaryStatistics) {
-                        Binary min = ((BinaryStatistics) statistics).genericGetMin();
-                        Binary max = ((BinaryStatistics) statistics).genericGetMax();
-                        if (min != null) {
-                            builder.setMin(
-                                    binaryToDecimal(min, ((DecimalType) logicalType).getScale()));
-                        } else {
-                            builder.setMin(null);
-                        }
-                        if (max != null) {
-                            builder.setMax(
-                                    binaryToDecimal(max, ((DecimalType) logicalType).getScale()));
-                        } else {
-                            builder.setMax(null);
-                        }
-                    } else {
-                        return null;
-                    }
-                    break;
-                default:
-                    return null;
-            }
-            return builder.build();
-        }
-
-        private long updateStatistics(
-                Configuration hadoopConfig,
-                Path file,
-                Map<String, Statistics<?>> columnStatisticsMap)
-                throws IOException {
-            org.apache.hadoop.fs.Path hadoopPath = new org.apache.hadoop.fs.Path(file.toUri());
-            ParquetMetadata metadata = ParquetFileReader.readFooter(hadoopConfig, hadoopPath);
-            MessageType schema = metadata.getFileMetaData().getSchema();
-            List<String> columns =
-                    schema.asGroupType().getFields().stream()
-                            .map(Type::getName)
-                            .collect(Collectors.toList());
-            List<BlockMetaData> blocks = metadata.getBlocks();
-            long rowCount = 0;
-            for (BlockMetaData block : blocks) {
-                rowCount += block.getRowCount();
-                for (int i = 0; i < columns.size(); ++i) {
-                    updateStatistics(
-                            block.getColumns().get(i).getStatistics(),
-                            columns.get(i),
-                            columnStatisticsMap);
-                }
-            }
-            return rowCount;
-        }
-
-        private void updateStatistics(
-                Statistics<?> statistics,
-                String column,
-                Map<String, Statistics<?>> columnStatisticsMap) {
-            Statistics<?> previousStatistics = columnStatisticsMap.get(column);
-            if (previousStatistics == null) {
-                columnStatisticsMap.put(column, statistics);
-            } else {
-                previousStatistics.mergeStatistics(statistics);
-            }
-        }
-
-        private static BigDecimal binaryToDecimal(Binary decimal, int scale) {
-            BigInteger bigInteger = new BigInteger(decimal.getBytesUnsafe());
-            return new BigDecimal(bigInteger, scale);
-        }
-
-        private static Timestamp binaryToTimestamp(Binary timestamp, boolean utcTimestamp) {
-            Preconditions.checkArgument(timestamp.length() == 12, "Must be 12 bytes");
-            ByteBuffer buf = timestamp.toByteBuffer();
-            buf.order(ByteOrder.LITTLE_ENDIAN);
-            long timeOfDayNanos = buf.getLong();
-            int julianDay = buf.getInt();
-
-            TimestampData timestampData =
-                    TimestampColumnReader.int96ToTimestamp(utcTimestamp, timeOfDayNanos, julianDay);
-            return timestampData.toTimestamp();
+            return ParquetFormatStatisticsReportUtil.getTableStatistics(
+                    files,
+                    producedDataType,
+                    getParquetConfiguration(formatOptions),
+                    formatOptions.get(UTC_TIMEZONE));
         }
     }
 }

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/ParquetVectorizedInputFormat.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/ParquetVectorizedInputFormat.java
@@ -81,12 +81,12 @@ public abstract class ParquetVectorizedInputFormat<T, SplitT extends FileSourceS
     private static final Logger LOG = LoggerFactory.getLogger(ParquetVectorizedInputFormat.class);
     private static final long serialVersionUID = 1L;
 
-    private final SerializableConfiguration hadoopConfig;
+    protected final SerializableConfiguration hadoopConfig;
     private final String[] projectedFields;
     private final LogicalType[] projectedTypes;
     private final ColumnBatchFactory<SplitT> batchFactory;
     private final int batchSize;
-    private final boolean isUtcTimestamp;
+    protected final boolean isUtcTimestamp;
     private final boolean isCaseSensitive;
     private final Set<Integer> unknownFieldsIndices = new HashSet<>();
 

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/utils/ParquetFormatStatisticsReportUtil.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/utils/ParquetFormatStatisticsReportUtil.java
@@ -43,6 +43,8 @@ import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.Type;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -59,6 +61,10 @@ import java.util.stream.Collectors;
 
 /** Utils for Parquet format statistics report. */
 public class ParquetFormatStatisticsReportUtil {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(ParquetFormatStatisticsReportUtil.class);
+
     public static TableStats getTableStatistics(
             List<Path> files,
             DataType producedDataType,
@@ -75,6 +81,7 @@ public class ParquetFormatStatisticsReportUtil {
                     convertToColumnStats(columnStatisticsMap, producedRowType, isUtcTimestamp);
             return new TableStats(rowCount, columnStatsMap);
         } catch (Exception e) {
+            LOG.info(String.format("Reporting statistics failed for Parquet format: %s", e));
             return TableStats.UNKNOWN;
         }
     }

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/utils/ParquetFormatStatisticsReportUtil.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/utils/ParquetFormatStatisticsReportUtil.java
@@ -81,7 +81,7 @@ public class ParquetFormatStatisticsReportUtil {
                     convertToColumnStats(columnStatisticsMap, producedRowType, isUtcTimestamp);
             return new TableStats(rowCount, columnStatsMap);
         } catch (Exception e) {
-            LOG.info(String.format("Reporting statistics failed for Parquet format: %s", e));
+            LOG.warn("Reporting statistics failed for Parquet format: {}", e.getMessage());
             return TableStats.UNKNOWN;
         }
     }

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/utils/ParquetFormatStatisticsReportUtil.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/utils/ParquetFormatStatisticsReportUtil.java
@@ -1,0 +1,300 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.parquet.utils;
+
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.formats.parquet.vector.reader.TimestampColumnReader;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.plan.stats.ColumnStats;
+import org.apache.flink.table.plan.stats.TableStats;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.utils.DateTimeUtils;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.Preconditions;
+import org.apache.parquet.column.statistics.BinaryStatistics;
+import org.apache.parquet.column.statistics.DoubleStatistics;
+import org.apache.parquet.column.statistics.FloatStatistics;
+import org.apache.parquet.column.statistics.IntStatistics;
+import org.apache.parquet.column.statistics.LongStatistics;
+import org.apache.parquet.column.statistics.Statistics;
+import org.apache.parquet.hadoop.ParquetFileReader;
+import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
+import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.Type;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/** Utils for Parquet format statistics report. */
+public class ParquetFormatStatisticsReportUtil {
+    public static TableStats getTableStatistics(
+            List<Path> files,
+            DataType producedDataType,
+            Configuration hadoopConfig,
+            boolean isUtcTimestamp) {
+        try {
+            Map<String, Statistics<?>> columnStatisticsMap = new HashMap<>();
+            RowType producedRowType = (RowType) producedDataType.getLogicalType();
+            long rowCount = 0;
+            for (Path file : files) {
+                rowCount += updateStatistics(hadoopConfig, file, columnStatisticsMap);
+            }
+            Map<String, ColumnStats> columnStatsMap =
+                    convertToColumnStats(columnStatisticsMap, producedRowType, isUtcTimestamp);
+            return new TableStats(rowCount, columnStatsMap);
+        } catch (Exception e) {
+            return TableStats.UNKNOWN;
+        }
+    }
+
+    private static Map<String, ColumnStats> convertToColumnStats(
+            Map<String, Statistics<?>> columnStatisticsMap,
+            RowType producedRowType,
+            boolean isUtcTimestamp) {
+        Map<String, ColumnStats> columnStatMap = new HashMap<>();
+        for (String column : producedRowType.getFieldNames()) {
+            Statistics<?> statistics = columnStatisticsMap.get(column);
+            if (statistics == null) {
+                continue;
+            }
+            ColumnStats columnStats =
+                    convertToColumnStats(
+                            producedRowType.getTypeAt(producedRowType.getFieldIndex(column)),
+                            statistics,
+                            isUtcTimestamp);
+            columnStatMap.put(column, columnStats);
+        }
+        return columnStatMap;
+    }
+
+    private static ColumnStats convertToColumnStats(
+            LogicalType logicalType, Statistics<?> statistics, boolean isUtcTimestamp) {
+        ColumnStats.Builder builder =
+                new ColumnStats.Builder().setNullCount(statistics.getNumNulls());
+
+        // For complex types: ROW, ARRAY, MAP. The returned statistics have wrong null count
+        // value, so now complex types stats return null.
+        switch (logicalType.getTypeRoot()) {
+            case BOOLEAN:
+            case BINARY:
+            case VARBINARY:
+                break;
+            case TINYINT:
+            case SMALLINT:
+            case INTEGER:
+            case BIGINT:
+                if (statistics instanceof IntStatistics) {
+                    builder.setMin(((IntStatistics) statistics).getMin())
+                            .setMax(((IntStatistics) statistics).getMax());
+                } else if (statistics instanceof LongStatistics) {
+                    builder.setMin(((LongStatistics) statistics).getMin())
+                            .setMax(((LongStatistics) statistics).getMax());
+                } else {
+                    return null;
+                }
+                break;
+            case DOUBLE:
+                if (statistics instanceof DoubleStatistics) {
+                    builder.setMin(((DoubleStatistics) statistics).getMin())
+                            .setMax(((DoubleStatistics) statistics).getMax());
+                    break;
+                } else {
+                    return null;
+                }
+            case FLOAT:
+                if (statistics instanceof FloatStatistics) {
+                    builder.setMin(((FloatStatistics) statistics).getMin())
+                            .setMax(((FloatStatistics) statistics).getMax());
+                    break;
+                } else {
+                    return null;
+                }
+            case DATE:
+                if (statistics instanceof IntStatistics) {
+                    Date min =
+                            Date.valueOf(
+                                    DateTimeUtils.formatDate(
+                                            ((IntStatistics) statistics).getMin()));
+                    Date max =
+                            Date.valueOf(
+                                    DateTimeUtils.formatDate(
+                                            ((IntStatistics) statistics).getMax()));
+                    builder.setMin(min).setMax(max);
+                    break;
+                } else {
+                    return null;
+                }
+            case TIME_WITHOUT_TIME_ZONE:
+                if (statistics instanceof IntStatistics) {
+                    Time min =
+                            Time.valueOf(
+                                    DateTimeUtils.toLocalTime(
+                                            ((IntStatistics) statistics).getMin()));
+                    Time max =
+                            Time.valueOf(
+                                    DateTimeUtils.toLocalTime(
+                                            ((IntStatistics) statistics).getMax()));
+                    builder.setMin(min).setMax(max);
+                    break;
+                } else {
+                    return null;
+                }
+            case CHAR:
+            case VARCHAR:
+                if (statistics instanceof BinaryStatistics) {
+                    Binary min = ((BinaryStatistics) statistics).genericGetMin();
+                    Binary max = ((BinaryStatistics) statistics).genericGetMax();
+                    if (min != null) {
+                        builder.setMin(min.toStringUsingUTF8());
+                    } else {
+                        builder.setMin(null);
+                    }
+                    if (max != null) {
+                        builder.setMax(max.toStringUsingUTF8());
+                    } else {
+                        builder.setMax(null);
+                    }
+                    break;
+                } else {
+                    return null;
+                }
+            case TIMESTAMP_WITHOUT_TIME_ZONE:
+            case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+            case TIMESTAMP_WITH_TIME_ZONE:
+                if (statistics instanceof LongStatistics) {
+                    builder.setMin(new Timestamp(((LongStatistics) statistics).getMin()))
+                            .setMax(new Timestamp(((LongStatistics) statistics).getMax()));
+                } else if (statistics instanceof BinaryStatistics) {
+                    Binary min = ((BinaryStatistics) statistics).genericGetMin();
+                    Binary max = ((BinaryStatistics) statistics).genericGetMax();
+                    if (min != null) {
+                        builder.setMin(binaryToTimestamp(min, isUtcTimestamp));
+                    } else {
+                        builder.setMin(null);
+                    }
+                    if (max != null) {
+                        builder.setMax(binaryToTimestamp(max, isUtcTimestamp));
+                    } else {
+                        builder.setMax(null);
+                    }
+                } else {
+                    return null;
+                }
+                break;
+            case DECIMAL:
+                if (statistics instanceof IntStatistics) {
+                    builder.setMin(BigDecimal.valueOf(((IntStatistics) statistics).getMin()))
+                            .setMax(BigDecimal.valueOf(((IntStatistics) statistics).getMax()));
+                } else if (statistics instanceof LongStatistics) {
+                    builder.setMin(BigDecimal.valueOf(((LongStatistics) statistics).getMin()))
+                            .setMax(BigDecimal.valueOf(((LongStatistics) statistics).getMax()));
+                } else if (statistics instanceof BinaryStatistics) {
+                    Binary min = ((BinaryStatistics) statistics).genericGetMin();
+                    Binary max = ((BinaryStatistics) statistics).genericGetMax();
+                    if (min != null) {
+                        builder.setMin(
+                                binaryToDecimal(min, ((DecimalType) logicalType).getScale()));
+                    } else {
+                        builder.setMin(null);
+                    }
+                    if (max != null) {
+                        builder.setMax(
+                                binaryToDecimal(max, ((DecimalType) logicalType).getScale()));
+                    } else {
+                        builder.setMax(null);
+                    }
+                } else {
+                    return null;
+                }
+                break;
+            default:
+                return null;
+        }
+        return builder.build();
+    }
+
+    private static long updateStatistics(
+            Configuration hadoopConfig, Path file, Map<String, Statistics<?>> columnStatisticsMap)
+            throws IOException {
+        org.apache.hadoop.fs.Path hadoopPath = new org.apache.hadoop.fs.Path(file.toUri());
+        ParquetMetadata metadata = ParquetFileReader.readFooter(hadoopConfig, hadoopPath);
+        MessageType schema = metadata.getFileMetaData().getSchema();
+        List<String> columns =
+                schema.asGroupType().getFields().stream()
+                        .map(Type::getName)
+                        .collect(Collectors.toList());
+        List<BlockMetaData> blocks = metadata.getBlocks();
+        long rowCount = 0;
+        for (BlockMetaData block : blocks) {
+            rowCount += block.getRowCount();
+            for (int i = 0; i < columns.size(); ++i) {
+                updateStatistics(
+                        block.getColumns().get(i).getStatistics(),
+                        columns.get(i),
+                        columnStatisticsMap);
+            }
+        }
+        return rowCount;
+    }
+
+    private static void updateStatistics(
+            Statistics<?> statistics,
+            String column,
+            Map<String, Statistics<?>> columnStatisticsMap) {
+        Statistics<?> previousStatistics = columnStatisticsMap.get(column);
+        if (previousStatistics == null) {
+            columnStatisticsMap.put(column, statistics);
+        } else {
+            previousStatistics.mergeStatistics(statistics);
+        }
+    }
+
+    private static BigDecimal binaryToDecimal(Binary decimal, int scale) {
+        BigInteger bigInteger = new BigInteger(decimal.getBytesUnsafe());
+        return new BigDecimal(bigInteger, scale);
+    }
+
+    private static Timestamp binaryToTimestamp(Binary timestamp, boolean utcTimestamp) {
+        Preconditions.checkArgument(timestamp.length() == 12, "Must be 12 bytes");
+        ByteBuffer buf = timestamp.toByteBuffer();
+        buf.order(ByteOrder.LITTLE_ENDIAN);
+        long timeOfDayNanos = buf.getLong();
+        int julianDay = buf.getInt();
+
+        TimestampData timestampData =
+                TimestampColumnReader.int96ToTimestamp(utcTimestamp, timeOfDayNanos, julianDay);
+        return timestampData.toTimestamp();
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushPartitionIntoTableSourceScanRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushPartitionIntoTableSourceScanRule.java
@@ -185,7 +185,7 @@ public class PushPartitionIntoTableSourceScanRule extends RelOptRule {
         TableSourceTable newTableSourceTable =
                 tableSourceTable.copy(
                         dynamicTableSource,
-                        // the statistics will be updated in FlinkCollectStatisticsProgram
+                        // The statistics will be updated in FlinkRecomputeStatisticsProgram.
                         tableSourceTable.getStatistic(),
                         new SourceAbilitySpec[] {partitionPushDownSpec});
         LogicalTableScan newScan =

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/connector/file/table/FileSystemStatisticsReportTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/connector/file/table/FileSystemStatisticsReportTest.java
@@ -309,6 +309,9 @@ public class FileSystemStatisticsReportTest extends StatisticsReportTestBase {
 
     @Test
     public void testFileSystemSourceWithoutDataWithLimitPushDown() {
+        // TODO for source support limit push down and query have limit condition, In
+        // PushLimitIntoTableSourceScanRule will give stats a new rowCount value even if this table
+        // have no data.
         FlinkStatistic statistic =
                 getStatisticsFromOptimizedPlan("select * from emptyTable limit 1");
         assertThat(statistic.getTableStats()).isEqualTo(new TableStats(1));

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/connector/file/table/FileSystemStatisticsReportTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/connector/file/table/FileSystemStatisticsReportTest.java
@@ -114,6 +114,11 @@ public class FileSystemStatisticsReportTest extends StatisticsReportTestBase {
         tEnv.executeSql(ddl3);
     }
 
+    @Override
+    protected String[] properties() {
+        return new String[0];
+    }
+
     private String createFileAndWriteData(File path, String fileName, List<String> data)
             throws IOException {
         String file = path.getAbsolutePath() + "/" + fileName;

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/connector/file/table/FileSystemStatisticsReportTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/connector/file/table/FileSystemStatisticsReportTest.java
@@ -189,6 +189,13 @@ public class FileSystemStatisticsReportTest extends StatisticsReportTestBase {
     }
 
     @Test
+    public void testLimitPushDownAndCatalogStatisticsDoNotExist() {
+        FlinkStatistic statistic =
+                getStatisticsFromOptimizedPlan("select * from NonPartTable limit 1");
+        assertThat(statistic.getTableStats()).isEqualTo(new TableStats(1));
+    }
+
+    @Test
     public void testNoPartitionPushDownAndCatalogStatisticsExist() throws Exception {
         tEnv.getCatalog(tEnv.getCurrentCatalog())
                 .orElseThrow(Exception::new)

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/formats/testcsv/TestCsvFormatFactory.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/formats/testcsv/TestCsvFormatFactory.java
@@ -178,7 +178,7 @@ public class TestCsvFormatFactory
                 long estimatedRowCount = totalFileSize * realSampledLineCnt / sampledRowSize;
                 return new TableStats(estimatedRowCount);
             } catch (Exception e) {
-                LOG.info(String.format("Reporting statistics failed for Csv format: %s", e));
+                LOG.warn("Reporting statistics failed for Csv format: {}", e.getMessage());
                 return TableStats.UNKNOWN;
             }
         }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/formats/testcsv/TestCsvFormatFactory.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/formats/testcsv/TestCsvFormatFactory.java
@@ -41,6 +41,9 @@ import org.apache.flink.table.plan.stats.TableStats;
 import org.apache.flink.table.runtime.connector.source.ScanRuntimeProviderContext;
 import org.apache.flink.table.types.DataType;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.InputStreamReader;
@@ -58,6 +61,8 @@ import java.util.Set;
  */
 public class TestCsvFormatFactory
         implements DeserializationFormatFactory, SerializationFormatFactory {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TestCsvFormatFactory.class);
 
     public static final String IDENTIFIER = "testcsv";
 
@@ -173,6 +178,7 @@ public class TestCsvFormatFactory
                 long estimatedRowCount = totalFileSize * realSampledLineCnt / sampledRowSize;
                 return new TableStats(estimatedRowCount);
             } catch (Exception e) {
+                LOG.info(String.format("Reporting statistics failed for Csv format: %s", e));
                 return TableStats.UNKNOWN;
             }
         }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/utils/StatisticsReportTestBase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/utils/StatisticsReportTestBase.java
@@ -294,7 +294,7 @@ public abstract class StatisticsReportTestBase extends TestLogger {
         }
     }
 
-    private static String[] ddlTypesMapToStringList(Map<String, String> ddlTypesMap) {
+    protected static String[] ddlTypesMapToStringList(Map<String, String> ddlTypesMap) {
         String[] types = new String[ddlTypesMap.size()];
         int i = 0;
         for (Map.Entry<String, String> entry : ddlTypesMap.entrySet()) {


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

In FLIP-231, [https://cwiki.apache.org/confluence/display/FLINK/FLIP-231%3A+Introduce+SupportsStatisticReport+to+support+reporting+statistics+from+source+connectors](https://github.com/apache/flink/pull/url), we aims to support multi  connectors for reporting statistics. This pr is a part of it to support Hive source. The details are as follows:

- For `HiveTableSource`, implements `SupportStatisticsReport` interface, and override `reportStatistics()` method.  In this method.
- For Hive source, we support multi formats, including Flink related format, like `ParquetVectorizedInputFormat`, `OrcColumnarRowInputFormat` and Hive related format, like `MapRedInputFormat`, to report stats.
- Adding one UT test `HiveTableSourceStatisticsReportTest` extends `StatisticsReportTestBase` to cover different realize formats.
- Abstract utils for common parts of format statistics report.


## Brief change log

- For `HiveTableSource`, implements `SupportStatisticsReport` interface, and override `reportStatistics()` method. 
- For Hive source, we support multi formats to report stats.
- Adding UT test.
- Abstract utils for common parts of format statistics report.
- Let `CsvFormatSatisticsReportTest` and `FileSystemStatisticsReportTest` extends from `StatisticsReportTestBase`.

## Verifying this change

- Adding UT test `HiveTableSourceStatisticsReportTest` extends `StatisticsReportTestBase` to cover different realize formats.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  yes
  - The serializers:  no
  - The runtime per-record code paths (performance sensitive):  no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper:  no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented?  no docs
