### PR TITLE
[FLINK-28353][k8s] Exclude unschedulable nodes using IP addresses of kubernetes nodes

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/services/LoadBalancerService.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/services/LoadBalancerService.java
@@ -101,6 +101,10 @@ public class LoadBalancerService extends ServiceType {
             // only consider IPs with the configured address type.
             address =
                     internalClient.nodes().list().getItems().stream()
+                            .filter(
+                                    node ->
+                                            node.getSpec().getUnschedulable() == null
+                                                    || !node.getSpec().getUnschedulable())
                             .flatMap(node -> node.getStatus().getAddresses().stream())
                             .filter(
                                     nodeAddress ->

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/services/NodePortService.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/services/NodePortService.java
@@ -60,6 +60,10 @@ public class NodePortService extends ServiceType {
         // only consider IPs with the configured address type.
         address =
                 internalClient.nodes().list().getItems().stream()
+                        .filter(
+                                node ->
+                                        node.getSpec().getUnschedulable() == null
+                                                || !node.getSpec().getUnschedulable())
                         .flatMap(node -> node.getStatus().getAddresses().stream())
                         .filter(
                                 nodeAddress ->

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesClientTestBase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesClientTestBase.java
@@ -31,6 +31,7 @@ import io.fabric8.kubernetes.api.model.Node;
 import io.fabric8.kubernetes.api.model.NodeAddressBuilder;
 import io.fabric8.kubernetes.api.model.NodeBuilder;
 import io.fabric8.kubernetes.api.model.NodeListBuilder;
+import io.fabric8.kubernetes.api.model.NodeSpecBuilder;
 import io.fabric8.kubernetes.api.model.NodeStatusBuilder;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServiceBuilder;
@@ -43,6 +44,7 @@ import io.fabric8.mockwebserver.dsl.HttpMethodable;
 import io.fabric8.mockwebserver.dsl.MockServerExpectation;
 import io.fabric8.mockwebserver.dsl.ReturnOrWebsocketable;
 import io.fabric8.mockwebserver.dsl.TimesOnceableOrHttpHeaderable;
+import org.apache.commons.lang3.StringUtils;
 
 import javax.annotation.Nullable;
 
@@ -66,9 +68,17 @@ public class KubernetesClientTestBase extends KubernetesTestBase {
         for (String address : addresses) {
             final String[] parts = address.split(":");
             Preconditions.checkState(
-                    parts.length == 2, "Address should be in format \"<type>:<ip>\".");
+                    parts.length == 3,
+                    "Address should be in format \"<type>:<ip>:<unschedulable>\".");
             nodes.add(
                     new NodeBuilder()
+                            .withSpec(
+                                    new NodeSpecBuilder()
+                                            .withUnschedulable(
+                                                    StringUtils.isBlank(parts[2])
+                                                            ? null
+                                                            : Boolean.parseBoolean(parts[2]))
+                                            .build())
                             .withStatus(
                                     new NodeStatusBuilder()
                                             .withAddresses(

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClientTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClientTest.java
@@ -319,9 +319,15 @@ public class Fabric8FlinkKubeClientTest extends KubernetesClientTestBase {
         flinkConfig.set(
                 KubernetesConfigOptions.REST_SERVICE_EXPOSED_NODE_PORT_ADDRESS_TYPE, addressType);
         final List<String> internalAddresses =
-                Arrays.asList("InternalIP:10.0.0.1", "InternalIP:10.0.0.2", "InternalIP:10.0.0.3");
+                Arrays.asList(
+                        "InternalIP:10.0.0.1:true",
+                        "InternalIP:10.0.0.2:false",
+                        "InternalIP:10.0.0.3: ");
         final List<String> externalAddresses =
-                Arrays.asList("ExternalIP:7.7.7.7", "ExternalIP:8.8.8.8", "ExternalIP:9.9.9.9");
+                Arrays.asList(
+                        "ExternalIP:7.7.7.7:true",
+                        "ExternalIP:8.8.8.8:false",
+                        "ExternalIP:9.9.9.9: ");
         final List<String> addresses = new ArrayList<>();
         addresses.addAll(internalAddresses);
         addresses.addAll(externalAddresses);
@@ -339,12 +345,14 @@ public class Fabric8FlinkKubeClientTest extends KubernetesClientTestBase {
                 case InternalIP:
                     expectedIps =
                             internalAddresses.stream()
+                                    .filter(s -> !"true".equals(s.split(":")[2]))
                                     .map(s -> s.split(":")[1])
                                     .collect(Collectors.toList());
                     break;
                 case ExternalIP:
                     expectedIps =
                             externalAddresses.stream()
+                                    .filter(s -> !"true".equals(s.split(":")[2]))
                                     .map(s -> s.split(":")[1])
                                     .collect(Collectors.toList());
                     break;
@@ -352,6 +360,7 @@ public class Fabric8FlinkKubeClientTest extends KubernetesClientTestBase {
                     throw new IllegalArgumentException(
                             String.format("Unexpected address type %s.", addressType));
             }
+            assertThat(expectedIps.size()).isEqualTo(2);
             assertThat(resultEndpoint.get().getAddress()).isIn(expectedIps);
             assertThat(resultEndpoint.get().getPort()).isEqualTo(NODE_PORT);
         }


### PR DESCRIPTION
## What is the purpose of the change

when the job is submitted to the k8s cluster and the parameter `-Dkubernetes.rest-service.exposed.type=NodePort` is used, the web ui address of the job obtained at this time is the IP of any machine in the k8s cluster.
but client will throw connect refuse exception when the node's schedule status is unschedulable. We should exclude those node IPs to choose web ui address


## Brief change log

*(for example:)*
  - `ServiceType#getRestEndpoint` search node exclude unschedulable node (spec.unschedulable = true)

## Verifying this change

update unit tests for the change. `Fabric8FlinkKubeClientTest#testNodePortServiceWithInternalIP`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
