### PR TITLE
[FLINK-28240][network] Fix the bug that NetworkBufferPool#getRequestedSegmentsUsage may throw ArithmeticException.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
@@ -381,8 +381,11 @@ public class NetworkBufferPool
     }
 
     public int getRequestedSegmentsUsage() {
-        return Math.toIntExact(
-                100L * getNumberOfRequestedMemorySegments() / getTotalNumberOfMemorySegments());
+        int totalNumberOfMemorySegments = getTotalNumberOfMemorySegments();
+        return totalNumberOfMemorySegments == 0
+                ? 0
+                : Math.toIntExact(
+                        100L * getNumberOfRequestedMemorySegments() / totalNumberOfMemorySegments);
     }
 
     @VisibleForTesting

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPoolTest.java
@@ -326,6 +326,15 @@ public class NetworkBufferPoolTest extends TestLogger {
     }
 
     @Test
+    public void testEmptyPoolSegmentsUsage() throws IOException {
+        try (CloseableRegistry closeableRegistry = new CloseableRegistry()) {
+            NetworkBufferPool globalPool = new NetworkBufferPool(0, 128);
+            closeableRegistry.registerCloseable(globalPool::destroy);
+            assertEquals(0, globalPool.getRequestedSegmentsUsage());
+        }
+    }
+
+    @Test
     public void testSegmentsUsage() throws IOException {
         try (CloseableRegistry closeableRegistry = new CloseableRegistry()) {
             NetworkBufferPool globalPool = new NetworkBufferPool(50, 128);


### PR DESCRIPTION
## What is the purpose of the change

There's a bug that NetworkBufferPool#getRequestedSegmentsUsage may throw ArithmeticException if the pool is initialized without any buffers. It may cause other metrics failing to report.


## Brief change log

  - Return 0 as the requested segments usage if the buffer pool is empty.

## Verifying this change

This change added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no
## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
