### PR TITLE
[FLINK-26600][tests] Wait with savepoint until job is running

### DIFF
--- a/flink-clients/src/test/java/org/apache/flink/client/program/PerJobMiniClusterFactoryTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/PerJobMiniClusterFactoryTest.java
@@ -102,6 +102,10 @@ public class PerJobMiniClusterFactoryTest extends TestLogger {
                         .submitJob(getCancellableJobGraph(), ClassLoader.getSystemClassLoader())
                         .get();
 
+        while (jobClient.getJobStatus().get() != JobStatus.RUNNING) {
+            Thread.sleep(50);
+        }
+
         assertThrows(
                 "is not a streaming job.",
                 ExecutionException.class,


### PR DESCRIPTION
It only makes sense to trigger savepoints when the job is actually RUNNING. Triggering a savepoint while the job is in the CREATED state is tolerated in the default scheduler (even though the checkpoint will immediately fail), but the adaptive scheduler rejects it eagerly.

Ideally we'd align the behavior in a follow-up.

Ideally ideally the clients would take care of that, but there are quite a few of them and so far they are pretty dumb in that they just forward the request as is. This is possible to change, but it's a larger effort.