### PR TITLE
[FLINK-28326][runtime] fix unstable test ResultPartitionTest.testIdleAndBackPressuredTime.

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartitionTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartitionTestUtils.java
@@ -31,14 +31,12 @@ import org.apache.flink.runtime.shuffle.PartitionDescriptorBuilder;
 import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
 import org.apache.flink.runtime.util.NettyShuffleDescriptorBuilder;
 
-import org.hamcrest.Matchers;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * This class should consolidate all mocking logic for ResultPartitions. While using Mockito
@@ -112,16 +110,19 @@ public enum PartitionTestUtils {
     }
 
     static void verifyCreateSubpartitionViewThrowsException(
-            ResultPartitionProvider partitionManager, ResultPartitionID partitionId)
-            throws IOException {
-        try {
-            partitionManager.createSubpartitionView(
-                    partitionId, 0, new NoOpBufferAvailablityListener());
-
-            fail("Should throw a PartitionNotFoundException.");
-        } catch (PartitionNotFoundException notFound) {
-            assertThat(partitionId, Matchers.is(notFound.getPartitionId()));
-        }
+            ResultPartitionProvider partitionManager, ResultPartitionID partitionId) {
+        assertThatThrownBy(
+                        () ->
+                                partitionManager.createSubpartitionView(
+                                        partitionId, 0, new NoOpBufferAvailablityListener()))
+                .as("Should throw a PartitionNotFoundException.")
+                .isInstanceOf(PartitionNotFoundException.class)
+                .satisfies(
+                        err ->
+                                assertThat(partitionId)
+                                        .isEqualTo(
+                                                ((PartitionNotFoundException) err)
+                                                        .getPartitionId()));
     }
 
     public static ResultPartitionDeploymentDescriptor createPartitionDeploymentDescriptor(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
@@ -41,6 +41,7 @@ import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 
+import static org.apache.flink.runtime.io.network.buffer.LocalBufferPoolDestroyTest.isInBlockingBufferRequest;
 import static org.apache.flink.runtime.io.network.partition.PartitionTestUtils.createPartition;
 import static org.apache.flink.runtime.io.network.partition.PartitionTestUtils.verifyCreateSubpartitionViewThrowsException;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -394,8 +395,10 @@ class ResultPartitionTest {
         // wait until request thread start to run.
         syncLock.await();
 
-        Thread.sleep(100);
-
+        // wait until request buffer blocking.
+        while (!isInBlockingBufferRequest(requestThread.getStackTrace())) {
+            Thread.sleep(50);
+        }
         // recycle the buffer
         buffer.recycleBuffer();
         requestThread.join();


### PR DESCRIPTION
## What is the purpose of the change

fix unstable test ResultPartitionTest.testIdleAndBackPressuredTime: Due to the race condition, the main thread may recycle buffer before the request thread requests from bufferPool, causing the test to fail.


## Brief change log

  - *Migrate ResultPartitionTest and PartitionTestUtils to junit5 and assertJ.*
  - *fix unstable test ResultPartitionTest.testIdleAndBackPressuredTime.*


## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
