### PR TITLE
[FLINK-28336][python][format] Support parquet-avro format DataStream API

### DIFF
--- a/docs/content.zh/docs/connectors/datastream/formats/parquet.md
+++ b/docs/content.zh/docs/connectors/datastream/formats/parquet.md
@@ -133,7 +133,7 @@ final DataStream<RowData> stream =
 
 ## Avro Records
 
-Flink 支持三种方式来读取 Parquet 文件并创建 Avro records ：
+Flink 支持三种方式来读取 Parquet 文件并创建 Avro records （PyFlink 只支持 generic record）：
 
 - [Generic record](https://avro.apache.org/docs/1.10.0/api/java/index.html)
 - [Specific record](https://avro.apache.org/docs/1.10.0/api/java/index.html)
@@ -163,6 +163,8 @@ Flink 会基于 JSON 字符串解析 Avro schema。也有很多其他的方式�
 请参考 [Avro Schema](https://avro.apache.org/docs/1.10.0/api/java/org/apache/avro/Schema.html) 以获取更多详细信息。
 然后，你可以通过 `AvroParquetReaders` 为 Avro Generic 记录创建 `AvroParquetRecordFormat`。
 
+{{< tabs "GenericRecord" >}}
+{{< tab "Java" >}}
 ```java
 // 解析 avro schema
 final Schema schema =
@@ -188,6 +190,33 @@ final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEn
 final DataStream<GenericRecord> stream =
         env.fromSource(source, WatermarkStrategy.noWatermarks(), "file-source");
 ```
+{{< /tab >}}
+{{< tab "Python" >}}
+```python
+# 解析 avro schema
+schema = Schema.parse_string("""
+{
+    "type": "record",
+    "name": "User",
+    "fields": [
+        {"name": "name", "type": "string"},
+        {"name": "favoriteNumber",  "type": ["int", "null"]},
+        {"name": "favoriteColor", "type": ["string", "null"]}
+    ]
+}
+""")
+
+source = FileSource.for_record_stream_format(
+    AvroParquetReaders.for_generic_record(schema), # file paths
+).build()
+
+env = StreamExecutionEnvironment.get_execution_environment()
+env.enable_checkpointing(10)
+
+stream = env.from_source(source, WatermarkStrategy.no_watermarks(), "file-source")
+```
+{{< /tab >}}
+{{< /tabs >}}
 
 ### Specific record
 

--- a/docs/content/docs/connectors/datastream/formats/parquet.md
+++ b/docs/content/docs/connectors/datastream/formats/parquet.md
@@ -137,7 +137,7 @@ final DataStream<RowData> stream =
 
 ## Avro Records
 
-Flink supports producing three types of Avro records by reading Parquet files:
+Flink supports producing three types of Avro records by reading Parquet files (only generic record is supported in PyFlink):
 
 - [Generic record](https://avro.apache.org/docs/1.10.0/api/java/index.html)
 - [Specific record](https://avro.apache.org/docs/1.10.0/api/java/index.html)
@@ -166,6 +166,8 @@ In the following example, you will create a DataStream containing Parquet record
 It will parse the Avro schema based on the JSON string. There are many other ways to parse a schema, e.g. from java.io.File or java.io.InputStream. Please refer to [Avro Schema](https://avro.apache.org/docs/1.10.0/api/java/org/apache/avro/Schema.html) for details.
 After that, you will create an `AvroParquetRecordFormat` via `AvroParquetReaders` for Avro Generic records.
 
+{{< tabs "GenericRecord" >}}
+{{< tab "Java" >}}
 ```java
 // parsing avro schema
 final Schema schema =
@@ -191,6 +193,33 @@ final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEn
 final DataStream<GenericRecord> stream =
         env.fromSource(source, WatermarkStrategy.noWatermarks(), "file-source");
 ```
+{{< /tab >}}
+{{< tab "Python" >}}
+```python
+# parsing avro schema
+schema = Schema.parse_string("""
+{
+    "type": "record",
+    "name": "User",
+    "fields": [
+        {"name": "name", "type": "string"},
+        {"name": "favoriteNumber",  "type": ["int", "null"]},
+        {"name": "favoriteColor", "type": ["string", "null"]}
+    ]
+}
+""")
+
+source = FileSource.for_record_stream_format(
+    AvroParquetReaders.for_generic_record(schema), # file paths
+).build()
+
+env = StreamExecutionEnvironment.get_execution_environment()
+env.enable_checkpointing(10)
+
+stream = env.from_source(source, WatermarkStrategy.no_watermarks(), "file-source")
+```
+{{< /tab >}}
+{{< /tabs >}}
 
 ### Specific record
 

--- a/flink-formats/flink-sql-parquet/pom.xml
+++ b/flink-formats/flink-sql-parquet/pom.xml
@@ -39,6 +39,22 @@ under the License.
 			<artifactId>flink-parquet</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+
+		<dependency>
+			<groupId>org.apache.parquet</groupId>
+			<artifactId>parquet-avro</artifactId>
+			<version>${flink.format.parquet.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.hadoop</groupId>
+					<artifactId>hadoop-client</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>it.unimi.dsi</groupId>
+					<artifactId>fastutil</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -57,6 +73,7 @@ under the License.
 							<artifactSet>
 								<includes>
 									<include>org.apache.flink:flink-parquet</include>
+									<include>org.apache.parquet:parquet-avro</include>
 									<include>org.apache.parquet:parquet-hadoop</include>
 									<include>org.apache.parquet:parquet-format</include>
 									<include>org.apache.parquet:parquet-column</include>
@@ -70,6 +87,12 @@ under the License.
 									<include>commons-codec:commons-codec</include>
 								</includes>
 							</artifactSet>
+							<relocations>
+								<relocation>
+									<pattern>org.apache.avro</pattern>
+									<shadedPattern>org.apache.flink.avro.shaded.org.apache.avro</shadedPattern>
+								</relocation>
+							</relocations>
 						</configuration>
 					</execution>
 				</executions>

--- a/flink-formats/flink-sql-parquet/src/main/resources/META-INF/NOTICE
+++ b/flink-formats/flink-sql-parquet/src/main/resources/META-INF/NOTICE
@@ -6,6 +6,7 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+- org.apache.parquet:parquet-avro:1.12.2
 - org.apache.parquet:parquet-hadoop:1.12.2
 - org.apache.parquet:parquet-column:1.12.2
 - org.apache.parquet:parquet-common:1.12.2

--- a/flink-python/pyflink/datastream/connectors/tests/__init__.py
+++ b/flink-python/pyflink/datastream/connectors/tests/__init__.py
@@ -1,0 +1,17 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################

--- a/flink-python/pyflink/datastream/connectors/tests/test_file_system.py
+++ b/flink-python/pyflink/datastream/connectors/tests/test_file_system.py
@@ -17,27 +17,27 @@
 ################################################################################
 import os
 import tempfile
+import unittest
 
 from py4j.java_gateway import java_import
 
 from pyflink.common.watermark_strategy import WatermarkStrategy
-from pyflink.datastream import StreamExecutionEnvironment
 from pyflink.datastream.functions import MapFunction
 from pyflink.datastream.connectors.file_system import FileSource
 from pyflink.datastream.formats.avro import Schema as AvroSchema
 from pyflink.datastream.formats.parquet import AvroParquetReaders
 from pyflink.datastream.tests.test_util import DataStreamTestSinkFunction
 from pyflink.java_gateway import get_gateway
-from pyflink.testing.test_case_utils import PyFlinkTestCase
+from pyflink.testing.test_case_utils import PyFlinkStreamingTestCase
 
 
-class FileSourceParquetAvroFormatTests(PyFlinkTestCase):
+@unittest.skipIf(os.environ.get('HADOOP_CLASSPATH') is None,
+                 'Some Hadoop lib is needed for Parquet-Avro format tests')
+class FileSourceParquetAvroFormatTests(PyFlinkStreamingTestCase):
 
     def setUp(self):
         assert os.environ.get('HADOOP_CLASSPATH') is not None, 'Hadoop is needed for this test'
         super().setUp()
-        self.env = StreamExecutionEnvironment.get_execution_environment()
-        self.env.set_parallelism(2)
         self.test_sink = DataStreamTestSinkFunction()
         self._import_avro_classes()
 
@@ -237,7 +237,6 @@ class FileSourceParquetAvroFormatTests(PyFlinkTestCase):
         jvm = get_gateway().jvm
         classes = ['org.apache.avro.generic.GenericData']
         prefix = 'org.apache.flink.avro.shaded.'
-        # prefix = ''
         for cls in classes:
             java_import(jvm, prefix + cls)
 

--- a/flink-python/pyflink/datastream/connectors/tests/test_file_system.py
+++ b/flink-python/pyflink/datastream/connectors/tests/test_file_system.py
@@ -1,0 +1,308 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+import os
+import tempfile
+
+from py4j.java_gateway import java_import
+
+from pyflink.common.watermark_strategy import WatermarkStrategy
+from pyflink.datastream import StreamExecutionEnvironment
+from pyflink.datastream.functions import MapFunction
+from pyflink.datastream.connectors.file_system import FileSource
+from pyflink.datastream.formats.avro import Schema as AvroSchema
+from pyflink.datastream.formats.parquet import AvroParquetReaders
+from pyflink.datastream.tests.test_util import DataStreamTestSinkFunction
+from pyflink.java_gateway import get_gateway
+from pyflink.testing.test_case_utils import PyFlinkTestCase
+
+
+class FileSourceParquetAvroFormatTests(PyFlinkTestCase):
+
+    def setUp(self):
+        assert os.environ.get('HADOOP_CLASSPATH') is not None, 'Hadoop is needed for this test'
+        super().setUp()
+        self.env = StreamExecutionEnvironment.get_execution_environment()
+        self.env.set_parallelism(2)
+        self.test_sink = DataStreamTestSinkFunction()
+        self._import_avro_classes()
+
+    def test_avro_parquet_basic(self):
+        parquet_file_name = tempfile.mktemp(suffix='.parquet', dir=self.tempdir)
+        record_schema = """
+        {
+            "type": "record",
+            "name": "test",
+            "fields": [
+                { "name": "null", "type": "null" },
+                { "name": "boolean", "type": "boolean" },
+                { "name": "int", "type": "int" },
+                { "name": "long", "type": "long" },
+                { "name": "float", "type": "float" },
+                { "name": "double", "type": "double" },
+                { "name": "string", "type": "string" }
+            ]
+        }
+        """
+        schema = AvroSchema.parse_string(record_schema)
+        records = [self._create_basic_avro_record(schema, True, 0, 1, 2, 3, 's1'),
+                   self._create_basic_avro_record(schema, False, 4, 5, 6, 7, 's2')]
+        self._create_avro_parquet_file(parquet_file_name, schema, records)
+
+        self._build_avro_parquet_job(schema, parquet_file_name)
+        self.env.execute("test_avro_parquet_basic")
+        results = self.test_sink.get_results(True, False)
+        result1 = results[0]
+        result2 = results[1]
+        self.assertEqual(result1['null'], None)
+        self.assertEqual(result1['boolean'], True)
+        self.assertEqual(result1['int'], 0)
+        self.assertEqual(result1['long'], 1)
+        self.assertAlmostEqual(result1['float'], 2, delta=1e-3)
+        self.assertAlmostEqual(result1['double'], 3, delta=1e-3)
+        self.assertEqual(result1['string'], 's1')
+        self.assertEqual(result2['null'], None)
+        self.assertEqual(result2['boolean'], False)
+        self.assertEqual(result2['int'], 4)
+        self.assertEqual(result2['long'], 5)
+        self.assertAlmostEqual(result2['float'], 6, delta=1e-3)
+        self.assertAlmostEqual(result2['double'], 7, delta=1e-3)
+        self.assertEqual(result2['string'], 's2')
+
+    def test_avro_parquet_enum(self):
+        parquet_file_name = tempfile.mktemp(suffix='.parquet', dir=self.tempdir)
+        record_schema = """
+        {
+            "type": "record",
+            "name": "test",
+            "fields": [
+                { 
+                    "name": "suit",
+                    "type": {
+                        "type": "enum",
+                        "name": "Suit",
+                        "symbols" : ["SPADES", "HEARTS", "DIAMONDS", "CLUBS"]
+                    }
+                }
+            ]
+        }
+        """
+        schema = AvroSchema.parse_string(record_schema)
+        records = [self._create_enum_avro_record(schema, 'SPADES'),
+                   self._create_enum_avro_record(schema, 'DIAMONDS')]
+        self._create_avro_parquet_file(parquet_file_name, schema, records)
+
+        self._build_avro_parquet_job(schema, parquet_file_name)
+        self.env.execute("test_avro_record_enum")
+        results = self.test_sink.get_results(True, False)
+        self.assertEqual(results[0]['suit'], 'SPADES')
+        self.assertEqual(results[1]['suit'], 'DIAMONDS')
+
+    def test_avro_parquet_union(self):
+        parquet_file_name = tempfile.mktemp(suffix='.parquet', dir=self.tempdir)
+        record_schema = """
+        {
+            "type": "record",
+            "name": "test",
+            "fields": [
+                { 
+                    "name": "union",
+                    "type": [ "int", "double", "null" ]
+                }
+            ]
+        }
+        """
+        schema = AvroSchema.parse_string(record_schema)
+        records = [self._create_union_avro_record(schema, 1),
+                   self._create_union_avro_record(schema, 2.),
+                   self._create_union_avro_record(schema, None)]
+        self._create_avro_parquet_file(parquet_file_name, schema, records)
+
+        self._build_avro_parquet_job(schema, parquet_file_name)
+        self.env.execute("test_avro_record_union")
+        results = self.test_sink.get_results(True, False)
+        self.assertEqual(results[0]['union'], 1)
+        self.assertAlmostEqual(results[1]['union'], 2.0, delta=1e-3)
+        self.assertEqual(results[2]['union'], None)
+
+    def test_avro_parquet_array(self):
+        parquet_file_name = tempfile.mktemp(suffix='.parquet', dir=self.tempdir)
+        # It seems there's bug when array item record contains only one field, which throws
+        # java.lang.ClassCastException: required ... is not a group when reading
+        record_schema = """
+        {
+            "type": "record",
+            "name": "test",
+            "fields": [
+                { 
+                    "name": "array",
+                    "type": {
+                        "type": "array",
+                        "items": {
+                            "type": "record",
+                            "name": "item",
+                            "fields": [
+                                { "name": "int", "type": "int" },
+                                { "name": "double", "type": "double" }
+                            ]
+                        }
+                    }
+                }
+            ]
+        }
+        """
+        schema = AvroSchema.parse_string(record_schema)
+        records = [self._create_array_avro_record(schema, [(1, 2.), (3, 4.)]),
+                   self._create_array_avro_record(schema, [(5, 6.), (7, 8.)])]
+        self._create_avro_parquet_file(parquet_file_name, schema, records)
+
+        self._build_avro_parquet_job(schema, parquet_file_name)
+        self.env.execute("test_avro_record_array")
+        results = self.test_sink.get_results(True, False)
+        result1 = results[0]
+        result2 = results[1]
+        self.assertEqual(result1['array'][0]['int'], 1)
+        self.assertAlmostEqual(result1['array'][0]['double'], 2., delta=1e-3)
+        self.assertEqual(result1['array'][1]['int'], 3)
+        self.assertAlmostEqual(result1['array'][1]['double'], 4., delta=1e-3)
+        self.assertEqual(result2['array'][0]['int'], 5)
+        self.assertAlmostEqual(result2['array'][0]['double'], 6., delta=1e-3)
+        self.assertEqual(result2['array'][1]['int'], 7)
+        self.assertAlmostEqual(result2['array'][1]['double'], 8., delta=1e-3)
+
+    def test_avro_parquet_map(self):
+        parquet_file_name = tempfile.mktemp(suffix='.parquet', dir=self.tempdir)
+        record_schema = """
+        {
+            "type": "record",
+            "name": "test",
+            "fields": [
+                { 
+                    "name": "map",
+                    "type": {
+                        "type": "map",
+                        "values": "long"
+                    }
+                }
+            ]
+        }
+        """
+        schema = AvroSchema.parse_string(record_schema)
+        records = [self._create_map_avro_record(schema, {'a': 1, 'b': 2}),
+                   self._create_map_avro_record(schema, {'c': 3, 'd': 4})]
+        self._create_avro_parquet_file(parquet_file_name, schema, records)
+
+        self._build_avro_parquet_job(schema, parquet_file_name)
+        self.env.execute("test_avro_record_map")
+        results = self.test_sink.get_results(True, False)
+        result1 = results[0]
+        result2 = results[1]
+        self.assertEqual(result1['map']['a'], 1)
+        self.assertEqual(result1['map']['b'], 2)
+        self.assertEqual(result2['map']['c'], 3)
+        self.assertEqual(result2['map']['d'], 4)
+
+    def _build_avro_parquet_job(self, record_schema, parquet_file_name):
+        ds = self.env.from_source(
+            FileSource.for_record_stream_format(
+                AvroParquetReaders.for_generic_record(record_schema),
+                parquet_file_name
+            ).build(),
+            WatermarkStrategy.for_monotonous_timestamps(),
+            "parquet-source"
+        )
+        ds.map(self.PassThroughMapFunction()).add_sink(self.test_sink)
+
+    class PassThroughMapFunction(MapFunction):
+
+        def map(self, value):
+            return value
+
+    @staticmethod
+    def _import_avro_classes():
+        jvm = get_gateway().jvm
+        classes = ['org.apache.avro.generic.GenericData']
+        prefix = 'org.apache.flink.avro.shaded.'
+        # prefix = ''
+        for cls in classes:
+            java_import(jvm, prefix + cls)
+
+    @staticmethod
+    def _create_basic_avro_record(schema: AvroSchema, boolean_value, int_value, long_value,
+                                  float_value, double_value, string_value):
+        jvm = get_gateway().jvm
+        j_record = jvm.GenericData.Record(schema._j_schema)
+        j_record.put('boolean', boolean_value)
+        j_record.put('int', int_value)
+        j_record.put('long', long_value)
+        j_record.put('float', float_value)
+        j_record.put('double', double_value)
+        j_record.put('string', string_value)
+        return j_record
+
+    @staticmethod
+    def _create_enum_avro_record(schema: AvroSchema, enum_value):
+        jvm = get_gateway().jvm
+        j_record = jvm.GenericData.Record(schema._j_schema)
+        j_record.put('suit', enum_value)
+        return j_record
+
+    @staticmethod
+    def _create_union_avro_record(schema, union_value):
+        jvm = get_gateway().jvm
+        j_record = jvm.GenericData.Record(schema._j_schema)
+        j_record.put('union', union_value)
+        return j_record
+
+    @staticmethod
+    def _create_array_avro_record(schema, item_values: list):
+        jvm = get_gateway().jvm
+        j_record = jvm.GenericData.Record(schema._j_schema)
+        item_schema = AvroSchema(schema._j_schema.getField('array').schema().getElementType())
+        j_array = jvm.java.util.ArrayList()
+        for idx, item_value in enumerate(item_values):
+            j_item = jvm.GenericData.Record(item_schema._j_schema)
+            j_item.put('int', item_value[0])
+            j_item.put('double', item_value[1])
+            j_array.add(j_item)
+        j_record.put('array', j_array)
+        return j_record
+
+    @staticmethod
+    def _create_map_avro_record(schema, map: dict):
+        jvm = get_gateway().jvm
+        j_record = jvm.GenericData.Record(schema._j_schema)
+        j_map = jvm.java.util.HashMap()
+        for k, v in map.items():
+            j_map.put(k, v)
+        j_record.put('map', j_map)
+        return j_record
+
+    @staticmethod
+    def _create_avro_parquet_file(file_path: str, schema: AvroSchema, records: list):
+        jvm = get_gateway().jvm
+        j_path = jvm.org.apache.flink.core.fs.Path(file_path)
+        writer = jvm.org.apache.flink.formats.parquet.avro.AvroParquetWriters \
+            .forGenericRecord(schema._j_schema) \
+            .create(j_path.getFileSystem().create(
+                j_path,
+                jvm.org.apache.flink.core.fs.FileSystem.WriteMode.OVERWRITE
+        ))
+        for record in records:
+            writer.addElement(record)
+        writer.flush()
+        writer.finish()

--- a/flink-python/pyflink/datastream/connectors/tests/test_file_system.py
+++ b/flink-python/pyflink/datastream/connectors/tests/test_file_system.py
@@ -90,7 +90,7 @@ class FileSourceParquetAvroFormatTests(PyFlinkStreamingTestCase):
             "type": "record",
             "name": "test",
             "fields": [
-                { 
+                {
                     "name": "suit",
                     "type": {
                         "type": "enum",
@@ -119,7 +119,7 @@ class FileSourceParquetAvroFormatTests(PyFlinkStreamingTestCase):
             "type": "record",
             "name": "test",
             "fields": [
-                { 
+                {
                     "name": "union",
                     "type": [ "int", "double", "null" ]
                 }
@@ -148,7 +148,7 @@ class FileSourceParquetAvroFormatTests(PyFlinkStreamingTestCase):
             "type": "record",
             "name": "test",
             "fields": [
-                { 
+                {
                     "name": "array",
                     "type": {
                         "type": "array",
@@ -191,7 +191,7 @@ class FileSourceParquetAvroFormatTests(PyFlinkStreamingTestCase):
             "type": "record",
             "name": "test",
             "fields": [
-                { 
+                {
                     "name": "map",
                     "type": {
                         "type": "map",
@@ -300,7 +300,7 @@ class FileSourceParquetAvroFormatTests(PyFlinkStreamingTestCase):
             .create(j_path.getFileSystem().create(
                 j_path,
                 jvm.org.apache.flink.core.fs.FileSystem.WriteMode.OVERWRITE
-        ))
+            ))
         for record in records:
             writer.addElement(record)
         writer.flush()

--- a/flink-python/pyflink/datastream/formats/__init__.py
+++ b/flink-python/pyflink/datastream/formats/__init__.py
@@ -1,0 +1,17 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################

--- a/flink-python/pyflink/datastream/formats/avro.py
+++ b/flink-python/pyflink/datastream/formats/avro.py
@@ -1,0 +1,36 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+from pyflink.java_gateway import get_gateway
+
+
+class Schema(object):
+
+    def __init__(self, j_schema):
+        self._j_schema = j_schema
+
+    @staticmethod
+    def parse_string(json_schema: str) -> 'Schema':
+        JSchema = get_gateway().jvm.org.apache.flink.avro.shaded.org.apache.avro.Schema
+        return Schema(JSchema.Parser().parse(json_schema))
+
+    @staticmethod
+    def parse_file(file_path: str) -> 'Schema':
+        jvm = get_gateway().jvm
+        j_file = jvm.java.io.File(file_path)
+        JSchema = jvm.org.apache.flink.avro.shaded.org.apache.avro.Schema
+        return Schema(JSchema.Parser().parse(j_file))

--- a/flink-python/pyflink/datastream/formats/avro.py
+++ b/flink-python/pyflink/datastream/formats/avro.py
@@ -19,17 +19,34 @@ from pyflink.java_gateway import get_gateway
 
 
 class Schema(object):
+    """
+    Avro Schema class contains Java org.apache.avro.Schema.
+
+    .. versionadded:: 1.16.0
+    """
 
     def __init__(self, j_schema):
         self._j_schema = j_schema
 
     @staticmethod
     def parse_string(json_schema: str) -> 'Schema':
+        """
+        Parse JSON string as Avro Schema.
+
+        :param json_schema: JSON represented schema string.
+        :return: the Avro Schema.
+        """
         JSchema = get_gateway().jvm.org.apache.flink.avro.shaded.org.apache.avro.Schema
         return Schema(JSchema.Parser().parse(json_schema))
 
     @staticmethod
     def parse_file(file_path: str) -> 'Schema':
+        """
+        Parse a schema definition file as Avro Schema.
+
+        :param file_path: path to schema definition file.
+        :return: the Avro Schema.
+        """
         jvm = get_gateway().jvm
         j_file = jvm.java.io.File(file_path)
         JSchema = jvm.org.apache.flink.avro.shaded.org.apache.avro.Schema

--- a/flink-python/pyflink/datastream/formats/parquet.py
+++ b/flink-python/pyflink/datastream/formats/parquet.py
@@ -1,0 +1,29 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+from pyflink.datastream.connectors.file_system import StreamFormat
+from pyflink.datastream.formats.avro import Schema
+from pyflink.java_gateway import get_gateway
+
+
+class AvroParquetReaders(object):
+
+    @staticmethod
+    def for_generic_record(schema: 'Schema'):
+        jvm = get_gateway().jvm
+        JAvroParquetReaders = jvm.org.apache.flink.formats.parquet.avro.AvroParquetReaders
+        return StreamFormat(JAvroParquetReaders.forGenericRecord(schema._j_schema))

--- a/flink-python/pyflink/datastream/formats/parquet.py
+++ b/flink-python/pyflink/datastream/formats/parquet.py
@@ -21,9 +21,27 @@ from pyflink.java_gateway import get_gateway
 
 
 class AvroParquetReaders(object):
+    """
+    A convenience builder to create AvroParquetRecordFormat instances for the different kinds of
+    Avro record types. Only GenericRecord is supported in PyFlink.
+
+    .. versionadded:: 1.16.0
+    """
 
     @staticmethod
-    def for_generic_record(schema: 'Schema'):
+    def for_generic_record(schema: 'Schema') -> 'StreamFormat':
+        """
+        Creates a new AvroParquetRecordFormat that reads the parquet file into Avro GenericRecords.
+
+        To read into GenericRecords, this method needs an Avro Schema. That is because Flink needs
+        to be able to serialize the results in its data flow, which is very inefficient without the
+        schema. And while the Schema is stored in the Avro file header, Flink needs this schema
+        during 'pre-flight' time when the data flow is set up and wired, which is before there is
+        access to the files.
+
+        :param schema: the Avro Schema.
+        :return: StreamFormat for reading Avro GenericRecords.
+        """
         jvm = get_gateway().jvm
         JAvroParquetReaders = jvm.org.apache.flink.formats.parquet.avro.AvroParquetReaders
         return StreamFormat(JAvroParquetReaders.forGenericRecord(schema._j_schema))

--- a/flink-python/pyflink/datastream/tests/test_util.py
+++ b/flink-python/pyflink/datastream/tests/test_util.py
@@ -32,7 +32,7 @@ class DataStreamTestSinkFunction(SinkFunction):
             .org.apache.flink.python.util.DataStreamTestCollectSink()
         super(DataStreamTestSinkFunction, self).__init__(sink_func=self.j_data_stream_collect_sink)
 
-    def get_results(self, is_python_object: bool = False):
+    def get_results(self, is_python_object: bool = False, stringify: bool = True):
         j_results = self.get_java_function().collectAndClear(is_python_object)
         results = list(j_results)
         if not is_python_object:
@@ -41,7 +41,10 @@ class DataStreamTestSinkFunction(SinkFunction):
             str_results = []
             for result in results:
                 pickled_result = pickle.loads(result)
-                str_results.append(str(pickled_result))
+                if stringify:
+                    str_results.append(str(pickled_result))
+                else:
+                    str_results.append(pickled_result)
             return str_results
 
     def clear(self):

--- a/flink-python/pyflink/pyflink_gateway_server.py
+++ b/flink-python/pyflink/pyflink_gateway_server.py
@@ -217,6 +217,7 @@ def construct_test_classpath():
         "flink-streaming-java/target/flink-streaming-java*tests.jar",
         "flink-formats/flink-csv/target/flink-csv*.jar",
         "flink-formats/flink-sql-avro/target/flink-sql-avro*.jar",
+        "flink-formats/flink-sql-parquet/target/flink-sql-parquet*.jar",
         "flink-formats/flink-json/target/flink-json*.jar",
         "flink-python/target/artifacts/testDataStream.jar",
         "flink-python/target/flink-python*-tests.jar",


### PR DESCRIPTION
## What is the purpose of the change

This PR supports parquet-avro format for FileSource in PyFlink DataStream API.


## Brief change log

- shade optional dependency parquet-avro into flink-sql-parquet
- add avro Schema and AvroParquetReaders class

## Verifying this change


This change added tests and can be verified as follows:

- intergration tests in pyflink/datastream/connectors/tests/test_file_system.py#FileSourceParquetAvroFormatTests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs & Python Sphinx Doc)
