### PR TITLE
[FLINK-28379][security] Run all UGI mocking tests in separate JVM

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/KerberosLoginProviderITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/KerberosLoginProviderITCase.java
@@ -40,8 +40,13 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
-/** Test for {@link KerberosLoginProvider}. */
-public class KerberosLoginProviderTest {
+/**
+ * Test for {@link KerberosLoginProvider}.
+ *
+ * <p>This class is an ITCase because the mocking breaks the {@link UserGroupInformation} class for
+ * other tests.
+ */
+public class KerberosLoginProviderITCase {
 
     @Test
     public void isLoginPossibleMustReturnFalseByDefault() throws IOException {


### PR DESCRIPTION
Similar to https://github.com/apache/flink/pull/19910; extended to all classes that mock the `UserGroupInformation`.