### PR TITLE
[FLINK-28178][runtime-web] Show the delegated StateBackend and whethe…

### DIFF
--- a/docs/layouts/shortcodes/generated/rest_v1_dispatcher.html
+++ b/docs/layouts/shortcodes/generated/rest_v1_dispatcher.html
@@ -2335,6 +2335,9 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
     "state_backend" : {
       "type" : "string"
     },
+    "state_changelog_enabled" : {
+      "type" : "boolean"
+    },
     "timeout" : {
       "type" : "integer"
     },

--- a/docs/static/generated/rest_v1_dispatcher.yml
+++ b/docs/static/generated/rest_v1_dispatcher.yml
@@ -2864,6 +2864,8 @@ components:
           format: int64
         checkpoints_after_tasks_finish:
           type: boolean
+        state_changelog_enabled:
+          type: boolean
         changelog_periodic_materialization_interval:
           type: integer
           format: int64

--- a/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
+++ b/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
@@ -1408,6 +1408,9 @@
         "checkpoints_after_tasks_finish" : {
           "type" : "boolean"
         },
+        "state_changelog_enabled" : {
+          "type" : "boolean"
+        },
         "changelog_periodic_materialization_interval" : {
           "type" : "integer"
         },

--- a/flink-runtime-web/web-dashboard/src/app/interfaces/job-checkpoint.ts
+++ b/flink-runtime-web/web-dashboard/src/app/interfaces/job-checkpoint.ts
@@ -128,6 +128,7 @@ export interface CheckpointConfig {
     delete_on_cancellation: boolean;
   };
   state_backend: string;
+  state_changelog_enabled: boolean;
   checkpoint_storage: string;
   unaligned_checkpoints: boolean;
   tolerable_failed_checkpoints: number;

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/checkpoints/job-checkpoints.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/checkpoints/job-checkpoints.component.html
@@ -551,15 +551,15 @@
             </td>
           </tr>
           <tr>
-            <td>Changelog state-backend</td>
-            <td *ngIf="checkPointConfig['state_backend'] === 'ChangelogStateBackend'">Enabled</td>
-            <td *ngIf="checkPointConfig['state_backend'] !== 'ChangelogStateBackend'">Disabled</td>
+            <td>State Changelog</td>
+            <td *ngIf="checkPointConfig['state_changelog_enabled']">Enabled</td>
+            <td *ngIf="!checkPointConfig['state_changelog_enabled']">Disabled</td>
           </tr>
-          <tr *ngIf="checkPointConfig['state_backend'] === 'ChangelogStateBackend'">
+          <tr *ngIf="checkPointConfig['state_changelog_enabled']">
             <td>Changelog Storage</td>
             <td>{{ checkPointConfig['changelog_storage'] }}</td>
           </tr>
-          <tr *ngIf="checkPointConfig['state_backend'] === 'ChangelogStateBackend'">
+          <tr *ngIf="checkPointConfig['state_changelog_enabled']">
             <td>Changelog Periodic Materialization Interval</td>
             <td>
               {{

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/AccessExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/AccessExecutionGraph.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
 import org.apache.flink.util.OptionalFailure;
 import org.apache.flink.util.SerializedValue;
+import org.apache.flink.util.TernaryBoolean;
 
 import javax.annotation.Nullable;
 
@@ -175,6 +176,13 @@ public interface AccessExecutionGraph extends JobStatusProvider {
      * @return The checkpoint storage name, or an empty Optional in the case of batch jobs
      */
     Optional<String> getCheckpointStorageName();
+
+    /**
+     * Returns whether the state changelog is enabled for this ExecutionGraph.
+     *
+     * @return true, if state changelog enabled, false otherwise.
+     */
+    TernaryBoolean isChangelogStateBackendEnabled();
 
     /**
      * Returns the changelog storage name for this ExecutionGraph.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraph.java
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.jobgraph.tasks.JobCheckpointingSettings;
 import org.apache.flink.util.OptionalFailure;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.SerializedValue;
+import org.apache.flink.util.TernaryBoolean;
 
 import javax.annotation.Nullable;
 
@@ -98,6 +99,8 @@ public class ArchivedExecutionGraph implements AccessExecutionGraph, Serializabl
 
     @Nullable private final String checkpointStorageName;
 
+    @Nullable private final TernaryBoolean stateChangelogEnabled;
+
     @Nullable private final String changelogStorageName;
 
     public ArchivedExecutionGraph(
@@ -117,6 +120,7 @@ public class ArchivedExecutionGraph implements AccessExecutionGraph, Serializabl
             @Nullable CheckpointStatsSnapshot checkpointStatsSnapshot,
             @Nullable String stateBackendName,
             @Nullable String checkpointStorageName,
+            @Nullable TernaryBoolean stateChangelogEnabled,
             @Nullable String changelogStorageName) {
 
         this.jobID = Preconditions.checkNotNull(jobID);
@@ -135,6 +139,7 @@ public class ArchivedExecutionGraph implements AccessExecutionGraph, Serializabl
         this.checkpointStatsSnapshot = checkpointStatsSnapshot;
         this.stateBackendName = stateBackendName;
         this.checkpointStorageName = checkpointStorageName;
+        this.stateChangelogEnabled = stateChangelogEnabled;
         this.changelogStorageName = changelogStorageName;
     }
 
@@ -267,6 +272,11 @@ public class ArchivedExecutionGraph implements AccessExecutionGraph, Serializabl
     }
 
     @Override
+    public TernaryBoolean isChangelogStateBackendEnabled() {
+        return stateChangelogEnabled;
+    }
+
+    @Override
     public Optional<String> getChangelogStorageName() {
         return Optional.ofNullable(changelogStorageName);
     }
@@ -337,6 +347,7 @@ public class ArchivedExecutionGraph implements AccessExecutionGraph, Serializabl
                 executionGraph.getCheckpointStatsSnapshot(),
                 executionGraph.getStateBackendName().orElse(null),
                 executionGraph.getCheckpointStorageName().orElse(null),
+                executionGraph.isChangelogStateBackendEnabled(),
                 executionGraph.getChangelogStorageName().orElse(null));
     }
 
@@ -391,6 +402,9 @@ public class ArchivedExecutionGraph implements AccessExecutionGraph, Serializabl
                 checkpointingSettings == null ? null : CheckpointStatsSnapshot.empty(),
                 checkpointingSettings == null ? null : "Unknown",
                 checkpointingSettings == null ? null : "Unknown",
+                checkpointingSettings == null
+                        ? TernaryBoolean.UNDEFINED
+                        : checkpointingSettings.isChangelogStateBackendEnabled(),
                 checkpointingSettings == null ? null : "Unknown");
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/checkpoints/CheckpointConfigHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/checkpoints/CheckpointConfigHandler.java
@@ -122,6 +122,11 @@ public class CheckpointConfigHandler
                             .getPeriodicMaterializeIntervalMillis();
             String changelogStorageName = executionGraph.getChangelogStorageName().orElse(null);
 
+            boolean stateChangelogEnabled =
+                    executionGraph.isChangelogStateBackendEnabled() != null
+                            ? executionGraph.isChangelogStateBackendEnabled().getOrDefault(false)
+                            : false;
+
             return new CheckpointConfigInfo(
                     checkpointCoordinatorConfiguration.isExactlyOnce()
                             ? CheckpointConfigInfo.ProcessingMode.EXACTLY_ONCE
@@ -137,6 +142,7 @@ public class CheckpointConfigHandler
                     checkpointCoordinatorConfiguration.getTolerableCheckpointFailureNumber(),
                     checkpointCoordinatorConfiguration.getAlignedCheckpointTimeout(),
                     checkpointCoordinatorConfiguration.isEnableCheckpointsAfterTasksFinish(),
+                    stateChangelogEnabled,
                     periodicMaterializeIntervalMillis,
                     changelogStorageName);
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/CheckpointConfigInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/CheckpointConfigInfo.java
@@ -65,6 +65,8 @@ public class CheckpointConfigInfo implements ResponseBody {
     public static final String FIELD_NAME_CHECKPOINTS_AFTER_TASKS_FINISH =
             "checkpoints_after_tasks_finish";
 
+    public static final String FIELD_NAME_STATE_CHANGELOG = "state_changelog_enabled";
+
     public static final String FIELD_NAME_PERIODIC_MATERIALIZATION_INTERVAL =
             "changelog_periodic_materialization_interval";
 
@@ -106,6 +108,9 @@ public class CheckpointConfigInfo implements ResponseBody {
     @JsonProperty(FIELD_NAME_CHECKPOINTS_AFTER_TASKS_FINISH)
     private final boolean checkpointsWithFinishedTasks;
 
+    @JsonProperty(FIELD_NAME_STATE_CHANGELOG)
+    private final boolean stateChangelog;
+
     @JsonProperty(FIELD_NAME_PERIODIC_MATERIALIZATION_INTERVAL)
     private final long periodicMaterializationInterval;
 
@@ -128,6 +133,7 @@ public class CheckpointConfigInfo implements ResponseBody {
             @JsonProperty(FIELD_NAME_ALIGNED_CHECKPOINT_TIMEOUT) long alignedCheckpointTimeout,
             @JsonProperty(FIELD_NAME_CHECKPOINTS_AFTER_TASKS_FINISH)
                     boolean checkpointsWithFinishedTasks,
+            @JsonProperty(FIELD_NAME_STATE_CHANGELOG) boolean stateChangelog,
             @JsonProperty(FIELD_NAME_PERIODIC_MATERIALIZATION_INTERVAL)
                     long periodicMaterializationInterval,
             @JsonProperty(FIELD_NAME_CHANGELOG_STORAGE) String changelogStorage) {
@@ -143,6 +149,7 @@ public class CheckpointConfigInfo implements ResponseBody {
         this.tolerableFailedCheckpoints = tolerableFailedCheckpoints;
         this.alignedCheckpointTimeout = alignedCheckpointTimeout;
         this.checkpointsWithFinishedTasks = checkpointsWithFinishedTasks;
+        this.stateChangelog = stateChangelog;
         this.periodicMaterializationInterval = periodicMaterializationInterval;
         this.changelogStorage = changelogStorage;
     }
@@ -168,6 +175,7 @@ public class CheckpointConfigInfo implements ResponseBody {
                 && tolerableFailedCheckpoints == that.tolerableFailedCheckpoints
                 && alignedCheckpointTimeout == that.alignedCheckpointTimeout
                 && checkpointsWithFinishedTasks == that.checkpointsWithFinishedTasks
+                && stateChangelog == that.stateChangelog
                 && periodicMaterializationInterval == that.periodicMaterializationInterval
                 && changelogStorage == that.changelogStorage;
     }
@@ -187,6 +195,7 @@ public class CheckpointConfigInfo implements ResponseBody {
                 tolerableFailedCheckpoints,
                 alignedCheckpointTimeout,
                 checkpointsWithFinishedTasks,
+                stateChangelog,
                 periodicMaterializationInterval,
                 changelogStorage);
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackend.java
@@ -81,6 +81,15 @@ import java.util.Collection;
 public interface StateBackend extends java.io.Serializable {
 
     /**
+     * Return the name of this backend, default is simple class name. {@link
+     * org.apache.flink.runtime.state.delegate.DelegatingStateBackend} may return the simple class
+     * name of the delegated backend.
+     */
+    default String getName() {
+        return this.getClass().getSimpleName();
+    }
+
+    /**
      * Creates a new {@link CheckpointableKeyedStateBackend} that is responsible for holding
      * <b>keyed state</b> and checkpointing it.
      *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackendLoader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackendLoader.java
@@ -391,7 +391,7 @@ public class StateBackendLoader {
         return originalStateBackend;
     }
 
-    private static boolean isChangelogStateBackend(StateBackend backend) {
+    public static boolean isChangelogStateBackend(StateBackend backend) {
         return CHANGELOG_STATE_BACKEND.equals(backend.getClass().getName());
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/delegate/DelegatingStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/delegate/DelegatingStateBackend.java
@@ -29,4 +29,9 @@ import org.apache.flink.runtime.state.StateBackend;
 @Internal
 public interface DelegatingStateBackend extends StateBackend {
     StateBackend getDelegatedStateBackend();
+
+    @Override
+    default String getName() {
+        return getDelegatedStateBackend().getName();
+    }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/utils/ArchivedExecutionGraphBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/utils/ArchivedExecutionGraphBuilder.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.util.OptionalFailure;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.SerializedValue;
+import org.apache.flink.util.TernaryBoolean;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -159,6 +160,7 @@ public class ArchivedExecutionGraphBuilder {
                 null,
                 "stateBackendName",
                 "checkpointStorageName",
+                TernaryBoolean.UNDEFINED,
                 "changelogStorageName");
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/checkpoints/CheckpointConfigInfoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/checkpoints/CheckpointConfigInfoTest.java
@@ -46,6 +46,7 @@ public class CheckpointConfigInfoTest
                 3,
                 4,
                 true,
+                false,
                 0,
                 null);
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/StateTrackingMockExecutionGraph.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/StateTrackingMockExecutionGraph.java
@@ -59,6 +59,7 @@ import org.apache.flink.runtime.state.CheckpointStorage;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.util.OptionalFailure;
 import org.apache.flink.util.SerializedValue;
+import org.apache.flink.util.TernaryBoolean;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -218,6 +219,11 @@ class StateTrackingMockExecutionGraph implements ExecutionGraph {
     @Override
     public Optional<String> getCheckpointStorageName() {
         return Optional.empty();
+    }
+
+    @Override
+    public TernaryBoolean isChangelogStateBackendEnabled() {
+        return TernaryBoolean.fromBoolean(false);
     }
 
     @Override


### PR DESCRIPTION
…r changelog is enabled in the UI


## What is the purpose of the change

Show the delegated StateBackend and whether changelog is enabled in the UI, described in [FLINK-28178](https://issues.apache.org/jira/browse/FLINK-28178).


## Brief change log

  - set field 'state_backend' in /jobs/:jobid/checkpoints/config to delegated StateBackend
  - /jobs/:jobid/checkpoints/config add field 'state_changelog', which indicates whether the State Changelog enabled

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
