### PR TITLE
[FLINK-28284][Connectors/Jdbc] Add JdbcSink with new format

### DIFF
--- a/flink-connectors/flink-connector-jdbc/pom.xml
+++ b/flink-connectors/flink-connector-jdbc/pom.xml
@@ -40,6 +40,11 @@ under the License.
 	</properties>
 
 	<dependencies>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-base</artifactId>
+			<version>${project.version}</version>
+		</dependency>
 		<!-- Table ecosystem -->
 
 		<!-- Projects depending on this project won't depend on flink-table-*. -->

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/sink2/JdbcSink.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/sink2/JdbcSink.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.sink2;
+
+import org.apache.flink.api.connector.sink2.Sink;
+import org.apache.flink.connector.jdbc.JdbcExecutionOptions;
+import org.apache.flink.connector.jdbc.internal.connection.JdbcConnectionProvider;
+import org.apache.flink.connector.jdbc.sink2.statement.JdbcQueryStatement;
+
+import java.io.IOException;
+
+/**
+ * Flink Sink to produce data into a jdbc database.
+ *
+ * @see JdbcSinkBuilder on how to construct a JdbcSink
+ */
+public class JdbcSink<IN> implements Sink<IN> {
+
+    private final JdbcConnectionProvider connectionProvider;
+    private final JdbcExecutionOptions executionOptions;
+    private final JdbcQueryStatement<IN> queryStatement;
+
+    public JdbcSink(
+            JdbcConnectionProvider connectionProvider,
+            JdbcExecutionOptions executionOptions,
+            JdbcQueryStatement<IN> queryStatement) {
+        this.connectionProvider = connectionProvider;
+        this.executionOptions = executionOptions;
+        this.queryStatement = queryStatement;
+    }
+
+    @Override
+    public JdbcWriter<IN> createWriter(InitContext context) throws IOException {
+        return new JdbcWriter<>(
+                this.connectionProvider, this.executionOptions, this.queryStatement);
+    }
+
+    public static <IN> JdbcSinkBuilder<IN> builder() {
+        return new JdbcSinkBuilder<>();
+    }
+}

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/sink2/JdbcSinkBuilder.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/sink2/JdbcSinkBuilder.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.sink2;
+
+import org.apache.flink.connector.jdbc.JdbcConnectionOptions;
+import org.apache.flink.connector.jdbc.JdbcExecutionOptions;
+import org.apache.flink.connector.jdbc.JdbcStatementBuilder;
+import org.apache.flink.connector.jdbc.internal.connection.JdbcConnectionProvider;
+import org.apache.flink.connector.jdbc.internal.connection.SimpleJdbcConnectionProvider;
+import org.apache.flink.connector.jdbc.sink2.statement.JdbcQueryStatement;
+import org.apache.flink.connector.jdbc.sink2.statement.SimpleJdbcQueryStatement;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** Builder to construct {@link JdbcSink}. */
+public class JdbcSinkBuilder<IN> {
+
+    private JdbcConnectionProvider connectionProvider;
+    private JdbcExecutionOptions executionOptions;
+    private JdbcQueryStatement<IN> queryStatement;
+
+    protected JdbcSinkBuilder() {
+        executionOptions = JdbcExecutionOptions.defaults();
+    }
+
+    public JdbcSinkBuilder<IN> withExecutionOptions(JdbcExecutionOptions executionOptions) {
+        this.executionOptions = checkNotNull(executionOptions, "executionOptions cannot be empty");
+        return this;
+    }
+
+    public JdbcSinkBuilder<IN> withConnectionProvider(JdbcConnectionProvider connectionProvider) {
+        this.connectionProvider =
+                checkNotNull(connectionProvider, "connectionProvider cannot be empty");
+        return this;
+    }
+
+    public JdbcSinkBuilder<IN> withConnectionProvider(JdbcConnectionOptions connectionOptions) {
+        return withConnectionProvider(new SimpleJdbcConnectionProvider(connectionOptions));
+    }
+
+    public JdbcSinkBuilder<IN> withQueryStatement(JdbcQueryStatement<IN> queryStatement) {
+        this.queryStatement = queryStatement;
+        return this;
+    }
+
+    public JdbcSinkBuilder<IN> withQueryStatement(
+            String query, JdbcStatementBuilder<IN> statement) {
+        this.queryStatement = new SimpleJdbcQueryStatement<>(query, statement);
+        return this;
+    }
+
+    public JdbcSink<IN> build() {
+        checkNotNull(connectionProvider, "connectionProvider cannot be empty");
+        checkNotNull(executionOptions, "executionOptions cannot be empty");
+        checkNotNull(queryStatement, "queryStatement cannot be empty");
+
+        return new JdbcSink<>(connectionProvider, executionOptions, queryStatement);
+    }
+}

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/sink2/JdbcWriter.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/sink2/JdbcWriter.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.sink2;
+
+import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.connector.jdbc.JdbcExecutionOptions;
+import org.apache.flink.connector.jdbc.internal.connection.JdbcConnectionProvider;
+import org.apache.flink.connector.jdbc.sink2.statement.JdbcQueryStatement;
+import org.apache.flink.util.concurrent.ExecutorThreadFactory;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+class JdbcWriter<IN> implements SinkWriter<IN> {
+
+    private final Deque<IN> bufferedRequests = new ArrayDeque<>();
+    private final JdbcConnectionProvider connectionProvider;
+    private final JdbcExecutionOptions executionOptions;
+    private final JdbcQueryStatement<IN> queryStatement;
+    private transient PreparedStatement preparedStatement;
+
+    private transient ScheduledExecutorService scheduler;
+    private transient ScheduledFuture<?> schedulerFuture;
+    private transient volatile Exception schedulerException;
+
+    JdbcWriter(
+            JdbcConnectionProvider connectionProvider,
+            JdbcExecutionOptions executionOptions,
+            JdbcQueryStatement<IN> queryStatement)
+            throws IOException {
+        this.connectionProvider = connectionProvider;
+        this.executionOptions = executionOptions;
+        this.queryStatement = queryStatement;
+
+        open();
+    }
+
+    private void open() throws IOException {
+        try {
+            Connection connection = connectionProvider.getOrEstablishConnection();
+            if (connection == null) {
+                throw new IOException("cant establish connection");
+            }
+            preparedStatement = connection.prepareStatement(queryStatement.query());
+        } catch (Exception e) {
+            throw new IOException(e.getLocalizedMessage(), e);
+        }
+        this.createScheduler();
+    }
+
+    @Override
+    public void write(IN element, Context context) throws IOException, InterruptedException {
+        checkSchedulerException();
+
+        bufferedRequests.add(element);
+
+        if (executionOptions.getBatchSize() > 0
+                && executionOptions.getBatchSize() >= bufferedRequests.size()) {
+            flush();
+        }
+    }
+
+    @Override
+    public void flush(boolean endOfInput) throws IOException, InterruptedException {
+        flush();
+    }
+
+    private void flush() throws IOException, InterruptedException {
+        checkSchedulerException();
+
+        if (bufferedRequests.isEmpty()) {
+            return;
+        }
+        for (int i = 0; i <= executionOptions.getMaxRetries(); i++) {
+            try {
+                List<IN> entries = new ArrayList<>(bufferedRequests);
+                for (IN elem : entries) {
+                    queryStatement.map(preparedStatement, elem);
+                    preparedStatement.addBatch();
+                }
+                preparedStatement.executeBatch();
+                bufferedRequests.clear();
+            } catch (Exception e) {
+                if (i >= executionOptions.getMaxRetries()) {
+                    throw new IOException(e);
+                }
+                try {
+                    if (!connectionProvider.isConnectionValid()) {
+                        this.open();
+                    }
+                } catch (Exception exception) {
+                    throw new IOException("Reestablish JDBC connection failed", exception);
+                }
+                try {
+                    Thread.sleep(1000L * i);
+                } catch (InterruptedException ex) {
+                    Thread.currentThread().interrupt();
+                    throw new IOException(
+                            "unable to flush; interrupted while doing another attempt", e);
+                }
+            }
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (this.schedulerFuture != null) {
+            this.schedulerFuture.cancel(false);
+            this.scheduler.shutdown();
+        }
+
+        if (this.bufferedRequests.size() > 0) {
+            flush();
+        }
+
+        if (this.preparedStatement != null) {
+            preparedStatement.close();
+            preparedStatement = null;
+        }
+
+        connectionProvider.closeConnection();
+
+        checkSchedulerException();
+    }
+
+    private void createScheduler() {
+        if (executionOptions.getBatchIntervalMs() != 0 && executionOptions.getBatchSize() != 1) {
+            this.scheduler =
+                    Executors.newScheduledThreadPool(
+                            1, new ExecutorThreadFactory("jdbc-upsert-sink"));
+            this.schedulerFuture =
+                    this.scheduler.scheduleWithFixedDelay(
+                            () -> {
+                                synchronized (this) {
+                                    try {
+                                        flush();
+                                    } catch (Exception e) {
+                                        this.schedulerException = e;
+                                    }
+                                }
+                            },
+                            executionOptions.getBatchIntervalMs(),
+                            executionOptions.getBatchIntervalMs(),
+                            TimeUnit.MILLISECONDS);
+        }
+    }
+
+    private void checkSchedulerException() {
+        if (schedulerException != null) {
+            throw new RuntimeException("Writing records to JDBC failed.", schedulerException);
+        }
+    }
+}

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/sink2/statement/JdbcQueryStatement.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/sink2/statement/JdbcQueryStatement.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.sink2.statement;
+
+import java.io.Serializable;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+/**
+ * Sets {@link PreparedStatement} parameters to use in JDBC Sink based on a specific type of record.
+ */
+public interface JdbcQueryStatement<T> extends Serializable {
+    String query();
+
+    void map(PreparedStatement ps, T data) throws SQLException;
+}

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/sink2/statement/SimpleJdbcQueryStatement.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/sink2/statement/SimpleJdbcQueryStatement.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.sink2.statement;
+
+import org.apache.flink.connector.jdbc.JdbcStatementBuilder;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+/** A simple implementation for {@link JdbcQueryStatement}. */
+public class SimpleJdbcQueryStatement<IN> implements JdbcQueryStatement<IN> {
+    private final String query;
+    private final JdbcStatementBuilder<IN> statement;
+
+    public SimpleJdbcQueryStatement(String query, JdbcStatementBuilder<IN> statement) {
+        this.query = query;
+        this.statement = statement;
+    }
+
+    @Override
+    public String query() {
+        return query;
+    }
+
+    @Override
+    public void map(PreparedStatement ps, IN data) throws SQLException {
+        statement.accept(ps, data);
+    }
+}

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/sink2/JdbcSinkTest.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/sink2/JdbcSinkTest.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.sink2;
+
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.jdbc.DbMetadata;
+import org.apache.flink.connector.jdbc.JdbcConnectionOptions;
+import org.apache.flink.connector.jdbc.JdbcTestBase;
+import org.apache.flink.connector.jdbc.JdbcTestFixture;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.util.function.FunctionWithException;
+
+import org.junit.Test;
+
+import java.io.Serializable;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.apache.flink.configuration.PipelineOptions.OBJECT_REUSE;
+import static org.apache.flink.connector.jdbc.JdbcTestFixture.DERBY_EBOOKSHOP_DB;
+import static org.apache.flink.connector.jdbc.JdbcTestFixture.INPUT_TABLE;
+import static org.apache.flink.connector.jdbc.JdbcTestFixture.INSERT_TEMPLATE;
+import static org.apache.flink.connector.jdbc.JdbcTestFixture.TEST_DATA;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Smoke tests for the {@link org.apache.flink.connector.jdbc.sink2.JdbcSink} and the underlying
+ * classes.
+ */
+public class JdbcSinkTest extends JdbcTestBase {
+
+    @Override
+    protected DbMetadata getDbMetadata() {
+        return DERBY_EBOOKSHOP_DB;
+    }
+
+    private static <T> T getNullable(
+            ResultSet rs, FunctionWithException<ResultSet, T, SQLException> get)
+            throws SQLException {
+        T value = get.apply(rs);
+        return rs.wasNull() ? null : value;
+    }
+
+    private List<JdbcTestFixture.TestEntry> selectBooks() throws SQLException {
+        List<JdbcTestFixture.TestEntry> result = new ArrayList<>();
+        try (Connection connection = DriverManager.getConnection(getDbMetadata().getUrl())) {
+            connection.setTransactionIsolation(Connection.TRANSACTION_READ_COMMITTED);
+            connection.setReadOnly(true);
+            try (Statement st = connection.createStatement()) {
+                try (ResultSet rs =
+                        st.executeQuery(
+                                "select id, title, author, price, qty from " + INPUT_TABLE)) {
+                    while (rs.next()) {
+                        result.add(
+                                new JdbcTestFixture.TestEntry(
+                                        getNullable(rs, r -> r.getInt(1)),
+                                        getNullable(rs, r -> r.getString(2)),
+                                        getNullable(rs, r -> r.getString(3)),
+                                        getNullable(rs, r -> r.getDouble(4)),
+                                        getNullable(rs, r -> r.getInt(5))));
+                    }
+                }
+            }
+        }
+        return result;
+    }
+
+    private List<String> selectWords() throws SQLException {
+        ArrayList<String> strings = new ArrayList<>();
+        try (Connection connection = DriverManager.getConnection(getDbMetadata().getUrl())) {
+            try (Statement st = connection.createStatement()) {
+                try (ResultSet rs = st.executeQuery("select word from words")) {
+                    while (rs.next()) {
+                        strings.add(rs.getString(1));
+                    }
+                }
+            }
+        }
+        return strings;
+    }
+
+    private static class StringHolder implements Serializable {
+        private static final long serialVersionUID = 1L;
+        private String content;
+
+        public String getContent() {
+            return checkNotNull(content);
+        }
+
+        public void setContent(String payload) {
+            this.content = checkNotNull(payload);
+        }
+    }
+
+    @Test
+    public void testInsertWithSinkTo() throws Exception {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setRestartStrategy(new RestartStrategies.NoRestartStrategyConfiguration());
+        env.setParallelism(1);
+
+        env.fromElements(TEST_DATA)
+                .sinkTo(
+                        JdbcSink.<JdbcTestFixture.TestEntry>builder()
+                                .withConnectionProvider(
+                                        new JdbcConnectionOptions.JdbcConnectionOptionsBuilder()
+                                                .withUrl(getDbMetadata().getUrl())
+                                                .withDriverName(getDbMetadata().getDriverClass())
+                                                .build())
+                                .withQueryStatement(
+                                        String.format(INSERT_TEMPLATE, INPUT_TABLE),
+                                        (ps, t) -> {
+                                            ps.setInt(1, t.id);
+                                            ps.setString(2, t.title);
+                                            ps.setString(3, t.author);
+                                            if (t.price == null) {
+                                                ps.setNull(4, Types.DOUBLE);
+                                            } else {
+                                                ps.setDouble(4, t.price);
+                                            }
+                                            ps.setInt(5, t.qty);
+                                        })
+                                .build());
+        env.execute();
+
+        assertThat(selectBooks()).isEqualTo(Arrays.asList(TEST_DATA));
+    }
+
+    @Test
+    public void testObjectReuseWithSinkTo() throws Exception {
+        Configuration configuration = new Configuration();
+        configuration.set(OBJECT_REUSE, true);
+        StreamExecutionEnvironment env =
+                StreamExecutionEnvironment.getExecutionEnvironment(configuration);
+        env.setRestartStrategy(new RestartStrategies.NoRestartStrategyConfiguration());
+        env.setParallelism(1);
+
+        AtomicInteger counter = new AtomicInteger(0);
+        String[] words = {"a", "and", "b", "were", "sitting in the buffer"};
+        StringHolder reused = new StringHolder();
+
+        env.fromElements(words)
+                .map(
+                        word -> {
+                            reused.setContent(word);
+                            return reused;
+                        })
+                .sinkTo(
+                        JdbcSink.<StringHolder>builder()
+                                .withConnectionProvider(
+                                        new JdbcConnectionOptions.JdbcConnectionOptionsBuilder()
+                                                .withUrl(getDbMetadata().getUrl())
+                                                .withDriverName(getDbMetadata().getDriverClass())
+                                                .build())
+                                .withQueryStatement(
+                                        JdbcTestFixture.INSERT_INTO_WORDS_TEMPLATE,
+                                        (ps, e) -> {
+                                            ps.setInt(1, counter.getAndIncrement());
+                                            ps.setString(2, e.content);
+                                        })
+                                .build());
+        env.execute();
+
+        assertThat(selectWords()).isEqualTo(Arrays.asList(words));
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Add a JdbcSink with new format (sink2)

## Brief change log

  - *JdbcSink* the new sink
  - *JdbcSinkWriter* the writer used by the new sink
  - *JdbcQueryStatement* the query and preparestatement that will be used
  - *JdbcWriterStatement* the writer statement that will write to jdbc, this allow to implement database specific connection provider
  - *SimpleJdbcWriterStatement* a simple implementation of JdbcWriterStatement


## Verifying this change

This change added tests and can be verified as follows:

- JdbcITCase.testInsertWithSinkTo
- JdbcITCase.testObjectReuseWithSinkTo

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): (no 
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes )
  - If yes, how is the feature documented? ( JavaDocs / not documented)
