### PR TITLE
FLINK-28359 Test case to replicate TO_TIMESTAMP bug

### DIFF
--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/SqlExpressionTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/SqlExpressionTest.scala
@@ -214,6 +214,13 @@ class SqlExpressionTest extends ExpressionTestBase {
   @Test
   def testTypeConversionFunctions(): Unit = {
     testSqlApi("CAST(2 AS DOUBLE)", "2.0")
+    testSqlApi(
+      "TO_TIMESTAMP('2020-01-01 15:35:00.123456', 'yyyy-MM-dd HH:mm:ss.SSSSSS')",
+      "2020-01-01 15:35:00.123456")
+    testSqlApi("TO_TIMESTAMP('2020-01-01 15:35:00.123456')", "2020-01-01 15:35:00.123456")
+    testSqlApi(
+      "TO_TIMESTAMP('2020-01-01 15:35:00.123456', 'yyyy-MM-dd HH:mm:ss.SSSS')",
+      "2020-01-01 15:35:00.1234")
   }
 
   @Test


### PR DESCRIPTION
Added test cases to show that TO_TIMESTAMP does not preserve precision
----

Hi, I open this PR to show there might be a bug, this is not intended to be merged