### PR TITLE
[FLINK-28340][python][ci] Support using system conda env for testing

### DIFF
--- a/flink-python/README.md
+++ b/flink-python/README.md
@@ -52,10 +52,10 @@ We can enter the directory where this README.md file is located and run test cas
 ./dev/lint-python.sh
 ```
 
-To use your system conda environment, you can set `CONDA_HOME` variable:
+To use your system conda environment, you can set `FLINK_CONDA_HOME` variable:
 
 ```shell
-export CONDA_HOME=$(dirname $(dirname $CONDA_EXE))
+export FLINK_CONDA_HOME=$(dirname $(dirname $CONDA_EXE))
 ```
 
 Then you can activate your environment and run tests, for example:

--- a/flink-python/README.md
+++ b/flink-python/README.md
@@ -51,3 +51,16 @@ We can enter the directory where this README.md file is located and run test cas
 ```
 ./dev/lint-python.sh
 ```
+
+To use your system conda environment, you can set `CONDA_HOME` variable:
+
+```shell
+export CONDA_HOME=$(dirname $(dirname $CONDA_EXE))
+```
+
+Then you can activate your environment and run tests, for example:
+
+```shell
+conda activate flink-python
+./dev/lint-python.sh
+```

--- a/flink-python/dev/lint-python.sh
+++ b/flink-python/dev/lint-python.sh
@@ -663,6 +663,7 @@ function sphinx_check() {
     else
         print_function "STAGE" "sphinx checks... [SUCCESS]"
     fi
+    popd
 }
 
 # mypy check
@@ -691,22 +692,27 @@ CURRENT_DIR="$(cd "$( dirname "$0" )" && pwd)"
 FLINK_PYTHON_DIR=$(dirname "$CURRENT_DIR")
 
 # conda home path
-CONDA_HOME=$CURRENT_DIR/.conda
+if [ -z "${CONDA_HOME+x}" ]; then
+    CONDA_HOME="$CURRENT_DIR/.conda"
+    ENV_HOME="$CONDA_HOME"
+else
+    ENV_HOME="${CONDA_PREFIX-$CONDA_HOME}"
+fi
 
 # conda path
 CONDA_PATH=$CONDA_HOME/bin/conda
 
 # pip path
-PIP_PATH=$CONDA_HOME/bin/pip
+PIP_PATH=$ENV_HOME/bin/pip
 
 # tox path
-TOX_PATH=$CONDA_HOME/bin/tox
+TOX_PATH=$ENV_HOME/bin/tox
 
 # flake8 path
-FLAKE8_PATH=$CONDA_HOME/bin/flake8
+FLAKE8_PATH=$ENV_HOME/bin/flake8
 
 # sphinx path
-SPHINX_PATH=$CONDA_HOME/bin/sphinx-build
+SPHINX_PATH=$ENV_HOME/bin/sphinx-build
 
 # mypy path
 MYPY_PATH=${CONDA_HOME}/bin/mypy

--- a/flink-python/dev/lint-python.sh
+++ b/flink-python/dev/lint-python.sh
@@ -716,7 +716,7 @@ FLAKE8_PATH=$ENV_HOME/bin/flake8
 SPHINX_PATH=$ENV_HOME/bin/sphinx-build
 
 # mypy path
-MYPY_PATH=${CONDA_HOME}/bin/mypy
+MYPY_PATH=$ENV_HOME/bin/mypy
 
 _OLD_PATH="$PATH"
 

--- a/flink-python/dev/lint-python.sh
+++ b/flink-python/dev/lint-python.sh
@@ -692,10 +692,11 @@ CURRENT_DIR="$(cd "$( dirname "$0" )" && pwd)"
 FLINK_PYTHON_DIR=$(dirname "$CURRENT_DIR")
 
 # conda home path
-if [ -z "${CONDA_HOME+x}" ]; then
+if [ -z "${FLINK_CONDA_HOME+x}" ]; then
     CONDA_HOME="$CURRENT_DIR/.conda"
     ENV_HOME="$CONDA_HOME"
 else
+    CONDA_HOME=$FLINK_CONDA_HOME
     ENV_HOME="${CONDA_PREFIX-$CONDA_HOME}"
 fi
 


### PR DESCRIPTION
## What is the purpose of the change

This PR enables users to use system conda env for testing rather than creating a dedicated one.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
