### PR TITLE
[FLINK-28274][runtime] set the max parallelism of ContinuousFileMonitoringFunction explicitly

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -1853,6 +1853,10 @@ public class StreamExecutionEnvironment {
 
         SingleOutputStreamOperator<OUT> source =
                 addSource(monitoringFunction, sourceName, null, boundedness)
+                        // Set the parallelism and maximum parallelism of
+                        // ContinuousFileMonitoringFunction to 1 in
+                        // case reactive mode changes it. See FLINK-28274 for more information.
+                        .forceNonParallel()
                         .transform("Split Reader: " + sourceName, typeInfo, factory);
 
         return new DataStreamSource<>(source);


### PR DESCRIPTION
## What is the purpose of the change

set the max parallelism of ContinuousFileMonitoringFunction explicitly in case AdaptiveScheduler changes the parallelism of this function.

## Verifying this change

  - covered by existed ut.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
