### PR TITLE
[FLINK-28150][sql-gateway][hive] Introduce the hiveserver2 endpoint and factory

### DIFF
--- a/flink-architecture-tests/flink-architecture-tests-base/src/main/java/org/apache/flink/architecture/common/JavaFieldPredicates.java
+++ b/flink-architecture-tests/flink-architecture-tests-base/src/main/java/org/apache/flink/architecture/common/JavaFieldPredicates.java
@@ -113,6 +113,6 @@ public class JavaFieldPredicates {
                                                 annotation
                                                         .getRawType()
                                                         .isEquivalentTo(annotationType))
-                                .reduce(false, (a, b) -> a || b));
+                                .reduce(false, Boolean::logicalOr));
     }
 }

--- a/flink-architecture-tests/flink-architecture-tests-base/src/main/java/org/apache/flink/architecture/common/JavaFieldPredicates.java
+++ b/flink-architecture-tests/flink-architecture-tests-base/src/main/java/org/apache/flink/architecture/common/JavaFieldPredicates.java
@@ -107,11 +107,12 @@ public class JavaFieldPredicates {
         return DescribedPredicate.describe(
                 "annotated with @" + annotationType.getSimpleName(),
                 field ->
-                        field.getAnnotations().size() == 1
-                                && field.getAnnotations()
-                                        .iterator()
-                                        .next()
-                                        .getRawType()
-                                        .isEquivalentTo(annotationType));
+                        field.getAnnotations().stream()
+                                .map(
+                                        annotation ->
+                                                annotation
+                                                        .getRawType()
+                                                        .isEquivalentTo(annotationType))
+                                .reduce(false, (a, b) -> a || b));
     }
 }

--- a/flink-architecture-tests/flink-architecture-tests-production/pom.xml
+++ b/flink-architecture-tests/flink-architecture-tests-production/pom.xml
@@ -112,6 +112,16 @@ under the License.
 			<artifactId>flink-sql-client</artifactId>
 		</dependency>
 
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-sql-gateway-api</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-sql-gateway</artifactId>
+		</dependency>
+
 		<!-- Connectors -->
 
 		<dependency>

--- a/flink-architecture-tests/pom.xml
+++ b/flink-architecture-tests/pom.xml
@@ -116,6 +116,20 @@ under the License.
 				<scope>test</scope>
 			</dependency>
 
+			<dependency>
+				<groupId>org.apache.flink</groupId>
+				<artifactId>flink-sql-gateway-api</artifactId>
+				<version>${project.version}</version>
+				<scope>test</scope>
+			</dependency>
+
+			<dependency>
+				<groupId>org.apache.flink</groupId>
+				<artifactId>flink-sql-gateway</artifactId>
+				<version>${project.version}</version>
+				<scope>test</scope>
+			</dependency>
+
 			<!-- Connectors -->
 
 			<dependency>

--- a/flink-connectors/flink-connector-hive/pom.xml
+++ b/flink-connectors/flink-connector-hive/pom.xml
@@ -158,6 +158,14 @@ under the License.
 			<scope>provided</scope>
 		</dependency>
 
+		<!-- HiveServer2 Endpoint -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-sql-gateway-api</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
 		<!-- Connectors -->
 
 		<dependency>
@@ -882,6 +890,48 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-architecture-tests-test</artifactId>
 			<scope>test</scope>
+		</dependency>
+
+		<!-- HiveServer2 Endpoint -->
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-sql-gateway-api</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-sql-gateway</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-sql-gateway</artifactId>
+			<type>test-jar</type>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.hive</groupId>
+			<artifactId>hive-jdbc</artifactId>
+			<version>${hive.version}</version>
+			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>log4j</groupId>
+					<artifactId>log4j</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-log4j12</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 	</dependencies>
 

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
@@ -189,7 +189,7 @@ public class HiveCatalog extends AbstractCatalog {
             @Nullable String hiveVersion) {
         this(
                 catalogName,
-                defaultDatabase == null ? DEFAULT_DB : defaultDatabase,
+                defaultDatabase,
                 hiveConf,
                 isNullOrWhitespaceOnly(hiveVersion) ? HiveShimLoader.getHiveVersion() : hiveVersion,
                 false);

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
@@ -195,10 +195,9 @@ public class HiveCatalog extends AbstractCatalog {
                 false);
     }
 
-    @VisibleForTesting
-    protected HiveCatalog(
+    public HiveCatalog(
             String catalogName,
-            String defaultDatabase,
+            @Nullable String defaultDatabase,
             @Nullable HiveConf hiveConf,
             String hiveVersion,
             boolean allowEmbedded) {
@@ -221,8 +220,8 @@ public class HiveCatalog extends AbstractCatalog {
         LOG.info("Created HiveCatalog '{}'", catalogName);
     }
 
-    @VisibleForTesting
-    static HiveConf createHiveConf(@Nullable String hiveConfDir, @Nullable String hadoopConfDir) {
+    public static HiveConf createHiveConf(
+            @Nullable String hiveConfDir, @Nullable String hadoopConfDir) {
         // create HiveConf from hadoop configuration with hadoop conf directory configured.
         Configuration hadoopConf = null;
         if (isNullOrWhitespaceOnly(hadoopConfDir)) {

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/endpoint/hive/HiveServer2Endpoint.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/endpoint/hive/HiveServer2Endpoint.java
@@ -237,8 +237,10 @@ public class HiveServer2Endpoint implements TCLIService.Iface, SqlGatewayEndpoin
         LOG.debug("Client protocol version: {}.", tOpenSessionReq.getClient_protocol());
         TOpenSessionResp resp = new TOpenSessionResp();
         try {
-            // negotiate connection protocol version
+            // negotiate connection protocol
             TProtocolVersion clientProtocol = tOpenSessionReq.getClient_protocol();
+            // the session version is not larger than the server version because of the
+            // min(server_version, ...)
             HiveServer2EndpointVersion sessionVersion =
                     HiveServer2EndpointVersion.valueOf(
                             TProtocolVersion.findByValue(

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/endpoint/hive/HiveServer2Endpoint.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/endpoint/hive/HiveServer2Endpoint.java
@@ -1,0 +1,492 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.endpoint.hive;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.table.api.SqlDialect;
+import org.apache.flink.table.catalog.Catalog;
+import org.apache.flink.table.catalog.hive.HiveCatalog;
+import org.apache.flink.table.catalog.hive.client.HiveShimLoader;
+import org.apache.flink.table.gateway.api.SqlGatewayService;
+import org.apache.flink.table.gateway.api.endpoint.SqlGatewayEndpoint;
+import org.apache.flink.table.gateway.api.session.SessionEnvironment;
+import org.apache.flink.table.gateway.api.session.SessionHandle;
+import org.apache.flink.table.gateway.api.utils.SqlGatewayException;
+import org.apache.flink.table.gateway.api.utils.ThreadUtils;
+import org.apache.flink.table.module.Module;
+import org.apache.flink.table.module.hive.HiveModule;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hive.service.rpc.thrift.TCLIService;
+import org.apache.hive.service.rpc.thrift.TCancelDelegationTokenReq;
+import org.apache.hive.service.rpc.thrift.TCancelDelegationTokenResp;
+import org.apache.hive.service.rpc.thrift.TCancelOperationReq;
+import org.apache.hive.service.rpc.thrift.TCancelOperationResp;
+import org.apache.hive.service.rpc.thrift.TCloseOperationReq;
+import org.apache.hive.service.rpc.thrift.TCloseOperationResp;
+import org.apache.hive.service.rpc.thrift.TCloseSessionReq;
+import org.apache.hive.service.rpc.thrift.TCloseSessionResp;
+import org.apache.hive.service.rpc.thrift.TExecuteStatementReq;
+import org.apache.hive.service.rpc.thrift.TExecuteStatementResp;
+import org.apache.hive.service.rpc.thrift.TFetchResultsReq;
+import org.apache.hive.service.rpc.thrift.TFetchResultsResp;
+import org.apache.hive.service.rpc.thrift.TGetCatalogsReq;
+import org.apache.hive.service.rpc.thrift.TGetCatalogsResp;
+import org.apache.hive.service.rpc.thrift.TGetColumnsReq;
+import org.apache.hive.service.rpc.thrift.TGetColumnsResp;
+import org.apache.hive.service.rpc.thrift.TGetCrossReferenceReq;
+import org.apache.hive.service.rpc.thrift.TGetCrossReferenceResp;
+import org.apache.hive.service.rpc.thrift.TGetDelegationTokenReq;
+import org.apache.hive.service.rpc.thrift.TGetDelegationTokenResp;
+import org.apache.hive.service.rpc.thrift.TGetFunctionsReq;
+import org.apache.hive.service.rpc.thrift.TGetFunctionsResp;
+import org.apache.hive.service.rpc.thrift.TGetInfoReq;
+import org.apache.hive.service.rpc.thrift.TGetInfoResp;
+import org.apache.hive.service.rpc.thrift.TGetOperationStatusReq;
+import org.apache.hive.service.rpc.thrift.TGetOperationStatusResp;
+import org.apache.hive.service.rpc.thrift.TGetPrimaryKeysReq;
+import org.apache.hive.service.rpc.thrift.TGetPrimaryKeysResp;
+import org.apache.hive.service.rpc.thrift.TGetResultSetMetadataReq;
+import org.apache.hive.service.rpc.thrift.TGetResultSetMetadataResp;
+import org.apache.hive.service.rpc.thrift.TGetSchemasReq;
+import org.apache.hive.service.rpc.thrift.TGetSchemasResp;
+import org.apache.hive.service.rpc.thrift.TGetTableTypesReq;
+import org.apache.hive.service.rpc.thrift.TGetTableTypesResp;
+import org.apache.hive.service.rpc.thrift.TGetTablesReq;
+import org.apache.hive.service.rpc.thrift.TGetTablesResp;
+import org.apache.hive.service.rpc.thrift.TGetTypeInfoReq;
+import org.apache.hive.service.rpc.thrift.TGetTypeInfoResp;
+import org.apache.hive.service.rpc.thrift.TOpenSessionReq;
+import org.apache.hive.service.rpc.thrift.TOpenSessionResp;
+import org.apache.hive.service.rpc.thrift.TProtocolVersion;
+import org.apache.hive.service.rpc.thrift.TRenewDelegationTokenReq;
+import org.apache.hive.service.rpc.thrift.TRenewDelegationTokenResp;
+import org.apache.hive.service.rpc.thrift.TStatus;
+import org.apache.hive.service.rpc.thrift.TStatusCode;
+import org.apache.thrift.TException;
+import org.apache.thrift.TProcessorFactory;
+import org.apache.thrift.protocol.TBinaryProtocol;
+import org.apache.thrift.server.TThreadPoolServer;
+import org.apache.thrift.transport.TServerSocket;
+import org.apache.thrift.transport.TTransportFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.flink.table.api.config.TableConfigOptions.TABLE_SQL_DIALECT;
+import static org.apache.flink.table.endpoint.hive.HiveServer2EndpointVersion.HIVE_CLI_SERVICE_PROTOCOL_V10;
+import static org.apache.flink.table.endpoint.hive.util.HiveJdbcParameterUtils.getUsedDefaultDatabase;
+import static org.apache.flink.table.endpoint.hive.util.HiveJdbcParameterUtils.validateAndNormalize;
+import static org.apache.flink.table.endpoint.hive.util.ThriftObjectConversions.toSessionHandle;
+import static org.apache.flink.table.endpoint.hive.util.ThriftObjectConversions.toTSessionHandle;
+import static org.apache.flink.table.endpoint.hive.util.ThriftObjectConversions.toTStatus;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * HiveServer2 Endpoint that allows to accept the request from the hive client, e.g. Hive JDBC, Hive
+ * Beeline.
+ */
+public class HiveServer2Endpoint implements TCLIService.Iface, SqlGatewayEndpoint, Runnable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HiveServer2Endpoint.class);
+    private static final HiveServer2EndpointVersion SERVER_VERSION = HIVE_CLI_SERVICE_PROTOCOL_V10;
+    private static final TStatus OK_STATUS = new TStatus(TStatusCode.SUCCESS_STATUS);
+    private static final String ERROR_MESSAGE =
+            "The HiveServer2 Endpoint currently doesn't support this API.";
+
+    // --------------------------------------------------------------------------------------------
+    // Server attributes
+    // --------------------------------------------------------------------------------------------
+
+    private final SqlGatewayService service;
+    private final int minWorkerThreads;
+    private final int maxWorkerThreads;
+    private final Duration workerKeepAliveTime;
+    private final int requestTimeoutMs;
+    private final int backOffSlotLengthMs;
+    private final long maxMessageSize;
+    private final int port;
+
+    private final Thread serverThread = new Thread(this, "HiveServer2 Endpoint");
+    private ThreadPoolExecutor executor;
+    private TThreadPoolServer server;
+
+    // --------------------------------------------------------------------------------------------
+    // Catalog attributes
+    // --------------------------------------------------------------------------------------------
+
+    private final String catalogName;
+    @Nullable private final String defaultDatabase;
+    @Nullable private final String hiveConfPath;
+    private final boolean allowEmbedded;
+
+    // --------------------------------------------------------------------------------------------
+    // Module attributes
+    // --------------------------------------------------------------------------------------------
+
+    private final String moduleName;
+
+    public HiveServer2Endpoint(
+            SqlGatewayService service,
+            int port,
+            long maxMessageSize,
+            int requestTimeoutMs,
+            int backOffSlotLengthMs,
+            int minWorkerThreads,
+            int maxWorkerThreads,
+            Duration workerKeepAliveTime,
+            String catalogName,
+            @Nullable String hiveConfPath,
+            @Nullable String defaultDatabase,
+            String moduleName) {
+        this(
+                service,
+                port,
+                maxMessageSize,
+                requestTimeoutMs,
+                backOffSlotLengthMs,
+                minWorkerThreads,
+                maxWorkerThreads,
+                workerKeepAliveTime,
+                catalogName,
+                hiveConfPath,
+                defaultDatabase,
+                moduleName,
+                false);
+    }
+
+    @VisibleForTesting
+    public HiveServer2Endpoint(
+            SqlGatewayService service,
+            int port,
+            long maxMessageSize,
+            int requestTimeoutMs,
+            int backOffSlotLengthMs,
+            int minWorkerThreads,
+            int maxWorkerThreads,
+            Duration workerKeepAliveTime,
+            String catalogName,
+            @Nullable String hiveConfPath,
+            @Nullable String defaultDatabase,
+            String moduleName,
+            boolean allowEmbedded) {
+        this.service = service;
+
+        this.port = port;
+        this.maxMessageSize = maxMessageSize;
+        this.requestTimeoutMs = requestTimeoutMs;
+        this.backOffSlotLengthMs = backOffSlotLengthMs;
+        this.minWorkerThreads = minWorkerThreads;
+        this.maxWorkerThreads = maxWorkerThreads;
+        this.workerKeepAliveTime = checkNotNull(workerKeepAliveTime);
+
+        this.catalogName = checkNotNull(catalogName);
+        this.hiveConfPath = hiveConfPath;
+        this.defaultDatabase = defaultDatabase;
+        this.allowEmbedded = allowEmbedded;
+
+        this.moduleName = moduleName;
+    }
+
+    @Override
+    public void start() throws Exception {
+        initialize();
+        serverThread.start();
+    }
+
+    @Override
+    public void stop() throws Exception {
+        if (server != null) {
+            server.stop();
+        }
+
+        if (executor != null) {
+            executor.shutdown();
+        }
+    }
+
+    @Override
+    public TOpenSessionResp OpenSession(TOpenSessionReq tOpenSessionReq) throws TException {
+        LOG.debug("Client protocol version: " + tOpenSessionReq.getClient_protocol());
+        TOpenSessionResp resp = new TOpenSessionResp();
+        try {
+            // negotiate connection protocol version
+            TProtocolVersion clientProtocol = tOpenSessionReq.getClient_protocol();
+            HiveServer2EndpointVersion sessionVersion =
+                    HiveServer2EndpointVersion.valueOf(
+                            TProtocolVersion.findByValue(
+                                    Math.min(
+                                            clientProtocol.getValue(),
+                                            SERVER_VERSION.getVersion().getValue())));
+
+            // prepare session environment
+            Map<String, String> originSessionConf =
+                    tOpenSessionReq.getConfiguration() == null
+                            ? Collections.emptyMap()
+                            : tOpenSessionReq.getConfiguration();
+            Map<String, String> sessionConfig = new HashMap<>();
+            sessionConfig.put(TABLE_SQL_DIALECT.key(), SqlDialect.HIVE.name());
+            sessionConfig.putAll(validateAndNormalize(originSessionConf));
+
+            HiveConf conf = HiveCatalog.createHiveConf(hiveConfPath, null);
+            sessionConfig.forEach(conf::set);
+            Catalog hiveCatalog =
+                    new HiveCatalog(
+                            catalogName,
+                            defaultDatabase,
+                            conf,
+                            HiveShimLoader.getHiveVersion(),
+                            allowEmbedded);
+            Module hiveModule = new HiveModule();
+            SessionHandle sessionHandle =
+                    service.openSession(
+                            SessionEnvironment.newBuilder()
+                                    .setSessionEndpointVersion(sessionVersion)
+                                    .registerCatalog(catalogName, hiveCatalog)
+                                    .registerModule(moduleName, hiveModule)
+                                    .setDefaultCatalog(catalogName)
+                                    .setDefaultDatabase(
+                                            getUsedDefaultDatabase(originSessionConf).orElse(null))
+                                    .addSessionConfig(sessionConfig)
+                                    .build());
+            // response
+            resp.setStatus(OK_STATUS);
+            resp.setServerProtocolVersion(sessionVersion.getVersion());
+            resp.setSessionHandle(toTSessionHandle(sessionHandle));
+            resp.setConfiguration(service.getSessionConfig(sessionHandle));
+        } catch (Exception e) {
+            LOG.error("Failed to openSession.", e);
+            resp.setStatus(toTStatus(e));
+        }
+        return resp;
+    }
+
+    @Override
+    public TCloseSessionResp CloseSession(TCloseSessionReq tCloseSessionReq) throws TException {
+        TCloseSessionResp resp = new TCloseSessionResp();
+        try {
+            SessionHandle sessionHandle = toSessionHandle(tCloseSessionReq.getSessionHandle());
+            service.closeSession(sessionHandle);
+            resp.setStatus(OK_STATUS);
+        } catch (Throwable t) {
+            LOG.warn("Error closing session: ", t);
+            resp.setStatus(toTStatus(t));
+        }
+        return resp;
+    }
+
+    @Override
+    public TGetInfoResp GetInfo(TGetInfoReq tGetInfoReq) throws TException {
+        throw new UnsupportedOperationException(ERROR_MESSAGE);
+    }
+
+    @Override
+    public TExecuteStatementResp ExecuteStatement(TExecuteStatementReq tExecuteStatementReq)
+            throws TException {
+        throw new UnsupportedOperationException(ERROR_MESSAGE);
+    }
+
+    @Override
+    public TGetTypeInfoResp GetTypeInfo(TGetTypeInfoReq tGetTypeInfoReq) throws TException {
+        throw new UnsupportedOperationException(ERROR_MESSAGE);
+    }
+
+    @Override
+    public TGetCatalogsResp GetCatalogs(TGetCatalogsReq tGetCatalogsReq) throws TException {
+        throw new UnsupportedOperationException(ERROR_MESSAGE);
+    }
+
+    @Override
+    public TGetSchemasResp GetSchemas(TGetSchemasReq tGetSchemasReq) throws TException {
+        throw new UnsupportedOperationException(ERROR_MESSAGE);
+    }
+
+    @Override
+    public TGetTablesResp GetTables(TGetTablesReq tGetTablesReq) throws TException {
+        throw new UnsupportedOperationException(ERROR_MESSAGE);
+    }
+
+    @Override
+    public TGetTableTypesResp GetTableTypes(TGetTableTypesReq tGetTableTypesReq) throws TException {
+        throw new UnsupportedOperationException(ERROR_MESSAGE);
+    }
+
+    @Override
+    public TGetColumnsResp GetColumns(TGetColumnsReq tGetColumnsReq) throws TException {
+        throw new UnsupportedOperationException(ERROR_MESSAGE);
+    }
+
+    @Override
+    public TGetFunctionsResp GetFunctions(TGetFunctionsReq tGetFunctionsReq) throws TException {
+        throw new UnsupportedOperationException(ERROR_MESSAGE);
+    }
+
+    @Override
+    public TGetPrimaryKeysResp GetPrimaryKeys(TGetPrimaryKeysReq tGetPrimaryKeysReq)
+            throws TException {
+        throw new UnsupportedOperationException(ERROR_MESSAGE);
+    }
+
+    @Override
+    public TGetCrossReferenceResp GetCrossReference(TGetCrossReferenceReq tGetCrossReferenceReq)
+            throws TException {
+        throw new UnsupportedOperationException(ERROR_MESSAGE);
+    }
+
+    @Override
+    public TGetOperationStatusResp GetOperationStatus(TGetOperationStatusReq tGetOperationStatusReq)
+            throws TException {
+        throw new UnsupportedOperationException(ERROR_MESSAGE);
+    }
+
+    @Override
+    public TCancelOperationResp CancelOperation(TCancelOperationReq tCancelOperationReq)
+            throws TException {
+        throw new UnsupportedOperationException(ERROR_MESSAGE);
+    }
+
+    @Override
+    public TCloseOperationResp CloseOperation(TCloseOperationReq tCloseOperationReq)
+            throws TException {
+        throw new UnsupportedOperationException(ERROR_MESSAGE);
+    }
+
+    @Override
+    public TGetResultSetMetadataResp GetResultSetMetadata(
+            TGetResultSetMetadataReq tGetResultSetMetadataReq) throws TException {
+        throw new UnsupportedOperationException(ERROR_MESSAGE);
+    }
+
+    @Override
+    public TFetchResultsResp FetchResults(TFetchResultsReq tFetchResultsReq) throws TException {
+        throw new UnsupportedOperationException(ERROR_MESSAGE);
+    }
+
+    @Override
+    public TGetDelegationTokenResp GetDelegationToken(TGetDelegationTokenReq tGetDelegationTokenReq)
+            throws TException {
+        throw new UnsupportedOperationException(ERROR_MESSAGE);
+    }
+
+    @Override
+    public TCancelDelegationTokenResp CancelDelegationToken(
+            TCancelDelegationTokenReq tCancelDelegationTokenReq) throws TException {
+        throw new UnsupportedOperationException(ERROR_MESSAGE);
+    }
+
+    @Override
+    public TRenewDelegationTokenResp RenewDelegationToken(
+            TRenewDelegationTokenReq tRenewDelegationTokenReq) throws TException {
+        throw new UnsupportedOperationException(ERROR_MESSAGE);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof HiveServer2Endpoint)) {
+            return false;
+        }
+        HiveServer2Endpoint that = (HiveServer2Endpoint) o;
+        return minWorkerThreads == that.minWorkerThreads
+                && maxWorkerThreads == that.maxWorkerThreads
+                && requestTimeoutMs == that.requestTimeoutMs
+                && backOffSlotLengthMs == that.backOffSlotLengthMs
+                && maxMessageSize == that.maxMessageSize
+                && port == that.port
+                && Objects.equals(workerKeepAliveTime, that.workerKeepAliveTime)
+                && Objects.equals(catalogName, that.catalogName)
+                && Objects.equals(defaultDatabase, that.defaultDatabase)
+                && Objects.equals(hiveConfPath, that.hiveConfPath)
+                && Objects.equals(moduleName, that.moduleName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                minWorkerThreads,
+                maxWorkerThreads,
+                workerKeepAliveTime,
+                requestTimeoutMs,
+                backOffSlotLengthMs,
+                maxMessageSize,
+                port,
+                catalogName,
+                defaultDatabase,
+                hiveConfPath,
+                moduleName);
+    }
+
+    @Override
+    public void run() {
+        try {
+            server.serve();
+        } catch (Throwable t) {
+            LOG.info("Exception caught by " + this.getClass().getSimpleName() + ". Exiting.", t);
+        }
+    }
+
+    private void initialize() {
+        executor =
+                ThreadUtils.newThreadPool(
+                        minWorkerThreads,
+                        maxWorkerThreads,
+                        workerKeepAliveTime.toMillis(),
+                        "hiveserver2-endpoint-thread-pool");
+
+        try {
+            server =
+                    new TThreadPoolServer(
+                            new TThreadPoolServer.Args(
+                                            new TServerSocket(
+                                                    new ServerSocket(
+                                                            port, -1, InetAddress.getByName(null))))
+                                    .processorFactory(
+                                            new TProcessorFactory(
+                                                    new TCLIService.Processor<>(this)))
+                                    .transportFactory(new TTransportFactory())
+                                    // Currently, only support binary mode.
+                                    .protocolFactory(new TBinaryProtocol.Factory())
+                                    .inputProtocolFactory(
+                                            new TBinaryProtocol.Factory(
+                                                    true, true, maxMessageSize, maxMessageSize))
+                                    .requestTimeout(requestTimeoutMs)
+                                    .requestTimeoutUnit(TimeUnit.MILLISECONDS)
+                                    .beBackoffSlotLength(backOffSlotLengthMs)
+                                    .beBackoffSlotLengthUnit(TimeUnit.MILLISECONDS)
+                                    .executorService(executor));
+
+            LOG.info(String.format("HiveServer2 Endpoint begins to listen on %s.", port));
+        } catch (Exception e) {
+            throw new SqlGatewayException("Failed to start endpoint.", e);
+        }
+    }
+}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/endpoint/hive/HiveServer2EndpointConfigOptions.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/endpoint/hive/HiveServer2EndpointConfigOptions.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.endpoint.hive;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+
+import java.time.Duration;
+
+import static org.apache.flink.table.catalog.hive.factories.HiveCatalogFactoryOptions.DEFAULT_DATABASE;
+import static org.apache.flink.table.catalog.hive.factories.HiveCatalogFactoryOptions.HIVE_CONF_DIR;
+
+/** Config Options for {@code HiveServer2Endpoint}. */
+@PublicEvolving
+public class HiveServer2EndpointConfigOptions {
+
+    // --------------------------------------------------------------------------------------------
+    // Server Options
+    // --------------------------------------------------------------------------------------------
+
+    public static final ConfigOption<Integer> THRIFT_PORT =
+            ConfigOptions.key("thrift.port")
+                    .intType()
+                    .defaultValue(8084)
+                    .withDescription("The port of the HiveServer2 endpoint");
+
+    public static final ConfigOption<Integer> THRIFT_WORKER_THREADS_MIN =
+            ConfigOptions.key("thrift.worker.threads.min")
+                    .intType()
+                    .defaultValue(5)
+                    .withDescription("The minimum number of Thrift worker threads");
+
+    public static final ConfigOption<Integer> THRIFT_WORKER_THREADS_MAX =
+            ConfigOptions.key("thrift.worker.threads.max")
+                    .intType()
+                    .defaultValue(512)
+                    .withDescription("The maximum number of Thrift worker threads");
+
+    public static final ConfigOption<Duration> THRIFT_WORKER_KEEPALIVE_TIME =
+            ConfigOptions.key("thrift.worker.keepalive-time")
+                    .durationType()
+                    .defaultValue(Duration.ofSeconds(60))
+                    .withDescription(
+                            "Keepalive time for an idle worker thread. When the number of workers exceeds min workers, "
+                                    + "excessive threads are killed after this time interval.");
+
+    public static final ConfigOption<Long> THRIFT_MAX_MESSAGE_SIZE =
+            ConfigOptions.key("thrift.max.message.size")
+                    .longType()
+                    .defaultValue(100 * 1024 * 1024L)
+                    .withDescription("Maximum message size in bytes a HS2 server will accept.");
+
+    public static final ConfigOption<Duration> THRIFT_LOGIN_TIMEOUT =
+            ConfigOptions.key("thrift.login.timeout")
+                    .durationType()
+                    .defaultValue(Duration.ofSeconds(20))
+                    .withDescription("Timeout for Thrift clients during login to HiveServer2");
+
+    public static final ConfigOption<Duration> THRIFT_LOGIN_BEBACKOFF_SLOT_LENGTH =
+            ConfigOptions.key("thrift.exponential.backoff.slot.length")
+                    .durationType()
+                    .defaultValue(Duration.ofMillis(100))
+                    .withDescription(
+                            "Binary exponential backoff slot time for Thrift clients during login to HiveServer2,"
+                                    + "for retries until hitting Thrift client timeout");
+
+    // --------------------------------------------------------------------------------------------
+    // Hive Catalog Options
+    // --------------------------------------------------------------------------------------------
+
+    public static final ConfigOption<String> CATALOG_HIVE_CONF_DIR =
+            ConfigOptions.key("catalog." + HIVE_CONF_DIR.key())
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "URI to your Hive conf dir containing hive-site.xml. The URI needs to be supported by Hadoop FileSystem. "
+                                    + "If the URI is relative, i.e. without a scheme, local file system is assumed. If the option is not specified,"
+                                    + " hive-site.xml is searched in class path.");
+
+    public static final ConfigOption<String> CATALOG_NAME =
+            ConfigOptions.key("catalog.name")
+                    .stringType()
+                    .defaultValue("hive")
+                    .withDescription("Name for the pre-registered hive catalog.");
+
+    public static final ConfigOption<String> CATALOG_DEFAULT_DATABASE =
+            ConfigOptions.key("catalog." + DEFAULT_DATABASE.key())
+                    .stringType()
+                    .defaultValue(DEFAULT_DATABASE.defaultValue())
+                    .withDescription(
+                            "The default database to use when the catalog is set as the current catalog.");
+
+    // --------------------------------------------------------------------------------------------
+    // Hive Module Options
+    // --------------------------------------------------------------------------------------------
+
+    public static final ConfigOption<String> MODULE_NAME =
+            ConfigOptions.key("module.name")
+                    .stringType()
+                    .defaultValue("hive")
+                    .withDescription("Name for the pre-registered hive module.");
+}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/endpoint/hive/HiveServer2EndpointFactory.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/endpoint/hive/HiveServer2EndpointFactory.java
@@ -102,13 +102,13 @@ public class HiveServer2EndpointFactory implements SqlGatewayEndpointFactory {
         if (configuration.get(THRIFT_WORKER_THREADS_MIN) <= 0) {
             throw new ValidationException(
                     String.format(
-                            "The specified min thrift worker thread number is %s, which is not larger than 0.",
+                            "The specified min thrift worker thread number is %s, which should be larger than 0.",
                             configuration.get(THRIFT_WORKER_THREADS_MIN)));
         }
         if (configuration.get(THRIFT_WORKER_THREADS_MAX) <= 0) {
             throw new ValidationException(
                     String.format(
-                            "The specified max thrift worker thread number is %s, which is not larger than 0.",
+                            "The specified max thrift worker thread number is %s, which should be larger than 0.",
                             configuration.get(THRIFT_WORKER_THREADS_MAX)));
         }
         if (configuration.get(THRIFT_LOGIN_TIMEOUT).toMillis() > Integer.MAX_VALUE

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/endpoint/hive/HiveServer2EndpointFactory.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/endpoint/hive/HiveServer2EndpointFactory.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.endpoint.hive;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.gateway.api.endpoint.SqlGatewayEndpoint;
+import org.apache.flink.table.gateway.api.endpoint.SqlGatewayEndpointFactory;
+import org.apache.flink.table.gateway.api.endpoint.SqlGatewayEndpointFactoryUtils;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.apache.flink.table.endpoint.hive.HiveServer2EndpointConfigOptions.CATALOG_DEFAULT_DATABASE;
+import static org.apache.flink.table.endpoint.hive.HiveServer2EndpointConfigOptions.CATALOG_HIVE_CONF_DIR;
+import static org.apache.flink.table.endpoint.hive.HiveServer2EndpointConfigOptions.CATALOG_NAME;
+import static org.apache.flink.table.endpoint.hive.HiveServer2EndpointConfigOptions.MODULE_NAME;
+import static org.apache.flink.table.endpoint.hive.HiveServer2EndpointConfigOptions.THRIFT_LOGIN_BEBACKOFF_SLOT_LENGTH;
+import static org.apache.flink.table.endpoint.hive.HiveServer2EndpointConfigOptions.THRIFT_LOGIN_TIMEOUT;
+import static org.apache.flink.table.endpoint.hive.HiveServer2EndpointConfigOptions.THRIFT_MAX_MESSAGE_SIZE;
+import static org.apache.flink.table.endpoint.hive.HiveServer2EndpointConfigOptions.THRIFT_PORT;
+import static org.apache.flink.table.endpoint.hive.HiveServer2EndpointConfigOptions.THRIFT_WORKER_KEEPALIVE_TIME;
+import static org.apache.flink.table.endpoint.hive.HiveServer2EndpointConfigOptions.THRIFT_WORKER_THREADS_MAX;
+import static org.apache.flink.table.endpoint.hive.HiveServer2EndpointConfigOptions.THRIFT_WORKER_THREADS_MIN;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** Endpoint Factory to create {@code HiveServer2Endpoint}. */
+public class HiveServer2EndpointFactory implements SqlGatewayEndpointFactory {
+
+    static final String IDENTIFIER = "hiveserver2";
+
+    @Override
+    public SqlGatewayEndpoint createSqlGatewayEndpoint(Context context) {
+        SqlGatewayEndpointFactoryUtils.EndpointFactoryHelper helper =
+                SqlGatewayEndpointFactoryUtils.createEndpointFactoryHelper(this, context);
+        ReadableConfig configuration = helper.getOptions();
+        validate(configuration);
+        return new HiveServer2Endpoint(
+                context.getSqlGatewayService(),
+                configuration.get(THRIFT_PORT),
+                checkNotNull(configuration.get(THRIFT_MAX_MESSAGE_SIZE)),
+                (int) configuration.get(THRIFT_LOGIN_TIMEOUT).toMillis(),
+                (int) configuration.get(THRIFT_LOGIN_BEBACKOFF_SLOT_LENGTH).toMillis(),
+                configuration.get(THRIFT_WORKER_THREADS_MIN),
+                configuration.get(THRIFT_WORKER_THREADS_MAX),
+                configuration.get(THRIFT_WORKER_KEEPALIVE_TIME),
+                configuration.get(CATALOG_NAME),
+                configuration.get(CATALOG_HIVE_CONF_DIR),
+                configuration.get(CATALOG_DEFAULT_DATABASE),
+                configuration.get(MODULE_NAME));
+    }
+
+    @Override
+    public String factoryIdentifier() {
+        return IDENTIFIER;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> requiredOptions() {
+        return new HashSet<>(
+                Arrays.asList(
+                        THRIFT_PORT,
+                        THRIFT_MAX_MESSAGE_SIZE,
+                        THRIFT_LOGIN_TIMEOUT,
+                        THRIFT_WORKER_THREADS_MIN,
+                        THRIFT_WORKER_THREADS_MAX,
+                        THRIFT_WORKER_KEEPALIVE_TIME,
+                        CATALOG_NAME,
+                        MODULE_NAME));
+    }
+
+    @Override
+    public Set<ConfigOption<?>> optionalOptions() {
+        return new HashSet<>(Arrays.asList(CATALOG_HIVE_CONF_DIR, CATALOG_DEFAULT_DATABASE));
+    }
+
+    private static void validate(ReadableConfig configuration) {
+        int port = configuration.get(THRIFT_PORT);
+        if (port < 0 || port > 65535) {
+            throw new ValidationException(
+                    String.format(
+                            "The specified port is %s, which should range from 0 to 65535.", port));
+        }
+        if (configuration.get(THRIFT_WORKER_THREADS_MIN) <= 0) {
+            throw new ValidationException(
+                    String.format(
+                            "The specified min thrift worker thread number is %s, which is not larger than 0.",
+                            configuration.get(THRIFT_WORKER_THREADS_MIN)));
+        }
+        if (configuration.get(THRIFT_WORKER_THREADS_MAX) <= 0) {
+            throw new ValidationException(
+                    String.format(
+                            "The specified max thrift worker thread number is %s, which is not larger than 0.",
+                            configuration.get(THRIFT_WORKER_THREADS_MAX)));
+        }
+        if (configuration.get(THRIFT_LOGIN_TIMEOUT).toMillis() > Integer.MAX_VALUE
+                || configuration.get(THRIFT_LOGIN_TIMEOUT).toMillis() < 0) {
+            throw new ValidationException(
+                    String.format(
+                            "The specified login timeout should range from 0 ms to %s ms but the specified value is %s ms.",
+                            Integer.MAX_VALUE, configuration.get(THRIFT_LOGIN_TIMEOUT).toMillis()));
+        }
+        if (configuration.get(THRIFT_LOGIN_BEBACKOFF_SLOT_LENGTH).toMillis() > Integer.MAX_VALUE
+                || configuration.get(THRIFT_LOGIN_BEBACKOFF_SLOT_LENGTH).toMillis() < 0) {
+            throw new ValidationException(
+                    String.format(
+                            "The specified binary exponential backoff slot time should range from 0 ms to %s ms but the specified value is %s ms.",
+                            Integer.MAX_VALUE,
+                            configuration.get(THRIFT_LOGIN_BEBACKOFF_SLOT_LENGTH).toMillis()));
+        }
+    }
+}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/endpoint/hive/HiveServer2EndpointVersion.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/endpoint/hive/HiveServer2EndpointVersion.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.endpoint.hive;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.gateway.api.endpoint.EndpointVersion;
+
+import org.apache.hive.service.rpc.thrift.TProtocolVersion;
+
+/** Mapping between {@link HiveServer2EndpointVersion} and {@link TProtocolVersion} in Hive. */
+@PublicEvolving
+public enum HiveServer2EndpointVersion implements EndpointVersion {
+    HIVE_CLI_SERVICE_PROTOCOL_V1(TProtocolVersion.HIVE_CLI_SERVICE_PROTOCOL_V1),
+
+    HIVE_CLI_SERVICE_PROTOCOL_V2(TProtocolVersion.HIVE_CLI_SERVICE_PROTOCOL_V2),
+
+    HIVE_CLI_SERVICE_PROTOCOL_V3(TProtocolVersion.HIVE_CLI_SERVICE_PROTOCOL_V3),
+
+    HIVE_CLI_SERVICE_PROTOCOL_V4(TProtocolVersion.HIVE_CLI_SERVICE_PROTOCOL_V4),
+
+    HIVE_CLI_SERVICE_PROTOCOL_V5(TProtocolVersion.HIVE_CLI_SERVICE_PROTOCOL_V5),
+
+    HIVE_CLI_SERVICE_PROTOCOL_V6(TProtocolVersion.HIVE_CLI_SERVICE_PROTOCOL_V6),
+
+    HIVE_CLI_SERVICE_PROTOCOL_V7(TProtocolVersion.HIVE_CLI_SERVICE_PROTOCOL_V7),
+
+    HIVE_CLI_SERVICE_PROTOCOL_V8(TProtocolVersion.HIVE_CLI_SERVICE_PROTOCOL_V8),
+
+    HIVE_CLI_SERVICE_PROTOCOL_V9(TProtocolVersion.HIVE_CLI_SERVICE_PROTOCOL_V9),
+
+    HIVE_CLI_SERVICE_PROTOCOL_V10(TProtocolVersion.HIVE_CLI_SERVICE_PROTOCOL_V10);
+
+    private final TProtocolVersion version;
+
+    HiveServer2EndpointVersion(TProtocolVersion version) {
+        this.version = version;
+    }
+
+    public TProtocolVersion getVersion() {
+        return version;
+    }
+
+    public static HiveServer2EndpointVersion valueOf(TProtocolVersion version) {
+        switch (version) {
+            case HIVE_CLI_SERVICE_PROTOCOL_V1:
+                return HIVE_CLI_SERVICE_PROTOCOL_V1;
+            case HIVE_CLI_SERVICE_PROTOCOL_V2:
+                return HIVE_CLI_SERVICE_PROTOCOL_V2;
+            case HIVE_CLI_SERVICE_PROTOCOL_V3:
+                return HIVE_CLI_SERVICE_PROTOCOL_V3;
+            case HIVE_CLI_SERVICE_PROTOCOL_V4:
+                return HIVE_CLI_SERVICE_PROTOCOL_V4;
+            case HIVE_CLI_SERVICE_PROTOCOL_V5:
+                return HIVE_CLI_SERVICE_PROTOCOL_V5;
+            case HIVE_CLI_SERVICE_PROTOCOL_V6:
+                return HIVE_CLI_SERVICE_PROTOCOL_V6;
+            case HIVE_CLI_SERVICE_PROTOCOL_V7:
+                return HIVE_CLI_SERVICE_PROTOCOL_V7;
+            case HIVE_CLI_SERVICE_PROTOCOL_V8:
+                return HIVE_CLI_SERVICE_PROTOCOL_V8;
+            case HIVE_CLI_SERVICE_PROTOCOL_V9:
+                return HIVE_CLI_SERVICE_PROTOCOL_V9;
+            case HIVE_CLI_SERVICE_PROTOCOL_V10:
+                return HIVE_CLI_SERVICE_PROTOCOL_V10;
+            default:
+                throw new IllegalArgumentException(
+                        String.format("Unknown TProtocolVersion: %s.", version));
+        }
+    }
+}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/endpoint/hive/HiveServer2EndpointVersion.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/endpoint/hive/HiveServer2EndpointVersion.java
@@ -18,13 +18,11 @@
 
 package org.apache.flink.table.endpoint.hive;
 
-import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.table.gateway.api.endpoint.EndpointVersion;
 
 import org.apache.hive.service.rpc.thrift.TProtocolVersion;
 
 /** Mapping between {@link HiveServer2EndpointVersion} and {@link TProtocolVersion} in Hive. */
-@PublicEvolving
 public enum HiveServer2EndpointVersion implements EndpointVersion {
     HIVE_CLI_SERVICE_PROTOCOL_V1(TProtocolVersion.HIVE_CLI_SERVICE_PROTOCOL_V1),
 

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/endpoint/hive/util/HiveJdbcParameterUtils.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/endpoint/hive/util/HiveJdbcParameterUtils.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.endpoint.hive.util;
+
+import org.apache.flink.table.api.ValidationException;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Utils to normalize and validate hive jdbc conf.
+ *
+ * <p>Hive JDBC allows users to configure the session during the open session by setting values in
+ * its jdbc URL. The syntax is
+ *
+ * <pre>
+ *     jdbc:hive2://host1:port1,host2:port2/dbName;initFile=file;sess_var_list?hive_conf_list#hive_var_list
+ * </pre>
+ *
+ * <p>For different parts in the URL, {@code HiveConnection} encodes different parts with different
+ * prefix and store them into the configuration.
+ */
+public class HiveJdbcParameterUtils {
+
+    private static final String SET_PREFIX = "set:";
+    private static final String ENV_PREFIX = "env:";
+    private static final String SYSTEM_PREFIX = "system:";
+    private static final String HIVECONF_PREFIX = "hiveconf:";
+    private static final String HIVEVAR_PREFIX = "hivevar:";
+    private static final String METACONF_PREFIX = "metaconf:";
+
+    private static final String USE_PREFIX = "use:";
+    private static final String USE_DATABASE = "database";
+
+    public static Map<String, String> validateAndNormalize(Map<String, String> parameters) {
+        Map<String, String> normalized = new HashMap<>();
+        for (Map.Entry<String, String> entry : parameters.entrySet()) {
+            String key = entry.getKey();
+            String normalizedKey = key;
+            if (key.startsWith(SET_PREFIX)) {
+                String newKey = key.substring(SET_PREFIX.length());
+                // TODO: use HiveParserSetProcessor when FLINK-28096 is fix
+                if (newKey.startsWith(ENV_PREFIX)) {
+                    throw new ValidationException(
+                            String.format(
+                                    "Can not set env variables %s during the session connection.",
+                                    key));
+                } else if (newKey.startsWith(SYSTEM_PREFIX)) {
+                    normalizedKey = newKey.substring(SYSTEM_PREFIX.length());
+                } else if (newKey.startsWith(HIVECONF_PREFIX)) {
+                    normalizedKey = newKey.substring(HIVECONF_PREFIX.length());
+                } else if (newKey.startsWith(HIVEVAR_PREFIX)) {
+                    normalizedKey = newKey.substring(HIVEVAR_PREFIX.length());
+                } else if (newKey.startsWith(METACONF_PREFIX)) {
+                    normalizedKey = newKey.substring(METACONF_PREFIX.length());
+                } else {
+                    normalizedKey = newKey;
+                }
+            } else if (key.startsWith(USE_PREFIX)) {
+                // ignore use parameters
+                continue;
+            }
+            normalized.put(normalizedKey, entry.getValue());
+        }
+        return normalized;
+    }
+
+    public static Optional<String> getUsedDefaultDatabase(Map<String, String> parameters) {
+        for (Map.Entry<String, String> entry : parameters.entrySet()) {
+            String key = entry.getKey();
+            if (!key.startsWith(USE_PREFIX)) {
+                // ignore
+                continue;
+            }
+            if (!key.equals(USE_PREFIX + USE_DATABASE)) {
+                throw new ValidationException(String.format("Unknown use parameter: %s.", key));
+            }
+
+            return Optional.of(entry.getValue());
+        }
+        return Optional.empty();
+    }
+}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/endpoint/hive/util/HiveJdbcParameterUtils.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/endpoint/hive/util/HiveJdbcParameterUtils.java
@@ -24,6 +24,12 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
+import static org.apache.hadoop.hive.conf.SystemVariables.ENV_PREFIX;
+import static org.apache.hadoop.hive.conf.SystemVariables.HIVECONF_PREFIX;
+import static org.apache.hadoop.hive.conf.SystemVariables.HIVEVAR_PREFIX;
+import static org.apache.hadoop.hive.conf.SystemVariables.METACONF_PREFIX;
+import static org.apache.hadoop.hive.conf.SystemVariables.SYSTEM_PREFIX;
+
 /**
  * Utils to normalize and validate hive jdbc conf.
  *
@@ -40,12 +46,6 @@ import java.util.Optional;
 public class HiveJdbcParameterUtils {
 
     private static final String SET_PREFIX = "set:";
-    private static final String ENV_PREFIX = "env:";
-    private static final String SYSTEM_PREFIX = "system:";
-    private static final String HIVECONF_PREFIX = "hiveconf:";
-    private static final String HIVEVAR_PREFIX = "hivevar:";
-    private static final String METACONF_PREFIX = "metaconf:";
-
     private static final String USE_PREFIX = "use:";
     private static final String USE_DATABASE = "database";
 
@@ -56,7 +56,7 @@ public class HiveJdbcParameterUtils {
             String normalizedKey = key;
             if (key.startsWith(SET_PREFIX)) {
                 String newKey = key.substring(SET_PREFIX.length());
-                // TODO: use HiveParserSetProcessor when FLINK-28096 is fix
+                // TODO: use HiveParserSetProcessor when FLINK-28096 is fixed
                 if (newKey.startsWith(ENV_PREFIX)) {
                     throw new ValidationException(
                             String.format(

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/endpoint/hive/util/ThriftObjectConversions.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/endpoint/hive/util/ThriftObjectConversions.java
@@ -20,7 +20,6 @@ package org.apache.flink.table.endpoint.hive.util;
 
 import org.apache.flink.table.gateway.api.HandleIdentifier;
 import org.apache.flink.table.gateway.api.session.SessionHandle;
-import org.apache.flink.util.ExceptionUtils;
 
 import org.apache.hive.service.rpc.thrift.THandleIdentifier;
 import org.apache.hive.service.rpc.thrift.TSessionHandle;
@@ -45,8 +44,7 @@ public class ThriftObjectConversions {
 
     public static TStatus toTStatus(Throwable t) {
         TStatus tStatus = new TStatus(TStatusCode.ERROR_STATUS);
-        String errMsg = ExceptionUtils.stringifyException(t);
-        tStatus.setErrorMessage(errMsg);
+        tStatus.setErrorMessage(t.getMessage());
         tStatus.setInfoMessages(toString(t));
         return tStatus;
     }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/endpoint/hive/util/ThriftObjectConversions.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/endpoint/hive/util/ThriftObjectConversions.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.endpoint.hive.util;
+
+import org.apache.flink.table.gateway.api.HandleIdentifier;
+import org.apache.flink.table.gateway.api.session.SessionHandle;
+import org.apache.flink.util.ExceptionUtils;
+
+import org.apache.hive.service.rpc.thrift.THandleIdentifier;
+import org.apache.hive.service.rpc.thrift.TSessionHandle;
+import org.apache.hive.service.rpc.thrift.TStatus;
+import org.apache.hive.service.rpc.thrift.TStatusCode;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/** Conversion between thrift object and flink object. */
+public class ThriftObjectConversions {
+
+    public static TSessionHandle toTSessionHandle(SessionHandle sessionHandle) {
+        return new TSessionHandle(toTHandleIdentifier(sessionHandle.getIdentifier()));
+    }
+
+    public static SessionHandle toSessionHandle(TSessionHandle tSessionHandle) {
+        return new SessionHandle(toHandleIdentifier(tSessionHandle.getSessionId()));
+    }
+
+    public static TStatus toTStatus(Throwable t) {
+        TStatus tStatus = new TStatus(TStatusCode.ERROR_STATUS);
+        String errMsg = ExceptionUtils.stringifyException(t);
+        tStatus.setErrorMessage(errMsg);
+        tStatus.setInfoMessages(toString(t));
+        return tStatus;
+    }
+
+    // --------------------------------------------------------------------------------------------
+
+    private static THandleIdentifier toTHandleIdentifier(HandleIdentifier identifier) {
+        byte[] guid = new byte[16];
+        byte[] secret = new byte[16];
+        ByteBuffer guidBB = ByteBuffer.wrap(guid);
+        ByteBuffer secretBB = ByteBuffer.wrap(secret);
+
+        guidBB.putLong(identifier.getPublicId().getMostSignificantBits());
+        guidBB.putLong(identifier.getPublicId().getLeastSignificantBits());
+        secretBB.putLong(identifier.getSecretId().getMostSignificantBits());
+        secretBB.putLong(identifier.getSecretId().getLeastSignificantBits());
+        return new THandleIdentifier(ByteBuffer.wrap(guid), ByteBuffer.wrap(secret));
+    }
+
+    private static HandleIdentifier toHandleIdentifier(THandleIdentifier tHandleId) {
+        ByteBuffer bb = ByteBuffer.wrap(tHandleId.getGuid());
+        UUID publicId = new UUID(bb.getLong(), bb.getLong());
+        bb = ByteBuffer.wrap(tHandleId.getSecret());
+        UUID secretId = new UUID(bb.getLong(), bb.getLong());
+        return new HandleIdentifier(publicId, secretId);
+    }
+
+    /**
+     * Converts a {@link Throwable} object into a flattened list of texts including its stack trace
+     * and the stack traces of the nested causes.
+     *
+     * @param ex a {@link Throwable} object
+     * @return a flattened list of texts including the {@link Throwable} object's stack trace and
+     *     the stack traces of the nested causes.
+     */
+    private static List<String> toString(Throwable ex) {
+        return toString(ex, null);
+    }
+
+    private static List<String> toString(Throwable cause, StackTraceElement[] parent) {
+        StackTraceElement[] trace = cause.getStackTrace();
+        int m = trace.length - 1;
+        if (parent != null) {
+            int n = parent.length - 1;
+            while (m >= 0 && n >= 0 && trace[m].equals(parent[n])) {
+                m--;
+                n--;
+            }
+        }
+        List<String> detail = enroll(cause, trace, m);
+        cause = cause.getCause();
+        if (cause != null) {
+            detail.addAll(toString(cause, trace));
+        }
+        return detail;
+    }
+
+    private static List<String> enroll(Throwable ex, StackTraceElement[] trace, int max) {
+        List<String> details = new ArrayList<String>();
+        StringBuilder builder = new StringBuilder();
+        builder.append('*').append(ex.getClass().getName()).append(':');
+        builder.append(ex.getMessage()).append(':');
+        builder.append(trace.length).append(':').append(max);
+        details.add(builder.toString());
+        for (int i = 0; i <= max; i++) {
+            builder.setLength(0);
+            builder.append(trace[i].getClassName()).append(':');
+            builder.append(trace[i].getMethodName()).append(':');
+            String fileName = trace[i].getFileName();
+            builder.append(fileName == null ? "" : fileName).append(':');
+            builder.append(trace[i].getLineNumber());
+            details.add(builder.toString());
+        }
+        return details;
+    }
+}

--- a/flink-connectors/flink-connector-hive/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/flink-connectors/flink-connector-hive/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -16,3 +16,4 @@
 org.apache.flink.table.catalog.hive.factories.HiveCatalogFactory
 org.apache.flink.table.module.hive.HiveModuleFactory
 org.apache.flink.table.planner.delegation.hive.HiveParserFactory
+org.apache.flink.table.endpoint.hive.HiveServer2EndpointFactory

--- a/flink-connectors/flink-connector-hive/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/flink-connectors/flink-connector-hive/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -14,6 +14,6 @@
 # limitations under the License.
 
 org.apache.flink.table.catalog.hive.factories.HiveCatalogFactory
+org.apache.flink.table.endpoint.hive.HiveServer2EndpointFactory
 org.apache.flink.table.module.hive.HiveModuleFactory
 org.apache.flink.table.planner.delegation.hive.HiveParserFactory
-org.apache.flink.table.endpoint.hive.HiveServer2EndpointFactory

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveTestUtils.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveTestUtils.java
@@ -44,8 +44,10 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.BufferedWriter;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.net.BindException;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
@@ -127,6 +129,15 @@ public class HiveTestUtils {
         } catch (IOException e) {
             throw new CatalogException("Failed to create test HiveConf to HiveCatalog.", e);
         }
+    }
+
+    public static File createHiveSite() throws Exception {
+        HiveConf conf = createHiveConf();
+        File site = TEMPORARY_FOLDER.newFile("hive-site.xml");
+        try (OutputStream out = new FileOutputStream(site)) {
+            conf.writeXml(out);
+        }
+        return site;
     }
 
     // Gets a free port of localhost. Note that this method suffers the "time of check to time of

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/endpoint/hive/HiveServer2EndpointFactoryTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/endpoint/hive/HiveServer2EndpointFactoryTest.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.endpoint.hive;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.testutils.FlinkAssertions;
+import org.apache.flink.table.gateway.api.endpoint.SqlGatewayEndpointFactoryUtils;
+import org.apache.flink.table.gateway.api.utils.MockedSqlGatewayService;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import static org.apache.flink.table.endpoint.hive.HiveServer2EndpointConfigOptions.CATALOG_DEFAULT_DATABASE;
+import static org.apache.flink.table.endpoint.hive.HiveServer2EndpointConfigOptions.CATALOG_HIVE_CONF_DIR;
+import static org.apache.flink.table.endpoint.hive.HiveServer2EndpointConfigOptions.CATALOG_NAME;
+import static org.apache.flink.table.endpoint.hive.HiveServer2EndpointConfigOptions.MODULE_NAME;
+import static org.apache.flink.table.endpoint.hive.HiveServer2EndpointConfigOptions.THRIFT_LOGIN_BEBACKOFF_SLOT_LENGTH;
+import static org.apache.flink.table.endpoint.hive.HiveServer2EndpointConfigOptions.THRIFT_LOGIN_TIMEOUT;
+import static org.apache.flink.table.endpoint.hive.HiveServer2EndpointConfigOptions.THRIFT_MAX_MESSAGE_SIZE;
+import static org.apache.flink.table.endpoint.hive.HiveServer2EndpointConfigOptions.THRIFT_PORT;
+import static org.apache.flink.table.endpoint.hive.HiveServer2EndpointConfigOptions.THRIFT_WORKER_KEEPALIVE_TIME;
+import static org.apache.flink.table.endpoint.hive.HiveServer2EndpointConfigOptions.THRIFT_WORKER_THREADS_MAX;
+import static org.apache.flink.table.endpoint.hive.HiveServer2EndpointConfigOptions.THRIFT_WORKER_THREADS_MIN;
+import static org.apache.flink.table.endpoint.hive.HiveServer2EndpointFactory.IDENTIFIER;
+import static org.apache.flink.table.gateway.api.endpoint.SqlGatewayEndpointFactoryUtils.GATEWAY_ENDPOINT_PREFIX;
+import static org.apache.flink.table.gateway.api.endpoint.SqlGatewayEndpointFactoryUtils.SQL_GATEWAY_ENDPOINT_TYPE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** Test for {@link HiveServer2EndpointFactory}. */
+class HiveServer2EndpointFactoryTest {
+
+    private final MockedSqlGatewayService service = new MockedSqlGatewayService();
+
+    private final int port = 9091;
+    private final int minWorkerThreads = 100;
+    private final int maxWorkerThreads = 200;
+    private final Duration workerAliveDuration = Duration.ofSeconds(10);
+    private final long maxMessageSize = 1024L;
+    private final Duration loginTimeout = Duration.ofSeconds(10);
+    private final Duration backOffSlotLength = Duration.ofMillis(300);
+
+    private final String catalogName = "test-hive";
+    private final String hiveConfPath = "/path/to/conf";
+    private final String defaultDatabase = "test-db";
+    private final String moduleName = "test-module";
+
+    @Test
+    public void testCreateHiveServer2Endpoint() {
+        assertEquals(
+                Collections.singletonList(
+                        new HiveServer2Endpoint(
+                                service,
+                                port,
+                                maxMessageSize,
+                                (int) loginTimeout.toMillis(),
+                                (int) backOffSlotLength.toMillis(),
+                                minWorkerThreads,
+                                maxWorkerThreads,
+                                workerAliveDuration,
+                                catalogName,
+                                hiveConfPath,
+                                defaultDatabase,
+                                moduleName)),
+                SqlGatewayEndpointFactoryUtils.createSqlGatewayEndpoint(
+                        service, Configuration.fromMap(getDefaultConfig())));
+    }
+
+    @Test
+    public void testCreateHiveServer2EndpointWithIllegalArgument() {
+        List<TestSpec<?>> specs =
+                Arrays.asList(
+                        new TestSpec<>(
+                                THRIFT_WORKER_THREADS_MIN,
+                                -1,
+                                "The specified min thrift worker thread number is -1, which is not larger than 0."),
+                        new TestSpec<>(
+                                THRIFT_WORKER_THREADS_MAX,
+                                0,
+                                "The specified max thrift worker thread number is 0, which is not larger than 0."),
+                        new TestSpec<>(
+                                THRIFT_PORT,
+                                1008668001,
+                                "The specified port is 1008668001, which should range from 0 to 65535."),
+                        new TestSpec<>(
+                                THRIFT_LOGIN_TIMEOUT,
+                                "9223372036854775807 ms",
+                                "The specified login timeout should range from 0 ms to 2147483647 ms but the specified value is 9223372036854775807 ms."),
+                        new TestSpec<>(
+                                THRIFT_LOGIN_BEBACKOFF_SLOT_LENGTH,
+                                "9223372036854775807 ms",
+                                "The specified binary exponential backoff slot time should range from 0 ms to 2147483647 ms but the specified value is 9223372036854775807 ms."));
+
+        for (TestSpec<?> spec : specs) {
+            Assertions.assertThatThrownBy(
+                            () ->
+                                    SqlGatewayEndpointFactoryUtils.createSqlGatewayEndpoint(
+                                            service,
+                                            Configuration.fromMap(
+                                                    getModifiedConfig(
+                                                            config ->
+                                                                    setEndpointOption(
+                                                                            config,
+                                                                            spec.option,
+                                                                            spec.value)))))
+                    .satisfies(FlinkAssertions.anyCauseMatches(spec.exceptionMessage));
+        }
+    }
+
+    // --------------------------------------------------------------------------------------------
+
+    private static class TestSpec<T> {
+
+        private final ConfigOption<?> option;
+        private final T value;
+        private final String exceptionMessage;
+
+        public TestSpec(ConfigOption<?> option, T value, String exceptionMessage) {
+            this.option = option;
+            this.value = value;
+            this.exceptionMessage = exceptionMessage;
+        }
+    }
+
+    private Map<String, String> getModifiedConfig(Consumer<Map<String, String>> consumer) {
+        Map<String, String> config = getDefaultConfig();
+        consumer.accept(config);
+        return config;
+    }
+
+    private Map<String, String> getDefaultConfig() {
+        Map<String, String> config = new HashMap<>();
+
+        config.put(SQL_GATEWAY_ENDPOINT_TYPE.key(), IDENTIFIER);
+
+        setEndpointOption(config, THRIFT_PORT, port);
+        setEndpointOption(config, THRIFT_WORKER_THREADS_MIN, minWorkerThreads);
+        setEndpointOption(config, THRIFT_WORKER_THREADS_MAX, maxWorkerThreads);
+        setEndpointOption(config, THRIFT_LOGIN_BEBACKOFF_SLOT_LENGTH, "300ms");
+        setEndpointOption(config, THRIFT_WORKER_KEEPALIVE_TIME, "10s");
+        setEndpointOption(config, THRIFT_MAX_MESSAGE_SIZE, maxMessageSize);
+        setEndpointOption(config, THRIFT_LOGIN_TIMEOUT, "10s");
+
+        setEndpointOption(config, CATALOG_NAME, catalogName);
+        setEndpointOption(config, CATALOG_HIVE_CONF_DIR, hiveConfPath);
+        setEndpointOption(config, CATALOG_DEFAULT_DATABASE, defaultDatabase);
+
+        setEndpointOption(config, MODULE_NAME, moduleName);
+        return config;
+    }
+
+    private <T> void setEndpointOption(
+            Map<String, String> config, ConfigOption<?> option, T value) {
+        String prefix = String.format("%s.%s.", GATEWAY_ENDPOINT_PREFIX, IDENTIFIER);
+        config.put(prefix + option.key(), String.valueOf(value));
+    }
+}

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/endpoint/hive/HiveServer2EndpointFactoryTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/endpoint/hive/HiveServer2EndpointFactoryTest.java
@@ -97,11 +97,11 @@ class HiveServer2EndpointFactoryTest {
                         new TestSpec<>(
                                 THRIFT_WORKER_THREADS_MIN,
                                 -1,
-                                "The specified min thrift worker thread number is -1, which is not larger than 0."),
+                                "The specified min thrift worker thread number is -1, which should be larger than 0."),
                         new TestSpec<>(
                                 THRIFT_WORKER_THREADS_MAX,
                                 0,
-                                "The specified max thrift worker thread number is 0, which is not larger than 0."),
+                                "The specified max thrift worker thread number is 0, which should be larger than 0."),
                         new TestSpec<>(
                                 THRIFT_PORT,
                                 1008668001,

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/endpoint/hive/HiveServer2EndpointFactoryTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/endpoint/hive/HiveServer2EndpointFactoryTest.java
@@ -24,7 +24,6 @@ import org.apache.flink.core.testutils.FlinkAssertions;
 import org.apache.flink.table.gateway.api.endpoint.SqlGatewayEndpointFactoryUtils;
 import org.apache.flink.table.gateway.api.utils.MockedSqlGatewayService;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
@@ -49,7 +48,8 @@ import static org.apache.flink.table.endpoint.hive.HiveServer2EndpointConfigOpti
 import static org.apache.flink.table.endpoint.hive.HiveServer2EndpointFactory.IDENTIFIER;
 import static org.apache.flink.table.factories.FactoryUtil.SQL_GATEWAY_ENDPOINT_TYPE;
 import static org.apache.flink.table.gateway.api.endpoint.SqlGatewayEndpointFactoryUtils.GATEWAY_ENDPOINT_PREFIX;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test for {@link HiveServer2EndpointFactory}. */
 class HiveServer2EndpointFactoryTest {
@@ -71,23 +71,24 @@ class HiveServer2EndpointFactoryTest {
 
     @Test
     public void testCreateHiveServer2Endpoint() {
-        assertEquals(
-                Collections.singletonList(
-                        new HiveServer2Endpoint(
-                                service,
-                                port,
-                                maxMessageSize,
-                                (int) loginTimeout.toMillis(),
-                                (int) backOffSlotLength.toMillis(),
-                                minWorkerThreads,
-                                maxWorkerThreads,
-                                workerAliveDuration,
-                                catalogName,
-                                hiveConfPath,
-                                defaultDatabase,
-                                moduleName)),
-                SqlGatewayEndpointFactoryUtils.createSqlGatewayEndpoint(
-                        service, Configuration.fromMap(getDefaultConfig())));
+        assertThat(
+                        SqlGatewayEndpointFactoryUtils.createSqlGatewayEndpoint(
+                                service, Configuration.fromMap(getDefaultConfig())))
+                .isEqualTo(
+                        Collections.singletonList(
+                                new HiveServer2Endpoint(
+                                        service,
+                                        port,
+                                        maxMessageSize,
+                                        (int) loginTimeout.toMillis(),
+                                        (int) backOffSlotLength.toMillis(),
+                                        minWorkerThreads,
+                                        maxWorkerThreads,
+                                        workerAliveDuration,
+                                        catalogName,
+                                        hiveConfPath,
+                                        defaultDatabase,
+                                        moduleName)));
     }
 
     @Test
@@ -116,7 +117,7 @@ class HiveServer2EndpointFactoryTest {
                                 "The specified binary exponential backoff slot time should range from 0 ms to 2147483647 ms but the specified value is 9223372036854775807 ms."));
 
         for (TestSpec<?> spec : specs) {
-            Assertions.assertThatThrownBy(
+            assertThatThrownBy(
                             () ->
                                     SqlGatewayEndpointFactoryUtils.createSqlGatewayEndpoint(
                                             service,

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/endpoint/hive/HiveServer2EndpointFactoryTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/endpoint/hive/HiveServer2EndpointFactoryTest.java
@@ -47,8 +47,8 @@ import static org.apache.flink.table.endpoint.hive.HiveServer2EndpointConfigOpti
 import static org.apache.flink.table.endpoint.hive.HiveServer2EndpointConfigOptions.THRIFT_WORKER_THREADS_MAX;
 import static org.apache.flink.table.endpoint.hive.HiveServer2EndpointConfigOptions.THRIFT_WORKER_THREADS_MIN;
 import static org.apache.flink.table.endpoint.hive.HiveServer2EndpointFactory.IDENTIFIER;
+import static org.apache.flink.table.factories.FactoryUtil.SQL_GATEWAY_ENDPOINT_TYPE;
 import static org.apache.flink.table.gateway.api.endpoint.SqlGatewayEndpointFactoryUtils.GATEWAY_ENDPOINT_PREFIX;
-import static org.apache.flink.table.gateway.api.endpoint.SqlGatewayEndpointFactoryUtils.SQL_GATEWAY_ENDPOINT_TYPE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /** Test for {@link HiveServer2EndpointFactory}. */

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/endpoint/hive/HiveServer2EndpointITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/endpoint/hive/HiveServer2EndpointITCase.java
@@ -1,0 +1,120 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.flink.table.endpoint.hive;
+
+import org.apache.flink.table.api.SqlDialect;
+import org.apache.flink.table.api.config.TableConfigOptions;
+import org.apache.flink.table.endpoint.hive.util.HiveServer2EndpointExtension;
+import org.apache.flink.table.endpoint.hive.util.ThriftObjectConversions;
+import org.apache.flink.table.gateway.api.session.SessionHandle;
+import org.apache.flink.table.gateway.service.session.SessionManager;
+import org.apache.flink.table.gateway.service.utils.SqlGatewayServiceExtension;
+
+import org.apache.hadoop.hive.common.auth.HiveAuthUtils;
+import org.apache.hive.service.rpc.thrift.TCLIService;
+import org.apache.hive.service.rpc.thrift.TCloseSessionReq;
+import org.apache.hive.service.rpc.thrift.TCloseSessionResp;
+import org.apache.hive.service.rpc.thrift.TOpenSessionReq;
+import org.apache.hive.service.rpc.thrift.TOpenSessionResp;
+import org.apache.hive.service.rpc.thrift.TStatusCode;
+import org.apache.thrift.protocol.TBinaryProtocol;
+import org.apache.thrift.transport.TTransport;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.util.AbstractMap;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** ITCase for {@link HiveServer2Endpoint}. */
+public class HiveServer2EndpointITCase {
+
+    @RegisterExtension
+    @Order(1)
+    public static final SqlGatewayServiceExtension SQL_GATEWAY_SERVICE_EXTENSION =
+            new SqlGatewayServiceExtension();
+
+    @RegisterExtension
+    @Order(2)
+    public static final HiveServer2EndpointExtension ENDPOINT_EXTENSION =
+            new HiveServer2EndpointExtension(SQL_GATEWAY_SERVICE_EXTENSION::getService);
+
+    @Test
+    public void testOpenCloseJdbcConnection() throws Exception {
+        SessionManager sessionManager = SQL_GATEWAY_SERVICE_EXTENSION.getSessionManager();
+        int originSessionCount = sessionManager.currentSessionCount();
+        try (Connection ignore = getConnection()) {
+            assertEquals(1 + originSessionCount, sessionManager.currentSessionCount());
+        }
+        assertEquals(originSessionCount, sessionManager.currentSessionCount());
+    }
+
+    @Test
+    public void testOpenSessionWithConfig() throws Exception {
+        TCLIService.Client client = createClient();
+        TOpenSessionReq openSessionReq = new TOpenSessionReq();
+        TOpenSessionResp openSessionResp = client.OpenSession(openSessionReq);
+        SessionHandle sessionHandle =
+                ThriftObjectConversions.toSessionHandle(openSessionResp.getSessionHandle());
+
+        Map<String, String> actualConfig =
+                SQL_GATEWAY_SERVICE_EXTENSION.getService().getSessionConfig(sessionHandle);
+        assertThat(
+                actualConfig.entrySet(),
+                hasItem(
+                        new AbstractMap.SimpleEntry<>(
+                                TableConfigOptions.TABLE_SQL_DIALECT.key(),
+                                SqlDialect.HIVE.name())));
+    }
+
+    @Test
+    public void testGetException() throws Exception {
+        TCLIService.Client client = createClient();
+        TCloseSessionReq closeSessionReq = new TCloseSessionReq();
+        SessionHandle sessionHandle = SessionHandle.create();
+        closeSessionReq.setSessionHandle(ThriftObjectConversions.toTSessionHandle(sessionHandle));
+        TCloseSessionResp resp = client.CloseSession(closeSessionReq);
+        assertEquals(TStatusCode.ERROR_STATUS, resp.getStatus().getStatusCode());
+        assertTrue(
+                resp.getStatus()
+                        .getErrorMessage()
+                        .contains(String.format("Session '%s' does not exist", sessionHandle)));
+    }
+
+    private Connection getConnection() throws Exception {
+        return DriverManager.getConnection(
+                String.format(
+                        "jdbc:hive2://localhost:%s/default;auth=noSasl",
+                        ENDPOINT_EXTENSION.getPort()));
+    }
+
+    private TCLIService.Client createClient() throws Exception {
+        TTransport transport =
+                HiveAuthUtils.getSocketTransport("localhost", ENDPOINT_EXTENSION.getPort(), 0);
+        transport.open();
+        return new TCLIService.Client(new TBinaryProtocol(transport));
+    }
+}

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/endpoint/hive/HiveServer2EndpointITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/endpoint/hive/HiveServer2EndpointITCase.java
@@ -25,6 +25,8 @@ import org.apache.flink.table.endpoint.hive.util.ThriftObjectConversions;
 import org.apache.flink.table.gateway.api.session.SessionHandle;
 import org.apache.flink.table.gateway.service.session.SessionManager;
 import org.apache.flink.table.gateway.service.utils.SqlGatewayServiceExtension;
+import org.apache.flink.test.junit5.MiniClusterExtension;
+import org.apache.flink.util.TestLogger;
 
 import org.apache.hadoop.hive.common.auth.HiveAuthUtils;
 import org.apache.hive.service.rpc.thrift.TCLIService;
@@ -50,15 +52,19 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** ITCase for {@link HiveServer2Endpoint}. */
-public class HiveServer2EndpointITCase {
+public class HiveServer2EndpointITCase extends TestLogger {
 
     @RegisterExtension
     @Order(1)
-    public static final SqlGatewayServiceExtension SQL_GATEWAY_SERVICE_EXTENSION =
-            new SqlGatewayServiceExtension();
+    public static final MiniClusterExtension MINI_CLUSTER = new MiniClusterExtension();
 
     @RegisterExtension
     @Order(2)
+    public static final SqlGatewayServiceExtension SQL_GATEWAY_SERVICE_EXTENSION =
+            new SqlGatewayServiceExtension(MINI_CLUSTER::getClientConfiguration);
+
+    @RegisterExtension
+    @Order(3)
     public static final HiveServer2EndpointExtension ENDPOINT_EXTENSION =
             new HiveServer2EndpointExtension(SQL_GATEWAY_SERVICE_EXTENSION::getService);
 

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/endpoint/hive/util/HiveServer2EndpointExtension.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/endpoint/hive/util/HiveServer2EndpointExtension.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.endpoint.hive.util;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.catalog.hive.HiveTestUtils;
+import org.apache.flink.table.endpoint.hive.HiveServer2Endpoint;
+import org.apache.flink.table.gateway.api.SqlGatewayService;
+import org.apache.flink.util.NetUtils;
+
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.util.function.Supplier;
+
+import static org.apache.flink.table.endpoint.hive.HiveServer2EndpointConfigOptions.CATALOG_DEFAULT_DATABASE;
+import static org.apache.flink.table.endpoint.hive.HiveServer2EndpointConfigOptions.CATALOG_NAME;
+import static org.apache.flink.table.endpoint.hive.HiveServer2EndpointConfigOptions.MODULE_NAME;
+import static org.apache.flink.table.endpoint.hive.HiveServer2EndpointConfigOptions.THRIFT_LOGIN_BEBACKOFF_SLOT_LENGTH;
+import static org.apache.flink.table.endpoint.hive.HiveServer2EndpointConfigOptions.THRIFT_LOGIN_TIMEOUT;
+import static org.apache.flink.table.endpoint.hive.HiveServer2EndpointConfigOptions.THRIFT_MAX_MESSAGE_SIZE;
+import static org.apache.flink.table.endpoint.hive.HiveServer2EndpointConfigOptions.THRIFT_WORKER_KEEPALIVE_TIME;
+import static org.apache.flink.table.endpoint.hive.HiveServer2EndpointConfigOptions.THRIFT_WORKER_THREADS_MAX;
+import static org.apache.flink.table.endpoint.hive.HiveServer2EndpointConfigOptions.THRIFT_WORKER_THREADS_MIN;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** Extension for HiveServer2 endpoint. */
+public class HiveServer2EndpointExtension implements BeforeAllCallback, AfterAllCallback {
+
+    private final Supplier<SqlGatewayService> serviceSupplier;
+    private final Configuration endpointConfig;
+
+    private NetUtils.Port port;
+    private HiveServer2Endpoint endpoint;
+
+    public HiveServer2EndpointExtension(Supplier<SqlGatewayService> serviceSupplier) {
+        this(serviceSupplier, new Configuration());
+    }
+
+    public HiveServer2EndpointExtension(
+            Supplier<SqlGatewayService> serviceSupplier, Configuration configuration) {
+        this.serviceSupplier = serviceSupplier;
+        this.endpointConfig = configuration;
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext context) throws Exception {
+        port = NetUtils.getAvailablePort();
+
+        endpoint =
+                new HiveServer2Endpoint(
+                        serviceSupplier.get(),
+                        port.getPort(),
+                        checkNotNull(endpointConfig.get(THRIFT_MAX_MESSAGE_SIZE)),
+                        (int) endpointConfig.get(THRIFT_LOGIN_TIMEOUT).toMillis(),
+                        (int) endpointConfig.get(THRIFT_LOGIN_BEBACKOFF_SLOT_LENGTH).toMillis(),
+                        endpointConfig.get(THRIFT_WORKER_THREADS_MIN),
+                        endpointConfig.get(THRIFT_WORKER_THREADS_MAX),
+                        endpointConfig.get(THRIFT_WORKER_KEEPALIVE_TIME),
+                        endpointConfig.get(CATALOG_NAME),
+                        HiveTestUtils.createHiveSite().getParent(),
+                        endpointConfig.get(CATALOG_DEFAULT_DATABASE),
+                        endpointConfig.get(MODULE_NAME),
+                        true);
+        endpoint.start();
+    }
+
+    @Override
+    public void afterAll(ExtensionContext context) throws Exception {
+        if (port != null) {
+            port.close();
+        }
+        if (endpoint != null) {
+            endpoint.stop();
+        }
+    }
+
+    public int getPort() {
+        return checkNotNull(port).getPort();
+    }
+}

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/endpoint/hive/util/ThriftObjectConversionsTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/endpoint/hive/util/ThriftObjectConversionsTest.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.endpoint.hive.util;
+
+import org.apache.flink.table.gateway.api.session.SessionHandle;
+
+import org.junit.jupiter.api.Test;
+
+import static org.apache.flink.table.endpoint.hive.util.ThriftObjectConversions.toSessionHandle;
+import static org.apache.flink.table.endpoint.hive.util.ThriftObjectConversions.toTSessionHandle;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** Test for {@link ThriftObjectConversions}. */
+class ThriftObjectConversionsTest {
+
+    @Test
+    public void testConvertSessionHandle() {
+        SessionHandle originSessionHandle = SessionHandle.create();
+        assertEquals(toSessionHandle(toTSessionHandle(originSessionHandle)), originSessionHandle);
+    }
+}

--- a/flink-core/src/main/java/org/apache/flink/util/FileLock.java
+++ b/flink-core/src/main/java/org/apache/flink/util/FileLock.java
@@ -48,7 +48,7 @@ public class FileLock {
         }
         this.file =
                 path.getParent() == null
-                        ? new File(normalizedFileName)
+                        ? new File(TEMP_DIR, normalizedFileName)
                         : new File(path.getParent().toString(), normalizedFileName);
     }
 

--- a/flink-table/flink-sql-client/pom.xml
+++ b/flink-table/flink-sql-client/pom.xml
@@ -51,6 +51,13 @@ under the License.
 			<version>${project.version}</version>
 		</dependency>
 
+		<!-- SQL Gateway -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-sql-gateway-api</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
 		<!-- CLI for SQL CLI client -->
 		<dependency>
 			<groupId>org.jline</groupId>

--- a/flink-table/flink-sql-gateway-api/src/main/java/org/apache/flink/table/gateway/api/HandleIdentifier.java
+++ b/flink-table/flink-sql-gateway-api/src/main/java/org/apache/flink/table/gateway/api/HandleIdentifier.java
@@ -39,6 +39,10 @@ public class HandleIdentifier {
         return publicId;
     }
 
+    public UUID getSecretId() {
+        return secretId;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/flink-table/flink-sql-gateway-api/src/main/java/org/apache/flink/table/gateway/api/endpoint/SqlGatewayEndpointFactory.java
+++ b/flink-table/flink-sql-gateway-api/src/main/java/org/apache/flink/table/gateway/api/endpoint/SqlGatewayEndpointFactory.java
@@ -41,6 +41,7 @@ public interface SqlGatewayEndpointFactory extends Factory {
     SqlGatewayEndpoint createSqlGatewayEndpoint(Context context);
 
     /** Provides information describing the endpoint to be accessed. */
+    @PublicEvolving
     interface Context {
 
         /** Get the service to execute the request. */

--- a/flink-table/flink-sql-gateway-api/src/main/java/org/apache/flink/table/gateway/api/endpoint/SqlGatewayEndpointFactoryUtils.java
+++ b/flink-table/flink-sql-gateway-api/src/main/java/org/apache/flink/table/gateway/api/endpoint/SqlGatewayEndpointFactoryUtils.java
@@ -41,7 +41,7 @@ import static org.apache.flink.table.factories.FactoryUtil.PROPERTY_VERSION;
 @PublicEvolving
 public class SqlGatewayEndpointFactoryUtils {
 
-    private static final String GATEWAY_ENDPOINT_PREFIX = "sql-gateway.endpoint";
+    public static final String GATEWAY_ENDPOINT_PREFIX = "sql-gateway.endpoint";
 
     public static final ConfigOption<List<String>> SQL_GATEWAY_ENDPOINT_TYPE =
             ConfigOptions.key(String.format("%s.type", GATEWAY_ENDPOINT_PREFIX))

--- a/flink-table/flink-sql-gateway-api/src/main/java/org/apache/flink/table/gateway/api/endpoint/SqlGatewayEndpointFactoryUtils.java
+++ b/flink-table/flink-sql-gateway-api/src/main/java/org/apache/flink/table/gateway/api/endpoint/SqlGatewayEndpointFactoryUtils.java
@@ -19,8 +19,6 @@
 package org.apache.flink.table.gateway.api.endpoint;
 
 import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.configuration.ConfigOption;
-import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.DelegatingConfiguration;
 import org.apache.flink.configuration.ReadableConfig;
@@ -36,19 +34,13 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.apache.flink.table.factories.FactoryUtil.PROPERTY_VERSION;
+import static org.apache.flink.table.factories.FactoryUtil.SQL_GATEWAY_ENDPOINT_TYPE;
 
 /** Util to discover the {@link SqlGatewayEndpoint}. */
 @PublicEvolving
 public class SqlGatewayEndpointFactoryUtils {
 
     public static final String GATEWAY_ENDPOINT_PREFIX = "sql-gateway.endpoint";
-
-    public static final ConfigOption<List<String>> SQL_GATEWAY_ENDPOINT_TYPE =
-            ConfigOptions.key(String.format("%s.type", GATEWAY_ENDPOINT_PREFIX))
-                    .stringType()
-                    .asList()
-                    .noDefaultValue()
-                    .withDescription("Specify the endpoints that are used.");
 
     /**
      * Attempts to discover the appropriate endpoint factory and creates the instance of the
@@ -105,6 +97,7 @@ public class SqlGatewayEndpointFactoryUtils {
      * @see #createEndpointFactoryHelper(SqlGatewayEndpointFactory,
      *     SqlGatewayEndpointFactory.Context)
      */
+    @PublicEvolving
     public static class EndpointFactoryHelper extends FactoryHelper<SqlGatewayEndpointFactory> {
 
         private EndpointFactoryHelper(

--- a/flink-table/flink-sql-gateway-api/src/main/java/org/apache/flink/table/gateway/api/results/ResultSet.java
+++ b/flink-table/flink-sql-gateway-api/src/main/java/org/apache/flink/table/gateway/api/results/ResultSet.java
@@ -135,6 +135,7 @@ public class ResultSet {
     }
 
     /** Describe the kind of the result. */
+    @PublicEvolving
     public enum ResultType {
         /** Indicate the result is not ready. */
         NOT_READY,

--- a/flink-table/flink-sql-gateway-api/src/main/java/org/apache/flink/table/gateway/api/session/SessionEnvironment.java
+++ b/flink-table/flink-sql-gateway-api/src/main/java/org/apache/flink/table/gateway/api/session/SessionEnvironment.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.gateway.api.session;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.Catalog;
 import org.apache.flink.table.gateway.api.endpoint.EndpointVersion;
 import org.apache.flink.table.module.Module;
@@ -161,11 +162,6 @@ public class SessionEnvironment {
             return this;
         }
 
-        public Builder registerCatalog(String catalogName, Catalog catalog) {
-            this.registeredCatalogs.put(catalogName, catalog);
-            return this;
-        }
-
         public Builder setDefaultCatalog(@Nullable String defaultCatalog) {
             this.defaultCatalog = defaultCatalog;
             return this;
@@ -176,7 +172,21 @@ public class SessionEnvironment {
             return this;
         }
 
+        public Builder registerCatalog(String catalogName, Catalog catalog) {
+            if (registeredCatalogs.containsKey(catalogName)) {
+                throw new ValidationException(
+                        String.format("A catalog with name '%s' already exists.", catalogName));
+            }
+            this.registeredCatalogs.put(catalogName, catalog);
+            return this;
+        }
+
         public Builder registerModule(String moduleName, Module module) {
+            if (registeredModules.containsKey(moduleName)) {
+                throw new ValidationException(
+                        String.format("A module with name '%s' already exists", moduleName));
+            }
+
             this.registeredModules.put(moduleName, module);
             return this;
         }

--- a/flink-table/flink-sql-gateway-api/src/main/java/org/apache/flink/table/gateway/api/session/SessionEnvironment.java
+++ b/flink-table/flink-sql-gateway-api/src/main/java/org/apache/flink/table/gateway/api/session/SessionEnvironment.java
@@ -20,7 +20,9 @@ package org.apache.flink.table.gateway.api.session;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.table.catalog.Catalog;
 import org.apache.flink.table.gateway.api.endpoint.EndpointVersion;
+import org.apache.flink.table.module.Module;
 
 import javax.annotation.Nullable;
 
@@ -37,15 +39,27 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public class SessionEnvironment {
     private final @Nullable String sessionName;
     private final EndpointVersion version;
+    private final Map<String, Catalog> registeredCatalogs;
+    private final Map<String, Module> registeredModules;
+    private final @Nullable String defaultCatalog;
+    private final @Nullable String defaultDatabase;
     private final Map<String, String> sessionConfig;
 
     @VisibleForTesting
     SessionEnvironment(
             @Nullable String sessionName,
             EndpointVersion version,
+            Map<String, Catalog> registeredCatalogs,
+            Map<String, Module> registeredModules,
+            @Nullable String defaultCatalog,
+            @Nullable String defaultDatabase,
             Map<String, String> sessionConfig) {
         this.sessionName = sessionName;
         this.version = version;
+        this.registeredCatalogs = registeredCatalogs;
+        this.registeredModules = registeredModules;
+        this.defaultCatalog = defaultCatalog;
+        this.defaultDatabase = defaultDatabase;
         this.sessionConfig = sessionConfig;
     }
 
@@ -65,6 +79,22 @@ public class SessionEnvironment {
         return Collections.unmodifiableMap(sessionConfig);
     }
 
+    public Map<String, Catalog> getRegisteredCatalogs() {
+        return Collections.unmodifiableMap(registeredCatalogs);
+    }
+
+    public Map<String, Module> getRegisteredModules() {
+        return Collections.unmodifiableMap(registeredModules);
+    }
+
+    public Optional<String> getDefaultCatalog() {
+        return Optional.ofNullable(defaultCatalog);
+    }
+
+    public Optional<String> getDefaultDatabase() {
+        return Optional.ofNullable(defaultDatabase);
+    }
+
     // -------------------------------------------------------------------------------------------
 
     @Override
@@ -78,12 +108,23 @@ public class SessionEnvironment {
         SessionEnvironment that = (SessionEnvironment) o;
         return Objects.equals(sessionName, that.sessionName)
                 && Objects.equals(version, that.version)
+                && Objects.equals(registeredCatalogs, that.registeredCatalogs)
+                && Objects.equals(registeredModules, that.registeredModules)
+                && Objects.equals(defaultCatalog, that.defaultCatalog)
+                && Objects.equals(defaultDatabase, that.defaultDatabase)
                 && Objects.equals(sessionConfig, that.sessionConfig);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(sessionName, version, sessionConfig);
+        return Objects.hash(
+                sessionName,
+                version,
+                registeredCatalogs,
+                registeredModules,
+                defaultCatalog,
+                defaultDatabase,
+                sessionConfig);
     }
 
     // -------------------------------------------------------------------------------------------
@@ -99,6 +140,10 @@ public class SessionEnvironment {
         private @Nullable String sessionName;
         private EndpointVersion version;
         private final Map<String, String> sessionConfig = new HashMap<>();
+        private final Map<String, Catalog> registeredCatalogs = new HashMap<>();
+        private final Map<String, Module> registeredModules = new HashMap<>();
+        private @Nullable String defaultCatalog;
+        private @Nullable String defaultDatabase;
 
         public Builder setSessionName(String sessionName) {
             this.sessionName = sessionName;
@@ -115,8 +160,35 @@ public class SessionEnvironment {
             return this;
         }
 
+        public Builder registerCatalog(String catalogName, Catalog catalog) {
+            this.registeredCatalogs.put(catalogName, catalog);
+            return this;
+        }
+
+        public Builder setDefaultCatalog(@Nullable String defaultCatalog) {
+            this.defaultCatalog = defaultCatalog;
+            return this;
+        }
+
+        public Builder setDefaultDatabase(@Nullable String defaultDatabase) {
+            this.defaultDatabase = defaultDatabase;
+            return this;
+        }
+
+        public Builder registerModule(String moduleName, Module module) {
+            this.registeredModules.put(moduleName, module);
+            return this;
+        }
+
         public SessionEnvironment build() {
-            return new SessionEnvironment(sessionName, checkNotNull(version), sessionConfig);
+            return new SessionEnvironment(
+                    sessionName,
+                    checkNotNull(version),
+                    registeredCatalogs,
+                    registeredModules,
+                    defaultCatalog,
+                    defaultDatabase,
+                    sessionConfig);
         }
     }
 }

--- a/flink-table/flink-sql-gateway-api/src/main/java/org/apache/flink/table/gateway/api/session/SessionEnvironment.java
+++ b/flink-table/flink-sql-gateway-api/src/main/java/org/apache/flink/table/gateway/api/session/SessionEnvironment.java
@@ -136,6 +136,7 @@ public class SessionEnvironment {
     }
 
     /** Builder to build the {@link SessionEnvironment}. */
+    @PublicEvolving
     public static class Builder {
         private @Nullable String sessionName;
         private EndpointVersion version;

--- a/flink-table/flink-sql-gateway-api/src/main/java/org/apache/flink/table/gateway/api/utils/ThreadUtils.java
+++ b/flink-table/flink-sql-gateway-api/src/main/java/org/apache/flink/table/gateway/api/utils/ThreadUtils.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.table.gateway.api.utils;
 
+import org.apache.flink.annotation.Internal;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,6 +28,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 /** Utils for thread pool executor. */
+@Internal
 public class ThreadUtils {
 
     private static final Logger LOG = LoggerFactory.getLogger(ThreadUtils.class);

--- a/flink-table/flink-sql-gateway-api/src/main/java/org/apache/flink/table/gateway/api/utils/ThreadUtils.java
+++ b/flink-table/flink-sql-gateway-api/src/main/java/org/apache/flink/table/gateway/api/utils/ThreadUtils.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.gateway.service.utils;
+package org.apache.flink.table.gateway.api.utils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/flink-table/flink-sql-gateway-api/src/test/java/org/apache/flink/table/gateway/api/session/SessionEnvironmentTest.java
+++ b/flink-table/flink-sql-gateway-api/src/test/java/org/apache/flink/table/gateway/api/session/SessionEnvironmentTest.java
@@ -39,13 +39,22 @@ public class SessionEnvironmentTest {
         configMap.put("key2", "value2");
 
         SessionEnvironment expectedEnvironment =
-                new SessionEnvironment(sessionName, MockedEndpointVersion.V1, configMap);
+                new SessionEnvironment(
+                        sessionName,
+                        MockedEndpointVersion.V1,
+                        new HashMap<>(),
+                        new HashMap<>(),
+                        "default",
+                        "default_db",
+                        configMap);
 
         SessionEnvironment actualEnvironment =
                 SessionEnvironment.newBuilder()
                         .setSessionName(sessionName)
                         .setSessionEndpointVersion(MockedEndpointVersion.V1)
                         .addSessionConfig(configMap)
+                        .setDefaultCatalog("default")
+                        .setDefaultDatabase("default_db")
                         .build();
         assertEquals(expectedEnvironment, actualEnvironment);
     }

--- a/flink-table/flink-sql-gateway/pom.xml
+++ b/flink-table/flink-sql-gateway/pom.xml
@@ -32,6 +32,8 @@
     <artifactId>flink-sql-gateway</artifactId>
     <name>Flink : Table : SQL Gateway</name>
 
+    <packaging>jar</packaging>
+
     <dependencies>
         <!-- Flink client to submit jobs -->
         <dependency>

--- a/flink-table/flink-sql-gateway/pom.xml
+++ b/flink-table/flink-sql-gateway/pom.xml
@@ -95,28 +95,40 @@
 
     <build>
     <plugins>
-    <!-- Build flink-sql-gateway jar -->
-    <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-        <executions>
-            <!-- Exclude all flink-dist files and only contain sql-gateway files -->
-            <execution>
-                <id>shade-flink</id>
-                <phase>package</phase>
-                <goals>
-                    <goal>shade</goal>
-                </goals>
-                <configuration>
-                    <artifactSet>
-                        <includes combine.children="append">
-                            <include>org.apache.flink:flink-sql-gateway-api</include>
-                        </includes>
-                    </artifactSet>
-                </configuration>
-            </execution>
-        </executions>
-    </plugin>
+        <!-- Build flink-sql-gateway jar -->
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-shade-plugin</artifactId>
+            <executions>
+                <!-- Exclude all flink-dist files and only contain sql-gateway files -->
+                <execution>
+                    <id>shade-flink</id>
+                    <phase>package</phase>
+                    <goals>
+                        <goal>shade</goal>
+                    </goals>
+                    <configuration>
+                        <artifactSet>
+                            <includes combine.children="append">
+                                <include>org.apache.flink:flink-sql-gateway-api</include>
+                            </includes>
+                        </artifactSet>
+                    </configuration>
+                </execution>
+            </executions>
+        </plugin>
+        <!-- Make test classes available to other modules. -->
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-jar-plugin</artifactId>
+            <executions>
+                <execution>
+                    <goals>
+                        <goal>test-jar</goal>
+                    </goals>
+                </execution>
+            </executions>
+        </plugin>
     </plugins>
     </build>
 </project>

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/context/SessionContext.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/context/SessionContext.java
@@ -173,7 +173,11 @@ public class SessionContext {
     public void close() {
         operationManager.close();
         for (String name : sessionState.catalogManager.listCatalogs()) {
-            sessionState.catalogManager.getCatalog(name).ifPresent(Catalog::close);
+            try {
+                sessionState.catalogManager.getCatalog(name).ifPresent(Catalog::close);
+            } catch (Throwable t) {
+                LOG.error("Failed to close catalog %s.", t);
+            }
         }
         try {
             userClassloader.close();

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/context/SessionContext.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/context/SessionContext.java
@@ -42,6 +42,7 @@ import org.apache.flink.table.gateway.api.session.SessionHandle;
 import org.apache.flink.table.gateway.service.operation.OperationExecutor;
 import org.apache.flink.table.gateway.service.operation.OperationManager;
 import org.apache.flink.table.gateway.service.utils.SqlExecutionException;
+import org.apache.flink.table.module.Module;
 import org.apache.flink.table.module.ModuleManager;
 import org.apache.flink.table.resource.ResourceManager;
 import org.apache.flink.util.FlinkUserCodeClassLoaders;
@@ -97,20 +98,6 @@ public class SessionContext {
         this.operationManager = operationManager;
     }
 
-    /** Close resources, e.g. catalogs. */
-    public void close() {
-        operationManager.close();
-
-        for (String name : sessionState.catalogManager.listCatalogs()) {
-            sessionState.catalogManager.getCatalog(name).ifPresent(Catalog::close);
-        }
-        try {
-            userClassloader.close();
-        } catch (IOException e) {
-            LOG.debug("Error while closing class loader.", e);
-        }
-    }
-
     // --------------------------------------------------------------------------------------------
     // Getter/Setter
     // --------------------------------------------------------------------------------------------
@@ -121,6 +108,10 @@ public class SessionContext {
 
     public Map<String, String> getConfigMap() {
         return sessionConf.toMap();
+    }
+
+    public OperationManager getOperationManager() {
+        return operationManager;
     }
 
     public void set(String key, String value) {
@@ -158,8 +149,37 @@ public class SessionContext {
     // Method to execute commands
     // --------------------------------------------------------------------------------------------
 
+    public void registerCatalog(String catalogName, Catalog catalog) {
+        sessionState.catalogManager.registerCatalog(catalogName, catalog);
+    }
+
+    public void registerModule(String moduleName, Module module) {
+        sessionState.moduleManager.loadModule(moduleName, module);
+    }
+
+    public void setCurrentCatalog(String catalog) {
+        sessionState.catalogManager.setCurrentCatalog(catalog);
+    }
+
+    public void setCurrentDatabase(String database) {
+        sessionState.catalogManager.setCurrentDatabase(database);
+    }
+
     public OperationExecutor createOperationExecutor(Configuration executionConfig) {
         return new OperationExecutor(this, executionConfig);
+    }
+
+    /** Close resources, e.g. catalogs. */
+    public void close() {
+        operationManager.close();
+        for (String name : sessionState.catalogManager.listCatalogs()) {
+            sessionState.catalogManager.getCatalog(name).ifPresent(Catalog::close);
+        }
+        try {
+            userClassloader.close();
+        } catch (IOException e) {
+            LOG.debug("Error while closing class loader.", e);
+        }
     }
 
     // --------------------------------------------------------------------------------------------
@@ -253,11 +273,7 @@ public class SessionContext {
                 sessionState.functionCatalog);
     }
 
-    public OperationManager getOperationManager() {
-        return operationManager;
-    }
-
-    private static TableEnvironmentInternal createStreamTableEnvironment(
+    private TableEnvironmentInternal createStreamTableEnvironment(
             StreamExecutionEnvironment env,
             EnvironmentSettings settings,
             TableConfig tableConfig,

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/operation/OperationExecutor.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/operation/OperationExecutor.java
@@ -65,9 +65,7 @@ public class OperationExecutor {
 
     public ResultFetcher executeStatement(OperationHandle handle, String statement) {
         // Instantiate the TableEnvironment lazily
-        TableEnvironmentInternal tableEnv = sessionContext.createTableEnvironment();
-        tableEnv.getConfig().getConfiguration().addAll(executionConfig);
-
+        TableEnvironmentInternal tableEnv = getTableEnvironment();
         List<Operation> parsedOperations = tableEnv.getParser().parse(statement);
         if (parsedOperations.size() > 1) {
             throw new UnsupportedOperationException(
@@ -99,6 +97,13 @@ public class OperationExecutor {
             return new ResultFetcher(
                     handle, result.getResolvedSchema(), collect(result.collectInternal()));
         }
+    }
+
+    @VisibleForTesting
+    public TableEnvironmentInternal getTableEnvironment() {
+        TableEnvironmentInternal tableEnv = sessionContext.createTableEnvironment();
+        tableEnv.getConfig().getConfiguration().addAll(executionConfig);
+        return tableEnv;
     }
 
     private ResultFetcher callSetOperation(

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/session/SessionManager.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/session/SessionManager.java
@@ -24,9 +24,9 @@ import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.table.gateway.api.session.SessionEnvironment;
 import org.apache.flink.table.gateway.api.session.SessionHandle;
 import org.apache.flink.table.gateway.api.utils.SqlGatewayException;
+import org.apache.flink.table.gateway.api.utils.ThreadUtils;
 import org.apache.flink.table.gateway.service.context.DefaultContext;
 import org.apache.flink.table.gateway.service.context.SessionContext;
-import org.apache.flink.table.gateway.service.utils.ThreadUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -154,6 +154,12 @@ public class SessionManager {
                         environment.getSessionEndpointVersion(),
                         Configuration.fromMap(environment.getSessionConfig()),
                         operationExecutorService);
+
+        environment.getRegisteredCatalogs().forEach(sessionContext::registerCatalog);
+        environment.getRegisteredModules().forEach(sessionContext::registerModule);
+        environment.getDefaultCatalog().ifPresent(sessionContext::setCurrentCatalog);
+        environment.getDefaultDatabase().ifPresent(sessionContext::setCurrentDatabase);
+
         session = new Session(sessionContext);
         sessions.put(sessionId, session);
 
@@ -209,7 +215,7 @@ public class SessionManager {
     }
 
     @VisibleForTesting
-    int currentSessionCount() {
+    public int currentSessionCount() {
         return sessions.size();
     }
 

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/context/SessionContextTest.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/context/SessionContextTest.java
@@ -23,7 +23,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.table.gateway.api.session.SessionHandle;
 import org.apache.flink.table.gateway.api.utils.MockedEndpointVersion;
-import org.apache.flink.table.gateway.service.utils.ThreadUtils;
+import org.apache.flink.table.gateway.api.utils.ThreadUtils;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;

--- a/flink-table/flink-table-api-java-uber/pom.xml
+++ b/flink-table/flink-table-api-java-uber/pom.xml
@@ -56,6 +56,11 @@ under the License.
 			<artifactId>flink-table-api-java-bridge</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-sql-gateway-api</artifactId>
+			<version>${project.version}</version>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -88,6 +93,7 @@ under the License.
 									<include>org.apache.flink:flink-table-api-java</include>
 									<include>org.apache.flink:flink-table-api-bridge-base</include>
 									<include>org.apache.flink:flink-table-api-java-bridge</include>
+									<include>org.apache.flink:flink-sql-gateway-api</include>
 
 									<!-- Tools to unify display format for different languages -->
 									<include>com.ibm.icu:icu4j</include>

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FactoryUtil.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FactoryUtil.java
@@ -110,6 +110,13 @@ public final class FactoryUtil {
                                     + "By default, if this option is not defined, the planner will derive the parallelism "
                                     + "for each statement individually by also considering the global configuration.");
 
+    public static final ConfigOption<List<String>> SQL_GATEWAY_ENDPOINT_TYPE =
+            ConfigOptions.key("sql-gateway.endpoint.type")
+                    .stringType()
+                    .asList()
+                    .noDefaultValue()
+                    .withDescription("Specify the endpoints that are used.");
+
     /**
      * Suffix for keys of {@link ConfigOption} in case a connector requires multiple formats (e.g.
      * for both key and value).


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*Introduce the HiveServer2 Endpoint and its Factory. With the HiveServer2 Endpoint, users is avaliable to connect to the SqlGateway with Hive JDBC.*


## Brief change log

  - *Introduce the endpoint and its factory. With the factory, the SqlGateway is able to load the HiveServer2 Endpoint*
  - *Expose the required options to configure HiveServer2 Endpoint. The options are discussed in the FLIP-223 except the option `thrift.max.message.size`, `thrift.login.timeout`, `thrift.exponential.backoff.slot.length`. The newly introduced options are align with the hive, please refer to the [HiveConf](https://github.com/apache/hive/blob/master/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java#L4036). The PR also introduce the option `module.name` that aligns with the option `catalog.name` as the default hive module name.*
  - *Supports `OpenSession` and `CloseSession` in HiveServer2Endpoint.*


## Verifying this change

This change added tests and can be verified as follows:

  - *Added ITCase to openSession and closeSession with HiveServerEndoint2*
  - *Added test that the endpoint factory can create the expected endpoint.*
  - *Added the client can get expected error message with HiveServer2 endpoint*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**yes** / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
