### PR TITLE
[FLINK-28169][e2e-test/glue,kinesis] Re-enabled integration test that…

### DIFF
--- a/flink-end-to-end-tests/flink-glue-schema-registry-json-test/pom.xml
+++ b/flink-end-to-end-tests/flink-glue-schema-registry-json-test/pom.xml
@@ -47,7 +47,7 @@ under the License.
 			<!-- can be removed once new version of Glue Schema Registry releases -->
 
 			<dependency>
-				<groupId >com.google.guava</groupId>
+				<groupId>com.google.guava</groupId>
 				<artifactId>guava</artifactId>
 				<version>${guava.version}</version>
 			</dependency>
@@ -106,6 +106,13 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-aws-kinesis-streams</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-connector-aws-base</artifactId>
 			<version>${project.version}</version>
 			<type>test-jar</type>
@@ -114,13 +121,6 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-connector-kinesis</artifactId>
-			<version>${project.version}</version>
-			<type>test-jar</type>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-connector-aws-kinesis-streams</artifactId>
 			<version>${project.version}</version>
 			<type>test-jar</type>
 		</dependency>

--- a/flink-end-to-end-tests/flink-glue-schema-registry-json-test/src/test/java/org/apache/flink/glue/schema/registry/test/json/GlueSchemaRegistryJsonKinesisITCase.java
+++ b/flink-end-to-end-tests/flink-glue-schema-registry-json-test/src/test/java/org/apache/flink/glue/schema/registry/test/json/GlueSchemaRegistryJsonKinesisITCase.java
@@ -35,7 +35,6 @@ import org.junit.After;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.rules.Timeout;
 import org.testcontainers.containers.Network;
@@ -57,7 +56,6 @@ import static org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfi
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** End-to-end test for Glue Schema Registry Json format using Kinesalite. */
-@Ignore("FLINK-28169")
 public class GlueSchemaRegistryJsonKinesisITCase extends TestLogger {
     private static final String INPUT_STREAM = "gsr_json_input_stream";
     private static final String OUTPUT_STREAM = "gsr_json_output_stream";


### PR DESCRIPTION
… was failing due a shaded dependency test-jar requiring a transitive shaded test-jar being satisfied by a later unshaded dependency test-jar, changed so that unshaded dependency test-jar is loaded earlier in pom

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Re-enabled e2e test that was failing due a shaded dependency test-jar requiring a transitive shaded test-jar being satisfied by a later unshaded dependency test-jar, changed so that unshaded dependency test-jar is loaded earlier in pom


## Brief change log

* re-enabled previously failing e2e test
* ordered the test-jar dependency `flink-connector-aws-kinesis-streams` to be earlier than `flink-connector-kinesis` and `flink-connector-aws-base` so that the package `software.amazon.awssdk.http.SdkHttpClient` loaded may be recognized by the later shaded package and mapped to `org.apache.flink.kinesis.shaded.software.amazon.awssdk.http.SdkHttpClient`.


## Verifying this change

1. clone the repository on the master branch and run `mvn clean install -pl :flink-glue-schema-registry-json-test -Prun-end-to-end-tests` - the test fails consistently with exactly the error displayed in the jira
2. apply the fix and run the same command, it passes

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)y
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)n
  - The serializers: (yes / no / don't know)n
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)n
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)n
  - The S3 file system connector: (yes / no / don't know)n

## Documentation

  - Does this pull request introduce a new feature? (yes / no)n
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)n/a
