### PR TITLE
[FLINK-27905][runtime] Introduce HsSpillingStrategy and HsSelectiveSpillingStrategy implementation

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFullSpillingStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFullSpillingStrategy.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid;
+
+import org.apache.flink.runtime.io.network.partition.hybrid.HsSpillingInfoProvider.ConsumeStatus;
+import org.apache.flink.runtime.io.network.partition.hybrid.HsSpillingInfoProvider.SpillStatus;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.Optional;
+import java.util.TreeMap;
+
+import static org.apache.flink.runtime.io.network.partition.hybrid.HsSpillingStrategyUtils.getBuffersByConsumptionPriorityInOrder;
+
+/** A special implementation of {@link HsSpillingStrategy} that spilled all buffers to disk. */
+public class HsFullSpillingStrategy implements HsSpillingStrategy {
+    private final int numBuffersTriggerSpilling;
+
+    private final float releaseBufferRatio;
+
+    private final float releaseThreshold;
+
+    public HsFullSpillingStrategy(HybridShuffleConfiguration hybridShuffleConfiguration) {
+        this.numBuffersTriggerSpilling =
+                hybridShuffleConfiguration.getFullStrategyNumBuffersTriggerSpilling();
+        this.releaseThreshold = hybridShuffleConfiguration.getFullStrategyReleaseThreshold();
+        this.releaseBufferRatio = hybridShuffleConfiguration.getFullStrategyReleaseBufferRatio();
+    }
+
+    // For the case of buffer finished, whenever the number of unSpillBuffers reaches
+    // numBuffersTriggerSpilling, make a decision based on global information. Otherwise, no need to
+    // take action.
+    @Override
+    public Optional<Decision> onBufferFinished(int numTotalUnSpillBuffers) {
+        return numTotalUnSpillBuffers < numBuffersTriggerSpilling
+                ? Optional.of(Decision.NO_ACTION)
+                : Optional.empty();
+    }
+
+    // For the case of buffer consumed, there is no need to take action for HsFullSpillingStrategy.
+    @Override
+    public Optional<Decision> onBufferConsumed(BufferWithIdentity consumedBuffer) {
+        return Optional.of(Decision.NO_ACTION);
+    }
+
+    // When the amount of memory used exceeds the threshold, decide action based on global
+    // information. Otherwise, no need to take action.
+    @Override
+    public Optional<Decision> onMemoryUsageChanged(
+            int numTotalRequestedBuffers, int currentPoolSize) {
+        return numTotalRequestedBuffers < currentPoolSize * releaseThreshold
+                ? Optional.of(Decision.NO_ACTION)
+                : Optional.empty();
+    }
+
+    @Override
+    public Decision decideActionWithGlobalInfo(HsSpillingInfoProvider spillingInfoProvider) {
+        Decision.Builder builder = Decision.builder();
+        checkSpill(spillingInfoProvider, builder);
+        checkRelease(spillingInfoProvider, builder);
+        return builder.build();
+    }
+
+    private void checkSpill(HsSpillingInfoProvider spillingInfoProvider, Decision.Builder builder) {
+        if (spillingInfoProvider.getNumTotalUnSpillBuffers() < numBuffersTriggerSpilling) {
+            // In case situation changed since onBufferFinished() returns Optional#empty()
+            return;
+        }
+        // Spill all not spill buffers.
+        List<BufferWithIdentity> unSpillBuffers = new ArrayList<>();
+        for (int i = 0; i < spillingInfoProvider.getNumSubpartitions(); i++) {
+            unSpillBuffers.addAll(
+                    spillingInfoProvider.getBuffersInOrder(
+                            i, SpillStatus.NOT_SPILL, ConsumeStatus.ALL));
+        }
+        builder.addBufferToSpill(unSpillBuffers);
+    }
+
+    private void checkRelease(
+            HsSpillingInfoProvider spillingInfoProvider, Decision.Builder builder) {
+        if (spillingInfoProvider.getNumTotalRequestedBuffers()
+                < spillingInfoProvider.getPoolSize() * releaseThreshold) {
+            // In case situation changed since onMemoryUsageChanged() returns Optional#empty()
+            return;
+        }
+
+        int releaseNum = (int) (spillingInfoProvider.getPoolSize() * releaseBufferRatio);
+
+        // first, release all consumed buffers
+        TreeMap<Integer, Deque<BufferWithIdentity>> consumedBuffersToRelease = new TreeMap<>();
+        int numConsumedBuffers = 0;
+        for (int subpartitionId = 0;
+                subpartitionId < spillingInfoProvider.getNumSubpartitions();
+                subpartitionId++) {
+
+            Deque<BufferWithIdentity> consumedSpillSubpartitionBuffers =
+                    spillingInfoProvider.getBuffersInOrder(
+                            subpartitionId, SpillStatus.SPILL, ConsumeStatus.CONSUMED);
+            numConsumedBuffers += consumedSpillSubpartitionBuffers.size();
+            consumedBuffersToRelease.put(subpartitionId, consumedSpillSubpartitionBuffers);
+        }
+
+        // make up the releaseNum with unconsumed buffers, if needed, w.r.t. the consuming priority
+        TreeMap<Integer, List<BufferWithIdentity>> unconsumedBufferToRelease = new TreeMap<>();
+        if (releaseNum > numConsumedBuffers) {
+            TreeMap<Integer, Deque<BufferWithIdentity>> unconsumedBuffers = new TreeMap<>();
+            for (int subpartitionId = 0;
+                    subpartitionId < spillingInfoProvider.getNumSubpartitions();
+                    subpartitionId++) {
+                unconsumedBuffers.put(
+                        subpartitionId,
+                        spillingInfoProvider.getBuffersInOrder(
+                                subpartitionId, SpillStatus.SPILL, ConsumeStatus.NOT_CONSUMED));
+            }
+            unconsumedBufferToRelease.putAll(
+                    getBuffersByConsumptionPriorityInOrder(
+                            spillingInfoProvider.getNextBufferIndexToConsume(),
+                            unconsumedBuffers,
+                            releaseNum - numConsumedBuffers));
+        }
+
+        // collect results in order
+        List<BufferWithIdentity> toRelease = new ArrayList<>();
+        for (int i = 0; i < spillingInfoProvider.getNumSubpartitions(); i++) {
+            toRelease.addAll(consumedBuffersToRelease.getOrDefault(i, new ArrayDeque<>()));
+            toRelease.addAll(unconsumedBufferToRelease.getOrDefault(i, new ArrayList<>()));
+        }
+        builder.addBufferToRelease(toRelease);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSelectiveSpillingStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSelectiveSpillingStrategy.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid;
+
+import org.apache.flink.runtime.io.network.partition.hybrid.HsSpillingInfoProvider.ConsumeStatus;
+import org.apache.flink.runtime.io.network.partition.hybrid.HsSpillingInfoProvider.SpillStatus;
+
+import java.util.Deque;
+import java.util.List;
+import java.util.Optional;
+import java.util.TreeMap;
+
+import static org.apache.flink.runtime.io.network.partition.hybrid.HsSpillingStrategyUtils.getBuffersByConsumptionPriorityInOrder;
+
+/**
+ * A special implementation of {@link HsSpillingStrategy} that reduce disk writes as much as
+ * possible.
+ */
+public class HsSelectiveSpillingStrategy implements HsSpillingStrategy {
+    private final float spillBufferRatio;
+
+    private final float spillThreshold;
+
+    public HsSelectiveSpillingStrategy(HybridShuffleConfiguration hybridShuffleConfiguration) {
+        spillThreshold = hybridShuffleConfiguration.getSelectiveStrategySpillThreshold();
+        spillBufferRatio = hybridShuffleConfiguration.getSelectiveStrategySpillBufferRatio();
+    }
+
+    // For the case of buffer finished, there is no need to take action for
+    // HsSelectiveSpillingStrategy.
+    @Override
+    public Optional<Decision> onBufferFinished(int numTotalUnSpillBuffers) {
+        return Optional.of(Decision.NO_ACTION);
+    }
+
+    // For the case of buffer consumed, this buffer need release. The control of the buffer is taken
+    // over by the downstream task.
+    @Override
+    public Optional<Decision> onBufferConsumed(BufferWithIdentity consumedBuffer) {
+        return Optional.of(Decision.builder().addBufferToRelease(consumedBuffer).build());
+    }
+
+    // When the amount of memory used exceeds the threshold, decide action based on global
+    // information. Otherwise, no need to take action.
+    @Override
+    public Optional<Decision> onMemoryUsageChanged(
+            int numTotalRequestedBuffers, int currentPoolSize) {
+        return numTotalRequestedBuffers < currentPoolSize * spillThreshold
+                ? Optional.of(Decision.NO_ACTION)
+                : Optional.empty();
+    }
+
+    // Score the buffer of each subpartition and decide the spill and release action. The lower the
+    // score, the more likely the buffer will be consumed in the next time, and should be kept in
+    // memory as much as possible. Select all buffers that need to be spilled according to the score
+    // from high to low.
+    @Override
+    public Decision decideActionWithGlobalInfo(HsSpillingInfoProvider spillingInfoProvider) {
+        if (spillingInfoProvider.getNumTotalRequestedBuffers()
+                < spillingInfoProvider.getPoolSize() * spillThreshold) {
+            // In case situation changed since onMemoryUsageChanged() returns Optional#empty()
+            return Decision.NO_ACTION;
+        }
+
+        int spillNum = (int) (spillingInfoProvider.getPoolSize() * spillBufferRatio);
+
+        TreeMap<Integer, Deque<BufferWithIdentity>> subpartitionToBuffers = new TreeMap<>();
+        for (int channel = 0; channel < spillingInfoProvider.getNumSubpartitions(); channel++) {
+            subpartitionToBuffers.put(
+                    channel,
+                    spillingInfoProvider.getBuffersInOrder(
+                            channel, SpillStatus.NOT_SPILL, ConsumeStatus.NOT_CONSUMED));
+        }
+
+        TreeMap<Integer, List<BufferWithIdentity>> subpartitionToHighPriorityBuffers =
+                getBuffersByConsumptionPriorityInOrder(
+                        spillingInfoProvider.getNextBufferIndexToConsume(),
+                        subpartitionToBuffers,
+                        spillNum);
+
+        Decision.Builder builder = Decision.builder();
+        subpartitionToHighPriorityBuffers
+                .values()
+                .forEach(
+                        buffers -> {
+                            builder.addBufferToSpill(buffers);
+                            builder.addBufferToRelease(buffers);
+                        });
+        return builder.build();
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSpillingInfoProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSpillingInfoProvider.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid;
+
+import java.util.Deque;
+import java.util.List;
+
+/** This component is responsible for providing some information needed for the spill decision. */
+public interface HsSpillingInfoProvider {
+    /**
+     * Get the number of downstream consumers.
+     *
+     * @return Number of subpartitions.
+     */
+    int getNumSubpartitions();
+
+    /**
+     * Get all downstream next buffer index to consume.
+     *
+     * @return A list containing all downstream next buffer index to consume, if the downstream
+     *     subpartition view has not been registered, the corresponding return value is -1.
+     */
+    List<Integer> getNextBufferIndexToConsume();
+
+    /**
+     * Get all buffers with the expected status from the subpartition.
+     *
+     * @param subpartitionId target buffers belong to.
+     * @param spillStatus expected buffer spill status.
+     * @param consumeStatus expected buffer consume status.
+     * @return all buffers satisfy specific status of this subpartition, This queue must be sorted
+     *     according to bufferIndex from small to large, in other words, head is the buffer with the
+     *     minimum bufferIndex in the current subpartition.
+     */
+    Deque<BufferWithIdentity> getBuffersInOrder(
+            int subpartitionId, SpillStatus spillStatus, ConsumeStatus consumeStatus);
+
+    /** Get total number of not decided to spill buffers. */
+    int getNumTotalUnSpillBuffers();
+
+    /** Get total number of buffers requested from buffer pool. */
+    int getNumTotalRequestedBuffers();
+
+    /** Get the current size of buffer pool. */
+    int getPoolSize();
+
+    /** This enum represents buffer status of spill in hybrid shuffle mode. */
+    enum SpillStatus {
+        /** The buffer is spilling or spilled already. */
+        SPILL,
+        /** The buffer not start spilling. */
+        NOT_SPILL,
+        /** The buffer is either spill or not spill. */
+        ALL
+    }
+
+    /** This enum represents buffer status of consume in hybrid shuffle mode. */
+    enum ConsumeStatus {
+        /** The buffer has already consumed by downstream. */
+        CONSUMED,
+        /** The buffer is not consumed by downstream. */
+        NOT_CONSUMED,
+        /** The buffer is either consumed or not consumed. */
+        ALL
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSpillingStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSpillingStrategy.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Spilling strategy for hybrid shuffle mode.
+ *
+ * <p>Note: {@link #decideActionWithGlobalInfo} is usually expensive, in the sense of both the
+ * computation complexity of the strategy algorithm and the synchronization overhead for providing
+ * the global information. Thus, it should only be called when global information is needed.
+ */
+public interface HsSpillingStrategy {
+    /**
+     * Make a decision when memory usage is changed.
+     *
+     * @param numTotalRequestedBuffers total number of buffers requested.
+     * @param currentPoolSize current value of buffer pool size.
+     * @return A {@link Decision} based on the provided information, or {@link Optional#empty()} if
+     *     the decision cannot be made, which indicates global information is needed.
+     */
+    Optional<Decision> onMemoryUsageChanged(int numTotalRequestedBuffers, int currentPoolSize);
+
+    /**
+     * Make a decision when a buffer becomes finished.
+     *
+     * @param numTotalUnSpillBuffers total number of buffers not spill.
+     * @return A {@link Decision} based on the provided information, or {@link Optional#empty()} if
+     *     the decision cannot be made, which indicates global information is needed.
+     */
+    Optional<Decision> onBufferFinished(int numTotalUnSpillBuffers);
+
+    /**
+     * Make a decision when a buffer is consumed.
+     *
+     * @param consumedBuffer the buffer that is consumed.
+     * @return A {@link Decision} based on the provided information, or {@link Optional#empty()} if
+     *     the decision cannot be made, which indicates global information is needed.
+     */
+    Optional<Decision> onBufferConsumed(BufferWithIdentity consumedBuffer);
+
+    /**
+     * Make a decision based on global information. Because this method will directly touch the
+     * {@link HsSpillingInfoProvider}, the caller should take care of the thread safety.
+     *
+     * @param spillingInfoProvider that provides information about the current status.
+     * @return A {@link Decision} based on the global information.
+     */
+    Decision decideActionWithGlobalInfo(HsSpillingInfoProvider spillingInfoProvider);
+
+    /**
+     * This class represents the spill and release decision made by {@link HsSpillingStrategy}, in
+     * other words, which data is to be spilled and which data is to be released.
+     */
+    class Decision {
+        /** A collection of buffer that needs to be spilled to disk. */
+        private final List<BufferWithIdentity> bufferToSpill;
+
+        /** A collection of buffer that needs to be released. */
+        private final List<BufferWithIdentity> bufferToRelease;
+
+        public static final Decision NO_ACTION =
+                new Decision(Collections.emptyList(), Collections.emptyList());
+
+        private Decision(
+                List<BufferWithIdentity> bufferToSpill, List<BufferWithIdentity> bufferToRelease) {
+            this.bufferToSpill = bufferToSpill;
+            this.bufferToRelease = bufferToRelease;
+        }
+
+        public List<BufferWithIdentity> getBufferToSpill() {
+            return bufferToSpill;
+        }
+
+        public List<BufferWithIdentity> getBufferToRelease() {
+            return bufferToRelease;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        /** Builder for {@link Decision}. */
+        static class Builder {
+            /** A collection of buffer that needs to be spilled to disk. */
+            private final List<BufferWithIdentity> bufferToSpill = new ArrayList<>();
+
+            /** A collection of buffer that needs to be released. */
+            private final List<BufferWithIdentity> bufferToRelease = new ArrayList<>();
+
+            private Builder() {}
+
+            public Builder addBufferToSpill(BufferWithIdentity buffer) {
+                bufferToSpill.add(buffer);
+                return this;
+            }
+
+            public Builder addBufferToSpill(List<BufferWithIdentity> buffers) {
+                bufferToSpill.addAll(buffers);
+                return this;
+            }
+
+            public Builder addBufferToRelease(BufferWithIdentity buffer) {
+                bufferToRelease.add(buffer);
+                return this;
+            }
+
+            public Builder addBufferToRelease(List<BufferWithIdentity> buffers) {
+                bufferToRelease.addAll(buffers);
+                return this;
+            }
+
+            public Decision build() {
+                return new Decision(bufferToSpill, bufferToRelease);
+            }
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSpillingStrategyUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSpillingStrategyUtils.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid;
+
+import org.apache.flink.shaded.guava30.com.google.common.collect.Iterators;
+import org.apache.flink.shaded.guava30.com.google.common.collect.PeekingIterator;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.List;
+import java.util.PriorityQueue;
+import java.util.TreeMap;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** Utilities for {@link HsSpillingStrategy}. */
+public class HsSpillingStrategyUtils {
+    /**
+     * Calculate and get expected number of buffers with the highest consumption priority. For each
+     * buffer, The greater the difference between next buffer index to consume of subpartition it
+     * belongs to and buffer index, the higher the priority.
+     *
+     * @param nextBufferIndexToConsume downstream next buffer index to consume.
+     * @param subpartitionToAllBuffers the buffers want to compute priority, are grouped by
+     *     subpartitionId.
+     * @param expectedSize number of result buffers.
+     * @return mapping for subpartitionId to buffers, the value of map entry must be order by
+     *     bufferIndex ascending.
+     */
+    public static TreeMap<Integer, List<BufferWithIdentity>> getBuffersByConsumptionPriorityInOrder(
+            List<Integer> nextBufferIndexToConsume,
+            TreeMap<Integer, Deque<BufferWithIdentity>> subpartitionToAllBuffers,
+            int expectedSize) {
+        if (expectedSize <= 0) {
+            return new TreeMap<>();
+        }
+
+        PriorityQueue<BufferConsumptionPriorityIterator> heap = new PriorityQueue<>();
+        subpartitionToAllBuffers.forEach(
+                (subpartitionId, buffers) -> {
+                    if (!buffers.isEmpty()) {
+                        heap.add(
+                                new BufferConsumptionPriorityIterator(
+                                        buffers, nextBufferIndexToConsume.get(subpartitionId)));
+                    }
+                });
+
+        TreeMap<Integer, List<BufferWithIdentity>> subpartitionToHighPriorityBuffers =
+                new TreeMap<>();
+        for (int i = 0; i < expectedSize; i++) {
+            if (heap.isEmpty()) {
+                break;
+            }
+            BufferConsumptionPriorityIterator bufferConsumptionPriorityIterator = heap.poll();
+            BufferWithIdentity bufferWithIdentity = bufferConsumptionPriorityIterator.next();
+            subpartitionToHighPriorityBuffers
+                    .computeIfAbsent(bufferWithIdentity.getChannelIndex(), ArrayList::new)
+                    .add(bufferWithIdentity);
+            // if this iterator has next, re-added it.
+            if (bufferConsumptionPriorityIterator.hasNext()) {
+                heap.add(bufferConsumptionPriorityIterator);
+            }
+        }
+        // treeMap will ensure that the key are sorted by subpartitionId
+        // ascending. Within the same subpartition, the larger the bufferIndex,
+        // the higher the consumption priority, reserve the value so that buffers are ordered
+        // by (subpartitionId, bufferIndex) ascending.
+        subpartitionToHighPriorityBuffers.values().forEach(Collections::reverse);
+        return subpartitionToHighPriorityBuffers;
+    }
+
+    /**
+     * Special {@link Iterator} for hybrid shuffle mode that wrapped a deque of {@link
+     * BufferWithIdentity}. Tow iterator can compare by compute consumption priority of peek
+     * element.
+     */
+    private static class BufferConsumptionPriorityIterator
+            implements Comparable<BufferConsumptionPriorityIterator>, Iterator<BufferWithIdentity> {
+
+        private final int consumptionProgress;
+
+        private final PeekingIterator<BufferWithIdentity> bufferIterator;
+
+        public BufferConsumptionPriorityIterator(
+                Deque<BufferWithIdentity> bufferQueue, int consumptionProgress) {
+            this.consumptionProgress = consumptionProgress;
+            this.bufferIterator = Iterators.peekingIterator(bufferQueue.descendingIterator());
+        }
+
+        // move the iterator to next item.
+        public BufferWithIdentity next() {
+            return bufferIterator.next();
+        }
+
+        public boolean hasNext() {
+            return bufferIterator.hasNext();
+        }
+
+        @Override
+        public int compareTo(BufferConsumptionPriorityIterator that) {
+            // implement compareTo function to construct max-heap.
+            // It has been guaranteed that buffer iterator must have element.
+            return Integer.compare(
+                    checkNotNull(that.bufferIterator.peek()).getBufferIndex()
+                            - that.consumptionProgress,
+                    checkNotNull(bufferIterator.peek()).getBufferIndex() - consumptionProgress);
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HybridShuffleConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HybridShuffleConfiguration.java
@@ -22,8 +22,19 @@ import java.time.Duration;
 
 /** Configuration for hybrid shuffle mode. */
 public class HybridShuffleConfiguration {
-    private static final int MAX_BUFFERS_READ_AHEAD = 5;
+    private static final int DEFAULT_MAX_BUFFERS_READ_AHEAD = 5;
+
     private static final Duration DEFAULT_BUFFER_REQUEST_TIMEOUT = Duration.ofMillis(5);
+
+    private static final float DEFAULT_SELECTIVE_STRATEGY_SPILL_THRESHOLD = 0.7f;
+
+    private static final float DEFAULT_SELECTIVE_STRATEGY_SPILL_BUFFER_RATIO = 0.4f;
+
+    private static final int DEFAULT_FULL_STRATEGY_NUM_BUFFERS_TRIGGER_SPILLED = 10;
+
+    private static final float DEFAULT_FULL_STRATEGY_RELEASE_THRESHOLD = 0.7f;
+
+    private static final float DEFAULT_FULL_STRATEGY_RELEASE_BUFFER_RATIO = 0.4f;
 
     private final int maxBuffersReadAhead;
 
@@ -31,28 +42,43 @@ public class HybridShuffleConfiguration {
 
     private final int maxRequestedBuffers;
 
-    public HybridShuffleConfiguration(
-            int maxBuffersReadAhead, Duration bufferRequestTimeout, int maxRequestedBuffers) {
+    // ----------------------------------------
+    //        Selective Spilling Strategy
+    // ----------------------------------------
+    private final float selectiveStrategySpillThreshold;
+
+    private final float selectiveStrategySpillBufferRatio;
+
+    // ----------------------------------------
+    //        Full Spilling Strategy
+    // ----------------------------------------
+    private final int fullStrategyNumBuffersTriggerSpilling;
+
+    private final float fullStrategyReleaseThreshold;
+
+    private final float fullStrategyReleaseBufferRatio;
+
+    private HybridShuffleConfiguration(
+            int maxBuffersReadAhead,
+            Duration bufferRequestTimeout,
+            int maxRequestedBuffers,
+            float selectiveStrategySpillThreshold,
+            float selectiveStrategySpillBufferRatio,
+            int fullStrategyNumBuffersTriggerSpilling,
+            float fullStrategyReleaseThreshold,
+            float fullStrategyReleaseBufferRatio) {
         this.maxBuffersReadAhead = maxBuffersReadAhead;
         this.bufferRequestTimeout = bufferRequestTimeout;
         this.maxRequestedBuffers = maxRequestedBuffers;
+        this.selectiveStrategySpillThreshold = selectiveStrategySpillThreshold;
+        this.selectiveStrategySpillBufferRatio = selectiveStrategySpillBufferRatio;
+        this.fullStrategyNumBuffersTriggerSpilling = fullStrategyNumBuffersTriggerSpilling;
+        this.fullStrategyReleaseThreshold = fullStrategyReleaseThreshold;
+        this.fullStrategyReleaseBufferRatio = fullStrategyReleaseBufferRatio;
     }
 
-    /**
-     * Temporarily adopt a fixed value, and then adjust the default value according to the
-     * experiment, and introduce configuration options.
-     */
-    public static HybridShuffleConfiguration createConfiguration(
-            int numSubpartitions, int numBuffersPerRequest, Duration bufferRequestTimeout) {
-        final int maxRequestedBuffers = Math.max(2 * numBuffersPerRequest, numSubpartitions);
-        return new HybridShuffleConfiguration(
-                MAX_BUFFERS_READ_AHEAD, bufferRequestTimeout, maxRequestedBuffers);
-    }
-
-    public static HybridShuffleConfiguration createConfiguration(
-            int numSubpartitions, int numBuffersPerRequest) {
-        return createConfiguration(
-                numSubpartitions, numBuffersPerRequest, DEFAULT_BUFFER_REQUEST_TIMEOUT);
+    public static Builder builder(int numSubpartitions, int numBuffersPerRequest) {
+        return new Builder(numSubpartitions, numBuffersPerRequest);
     }
 
     public int getMaxRequestedBuffers() {
@@ -73,5 +99,116 @@ public class HybridShuffleConfiguration {
      */
     public Duration getBufferRequestTimeout() {
         return bufferRequestTimeout;
+    }
+
+    /**
+     * When the number of buffers that have been requested exceeds this threshold, trigger the
+     * spilling operation. Used by {@link HsSelectiveSpillingStrategy}.
+     */
+    public float getSelectiveStrategySpillThreshold() {
+        return selectiveStrategySpillThreshold;
+    }
+
+    /** The proportion of buffers to be spilled. Used by {@link HsSelectiveSpillingStrategy}. */
+    public float getSelectiveStrategySpillBufferRatio() {
+        return selectiveStrategySpillBufferRatio;
+    }
+
+    /**
+     * When the number of unSpilled buffers equal to this value, trigger the spilling operation.
+     * Used by {@link HsFullSpillingStrategy}.
+     */
+    public int getFullStrategyNumBuffersTriggerSpilling() {
+        return fullStrategyNumBuffersTriggerSpilling;
+    }
+
+    /**
+     * When the number of buffers that have been requested exceeds this threshold, trigger the
+     * release operation. Used by {@link HsFullSpillingStrategy}.
+     */
+    public float getFullStrategyReleaseThreshold() {
+        return fullStrategyReleaseThreshold;
+    }
+
+    /** The proportion of buffers to be released. Used by {@link HsFullSpillingStrategy}. */
+    public float getFullStrategyReleaseBufferRatio() {
+        return fullStrategyReleaseBufferRatio;
+    }
+
+    /** Builder for {@link HybridShuffleConfiguration}. */
+    static class Builder {
+        private int maxBuffersReadAhead = DEFAULT_MAX_BUFFERS_READ_AHEAD;
+
+        private Duration bufferRequestTimeout = DEFAULT_BUFFER_REQUEST_TIMEOUT;
+
+        private float selectiveStrategySpillThreshold = DEFAULT_SELECTIVE_STRATEGY_SPILL_THRESHOLD;
+
+        private float selectiveStrategySpillBufferRatio =
+                DEFAULT_SELECTIVE_STRATEGY_SPILL_BUFFER_RATIO;
+
+        private int fullStrategyNumBuffersTriggerSpilling =
+                DEFAULT_FULL_STRATEGY_NUM_BUFFERS_TRIGGER_SPILLED;
+
+        private float fullStrategyReleaseThreshold = DEFAULT_FULL_STRATEGY_RELEASE_THRESHOLD;
+
+        private float fullStrategyReleaseBufferRatio = DEFAULT_FULL_STRATEGY_RELEASE_BUFFER_RATIO;
+
+        private final int numSubpartitions;
+
+        private final int numBuffersPerRequest;
+
+        private Builder(int numSubpartitions, int numBuffersPerRequest) {
+            this.numSubpartitions = numSubpartitions;
+            this.numBuffersPerRequest = numBuffersPerRequest;
+        }
+
+        public Builder setMaxBuffersReadAhead(int maxBuffersReadAhead) {
+            this.maxBuffersReadAhead = maxBuffersReadAhead;
+            return this;
+        }
+
+        public Builder setBufferRequestTimeout(Duration bufferRequestTimeout) {
+            this.bufferRequestTimeout = bufferRequestTimeout;
+            return this;
+        }
+
+        public Builder setSelectiveStrategySpillThreshold(float selectiveStrategySpillThreshold) {
+            this.selectiveStrategySpillThreshold = selectiveStrategySpillThreshold;
+            return this;
+        }
+
+        public Builder setSelectiveStrategySpillBufferRatio(
+                float selectiveStrategySpillBufferRatio) {
+            this.selectiveStrategySpillBufferRatio = selectiveStrategySpillBufferRatio;
+            return this;
+        }
+
+        public Builder setFullStrategyNumBuffersTriggerSpilling(
+                int fullStrategyNumBuffersTriggerSpilling) {
+            this.fullStrategyNumBuffersTriggerSpilling = fullStrategyNumBuffersTriggerSpilling;
+            return this;
+        }
+
+        public Builder setFullStrategyReleaseThreshold(float fullStrategyReleaseThreshold) {
+            this.fullStrategyReleaseThreshold = fullStrategyReleaseThreshold;
+            return this;
+        }
+
+        public Builder setFullStrategyReleaseBufferRatio(float fullStrategyReleaseBufferRatio) {
+            this.fullStrategyReleaseBufferRatio = fullStrategyReleaseBufferRatio;
+            return this;
+        }
+
+        public HybridShuffleConfiguration build() {
+            return new HybridShuffleConfiguration(
+                    maxBuffersReadAhead,
+                    bufferRequestTimeout,
+                    Math.max(2 * numBuffersPerRequest, numSubpartitions),
+                    selectiveStrategySpillThreshold,
+                    selectiveStrategySpillBufferRatio,
+                    fullStrategyNumBuffersTriggerSpilling,
+                    fullStrategyReleaseThreshold,
+                    fullStrategyReleaseBufferRatio);
+        }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFullSpillingStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFullSpillingStrategyTest.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid;
+
+import org.apache.flink.runtime.io.network.partition.hybrid.HsSpillingStrategy.Decision;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.apache.flink.runtime.io.network.partition.hybrid.HsSpillingStrategyTestUtils.createBuffer;
+import static org.apache.flink.runtime.io.network.partition.hybrid.HsSpillingStrategyTestUtils.createBufferWithIdentitiesList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link HsFullSpillingStrategy}. */
+class HsFullSpillingStrategyTest {
+    public static final int NUM_SUBPARTITIONS = 2;
+
+    public static final int NUM_BUFFERS_TRIGGER_SPILLING = 2;
+
+    public static final float FULL_SPILL_RELEASE_THRESHOLD = 0.8f;
+
+    public static final float FULL_SPILL_RELEASE_RATIO = 0.6f;
+
+    private final HsSpillingStrategy spillStrategy =
+            new HsFullSpillingStrategy(
+                    HybridShuffleConfiguration.builder(NUM_SUBPARTITIONS, 1)
+                            .setFullStrategyNumBuffersTriggerSpilling(NUM_BUFFERS_TRIGGER_SPILLING)
+                            .setFullStrategyReleaseThreshold(FULL_SPILL_RELEASE_THRESHOLD)
+                            .setFullStrategyReleaseBufferRatio(FULL_SPILL_RELEASE_RATIO)
+                            .build());
+
+    @Test
+    void testOnBufferFinishedUnSpillBufferBelowThreshold() {
+        Optional<Decision> finishedDecision =
+                spillStrategy.onBufferFinished(NUM_BUFFERS_TRIGGER_SPILLING - 1);
+        assertThat(finishedDecision).hasValue(Decision.NO_ACTION);
+    }
+
+    @Test
+    void testOnBufferFinishedUnSpillBufferEqualToOrGreatThenThreshold() {
+        Optional<Decision> finishedDecision =
+                spillStrategy.onBufferFinished(NUM_BUFFERS_TRIGGER_SPILLING);
+        assertThat(finishedDecision).isNotPresent();
+        finishedDecision = spillStrategy.onBufferFinished(NUM_BUFFERS_TRIGGER_SPILLING + 1);
+        assertThat(finishedDecision).isNotPresent();
+    }
+
+    @Test
+    void testOnBufferConsumed() {
+        BufferWithIdentity bufferWithIdentity = new BufferWithIdentity(createBuffer(), 0, 0);
+        Optional<Decision> bufferConsumedDecision =
+                spillStrategy.onBufferConsumed(bufferWithIdentity);
+        assertThat(bufferConsumedDecision).hasValue(Decision.NO_ACTION);
+    }
+
+    @Test
+    void testOnUsedMemoryBelowThreshold() {
+        Optional<Decision> memoryUsageChangedDecision = spillStrategy.onMemoryUsageChanged(5, 10);
+        assertThat(memoryUsageChangedDecision).hasValue(Decision.NO_ACTION);
+    }
+
+    @Test
+    void testOnUsedMemoryExceedThreshold() {
+        final int poolSize = 10;
+        final int threshold = (int) (poolSize * FULL_SPILL_RELEASE_THRESHOLD);
+        Optional<Decision> memoryUsageChangedDecision =
+                spillStrategy.onMemoryUsageChanged(threshold + 1, poolSize);
+        assertThat(memoryUsageChangedDecision).isNotPresent();
+    }
+
+    @Test
+    void testDecideActionWithGlobalInfo() {
+        final int subpartition1 = 0;
+        final int subpartition2 = 1;
+
+        final int progress1 = 10;
+        final int progress2 = 20;
+
+        List<BufferWithIdentity> subpartitionBuffers1 =
+                createBufferWithIdentitiesList(
+                        subpartition1,
+                        progress1,
+                        progress1 + 2,
+                        progress1 + 4,
+                        progress1 + 6,
+                        progress1 + 8);
+        List<BufferWithIdentity> subpartitionBuffers2 =
+                createBufferWithIdentitiesList(
+                        subpartition2,
+                        progress2 + 1,
+                        progress2 + 3,
+                        progress2 + 5,
+                        progress2 + 7,
+                        progress2 + 9);
+
+        TestingSpillingInfoProvider spillInfoProvider =
+                TestingSpillingInfoProvider.builder()
+                        .setGetNumSubpartitionsSupplier(() -> NUM_SUBPARTITIONS)
+                        .addSubpartitionBuffers(subpartition1, subpartitionBuffers1)
+                        .addSubpartitionBuffers(subpartition2, subpartitionBuffers2)
+                        .addSpillBuffers(subpartition1, Arrays.asList(0, 1, 2, 3))
+                        .addConsumedBuffers(subpartition1, Arrays.asList(0, 1))
+                        .addSpillBuffers(subpartition2, Arrays.asList(1, 2, 3))
+                        .addConsumedBuffers(subpartition2, Arrays.asList(0, 1))
+                        .setGetNumTotalUnSpillBuffersSupplier(() -> NUM_BUFFERS_TRIGGER_SPILLING)
+                        .setGetNumTotalRequestedBuffersSupplier(() -> 10)
+                        .setGetPoolSizeSupplier(() -> 10)
+                        .setGetNextBufferIndexToConsumeSupplier(
+                                () -> Arrays.asList(progress1, progress2))
+                        .build();
+
+        Decision decision = spillStrategy.decideActionWithGlobalInfo(spillInfoProvider);
+
+        // all not spilled buffers need to spill.
+        ArrayList<BufferWithIdentity> expectedSpillBuffers =
+                new ArrayList<>(subpartitionBuffers1.subList(4, 5));
+        expectedSpillBuffers.add(subpartitionBuffers2.get(0));
+        expectedSpillBuffers.addAll(subpartitionBuffers2.subList(4, 5));
+        assertThat(decision.getBufferToSpill()).isEqualTo(expectedSpillBuffers);
+
+        ArrayList<BufferWithIdentity> expectedReleaseBuffers = new ArrayList<>();
+        // all consumed spill buffers should release.
+        expectedReleaseBuffers.addAll(subpartitionBuffers1.subList(0, 2));
+        // priority higher buffers should release.
+        expectedReleaseBuffers.addAll(subpartitionBuffers1.subList(3, 4));
+        // all consumed spill buffers should release.
+        expectedReleaseBuffers.addAll(subpartitionBuffers2.subList(1, 2));
+        // priority higher buffers should release.
+        expectedReleaseBuffers.addAll(subpartitionBuffers2.subList(2, 4));
+        assertThat(decision.getBufferToRelease()).isEqualTo(expectedReleaseBuffers);
+    }
+
+    /** All consumed buffers that already spill should release regardless of the release ratio. */
+    @Test
+    void testDecideActionWithGlobalInfoAllConsumedSpillBufferShouldRelease() {
+        final int subpartitionId = 0;
+        List<BufferWithIdentity> subpartitionBuffers =
+                createBufferWithIdentitiesList(subpartitionId, 0, 1, 2, 3, 4);
+
+        final int poolSize = 5;
+        TestingSpillingInfoProvider spillInfoProvider =
+                TestingSpillingInfoProvider.builder()
+                        .setGetNumSubpartitionsSupplier(() -> 1)
+                        .addSubpartitionBuffers(subpartitionId, subpartitionBuffers)
+                        .addSpillBuffers(subpartitionId, Arrays.asList(0, 1, 2, 3, 4))
+                        .addConsumedBuffers(subpartitionId, Arrays.asList(0, 1, 2, 3))
+                        .setGetNumTotalUnSpillBuffersSupplier(() -> 0)
+                        .setGetNumTotalRequestedBuffersSupplier(() -> poolSize)
+                        .setGetPoolSizeSupplier(() -> poolSize)
+                        .build();
+
+        int numReleaseBuffer = (int) (poolSize * FULL_SPILL_RELEASE_RATIO);
+        Decision decision = spillStrategy.decideActionWithGlobalInfo(spillInfoProvider);
+        assertThat(decision.getBufferToSpill()).isEmpty();
+        assertThat(decision.getBufferToRelease())
+                .isEqualTo(subpartitionBuffers.subList(0, 4))
+                .hasSizeGreaterThan(numReleaseBuffer);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsResultPartitionReadSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsResultPartitionReadSchedulerTest.java
@@ -92,8 +92,9 @@ class HsResultPartitionReadSchedulerTest {
                         new HsFileDataIndexImpl(NUM_SUBPARTITIONS),
                         dataFilePath,
                         factory,
-                        HybridShuffleConfiguration.createConfiguration(
-                                bufferPool.getNumBuffersPerRequest(), NUM_SUBPARTITIONS));
+                        HybridShuffleConfiguration.builder(
+                                        NUM_SUBPARTITIONS, bufferPool.getNumBuffersPerRequest())
+                                .build());
         subpartitionViewOperation = new TestingSubpartitionViewInternalOperation();
     }
 
@@ -224,10 +225,10 @@ class HsResultPartitionReadSchedulerTest {
                         new HsFileDataIndexImpl(NUM_SUBPARTITIONS),
                         dataFilePath,
                         factory,
-                        HybridShuffleConfiguration.createConfiguration(
-                                bufferPool.getNumBuffersPerRequest(),
-                                NUM_SUBPARTITIONS,
-                                bufferRequestTimeout));
+                        HybridShuffleConfiguration.builder(
+                                        NUM_SUBPARTITIONS, bufferPool.getNumBuffersPerRequest())
+                                .setBufferRequestTimeout(bufferRequestTimeout)
+                                .build());
 
         TestingHsSubpartitionFileReader reader = new TestingHsSubpartitionFileReader();
         CompletableFuture<Void> prepareForSchedulingFinished = new CompletableFuture<>();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSelectiveSpillingStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSelectiveSpillingStrategyTest.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid;
+
+import org.apache.flink.runtime.io.network.partition.hybrid.HsSpillingStrategy.Decision;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.apache.flink.runtime.io.network.partition.hybrid.HsSpillingStrategyTestUtils.createBuffer;
+import static org.apache.flink.runtime.io.network.partition.hybrid.HsSpillingStrategyTestUtils.createBufferWithIdentitiesList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link HsSelectiveSpillingStrategy}. */
+class HsSelectiveSpillingStrategyTest {
+    public static final int NUM_SUBPARTITIONS = 3;
+
+    public static final float SELECTIVE_SPILL_THRESHOLD = 0.7f;
+
+    public static final float SELECTIVE_SPILL_BUFFER_RATIO = 0.3f;
+
+    private final HsSpillingStrategy spillStrategy =
+            new HsSelectiveSpillingStrategy(
+                    HybridShuffleConfiguration.builder(NUM_SUBPARTITIONS, 1)
+                            .setSelectiveStrategySpillThreshold(SELECTIVE_SPILL_THRESHOLD)
+                            .setSelectiveStrategySpillBufferRatio(SELECTIVE_SPILL_BUFFER_RATIO)
+                            .build());
+
+    @Test
+    void testOnBufferFinished() {
+        Optional<Decision> finishedDecision = spillStrategy.onBufferFinished(5);
+        assertThat(finishedDecision).hasValue(Decision.NO_ACTION);
+    }
+
+    @Test
+    void testOnBufferConsumed() {
+        BufferWithIdentity bufferWithIdentity = new BufferWithIdentity(createBuffer(), 0, 0);
+        Optional<Decision> consumedDecision = spillStrategy.onBufferConsumed(bufferWithIdentity);
+        assertThat(consumedDecision)
+                .hasValueSatisfying(
+                        (decision -> {
+                            assertThat(decision.getBufferToRelease())
+                                    .hasSize(1)
+                                    .element(0)
+                                    .isEqualTo(bufferWithIdentity);
+                            assertThat(decision.getBufferToSpill()).isEmpty();
+                        }));
+    }
+
+    @Test
+    void testOnUsedMemoryLow() {
+        final int bufferPoolSize = 10;
+        final int bufferThreshold = (int) (bufferPoolSize * SELECTIVE_SPILL_THRESHOLD);
+        Optional<Decision> memoryUsageChangedDecision =
+                spillStrategy.onMemoryUsageChanged(bufferThreshold - 1, bufferPoolSize);
+        assertThat(memoryUsageChangedDecision).hasValue(Decision.NO_ACTION);
+    }
+
+    @Test
+    void testOnUsedMemoryHigh() {
+        final int subpartition1 = 0;
+        final int subpartition2 = 1;
+        final int subpartition3 = 2;
+
+        final int progress1 = 10;
+        final int progress2 = 20;
+        final int progress3 = 30;
+
+        List<BufferWithIdentity> subpartitionBuffer1 =
+                createBufferWithIdentitiesList(
+                        subpartition1, progress1 + 0, progress1 + 3, progress1 + 6, progress1 + 9);
+        List<BufferWithIdentity> subpartitionBuffer2 =
+                createBufferWithIdentitiesList(
+                        subpartition2, progress2 + 1, progress2 + 4, progress2 + 7);
+        List<BufferWithIdentity> subpartitionBuffer3 =
+                createBufferWithIdentitiesList(
+                        subpartition3, progress3 + 2, progress3 + 5, progress3 + 8);
+
+        final int bufferPoolSize = 10;
+        final int totalBuffers = 10;
+
+        TestingSpillingInfoProvider spillInfoProvider =
+                TestingSpillingInfoProvider.builder()
+                        .setGetNumSubpartitionsSupplier(() -> NUM_SUBPARTITIONS)
+                        .addSubpartitionBuffers(subpartition1, subpartitionBuffer1)
+                        .addSubpartitionBuffers(subpartition2, subpartitionBuffer2)
+                        .addSubpartitionBuffers(subpartition3, subpartitionBuffer3)
+                        .addSpillBuffers(subpartition1, Collections.singletonList(3))
+                        .setGetNextBufferIndexToConsumeSupplier(
+                                () -> Arrays.asList(progress1, progress2, progress3))
+                        .setGetPoolSizeSupplier(() -> bufferPoolSize)
+                        .setGetNumTotalRequestedBuffersSupplier(() -> totalBuffers)
+                        .build();
+
+        Optional<Decision> decision =
+                spillStrategy.onMemoryUsageChanged(totalBuffers, bufferPoolSize);
+        assertThat(decision).isNotPresent();
+        Decision globalDecision = spillStrategy.decideActionWithGlobalInfo(spillInfoProvider);
+
+        // progress1 + 9 has the highest priority, but it cannot be decided to spill, as its
+        // spillStatus is SPILL. expected buffer's index : progress1 + 6, progress2 + 7, progress3 +
+        // 8
+        List<BufferWithIdentity> expectedBuffers = new ArrayList<>();
+        expectedBuffers.addAll(subpartitionBuffer1.subList(2, 3));
+        expectedBuffers.addAll(subpartitionBuffer2.subList(2, 3));
+        expectedBuffers.addAll(subpartitionBuffer3.subList(2, 3));
+
+        assertThat(globalDecision.getBufferToSpill()).isEqualTo(expectedBuffers);
+        assertThat(globalDecision.getBufferToRelease()).isEqualTo(expectedBuffers);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSpillingStrategyTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSpillingStrategyTestUtils.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid;
+
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.core.memory.MemorySegmentFactory;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+
+/** Test utils for {@link HsSpillingStrategy}. */
+public class HsSpillingStrategyTestUtils {
+    public static final int MEMORY_SEGMENT_SIZE = 128;
+
+    public static List<BufferWithIdentity> createBufferWithIdentitiesList(
+            int subpartitionId, int... bufferIndexes) {
+        List<BufferWithIdentity> bufferWithIdentityList = new ArrayList<>();
+        for (int bufferIndex : bufferIndexes) {
+            MemorySegment segment =
+                    MemorySegmentFactory.allocateUnpooledSegment(MEMORY_SEGMENT_SIZE);
+            NetworkBuffer buffer = new NetworkBuffer(segment, (ignore) -> {});
+            bufferWithIdentityList.add(new BufferWithIdentity(buffer, bufferIndex, subpartitionId));
+        }
+        return bufferWithIdentityList;
+    }
+
+    public static Deque<BufferWithIdentity> createBufferWithIdentitiesDeque(
+            int subpartitionId, int... bufferIndexes) {
+        Deque<BufferWithIdentity> bufferWithIdentityList = new ArrayDeque<>();
+        for (int bufferIndex : bufferIndexes) {
+            Buffer buffer = createBuffer();
+            bufferWithIdentityList.add(new BufferWithIdentity(buffer, bufferIndex, subpartitionId));
+        }
+        return bufferWithIdentityList;
+    }
+
+    public static Buffer createBuffer() {
+        MemorySegment segment = MemorySegmentFactory.allocateUnpooledSegment(MEMORY_SEGMENT_SIZE);
+        return new NetworkBuffer(segment, (ignore) -> {});
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSpillingStrategyUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSpillingStrategyUtilsTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.List;
+import java.util.TreeMap;
+
+import static org.apache.flink.runtime.io.network.partition.hybrid.HsSpillingStrategyTestUtils.createBufferWithIdentitiesList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link HsSpillingStrategyUtils}. */
+class HsSpillingStrategyUtilsTest {
+    @Test
+    void testGetBuffersByConsumptionPriorityInOrderEmptyExpectedSize() {
+        TreeMap<Integer, List<BufferWithIdentity>> buffersByConsumptionPriorityInOrder =
+                HsSpillingStrategyUtils.getBuffersByConsumptionPriorityInOrder(
+                        Arrays.asList(0, 1), new TreeMap<>(), 0);
+        assertThat(buffersByConsumptionPriorityInOrder).isEmpty();
+    }
+
+    @Test
+    void testGetBuffersByConsumptionPriorityInOrder() {
+        final int subpartition1 = 0;
+        final int subpartition2 = 1;
+
+        final int progress1 = 10;
+        final int progress2 = 20;
+
+        TreeMap<Integer, Deque<BufferWithIdentity>> subpartitionBuffers = new TreeMap<>();
+        List<BufferWithIdentity> subpartitionBuffers1 =
+                createBufferWithIdentitiesList(
+                        subpartition1, progress1, progress1 + 2, progress1 + 6);
+        List<BufferWithIdentity> subpartitionBuffers2 =
+                createBufferWithIdentitiesList(
+                        subpartition2, progress2 + 1, progress2 + 2, progress2 + 5);
+        subpartitionBuffers.put(subpartition1, new ArrayDeque<>(subpartitionBuffers1));
+        subpartitionBuffers.put(subpartition2, new ArrayDeque<>(subpartitionBuffers2));
+
+        TreeMap<Integer, List<BufferWithIdentity>> buffersByConsumptionPriorityInOrder =
+                HsSpillingStrategyUtils.getBuffersByConsumptionPriorityInOrder(
+                        Arrays.asList(progress1, progress2), subpartitionBuffers, 5);
+
+        assertThat(buffersByConsumptionPriorityInOrder).hasSize(2);
+        assertThat(buffersByConsumptionPriorityInOrder.get(subpartition1))
+                .isEqualTo(subpartitionBuffers1.subList(1, 3));
+        assertThat(buffersByConsumptionPriorityInOrder.get(subpartition2))
+                .isEqualTo(subpartitionBuffers2.subList(0, 3));
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSpillingStrategyUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSpillingStrategyUtilsTest.java
@@ -26,6 +26,7 @@ import java.util.Deque;
 import java.util.List;
 import java.util.TreeMap;
 
+import static org.apache.flink.runtime.io.network.partition.hybrid.HsSpillingStrategyTestUtils.createBufferWithIdentitiesDeque;
 import static org.apache.flink.runtime.io.network.partition.hybrid.HsSpillingStrategyTestUtils.createBufferWithIdentitiesList;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -33,9 +34,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 class HsSpillingStrategyUtilsTest {
     @Test
     void testGetBuffersByConsumptionPriorityInOrderEmptyExpectedSize() {
+        TreeMap<Integer, Deque<BufferWithIdentity>> subpartitionToAllBuffers = new TreeMap<>();
+        subpartitionToAllBuffers.put(0, createBufferWithIdentitiesDeque(0, 0, 1));
+        subpartitionToAllBuffers.put(1, createBufferWithIdentitiesDeque(1, 2, 4));
         TreeMap<Integer, List<BufferWithIdentity>> buffersByConsumptionPriorityInOrder =
                 HsSpillingStrategyUtils.getBuffersByConsumptionPriorityInOrder(
-                        Arrays.asList(0, 1), new TreeMap<>(), 0);
+                        Arrays.asList(0, 1), subpartitionToAllBuffers, 0);
         assertThat(buffersByConsumptionPriorityInOrder).isEmpty();
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/TestingSpillingInfoProvider.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/TestingSpillingInfoProvider.java
@@ -1,0 +1,233 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+
+/** Mock {@link HsSpillingInfoProvider} for test. */
+public class TestingSpillingInfoProvider implements HsSpillingInfoProvider {
+
+    private final Supplier<List<Integer>> getNextBufferIndexToConsumeSupplier;
+
+    private final Supplier<Integer> getNumTotalUnSpillBuffersSupplier;
+
+    private final Supplier<Integer> getNumTotalRequestedBuffersSupplier;
+
+    private final Supplier<Integer> getPoolSizeSupplier;
+
+    private final Supplier<Integer> getNumSubpartitionsSupplier;
+
+    private final Map<Integer, List<BufferWithIdentity>> allBuffers;
+
+    private final Map<Integer, Set<Integer>> spillBufferIndexes;
+
+    private final Map<Integer, Set<Integer>> consumedBufferIndexes;
+
+    public TestingSpillingInfoProvider(
+            Supplier<List<Integer>> getNextBufferIndexToConsumeSupplier,
+            Supplier<Integer> getNumTotalUnSpillBuffersSupplier,
+            Supplier<Integer> getNumTotalRequestedBuffersSupplier,
+            Supplier<Integer> getPoolSizeSupplier,
+            Supplier<Integer> getNumSubpartitionsSupplier,
+            Map<Integer, List<BufferWithIdentity>> allBuffers,
+            Map<Integer, Set<Integer>> spillBufferIndexes,
+            Map<Integer, Set<Integer>> consumedBufferIndexes) {
+        this.getNextBufferIndexToConsumeSupplier = getNextBufferIndexToConsumeSupplier;
+        this.getNumTotalUnSpillBuffersSupplier = getNumTotalUnSpillBuffersSupplier;
+        this.getNumTotalRequestedBuffersSupplier = getNumTotalRequestedBuffersSupplier;
+        this.getPoolSizeSupplier = getPoolSizeSupplier;
+        this.getNumSubpartitionsSupplier = getNumSubpartitionsSupplier;
+        this.allBuffers = allBuffers;
+        this.spillBufferIndexes = spillBufferIndexes;
+        this.consumedBufferIndexes = consumedBufferIndexes;
+    }
+
+    @Override
+    public int getNumSubpartitions() {
+        return getNumSubpartitionsSupplier.get();
+    }
+
+    @Override
+    public List<Integer> getNextBufferIndexToConsume() {
+        return getNextBufferIndexToConsumeSupplier.get();
+    }
+
+    @Override
+    public Deque<BufferWithIdentity> getBuffersInOrder(
+            int subpartitionId, SpillStatus spillStatus, ConsumeStatus consumeStatus) {
+        Deque<BufferWithIdentity> buffersInOrder = new ArrayDeque<>();
+
+        List<BufferWithIdentity> subpartitionBuffers = allBuffers.get(subpartitionId);
+        if (subpartitionBuffers == null) {
+            return buffersInOrder;
+        }
+
+        for (int i = 0; i < subpartitionBuffers.size(); i++) {
+            if (isBufferSatisfyStatus(
+                    spillStatus,
+                    consumeStatus,
+                    spillBufferIndexes
+                            .getOrDefault(subpartitionId, Collections.emptySet())
+                            .contains(i),
+                    consumedBufferIndexes
+                            .getOrDefault(subpartitionId, Collections.emptySet())
+                            .contains(i))) {
+                buffersInOrder.add(subpartitionBuffers.get(i));
+            }
+        }
+        return buffersInOrder;
+    }
+
+    @Override
+    public int getNumTotalUnSpillBuffers() {
+        return getNumTotalUnSpillBuffersSupplier.get();
+    }
+
+    @Override
+    public int getNumTotalRequestedBuffers() {
+        return getNumTotalRequestedBuffersSupplier.get();
+    }
+
+    @Override
+    public int getPoolSize() {
+        return getPoolSizeSupplier.get();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    private static boolean isBufferSatisfyStatus(
+            SpillStatus spillStatus,
+            ConsumeStatus consumeStatus,
+            boolean isSpill,
+            boolean isConsumed) {
+        boolean isNeeded = true;
+        switch (spillStatus) {
+            case NOT_SPILL:
+                isNeeded = !isSpill;
+                break;
+            case SPILL:
+                isNeeded = isSpill;
+                break;
+        }
+        switch (consumeStatus) {
+            case NOT_CONSUMED:
+                isNeeded &= !isConsumed;
+                break;
+            case CONSUMED:
+                isNeeded &= isConsumed;
+                break;
+        }
+        return isNeeded;
+    }
+
+    /** Builder for {@link TestingSpillingInfoProvider}. */
+    public static class Builder {
+        private Supplier<List<Integer>> getNextBufferIndexToConsumeSupplier = ArrayList::new;
+
+        private Supplier<Integer> getNumTotalUnSpillBuffersSupplier = () -> 0;
+
+        private Supplier<Integer> getNumTotalRequestedBuffersSupplier = () -> 0;
+
+        private Supplier<Integer> getPoolSizeSupplier = () -> 0;
+
+        private Supplier<Integer> getNumSubpartitionsSupplier = () -> 0;
+
+        private final Map<Integer, List<BufferWithIdentity>> allBuffers = new HashMap<>();
+
+        private final Map<Integer, Set<Integer>> spillBufferIndexes = new HashMap<>();
+
+        private final Map<Integer, Set<Integer>> consumedBufferIndexes = new HashMap<>();
+
+        private Builder() {}
+
+        public Builder setGetNextBufferIndexToConsumeSupplier(
+                Supplier<List<Integer>> getNextBufferIndexToConsumeSupplier) {
+            this.getNextBufferIndexToConsumeSupplier = getNextBufferIndexToConsumeSupplier;
+            return this;
+        }
+
+        public Builder setGetNumTotalUnSpillBuffersSupplier(
+                Supplier<Integer> getNumTotalUnSpillBuffersSupplier) {
+            this.getNumTotalUnSpillBuffersSupplier = getNumTotalUnSpillBuffersSupplier;
+            return this;
+        }
+
+        public Builder setGetNumTotalRequestedBuffersSupplier(
+                Supplier<Integer> getNumTotalRequestedBuffersSupplier) {
+            this.getNumTotalRequestedBuffersSupplier = getNumTotalRequestedBuffersSupplier;
+            return this;
+        }
+
+        public Builder setGetPoolSizeSupplier(Supplier<Integer> getPoolSizeSupplier) {
+            this.getPoolSizeSupplier = getPoolSizeSupplier;
+            return this;
+        }
+
+        public Builder setGetNumSubpartitionsSupplier(
+                Supplier<Integer> getNumSubpartitionsSupplier) {
+            this.getNumSubpartitionsSupplier = getNumSubpartitionsSupplier;
+            return this;
+        }
+
+        public Builder addSubpartitionBuffers(
+                int subpartitionId, List<BufferWithIdentity> subpartitionBuffers) {
+            allBuffers.computeIfAbsent(subpartitionId, ArrayList::new).addAll(subpartitionBuffers);
+            return this;
+        }
+
+        public Builder addSpillBuffers(
+                int subpartitionId, List<Integer> subpartitionSpillBufferIndexes) {
+            spillBufferIndexes
+                    .computeIfAbsent(subpartitionId, HashSet::new)
+                    .addAll(subpartitionSpillBufferIndexes);
+            return this;
+        }
+
+        public Builder addConsumedBuffers(
+                int subpartitionId, List<Integer> subpartitionConsumedBufferIndexes) {
+            consumedBufferIndexes
+                    .computeIfAbsent(subpartitionId, HashSet::new)
+                    .addAll(subpartitionConsumedBufferIndexes);
+            return this;
+        }
+
+        public TestingSpillingInfoProvider build() {
+            return new TestingSpillingInfoProvider(
+                    getNextBufferIndexToConsumeSupplier,
+                    getNumTotalUnSpillBuffersSupplier,
+                    getNumTotalRequestedBuffersSupplier,
+                    getPoolSizeSupplier,
+                    getNumSubpartitionsSupplier,
+                    allBuffers,
+                    spillBufferIndexes,
+                    consumedBufferIndexes);
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

*Introduce `HsSpillingStrategy` and Implement `HsSelectiveSpillingStrategy` to support make a spilling decision for hybrid shuffle.*

## Brief change log
  - *Introduce `HsSpillingStrategy` interface for all spilling strategy.*
  - *Introduce `HsSelectiveSpillingStrategy` to reduce disk writes as much as possible.*
  - *Introduce `HsAllSpillingStrategy` to spill all data into disk.*


## Verifying this change

Covered by `HsSelectiveSpillingStrategyTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive):  no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
