### PR TITLE
[FLINK-28329][Tests] Output the top 15 directories in terms of used disk space

### DIFF
--- a/flink-end-to-end-tests/test-scripts/test-runner-common.sh
+++ b/flink-end-to-end-tests/test-scripts/test-runner-common.sh
@@ -109,7 +109,10 @@ function log_environment_info {
     jps
 
     echo "Disk information"
-    df -hH
+    df -h
+
+    echo "##[group]Top 15 biggest directories in terms of used disk space"
+    du -a . | sort -n -r | head -n 15
 
     if sudo -n true 2>/dev/null; then
       echo "Allocated ports"

--- a/tools/ci/controller_utils.sh
+++ b/tools/ci/controller_utils.sh
@@ -25,7 +25,7 @@ print_system_info() {
     cat /proc/meminfo
 
     echo "Disk information"
-    df -hH
+    df -h
 
     echo "Running build as"
     whoami


### PR DESCRIPTION
## What is the purpose of the change

We are having the situation where a lot of disk space gets used by both Bash and Java E2E tests. In order to identify which tests aren't properly cleaning up, it would be good if we output the top 15 directories which are the biggest in used disk space

## Brief change log

* Output top 15 directories with that are using the most disk space in Bash E2E tests

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable