### PR TITLE
[FLINK-25097][table-planner] Fix bug in inner join when the filter co…

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/ColumnIntervalUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/ColumnIntervalUtil.scala
@@ -233,34 +233,37 @@ object ColumnIntervalUtil {
   }
 
   private def columnIntervalOfSinglePredicate(condition: RexNode): ValueInterval = {
-    val convertedCondition = condition.asInstanceOf[RexCall]
-    if (convertedCondition == null || convertedCondition.operands.size() != 2) {
-      null
-    } else {
-      val (literalValue, op) = (convertedCondition.operands.head, convertedCondition.operands.last)
-      match {
-        case (_: RexInputRef, literal: RexLiteral) =>
-          (getLiteralValueByBroadType(literal), convertedCondition.getKind)
-        case (rex: RexCall, literal: RexLiteral) if rex.getKind == SqlKind.AS =>
-          (getLiteralValueByBroadType(literal), convertedCondition.getKind)
-        case (literal: RexLiteral, _: RexInputRef) =>
-          (getLiteralValueByBroadType(literal), convertedCondition.getKind.reverse())
-        case (literal: RexLiteral, rex: RexCall) if rex.getKind == SqlKind.AS =>
-          (getLiteralValueByBroadType(literal), convertedCondition.getKind.reverse())
-        case _ => (null, null)
-      }
-      if (op == null || literalValue == null) {
-        null
-      } else {
-        op match {
-          case EQUALS => ValueInterval(literalValue, literalValue)
-          case LESS_THAN => ValueInterval(null, literalValue, includeUpper = false)
-          case LESS_THAN_OR_EQUAL => ValueInterval(null, literalValue)
-          case GREATER_THAN => ValueInterval(literalValue, null, includeLower = false)
-          case GREATER_THAN_OR_EQUAL => ValueInterval(literalValue, null)
-          case _ => null
+    condition match {
+      case call: RexCall =>
+        if (call.operands.size() != 2) {
+          null
+        } else {
+          val (literalValue, op) =
+            (call.operands.head, call.operands.last) match {
+              case (_: RexInputRef, literal: RexLiteral) =>
+                (getLiteralValueByBroadType(literal), call.getKind)
+              case (rex: RexCall, literal: RexLiteral) if rex.getKind == SqlKind.AS =>
+                (getLiteralValueByBroadType(literal), call.getKind)
+              case (literal: RexLiteral, _: RexInputRef) =>
+                (getLiteralValueByBroadType(literal), call.getKind.reverse())
+              case (literal: RexLiteral, rex: RexCall) if rex.getKind == SqlKind.AS =>
+                (getLiteralValueByBroadType(literal), call.getKind.reverse())
+              case _ => (null, null)
+            }
+          if (op == null || literalValue == null) {
+            null
+          } else {
+            op match {
+              case EQUALS => ValueInterval(literalValue, literalValue)
+              case LESS_THAN => ValueInterval(null, literalValue, includeUpper = false)
+              case LESS_THAN_OR_EQUAL => ValueInterval(null, literalValue)
+              case GREATER_THAN => ValueInterval(literalValue, null, includeLower = false)
+              case GREATER_THAN_OR_EQUAL => ValueInterval(literalValue, null)
+              case _ => null
+            }
+          }
         }
-      }
+      case _ => null
     }
   }
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/join/JoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/join/JoinITCase.scala
@@ -19,7 +19,7 @@
 package org.apache.flink.table.planner.runtime.batch.sql.join
 
 import org.apache.flink.api.common.ExecutionConfig
-import org.apache.flink.api.common.typeinfo.BasicTypeInfo.{DOUBLE_TYPE_INFO, INT_TYPE_INFO, LONG_TYPE_INFO}
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo._
 import org.apache.flink.api.common.typeinfo.Types
 import org.apache.flink.api.common.typeutils.TypeComparator
 import org.apache.flink.api.dag.Transformation
@@ -44,7 +44,6 @@ import org.junit.{Assert, Before, Test}
 import java.util
 
 import scala.collection.JavaConversions._
-import scala.collection.Seq
 
 @RunWith(classOf[Parameterized])
 class JoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
@@ -217,6 +216,25 @@ class JoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
         row("Hello world, how are you?", "Hallo Welt wie"),
         row("I am fine.", "Hallo Welt wie")
       ))
+  }
+
+  @Test
+  def testInnerJoinWithBooleanFilterCondition(): Unit = {
+    val data1: Seq[Row] =
+      Seq(row(1, 1L, "Hi", true), row(2, 2L, "Hello", false), row(3, 2L, "Hello world", true))
+    val type3 = new RowTypeInfo(INT_TYPE_INFO, LONG_TYPE_INFO, STRING_TYPE_INFO, BOOLEAN_TYPE_INFO)
+    registerCollection("table5", data1, type3, "a1, b1, c1, d1")
+    registerCollection("table6", data1, type3, "a2, b2, c2, d2")
+
+    checkResult(
+      "SELECT a1, a1, c2 FROM table5 INNER JOIN table6 ON d1 = d2 where d1 is true",
+      Seq(
+        row("1, 1, Hello world"),
+        row("1, 1, Hi"),
+        row("3, 3, Hello world"),
+        row("3, 3, Hi")
+      )
+    )
   }
 
   @Test

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/JoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/JoinITCase.scala
@@ -244,6 +244,28 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
   }
 
   @Test
+  def testInnerJoinWithBooleanFilterCondition(): Unit = {
+    val data1 = new mutable.MutableList[(Int, Long, String, Boolean)]
+    data1.+=((1, 1L, "Hi", true))
+    data1.+=((2, 2L, "Hello", false))
+    data1.+=((3, 2L, "Hello world", true))
+
+    val t1 = failingDataSource(data1).toTable(tEnv, 'a1, 'b1, 'c1, 'd1)
+    val t2 = failingDataSource(data1).toTable(tEnv, 'a2, 'b2, 'c2, 'd2)
+    tEnv.registerTable("Table3", t1)
+    tEnv.registerTable("Table5", t2)
+
+    val sqlQuery = "SELECT a1, a1, c2 FROM Table3 INNER JOIN Table5 ON d1 = d2 where d1 is true"
+
+    val sink = new TestingRetractSink
+    tEnv.sqlQuery(sqlQuery).toRetractStream[Row].addSink(sink).setParallelism(1)
+    env.execute()
+
+    val expected = Seq("1,1,Hello world", "1,1,Hi", "3,3,Hello world", "3,3,Hi")
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
+
+  @Test
   def testInnerJoinWithNonEquiJoinPredicate(): Unit = {
     val sqlQuery = "SELECT c, g FROM Table3, Table5 WHERE b = e AND a < 6 AND h < b"
 


### PR DESCRIPTION
…ndition is boolean type

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

To fix bug in inner join when the filter condition is boolean type. this issue is fixed in master by FLINK-25097, this pr item to fix it on release-1.14.


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
