### PR TITLE
[FLINK-27941][kinesis][test] Migrate tests to junit5

### DIFF
--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisProducerTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisProducerTest.java
@@ -38,9 +38,8 @@ import com.amazonaws.services.kinesis.producer.KinesisProducer;
 import com.amazonaws.services.kinesis.producer.KinesisProducerConfiguration;
 import com.amazonaws.services.kinesis.producer.UserRecordResult;
 import com.google.common.util.concurrent.SettableFuture;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -62,19 +61,20 @@ import static org.mockito.Mockito.when;
 /** Suite of {@link FlinkKinesisProducer} tests. */
 public class FlinkKinesisProducerTest extends TestLogger {
 
-    @Rule public ExpectedException exception = ExpectedException.none();
-
     // ----------------------------------------------------------------------
     // Tests to verify serializability
     // ----------------------------------------------------------------------
 
     @Test
     public void testCreateWithNonSerializableDeserializerFails() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("The provided serialization schema is not serializable");
-
-        new FlinkKinesisProducer<>(
-                new NonSerializableSerializationSchema(), TestUtils.getStandardProperties());
+        assertThatThrownBy(
+                        () -> {
+                            new FlinkKinesisProducer<>(
+                                    new NonSerializableSerializationSchema(),
+                                    TestUtils.getStandardProperties());
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("The provided serialization schema is not serializable");
     }
 
     @Test
@@ -85,11 +85,15 @@ public class FlinkKinesisProducerTest extends TestLogger {
 
     @Test
     public void testConfigureWithNonSerializableCustomPartitionerFails() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("The provided custom partitioner is not serializable");
-
-        new FlinkKinesisProducer<>(new SimpleStringSchema(), TestUtils.getStandardProperties())
-                .setCustomPartitioner(new NonSerializableCustomPartitioner());
+        assertThatThrownBy(
+                        () -> {
+                            new FlinkKinesisProducer<>(
+                                            new SimpleStringSchema(),
+                                            TestUtils.getStandardProperties())
+                                    .setCustomPartitioner(new NonSerializableCustomPartitioner());
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("The provided custom partitioner is not serializable");
     }
 
     @Test
@@ -169,7 +173,8 @@ public class FlinkKinesisProducerTest extends TestLogger {
      * pending records. The test for that is covered in testAtLeastOnceProducer.
      */
     @SuppressWarnings("ResultOfMethodCallIgnored")
-    @Test(timeout = 10000)
+    @Test
+    @Timeout(10)
     public void testAsyncErrorRethrownAfterFlush() throws Throwable {
         final DummyFlinkKinesisProducer<String> producer =
                 new DummyFlinkKinesisProducer<>(new SimpleStringSchema());
@@ -214,7 +219,8 @@ public class FlinkKinesisProducerTest extends TestLogger {
      * the test will not finish if the logic is broken.
      */
     @SuppressWarnings({"unchecked", "ResultOfMethodCallIgnored"})
-    @Test(timeout = 10000)
+    @Test
+    @Timeout(10)
     public void testAtLeastOnceProducer() throws Throwable {
         final DummyFlinkKinesisProducer<String> producer =
                 new DummyFlinkKinesisProducer<>(new SimpleStringSchema());
@@ -277,7 +283,8 @@ public class FlinkKinesisProducerTest extends TestLogger {
      * drops below the limit; we set a timeout because the test will not finish if the logic is
      * broken.
      */
-    @Test(timeout = 10000)
+    @Test
+    @Timeout(10)
     public void testBackpressure() throws Throwable {
         final Deadline deadline = Deadline.fromNow(Duration.ofSeconds(10));
 

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/KinesisConsumerTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/KinesisConsumerTest.java
@@ -23,20 +23,18 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.TestLogger;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Tests for {@link FlinkKinesisConsumer}. In contrast to tests in {@link FlinkKinesisConsumerTest}
  * it does not use power mock, which makes it possible to use e.g. the {@link ExpectedException}.
  */
 public class KinesisConsumerTest extends TestLogger {
-
-    @Rule public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void testKinesisConsumerThrowsExceptionIfSchemaImplementsCollector() {
@@ -64,12 +62,15 @@ public class KinesisConsumerTest extends TestLogger {
                         return null;
                     }
                 };
-
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage(
-                "Kinesis consumer does not support DeserializationSchema that implements deserialization with a"
-                        + " Collector. Unsupported DeserializationSchema: "
-                        + "org.apache.flink.streaming.connectors.kinesis.KinesisConsumerTest");
-        new FlinkKinesisConsumer<>("fakeStream", schemaWithCollector, new Properties());
+        assertThatThrownBy(
+                        () -> {
+                            new FlinkKinesisConsumer<>(
+                                    "fakeStream", schemaWithCollector, new Properties());
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Kinesis consumer does not support DeserializationSchema that implements deserialization with a"
+                                + " Collector. Unsupported DeserializationSchema: "
+                                + "org.apache.flink.streaming.connectors.kinesis.KinesisConsumerTest");
     }
 }

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/DynamoDBStreamsDataFetcherTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/DynamoDBStreamsDataFetcherTest.java
@@ -25,7 +25,7 @@ import org.apache.flink.streaming.connectors.kinesis.serialization.KinesisDeseri
 import org.apache.flink.streaming.connectors.kinesis.testutils.TestSourceContext;
 import org.apache.flink.streaming.connectors.kinesis.testutils.TestUtils;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Properties;
 

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcherTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcherTest.java
@@ -50,7 +50,8 @@ import com.amazonaws.services.kinesis.model.SequenceNumberRange;
 import com.amazonaws.services.kinesis.model.Shard;
 import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.apache.commons.lang3.mutable.MutableLong;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.powermock.reflect.Whitebox;
 
 import java.util.ArrayList;
@@ -89,7 +90,8 @@ public class KinesisDataFetcherTest extends TestLogger {
         assertThat(fetcher.isRunning()).isTrue();
     }
 
-    @Test(timeout = 10000)
+    @Test
+    @Timeout(10)
     public void testIsRunningFalseAfterShutDown() throws InterruptedException {
         KinesisDataFetcher<String> fetcher =
                 createTestDataFetcherWithNoShards(10, 2, "test-stream");
@@ -147,12 +149,17 @@ public class KinesisDataFetcherTest extends TestLogger {
         consumerThread.sync();
     }
 
-    @Test(expected = RuntimeException.class)
-    public void testIfNoShardsAreFoundShouldThrowException() throws Exception {
-        KinesisDataFetcher<String> fetcher =
-                createTestDataFetcherWithNoShards(10, 2, "fakeStream1", "fakeStream2");
+    @Test
+    public void testIfNoShardsAreFoundShouldThrowException() {
+        assertThatThrownBy(
+                        () -> {
+                            KinesisDataFetcher<String> fetcher =
+                                    createTestDataFetcherWithNoShards(
+                                            10, 2, "fakeStream1", "fakeStream2");
 
-        fetcher.runFetcher(); // this should throw RuntimeException
+                            fetcher.runFetcher(); // this should throw RuntimeException
+                        })
+                .isInstanceOf(RuntimeException.class);
     }
 
     @Test
@@ -1014,7 +1021,8 @@ public class KinesisDataFetcherTest extends TestLogger {
                 .isTrue();
     }
 
-    @Test(timeout = 1000L)
+    @Test
+    @Timeout(1)
     public void testRecordPublisherFactoryIsTornDown() throws InterruptedException {
         KinesisProxyV2Interface kinesisV2 = mock(KinesisProxyV2Interface.class);
 
@@ -1037,7 +1045,8 @@ public class KinesisDataFetcherTest extends TestLogger {
         fetcher.awaitTermination();
     }
 
-    @Test(timeout = 10000)
+    @Test
+    @Timeout(10)
     public void testRecordPublisherFactoryIsTornDownWhenDeregisterStreamConsumerThrowsException()
             throws InterruptedException {
         KinesisProxyV2Interface kinesisV2 = mock(KinesisProxyV2Interface.class);
@@ -1067,7 +1076,8 @@ public class KinesisDataFetcherTest extends TestLogger {
         fetcher.awaitTermination();
     }
 
-    @Test(timeout = 10000)
+    @Test
+    @Timeout(10)
     public void testExecutorServiceShutDownWhenCloseRecordPublisherFactoryThrowsException()
             throws InterruptedException {
         TestableKinesisDataFetcher<String> fetcher =

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumerFanOutTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumerFanOutTest.java
@@ -27,7 +27,7 @@ import org.apache.flink.streaming.connectors.kinesis.testutils.FakeKinesisFanOut
 
 import com.amazonaws.SdkClientException;
 import com.amazonaws.http.timers.client.SdkInterruptedException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.kinesis.model.StartingPosition;
 
 import java.text.SimpleDateFormat;

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumerTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumerTest.java
@@ -25,7 +25,7 @@ import org.apache.flink.streaming.connectors.kinesis.model.SequenceNumber;
 import org.apache.flink.streaming.connectors.kinesis.proxy.KinesisProxyInterface;
 import org.apache.flink.streaming.connectors.kinesis.testutils.FakeKinesisBehavioursFactory;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/RecordBatchTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/RecordBatchTest.java
@@ -22,7 +22,7 @@ import org.apache.flink.streaming.connectors.kinesis.testutils.TestUtils;
 
 import com.amazonaws.services.kinesis.model.Record;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/fanout/FanOutShardSubscriberTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/fanout/FanOutShardSubscriberTest.java
@@ -23,143 +23,174 @@ import org.apache.flink.streaming.connectors.kinesis.testutils.FakeKinesisFanOut
 
 import com.amazonaws.http.timers.client.SdkInterruptedException;
 import io.netty.handler.timeout.ReadTimeoutException;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import software.amazon.awssdk.services.kinesis.model.StartingPosition;
 
 import java.time.Duration;
 
 import static org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants.DEFAULT_SUBSCRIBE_TO_SHARD_TIMEOUT;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link FanOutShardSubscriber}. */
 public class FanOutShardSubscriberTest {
 
-    @Rule public ExpectedException thrown = ExpectedException.none();
-
     @Test
-    public void testRecoverableErrorThrownToConsumer() throws Exception {
-        thrown.expect(FanOutShardSubscriber.RecoverableFanOutSubscriberException.class);
-        thrown.expectMessage("io.netty.handler.timeout.ReadTimeoutException");
+    public void testRecoverableErrorThrownToConsumer() {
+        assertThatThrownBy(
+                        () -> {
+                            SubscriptionErrorKinesisV2 errorKinesisV2 =
+                                    FakeKinesisFanOutBehavioursFactory.errorDuringSubscription(
+                                            ReadTimeoutException.INSTANCE);
 
-        SubscriptionErrorKinesisV2 errorKinesisV2 =
-                FakeKinesisFanOutBehavioursFactory.errorDuringSubscription(
-                        ReadTimeoutException.INSTANCE);
+                            FanOutShardSubscriber subscriber =
+                                    new FanOutShardSubscriber(
+                                            "consumerArn",
+                                            "shardId",
+                                            errorKinesisV2,
+                                            DEFAULT_SUBSCRIBE_TO_SHARD_TIMEOUT);
 
-        FanOutShardSubscriber subscriber =
-                new FanOutShardSubscriber(
-                        "consumerArn",
-                        "shardId",
-                        errorKinesisV2,
-                        DEFAULT_SUBSCRIBE_TO_SHARD_TIMEOUT);
-
-        software.amazon.awssdk.services.kinesis.model.StartingPosition startingPosition =
-                software.amazon.awssdk.services.kinesis.model.StartingPosition.builder().build();
-        subscriber.subscribeToShardAndConsumeRecords(startingPosition, event -> {});
+                            software.amazon.awssdk.services.kinesis.model.StartingPosition
+                                    startingPosition =
+                                            software.amazon.awssdk.services.kinesis.model
+                                                    .StartingPosition.builder()
+                                                    .build();
+                            subscriber.subscribeToShardAndConsumeRecords(
+                                    startingPosition, event -> {});
+                        })
+                .isInstanceOf(FanOutShardSubscriber.RecoverableFanOutSubscriberException.class)
+                .hasMessageContaining("io.netty.handler.timeout.ReadTimeoutException");
     }
 
     @Test
-    public void testRetryableErrorThrownToConsumer() throws Exception {
-        thrown.expect(FanOutShardSubscriber.RetryableFanOutSubscriberException.class);
-        thrown.expectMessage("Error!");
+    public void testRetryableErrorThrownToConsumer() {
+        assertThatThrownBy(
+                        () -> {
+                            RuntimeException error = new RuntimeException("Error!");
+                            SubscriptionErrorKinesisV2 errorKinesisV2 =
+                                    FakeKinesisFanOutBehavioursFactory.errorDuringSubscription(
+                                            error);
 
-        RuntimeException error = new RuntimeException("Error!");
-        SubscriptionErrorKinesisV2 errorKinesisV2 =
-                FakeKinesisFanOutBehavioursFactory.errorDuringSubscription(error);
+                            FanOutShardSubscriber subscriber =
+                                    new FanOutShardSubscriber(
+                                            "consumerArn",
+                                            "shardId",
+                                            errorKinesisV2,
+                                            DEFAULT_SUBSCRIBE_TO_SHARD_TIMEOUT);
 
-        FanOutShardSubscriber subscriber =
-                new FanOutShardSubscriber(
-                        "consumerArn",
-                        "shardId",
-                        errorKinesisV2,
-                        DEFAULT_SUBSCRIBE_TO_SHARD_TIMEOUT);
-
-        software.amazon.awssdk.services.kinesis.model.StartingPosition startingPosition =
-                software.amazon.awssdk.services.kinesis.model.StartingPosition.builder().build();
-        subscriber.subscribeToShardAndConsumeRecords(startingPosition, event -> {});
+                            software.amazon.awssdk.services.kinesis.model.StartingPosition
+                                    startingPosition =
+                                            software.amazon.awssdk.services.kinesis.model
+                                                    .StartingPosition.builder()
+                                                    .build();
+                            subscriber.subscribeToShardAndConsumeRecords(
+                                    startingPosition, event -> {});
+                        })
+                .isInstanceOf(FanOutShardSubscriber.RetryableFanOutSubscriberException.class)
+                .hasMessageContaining("Error!");
     }
 
     @Test
-    public void testInterruptedErrorThrownToConsumer() throws Exception {
-        thrown.expect(FanOutShardSubscriber.FanOutSubscriberInterruptedException.class);
+    public void testInterruptedErrorThrownToConsumer() {
+        assertThatThrownBy(
+                        () -> {
+                            SdkInterruptedException error = new SdkInterruptedException(null);
+                            SubscriptionErrorKinesisV2 errorKinesisV2 =
+                                    FakeKinesisFanOutBehavioursFactory.errorDuringSubscription(
+                                            error);
 
-        SdkInterruptedException error = new SdkInterruptedException(null);
-        SubscriptionErrorKinesisV2 errorKinesisV2 =
-                FakeKinesisFanOutBehavioursFactory.errorDuringSubscription(error);
+                            FanOutShardSubscriber subscriber =
+                                    new FanOutShardSubscriber(
+                                            "consumerArn",
+                                            "shardId",
+                                            errorKinesisV2,
+                                            DEFAULT_SUBSCRIBE_TO_SHARD_TIMEOUT);
 
-        FanOutShardSubscriber subscriber =
-                new FanOutShardSubscriber(
-                        "consumerArn",
-                        "shardId",
-                        errorKinesisV2,
-                        DEFAULT_SUBSCRIBE_TO_SHARD_TIMEOUT);
-
-        software.amazon.awssdk.services.kinesis.model.StartingPosition startingPosition =
-                software.amazon.awssdk.services.kinesis.model.StartingPosition.builder().build();
-        subscriber.subscribeToShardAndConsumeRecords(startingPosition, event -> {});
+                            software.amazon.awssdk.services.kinesis.model.StartingPosition
+                                    startingPosition =
+                                            software.amazon.awssdk.services.kinesis.model
+                                                    .StartingPosition.builder()
+                                                    .build();
+                            subscriber.subscribeToShardAndConsumeRecords(
+                                    startingPosition, event -> {});
+                        })
+                .isInstanceOf(FanOutShardSubscriber.FanOutSubscriberInterruptedException.class);
     }
 
     @Test
-    public void testMultipleErrorsThrownPassesFirstErrorToConsumer() throws Exception {
-        thrown.expect(FanOutShardSubscriber.FanOutSubscriberException.class);
-        thrown.expectMessage("Error 1!");
+    public void testMultipleErrorsThrownPassesFirstErrorToConsumer() {
+        assertThatThrownBy(
+                        () -> {
+                            RuntimeException error1 = new RuntimeException("Error 1!");
+                            RuntimeException error2 = new RuntimeException("Error 2!");
+                            SubscriptionErrorKinesisV2 errorKinesisV2 =
+                                    FakeKinesisFanOutBehavioursFactory.errorDuringSubscription(
+                                            error1, error2);
 
-        RuntimeException error1 = new RuntimeException("Error 1!");
-        RuntimeException error2 = new RuntimeException("Error 2!");
-        SubscriptionErrorKinesisV2 errorKinesisV2 =
-                FakeKinesisFanOutBehavioursFactory.errorDuringSubscription(error1, error2);
+                            FanOutShardSubscriber subscriber =
+                                    new FanOutShardSubscriber(
+                                            "consumerArn",
+                                            "shardId",
+                                            errorKinesisV2,
+                                            DEFAULT_SUBSCRIBE_TO_SHARD_TIMEOUT);
 
-        FanOutShardSubscriber subscriber =
-                new FanOutShardSubscriber(
-                        "consumerArn",
-                        "shardId",
-                        errorKinesisV2,
-                        DEFAULT_SUBSCRIBE_TO_SHARD_TIMEOUT);
-
-        StartingPosition startingPosition = StartingPosition.builder().build();
-        subscriber.subscribeToShardAndConsumeRecords(startingPosition, event -> {});
+                            StartingPosition startingPosition = StartingPosition.builder().build();
+                            subscriber.subscribeToShardAndConsumeRecords(
+                                    startingPosition, event -> {});
+                        })
+                .isInstanceOf(FanOutShardSubscriber.FanOutSubscriberException.class)
+                .hasMessageContaining("Error 1!");
     }
 
     @Test
-    public void testTimeoutSubscribingToShard() throws Exception {
-        thrown.expect(FanOutShardSubscriber.RecoverableFanOutSubscriberException.class);
-        thrown.expectMessage("Timed out acquiring subscription");
+    public void testTimeoutSubscribingToShard() {
+        assertThatThrownBy(
+                        () -> {
+                            KinesisProxyV2Interface kinesis =
+                                    FakeKinesisFanOutBehavioursFactory.failsToAcquireSubscription();
 
-        KinesisProxyV2Interface kinesis =
-                FakeKinesisFanOutBehavioursFactory.failsToAcquireSubscription();
+                            FanOutShardSubscriber subscriber =
+                                    new FanOutShardSubscriber(
+                                            "consumerArn",
+                                            "shardId",
+                                            kinesis,
+                                            Duration.ofMillis(1));
 
-        FanOutShardSubscriber subscriber =
-                new FanOutShardSubscriber("consumerArn", "shardId", kinesis, Duration.ofMillis(1));
-
-        StartingPosition startingPosition = StartingPosition.builder().build();
-        subscriber.subscribeToShardAndConsumeRecords(startingPosition, event -> {});
+                            StartingPosition startingPosition = StartingPosition.builder().build();
+                            subscriber.subscribeToShardAndConsumeRecords(
+                                    startingPosition, event -> {});
+                        })
+                .isInstanceOf(FanOutShardSubscriber.RecoverableFanOutSubscriberException.class)
+                .hasMessageContaining("Timed out acquiring subscription");
     }
 
     @Test
-    public void testTimeoutEnqueuingEvent() throws Exception {
-        thrown.expect(FanOutShardSubscriber.RecoverableFanOutSubscriberException.class);
-        thrown.expectMessage("Timed out enqueuing event SubscriptionNextEvent");
+    public void testTimeoutEnqueuingEvent() {
+        assertThatThrownBy(
+                        () -> {
+                            KinesisProxyV2Interface kinesis =
+                                    FakeKinesisFanOutBehavioursFactory
+                                            .shardThatCreatesBackpressureOnQueue();
 
-        KinesisProxyV2Interface kinesis =
-                FakeKinesisFanOutBehavioursFactory.shardThatCreatesBackpressureOnQueue();
+                            FanOutShardSubscriber subscriber =
+                                    new FanOutShardSubscriber(
+                                            "consumerArn",
+                                            "shardId",
+                                            kinesis,
+                                            DEFAULT_SUBSCRIBE_TO_SHARD_TIMEOUT,
+                                            Duration.ofMillis(100));
 
-        FanOutShardSubscriber subscriber =
-                new FanOutShardSubscriber(
-                        "consumerArn",
-                        "shardId",
-                        kinesis,
-                        DEFAULT_SUBSCRIBE_TO_SHARD_TIMEOUT,
-                        Duration.ofMillis(100));
-
-        StartingPosition startingPosition = StartingPosition.builder().build();
-        subscriber.subscribeToShardAndConsumeRecords(
-                startingPosition,
-                event -> {
-                    try {
-                        Thread.sleep(120);
-                    } catch (InterruptedException e) {
-                        e.printStackTrace();
-                    }
-                });
+                            StartingPosition startingPosition = StartingPosition.builder().build();
+                            subscriber.subscribeToShardAndConsumeRecords(
+                                    startingPosition,
+                                    event -> {
+                                        try {
+                                            Thread.sleep(120);
+                                        } catch (InterruptedException e) {
+                                            e.printStackTrace();
+                                        }
+                                    });
+                        })
+                .isInstanceOf(FanOutShardSubscriber.RecoverableFanOutSubscriberException.class)
+                .hasMessageContaining("Timed out enqueuing event SubscriptionNextEvent");
     }
 }

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/polling/PollingRecordPublisherConfigurationTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/polling/PollingRecordPublisherConfigurationTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.flink.streaming.connectors.kinesis.internals.publisher.polling;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Properties;
 

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/polling/PollingRecordPublisherFactoryTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/polling/PollingRecordPublisherFactoryTest.java
@@ -22,7 +22,7 @@ import org.apache.flink.streaming.connectors.kinesis.model.StartingPosition;
 import org.apache.flink.streaming.connectors.kinesis.model.StreamShardHandle;
 import org.apache.flink.streaming.connectors.kinesis.proxy.KinesisProxy;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Properties;
 

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/polling/PollingRecordPublisherTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/polling/PollingRecordPublisherTest.java
@@ -24,9 +24,7 @@ import org.apache.flink.streaming.connectors.kinesis.testutils.FakeKinesisBehavi
 import org.apache.flink.streaming.connectors.kinesis.testutils.TestUtils;
 import org.apache.flink.streaming.connectors.kinesis.testutils.TestUtils.TestConsumer;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.flink.streaming.connectors.kinesis.internals.ShardConsumerTestUtils.createFakeShardConsumerMetricGroup;
 import static org.apache.flink.streaming.connectors.kinesis.internals.publisher.RecordPublisher.RecordPublisherRunResult.COMPLETE;
@@ -34,6 +32,7 @@ import static org.apache.flink.streaming.connectors.kinesis.internals.publisher.
 import static org.apache.flink.streaming.connectors.kinesis.model.SentinelSequenceNumber.SENTINEL_EARLIEST_SEQUENCE_NUM;
 import static org.apache.flink.streaming.connectors.kinesis.testutils.FakeKinesisBehavioursFactory.totalNumOfRecordsAfterNumOfGetRecordsCalls;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.AdditionalMatchers.geq;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -45,8 +44,6 @@ import static org.mockito.Mockito.verify;
 public class PollingRecordPublisherTest {
 
     private static final long FETCH_INTERVAL_MILLIS = 500L;
-
-    @Rule public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void testRunPublishesRecordsToConsumer() throws Exception {
@@ -126,29 +123,35 @@ public class PollingRecordPublisherTest {
     }
 
     @Test
-    public void validateExpiredIteratorBackoffMillisNegativeThrows() throws Exception {
-        thrown.expect(IllegalArgumentException.class);
-
-        new PollingRecordPublisher(
-                StartingPosition.restartFromSequenceNumber(SENTINEL_EARLIEST_SEQUENCE_NUM.get()),
-                TestUtils.createDummyStreamShardHandle(),
-                mock(PollingRecordPublisherMetricsReporter.class),
-                mock(KinesisProxyInterface.class),
-                100,
-                -1);
+    public void validateExpiredIteratorBackoffMillisNegativeThrows() {
+        assertThatThrownBy(
+                        () -> {
+                            new PollingRecordPublisher(
+                                    StartingPosition.restartFromSequenceNumber(
+                                            SENTINEL_EARLIEST_SEQUENCE_NUM.get()),
+                                    TestUtils.createDummyStreamShardHandle(),
+                                    mock(PollingRecordPublisherMetricsReporter.class),
+                                    mock(KinesisProxyInterface.class),
+                                    100,
+                                    -1);
+                        })
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    public void validateMaxNumberOfRecordsPerFetchZeroThrows() throws Exception {
-        thrown.expect(IllegalArgumentException.class);
-
-        new PollingRecordPublisher(
-                StartingPosition.restartFromSequenceNumber(SENTINEL_EARLIEST_SEQUENCE_NUM.get()),
-                TestUtils.createDummyStreamShardHandle(),
-                mock(PollingRecordPublisherMetricsReporter.class),
-                mock(KinesisProxyInterface.class),
-                0,
-                100);
+    public void validateMaxNumberOfRecordsPerFetchZeroThrows() {
+        assertThatThrownBy(
+                        () -> {
+                            new PollingRecordPublisher(
+                                    StartingPosition.restartFromSequenceNumber(
+                                            SENTINEL_EARLIEST_SEQUENCE_NUM.get()),
+                                    TestUtils.createDummyStreamShardHandle(),
+                                    mock(PollingRecordPublisherMetricsReporter.class),
+                                    mock(KinesisProxyInterface.class),
+                                    0,
+                                    100);
+                        })
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     PollingRecordPublisher createPollingRecordPublisher(final KinesisProxyInterface kinesis)

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/metrics/PollingRecordPublisherMetricsReporterTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/metrics/PollingRecordPublisherMetricsReporterTest.java
@@ -19,8 +19,8 @@ package org.apache.flink.streaming.connectors.kinesis.metrics;
 
 import org.apache.flink.metrics.MetricGroup;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -37,7 +37,7 @@ public class PollingRecordPublisherMetricsReporterTest {
 
     @Mock private MetricGroup metricGroup;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         MockitoAnnotations.initMocks(this);
     }

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/metrics/ShardConsumerMetricsReporterTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/metrics/ShardConsumerMetricsReporterTest.java
@@ -21,8 +21,8 @@ import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.metrics.groups.AbstractMetricGroup;
 import org.apache.flink.streaming.connectors.kinesis.internals.ShardConsumerTestUtils;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -39,7 +39,7 @@ public class ShardConsumerMetricsReporterTest {
 
     @Mock private MetricGroup metricGroup;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         MockitoAnnotations.initMocks(this);
     }

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/model/DynamoDBStreamsShardHandleTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/model/DynamoDBStreamsShardHandleTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.flink.streaming.connectors.kinesis.model;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.flink.streaming.connectors.kinesis.model.DynamoDBStreamsShardHandle.SHARDID_PREFIX;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/model/SentinelSequenceNumberTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/model/SentinelSequenceNumberTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.flink.streaming.connectors.kinesis.model;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/model/StartingPositionTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/model/StartingPositionTest.java
@@ -18,18 +18,15 @@
 package org.apache.flink.streaming.connectors.kinesis.model;
 
 import com.amazonaws.services.kinesis.model.ShardIteratorType;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import java.util.Date;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link StartingPosition}. */
 public class StartingPositionTest {
-
-    @Rule public final ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void testStartingPositionFromTimestamp() {
@@ -83,12 +80,16 @@ public class StartingPositionTest {
 
     @Test
     public void testStartingPositionRestartFromSentinelEnding() {
-        thrown.expect(IllegalArgumentException.class);
-
-        SequenceNumber sequenceNumber =
-                SentinelSequenceNumber.SENTINEL_SHARD_ENDING_SEQUENCE_NUM.get();
-        StartingPosition position = StartingPosition.restartFromSequenceNumber(sequenceNumber);
-        assertThat(position.getShardIteratorType()).isEqualTo(ShardIteratorType.LATEST);
-        assertThat(position.getStartingMarker()).isNull();
+        assertThatThrownBy(
+                        () -> {
+                            SequenceNumber sequenceNumber =
+                                    SentinelSequenceNumber.SENTINEL_SHARD_ENDING_SEQUENCE_NUM.get();
+                            StartingPosition position =
+                                    StartingPosition.restartFromSequenceNumber(sequenceNumber);
+                            assertThat(position.getShardIteratorType())
+                                    .isEqualTo(ShardIteratorType.LATEST);
+                            assertThat(position.getStartingMarker()).isNull();
+                        })
+                .isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/model/StreamShardHandleTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/model/StreamShardHandleTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.flink.streaming.connectors.kinesis.model;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxyTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxyTest.java
@@ -42,7 +42,7 @@ import org.apache.http.HttpHost;
 import org.apache.http.conn.ConnectTimeoutException;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxyV2FactoryTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxyV2FactoryTest.java
@@ -20,7 +20,7 @@ package org.apache.flink.streaming.connectors.kinesis.proxy;
 import org.apache.flink.streaming.connectors.kinesis.config.AWSConfigConstants;
 import org.apache.flink.streaming.connectors.kinesis.testutils.TestUtils;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
 import software.amazon.awssdk.http.nio.netty.internal.NettyConfiguration;
 

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/table/KinesisDynamicTableFactoryTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/table/KinesisDynamicTableFactoryTest.java
@@ -39,9 +39,7 @@ import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.util.TestLogger;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -65,8 +63,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class KinesisDynamicTableFactoryTest extends TestLogger {
 
     private static final String STREAM_NAME = "myStream";
-
-    @Rule public ExpectedException thrown = ExpectedException.none();
 
     // --------------------------------------------------------------------------------------------
     // Positive tests

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/AWSUtilTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/AWSUtilTest.java
@@ -27,9 +27,7 @@ import com.amazonaws.auth.EnvironmentVariableCredentialsProvider;
 import com.amazonaws.auth.SystemPropertiesCredentialsProvider;
 import com.amazonaws.auth.WebIdentityTokenCredentialsProvider;
 import com.amazonaws.auth.profile.ProfileCredentialsProvider;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
@@ -45,13 +43,12 @@ import static org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfi
 import static org.apache.flink.streaming.connectors.kinesis.model.SentinelSequenceNumber.SENTINEL_AT_TIMESTAMP_SEQUENCE_NUM;
 import static org.apache.flink.streaming.connectors.kinesis.model.SentinelSequenceNumber.SENTINEL_LATEST_SEQUENCE_NUM;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for AWSUtil. */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(AWSUtil.class)
 public class AWSUtilTest {
-
-    @Rule private final ExpectedException exception = ExpectedException.none();
 
     @Test
     public void testDefaultCredentialsProvider() {
@@ -117,12 +114,14 @@ public class AWSUtilTest {
 
     @Test
     public void testInvalidCredentialsProvider() {
-        exception.expect(IllegalArgumentException.class);
+        assertThatThrownBy(
+                        () -> {
+                            Properties testConfig = new Properties();
+                            testConfig.setProperty(AWS_CREDENTIALS_PROVIDER, "INVALID_PROVIDER");
 
-        Properties testConfig = new Properties();
-        testConfig.setProperty(AWS_CREDENTIALS_PROVIDER, "INVALID_PROVIDER");
-
-        AWSUtil.getCredentialsProvider(testConfig);
+                            AWSUtil.getCredentialsProvider(testConfig);
+                        })
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/AwsV2UtilTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/AwsV2UtilTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.flink.streaming.connectors.kinesis.util;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.http.SdkHttpConfigurationOption;
 import software.amazon.awssdk.services.kinesis.model.LimitExceededException;
 import software.amazon.awssdk.utils.AttributeMap;

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/JobManagerWatermarkTrackerTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/JobManagerWatermarkTrackerTest.java
@@ -18,23 +18,23 @@
 package org.apache.flink.streaming.connectors.kinesis.util;
 
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.runtime.testutils.MiniClusterResource;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.streaming.api.functions.source.RichSourceFunction;
+import org.apache.flink.test.junit5.MiniClusterExtension;
 
-import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link JobManagerWatermarkTracker}. */
 public class JobManagerWatermarkTrackerTest {
 
-    @ClassRule
-    public static final MiniClusterResource FLINK =
-            new MiniClusterResource(
+    @RegisterExtension
+    public static final MiniClusterExtension FLINK =
+            new MiniClusterExtension(
                     new MiniClusterResourceConfiguration.Builder()
                             .setNumberTaskManagers(1)
                             .setNumberSlotsPerTaskManager(1)

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtilTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtilTest.java
@@ -23,9 +23,7 @@ import org.apache.flink.streaming.connectors.kinesis.config.ProducerConfigConsta
 import org.apache.flink.streaming.connectors.kinesis.testutils.TestUtils;
 
 import com.amazonaws.services.kinesis.producer.KinesisProducerConfiguration;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -43,12 +41,11 @@ import static org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfi
 import static org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants.STREAM_TIMESTAMP_DATE_FORMAT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for KinesisConfigUtil. */
 @RunWith(PowerMockRunner.class)
 public class KinesisConfigUtilTest {
-
-    @Rule public ExpectedException exception = ExpectedException.none();
 
     // ----------------------------------------------------------------------
     // getValidatedProducerConfiguration() tests
@@ -56,15 +53,17 @@ public class KinesisConfigUtilTest {
 
     @Test
     public void testUnparsableLongForProducerConfiguration() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(
-                "Error trying to set field RateLimit with the value 'unparsableLong'");
+        assertThatThrownBy(
+                        () -> {
+                            Properties testConfig = new Properties();
+                            testConfig.setProperty(AWSConfigConstants.AWS_REGION, "us-east-1");
+                            testConfig.setProperty("RateLimit", "unparsableLong");
 
-        Properties testConfig = new Properties();
-        testConfig.setProperty(AWSConfigConstants.AWS_REGION, "us-east-1");
-        testConfig.setProperty("RateLimit", "unparsableLong");
-
-        KinesisConfigUtil.getValidatedProducerConfiguration(testConfig);
+                            KinesisConfigUtil.getValidatedProducerConfiguration(testConfig);
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Error trying to set field RateLimit with the value 'unparsableLong'");
     }
 
     @Test
@@ -146,14 +145,18 @@ public class KinesisConfigUtilTest {
                 String.format(
                         "For FlinkKinesisProducer AWS region ('%s') must be set in the config.",
                         AWSConfigConstants.AWS_REGION);
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(expectedMessage);
+        assertThatThrownBy(
+                        () -> {
+                            Properties testConfig = new Properties();
+                            testConfig.setProperty(
+                                    AWSConfigConstants.AWS_ACCESS_KEY_ID, "accessKey");
+                            testConfig.setProperty(
+                                    AWSConfigConstants.AWS_SECRET_ACCESS_KEY, "secretKey");
 
-        Properties testConfig = new Properties();
-        testConfig.setProperty(AWSConfigConstants.AWS_ACCESS_KEY_ID, "accessKey");
-        testConfig.setProperty(AWSConfigConstants.AWS_SECRET_ACCESS_KEY, "secretKey");
-
-        KinesisConfigUtil.getValidatedProducerConfiguration(testConfig);
+                            KinesisConfigUtil.getValidatedProducerConfiguration(testConfig);
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(expectedMessage);
     }
 
     // ----------------------------------------------------------------------
@@ -162,44 +165,55 @@ public class KinesisConfigUtilTest {
 
     @Test
     public void testUnrecognizableAwsRegionInConfig() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("Invalid AWS region");
+        assertThatThrownBy(
+                        () -> {
+                            Properties testConfig = new Properties();
+                            testConfig.setProperty(AWSConfigConstants.AWS_REGION, "wrongRegionId");
+                            testConfig.setProperty(
+                                    AWSConfigConstants.AWS_ACCESS_KEY_ID, "accessKeyId");
+                            testConfig.setProperty(
+                                    AWSConfigConstants.AWS_SECRET_ACCESS_KEY, "secretKey");
 
-        Properties testConfig = new Properties();
-        testConfig.setProperty(AWSConfigConstants.AWS_REGION, "wrongRegionId");
-        testConfig.setProperty(AWSConfigConstants.AWS_ACCESS_KEY_ID, "accessKeyId");
-        testConfig.setProperty(AWSConfigConstants.AWS_SECRET_ACCESS_KEY, "secretKey");
-
-        KinesisConfigUtil.validateAwsConfiguration(testConfig);
+                            KinesisConfigUtil.validateAwsConfiguration(testConfig);
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid AWS region");
     }
 
     @Test
     public void testCredentialProviderTypeSetToBasicButNoCredentialSetInConfig() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(
-                "Please set values for AWS Access Key ID ('"
-                        + AWSConfigConstants.AWS_ACCESS_KEY_ID
-                        + "') "
-                        + "and Secret Key ('"
-                        + AWSConfigConstants.AWS_SECRET_ACCESS_KEY
-                        + "') when using the BASIC AWS credential provider type.");
+        assertThatThrownBy(
+                        () -> {
+                            Properties testConfig = new Properties();
+                            testConfig.setProperty(AWSConfigConstants.AWS_REGION, "us-east-1");
+                            testConfig.setProperty(
+                                    AWSConfigConstants.AWS_CREDENTIALS_PROVIDER, "BASIC");
 
-        Properties testConfig = new Properties();
-        testConfig.setProperty(AWSConfigConstants.AWS_REGION, "us-east-1");
-        testConfig.setProperty(AWSConfigConstants.AWS_CREDENTIALS_PROVIDER, "BASIC");
-
-        KinesisConfigUtil.validateAwsConfiguration(testConfig);
+                            KinesisConfigUtil.validateAwsConfiguration(testConfig);
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Please set values for AWS Access Key ID ('"
+                                + AWSConfigConstants.AWS_ACCESS_KEY_ID
+                                + "') "
+                                + "and Secret Key ('"
+                                + AWSConfigConstants.AWS_SECRET_ACCESS_KEY
+                                + "') when using the BASIC AWS credential provider type.");
     }
 
     @Test
     public void testUnrecognizableCredentialProviderTypeInConfig() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("Invalid AWS Credential Provider Type");
+        assertThatThrownBy(
+                        () -> {
+                            Properties testConfig = TestUtils.getStandardProperties();
+                            testConfig.setProperty(
+                                    AWSConfigConstants.AWS_CREDENTIALS_PROVIDER,
+                                    "wrongProviderType");
 
-        Properties testConfig = TestUtils.getStandardProperties();
-        testConfig.setProperty(AWSConfigConstants.AWS_CREDENTIALS_PROVIDER, "wrongProviderType");
-
-        KinesisConfigUtil.validateAwsConfiguration(testConfig);
+                            KinesisConfigUtil.validateAwsConfiguration(testConfig);
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid AWS Credential Provider Type");
     }
 
     // ----------------------------------------------------------------------
@@ -223,13 +237,17 @@ public class KinesisConfigUtilTest {
         String msg =
                 "Invalid record publisher type in stream set in config. Valid values are: "
                         + errorMessage;
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(msg);
-        Properties testConfig = TestUtils.getStandardProperties();
-        testConfig.setProperty(
-                ConsumerConfigConstants.RECORD_PUBLISHER_TYPE, "unrecognizableRecordPublisher");
+        assertThatThrownBy(
+                        () -> {
+                            Properties testConfig = TestUtils.getStandardProperties();
+                            testConfig.setProperty(
+                                    ConsumerConfigConstants.RECORD_PUBLISHER_TYPE,
+                                    "unrecognizableRecordPublisher");
 
-        KinesisConfigUtil.validateRecordPublisherType(testConfig);
+                            KinesisConfigUtil.validateRecordPublisherType(testConfig);
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(msg);
     }
 
     // ----------------------------------------------------------------------
@@ -256,16 +274,21 @@ public class KinesisConfigUtilTest {
         String msg =
                 "Invalid efo registration type in stream set in config. Valid values are: "
                         + errorMessage;
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(msg);
-        Properties testConfig = TestUtils.getStandardProperties();
-        testConfig.setProperty(
-                ConsumerConfigConstants.RECORD_PUBLISHER_TYPE,
-                ConsumerConfigConstants.RecordPublisherType.EFO.toString());
-        testConfig.setProperty(
-                ConsumerConfigConstants.EFO_REGISTRATION_TYPE, "unrecogonizeEforegistrationtype");
+        assertThatThrownBy(
+                        () -> {
+                            Properties testConfig = TestUtils.getStandardProperties();
+                            testConfig.setProperty(
+                                    ConsumerConfigConstants.RECORD_PUBLISHER_TYPE,
+                                    ConsumerConfigConstants.RecordPublisherType.EFO.toString());
+                            testConfig.setProperty(
+                                    ConsumerConfigConstants.EFO_REGISTRATION_TYPE,
+                                    "unrecogonizeEforegistrationtype");
 
-        KinesisConfigUtil.validateEfoConfiguration(testConfig, new ArrayList<>());
+                            KinesisConfigUtil.validateEfoConfiguration(
+                                    testConfig, new ArrayList<>());
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(msg);
     }
 
     @Test
@@ -322,19 +345,23 @@ public class KinesisConfigUtilTest {
                 "Invalid efo consumer arn settings for not providing consumer arns: "
                         + ConsumerConfigConstants.EFO_CONSUMER_ARN_PREFIX
                         + ".stream2";
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(msg);
-        Properties testConfig = TestUtils.getStandardProperties();
-        testConfig.setProperty(
-                ConsumerConfigConstants.RECORD_PUBLISHER_TYPE,
-                ConsumerConfigConstants.RecordPublisherType.EFO.toString());
-        testConfig.setProperty(
-                ConsumerConfigConstants.EFO_REGISTRATION_TYPE,
-                ConsumerConfigConstants.EFORegistrationType.NONE.toString());
-        testConfig.setProperty(
-                ConsumerConfigConstants.EFO_CONSUMER_ARN_PREFIX + ".stream1", "fakedArn1");
-        List<String> streams = Arrays.asList("stream1", "stream2");
-        KinesisConfigUtil.validateEfoConfiguration(testConfig, streams);
+        assertThatThrownBy(
+                        () -> {
+                            Properties testConfig = TestUtils.getStandardProperties();
+                            testConfig.setProperty(
+                                    ConsumerConfigConstants.RECORD_PUBLISHER_TYPE,
+                                    ConsumerConfigConstants.RecordPublisherType.EFO.toString());
+                            testConfig.setProperty(
+                                    ConsumerConfigConstants.EFO_REGISTRATION_TYPE,
+                                    ConsumerConfigConstants.EFORegistrationType.NONE.toString());
+                            testConfig.setProperty(
+                                    ConsumerConfigConstants.EFO_CONSUMER_ARN_PREFIX + ".stream1",
+                                    "fakedArn1");
+                            List<String> streams = Arrays.asList("stream1", "stream2");
+                            KinesisConfigUtil.validateEfoConfiguration(testConfig, streams);
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(msg);
     }
 
     @Test
@@ -347,26 +374,30 @@ public class KinesisConfigUtilTest {
 
     @Test
     public void testValidateEfoMaxConcurrencyNonNumeric() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(
-                "Invalid value given for EFO HTTP client max concurrency. Must be positive.");
+        assertThatThrownBy(
+                        () -> {
+                            Properties testConfig = TestUtils.getStandardProperties();
+                            testConfig.setProperty(EFO_HTTP_CLIENT_MAX_CONCURRENCY, "abc");
 
-        Properties testConfig = TestUtils.getStandardProperties();
-        testConfig.setProperty(EFO_HTTP_CLIENT_MAX_CONCURRENCY, "abc");
-
-        KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                            KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Invalid value given for EFO HTTP client max concurrency. Must be positive.");
     }
 
     @Test
     public void testValidateEfoMaxConcurrencyNegative() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(
-                "Invalid value given for EFO HTTP client max concurrency. Must be positive.");
+        assertThatThrownBy(
+                        () -> {
+                            Properties testConfig = TestUtils.getStandardProperties();
+                            testConfig.setProperty(EFO_HTTP_CLIENT_MAX_CONCURRENCY, "-1");
 
-        Properties testConfig = TestUtils.getStandardProperties();
-        testConfig.setProperty(EFO_HTTP_CLIENT_MAX_CONCURRENCY, "-1");
-
-        KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                            KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Invalid value given for EFO HTTP client max concurrency. Must be positive.");
     }
 
     // ----------------------------------------------------------------------
@@ -379,14 +410,18 @@ public class KinesisConfigUtilTest {
                 String.format(
                         "For FlinkKinesisConsumer AWS region ('%s') and/or AWS endpoint ('%s') must be set in the config.",
                         AWSConfigConstants.AWS_REGION, AWSConfigConstants.AWS_ENDPOINT);
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(expectedMessage);
+        assertThatThrownBy(
+                        () -> {
+                            Properties testConfig = new Properties();
+                            testConfig.setProperty(
+                                    AWSConfigConstants.AWS_ACCESS_KEY_ID, "accessKey");
+                            testConfig.setProperty(
+                                    AWSConfigConstants.AWS_SECRET_ACCESS_KEY, "secretKey");
 
-        Properties testConfig = new Properties();
-        testConfig.setProperty(AWSConfigConstants.AWS_ACCESS_KEY_ID, "accessKey");
-        testConfig.setProperty(AWSConfigConstants.AWS_SECRET_ACCESS_KEY, "secretKey");
-
-        KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                            KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(expectedMessage);
     }
 
     @Test
@@ -422,58 +457,80 @@ public class KinesisConfigUtilTest {
 
     @Test
     public void testUnrecognizableStreamInitPositionTypeInConfig() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("Invalid initial position in stream");
+        assertThatThrownBy(
+                        () -> {
+                            Properties testConfig = TestUtils.getStandardProperties();
+                            testConfig.setProperty(
+                                    ConsumerConfigConstants.AWS_CREDENTIALS_PROVIDER, "BASIC");
+                            testConfig.setProperty(
+                                    ConsumerConfigConstants.STREAM_INITIAL_POSITION,
+                                    "wrongInitPosition");
 
-        Properties testConfig = TestUtils.getStandardProperties();
-        testConfig.setProperty(ConsumerConfigConstants.AWS_CREDENTIALS_PROVIDER, "BASIC");
-        testConfig.setProperty(
-                ConsumerConfigConstants.STREAM_INITIAL_POSITION, "wrongInitPosition");
-
-        KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                            KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid initial position in stream");
     }
 
     @Test
     public void testStreamInitPositionTypeSetToAtTimestampButNoInitTimestampSetInConfig() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(
-                "Please set value for initial timestamp ('"
-                        + ConsumerConfigConstants.STREAM_INITIAL_TIMESTAMP
-                        + "') when using AT_TIMESTAMP initial position.");
+        assertThatThrownBy(
+                        () -> {
+                            Properties testConfig = TestUtils.getStandardProperties();
+                            testConfig.setProperty(
+                                    ConsumerConfigConstants.AWS_CREDENTIALS_PROVIDER, "BASIC");
+                            testConfig.setProperty(
+                                    ConsumerConfigConstants.STREAM_INITIAL_POSITION,
+                                    "AT_TIMESTAMP");
 
-        Properties testConfig = TestUtils.getStandardProperties();
-        testConfig.setProperty(ConsumerConfigConstants.AWS_CREDENTIALS_PROVIDER, "BASIC");
-        testConfig.setProperty(ConsumerConfigConstants.STREAM_INITIAL_POSITION, "AT_TIMESTAMP");
-
-        KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                            KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Please set value for initial timestamp ('"
+                                + ConsumerConfigConstants.STREAM_INITIAL_TIMESTAMP
+                                + "') when using AT_TIMESTAMP initial position.");
     }
 
     @Test
     public void testUnparsableDateforInitialTimestampInConfig() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(
-                "Invalid value given for initial timestamp for AT_TIMESTAMP initial position in stream.");
+        assertThatThrownBy(
+                        () -> {
+                            Properties testConfig = TestUtils.getStandardProperties();
+                            testConfig.setProperty(
+                                    ConsumerConfigConstants.AWS_CREDENTIALS_PROVIDER, "BASIC");
+                            testConfig.setProperty(
+                                    ConsumerConfigConstants.STREAM_INITIAL_POSITION,
+                                    "AT_TIMESTAMP");
+                            testConfig.setProperty(
+                                    ConsumerConfigConstants.STREAM_INITIAL_TIMESTAMP,
+                                    "unparsableDate");
 
-        Properties testConfig = TestUtils.getStandardProperties();
-        testConfig.setProperty(ConsumerConfigConstants.AWS_CREDENTIALS_PROVIDER, "BASIC");
-        testConfig.setProperty(ConsumerConfigConstants.STREAM_INITIAL_POSITION, "AT_TIMESTAMP");
-        testConfig.setProperty(ConsumerConfigConstants.STREAM_INITIAL_TIMESTAMP, "unparsableDate");
-
-        KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                            KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Invalid value given for initial timestamp for AT_TIMESTAMP initial position in stream.");
     }
 
     @Test
     public void testIllegalValuEforInitialTimestampInConfig() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(
-                "Invalid value given for initial timestamp for AT_TIMESTAMP initial position in stream.");
+        assertThatThrownBy(
+                        () -> {
+                            Properties testConfig = TestUtils.getStandardProperties();
+                            testConfig.setProperty(
+                                    ConsumerConfigConstants.AWS_CREDENTIALS_PROVIDER, "BASIC");
+                            testConfig.setProperty(
+                                    ConsumerConfigConstants.STREAM_INITIAL_POSITION,
+                                    "AT_TIMESTAMP");
+                            testConfig.setProperty(
+                                    ConsumerConfigConstants.STREAM_INITIAL_TIMESTAMP, "-1.0");
 
-        Properties testConfig = TestUtils.getStandardProperties();
-        testConfig.setProperty(ConsumerConfigConstants.AWS_CREDENTIALS_PROVIDER, "BASIC");
-        testConfig.setProperty(ConsumerConfigConstants.STREAM_INITIAL_POSITION, "AT_TIMESTAMP");
-        testConfig.setProperty(ConsumerConfigConstants.STREAM_INITIAL_TIMESTAMP, "-1.0");
-
-        KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                            KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Invalid value given for initial timestamp for AT_TIMESTAMP initial position in stream.");
     }
 
     @Test
@@ -504,33 +561,49 @@ public class KinesisConfigUtilTest {
 
     @Test
     public void testInvalidPatternForInitialTimestampInConfig() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(
-                "Invalid value given for initial timestamp for AT_TIMESTAMP initial position in stream.");
+        assertThatThrownBy(
+                        () -> {
+                            Properties testConfig = TestUtils.getStandardProperties();
+                            testConfig.setProperty(
+                                    ConsumerConfigConstants.AWS_CREDENTIALS_PROVIDER, "BASIC");
+                            testConfig.setProperty(
+                                    ConsumerConfigConstants.STREAM_INITIAL_POSITION,
+                                    "AT_TIMESTAMP");
+                            testConfig.setProperty(
+                                    ConsumerConfigConstants.STREAM_INITIAL_TIMESTAMP, "2016-03-14");
+                            testConfig.setProperty(
+                                    ConsumerConfigConstants.STREAM_TIMESTAMP_DATE_FORMAT,
+                                    "InvalidPattern");
 
-        Properties testConfig = TestUtils.getStandardProperties();
-        testConfig.setProperty(ConsumerConfigConstants.AWS_CREDENTIALS_PROVIDER, "BASIC");
-        testConfig.setProperty(ConsumerConfigConstants.STREAM_INITIAL_POSITION, "AT_TIMESTAMP");
-        testConfig.setProperty(ConsumerConfigConstants.STREAM_INITIAL_TIMESTAMP, "2016-03-14");
-        testConfig.setProperty(
-                ConsumerConfigConstants.STREAM_TIMESTAMP_DATE_FORMAT, "InvalidPattern");
-
-        KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                            KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Invalid value given for initial timestamp for AT_TIMESTAMP initial position in stream.");
     }
 
     @Test
     public void testUnparsableDatEforUserDefinedDatEformatForInitialTimestampInConfig() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(
-                "Invalid value given for initial timestamp for AT_TIMESTAMP initial position in stream.");
+        assertThatThrownBy(
+                        () -> {
+                            Properties testConfig = TestUtils.getStandardProperties();
+                            testConfig.setProperty(
+                                    ConsumerConfigConstants.AWS_CREDENTIALS_PROVIDER, "BASIC");
+                            testConfig.setProperty(
+                                    ConsumerConfigConstants.STREAM_INITIAL_POSITION,
+                                    "AT_TIMESTAMP");
+                            testConfig.setProperty(
+                                    ConsumerConfigConstants.STREAM_INITIAL_TIMESTAMP,
+                                    "stillUnparsable");
+                            testConfig.setProperty(
+                                    ConsumerConfigConstants.STREAM_TIMESTAMP_DATE_FORMAT,
+                                    "yyyy-MM-dd");
 
-        Properties testConfig = TestUtils.getStandardProperties();
-        testConfig.setProperty(ConsumerConfigConstants.AWS_CREDENTIALS_PROVIDER, "BASIC");
-        testConfig.setProperty(ConsumerConfigConstants.STREAM_INITIAL_POSITION, "AT_TIMESTAMP");
-        testConfig.setProperty(ConsumerConfigConstants.STREAM_INITIAL_TIMESTAMP, "stillUnparsable");
-        testConfig.setProperty(ConsumerConfigConstants.STREAM_TIMESTAMP_DATE_FORMAT, "yyyy-MM-dd");
-
-        KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                            KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Invalid value given for initial timestamp for AT_TIMESTAMP initial position in stream.");
     }
 
     @Test
@@ -549,182 +622,228 @@ public class KinesisConfigUtilTest {
 
     @Test
     public void testUnparsableLongForListShardsBackoffBaseMillisInConfig() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(
-                "Invalid value given for list shards operation base backoff milliseconds");
+        assertThatThrownBy(
+                        () -> {
+                            Properties testConfig = TestUtils.getStandardProperties();
+                            testConfig.setProperty(
+                                    ConsumerConfigConstants.LIST_SHARDS_BACKOFF_BASE,
+                                    "unparsableLong");
 
-        Properties testConfig = TestUtils.getStandardProperties();
-        testConfig.setProperty(ConsumerConfigConstants.LIST_SHARDS_BACKOFF_BASE, "unparsableLong");
-
-        KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                            KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Invalid value given for list shards operation base backoff milliseconds");
     }
 
     @Test
     public void testUnparsableLongForListShardsBackoffMaxMillisInConfig() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(
-                "Invalid value given for list shards operation max backoff milliseconds");
+        assertThatThrownBy(
+                        () -> {
+                            Properties testConfig = TestUtils.getStandardProperties();
+                            testConfig.setProperty(
+                                    ConsumerConfigConstants.LIST_SHARDS_BACKOFF_MAX,
+                                    "unparsableLong");
 
-        Properties testConfig = TestUtils.getStandardProperties();
-        testConfig.setProperty(ConsumerConfigConstants.LIST_SHARDS_BACKOFF_MAX, "unparsableLong");
-
-        KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                            KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Invalid value given for list shards operation max backoff milliseconds");
     }
 
     @Test
     public void testUnparsableDoublEforListShardsBackoffExponentialConstantInConfig() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(
-                "Invalid value given for list shards operation backoff exponential constant");
+        assertThatThrownBy(
+                        () -> {
+                            Properties testConfig = TestUtils.getStandardProperties();
+                            testConfig.setProperty(
+                                    ConsumerConfigConstants
+                                            .LIST_SHARDS_BACKOFF_EXPONENTIAL_CONSTANT,
+                                    "unparsableDouble");
 
-        Properties testConfig = TestUtils.getStandardProperties();
-        testConfig.setProperty(
-                ConsumerConfigConstants.LIST_SHARDS_BACKOFF_EXPONENTIAL_CONSTANT,
-                "unparsableDouble");
-
-        KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                            KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Invalid value given for list shards operation backoff exponential constant");
     }
 
     @Test
     public void testUnparsableIntForGetRecordsRetriesInConfig() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(
-                "Invalid value given for maximum retry attempts for getRecords shard operation");
+        assertThatThrownBy(
+                        () -> {
+                            Properties testConfig = TestUtils.getStandardProperties();
+                            testConfig.setProperty(
+                                    ConsumerConfigConstants.SHARD_GETRECORDS_RETRIES,
+                                    "unparsableInt");
 
-        Properties testConfig = TestUtils.getStandardProperties();
-        testConfig.setProperty(ConsumerConfigConstants.SHARD_GETRECORDS_RETRIES, "unparsableInt");
-
-        KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                            KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Invalid value given for maximum retry attempts for getRecords shard operation");
     }
 
     @Test
     public void testUnparsableIntForGetRecordsMaxCountInConfig() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(
-                "Invalid value given for maximum records per getRecords shard operation");
+        assertThatThrownBy(
+                        () -> {
+                            Properties testConfig = TestUtils.getStandardProperties();
+                            testConfig.setProperty(
+                                    ConsumerConfigConstants.SHARD_GETRECORDS_MAX, "unparsableInt");
 
-        Properties testConfig = TestUtils.getStandardProperties();
-        testConfig.setProperty(ConsumerConfigConstants.SHARD_GETRECORDS_MAX, "unparsableInt");
-
-        KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                            KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Invalid value given for maximum records per getRecords shard operation");
     }
 
     @Test
     public void testUnparsableLongForGetRecordsBackoffBaseMillisInConfig() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(
-                "Invalid value given for get records operation base backoff milliseconds");
+        assertThatThrownBy(
+                        () -> {
+                            Properties testConfig = TestUtils.getStandardProperties();
+                            testConfig.setProperty(
+                                    ConsumerConfigConstants.SHARD_GETRECORDS_BACKOFF_BASE,
+                                    "unparsableLong");
 
-        Properties testConfig = TestUtils.getStandardProperties();
-        testConfig.setProperty(
-                ConsumerConfigConstants.SHARD_GETRECORDS_BACKOFF_BASE, "unparsableLong");
-
-        KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                            KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Invalid value given for get records operation base backoff milliseconds");
     }
 
     @Test
     public void testUnparsableLongForGetRecordsBackoffMaxMillisInConfig() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(
-                "Invalid value given for get records operation max backoff milliseconds");
+        assertThatThrownBy(
+                        () -> {
+                            Properties testConfig = TestUtils.getStandardProperties();
+                            testConfig.setProperty(
+                                    ConsumerConfigConstants.SHARD_GETRECORDS_BACKOFF_MAX,
+                                    "unparsableLong");
 
-        Properties testConfig = TestUtils.getStandardProperties();
-        testConfig.setProperty(
-                ConsumerConfigConstants.SHARD_GETRECORDS_BACKOFF_MAX, "unparsableLong");
-
-        KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                            KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Invalid value given for get records operation max backoff milliseconds");
     }
 
     @Test
     public void testUnparsableDoublEforGetRecordsBackoffExponentialConstantInConfig() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(
-                "Invalid value given for get records operation backoff exponential constant");
+        assertThatThrownBy(
+                        () -> {
+                            Properties testConfig = TestUtils.getStandardProperties();
+                            testConfig.setProperty(
+                                    ConsumerConfigConstants
+                                            .SHARD_GETRECORDS_BACKOFF_EXPONENTIAL_CONSTANT,
+                                    "unparsableDouble");
 
-        Properties testConfig = TestUtils.getStandardProperties();
-        testConfig.setProperty(
-                ConsumerConfigConstants.SHARD_GETRECORDS_BACKOFF_EXPONENTIAL_CONSTANT,
-                "unparsableDouble");
-
-        KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                            KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Invalid value given for get records operation backoff exponential constant");
     }
 
     @Test
     public void testUnparsableLongForGetRecordsIntervalMillisInConfig() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(
-                "Invalid value given for getRecords sleep interval in milliseconds");
+        assertThatThrownBy(
+                        () -> {
+                            Properties testConfig = TestUtils.getStandardProperties();
+                            testConfig.setProperty(
+                                    ConsumerConfigConstants.SHARD_GETRECORDS_INTERVAL_MILLIS,
+                                    "unparsableLong");
 
-        Properties testConfig = TestUtils.getStandardProperties();
-        testConfig.setProperty(
-                ConsumerConfigConstants.SHARD_GETRECORDS_INTERVAL_MILLIS, "unparsableLong");
-
-        KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                            KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Invalid value given for getRecords sleep interval in milliseconds");
     }
 
     @Test
     public void testUnparsableIntForGetShardIteratorRetriesInConfig() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(
-                "Invalid value given for maximum retry attempts for getShardIterator shard operation");
+        assertThatThrownBy(
+                        () -> {
+                            Properties testConfig = TestUtils.getStandardProperties();
+                            testConfig.setProperty(
+                                    ConsumerConfigConstants.SHARD_GETITERATOR_RETRIES,
+                                    "unparsableInt");
 
-        Properties testConfig = TestUtils.getStandardProperties();
-        testConfig.setProperty(ConsumerConfigConstants.SHARD_GETITERATOR_RETRIES, "unparsableInt");
-
-        KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                            KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Invalid value given for maximum retry attempts for getShardIterator shard operation");
     }
 
     @Test
     public void testUnparsableLongForGetShardIteratorBackoffBaseMillisInConfig() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(
-                "Invalid value given for get shard iterator operation base backoff milliseconds");
+        assertThatThrownBy(
+                        () -> {
+                            Properties testConfig = TestUtils.getStandardProperties();
+                            testConfig.setProperty(
+                                    ConsumerConfigConstants.SHARD_GETITERATOR_BACKOFF_BASE,
+                                    "unparsableLong");
 
-        Properties testConfig = TestUtils.getStandardProperties();
-        testConfig.setProperty(
-                ConsumerConfigConstants.SHARD_GETITERATOR_BACKOFF_BASE, "unparsableLong");
-
-        KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                            KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Invalid value given for get shard iterator operation base backoff milliseconds");
     }
 
     @Test
     public void testUnparsableLongForGetShardIteratorBackoffMaxMillisInConfig() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(
-                "Invalid value given for get shard iterator operation max backoff milliseconds");
+        assertThatThrownBy(
+                        () -> {
+                            Properties testConfig = TestUtils.getStandardProperties();
+                            testConfig.setProperty(
+                                    ConsumerConfigConstants.SHARD_GETITERATOR_BACKOFF_MAX,
+                                    "unparsableLong");
 
-        Properties testConfig = TestUtils.getStandardProperties();
-        testConfig.setProperty(
-                ConsumerConfigConstants.SHARD_GETITERATOR_BACKOFF_MAX, "unparsableLong");
-
-        KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                            KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Invalid value given for get shard iterator operation max backoff milliseconds");
     }
 
     @Test
     public void testUnparsableDoublEforGetShardIteratorBackoffExponentialConstantInConfig() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(
-                "Invalid value given for get shard iterator operation backoff exponential constant");
+        assertThatThrownBy(
+                        () -> {
+                            Properties testConfig = TestUtils.getStandardProperties();
+                            testConfig.setProperty(
+                                    ConsumerConfigConstants
+                                            .SHARD_GETITERATOR_BACKOFF_EXPONENTIAL_CONSTANT,
+                                    "unparsableDouble");
 
-        Properties testConfig = TestUtils.getStandardProperties();
-        testConfig.setProperty(
-                ConsumerConfigConstants.SHARD_GETITERATOR_BACKOFF_EXPONENTIAL_CONSTANT,
-                "unparsableDouble");
-
-        KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                            KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Invalid value given for get shard iterator operation backoff exponential constant");
     }
 
     @Test
     public void testUnparsableLongForShardDiscoveryIntervalMillisInConfig() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(
-                "Invalid value given for shard discovery sleep interval in milliseconds");
+        assertThatThrownBy(
+                        () -> {
+                            Properties testConfig = TestUtils.getStandardProperties();
+                            testConfig.setProperty(
+                                    ConsumerConfigConstants.SHARD_DISCOVERY_INTERVAL_MILLIS,
+                                    "unparsableLong");
 
-        Properties testConfig = TestUtils.getStandardProperties();
-        testConfig.setProperty(
-                ConsumerConfigConstants.SHARD_DISCOVERY_INTERVAL_MILLIS, "unparsableLong");
-
-        KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                            KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Invalid value given for shard discovery sleep interval in milliseconds");
     }
 
     @Test
@@ -760,254 +879,317 @@ public class KinesisConfigUtilTest {
 
     @Test
     public void testParseStreamTimestampStartingPositionUsingParseError() {
-        exception.expect(NumberFormatException.class);
+        assertThatThrownBy(
+                        () -> {
+                            Properties consumerProperties = new Properties();
+                            consumerProperties.setProperty(STREAM_INITIAL_TIMESTAMP, "bad");
 
-        Properties consumerProperties = new Properties();
-        consumerProperties.setProperty(STREAM_INITIAL_TIMESTAMP, "bad");
-
-        KinesisConfigUtil.parseStreamTimestampStartingPosition(consumerProperties);
+                            KinesisConfigUtil.parseStreamTimestampStartingPosition(
+                                    consumerProperties);
+                        })
+                .isInstanceOf(NumberFormatException.class);
     }
 
     @Test
     public void testParseStreamTimestampStartingPositionIllegalArgumentException() {
-        exception.expect(IllegalArgumentException.class);
+        assertThatThrownBy(
+                        () -> {
+                            Properties consumerProperties = new Properties();
 
-        Properties consumerProperties = new Properties();
-
-        KinesisConfigUtil.parseStreamTimestampStartingPosition(consumerProperties);
+                            KinesisConfigUtil.parseStreamTimestampStartingPosition(
+                                    consumerProperties);
+                        })
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     public void testUnparsableIntForRegisterStreamRetriesInConfig() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(
-                "Invalid value given for maximum retry attempts for register stream operation");
+        assertThatThrownBy(
+                        () -> {
+                            Properties testConfig = TestUtils.getStandardProperties();
+                            testConfig.setProperty(
+                                    ConsumerConfigConstants.REGISTER_STREAM_RETRIES,
+                                    "unparsableInt");
 
-        Properties testConfig = TestUtils.getStandardProperties();
-        testConfig.setProperty(ConsumerConfigConstants.REGISTER_STREAM_RETRIES, "unparsableInt");
-
-        KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                            KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Invalid value given for maximum retry attempts for register stream operation");
     }
 
     @Test
     public void testUnparsableIntForRegisterStreamTimeoutInConfig() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(
-                "Invalid value given for maximum timeout for register stream consumer. Must be a valid non-negative integer value.");
+        assertThatThrownBy(
+                        () -> {
+                            Properties testConfig = TestUtils.getStandardProperties();
+                            testConfig.setProperty(
+                                    ConsumerConfigConstants.REGISTER_STREAM_TIMEOUT_SECONDS,
+                                    "unparsableInt");
 
-        Properties testConfig = TestUtils.getStandardProperties();
-        testConfig.setProperty(
-                ConsumerConfigConstants.REGISTER_STREAM_TIMEOUT_SECONDS, "unparsableInt");
-
-        KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                            KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Invalid value given for maximum timeout for register stream consumer. Must be a valid non-negative integer value.");
     }
 
     @Test
     public void testUnparsableLongForRegisterStreamBackoffBaseMillisInConfig() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(
-                "Invalid value given for register stream operation base backoff milliseconds");
+        assertThatThrownBy(
+                        () -> {
+                            Properties testConfig = TestUtils.getStandardProperties();
+                            testConfig.setProperty(
+                                    ConsumerConfigConstants.REGISTER_STREAM_BACKOFF_BASE,
+                                    "unparsableLong");
 
-        Properties testConfig = TestUtils.getStandardProperties();
-        testConfig.setProperty(
-                ConsumerConfigConstants.REGISTER_STREAM_BACKOFF_BASE, "unparsableLong");
-
-        KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                            KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Invalid value given for register stream operation base backoff milliseconds");
     }
 
     @Test
     public void testUnparsableLongForRegisterStreamBackoffMaxMillisInConfig() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(
-                "Invalid value given for register stream operation max backoff milliseconds");
+        assertThatThrownBy(
+                        () -> {
+                            Properties testConfig = TestUtils.getStandardProperties();
+                            testConfig.setProperty(
+                                    ConsumerConfigConstants.REGISTER_STREAM_BACKOFF_MAX,
+                                    "unparsableLong");
 
-        Properties testConfig = TestUtils.getStandardProperties();
-        testConfig.setProperty(
-                ConsumerConfigConstants.REGISTER_STREAM_BACKOFF_MAX, "unparsableLong");
-
-        KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                            KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Invalid value given for register stream operation max backoff milliseconds");
     }
 
     @Test
     public void testUnparsableDoublEforRegisterStreamBackoffExponentialConstantInConfig() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(
-                "Invalid value given for register stream operation backoff exponential constant");
+        assertThatThrownBy(
+                        () -> {
+                            Properties testConfig = TestUtils.getStandardProperties();
+                            testConfig.setProperty(
+                                    ConsumerConfigConstants
+                                            .REGISTER_STREAM_BACKOFF_EXPONENTIAL_CONSTANT,
+                                    "unparsableDouble");
 
-        Properties testConfig = TestUtils.getStandardProperties();
-        testConfig.setProperty(
-                ConsumerConfigConstants.REGISTER_STREAM_BACKOFF_EXPONENTIAL_CONSTANT,
-                "unparsableDouble");
-
-        KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                            KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Invalid value given for register stream operation backoff exponential constant");
     }
 
     @Test
     public void testUnparsableIntForDeRegisterStreamRetriesInConfig() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(
-                "Invalid value given for maximum retry attempts for deregister stream operation");
+        assertThatThrownBy(
+                        () -> {
+                            Properties testConfig = TestUtils.getStandardProperties();
+                            testConfig.setProperty(
+                                    ConsumerConfigConstants.DEREGISTER_STREAM_RETRIES,
+                                    "unparsableInt");
 
-        Properties testConfig = TestUtils.getStandardProperties();
-        testConfig.setProperty(ConsumerConfigConstants.DEREGISTER_STREAM_RETRIES, "unparsableInt");
-
-        KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                            KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Invalid value given for maximum retry attempts for deregister stream operation");
     }
 
     @Test
     public void testUnparsableIntForDeRegisterStreamTimeoutInConfig() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(
-                "Invalid value given for maximum timeout for deregister stream consumer. Must be a valid non-negative integer value.");
+        assertThatThrownBy(
+                        () -> {
+                            Properties testConfig = TestUtils.getStandardProperties();
+                            testConfig.setProperty(
+                                    ConsumerConfigConstants.DEREGISTER_STREAM_TIMEOUT_SECONDS,
+                                    "unparsableInt");
 
-        Properties testConfig = TestUtils.getStandardProperties();
-        testConfig.setProperty(
-                ConsumerConfigConstants.DEREGISTER_STREAM_TIMEOUT_SECONDS, "unparsableInt");
-
-        KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                            KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Invalid value given for maximum timeout for deregister stream consumer. Must be a valid non-negative integer value.");
     }
 
     @Test
     public void testUnparsableLongForDeRegisterStreamBackoffBaseMillisInConfig() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(
-                "Invalid value given for deregister stream operation base backoff milliseconds");
+        assertThatThrownBy(
+                        () -> {
+                            Properties testConfig = TestUtils.getStandardProperties();
+                            testConfig.setProperty(
+                                    ConsumerConfigConstants.DEREGISTER_STREAM_BACKOFF_BASE,
+                                    "unparsableLong");
 
-        Properties testConfig = TestUtils.getStandardProperties();
-        testConfig.setProperty(
-                ConsumerConfigConstants.DEREGISTER_STREAM_BACKOFF_BASE, "unparsableLong");
-
-        KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                            KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Invalid value given for deregister stream operation base backoff milliseconds");
     }
 
     @Test
     public void testUnparsableLongForDeRegisterStreamBackoffMaxMillisInConfig() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(
-                "Invalid value given for deregister stream operation max backoff milliseconds");
+        assertThatThrownBy(
+                        () -> {
+                            Properties testConfig = TestUtils.getStandardProperties();
+                            testConfig.setProperty(
+                                    ConsumerConfigConstants.DEREGISTER_STREAM_BACKOFF_MAX,
+                                    "unparsableLong");
 
-        Properties testConfig = TestUtils.getStandardProperties();
-        testConfig.setProperty(
-                ConsumerConfigConstants.DEREGISTER_STREAM_BACKOFF_MAX, "unparsableLong");
-
-        KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                            KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Invalid value given for deregister stream operation max backoff milliseconds");
     }
 
     @Test
     public void testUnparsableDoublEforDeRegisterStreamBackoffExponentialConstantInConfig() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(
-                "Invalid value given for deregister stream operation backoff exponential constant");
+        assertThatThrownBy(
+                        () -> {
+                            Properties testConfig = TestUtils.getStandardProperties();
+                            testConfig.setProperty(
+                                    ConsumerConfigConstants
+                                            .DEREGISTER_STREAM_BACKOFF_EXPONENTIAL_CONSTANT,
+                                    "unparsableDouble");
 
-        Properties testConfig = TestUtils.getStandardProperties();
-        testConfig.setProperty(
-                ConsumerConfigConstants.DEREGISTER_STREAM_BACKOFF_EXPONENTIAL_CONSTANT,
-                "unparsableDouble");
-
-        KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                            KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Invalid value given for deregister stream operation backoff exponential constant");
     }
 
     @Test
     public void testUnparsableIntForDescribeStreamConsumerRetriesInConfig() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(
-                "Invalid value given for maximum retry attempts for describe stream consumer operation");
+        assertThatThrownBy(
+                        () -> {
+                            Properties testConfig = TestUtils.getStandardProperties();
+                            testConfig.setProperty(
+                                    ConsumerConfigConstants.DESCRIBE_STREAM_CONSUMER_RETRIES,
+                                    "unparsableInt");
 
-        Properties testConfig = TestUtils.getStandardProperties();
-        testConfig.setProperty(
-                ConsumerConfigConstants.DESCRIBE_STREAM_CONSUMER_RETRIES, "unparsableInt");
-
-        KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                            KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Invalid value given for maximum retry attempts for describe stream consumer operation");
     }
 
     @Test
     public void testUnparsableLongForDescribeStreamConsumerBackoffBaseMillisInConfig() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(
-                "Invalid value given for describe stream consumer operation base backoff milliseconds");
+        assertThatThrownBy(
+                        () -> {
+                            Properties testConfig = TestUtils.getStandardProperties();
+                            testConfig.setProperty(
+                                    ConsumerConfigConstants.DESCRIBE_STREAM_CONSUMER_BACKOFF_BASE,
+                                    "unparsableLong");
 
-        Properties testConfig = TestUtils.getStandardProperties();
-        testConfig.setProperty(
-                ConsumerConfigConstants.DESCRIBE_STREAM_CONSUMER_BACKOFF_BASE, "unparsableLong");
-
-        KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                            KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Invalid value given for describe stream consumer operation base backoff milliseconds");
     }
 
     @Test
     public void testUnparsableLongForDescribeStreamConsumerBackoffMaxMillisInConfig() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(
-                "Invalid value given for describe stream consumer operation max backoff milliseconds");
+        assertThatThrownBy(
+                        () -> {
+                            Properties testConfig = TestUtils.getStandardProperties();
+                            testConfig.setProperty(
+                                    ConsumerConfigConstants.DESCRIBE_STREAM_CONSUMER_BACKOFF_MAX,
+                                    "unparsableLong");
 
-        Properties testConfig = TestUtils.getStandardProperties();
-        testConfig.setProperty(
-                ConsumerConfigConstants.DESCRIBE_STREAM_CONSUMER_BACKOFF_MAX, "unparsableLong");
-
-        KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                            KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Invalid value given for describe stream consumer operation max backoff milliseconds");
     }
 
     @Test
     public void testUnparsableDoublEforDescribeStreamConsumerBackoffExponentialConstantInConfig() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(
-                "Invalid value given for describe stream consumer operation backoff exponential constant");
+        assertThatThrownBy(
+                        () -> {
+                            Properties testConfig = TestUtils.getStandardProperties();
+                            testConfig.setProperty(
+                                    ConsumerConfigConstants
+                                            .DESCRIBE_STREAM_CONSUMER_BACKOFF_EXPONENTIAL_CONSTANT,
+                                    "unparsableDouble");
 
-        Properties testConfig = TestUtils.getStandardProperties();
-        testConfig.setProperty(
-                ConsumerConfigConstants.DESCRIBE_STREAM_CONSUMER_BACKOFF_EXPONENTIAL_CONSTANT,
-                "unparsableDouble");
-
-        KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                            KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Invalid value given for describe stream consumer operation backoff exponential constant");
     }
 
     @Test
     public void testUnparsableIntForSubscribeToShardRetriesInConfig() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(
-                "Invalid value given for maximum retry attempts for subscribe to shard operation");
+        assertThatThrownBy(
+                        () -> {
+                            Properties testConfig = TestUtils.getStandardProperties();
+                            testConfig.setProperty(
+                                    ConsumerConfigConstants.SUBSCRIBE_TO_SHARD_RETRIES,
+                                    "unparsableInt");
 
-        Properties testConfig = TestUtils.getStandardProperties();
-        testConfig.setProperty(ConsumerConfigConstants.SUBSCRIBE_TO_SHARD_RETRIES, "unparsableInt");
-
-        KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                            KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Invalid value given for maximum retry attempts for subscribe to shard operation");
     }
 
     @Test
     public void testUnparsableLongForSubscribeToShardBackoffBaseMillisInConfig() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(
-                "Invalid value given for subscribe to shard operation base backoff milliseconds");
+        assertThatThrownBy(
+                        () -> {
+                            Properties testConfig = TestUtils.getStandardProperties();
+                            testConfig.setProperty(
+                                    ConsumerConfigConstants.SUBSCRIBE_TO_SHARD_BACKOFF_BASE,
+                                    "unparsableLong");
 
-        Properties testConfig = TestUtils.getStandardProperties();
-        testConfig.setProperty(
-                ConsumerConfigConstants.SUBSCRIBE_TO_SHARD_BACKOFF_BASE, "unparsableLong");
-
-        KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                            KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Invalid value given for subscribe to shard operation base backoff milliseconds");
     }
 
     @Test
     public void testUnparsableLongForSubscribeToShardBackoffMaxMillisInConfig() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(
-                "Invalid value given for subscribe to shard operation max backoff milliseconds");
+        assertThatThrownBy(
+                        () -> {
+                            Properties testConfig = TestUtils.getStandardProperties();
+                            testConfig.setProperty(
+                                    ConsumerConfigConstants.SUBSCRIBE_TO_SHARD_BACKOFF_MAX,
+                                    "unparsableLong");
 
-        Properties testConfig = TestUtils.getStandardProperties();
-        testConfig.setProperty(
-                ConsumerConfigConstants.SUBSCRIBE_TO_SHARD_BACKOFF_MAX, "unparsableLong");
-
-        KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                            KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Invalid value given for subscribe to shard operation max backoff milliseconds");
     }
 
     @Test
     public void testUnparsableDoublEforSubscribeToShardBackoffExponentialConstantInConfig() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(
-                "Invalid value given for subscribe to shard operation backoff exponential constant");
+        assertThatThrownBy(
+                        () -> {
+                            Properties testConfig = TestUtils.getStandardProperties();
+                            testConfig.setProperty(
+                                    ConsumerConfigConstants
+                                            .SUBSCRIBE_TO_SHARD_BACKOFF_EXPONENTIAL_CONSTANT,
+                                    "unparsableDouble");
 
-        Properties testConfig = TestUtils.getStandardProperties();
-        testConfig.setProperty(
-                ConsumerConfigConstants.SUBSCRIBE_TO_SHARD_BACKOFF_EXPONENTIAL_CONSTANT,
-                "unparsableDouble");
-
-        KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                            KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Invalid value given for subscribe to shard operation backoff exponential constant");
     }
 }

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/RecordEmitterTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/RecordEmitterTest.java
@@ -19,26 +19,26 @@ package org.apache.flink.streaming.connectors.kinesis.util;
 
 import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.streaming.runtime.operators.windowing.TimestampedValue;
-import org.apache.flink.testutils.executor.TestExecutorResource;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorExtension;
 
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link RecordEmitter}. */
 public class RecordEmitterTest {
 
-    @ClassRule
-    public static final TestExecutorResource<ExecutorService> EXECUTOR_RESOURCE =
-            new TestExecutorResource<>(() -> Executors.newSingleThreadExecutor());
+    @RegisterExtension
+    private static final TestExecutorExtension<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorExtension();
 
     private class TestRecordEmitter extends RecordEmitter<TimestampedValue> {
 

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/StreamConsumerRegistrarUtilTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/StreamConsumerRegistrarUtilTest.java
@@ -19,7 +19,7 @@ package org.apache.flink.streaming.connectors.kinesis.util;
 
 import org.apache.flink.streaming.connectors.kinesis.internals.publisher.fanout.StreamConsumerRegistrar;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/WatermarkTrackerTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/WatermarkTrackerTest.java
@@ -20,7 +20,7 @@ package org.apache.flink.streaming.connectors.kinesis.util;
 import org.apache.flink.streaming.util.MockStreamingRuntimeContext;
 
 import org.apache.commons.lang3.mutable.MutableLong;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;


### PR DESCRIPTION

## What is the purpose of the change

This pull request migrates kinesis connector's test module to Junit5


## Brief change log

  - migrate *org.junit.Test* to *org.junit.jupiter.api.Test*
  - migrate *@Test(expected=XXX)* to *@Test + assertThatThrownBy(() -> { ...}).isInstanceOf(XXX.class)*
  - use *@ParameterizedTest annotation* and *@MethodSource annotation* to substitute *@RunWith(Parameterized.class)*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature: no
