### PR TITLE
[FLINK-28351][Connector/Pulsar] Add dynamic sink topic support for Pulsar

### DIFF
--- a/docs/content/docs/connectors/datastream/pulsar.md
+++ b/docs/content/docs/connectors/datastream/pulsar.md
@@ -736,6 +736,18 @@ For example, when using the `PulsarSink.builder().setTopics("some-topic1", "some
 this is simplified to `PulsarSink.builder().setTopics("some-topic1")`.
 {{< /hint >}}
 
+#### Dynamic Topics by income messages
+
+Topics could be defined by the message content instead of providing the fix topic set. You can dynamically
+provide the topic by implementing `TopicExtractor`. The topic metadata in `TopicExtractor` can be queried
+by using `TopicMetadataProvider` and the query result would be expired after we have queried for
+`PulsarSinkOptions.PULSAR_TOPIC_METADATA_REFRESH_INTERVAL` time.
+
+You can return two types of value in `TopicExtractor`. A topic name with or without partition information.
+
+1. If you don't want to provide the partition, we would query the partition size and passing all the partitions to `TopicRouter`. The partition size would be cached in `PulsarSinkOptions.PULSAR_TOPIC_METADATA_REFRESH_INTERVAL`.
+2. If you provided the topic partition, we would do nothing but just pass it to downstream.
+
 ### Serializer
 
 A serializer (`PulsarSerializationSchema`) is required for serializing the record instance into bytes.

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/PulsarSink.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/PulsarSink.java
@@ -34,7 +34,7 @@ import org.apache.flink.connector.pulsar.sink.writer.router.RoundRobinTopicRoute
 import org.apache.flink.connector.pulsar.sink.writer.router.TopicRouter;
 import org.apache.flink.connector.pulsar.sink.writer.router.TopicRoutingMode;
 import org.apache.flink.connector.pulsar.sink.writer.serializer.PulsarSerializationSchema;
-import org.apache.flink.connector.pulsar.sink.writer.topic.TopicMetadataListener;
+import org.apache.flink.connector.pulsar.sink.writer.topic.TopicRegister;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -82,20 +82,20 @@ public class PulsarSink<IN> implements TwoPhaseCommittingSink<IN, PulsarCommitta
 
     private final SinkConfiguration sinkConfiguration;
     private final PulsarSerializationSchema<IN> serializationSchema;
-    private final TopicMetadataListener metadataListener;
+    private final TopicRegister<IN> topicRegister;
     private final MessageDelayer<IN> messageDelayer;
     private final TopicRouter<IN> topicRouter;
 
     PulsarSink(
             SinkConfiguration sinkConfiguration,
             PulsarSerializationSchema<IN> serializationSchema,
-            TopicMetadataListener metadataListener,
+            TopicRegister<IN> topicRegister,
             TopicRoutingMode topicRoutingMode,
             TopicRouter<IN> topicRouter,
             MessageDelayer<IN> messageDelayer) {
         this.sinkConfiguration = checkNotNull(sinkConfiguration);
         this.serializationSchema = checkNotNull(serializationSchema);
-        this.metadataListener = checkNotNull(metadataListener);
+        this.topicRegister = checkNotNull(topicRegister);
         this.messageDelayer = checkNotNull(messageDelayer);
         checkNotNull(topicRoutingMode);
 
@@ -125,7 +125,7 @@ public class PulsarSink<IN> implements TwoPhaseCommittingSink<IN, PulsarCommitta
         return new PulsarWriter<>(
                 sinkConfiguration,
                 serializationSchema,
-                metadataListener,
+                topicRegister,
                 topicRouter,
                 messageDelayer,
                 initContext);

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/topic/TopicExtractor.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/topic/TopicExtractor.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.sink.writer.topic;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.connector.pulsar.sink.config.SinkConfiguration;
+import org.apache.flink.connector.pulsar.sink.writer.router.TopicRouter;
+import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicMetadata;
+import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicPartition;
+
+import org.apache.pulsar.client.admin.PulsarAdmin;
+
+import java.io.Serializable;
+
+/** Choose topics from the message, used for dynamic generate topics in Pulsar sink. */
+@PublicEvolving
+public interface TopicExtractor<IN> extends Serializable {
+
+    /**
+     * @param in The message would be written to Pulsar.
+     * @param provider Used for query topic metadata.
+     * @return The topic you want to use. You can use both partitioned topic name or a topic name
+     *     without partition information. We would query the partition information and pass it to
+     *     {@link TopicRouter} if you return a topic name without partition information.
+     */
+    TopicPartition extract(IN in, TopicMetadataProvider provider);
+
+    /** Implement this method if you have some non-serializable field. */
+    default void open(SinkConfiguration sinkConfiguration) {
+        // Nothing to do by default.
+    }
+
+    /**
+     * A wrapper for {@link PulsarAdmin} instance, we won't expose the Pulsar admin interface for
+     * better control the abstraction. And add cache support.
+     */
+    @PublicEvolving
+    interface TopicMetadataProvider {
+
+        /** @throws Exception Failed to query Pulsar metadata would throw this exception. */
+        TopicMetadata query(String topic) throws Exception;
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/topic/TopicRegister.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/topic/TopicRegister.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.sink.writer.topic;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.operators.ProcessingTimeService;
+import org.apache.flink.connector.pulsar.sink.config.SinkConfiguration;
+
+import java.io.Closeable;
+import java.io.Serializable;
+import java.util.List;
+
+/** The topic register for returning the available topic partitions. */
+@Internal
+public interface TopicRegister<IN> extends Serializable, Closeable {
+
+    /**
+     * Return all the available topic partitions. We would recalculate the partitions if the topic
+     * metadata has been changed. Otherwise, we would return the cached result for better
+     * performance.
+     */
+    List<String> topics(IN in);
+
+    /** Register the topic metadata update in process time service. */
+    void open(SinkConfiguration sinkConfiguration, ProcessingTimeService timeService);
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/topic/register/DynamicTopicRegister.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/topic/register/DynamicTopicRegister.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.sink.writer.topic.register;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.operators.ProcessingTimeService;
+import org.apache.flink.connector.pulsar.sink.config.SinkConfiguration;
+import org.apache.flink.connector.pulsar.sink.writer.topic.TopicExtractor;
+import org.apache.flink.connector.pulsar.sink.writer.topic.TopicExtractor.TopicMetadataProvider;
+import org.apache.flink.connector.pulsar.sink.writer.topic.TopicRegister;
+import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicMetadata;
+import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicPartition;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import org.apache.flink.shaded.guava30.com.google.common.cache.CacheBuilder;
+import org.apache.flink.shaded.guava30.com.google.common.cache.CacheLoader;
+import org.apache.flink.shaded.guava30.com.google.common.cache.LoadingCache;
+
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.Collections.singletonList;
+import static org.apache.flink.connector.pulsar.common.config.PulsarClientFactory.createAdmin;
+import static org.apache.flink.connector.pulsar.source.enumerator.topic.TopicNameUtils.topicNameWithPartition;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** The register for returning dynamic topic partitions information. */
+@Internal
+public class DynamicTopicRegister<IN> implements TopicRegister<IN> {
+    private static final long serialVersionUID = 4374769306761301456L;
+
+    private final TopicExtractor<IN> topicExtractor;
+
+    // Dynamic fields.
+    private transient PulsarAdmin pulsarAdmin;
+    private transient TopicMetadataProvider metadataProvider;
+    private transient LoadingCache<String, List<String>> partitionsCache;
+
+    public DynamicTopicRegister(TopicExtractor<IN> topicExtractor) {
+        this.topicExtractor = checkNotNull(topicExtractor);
+    }
+
+    @Override
+    public List<String> topics(IN in) {
+        TopicPartition partition = topicExtractor.extract(in, metadataProvider);
+        String topicName = partition.getFullTopicName();
+
+        if (partition.isPartition()) {
+            return singletonList(topicName);
+        } else {
+            try {
+                return partitionsCache.get(topicName);
+            } catch (ExecutionException e) {
+                throw new FlinkRuntimeException("Failed to query Pulsar topic partitions.", e);
+            }
+        }
+    }
+
+    @Override
+    public void open(SinkConfiguration sinkConfiguration, ProcessingTimeService timeService) {
+        long refreshInterval = sinkConfiguration.getTopicMetadataRefreshInterval();
+
+        // Initialize Pulsar admin instance.
+        this.pulsarAdmin = createAdmin(sinkConfiguration);
+        this.metadataProvider = new DefaultTopicMetadataProvider(pulsarAdmin, refreshInterval);
+        this.partitionsCache =
+                CacheBuilder.newBuilder()
+                        .expireAfterWrite(refreshInterval, TimeUnit.MILLISECONDS)
+                        .build(
+                                new CacheLoader<String, List<String>>() {
+                                    @Override
+                                    public List<String> load(String topic) throws Exception {
+                                        TopicMetadata metadata = metadataProvider.query(topic);
+                                        if (metadata.isPartitioned()) {
+                                            int partitionSize = metadata.getPartitionSize();
+                                            List<String> partitions =
+                                                    new ArrayList<>(partitionSize);
+                                            for (int i = 0; i < partitionSize; i++) {
+                                                partitions.add(topicNameWithPartition(topic, i));
+                                            }
+                                            return partitions;
+                                        } else {
+                                            return singletonList(topic);
+                                        }
+                                    }
+                                });
+        // Open the topic extractor instance.
+        topicExtractor.open(sinkConfiguration);
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (pulsarAdmin != null) {
+            pulsarAdmin.close();
+        }
+    }
+
+    private static class DefaultTopicMetadataProvider implements TopicMetadataProvider {
+
+        private final LoadingCache<String, TopicMetadata> metadataCache;
+
+        private DefaultTopicMetadataProvider(PulsarAdmin pulsarAdmin, long refreshInterval) {
+            this.metadataCache =
+                    CacheBuilder.newBuilder()
+                            .expireAfterWrite(refreshInterval, TimeUnit.MILLISECONDS)
+                            .build(
+                                    new CacheLoader<String, TopicMetadata>() {
+                                        @Override
+                                        public TopicMetadata load(String topic) throws Exception {
+                                            PartitionedTopicMetadata metadata =
+                                                    pulsarAdmin
+                                                            .topics()
+                                                            .getPartitionedTopicMetadata(topic);
+                                            return new TopicMetadata(topic, metadata.partitions);
+                                        }
+                                    });
+        }
+
+        @Override
+        public TopicMetadata query(String topic) throws ExecutionException {
+            return metadataCache.get(topic);
+        }
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/topic/register/EmptyTopicRegister.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/topic/register/EmptyTopicRegister.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.sink.writer.topic.register;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.operators.ProcessingTimeService;
+import org.apache.flink.connector.pulsar.sink.config.SinkConfiguration;
+import org.apache.flink.connector.pulsar.sink.writer.topic.TopicRegister;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+/** The topic register which would do nothing for just return an empty topic partitions. */
+@Internal
+public class EmptyTopicRegister<IN> implements TopicRegister<IN> {
+    private static final long serialVersionUID = -9199261243659491097L;
+
+    @Override
+    public List<String> topics(IN in) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public void open(SinkConfiguration sinkConfiguration, ProcessingTimeService timeService) {
+        // Nothing to do.
+    }
+
+    @Override
+    public void close() throws IOException {
+        // Nothing to do.
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/subscriber/impl/BasePulsarSubscriber.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/subscriber/impl/BasePulsarSubscriber.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static java.util.stream.Collectors.toList;
+import static org.apache.flink.connector.pulsar.source.enumerator.topic.TopicPartition.NON_PARTITION_ID;
 
 /** PulsarSubscriber abstract class to simplify Pulsar admin related operations. */
 public abstract class BasePulsarSubscriber implements PulsarSubscriber {
@@ -60,7 +61,7 @@ public abstract class BasePulsarSubscriber implements PulsarSubscriber {
         if (!metadata.isPartitioned()) {
             // For non-partitioned topic.
             return ranges.stream()
-                    .map(range -> new TopicPartition(metadata.getName(), -1, range))
+                    .map(range -> new TopicPartition(metadata.getName(), NON_PARTITION_ID, range))
                     .collect(toList());
         } else {
             List<TopicPartition> partitions = new ArrayList<>();

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/topic/TopicRange.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/topic/TopicRange.java
@@ -48,6 +48,9 @@ public class TopicRange implements Serializable {
     /** The end position for hash range, it's 65535. */
     public static final int MAX_RANGE = RANGE_SIZE - 1;
 
+    /** A full topic range instance for avoiding multiple instance creation. */
+    private static final TopicRange FULL_RANGE = new TopicRange(MIN_RANGE, MAX_RANGE);
+
     /** The start of the range, default is zero. */
     private final int start;
 
@@ -68,9 +71,9 @@ public class TopicRange implements Serializable {
         return new Range(start, end);
     }
 
-    /** Create a topic range which contains the fully hash range. */
+    /** Create a topic range which contains the full hash range. */
     public static TopicRange createFullRange() {
-        return new TopicRange(MIN_RANGE, MAX_RANGE);
+        return FULL_RANGE;
     }
 
     public int getStart() {

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/sink/writer/PulsarWriterTest.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/sink/writer/PulsarWriterTest.java
@@ -31,7 +31,7 @@ import org.apache.flink.connector.pulsar.sink.writer.delayer.FixedMessageDelayer
 import org.apache.flink.connector.pulsar.sink.writer.delayer.MessageDelayer;
 import org.apache.flink.connector.pulsar.sink.writer.router.RoundRobinTopicRouter;
 import org.apache.flink.connector.pulsar.sink.writer.serializer.PulsarSerializationSchema;
-import org.apache.flink.connector.pulsar.sink.writer.topic.TopicMetadataListener;
+import org.apache.flink.connector.pulsar.sink.writer.topic.register.FixedTopicRegister;
 import org.apache.flink.connector.pulsar.testutils.PulsarTestSuiteBase;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.groups.OperatorIOMetricGroup;
@@ -72,7 +72,7 @@ class PulsarWriterTest extends PulsarTestSuiteBase {
 
         SinkConfiguration configuration = sinkConfiguration(guarantee);
         PulsarSerializationSchema<String> schema = pulsarSchema(STRING);
-        TopicMetadataListener listener = new TopicMetadataListener(singletonList(topic));
+        FixedTopicRegister listener = new FixedTopicRegister(singletonList(topic));
         RoundRobinTopicRouter<String> router = new RoundRobinTopicRouter<>(configuration);
         FixedMessageDelayer<String> delayer = MessageDelayer.never();
         MockInitContext initContext = new MockInitContext();

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/sink/writer/topic/ProducerRegisterTest.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/sink/writer/topic/ProducerRegisterTest.java
@@ -38,8 +38,8 @@ import static org.apache.flink.connector.base.DeliveryGuarantee.EXACTLY_ONCE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-/** Unit tests for {@link TopicProducerRegister}. */
-class TopicProducerRegisterTest extends PulsarTestSuiteBase {
+/** Unit tests for {@link ProducerRegister}. */
+class ProducerRegisterTest extends PulsarTestSuiteBase {
 
     @ParameterizedTest
     @EnumSource(DeliveryGuarantee.class)
@@ -49,7 +49,7 @@ class TopicProducerRegisterTest extends PulsarTestSuiteBase {
         operator().createTopic(topic, 8);
 
         SinkConfiguration configuration = sinkConfiguration(deliveryGuarantee);
-        TopicProducerRegister register = new TopicProducerRegister(configuration);
+        ProducerRegister register = new ProducerRegister(configuration);
 
         String message = randomAlphabetic(10);
         register.createMessageBuilder(topic, Schema.STRING).value(message).send();
@@ -76,7 +76,7 @@ class TopicProducerRegisterTest extends PulsarTestSuiteBase {
         operator().createTopic(topic, 8);
 
         SinkConfiguration configuration = sinkConfiguration(deliveryGuarantee);
-        TopicProducerRegister register = new TopicProducerRegister(configuration);
+        ProducerRegister register = new ProducerRegister(configuration);
 
         String message = randomAlphabetic(10);
         register.createMessageBuilder(topic, Schema.STRING).value(message).sendAsync();

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/sink/writer/topic/register/DynamicTopicRegisterTest.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/sink/writer/topic/register/DynamicTopicRegisterTest.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.sink.writer.topic.register;
+
+import org.apache.flink.api.common.operators.ProcessingTimeService;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.pulsar.sink.config.SinkConfiguration;
+import org.apache.flink.connector.pulsar.sink.writer.topic.TopicExtractor;
+import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicPartition;
+import org.apache.flink.connector.pulsar.testutils.PulsarTestSuiteBase;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
+import static org.apache.flink.connector.pulsar.sink.PulsarSinkOptions.PULSAR_TOPIC_METADATA_REFRESH_INTERVAL;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+/** Unit tests for {@link DynamicTopicRegister}. */
+class DynamicTopicRegisterTest extends PulsarTestSuiteBase {
+
+    private final MockTopicExtractor extractor = new MockTopicExtractor();
+
+    private static final class MockTopicExtractor implements TopicExtractor<String> {
+        private static final long serialVersionUID = 2456172645787498006L;
+
+        private TopicPartition partition;
+
+        @Override
+        public TopicPartition extract(String s, TopicMetadataProvider provider) {
+            return partition;
+        }
+
+        public void setPartition(TopicPartition partition) {
+            this.partition = partition;
+        }
+    }
+
+    @Test
+    void partitionedTopicWouldBeReturnedDirectly() throws IOException {
+        DynamicTopicRegister<String> register = topicRegister(50000);
+        TopicPartition partition = new TopicPartition("some", 1);
+        extractor.setPartition(partition);
+        List<String> topics = register.topics(randomAlphabetic(10));
+
+        assertThat(topics).hasSize(1).isEqualTo(partition.getFullTopicName());
+
+        register.close();
+    }
+
+    @Test
+    void rootTopicWillReturnAllThePartitions() throws IOException {
+        DynamicTopicRegister<String> register = topicRegister(50000);
+        TopicPartition partition = new TopicPartition("root-topic" + randomAlphabetic(10));
+        extractor.setPartition(partition);
+        operator().createTopic(partition.getFullTopicName(), 10);
+        List<String> topics = register.topics(randomAlphabetic(10));
+
+        assertThat(topics)
+                .hasSize(10)
+                .allSatisfy(topic -> assertThat(topic).startsWith(partition.getTopic()));
+
+        register.close();
+    }
+
+    private DynamicTopicRegister<String> topicRegister(long interval) {
+        DynamicTopicRegister<String> register = new DynamicTopicRegister<>(extractor);
+        register.open(sinkConfiguration(interval), mock(ProcessingTimeService.class));
+
+        return register;
+    }
+
+    private SinkConfiguration sinkConfiguration(long interval) {
+        Configuration configuration = operator().config();
+        configuration.set(PULSAR_TOPIC_METADATA_REFRESH_INTERVAL, interval);
+
+        return new SinkConfiguration(configuration);
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/sink/writer/topic/register/DynamicTopicRegisterTest.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/sink/writer/topic/register/DynamicTopicRegisterTest.java
@@ -62,7 +62,9 @@ class DynamicTopicRegisterTest extends PulsarTestSuiteBase {
         extractor.setPartition(partition);
         List<String> topics = register.topics(randomAlphabetic(10));
 
-        assertThat(topics).hasSize(1).isEqualTo(partition.getFullTopicName());
+        assertThat(topics)
+                .hasSize(1)
+                .allSatisfy(topic -> assertThat(topic).isEqualTo(partition.getFullTopicName()));
 
         register.close();
     }


### PR DESCRIPTION
## What is the purpose of the change

Some people would like to use dynamically-generated topics from messages and use the key hash range policy. This is not supported by the Pulsar sink currently. We would introduce a new interface named `TopicExacter` and add a new `setTopics(TopicExacter)` in `PulsarSinkBuilder` for supporting this.

## Brief change log

  - New `TopicExacter` interface.
  - Move common abstraction (`TopicRegister`) for query the topics to sink.

## Verifying this change

This change added tests and can be verified as follows:

1. `DynamicTopicRegisterTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
