### PR TITLE
[FLINK-28322][table-api] DataStreamScan(Sink)Provider's new method is not compatible

### DIFF
--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemTableSink.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemTableSink.java
@@ -136,8 +136,13 @@ public class FileSystemTableSink extends AbstractFileSystemTable
 
     @Override
     public SinkRuntimeProvider getSinkRuntimeProvider(Context sinkContext) {
-        return (DataStreamSinkProvider)
-                (providerContext, dataStream) -> consume(providerContext, dataStream, sinkContext);
+        return new DataStreamSinkProvider() {
+            @Override
+            public DataStreamSink<?> consumeDataStream(
+                    ProviderContext providerContext, DataStream<RowData> dataStream) {
+                return consume(providerContext, dataStream, sinkContext);
+            }
+        };
     }
 
     private DataStreamSink<?> consume(

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSink.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSink.java
@@ -163,9 +163,13 @@ public class HiveTableSink implements DynamicTableSink, SupportsPartitioning, Su
     public SinkRuntimeProvider getSinkRuntimeProvider(Context context) {
         DataStructureConverter converter =
                 context.createDataStructureConverter(tableSchema.toRowDataType());
-        return (DataStreamSinkProvider)
-                (providerContext, dataStream) ->
-                        consume(providerContext, dataStream, context.isBounded(), converter);
+        return new DataStreamSinkProvider() {
+            @Override
+            public DataStreamSink<?> consumeDataStream(
+                    ProviderContext providerContext, DataStream<RowData> dataStream) {
+                return consume(providerContext, dataStream, context.isBounded(), converter);
+            }
+        };
     }
 
     private DataStreamSink<?> consume(

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/connector/sink/DataStreamSinkProvider.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/connector/sink/DataStreamSinkProvider.java
@@ -54,8 +54,10 @@ public interface DataStreamSinkProvider
      *
      * @see SingleOutputStreamOperator#uid(String)
      */
-    DataStreamSink<?> consumeDataStream(
-            ProviderContext providerContext, DataStream<RowData> dataStream);
+    default DataStreamSink<?> consumeDataStream(
+            ProviderContext providerContext, DataStream<RowData> dataStream) {
+        return consumeDataStream(dataStream);
+    }
 
     /**
      * Consumes the given Java {@link DataStream} and returns the sink transformation {@link

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/connector/source/DataStreamScanProvider.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/connector/source/DataStreamScanProvider.java
@@ -48,8 +48,10 @@ public interface DataStreamScanProvider extends ScanTableSource.ScanRuntimeProvi
      *
      * @see SingleOutputStreamOperator#uid(String)
      */
-    DataStream<RowData> produceDataStream(
-            ProviderContext providerContext, StreamExecutionEnvironment execEnv);
+    default DataStream<RowData> produceDataStream(
+            ProviderContext providerContext, StreamExecutionEnvironment execEnv) {
+        return produceDataStream(execEnv);
+    }
 
     /** Creates a scan Java {@link DataStream} from a {@link StreamExecutionEnvironment}. */
     @Deprecated

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/connectors/CollectDynamicSink.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/connectors/CollectDynamicSink.java
@@ -23,6 +23,8 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamSink;
 import org.apache.flink.streaming.api.environment.CheckpointConfig;
 import org.apache.flink.streaming.api.operators.collect.CollectResultIterator;
 import org.apache.flink.streaming.api.operators.collect.CollectSinkOperator;
@@ -32,6 +34,7 @@ import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.api.internal.ResultProvider;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.ProviderContext;
 import org.apache.flink.table.connector.RuntimeConverter;
 import org.apache.flink.table.connector.sink.DataStreamSinkProvider;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
@@ -95,40 +98,40 @@ public final class CollectDynamicSink implements DynamicTableSink {
 
     @Override
     public SinkRuntimeProvider getSinkRuntimeProvider(Context context) {
-        return (DataStreamSinkProvider)
-                (providerContext, inputStream) -> {
-                    final CheckpointConfig checkpointConfig =
-                            inputStream.getExecutionEnvironment().getCheckpointConfig();
-                    final ExecutionConfig config = inputStream.getExecutionConfig();
+        return new DataStreamSinkProvider() {
+            @Override
+            public DataStreamSink<?> consumeDataStream(
+                    ProviderContext providerContext, DataStream<RowData> inputStream) {
+                final CheckpointConfig checkpointConfig =
+                        inputStream.getExecutionEnvironment().getCheckpointConfig();
+                final ExecutionConfig config = inputStream.getExecutionConfig();
 
-                    final TypeSerializer<RowData> externalSerializer =
-                            InternalTypeInfo.<RowData>of(consumedDataType.getLogicalType())
-                                    .createSerializer(config);
-                    final String accumulatorName = tableIdentifier.getObjectName();
+                final TypeSerializer<RowData> externalSerializer =
+                        InternalTypeInfo.<RowData>of(consumedDataType.getLogicalType())
+                                .createSerializer(config);
+                final String accumulatorName = tableIdentifier.getObjectName();
 
-                    final CollectSinkOperatorFactory<RowData> factory =
-                            new CollectSinkOperatorFactory<>(
-                                    externalSerializer,
-                                    accumulatorName,
-                                    maxBatchSize,
-                                    socketTimeout);
-                    final CollectSinkOperator<RowData> operator =
-                            (CollectSinkOperator<RowData>) factory.getOperator();
+                final CollectSinkOperatorFactory<RowData> factory =
+                        new CollectSinkOperatorFactory<>(
+                                externalSerializer, accumulatorName, maxBatchSize, socketTimeout);
+                final CollectSinkOperator<RowData> operator =
+                        (CollectSinkOperator<RowData>) factory.getOperator();
 
-                    iterator =
-                            new CollectResultIterator<>(
-                                    operator.getOperatorIdFuture(),
-                                    externalSerializer,
-                                    accumulatorName,
-                                    checkpointConfig);
-                    converter = context.createDataStructureConverter(consumedDataType);
-                    converter.open(RuntimeConverter.Context.create(classLoader));
+                iterator =
+                        new CollectResultIterator<>(
+                                operator.getOperatorIdFuture(),
+                                externalSerializer,
+                                accumulatorName,
+                                checkpointConfig);
+                converter = context.createDataStructureConverter(consumedDataType);
+                converter.open(RuntimeConverter.Context.create(classLoader));
 
-                    final CollectStreamSink<RowData> sink =
-                            new CollectStreamSink<>(inputStream, factory);
-                    providerContext.generateUid(COLLECT_TRANSFORMATION).ifPresent(sink::uid);
-                    return sink.name("Collect table sink");
-                };
+                final CollectStreamSink<RowData> sink =
+                        new CollectStreamSink<>(inputStream, factory);
+                providerContext.generateUid(COLLECT_TRANSFORMATION).ifPresent(sink::uid);
+                return sink.name("Collect table sink");
+            }
+        };
     }
 
     @Override

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecSinkITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecSinkITCase.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.table.planner.plan.nodes.exec.common;
 
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamSink;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
@@ -33,6 +35,7 @@ import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.table.api.config.ExecutionConfigOptions;
+import org.apache.flink.table.connector.ProviderContext;
 import org.apache.flink.table.connector.sink.DataStreamSinkProvider;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.sink.SinkProvider;
@@ -150,8 +153,14 @@ public class CommonExecSinkITCase extends AbstractTestBase {
                                     @Override
                                     public DataStreamSinkProvider getSinkRuntimeProvider(
                                             DynamicTableSink.Context context) {
-                                        return (providerContext, dataStream) ->
-                                                dataStream.addSink(sinkFunction);
+                                        return new DataStreamSinkProvider() {
+                                            @Override
+                                            public DataStreamSink<?> consumeDataStream(
+                                                    ProviderContext providerContext,
+                                                    DataStream<RowData> dataStream) {
+                                                return dataStream.addSink(sinkFunction);
+                                            }
+                                        };
                                     }
                                 })
                         .build();
@@ -451,8 +460,14 @@ public class CommonExecSinkITCase extends AbstractTestBase {
                                     @Override
                                     public DataStreamSinkProvider getSinkRuntimeProvider(
                                             DynamicTableSink.Context context) {
-                                        return (providerContext, dataStream) ->
-                                                dataStream.addSink(sinkFunction);
+                                        return new DataStreamSinkProvider() {
+                                            @Override
+                                            public DataStreamSink<?> consumeDataStream(
+                                                    ProviderContext providerContext,
+                                                    DataStream<RowData> dataStream) {
+                                                return dataStream.addSink(sinkFunction);
+                                            }
+                                        };
                                     }
                                 })
                         .build();
@@ -502,12 +517,17 @@ public class CommonExecSinkITCase extends AbstractTestBase {
         return new TableFactoryHarness.SinkBase() {
             @Override
             public DataStreamSinkProvider getSinkRuntimeProvider(Context context) {
-                return (providerContext, dataStream) -> {
-                    TestSink<RowData> sink = buildRecordWriterTestSink(new RecordWriter(fetched));
-                    if (useSinkV2) {
-                        return dataStream.sinkTo(SinkV1Adapter.wrap(sink));
+                return new DataStreamSinkProvider() {
+                    @Override
+                    public DataStreamSink<?> consumeDataStream(
+                            ProviderContext providerContext, DataStream<RowData> dataStream) {
+                        TestSink<RowData> sink =
+                                buildRecordWriterTestSink(new RecordWriter(fetched));
+                        if (useSinkV2) {
+                            return dataStream.sinkTo(SinkV1Adapter.wrap(sink));
+                        }
+                        return dataStream.sinkTo(sink);
                     }
-                    return dataStream.sinkTo(sink);
                 };
             }
         };


### PR DESCRIPTION
## What is the purpose of the change

In [FLINK-25990](https://issues.apache.org/jira/browse/FLINK-25990) ,
Add a method "DataStream<RowData> produceDataStream(ProviderContext providerContext, StreamExecutionEnvironment execEnv)" in DataStreamScanProvider.
But this method has no default implementation, this is not compatible when users upgrade their DataStreamScanProvider implementation from 1.14 to 1.15. (The old method will not be called)

DataStreamSinkProvider is the same.

## Brief change log

DataStreamScanProvider's new method should be:
```
    default DataStream<RowData> produceDataStream(
            ProviderContext providerContext, StreamExecutionEnvironment execEnv) {
        return produceDataStream(execEnv);
    }
```

Impact on DataStreamSinkProvider:
DataStreamSinkProvider is no longer a functional interface and requires the use of an anonymous internal class.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)