### PR TITLE
[FLINK-28269][Kubernetes] Install cri-dockerd and crictl so we can continue using driver `none` when running Kubernetes tests

### DIFF
--- a/flink-end-to-end-tests/test-scripts/common_kubernetes.sh
+++ b/flink-end-to-end-tests/test-scripts/common_kubernetes.sh
@@ -50,6 +50,25 @@ function setup_kubernetes_for_linux {
     fi
     # conntrack is required for minikube 1.9 and later
     sudo apt-get install conntrack
+    # crictl is required for cri-dockerd
+    VERSION="v1.24.2"
+    wget https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/crictl-$VERSION-linux-amd64.tar.gz
+    sudo tar zxvf crictl-$VERSION-linux-amd64.tar.gz -C /usr/local/bin
+    rm -f crictl-$VERSION-linux-amd64.tar.gz
+    # cri-dockerd is required to use Kubernetes 1.24+ and the none driver
+    git clone https://github.com/Mirantis/cri-dockerd.git
+    cd cri-dockerd
+    # Checkout version 0.2.3
+    git checkout tags/v0.2.3 -b v0.2.3
+    mkdir bin
+    go get && go build -o bin/cri-dockerd
+    mkdir -p /usr/local/bin
+    sudo install -o root -g root -m 0755 bin/cri-dockerd /usr/local/bin/cri-dockerd
+    sudo cp -a packaging/systemd/* /etc/systemd/system
+    sudo sed -i -e 's,/usr/bin/cri-dockerd,/usr/local/bin/cri-dockerd,' /etc/systemd/system/cri-docker.service
+    sudo systemctl daemon-reload
+    sudo systemctl enable cri-docker.service
+    sudo systemctl enable --now cri-docker.socket
     # required to resolve HOST_JUJU_LOCK_PERMISSION error of "minikube start --vm-driver=none"
     sudo sysctl fs.protected_regular=0
 }


### PR DESCRIPTION
## What is the purpose of the change

* All Kubernetes Bash tests are currently failing because Kubernetes 1.24+ has dropped support for Dockershim. If we want to continue using the combination of the none Driver, Kubernetes 1.24+ and the Docker container runtime, we'll need to install cri-dockerd. This also requires crictl. This is listed in the requirements at https://minikube.sigs.k8s.io/docs/drivers/none/#requirements

## Brief change log

* Install cri-dockerd and crictl during the setup of Kubernetes

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
