### PR TITLE
[FLINK-28323][python][connector] Support using new KafkaSource in PyFlink

### DIFF
--- a/flink-python/pyflink/datastream/connectors/__init__.py
+++ b/flink-python/pyflink/datastream/connectors/__init__.py
@@ -25,6 +25,9 @@ from pyflink.datastream.connectors.file_system import (FileEnumeratorProvider, F
                                                        StreamFormat, StreamingFileSink)
 from pyflink.datastream.connectors.jdbc import JdbcSink, JdbcConnectionOptions, JdbcExecutionOptions
 from pyflink.datastream.connectors.kafka import FlinkKafkaConsumer, FlinkKafkaProducer, Semantic
+from pyflink.datastream.connectors.kafka_new import (KafkaSource, KafkaSourceBuilder,
+                                                     KafkaOffsetsInitializer, KafkaTopicPartition,
+                                                     KafkaOffsetResetStrategy)
 from pyflink.datastream.connectors.number_seq import NumberSequenceSource
 from pyflink.datastream.connectors.pulsar import PulsarDeserializationSchema, PulsarSource, \
     PulsarSourceBuilder, SubscriptionType, StartCursor, StopCursor, PulsarSerializationSchema, \
@@ -48,6 +51,11 @@ __all__ = [
     'FlinkKafkaConsumer',
     'FlinkKafkaProducer',
     'Semantic',
+    'KafkaOffsetResetStrategy',
+    'KafkaOffsetsInitializer',
+    'KafkaSource',
+    'KafkaSourceBuilder',
+    'KafkaTopicPartition',
     'JdbcSink',
     'JdbcConnectionOptions',
     'JdbcExecutionOptions',

--- a/flink-python/pyflink/datastream/connectors/kafka_new.py
+++ b/flink-python/pyflink/datastream/connectors/kafka_new.py
@@ -1,0 +1,522 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+from enum import Enum
+from typing import Set, Dict, overload, Optional
+
+from py4j.java_gateway import JavaObject, get_java_class
+from pyflink.common.serialization import DeserializationSchema
+
+from pyflink.datastream.connectors import Source
+from pyflink.java_gateway import get_gateway
+from pyflink.util.java_utils import to_jarray
+
+__all__ = [
+    'KafkaOffsetResetStrategy',
+    'KafkaOffsetsInitializer',
+    'KafkaSource',
+    'KafkaSourceBuilder',
+    'KafkaTopicPartition',
+]
+
+
+class KafkaSource(Source):
+    """
+    The Source implementation of Kafka. Please use a :class:`KafkaSourceBuilder` to construct a
+    :class:`KafkaSource`. The following example shows how to create a KafkaSource emitting records
+    of String type.
+
+    ::
+
+        >>> source = KafkaSource \\
+        ...     .builder() \\
+        ...     .set_bootstrap_servers('MY_BOOTSTRAP_SERVERS') \\
+        ...     .set_group_id('MY_GROUP') \\
+        ...     .set_topics('TOPIC1', 'TOPIC2') \\
+        ...     .set_value_only_deserializer(SimpleStringSchema()) \\
+        ...     .set_starting_offsets(KafkaOffsetsInitializer.earliest()) \\
+        ...     .build()
+
+    .. versionadded:: 1.16.0
+    """
+
+    def __init__(self, j_kafka_source: JavaObject):
+        super().__init__(j_kafka_source)
+
+    @staticmethod
+    def builder() -> 'KafkaSourceBuilder':
+        """
+        Get a kafkaSourceBuilder to build a :class:`KafkaSource`.
+
+        :return: a Kafka source builder.
+        """
+        return KafkaSourceBuilder()
+
+
+class KafkaSourceBuilder(object):
+    """
+    The builder class for :class:`KafkaSource` to make it easier for the users to construct a
+    :class:`KafkaSource`.
+
+    The following example shows the minimum setup to create a KafkaSource that reads the String
+    values from a Kafka topic.
+
+    ::
+
+        >>> source = KafkaSource.builder() \\
+        ...     .set_bootstrap_servers('MY_BOOTSTRAP_SERVERS') \\
+        ...     .set_topics('TOPIC1', 'TOPIC2') \\
+        ...     .set_value_only_deserializer(SimpleStringSchema()) \\
+        ...     .build()
+
+    The bootstrap servers, topics/partitions to consume, and the record deserializer are required
+    fields that must be set.
+
+    To specify the starting offsets of the KafkaSource, one can call :meth:`set_starting_offsets`.
+
+    By default, the KafkaSource runs in an CONTINUOUS_UNBOUNDED mode and never stops until the Flink
+    job is canceled or fails. To let the KafkaSource run in CONTINUOUS_UNBOUNDED but stops at some
+    given offsets, one can call :meth:`set_stopping_offsets`. For example the following KafkaSource
+    stops after it consumes up to the latest partition offsets at the point when the Flink started.
+
+    ::
+
+        >>> source = KafkaSource.builder() \\
+        ...     .set_bootstrap_servers('MY_BOOTSTRAP_SERVERS') \\
+        ...     .set_topics('TOPIC1', 'TOPIC2') \\
+        ...     .set_value_only_deserializer(SimpleStringSchema()) \\
+        ...     .set_unbounded(KafkaOffsetsInitializer.latest()) \\
+        ...     .build()
+
+    .. versionadded:: 1.16.0
+    """
+
+    def __init__(self):
+        self._j_builder = get_gateway().jvm.org.apache.flink.connector.kafka.source \
+            .KafkaSource.builder()
+
+    def build(self) -> 'KafkaSource':
+        return KafkaSource(self._j_builder.build())
+
+    def set_bootstrap_servers(self, bootstrap_servers: str) -> 'KafkaSourceBuilder':
+        """
+        Sets the bootstrap servers for the KafkaConsumer of the KafkaSource.
+
+        :param bootstrap_servers: the bootstrap servers of the Kafka cluster.
+        :return: this KafkaSourceBuilder.
+        """
+        self._j_builder.setBootstrapServers(bootstrap_servers)
+        return self
+
+    def set_group_id(self, group_id: str) -> 'KafkaSourceBuilder':
+        """
+        Sets the consumer group id of the KafkaSource.
+
+        :param group_id: the group id of the KafkaSource.
+        :return: this KafkaSourceBuilder.
+        """
+        self._j_builder.setGroupId(group_id)
+        return self
+
+    def set_topics(self, *topics: str) -> 'KafkaSourceBuilder':
+        """
+        Set a list of topics the KafkaSource should consume from. All the topics in the list should
+        have existed in the Kafka cluster. Otherwise, an exception will be thrown. To allow some
+        topics to be created lazily, please use :meth:`set_topic_pattern` instead.
+
+        :param topics: the list of topics to consume from.
+        :return: this KafkaSourceBuilder.
+        """
+        self._j_builder.setTopics(to_jarray(get_gateway().jvm.java.lang.String, topics))
+        return self
+
+    def set_topic_pattern(self, topic_pattern: str) -> 'KafkaSourceBuilder':
+        """
+        Set a topic pattern to consume from use the java Pattern. For grammar, check out
+        `JavaDoc <https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html>`_ .
+
+        :param topic_pattern: the pattern of the topic name to consume from.
+        :return: this KafkaSourceBuilder.
+        """
+        self._j_builder.setTopicPattern(get_gateway().jvm.java.util.regex
+                                        .Pattern.compile(topic_pattern))
+        return self
+
+    def set_partitions(self, partitions: Set['KafkaTopicPartition']) -> 'KafkaSourceBuilder':
+        """
+        Set a set of partitions to consume from.
+
+        Example:
+        ::
+
+            >>> KafkaSource.builder().set_partitions({
+            ...     KafkaTopicPartition('TOPIC1', 0),
+            ...     KafkaTopicPartition('TOPIC1', 1),
+            ... })
+
+        :param partitions: the set of partitions to consume from.
+        :return: this KafkaSourceBuilder.
+        """
+        j_set = get_gateway().jvm.java.util.HashSet()
+        for tp in partitions:
+            j_set.add(tp._to_j_topic_partition())
+        self._j_builder.setPartitions(j_set)
+        return self
+
+    def set_starting_offsets(self, starting_offsets_initializer: 'KafkaOffsetsInitializer') \
+            -> 'KafkaSourceBuilder':
+        """
+        Specify from which offsets the KafkaSource should start consume from by providing an
+        :class:`KafkaOffsetsInitializer`.
+
+        The following :class:`KafkaOffsetsInitializer` s are commonly used and provided out of the
+        box. Currently, customized offset initializer is not supported in PyFlink.
+
+        * :meth:`KafkaOffsetsInitializer.earliest` - starting from the earliest offsets. This is
+          also the default offset initializer of the KafkaSource for starting offsets.
+        * :meth:`KafkaOffsetsInitializer.latest` - starting from the latest offsets.
+        * :meth:`KafkaOffsetsInitializer.committedOffsets` - starting from the committed offsets of
+          the consumer group. If there is no committed offsets, starting from the offsets
+          specified by the :class:`KafkaOffsetResetStrategy`.
+        * :meth:`KafkaOffsetsInitializer.offsets` - starting from the specified offsets for each
+          partition.
+        * :meth:`KafkaOffsetsInitializer.timestamp` - starting from the specified timestamp for each
+          partition. Note that the guarantee here is that all the records in Kafka whose timestamp
+          is greater than the given starting timestamp will be consumed. However, it is possible
+          that some consumer records whose timestamp is smaller than the given starting timestamp
+          are also consumed.
+
+        :param starting_offsets_initializer: the :class:`KafkaOffsetsInitializer` setting the
+            starting offsets for the Source.
+        :return: this KafkaSourceBuilder.
+        """
+        self._j_builder.setStartingOffsets(starting_offsets_initializer._j_initializer)
+        return self
+
+    def set_unbounded(self, stopping_offsets_initializer: 'KafkaOffsetsInitializer') \
+            -> 'KafkaSourceBuilder':
+        """
+        By default, the KafkaSource is set to run in CONTINUOUS_UNBOUNDED manner and thus never
+        stops until the Flink job fails or is canceled. To let the KafkaSource run as a streaming
+        source but still stops at some point, one can set an :class:`KafkaOffsetsInitializer`
+        to specify the stopping offsets for each partition. When all the partitions have reached
+        their stopping offsets, the KafkaSource will then exit.
+
+        This method is different from :meth:`set_bounded` that after setting the stopping offsets
+        with this method, KafkaSource will still be CONTINUOUS_UNBOUNDED even though it will stop at
+        the stopping offsets specified by the stopping offset initializer.
+
+        The following :class:`KafkaOffsetsInitializer` s are commonly used and provided out of the
+        box. Currently, customized offset initializer is not supported in PyFlink.
+
+        * :meth:`KafkaOffsetsInitializer.latest` - starting from the latest offsets.
+        * :meth:`KafkaOffsetsInitializer.committedOffsets` - starting from the committed offsets of
+          the consumer group. If there is no committed offsets, starting from the offsets
+          specified by the :class:`KafkaOffsetResetStrategy`.
+        * :meth:`KafkaOffsetsInitializer.offsets` - starting from the specified offsets for each
+          partition.
+        * :meth:`KafkaOffsetsInitializer.timestamp` - starting from the specified timestamp for each
+          partition. Note that the guarantee here is that all the records in Kafka whose timestamp
+          is greater than the given starting timestamp will be consumed. However, it is possible
+          that some consumer records whose timestamp is smaller than the given starting timestamp
+          are also consumed.
+
+        :param stopping_offsets_initializer: the :class:`KafkaOffsetsInitializer` to specify the
+            stopping offsets.
+        :return: this KafkaSourceBuilder
+        """
+        self._j_builder.setUnbounded(stopping_offsets_initializer._j_initializer)
+        return self
+
+    def set_bounded(self, stopping_offsets_initializer: 'KafkaOffsetsInitializer') \
+            -> 'KafkaSourceBuilder':
+        """
+        By default, the KafkaSource is set to run in CONTINUOUS_UNBOUNDED manner and thus never
+        stops until the Flink job fails or is canceled. To let the KafkaSource run in BOUNDED manner
+        and stop at some point, one can set an :class:`KafkaOffsetsInitializer` to specify the
+        stopping offsets for each partition. When all the partitions have reached their stopping
+        offsets, the KafkaSource will then exit.
+
+        This method is different from :meth:`set_unbounded` that after setting the stopping offsets
+        with this method, :meth:`KafkaSource.get_boundedness` will return BOUNDED instead of
+        CONTINUOUS_UNBOUNDED.
+
+        The following :class:`KafkaOffsetsInitializer` s are commonly used and provided out of the
+        box. Currently, customized offset initializer is not supported in PyFlink.
+
+        * :meth:`KafkaOffsetsInitializer.latest` - starting from the latest offsets.
+        * :meth:`KafkaOffsetsInitializer.committedOffsets` - starting from the committed offsets of
+          the consumer group. If there is no committed offsets, starting from the offsets
+          specified by the :class:`KafkaOffsetResetStrategy`.
+        * :meth:`KafkaOffsetsInitializer.offsets` - starting from the specified offsets for each
+          partition.
+        * :meth:`KafkaOffsetsInitializer.timestamp` - starting from the specified timestamp for each
+          partition. Note that the guarantee here is that all the records in Kafka whose timestamp
+          is greater than the given starting timestamp will be consumed. However, it is possible
+          that some consumer records whose timestamp is smaller than the given starting timestamp
+          are also consumed.
+
+        :param stopping_offsets_initializer: the :class:`KafkaOffsetsInitializer` to specify the
+            stopping offsets.
+        :return: this KafkaSourceBuilder
+        """
+        self._j_builder.setBounded(stopping_offsets_initializer._j_initializer)
+        return self
+
+    def set_value_only_deserializer(self, deserialization_schema: DeserializationSchema) \
+            -> 'KafkaSourceBuilder':
+        """
+        Sets the :class:`~pyflink.common.serialization.DeserializationSchema` for deserializing the
+        value of Kafka's ConsumerRecord. The other information (e.g. key) in a ConsumerRecord will
+        be ignored.
+
+        :param deserialization_schema: the :class:`DeserializationSchema` to use for
+            deserialization.
+        :return: this KafkaSourceBuilder.
+        """
+        self._j_builder.setValueOnlyDeserializer(deserialization_schema._j_deserialization_schema)
+        return self
+
+    def set_client_id_prefix(self, prefix: str) -> 'KafkaSourceBuilder':
+        """
+        Sets the client id prefix of this KafkaSource.
+
+        :param prefix: the client id prefix to use for this KafkaSource.
+        :return: this KafkaSourceBuilder.
+        """
+        self._j_builder.setClientIdPrefix(prefix)
+        return self
+
+    def set_property(self, key: str, value: str) -> 'KafkaSourceBuilder':
+        """
+        Set an arbitrary property for the KafkaSource and KafkaConsumer. The valid keys can be found
+        in ConsumerConfig and KafkaSourceOptions.
+
+        Note that the following keys will be overridden by the builder when the KafkaSource is
+        created.
+
+        * ``key.deserializer`` is always set to ByteArrayDeserializer.
+        * ``value.deserializer`` is always set to ByteArrayDeserializer.
+        * ``auto.offset.reset.strategy`` is overridden by AutoOffsetResetStrategy returned by
+          :class:`KafkaOffsetsInitializer` for the starting offsets, which is by default
+          :meth:`KafkaOffsetsInitializer.earliest`.
+        * ``partition.discovery.interval.ms`` is overridden to -1 when :meth:`set_bounded` has been
+          invoked.
+
+        :param key: the key of the property.
+        :param value: the value of the property.
+        :return: this KafkaSourceBuilder.
+        """
+        self._j_builder.setProperty(key, value)
+        return self
+
+
+class KafkaTopicPartition(object):
+    """
+    Corresponding to Java ``org.apache.kafka.common.TopicPartition`` class.
+
+    Example:
+    ::
+
+        >>> topic_partition = KafkaTopicPartition('TOPIC1', 0)
+
+    .. versionadded:: 1.16.0
+    """
+
+    def __init__(self, topic: str, partition: int):
+        self._topic = topic
+        self._partition = partition
+
+    def _to_j_topic_partition(self):
+        jvm = get_gateway().jvm
+        return jvm.org.apache.flink.kafka.shaded.org.apache.kafka.common.TopicPartition(
+            self._topic, self._partition)
+
+    def __eq__(self, other):
+        if not isinstance(other, KafkaTopicPartition):
+            return False
+        return self._topic == other._topic and self._partition == other._partition
+
+    def __hash__(self):
+        return 31 * (31 + self._partition) + hash(self._topic)
+
+
+class KafkaOffsetResetStrategy(Enum):
+    """
+    Corresponding to Java ``org.apache.kafka.client.consumer.OffsetResetStrategy`` class.
+
+    .. versionadded:: 1.16.0
+    """
+
+    LATEST = 0
+    EARLIEST = 1
+    NONE = 2
+
+    def _to_j_offset_reset_strategy(self):
+        jvm = get_gateway().jvm
+        if self.value == 0:
+            return jvm.org.apache.flink.kafka.shaded.org.apache.kafka.clients.consumer \
+                .OffsetResetStrategy.LATEST
+        if self.value == 1:
+            return jvm.org.apache.flink.kafka.shaded.org.apache.kafka.clients.consumer \
+                .OffsetResetStrategy.EARLIEST
+        if self.value == 2:
+            return jvm.org.apache.flink.kafka.shaded.org.apache.kafka.clients.consumer \
+                .OffsetResetStrategy.NONE
+
+
+class KafkaOffsetsInitializer(object):
+    """
+    An interface for users to specify the starting / stopping offset of a KafkaPartitionSplit.
+
+    .. versionadded:: 1.16.0
+    """
+
+    def __init__(self, j_initializer: JavaObject):
+        self._j_initializer = j_initializer
+
+    @staticmethod
+    @overload
+    def committed_offsets() -> 'KafkaOffsetsInitializer':
+        pass
+
+    @staticmethod
+    @overload
+    def committed_offsets(offset_reset_strategy: 'KafkaOffsetResetStrategy') \
+            -> 'KafkaOffsetsInitializer':
+        pass
+
+    @staticmethod
+    def committed_offsets(offset_reset_strategy: Optional['KafkaOffsetResetStrategy'] = None) \
+            -> 'KafkaOffsetsInitializer':
+        """
+        Get an :class:`KafkaOffsetsInitializer` which initializes the offsets to the committed
+        offsets. An exception will be thrown at runtime if there is no committed offsets.
+
+        An optional :class:`KafkaOffsetResetStrategy` can be specified to initialize the offsets if
+        the committed offsets does not exist.
+
+        :param offset_reset_strategy: the offset reset strategy to use when the committed offsets do
+            not exist.
+        :return: an offset initializer which initialize the offsets to the committed offsets.
+        """
+        jvm = get_gateway().jvm
+        if offset_reset_strategy is not None:
+            return KafkaOffsetsInitializer(
+                jvm.org.apache.flink.connector.kafka.source.enumerator.initializer
+                .OffsetsInitializer
+                .committedOffsets(offset_reset_strategy._to_j_offset_reset_strategy()))
+        else:
+            return KafkaOffsetsInitializer(
+                jvm.org.apache.flink.connector.kafka.source.enumerator.initializer
+                .OffsetsInitializer.committedOffsets())
+
+    @staticmethod
+    def timestamp(timestamp: int) -> 'KafkaOffsetsInitializer':
+        """
+        Get an :class:`KafkaOffsetsInitializer` which initializes the offsets in each partition so
+        that the initialized offset is the offset of the first record whose record timestamp is
+        greater than or equals the give timestamp.
+
+        :param timestamp: the timestamp to start the consumption.
+        :return: an :class:`OffsetsInitializer` which initializes the offsets based on the given
+            timestamp.
+        """
+        return KafkaOffsetsInitializer(get_gateway().jvm.org.apache.flink.connector.kafka.source
+                                       .enumerator.initializer
+                                       .OffsetsInitializer.timestamp(timestamp))
+
+    @staticmethod
+    def earliest() -> 'KafkaOffsetsInitializer':
+        """
+        Get an :class:`KafkaOffsetsInitializer` which initializes the offsets to the earliest
+        available offsets of each partition.
+
+        :return: an :class:`KafkaOffsetsInitializer` which initializes the offsets to the earliest
+            available offsets.
+        """
+        return KafkaOffsetsInitializer(get_gateway().jvm.org.apache.flink.connector.kafka.source
+                                       .enumerator.initializer
+                                       .OffsetsInitializer.earliest())
+
+    @staticmethod
+    def latest() -> 'KafkaOffsetsInitializer':
+        """
+        Get an :class:`KafkaOffsetsInitializer` which initializes the offsets to the latest offsets
+        of each partition.
+
+        :return: an :class:`KafkaOffsetsInitializer` which initializes the offsets to the latest
+            offsets.
+        """
+        return KafkaOffsetsInitializer(get_gateway().jvm.org.apache.flink.connector.kafka.source
+                                       .enumerator.initializer.OffsetsInitializer.latest())
+
+    @staticmethod
+    @overload
+    def offsets(offsets: Dict['KafkaTopicPartition', int]) -> 'KafkaOffsetsInitializer':
+        pass
+
+    @staticmethod
+    @overload
+    def offsets(offsets: Dict['KafkaTopicPartition', int],
+                offset_reset_strategy: 'KafkaOffsetResetStrategy') -> 'KafkaOffsetsInitializer':
+        pass
+
+    @staticmethod
+    def offsets(offsets: Dict['KafkaTopicPartition', int],
+                offset_reset_strategy: Optional['KafkaOffsetResetStrategy'] = None) \
+            -> 'KafkaOffsetsInitializer':
+        """
+        Get an :class:`KafkaOffsetsInitializer` which initializes the offsets to the specified
+        offsets.
+
+        An optional :class:`KafkaOffsetResetStrategy` can be specified to initialize the offsets in
+        case the specified offset is out of range.
+
+        Example:
+        ::
+
+            >>> KafkaOffsetsInitializer.offsets({
+            ...     KafkaTopicPartition('TOPIC1', 0): 0,
+            ...     KafkaTopicPartition('TOPIC1', 1): 10000
+            ... }, KafkaOffsetResetStrategy.EARLIEST)
+
+        :param offsets: the specified offsets for each partition.
+        :param offset_reset_strategy: the :class:`KafkaOffsetResetStrategy` to use when the
+            specified offset is out of range.
+        :return: an :class:`KafkaOffsetsInitializer` which initializes the offsets to the specified
+            offsets.
+        """
+        jvm = get_gateway().jvm
+        j_primitive_long_class = get_java_class(jvm.long)
+        j_long_class = get_java_class(jvm.Long)
+        j_map = jvm.org.apache.flink.python.util.PythonConfigUtil.HashMapHelper(
+            j_long_class.getDeclaredConstructor(to_jarray(jvm.Class, [j_primitive_long_class])),
+            False
+        )
+        for tp, offset in offsets.items():
+            j_map.put(tp._to_j_topic_partition(), to_jarray(jvm.Object, [offset]))
+
+        if offset_reset_strategy is not None:
+            return KafkaOffsetsInitializer(
+                jvm.org.apache.flink.connector.kafka.source.enumerator.initializer
+                .OffsetsInitializer
+                .offsets(j_map.getMap(), offset_reset_strategy._to_j_offset_reset_strategy()))
+        else:
+            return KafkaOffsetsInitializer(
+                jvm.org.apache.flink.connector.kafka.source.enumerator.initializer
+                .OffsetsInitializer.offsets(j_map.getMap()))

--- a/flink-python/pyflink/datastream/connectors/tests/__init__.py
+++ b/flink-python/pyflink/datastream/connectors/tests/__init__.py
@@ -1,0 +1,17 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################

--- a/flink-python/pyflink/datastream/connectors/tests/test_kafka_new.py
+++ b/flink-python/pyflink/datastream/connectors/tests/test_kafka_new.py
@@ -1,0 +1,371 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+from typing import Dict
+
+from pyflink.common.configuration import Configuration
+from pyflink.common.serialization import SimpleStringSchema, DeserializationSchema, \
+    JsonRowDeserializationSchema, CsvRowDeserializationSchema, AvroRowDeserializationSchema
+from pyflink.common.typeinfo import Types
+from pyflink.common.watermark_strategy import WatermarkStrategy
+from pyflink.datastream.connectors.kafka_new import KafkaSource, KafkaTopicPartition, \
+    KafkaOffsetsInitializer, KafkaOffsetResetStrategy
+from pyflink.datastream.stream_execution_environment import StreamExecutionEnvironment
+from pyflink.java_gateway import get_gateway
+from pyflink.testing.test_case_utils import PyFlinkTestCase
+from pyflink.util.java_utils import to_jarray, is_instance_of
+
+
+class KafkaSourceTest(PyFlinkTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.env = StreamExecutionEnvironment.get_execution_environment()
+
+    def test_compiling(self):
+        source = KafkaSource.builder() \
+            .set_bootstrap_servers('localhost:9092') \
+            .set_topics('test_topic') \
+            .set_value_only_deserializer(SimpleStringSchema()) \
+            .build()
+
+        ds = self.env.from_source(source=source,
+                                  watermark_strategy=WatermarkStrategy.for_monotonous_timestamps(),
+                                  source_name='kafka source')
+        ds.print()
+        plan = eval(self.env.get_execution_plan())
+        self.assertEqual('Source: kafka source', plan['nodes'][0]['type'])
+
+    def test_set_properties(self):
+        source = KafkaSource.builder() \
+            .set_bootstrap_servers('localhost:9092') \
+            .set_group_id('test_group_id') \
+            .set_client_id_prefix('test_client_id_prefix') \
+            .set_property('test_property', 'test_value') \
+            .set_topics('test_topic') \
+            .set_value_only_deserializer(SimpleStringSchema()) \
+            .build()
+        conf = self._get_kafka_source_configuration(source)
+        self.assertEqual(conf.get_string('bootstrap.servers', ''), 'localhost:9092')
+        self.assertEqual(conf.get_string('group.id', ''), 'test_group_id')
+        self.assertEqual(conf.get_string('client.id.prefix', ''), 'test_client_id_prefix')
+        self.assertEqual(conf.get_string('test_property', ''), 'test_value')
+
+    def test_set_topics(self):
+        source = KafkaSource.builder() \
+            .set_bootstrap_servers('localhost:9092') \
+            .set_topics('test_topic1', 'test_topic2') \
+            .set_value_only_deserializer(SimpleStringSchema()) \
+            .build()
+        kafka_subscriber = self._get_java_field(source.get_java_function(), 'subscriber')
+        self.assertEqual(
+            kafka_subscriber.getClass().getCanonicalName(),
+            'org.apache.flink.connector.kafka.source.enumerator.subscriber.TopicListSubscriber'
+        )
+        topics = self._get_java_field(kafka_subscriber, 'topics')
+        self.assertTrue(is_instance_of(topics, get_gateway().jvm.java.util.List))
+        self.assertEqual(topics.size(), 2)
+        self.assertEqual(topics[0], 'test_topic1')
+        self.assertEqual(topics[1], 'test_topic2')
+
+    def test_set_topic_pattern(self):
+        source = KafkaSource.builder() \
+            .set_bootstrap_servers('localhost:9092') \
+            .set_topic_pattern('test_topic*') \
+            .set_value_only_deserializer(SimpleStringSchema()) \
+            .build()
+        kafka_subscriber = self._get_java_field(source.get_java_function(), 'subscriber')
+        self.assertEqual(
+            kafka_subscriber.getClass().getCanonicalName(),
+            'org.apache.flink.connector.kafka.source.enumerator.subscriber.TopicPatternSubscriber'
+        )
+        topic_pattern = self._get_java_field(kafka_subscriber, 'topicPattern')
+        self.assertTrue(is_instance_of(topic_pattern, get_gateway().jvm.java.util.regex.Pattern))
+        self.assertEqual(topic_pattern.toString(), 'test_topic*')
+
+    def test_set_partitions(self):
+        topic_partition_1 = KafkaTopicPartition('test_topic', 1)
+        topic_partition_2 = KafkaTopicPartition('test_topic', 2)
+        source = KafkaSource.builder() \
+            .set_bootstrap_servers('localhost:9092') \
+            .set_partitions({topic_partition_1, topic_partition_2}) \
+            .set_value_only_deserializer(SimpleStringSchema()) \
+            .build()
+        kafka_subscriber = self._get_java_field(source.get_java_function(), 'subscriber')
+        self.assertEqual(
+            kafka_subscriber.getClass().getCanonicalName(),
+            'org.apache.flink.connector.kafka.source.enumerator.subscriber.PartitionSetSubscriber'
+        )
+        partitions = self._get_java_field(kafka_subscriber, 'subscribedPartitions')
+        self.assertTrue(is_instance_of(partitions, get_gateway().jvm.java.util.Set))
+        self.assertTrue(topic_partition_1._to_j_topic_partition() in partitions)
+        self.assertTrue(topic_partition_2._to_j_topic_partition() in partitions)
+
+    def test_set_starting_offsets(self):
+        def _build_source(initializer: KafkaOffsetsInitializer):
+            return KafkaSource.builder() \
+                .set_bootstrap_servers('localhost:9092') \
+                .set_topics('test_topic') \
+                .set_value_only_deserializer(SimpleStringSchema()) \
+                .set_group_id('test_group') \
+                .set_starting_offsets(initializer) \
+                .build()
+
+        self._check_reader_handled_offsets_initializer(
+            _build_source(KafkaOffsetsInitializer.latest()), -1, KafkaOffsetResetStrategy.LATEST
+        )
+        self._check_reader_handled_offsets_initializer(
+            _build_source(KafkaOffsetsInitializer.earliest()), -2,
+            KafkaOffsetResetStrategy.EARLIEST
+        )
+        self._check_reader_handled_offsets_initializer(
+            _build_source(KafkaOffsetsInitializer.committed_offsets()), -3,
+            KafkaOffsetResetStrategy.NONE
+        )
+        self._check_reader_handled_offsets_initializer(
+            _build_source(KafkaOffsetsInitializer.committed_offsets(
+                KafkaOffsetResetStrategy.LATEST
+            )), -3, KafkaOffsetResetStrategy.LATEST
+        )
+        self._check_timestamp_offsets_initializer(
+            _build_source(KafkaOffsetsInitializer.timestamp(100)), 100
+        )
+        specified_offsets = {
+            KafkaTopicPartition('test_topic1', 1): 1000,
+            KafkaTopicPartition('test_topic2', 2): 2000
+        }
+        self._check_specified_offsets_initializer(
+            _build_source(KafkaOffsetsInitializer.offsets(specified_offsets)), specified_offsets,
+            KafkaOffsetResetStrategy.EARLIEST
+        )
+        self._check_specified_offsets_initializer(
+            _build_source(KafkaOffsetsInitializer.offsets(
+                specified_offsets,
+                KafkaOffsetResetStrategy.LATEST
+            )),
+            specified_offsets,
+            KafkaOffsetResetStrategy.LATEST
+        )
+
+    def test_bounded(self):
+        def _build_source(initializer: KafkaOffsetsInitializer):
+            return KafkaSource.builder() \
+                .set_bootstrap_servers('localhost:9092') \
+                .set_topics('test_topic') \
+                .set_value_only_deserializer(SimpleStringSchema()) \
+                .set_group_id('test_group') \
+                .set_bounded(initializer) \
+                .build()
+
+        def _check_bounded(source: KafkaSource):
+            self.assertEqual(
+                self._get_java_field(source.get_java_function(), 'boundedness').toString(),
+                'BOUNDED'
+            )
+
+        self._test_set_bounded_or_unbounded(_build_source, _check_bounded)
+
+    def test_unbounded(self):
+        def _build_source(initializer: KafkaOffsetsInitializer):
+            return KafkaSource.builder() \
+                .set_bootstrap_servers('localhost:9092') \
+                .set_topics('test_topic') \
+                .set_value_only_deserializer(SimpleStringSchema()) \
+                .set_group_id('test_group') \
+                .set_unbounded(initializer) \
+                .build()
+
+        def _check_bounded(source: KafkaSource):
+            self.assertEqual(
+                self._get_java_field(source.get_java_function(), 'boundedness').toString(),
+                'CONTINUOUS_UNBOUNDED'
+            )
+
+        self._test_set_bounded_or_unbounded(_build_source, _check_bounded)
+
+    def _test_set_bounded_or_unbounded(self, _build_source, _check_boundedness):
+        source = _build_source(KafkaOffsetsInitializer.latest())
+        _check_boundedness(source)
+        self._check_reader_handled_offsets_initializer(
+            source, -1, KafkaOffsetResetStrategy.LATEST, False
+        )
+        source = _build_source(KafkaOffsetsInitializer.earliest())
+        _check_boundedness(source)
+        self._check_reader_handled_offsets_initializer(
+            source, -2, KafkaOffsetResetStrategy.EARLIEST, False
+        )
+        source = _build_source(KafkaOffsetsInitializer.committed_offsets())
+        _check_boundedness(source)
+        self._check_reader_handled_offsets_initializer(
+            source, -3, KafkaOffsetResetStrategy.NONE, False
+        )
+        source = _build_source(KafkaOffsetsInitializer.committed_offsets(
+            KafkaOffsetResetStrategy.LATEST
+        ))
+        _check_boundedness(source)
+        self._check_reader_handled_offsets_initializer(
+            source, -3, KafkaOffsetResetStrategy.LATEST, False
+        )
+        source = _build_source(KafkaOffsetsInitializer.timestamp(100))
+        _check_boundedness(source)
+        self._check_timestamp_offsets_initializer(source, 100, False)
+        specified_offsets = {
+            KafkaTopicPartition('test_topic1', 1): 1000,
+            KafkaTopicPartition('test_topic2', 2): 2000
+        }
+        source = _build_source(KafkaOffsetsInitializer.offsets(specified_offsets))
+        _check_boundedness(source)
+        self._check_specified_offsets_initializer(
+            source, specified_offsets, KafkaOffsetResetStrategy.EARLIEST, False
+        )
+        source = _build_source(KafkaOffsetsInitializer.offsets(
+            specified_offsets,
+            KafkaOffsetResetStrategy.LATEST)
+        )
+        _check_boundedness(source)
+        self._check_specified_offsets_initializer(
+            source, specified_offsets, KafkaOffsetResetStrategy.LATEST, False
+        )
+
+    def test_set_value_only_deserialization_schema(self):
+        def _check(schema: DeserializationSchema, class_name: str):
+            source = KafkaSource.builder() \
+                .set_bootstrap_servers('localhost:9092') \
+                .set_topics('test_topic') \
+                .set_value_only_deserializer(schema) \
+                .build()
+            deserialization_schema_wrapper = self._get_java_field(source.get_java_function(),
+                                                                  'deserializationSchema')
+            self.assertEqual(
+                deserialization_schema_wrapper.getClass().getCanonicalName(),
+                'org.apache.flink.connector.kafka.source.reader.deserializer'
+                '.KafkaValueOnlyDeserializationSchemaWrapper'
+            )
+            deserialization_schema = self._get_java_field(deserialization_schema_wrapper,
+                                                          'deserializationSchema')
+            self.assertEqual(deserialization_schema.getClass().getCanonicalName(),
+                             class_name)
+
+        _check(SimpleStringSchema(), 'org.apache.flink.api.common.serialization.SimpleStringSchema')
+        _check(
+            JsonRowDeserializationSchema.builder().type_info(Types.ROW([Types.STRING()])).build(),
+            'org.apache.flink.formats.json.JsonRowDeserializationSchema'
+        )
+        _check(
+            CsvRowDeserializationSchema.Builder(Types.ROW([Types.STRING()])).build(),
+            'org.apache.flink.formats.csv.CsvRowDeserializationSchema'
+        )
+        avro_schema_string = """
+        {
+            "type": "record",
+            "name": "test_record",
+            "fields": []
+        }
+        """
+        _check(
+            AvroRowDeserializationSchema(avro_schema_string=avro_schema_string),
+            'org.apache.flink.formats.avro.AvroRowDeserializationSchema'
+        )
+
+    def _check_reader_handled_offsets_initializer(self,
+                                                  source: KafkaSource,
+                                                  offset: int,
+                                                  reset_strategy: KafkaOffsetResetStrategy,
+                                                  is_start: bool = True):
+        if is_start:
+            field_name = 'startingOffsetsInitializer'
+        else:
+            field_name = 'stoppingOffsetsInitializer'
+        offsets_initializer = self._get_java_field(source.get_java_function(), field_name)
+        self.assertEqual(
+            offsets_initializer.getClass().getCanonicalName(),
+            'org.apache.flink.connector.kafka.source.enumerator.initializer'
+            '.ReaderHandledOffsetsInitializer'
+        )
+
+        starting_offset = self._get_java_field(offsets_initializer, 'startingOffset')
+        self.assertEqual(starting_offset, offset)
+
+        offset_reset_strategy = self._get_java_field(offsets_initializer, 'offsetResetStrategy')
+        self.assertTrue(
+            offset_reset_strategy.equals(reset_strategy._to_j_offset_reset_strategy())
+        )
+
+    def _check_timestamp_offsets_initializer(self,
+                                             source: KafkaSource,
+                                             timestamp: int,
+                                             is_start: bool = True):
+        if is_start:
+            field_name = 'startingOffsetsInitializer'
+        else:
+            field_name = 'stoppingOffsetsInitializer'
+        offsets_initializer = self._get_java_field(source.get_java_function(), field_name)
+        self.assertEqual(
+            offsets_initializer.getClass().getCanonicalName(),
+            'org.apache.flink.connector.kafka.source.enumerator.initializer'
+            '.TimestampOffsetsInitializer'
+        )
+
+        starting_timestamp = self._get_java_field(offsets_initializer, 'startingTimestamp')
+        self.assertEqual(starting_timestamp, timestamp)
+
+    def _check_specified_offsets_initializer(self,
+                                             source: KafkaSource,
+                                             offsets: Dict[KafkaTopicPartition, int],
+                                             reset_strategy: KafkaOffsetResetStrategy,
+                                             is_start: bool = True):
+        if is_start:
+            field_name = 'startingOffsetsInitializer'
+        else:
+            field_name = 'stoppingOffsetsInitializer'
+        offsets_initializer = self._get_java_field(source.get_java_function(), field_name)
+        self.assertEqual(
+            offsets_initializer.getClass().getCanonicalName(),
+            'org.apache.flink.connector.kafka.source.enumerator.initializer'
+            '.SpecifiedOffsetsInitializer'
+        )
+
+        initial_offsets = self._get_java_field(offsets_initializer, 'initialOffsets')
+        self.assertTrue(is_instance_of(initial_offsets, get_gateway().jvm.java.util.Map))
+        self.assertEqual(initial_offsets.size(), len(offsets))
+        for j_topic_partition in initial_offsets:
+            topic_partition = KafkaTopicPartition(j_topic_partition.topic(),
+                                                  j_topic_partition.partition())
+            self.assertIsNotNone(offsets.get(topic_partition))
+            self.assertEqual(initial_offsets[j_topic_partition], offsets[topic_partition])
+
+        offset_reset_strategy = self._get_java_field(offsets_initializer, 'offsetResetStrategy')
+        self.assertTrue(
+            offset_reset_strategy.equals(reset_strategy._to_j_offset_reset_strategy())
+        )
+
+    @staticmethod
+    def _get_kafka_source_configuration(source: KafkaSource):
+        jvm = get_gateway().jvm
+        j_source = source.get_java_function()
+        j_to_configuration = j_source.getClass().getDeclaredMethod(
+            'getConfiguration', to_jarray(jvm.java.lang.Class, [])
+        )
+        j_to_configuration.setAccessible(True)
+        j_configuration = j_to_configuration.invoke(j_source, to_jarray(jvm.java.lang.Object, []))
+        return Configuration(j_configuration=j_configuration)
+
+    @staticmethod
+    def _get_java_field(java_object, field_name: str):
+        j_field = java_object.getClass().getDeclaredField(field_name)
+        j_field.setAccessible(True)
+        return j_field.get(java_object)

--- a/flink-python/pyflink/pyflink_gateway_server.py
+++ b/flink-python/pyflink/pyflink_gateway_server.py
@@ -218,6 +218,7 @@ def construct_test_classpath():
         "flink-formats/flink-csv/target/flink-csv*.jar",
         "flink-formats/flink-sql-avro/target/flink-sql-avro*.jar",
         "flink-formats/flink-json/target/flink-json*.jar",
+        "flink-connectors/flink-sql-connector-kafka/target/flink-sql-connector-kafka*.jar",
         "flink-python/target/artifacts/testDataStream.jar",
         "flink-python/target/flink-python*-tests.jar",
         ("flink-state-backends/flink-statebackend-rocksdb/target/"


### PR DESCRIPTION

## What is the purpose of the change

This PR aligns the new KafkaSource connector for PyFlink.


## Verifying this change

This change added tests and can be verified as follows:

- datastream/connectors/tests/test_kafka_new.py


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (Python Sphinx doc)
