### PR TITLE
[FLINK-28358][connector/jdbc][Tests] fix when debug in local ,the SqlValidatorImpl.class conflict problem

### DIFF
--- a/flink-connectors/flink-connector-jdbc/pom.xml
+++ b/flink-connectors/flink-connector-jdbc/pom.xml
@@ -98,7 +98,6 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-table-planner_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
-			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>
 
@@ -106,6 +105,7 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-table-planner_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
+			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>
 


### PR DESCRIPTION
…ValidatorImpl.class conflict problem


## fix class conflict when run in idea

*  when run test `org.apache.flink.connector.jdbc.table.JdbcLookupTableITCase.testLookup` in local idea,the jar of calcite-core.jar is loaded before  mudule of flink-table-planner ,lead to  ValidatorImpl.class in calcite-core.jar load priority*


## Brief change log

  - *change the dependency order in pom*


## Verifying this change

This change is already covered by existing tests, such as *apache.flink.connector.jdbc.table.JdbcLookupTableITCase.testLookup*.

before
<img width="416" alt="image" src="https://user-images.githubusercontent.com/37330503/176981635-0c51ece1-d382-47cb-a684-030981991748.png">
after
<img width="413" alt="image" src="https://user-images.githubusercontent.com/37330503/176981669-f43ad95e-b517-4fd4-9cfb-eaa6a169d5bd.png">

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no )
  - The S3 file system connector: ( no )

## Documentation

  - Does this pull request introduce a new feature? (no)

because flink-table-planner use maven-shade-plugin if run with maven directly is ok，but run in idea may lead to exception 

hope to help others in the community, feel free to review
thanks