### PR TITLE
[FLINK-28393][python][format] Support AvroInputFormat

### DIFF
--- a/docs/content.zh/docs/connectors/datastream/formats/avro.md
+++ b/docs/content.zh/docs/connectors/datastream/formats/avro.md
@@ -67,7 +67,7 @@ Flink 的 POJO 字段选择也适用于从 Avro schema 生成的 POJO 类。但�
 在PyFlink中要读取 Avro 文件需要先定义 Avro schema，产生的 DataStream 元素为原生的 Python 对象。例如：
 
 ```python
-schema = Schema.parse_string("""
+schema = AvroSchema.parse_string("""
 {
     "type": "record",
     "name": "User",

--- a/docs/content.zh/docs/connectors/datastream/formats/avro.md
+++ b/docs/content.zh/docs/connectors/datastream/formats/avro.md
@@ -40,6 +40,8 @@ Flink 的序列化框架可以处理基于 Avro schemas 生成的类。为了能
 </dependency>
 ```
 
+{{< py_jar_download_link "avro" "flink-sql-avro.jar" >}}
+
 如果读取 Avro 文件数据，你必须指定 `AvroInputFormat`。
 
 **示例**：
@@ -60,3 +62,29 @@ usersDS.keyBy("name");
 
 Flink 的 POJO 字段选择也适用于从 Avro schema 生成的 POJO 类。但是，只有将字段类型正确写入生成的类时，才能使用。如果字段是 `Object` 类型，则不能将该字段用作 join 键或 grouping 键。
 在 Avro 中如 `{"name": "type_double_test", "type": "double"},` 这样指定字段是可行的，但是如 (`{"name": "type_double_test", "type": ["double"]},`) 这样指定包含一个字段的复合类型就会生成 `Object` 类型的字段。注意，如 (`{"name": "type_double_test", "type": ["null", "double"]},`) 这样指定 nullable 类型字段也是可能产生 `Object` 类型的!
+
+
+在PyFlink中要读取 Avro 文件需要先定义 Avro schema，产生的 DataStream 元素为原生的 Python 对象。例如：
+
+```python
+schema = Schema.parse_string("""
+{
+    "type": "record",
+    "name": "User",
+    "fields": [
+        {"name": "name", "type": "string"},
+        {"name": "favoriteNumber",  "type": ["int", "null"]},
+        {"name": "favoriteColor", "type": ["string", "null"]}
+    ]
+}
+""")
+
+env = StreamExecutionEnvironment.get_execution_environment()
+ds = env.create_input(AvroInputFormat(AVRO_FILE_PATH, schema))
+
+def json_dumps(record):
+    import json
+    return json.dumps(record)
+
+ds.map(json_dumps).print()
+```

--- a/docs/content.zh/docs/connectors/datastream/formats/parquet.md
+++ b/docs/content.zh/docs/connectors/datastream/formats/parquet.md
@@ -62,6 +62,8 @@ Flink 支持读取 [Parquet](https://parquet.apache.org/) 文件并生成 {{< ja
 </dependency>
 ```
 
+{{< py_jar_download_link "parquet" "flink-sql-parquet.jar" >}}
+
 此格式与新的 Source 兼容，可以同时在批和流模式下使用。
 因此，你可使用此格式处理以下两类数据：
 
@@ -133,7 +135,7 @@ final DataStream<RowData> stream =
 
 ## Avro Records
 
-Flink 支持三种方式来读取 Parquet 文件并创建 Avro records （PyFlink 只支持 generic record）：
+Flink 支持三种方式来读取 Parquet 文件并创建 Avro records （PyFlink 只支持 Generic record）：
 
 - [Generic record](https://avro.apache.org/docs/1.10.0/api/java/index.html)
 - [Specific record](https://avro.apache.org/docs/1.10.0/api/java/index.html)

--- a/docs/content.zh/docs/connectors/datastream/formats/parquet.md
+++ b/docs/content.zh/docs/connectors/datastream/formats/parquet.md
@@ -196,7 +196,7 @@ final DataStream<GenericRecord> stream =
 {{< tab "Python" >}}
 ```python
 # 解析 avro schema
-schema = Schema.parse_string("""
+schema = AvroSchema.parse_string("""
 {
     "type": "record",
     "name": "User",

--- a/docs/content/docs/connectors/datastream/formats/avro.md
+++ b/docs/content/docs/connectors/datastream/formats/avro.md
@@ -39,6 +39,8 @@ The serialization framework of Flink is able to handle classes generated from Av
 </dependency>
 ```
 
+{{< py_jar_download_link "avro" "flink-sql-avro.jar" >}}
+
 In order to read data from an Avro file, you have to specify an `AvroInputFormat`.
 
 **Example**:
@@ -59,3 +61,29 @@ Note that using the `GenericData.Record` type is possible with Flink, but not re
 
 Flink's POJO field selection also works with POJOs generated from Avro. However, the usage is only possible if the field types are written correctly to the generated class. If a field is of type `Object` you can not use the field as a join or grouping key.
 Specifying a field in Avro like this `{"name": "type_double_test", "type": "double"},` works fine, however specifying it as a UNION-type with only one field (`{"name": "type_double_test", "type": ["double"]},`) will generate a field of type `Object`. Note that specifying nullable types (`{"name": "type_double_test", "type": ["null", "double"]},`) is possible!
+
+
+For PyFlink, an Avro schema should be defined to read from Avro files, and the DataStream element will be a vanilla Python object. For example:
+
+```python
+schema = Schema.parse_string("""
+{
+    "type": "record",
+    "name": "User",
+    "fields": [
+        {"name": "name", "type": "string"},
+        {"name": "favoriteNumber",  "type": ["int", "null"]},
+        {"name": "favoriteColor", "type": ["string", "null"]}
+    ]
+}
+""")
+
+env = StreamExecutionEnvironment.get_execution_environment()
+ds = env.create_input(AvroInputFormat(AVRO_FILE_PATH, schema))
+
+def json_dumps(record):
+    import json
+    return json.dumps(record)
+
+ds.map(json_dumps).print()
+```

--- a/docs/content/docs/connectors/datastream/formats/avro.md
+++ b/docs/content/docs/connectors/datastream/formats/avro.md
@@ -66,7 +66,7 @@ Specifying a field in Avro like this `{"name": "type_double_test", "type": "doub
 For PyFlink, an Avro schema should be defined to read from Avro files, and the DataStream element will be a vanilla Python object. For example:
 
 ```python
-schema = Schema.parse_string("""
+schema = AvroSchema.parse_string("""
 {
     "type": "record",
     "name": "User",

--- a/docs/content/docs/connectors/datastream/formats/parquet.md
+++ b/docs/content/docs/connectors/datastream/formats/parquet.md
@@ -61,6 +61,8 @@ To read Avro records, you will need to add the `parquet-avro` dependency:
 </dependency>
 ```
 
+{{< py_jar_download_link "parquet" "flink-sql-parquet.jar" >}}
+
 This format is compatible with the new Source that can be used in both batch and streaming execution modes.
 Thus, you can use this format for two kinds of data:
 
@@ -137,7 +139,7 @@ final DataStream<RowData> stream =
 
 ## Avro Records
 
-Flink supports producing three types of Avro records by reading Parquet files (Only generic record is supported in PyFlink):
+Flink supports producing three types of Avro records by reading Parquet files (Only Generic record is supported in PyFlink):
 
 - [Generic record](https://avro.apache.org/docs/1.10.0/api/java/index.html)
 - [Specific record](https://avro.apache.org/docs/1.10.0/api/java/index.html)

--- a/docs/content/docs/connectors/datastream/formats/parquet.md
+++ b/docs/content/docs/connectors/datastream/formats/parquet.md
@@ -199,7 +199,7 @@ final DataStream<GenericRecord> stream =
 {{< tab "Python" >}}
 ```python
 # parsing avro schema
-schema = Schema.parse_string("""
+schema = AvroSchema.parse_string("""
 {
     "type": "record",
     "name": "User",

--- a/docs/layouts/shortcodes/py_jar_download_link.html
+++ b/docs/layouts/shortcodes/py_jar_download_link.html
@@ -1,0 +1,28 @@
+{{/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/}}{{/*
+Generates the SQL download connector table.
+*/}}
+{{ $name := .Get 0 }}
+{{ $text := .Get 1 }}
+{{ $connectors := .Site.Data.sql_connectors }}
+{{ $connector := index $connectors $name }}
+
+<p>For <b>PyFlink</b> users, you will need to download
+<a href="{{- partial "docs/interpolate" $connector.sql_url -}}">{{ $text }}</a>
+put it into <code>StreamExecutionEnvironment.add_jars()</code> .</p>

--- a/flink-python/docs/pyflink.datastream.rst
+++ b/flink-python/docs/pyflink.datastream.rst
@@ -41,6 +41,12 @@ pyflink.datastream.connectors module
     :members:
     :undoc-members:
 
+pyflink.datastream.formats module
+------------------------------------
+.. automodule:: pyflink.datastream.formats
+    :members:
+    :undoc-members:
+
 pyflink.datastream.window module
 --------------------------------
 .. automodule:: pyflink.datastream.window

--- a/flink-python/pom.xml
+++ b/flink-python/pom.xml
@@ -151,16 +151,6 @@ under the License.
 			<version>${arrow.version}</version>
 		</dependency>
 
-		<!-- Format dependencies -->
-
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-avro</artifactId>
-			<version>${project.version}</version>
-			<optional>true</optional>
-			<scope>provided</scope>
-		</dependency>
-
 		<!-- test dependencies -->
 
 		<dependency>

--- a/flink-python/pyflink/datastream/connectors/tests/test_file_system.py
+++ b/flink-python/pyflink/datastream/connectors/tests/test_file_system.py
@@ -18,13 +18,14 @@
 import os
 import tempfile
 import unittest
+from typing import Tuple, List
 
-from py4j.java_gateway import java_import
+from py4j.java_gateway import java_import, JavaObject
 
 from pyflink.common.watermark_strategy import WatermarkStrategy
 from pyflink.datastream.functions import MapFunction
 from pyflink.datastream.connectors.file_system import FileSource
-from pyflink.datastream.formats.avro import Schema as AvroSchema
+from pyflink.datastream.formats.avro import Schema as AvroSchema, AvroInputFormat
 from pyflink.datastream.formats.parquet import AvroParquetReaders
 from pyflink.datastream.tests.test_util import DataStreamTestSinkFunction
 from pyflink.java_gateway import get_gateway
@@ -36,185 +37,54 @@ from pyflink.testing.test_case_utils import PyFlinkStreamingTestCase
 class FileSourceParquetAvroFormatTests(PyFlinkStreamingTestCase):
 
     def setUp(self):
-        assert os.environ.get('HADOOP_CLASSPATH') is not None, 'Hadoop is needed for this test'
         super().setUp()
         self.test_sink = DataStreamTestSinkFunction()
-        self._import_avro_classes()
+        _import_avro_classes()
 
     def test_avro_parquet_basic(self):
         parquet_file_name = tempfile.mktemp(suffix='.parquet', dir=self.tempdir)
-        record_schema = """
-        {
-            "type": "record",
-            "name": "test",
-            "fields": [
-                { "name": "null", "type": "null" },
-                { "name": "boolean", "type": "boolean" },
-                { "name": "int", "type": "int" },
-                { "name": "long", "type": "long" },
-                { "name": "float", "type": "float" },
-                { "name": "double", "type": "double" },
-                { "name": "string", "type": "string" }
-            ]
-        }
-        """
-        schema = AvroSchema.parse_string(record_schema)
-        records = [self._create_basic_avro_record(schema, True, 0, 1, 2, 3, 's1'),
-                   self._create_basic_avro_record(schema, False, 4, 5, 6, 7, 's2')]
+        schema, records = _create_basic_avro_schema_and_records()
         self._create_avro_parquet_file(parquet_file_name, schema, records)
-
         self._build_avro_parquet_job(schema, parquet_file_name)
         self.env.execute("test_avro_parquet_basic")
         results = self.test_sink.get_results(True, False)
-        result1 = results[0]
-        result2 = results[1]
-        self.assertEqual(result1['null'], None)
-        self.assertEqual(result1['boolean'], True)
-        self.assertEqual(result1['int'], 0)
-        self.assertEqual(result1['long'], 1)
-        self.assertAlmostEqual(result1['float'], 2, delta=1e-3)
-        self.assertAlmostEqual(result1['double'], 3, delta=1e-3)
-        self.assertEqual(result1['string'], 's1')
-        self.assertEqual(result2['null'], None)
-        self.assertEqual(result2['boolean'], False)
-        self.assertEqual(result2['int'], 4)
-        self.assertEqual(result2['long'], 5)
-        self.assertAlmostEqual(result2['float'], 6, delta=1e-3)
-        self.assertAlmostEqual(result2['double'], 7, delta=1e-3)
-        self.assertEqual(result2['string'], 's2')
+        _check_basic_avro_schema_results(self, results)
 
     def test_avro_parquet_enum(self):
         parquet_file_name = tempfile.mktemp(suffix='.parquet', dir=self.tempdir)
-        record_schema = """
-        {
-            "type": "record",
-            "name": "test",
-            "fields": [
-                {
-                    "name": "suit",
-                    "type": {
-                        "type": "enum",
-                        "name": "Suit",
-                        "symbols" : ["SPADES", "HEARTS", "DIAMONDS", "CLUBS"]
-                    }
-                }
-            ]
-        }
-        """
-        schema = AvroSchema.parse_string(record_schema)
-        records = [self._create_enum_avro_record(schema, 'SPADES'),
-                   self._create_enum_avro_record(schema, 'DIAMONDS')]
+        schema, records = _create_enum_avro_schema_and_records()
         self._create_avro_parquet_file(parquet_file_name, schema, records)
-
         self._build_avro_parquet_job(schema, parquet_file_name)
         self.env.execute("test_avro_record_enum")
         results = self.test_sink.get_results(True, False)
-        self.assertEqual(results[0]['suit'], 'SPADES')
-        self.assertEqual(results[1]['suit'], 'DIAMONDS')
+        _check_enum_avro_schema_results(self, results)
 
     def test_avro_parquet_union(self):
         parquet_file_name = tempfile.mktemp(suffix='.parquet', dir=self.tempdir)
-        record_schema = """
-        {
-            "type": "record",
-            "name": "test",
-            "fields": [
-                {
-                    "name": "union",
-                    "type": [ "int", "double", "null" ]
-                }
-            ]
-        }
-        """
-        schema = AvroSchema.parse_string(record_schema)
-        records = [self._create_union_avro_record(schema, 1),
-                   self._create_union_avro_record(schema, 2.),
-                   self._create_union_avro_record(schema, None)]
+        schema, records = _create_union_avro_schema_and_records()
         self._create_avro_parquet_file(parquet_file_name, schema, records)
-
         self._build_avro_parquet_job(schema, parquet_file_name)
         self.env.execute("test_avro_record_union")
         results = self.test_sink.get_results(True, False)
-        self.assertEqual(results[0]['union'], 1)
-        self.assertAlmostEqual(results[1]['union'], 2.0, delta=1e-3)
-        self.assertEqual(results[2]['union'], None)
+        _check_union_avro_schema_results(self, results)
 
     def test_avro_parquet_array(self):
         parquet_file_name = tempfile.mktemp(suffix='.parquet', dir=self.tempdir)
-        # It seems there's bug when array item record contains only one field, which throws
-        # java.lang.ClassCastException: required ... is not a group when reading
-        record_schema = """
-        {
-            "type": "record",
-            "name": "test",
-            "fields": [
-                {
-                    "name": "array",
-                    "type": {
-                        "type": "array",
-                        "items": {
-                            "type": "record",
-                            "name": "item",
-                            "fields": [
-                                { "name": "int", "type": "int" },
-                                { "name": "double", "type": "double" }
-                            ]
-                        }
-                    }
-                }
-            ]
-        }
-        """
-        schema = AvroSchema.parse_string(record_schema)
-        records = [self._create_array_avro_record(schema, [(1, 2.), (3, 4.)]),
-                   self._create_array_avro_record(schema, [(5, 6.), (7, 8.)])]
+        schema, records = _create_array_avro_schema_and_records()
         self._create_avro_parquet_file(parquet_file_name, schema, records)
-
         self._build_avro_parquet_job(schema, parquet_file_name)
         self.env.execute("test_avro_record_array")
         results = self.test_sink.get_results(True, False)
-        result1 = results[0]
-        result2 = results[1]
-        self.assertEqual(result1['array'][0]['int'], 1)
-        self.assertAlmostEqual(result1['array'][0]['double'], 2., delta=1e-3)
-        self.assertEqual(result1['array'][1]['int'], 3)
-        self.assertAlmostEqual(result1['array'][1]['double'], 4., delta=1e-3)
-        self.assertEqual(result2['array'][0]['int'], 5)
-        self.assertAlmostEqual(result2['array'][0]['double'], 6., delta=1e-3)
-        self.assertEqual(result2['array'][1]['int'], 7)
-        self.assertAlmostEqual(result2['array'][1]['double'], 8., delta=1e-3)
+        _check_array_avro_schema_results(self, results)
 
     def test_avro_parquet_map(self):
         parquet_file_name = tempfile.mktemp(suffix='.parquet', dir=self.tempdir)
-        record_schema = """
-        {
-            "type": "record",
-            "name": "test",
-            "fields": [
-                {
-                    "name": "map",
-                    "type": {
-                        "type": "map",
-                        "values": "long"
-                    }
-                }
-            ]
-        }
-        """
-        schema = AvroSchema.parse_string(record_schema)
-        records = [self._create_map_avro_record(schema, {'a': 1, 'b': 2}),
-                   self._create_map_avro_record(schema, {'c': 3, 'd': 4})]
+        schema, records = _create_map_avro_schema_and_records()
         self._create_avro_parquet_file(parquet_file_name, schema, records)
-
         self._build_avro_parquet_job(schema, parquet_file_name)
         self.env.execute("test_avro_record_map")
         results = self.test_sink.get_results(True, False)
-        result1 = results[0]
-        result2 = results[1]
-        self.assertEqual(result1['map']['a'], 1)
-        self.assertEqual(result1['map']['b'], 2)
-        self.assertEqual(result2['map']['c'], 3)
-        self.assertEqual(result2['map']['d'], 4)
+        _check_map_avro_schema_results(self, results)
 
     def _build_avro_parquet_job(self, record_schema, parquet_file_name):
         ds = self.env.from_source(
@@ -225,71 +95,7 @@ class FileSourceParquetAvroFormatTests(PyFlinkStreamingTestCase):
             WatermarkStrategy.for_monotonous_timestamps(),
             "parquet-source"
         )
-        ds.map(self.PassThroughMapFunction()).add_sink(self.test_sink)
-
-    class PassThroughMapFunction(MapFunction):
-
-        def map(self, value):
-            return value
-
-    @staticmethod
-    def _import_avro_classes():
-        jvm = get_gateway().jvm
-        classes = ['org.apache.avro.generic.GenericData']
-        prefix = 'org.apache.flink.avro.shaded.'
-        for cls in classes:
-            java_import(jvm, prefix + cls)
-
-    @staticmethod
-    def _create_basic_avro_record(schema: AvroSchema, boolean_value, int_value, long_value,
-                                  float_value, double_value, string_value):
-        jvm = get_gateway().jvm
-        j_record = jvm.GenericData.Record(schema._j_schema)
-        j_record.put('boolean', boolean_value)
-        j_record.put('int', int_value)
-        j_record.put('long', long_value)
-        j_record.put('float', float_value)
-        j_record.put('double', double_value)
-        j_record.put('string', string_value)
-        return j_record
-
-    @staticmethod
-    def _create_enum_avro_record(schema: AvroSchema, enum_value):
-        jvm = get_gateway().jvm
-        j_record = jvm.GenericData.Record(schema._j_schema)
-        j_record.put('suit', enum_value)
-        return j_record
-
-    @staticmethod
-    def _create_union_avro_record(schema, union_value):
-        jvm = get_gateway().jvm
-        j_record = jvm.GenericData.Record(schema._j_schema)
-        j_record.put('union', union_value)
-        return j_record
-
-    @staticmethod
-    def _create_array_avro_record(schema, item_values: list):
-        jvm = get_gateway().jvm
-        j_record = jvm.GenericData.Record(schema._j_schema)
-        item_schema = AvroSchema(schema._j_schema.getField('array').schema().getElementType())
-        j_array = jvm.java.util.ArrayList()
-        for idx, item_value in enumerate(item_values):
-            j_item = jvm.GenericData.Record(item_schema._j_schema)
-            j_item.put('int', item_value[0])
-            j_item.put('double', item_value[1])
-            j_array.add(j_item)
-        j_record.put('array', j_array)
-        return j_record
-
-    @staticmethod
-    def _create_map_avro_record(schema, map: dict):
-        jvm = get_gateway().jvm
-        j_record = jvm.GenericData.Record(schema._j_schema)
-        j_map = jvm.java.util.HashMap()
-        for k, v in map.items():
-            j_map.put(k, v)
-        j_record.put('map', j_map)
-        return j_record
+        ds.map(PassThroughMapFunction()).add_sink(self.test_sink)
 
     @staticmethod
     def _create_avro_parquet_file(file_path: str, schema: AvroSchema, records: list):
@@ -305,3 +111,309 @@ class FileSourceParquetAvroFormatTests(PyFlinkStreamingTestCase):
             writer.addElement(record)
         writer.flush()
         writer.finish()
+
+
+class FileSourceAvroInputFormatTests(PyFlinkStreamingTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.test_sink = DataStreamTestSinkFunction()
+        _import_avro_classes()
+
+    def test_avro_basic(self):
+        avro_file_name = tempfile.mktemp(suffix='.avro', dir=self.tempdir)
+        schema, records = _create_basic_avro_schema_and_records()
+        self._create_avro_file(avro_file_name, schema, records)
+        self._build_avro_job(schema, avro_file_name)
+        self.env.execute("test_avro_basic")
+        results = self.test_sink.get_results(True, False)
+        _check_basic_avro_schema_results(self, results)
+
+    def test_avro_enum(self):
+        avro_file_name = tempfile.mktemp(suffix='.avro', dir=self.tempdir)
+        schema, records = _create_enum_avro_schema_and_records()
+        self._create_avro_file(avro_file_name, schema, records)
+        self._build_avro_job(schema, avro_file_name)
+        self.env.execute("test_avro_enum")
+        results = self.test_sink.get_results(True, False)
+        _check_enum_avro_schema_results(self, results)
+
+    def test_avro_union(self):
+        avro_file_name = tempfile.mktemp(suffix='.avro', dir=self.tempdir)
+        schema, records = _create_union_avro_schema_and_records()
+        self._create_avro_file(avro_file_name, schema, records)
+        self._build_avro_job(schema, avro_file_name)
+        self.env.execute("test_avro_union")
+        results = self.test_sink.get_results(True, False)
+        _check_union_avro_schema_results(self, results)
+
+    def test_avro_array(self):
+        avro_file_name = tempfile.mktemp(suffix='.avro', dir=self.tempdir)
+        schema, records = _create_array_avro_schema_and_records()
+        self._create_avro_file(avro_file_name, schema, records)
+        self._build_avro_job(schema, avro_file_name)
+        self.env.execute("test_avro_array")
+        results = self.test_sink.get_results(True, False)
+        _check_array_avro_schema_results(self, results)
+
+    def test_avro_map(self):
+        avro_file_name = tempfile.mktemp(suffix='.avro', dir=self.tempdir)
+        schema, records = _create_map_avro_schema_and_records()
+        self._create_avro_file(avro_file_name, schema, records)
+        self._build_avro_job(schema, avro_file_name)
+        self.env.execute("test_avro_map")
+        results = self.test_sink.get_results(True, False)
+        _check_map_avro_schema_results(self, results)
+
+    def _build_avro_job(self, record_schema, avro_file_name):
+        ds = self.env.create_input(AvroInputFormat(avro_file_name, record_schema))
+        ds.map(PassThroughMapFunction()).add_sink(self.test_sink)
+
+    @staticmethod
+    def _create_avro_file(file_path: str, schema: AvroSchema, records: list):
+        jvm = get_gateway().jvm
+        j_file = jvm.java.io.File(file_path)
+        j_datum_writer = jvm.org.apache.flink.avro.shaded.org.apache.avro.generic \
+            .GenericDatumWriter()
+        j_file_writer = jvm.org.apache.flink.avro.shaded.org.apache.avro.file \
+            .DataFileWriter(j_datum_writer)
+        j_file_writer.create(schema._j_schema, j_file)
+        for r in records:
+            j_file_writer.append(r)
+        j_file_writer.close()
+
+
+class PassThroughMapFunction(MapFunction):
+
+    def map(self, value):
+        return value
+
+
+def _import_avro_classes():
+    jvm = get_gateway().jvm
+    classes = ['org.apache.avro.generic.GenericData']
+    prefix = 'org.apache.flink.avro.shaded.'
+    for cls in classes:
+        java_import(jvm, prefix + cls)
+
+
+def _create_basic_avro_schema_and_records() -> Tuple[AvroSchema, List[JavaObject]]:
+    record_schema = """
+    {
+        "type": "record",
+        "name": "test",
+        "fields": [
+            { "name": "null", "type": "null" },
+            { "name": "boolean", "type": "boolean" },
+            { "name": "int", "type": "int" },
+            { "name": "long", "type": "long" },
+            { "name": "float", "type": "float" },
+            { "name": "double", "type": "double" },
+            { "name": "string", "type": "string" }
+        ]
+    }
+    """
+    schema = AvroSchema.parse_string(record_schema)
+    records = [_create_basic_avro_record(schema, True, 0, 1, 2, 3, 's1'),
+               _create_basic_avro_record(schema, False, 4, 5, 6, 7, 's2')]
+    return schema, records
+
+
+def _check_basic_avro_schema_results(test, results):
+    result1 = results[0]
+    result2 = results[1]
+    test.assertEqual(result1['null'], None)
+    test.assertEqual(result1['boolean'], True)
+    test.assertEqual(result1['int'], 0)
+    test.assertEqual(result1['long'], 1)
+    test.assertAlmostEqual(result1['float'], 2, delta=1e-3)
+    test.assertAlmostEqual(result1['double'], 3, delta=1e-3)
+    test.assertEqual(result1['string'], 's1')
+    test.assertEqual(result2['null'], None)
+    test.assertEqual(result2['boolean'], False)
+    test.assertEqual(result2['int'], 4)
+    test.assertEqual(result2['long'], 5)
+    test.assertAlmostEqual(result2['float'], 6, delta=1e-3)
+    test.assertAlmostEqual(result2['double'], 7, delta=1e-3)
+    test.assertEqual(result2['string'], 's2')
+
+
+def _create_enum_avro_schema_and_records() -> Tuple[AvroSchema, List[JavaObject]]:
+    record_schema = """
+    {
+        "type": "record",
+        "name": "test",
+        "fields": [
+            {
+                "name": "suit",
+                "type": {
+                    "type": "enum",
+                    "name": "Suit",
+                    "symbols" : ["SPADES", "HEARTS", "DIAMONDS", "CLUBS"]
+                }
+            }
+        ]
+    }
+    """
+    schema = AvroSchema.parse_string(record_schema)
+    records = [_create_enum_avro_record(schema, 'SPADES'),
+               _create_enum_avro_record(schema, 'DIAMONDS')]
+    return schema, records
+
+
+def _check_enum_avro_schema_results(test, results):
+    test.assertEqual(results[0]['suit'], 'SPADES')
+    test.assertEqual(results[1]['suit'], 'DIAMONDS')
+
+
+def _create_union_avro_schema_and_records() -> Tuple[AvroSchema, List[JavaObject]]:
+    record_schema = """
+    {
+        "type": "record",
+        "name": "test",
+        "fields": [
+            {
+                "name": "union",
+                "type": [ "int", "double", "null" ]
+            }
+        ]
+    }
+    """
+    schema = AvroSchema.parse_string(record_schema)
+    records = [_create_union_avro_record(schema, 1),
+               _create_union_avro_record(schema, 2.),
+               _create_union_avro_record(schema, None)]
+    return schema, records
+
+
+def _check_union_avro_schema_results(test, results):
+    test.assertEqual(results[0]['union'], 1)
+    test.assertAlmostEqual(results[1]['union'], 2.0, delta=1e-3)
+    test.assertEqual(results[2]['union'], None)
+
+
+def _create_array_avro_schema_and_records() -> Tuple[AvroSchema, List[JavaObject]]:
+    # It seems there's bug when array item record contains only one field, which throws
+    # java.lang.ClassCastException: required ... is not a group when reading
+    record_schema = """
+    {
+        "type": "record",
+        "name": "test",
+        "fields": [
+            {
+                "name": "array",
+                "type": {
+                    "type": "array",
+                    "items": {
+                        "type": "record",
+                        "name": "item",
+                        "fields": [
+                            { "name": "int", "type": "int" },
+                            { "name": "double", "type": "double" }
+                        ]
+                    }
+                }
+            }
+        ]
+    }
+    """
+    schema = AvroSchema.parse_string(record_schema)
+    records = [_create_array_avro_record(schema, [(1, 2.), (3, 4.)]),
+               _create_array_avro_record(schema, [(5, 6.), (7, 8.)])]
+    return schema, records
+
+
+def _check_array_avro_schema_results(test, results):
+    result1 = results[0]
+    result2 = results[1]
+    test.assertEqual(result1['array'][0]['int'], 1)
+    test.assertAlmostEqual(result1['array'][0]['double'], 2., delta=1e-3)
+    test.assertEqual(result1['array'][1]['int'], 3)
+    test.assertAlmostEqual(result1['array'][1]['double'], 4., delta=1e-3)
+    test.assertEqual(result2['array'][0]['int'], 5)
+    test.assertAlmostEqual(result2['array'][0]['double'], 6., delta=1e-3)
+    test.assertEqual(result2['array'][1]['int'], 7)
+    test.assertAlmostEqual(result2['array'][1]['double'], 8., delta=1e-3)
+
+
+def _create_map_avro_schema_and_records() -> Tuple[AvroSchema, List[JavaObject]]:
+    record_schema = """
+    {
+        "type": "record",
+        "name": "test",
+        "fields": [
+            {
+                "name": "map",
+                "type": {
+                    "type": "map",
+                    "values": "long"
+                }
+            }
+        ]
+    }
+    """
+    schema = AvroSchema.parse_string(record_schema)
+    records = [_create_map_avro_record(schema, {'a': 1, 'b': 2}),
+               _create_map_avro_record(schema, {'c': 3, 'd': 4})]
+    return schema, records
+
+
+def _check_map_avro_schema_results(test, results):
+    result1 = results[0]
+    result2 = results[1]
+    test.assertEqual(result1['map']['a'], 1)
+    test.assertEqual(result1['map']['b'], 2)
+    test.assertEqual(result2['map']['c'], 3)
+    test.assertEqual(result2['map']['d'], 4)
+
+
+def _create_basic_avro_record(schema: AvroSchema, boolean_value, int_value, long_value,
+                              float_value, double_value, string_value):
+    jvm = get_gateway().jvm
+    j_record = jvm.GenericData.Record(schema._j_schema)
+    j_record.put('boolean', boolean_value)
+    j_record.put('int', int_value)
+    j_record.put('long', long_value)
+    j_record.put('float', float_value)
+    j_record.put('double', double_value)
+    j_record.put('string', string_value)
+    return j_record
+
+
+def _create_enum_avro_record(schema: AvroSchema, enum_value):
+    jvm = get_gateway().jvm
+    j_record = jvm.GenericData.Record(schema._j_schema)
+    j_enum = jvm.GenericData.EnumSymbol(schema._j_schema.getField('suit').schema(), enum_value)
+    j_record.put('suit', j_enum)
+    return j_record
+
+
+def _create_union_avro_record(schema, union_value):
+    jvm = get_gateway().jvm
+    j_record = jvm.GenericData.Record(schema._j_schema)
+    j_record.put('union', union_value)
+    return j_record
+
+
+def _create_array_avro_record(schema, item_values: list):
+    jvm = get_gateway().jvm
+    j_record = jvm.GenericData.Record(schema._j_schema)
+    item_schema = AvroSchema(schema._j_schema.getField('array').schema().getElementType())
+    j_array = jvm.java.util.ArrayList()
+    for idx, item_value in enumerate(item_values):
+        j_item = jvm.GenericData.Record(item_schema._j_schema)
+        j_item.put('int', item_value[0])
+        j_item.put('double', item_value[1])
+        j_array.add(j_item)
+    j_record.put('array', j_array)
+    return j_record
+
+
+def _create_map_avro_record(schema, map: dict):
+    jvm = get_gateway().jvm
+    j_record = jvm.GenericData.Record(schema._j_schema)
+    j_map = jvm.java.util.HashMap()
+    for k, v in map.items():
+        j_map.put(k, v)
+    j_record.put('map', j_map)
+    return j_record

--- a/flink-python/pyflink/datastream/connectors/tests/test_file_system.py
+++ b/flink-python/pyflink/datastream/connectors/tests/test_file_system.py
@@ -25,7 +25,7 @@ from py4j.java_gateway import java_import, JavaObject
 from pyflink.common.watermark_strategy import WatermarkStrategy
 from pyflink.datastream.functions import MapFunction
 from pyflink.datastream.connectors.file_system import FileSource
-from pyflink.datastream.formats.avro import Schema as AvroSchema, AvroInputFormat
+from pyflink.datastream.formats.avro import AvroSchema, AvroInputFormat
 from pyflink.datastream.formats.parquet import AvroParquetReaders
 from pyflink.datastream.tests.test_util import DataStreamTestSinkFunction
 from pyflink.java_gateway import get_gateway

--- a/flink-python/pyflink/datastream/formats/__init__.py
+++ b/flink-python/pyflink/datastream/formats/__init__.py
@@ -15,12 +15,12 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
-from .avro import Schema, AvroInputFormat
+from .avro import AvroSchema, AvroInputFormat
 from .parquet import AvroParquetReaders
 
 
 __all__ = [
     'AvroInputFormat',
     'AvroParquetReaders',
-    'Schema'
+    'AvroSchema'
 ]

--- a/flink-python/pyflink/datastream/formats/avro.py
+++ b/flink-python/pyflink/datastream/formats/avro.py
@@ -15,6 +15,11 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
+from py4j.java_gateway import get_java_class, JavaObject
+from pyflink.common.typeinfo import TypeInformation
+
+from pyflink.datastream.formats.base import InputFormat
+from pyflink.datastream.utils import ResultTypeQueryable
 from pyflink.java_gateway import get_gateway
 
 
@@ -51,3 +56,53 @@ class Schema(object):
         j_file = jvm.java.io.File(file_path)
         JSchema = jvm.org.apache.flink.avro.shaded.org.apache.avro.Schema
         return Schema(JSchema.Parser().parse(j_file))
+
+
+class GenericRecordAvroTypeInfo(TypeInformation):
+    """
+    A :class:`TypeInformation` of Avro's GenericRecord, including the schema. This is a wrapper of
+    Java org.apache.flink.formats.avro.typeutils.GenericRecordAvroTypeInfo.
+
+    .. versionadded::1.16.0
+    """
+
+    def __init__(self, schema: Schema):
+        super().__init__()
+        self._schema = schema
+        self._j_typeinfo = get_gateway().jvm.org.apache.flink.formats.avro.typeutils \
+            .GenericRecordAvroTypeInfo(schema._j_schema)
+
+    def get_java_type_info(self) -> JavaObject:
+        return self._j_typeinfo
+
+
+class AvroInputFormat(InputFormat, ResultTypeQueryable):
+    """
+    Provides a FileInputFormat for Avro records.
+
+    Example:
+    ::
+
+        >>> env = StreamExecutionEnvironment.get_execution_environment()
+        >>> schema = Schema.parse_string(JSON_SCHEMA)
+        >>> ds = env.create_input(AvroInputFormat(FILE_PATH, schema))
+
+    .. versionadded:: 1.16.0
+    """
+
+    def __init__(self, path: str, schema: Schema):
+        """
+        :param path: The path to Avro data file.
+        :param schema: The :class:`Schema` of generic record.
+        """
+        jvm = get_gateway().jvm
+        j_avro_input_format = jvm.org.apache.flink.formats.avro.AvroInputFormat(
+            jvm.org.apache.flink.core.fs.Path(path),
+            get_java_class(jvm.org.apache.flink.avro.shaded.org.apache.avro.generic.GenericRecord)
+        )
+        super().__init__(j_avro_input_format)
+        self._schema = schema
+        self._type_info = GenericRecordAvroTypeInfo(schema)
+
+    def get_produced_type(self) -> GenericRecordAvroTypeInfo:
+        return self._type_info

--- a/flink-python/pyflink/datastream/formats/avro.py
+++ b/flink-python/pyflink/datastream/formats/avro.py
@@ -23,7 +23,7 @@ from pyflink.datastream.utils import ResultTypeQueryable
 from pyflink.java_gateway import get_gateway
 
 
-class Schema(object):
+class AvroSchema(object):
     """
     Avro Schema class contains Java org.apache.avro.Schema.
 
@@ -34,7 +34,7 @@ class Schema(object):
         self._j_schema = j_schema
 
     @staticmethod
-    def parse_string(json_schema: str) -> 'Schema':
+    def parse_string(json_schema: str) -> 'AvroSchema':
         """
         Parse JSON string as Avro Schema.
 
@@ -42,10 +42,10 @@ class Schema(object):
         :return: the Avro Schema.
         """
         JSchema = get_gateway().jvm.org.apache.flink.avro.shaded.org.apache.avro.Schema
-        return Schema(JSchema.Parser().parse(json_schema))
+        return AvroSchema(JSchema.Parser().parse(json_schema))
 
     @staticmethod
-    def parse_file(file_path: str) -> 'Schema':
+    def parse_file(file_path: str) -> 'AvroSchema':
         """
         Parse a schema definition file as Avro Schema.
 
@@ -55,7 +55,7 @@ class Schema(object):
         jvm = get_gateway().jvm
         j_file = jvm.java.io.File(file_path)
         JSchema = jvm.org.apache.flink.avro.shaded.org.apache.avro.Schema
-        return Schema(JSchema.Parser().parse(j_file))
+        return AvroSchema(JSchema.Parser().parse(j_file))
 
 
 class GenericRecordAvroTypeInfo(TypeInformation):
@@ -66,7 +66,7 @@ class GenericRecordAvroTypeInfo(TypeInformation):
     .. versionadded::1.16.0
     """
 
-    def __init__(self, schema: Schema):
+    def __init__(self, schema: 'AvroSchema'):
         super().__init__()
         self._schema = schema
         self._j_typeinfo = get_gateway().jvm.org.apache.flink.formats.avro.typeutils \
@@ -84,13 +84,13 @@ class AvroInputFormat(InputFormat, ResultTypeQueryable):
     ::
 
         >>> env = StreamExecutionEnvironment.get_execution_environment()
-        >>> schema = Schema.parse_string(JSON_SCHEMA)
+        >>> schema = AvroSchema.parse_string(JSON_SCHEMA)
         >>> ds = env.create_input(AvroInputFormat(FILE_PATH, schema))
 
     .. versionadded:: 1.16.0
     """
 
-    def __init__(self, path: str, schema: Schema):
+    def __init__(self, path: str, schema: 'AvroSchema'):
         """
         :param path: The path to Avro data file.
         :param schema: The :class:`Schema` of generic record.

--- a/flink-python/pyflink/datastream/formats/base.py
+++ b/flink-python/pyflink/datastream/formats/base.py
@@ -15,12 +15,18 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
-from .avro import Schema, AvroInputFormat
-from .parquet import AvroParquetReaders
+from typing import Union
+
+from py4j.java_gateway import JavaObject
+
+from pyflink.datastream.functions import JavaFunctionWrapper
 
 
-__all__ = [
-    'AvroInputFormat',
-    'AvroParquetReaders',
-    'Schema'
-]
+class InputFormat(JavaFunctionWrapper):
+    """
+    The Python wrapper of Java InputFormat interface, which is the base interface for data sources
+    that produce records.
+    """
+
+    def __init__(self, source: Union[str, JavaObject]):
+        super().__init__(source)

--- a/flink-python/pyflink/datastream/formats/parquet.py
+++ b/flink-python/pyflink/datastream/formats/parquet.py
@@ -39,6 +39,17 @@ class AvroParquetReaders(object):
         during 'pre-flight' time when the data flow is set up and wired, which is before there is
         access to the files.
 
+        Example:
+        ::
+
+            >>> env = StreamExecutionEnvironment.get_execution_environment()
+            >>> schema = Schema.parse_string(JSON_SCHEMA)
+            >>> source = FileSource.for_record_stream_format(
+            ...     AvroParquetReaders.for_generic_record(schema),
+            ...     FILE_PATH
+            ... ).build()
+            >>> ds = env.from_source(source, WatermarkStrategy.no_watermarks(), "parquet-source")
+
         :param schema: the Avro Schema.
         :return: StreamFormat for reading Avro GenericRecords.
         """

--- a/flink-python/pyflink/datastream/formats/parquet.py
+++ b/flink-python/pyflink/datastream/formats/parquet.py
@@ -16,7 +16,7 @@
 # limitations under the License.
 ################################################################################
 from pyflink.datastream.connectors.file_system import StreamFormat
-from pyflink.datastream.formats.avro import Schema
+from pyflink.datastream.formats.avro import AvroSchema
 from pyflink.java_gateway import get_gateway
 
 
@@ -29,7 +29,7 @@ class AvroParquetReaders(object):
     """
 
     @staticmethod
-    def for_generic_record(schema: 'Schema') -> 'StreamFormat':
+    def for_generic_record(schema: 'AvroSchema') -> 'StreamFormat':
         """
         Creates a new AvroParquetRecordFormat that reads the parquet file into Avro GenericRecords.
 
@@ -43,7 +43,7 @@ class AvroParquetReaders(object):
         ::
 
             >>> env = StreamExecutionEnvironment.get_execution_environment()
-            >>> schema = Schema.parse_string(JSON_SCHEMA)
+            >>> schema = AvroSchema.parse_string(JSON_SCHEMA)
             >>> source = FileSource.for_record_stream_format(
             ...     AvroParquetReaders.for_generic_record(schema),
             ...     FILE_PATH

--- a/flink-python/pyflink/datastream/utils.py
+++ b/flink-python/pyflink/datastream/utils.py
@@ -18,12 +18,20 @@
 import ast
 import datetime
 import pickle
+from abc import abstractmethod
 
 from pyflink.common import Row, RowKind
-from pyflink.common.typeinfo import (RowTypeInfo, TupleTypeInfo, Types,  BasicArrayTypeInfo,
+from pyflink.common.typeinfo import (RowTypeInfo, TupleTypeInfo, Types, BasicArrayTypeInfo,
                                      PrimitiveArrayTypeInfo, MapTypeInfo, ListTypeInfo,
-                                     ObjectArrayTypeInfo, ExternalTypeInfo)
+                                     ObjectArrayTypeInfo, ExternalTypeInfo, TypeInformation)
 from pyflink.java_gateway import get_gateway
+
+
+class ResultTypeQueryable(object):
+
+    @abstractmethod
+    def get_produced_type(self) -> TypeInformation:
+        pass
 
 
 def convert_to_python_obj(data, type_info):

--- a/flink-python/setup.py
+++ b/flink-python/setup.py
@@ -273,6 +273,7 @@ try:
                 'pyflink.util',
                 'pyflink.datastream',
                 'pyflink.datastream.connectors',
+                'pyflink.datastream.formats',
                 'pyflink.common',
                 'pyflink.fn_execution',
                 'pyflink.fn_execution.beam',

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/AbstractDataStreamPythonFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/AbstractDataStreamPythonFunctionOperator.java
@@ -152,7 +152,8 @@ public abstract class AbstractDataStreamPythonFunctionOperator<OUT>
                     createRawTypeCoderInfoDescriptorProto(
                             getSideOutputTypeInfo(entry.getValue()),
                             FlinkFnApi.CoderInfoDescriptor.Mode.MULTIPLE,
-                            false));
+                            false,
+                            getUserCodeClassloader()));
         }
         return descriptorMap;
     }

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/AbstractOneInputPythonFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/AbstractOneInputPythonFunctionOperator.java
@@ -149,12 +149,18 @@ public abstract class AbstractOneInputPythonFunctionOperator<IN, OUT>
 
     public FlinkFnApi.CoderInfoDescriptor createInputCoderInfoDescriptor() {
         return createRawTypeCoderInfoDescriptorProto(
-                runnerInputTypeInfo, FlinkFnApi.CoderInfoDescriptor.Mode.MULTIPLE, false);
+                runnerInputTypeInfo,
+                FlinkFnApi.CoderInfoDescriptor.Mode.MULTIPLE,
+                false,
+                getUserCodeClassloader());
     }
 
     public FlinkFnApi.CoderInfoDescriptor createOutputCoderInfoDescriptor() {
         return createRawTypeCoderInfoDescriptorProto(
-                runnerOutputTypeInfo, FlinkFnApi.CoderInfoDescriptor.Mode.MULTIPLE, false);
+                runnerOutputTypeInfo,
+                FlinkFnApi.CoderInfoDescriptor.Mode.MULTIPLE,
+                false,
+                getUserCodeClassloader());
     }
 
     // ----------------------------------------------------------------------

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/AbstractTwoInputPythonFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/AbstractTwoInputPythonFunctionOperator.java
@@ -141,12 +141,18 @@ public abstract class AbstractTwoInputPythonFunctionOperator<IN1, IN2, OUT>
 
     public FlinkFnApi.CoderInfoDescriptor createInputCoderInfoDescriptor() {
         return createRawTypeCoderInfoDescriptorProto(
-                runnerInputTypeInfo, FlinkFnApi.CoderInfoDescriptor.Mode.MULTIPLE, false);
+                runnerInputTypeInfo,
+                FlinkFnApi.CoderInfoDescriptor.Mode.MULTIPLE,
+                false,
+                getUserCodeClassloader());
     }
 
     public FlinkFnApi.CoderInfoDescriptor createOutputCoderInfoDescriptor() {
         return createRawTypeCoderInfoDescriptorProto(
-                runnerOutputTypeInfo, FlinkFnApi.CoderInfoDescriptor.Mode.MULTIPLE, false);
+                runnerOutputTypeInfo,
+                FlinkFnApi.CoderInfoDescriptor.Mode.MULTIPLE,
+                false,
+                getUserCodeClassloader());
     }
 
     // ----------------------------------------------------------------------

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/timer/TimerUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/timer/TimerUtils.java
@@ -40,6 +40,6 @@ public final class TimerUtils {
     public static FlinkFnApi.CoderInfoDescriptor createTimerDataCoderInfoDescriptorProto(
             TypeInformation<Row> timerDataType) {
         return ProtoUtils.createRawTypeCoderInfoDescriptorProto(
-                timerDataType, FlinkFnApi.CoderInfoDescriptor.Mode.SINGLE, false);
+                timerDataType, FlinkFnApi.CoderInfoDescriptor.Mode.SINGLE, false, null);
     }
 }

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/utils/ProtoUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/utils/ProtoUtils.java
@@ -272,7 +272,8 @@ public enum ProtoUtils {
 
         // set the key typeinfo for the head operator
         FlinkFnApi.TypeInfo builtKeyTypeInfo =
-                PythonTypeUtils.TypeInfoToProtoConverter.toTypeInfoProto(keyTypeInfo);
+                PythonTypeUtils.TypeInfoToProtoConverter.toTypeInfoProto(
+                        keyTypeInfo, runtimeContext.getUserCodeClassLoader());
         results.set(0, results.get(0).toBuilder().setKeyTypeInfo(builtKeyTypeInfo).build());
         return results;
     }
@@ -354,9 +355,11 @@ public enum ProtoUtils {
     public static FlinkFnApi.CoderInfoDescriptor createRawTypeCoderInfoDescriptorProto(
             TypeInformation<?> typeInformation,
             FlinkFnApi.CoderInfoDescriptor.Mode mode,
-            boolean separatedWithEndMessage) {
+            boolean separatedWithEndMessage,
+            ClassLoader userCodeClassLoader) {
         FlinkFnApi.TypeInfo typeinfo =
-                PythonTypeUtils.TypeInfoToProtoConverter.toTypeInfoProto(typeInformation);
+                PythonTypeUtils.TypeInfoToProtoConverter.toTypeInfoProto(
+                        typeInformation, userCodeClassLoader);
         return createCoderInfoDescriptorProto(
                 null,
                 null,

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/utils/PythonTypeUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/utils/PythonTypeUtils.java
@@ -61,7 +61,6 @@ import org.apache.flink.api.java.typeutils.runtime.TupleSerializer;
 import org.apache.flink.core.memory.ByteArrayInputStreamWithPos;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.fnexecution.v1.FlinkFnApi;
-import org.apache.flink.formats.avro.typeutils.GenericRecordAvroTypeInfo;
 import org.apache.flink.streaming.api.typeinfo.python.PickledByteArrayTypeInfo;
 import org.apache.flink.table.runtime.typeutils.ExternalTypeInfo;
 import org.apache.flink.table.runtime.typeutils.serializers.python.BigDecSerializer;
@@ -70,11 +69,14 @@ import org.apache.flink.table.runtime.typeutils.serializers.python.StringSeriali
 import org.apache.flink.table.runtime.typeutils.serializers.python.TimeSerializer;
 import org.apache.flink.table.runtime.typeutils.serializers.python.TimestampSerializer;
 import org.apache.flink.table.types.utils.LegacyTypeInfoDataTypeConverter;
+import org.apache.flink.util.Preconditions;
 import org.apache.flink.table.typeutils.TimeIntervalTypeInfo;
 import org.apache.flink.types.Row;
 import org.apache.flink.types.RowKind;
 
 import org.apache.flink.shaded.guava30.com.google.common.collect.Sets;
+
+import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.lang.reflect.Array;
@@ -150,18 +152,25 @@ public class PythonTypeUtils {
                         FlinkFnApi.TypeInfo.TypeName.SQL_TIME,
                         FlinkFnApi.TypeInfo.TypeName.SQL_TIMESTAMP);
 
-        public static FlinkFnApi.TypeInfo toTypeInfoProto(TypeInformation<?> typeInformation) {
+        /**
+         * userClassLoader could be null if no external class loading is needed, e.g. load Avro
+         * classes.
+         */
+        public static FlinkFnApi.TypeInfo toTypeInfoProto(
+                TypeInformation<?> typeInformation, @Nullable ClassLoader userClassLoader) {
 
             if (typeInformation instanceof BasicTypeInfo) {
                 return buildBasicTypeProto((BasicTypeInfo<?>) typeInformation);
             }
 
             if (typeInformation instanceof PrimitiveArrayTypeInfo) {
-                return buildPrimitiveArrayTypeProto((PrimitiveArrayTypeInfo<?>) typeInformation);
+                return buildPrimitiveArrayTypeProto(
+                        (PrimitiveArrayTypeInfo<?>) typeInformation, userClassLoader);
             }
 
             if (typeInformation instanceof ObjectArrayTypeInfo) {
-                return buildObjectArrayTypeProto((ObjectArrayTypeInfo<?, ?>) typeInformation);
+                return buildObjectArrayTypeProto(
+                        (ObjectArrayTypeInfo<?, ?>) typeInformation, userClassLoader);
             }
 
             if (typeInformation instanceof SqlTimeTypeInfo) {
@@ -169,7 +178,7 @@ public class PythonTypeUtils {
             }
 
             if (typeInformation instanceof RowTypeInfo) {
-                return buildRowTypeProto((RowTypeInfo) typeInformation);
+                return buildRowTypeProto((RowTypeInfo) typeInformation, userClassLoader);
             }
 
             if (typeInformation instanceof PickledByteArrayTypeInfo) {
@@ -179,25 +188,27 @@ public class PythonTypeUtils {
             }
 
             if (typeInformation instanceof TupleTypeInfo) {
-                return buildTupleTypeProto((TupleTypeInfo<?>) typeInformation);
+                return buildTupleTypeProto((TupleTypeInfo<?>) typeInformation, userClassLoader);
             }
 
             if (typeInformation instanceof BasicArrayTypeInfo) {
-                return buildBasicArrayTypeProto((BasicArrayTypeInfo<?, ?>) typeInformation);
+                return buildBasicArrayTypeProto(
+                        (BasicArrayTypeInfo<?, ?>) typeInformation, userClassLoader);
             }
 
             if (typeInformation instanceof MapTypeInfo) {
-                return buildMapTypeProto((MapTypeInfo<?, ?>) typeInformation);
+                return buildMapTypeProto((MapTypeInfo<?, ?>) typeInformation, userClassLoader);
             }
 
             if (typeInformation instanceof ListTypeInfo) {
-                return buildListTypeProto((ListTypeInfo<?>) typeInformation);
+                return buildListTypeProto((ListTypeInfo<?>) typeInformation, userClassLoader);
             }
 
             if (typeInformation instanceof ExternalTypeInfo) {
                 return toTypeInfoProto(
                         LegacyTypeInfoDataTypeConverter.toLegacyTypeInfo(
-                                ((ExternalTypeInfo<?>) typeInformation).getDataType()));
+                                ((ExternalTypeInfo<?>) typeInformation).getDataType()),
+                        userClassLoader);
             }
 
             if (typeInformation
@@ -205,7 +216,8 @@ public class PythonTypeUtils {
                     .getCanonicalName()
                     .equals("org.apache.flink.formats.avro.typeutils.GenericRecordAvroTypeInfo")) {
                 try {
-                    return buildAvroTypeProto((GenericRecordAvroTypeInfo) typeInformation);
+                    Preconditions.checkNotNull(userClassLoader);
+                    return buildAvroTypeProto(typeInformation, userClassLoader);
                 } catch (Exception e) {
                     throw new RuntimeException(
                             "Error when building proto for GenericRecordAvroTypeInfo", e);
@@ -244,9 +256,9 @@ public class PythonTypeUtils {
         }
 
         private static FlinkFnApi.TypeInfo buildPrimitiveArrayTypeProto(
-                PrimitiveArrayTypeInfo<?> primitiveArrayTypeInfo) {
+                PrimitiveArrayTypeInfo<?> primitiveArrayTypeInfo, ClassLoader userClassLoader) {
             FlinkFnApi.TypeInfo elementFieldType =
-                    toTypeInfoProto(primitiveArrayTypeInfo.getComponentType());
+                    toTypeInfoProto(primitiveArrayTypeInfo.getComponentType(), userClassLoader);
             if (!primitiveArrayElementTypeNames.contains(elementFieldType.getTypeName())) {
                 throw new UnsupportedOperationException(
                         String.format(
@@ -261,18 +273,19 @@ public class PythonTypeUtils {
         }
 
         private static FlinkFnApi.TypeInfo buildObjectArrayTypeProto(
-                ObjectArrayTypeInfo<?, ?> objectArrayTypeInfo) {
+                ObjectArrayTypeInfo<?, ?> objectArrayTypeInfo, ClassLoader userClassLoader) {
             return FlinkFnApi.TypeInfo.newBuilder()
                     .setTypeName(getTypeName(objectArrayTypeInfo))
                     .setCollectionElementType(
-                            toTypeInfoProto(objectArrayTypeInfo.getComponentInfo()))
+                            toTypeInfoProto(
+                                    objectArrayTypeInfo.getComponentInfo(), userClassLoader))
                     .build();
         }
 
         private static FlinkFnApi.TypeInfo buildBasicArrayTypeProto(
-                BasicArrayTypeInfo<?, ?> basicArrayTypeInfo) {
+                BasicArrayTypeInfo<?, ?> basicArrayTypeInfo, ClassLoader userClassLoader) {
             FlinkFnApi.TypeInfo elementFieldType =
-                    toTypeInfoProto(basicArrayTypeInfo.getComponentInfo());
+                    toTypeInfoProto(basicArrayTypeInfo.getComponentInfo(), userClassLoader);
             if (!basicArrayElementTypeNames.contains(elementFieldType.getTypeName())) {
                 throw new UnsupportedOperationException(
                         String.format(
@@ -286,7 +299,8 @@ public class PythonTypeUtils {
                     .build();
         }
 
-        private static FlinkFnApi.TypeInfo buildRowTypeProto(RowTypeInfo rowTypeInfo) {
+        private static FlinkFnApi.TypeInfo buildRowTypeProto(
+                RowTypeInfo rowTypeInfo, ClassLoader userClassLoader) {
             FlinkFnApi.TypeInfo.RowTypeInfo.Builder rowTypeInfoBuilder =
                     FlinkFnApi.TypeInfo.RowTypeInfo.newBuilder();
 
@@ -295,7 +309,9 @@ public class PythonTypeUtils {
                 rowTypeInfoBuilder.addFields(
                         FlinkFnApi.TypeInfo.RowTypeInfo.Field.newBuilder()
                                 .setFieldName(rowTypeInfo.getFieldNames()[index])
-                                .setFieldType(toTypeInfoProto(rowTypeInfo.getTypeAt(index)))
+                                .setFieldType(
+                                        toTypeInfoProto(
+                                                rowTypeInfo.getTypeAt(index), userClassLoader))
                                 .build());
             }
 
@@ -305,13 +321,15 @@ public class PythonTypeUtils {
                     .build();
         }
 
-        private static FlinkFnApi.TypeInfo buildTupleTypeProto(TupleTypeInfo<?> tupleTypeInfo) {
+        private static FlinkFnApi.TypeInfo buildTupleTypeProto(
+                TupleTypeInfo<?> tupleTypeInfo, ClassLoader userClassLoader) {
             FlinkFnApi.TypeInfo.TupleTypeInfo.Builder tupleTypeInfoBuilder =
                     FlinkFnApi.TypeInfo.TupleTypeInfo.newBuilder();
 
             int arity = tupleTypeInfo.getArity();
             for (int index = 0; index < arity; index++) {
-                tupleTypeInfoBuilder.addFieldTypes(toTypeInfoProto(tupleTypeInfo.getTypeAt(index)));
+                tupleTypeInfoBuilder.addFieldTypes(
+                        toTypeInfoProto(tupleTypeInfo.getTypeAt(index), userClassLoader));
             }
 
             return FlinkFnApi.TypeInfo.newBuilder()
@@ -320,13 +338,14 @@ public class PythonTypeUtils {
                     .build();
         }
 
-        private static FlinkFnApi.TypeInfo buildMapTypeProto(MapTypeInfo<?, ?> mapTypeInfo) {
+        private static FlinkFnApi.TypeInfo buildMapTypeProto(
+                MapTypeInfo<?, ?> mapTypeInfo, ClassLoader userClassLoader) {
             FlinkFnApi.TypeInfo.MapTypeInfo.Builder mapTypeInfoBuilder =
                     FlinkFnApi.TypeInfo.MapTypeInfo.newBuilder();
 
             mapTypeInfoBuilder
-                    .setKeyType(toTypeInfoProto(mapTypeInfo.getKeyTypeInfo()))
-                    .setValueType(toTypeInfoProto(mapTypeInfo.getValueTypeInfo()));
+                    .setKeyType(toTypeInfoProto(mapTypeInfo.getKeyTypeInfo(), userClassLoader))
+                    .setValueType(toTypeInfoProto(mapTypeInfo.getValueTypeInfo(), userClassLoader));
 
             return FlinkFnApi.TypeInfo.newBuilder()
                     .setTypeName(getTypeName(mapTypeInfo))
@@ -334,16 +353,23 @@ public class PythonTypeUtils {
                     .build();
         }
 
-        private static FlinkFnApi.TypeInfo buildListTypeProto(ListTypeInfo<?> listTypeInfo) {
+        private static FlinkFnApi.TypeInfo buildListTypeProto(
+                ListTypeInfo<?> listTypeInfo, ClassLoader userClassLoader) {
             return FlinkFnApi.TypeInfo.newBuilder()
                     .setTypeName(getTypeName(listTypeInfo))
-                    .setCollectionElementType(toTypeInfoProto(listTypeInfo.getElementTypeInfo()))
+                    .setCollectionElementType(
+                            toTypeInfoProto(listTypeInfo.getElementTypeInfo(), userClassLoader))
                     .build();
         }
 
         private static FlinkFnApi.TypeInfo buildAvroTypeProto(
-                GenericRecordAvroTypeInfo avroTypeInfo) throws Exception {
-            Field schemaField = avroTypeInfo.getClass().getDeclaredField("schema");
+                TypeInformation<?> avroTypeInfo, ClassLoader userClassLoader) throws Exception {
+            Class<?> clazz =
+                    Class.forName(
+                            "org.apache.flink.formats.avro.typeutils.GenericRecordAvroTypeInfo",
+                            true,
+                            userClassLoader);
+            Field schemaField = clazz.getDeclaredField("schema");
             schemaField.setAccessible(true);
             String schema = schemaField.get(avroTypeInfo).toString();
             return FlinkFnApi.TypeInfo.newBuilder()

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/utils/PythonTypeUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/utils/PythonTypeUtils.java
@@ -69,10 +69,10 @@ import org.apache.flink.table.runtime.typeutils.serializers.python.StringSeriali
 import org.apache.flink.table.runtime.typeutils.serializers.python.TimeSerializer;
 import org.apache.flink.table.runtime.typeutils.serializers.python.TimestampSerializer;
 import org.apache.flink.table.types.utils.LegacyTypeInfoDataTypeConverter;
-import org.apache.flink.util.Preconditions;
 import org.apache.flink.table.typeutils.TimeIntervalTypeInfo;
 import org.apache.flink.types.Row;
 import org.apache.flink.types.RowKind;
+import org.apache.flink.util.Preconditions;
 
 import org.apache.flink.shaded.guava30.com.google.common.collect.Sets;
 

--- a/flink-python/src/test/java/org/apache/flink/streaming/api/utils/PythonTypeUtilsTest.java
+++ b/flink-python/src/test/java/org/apache/flink/streaming/api/utils/PythonTypeUtilsTest.java
@@ -95,7 +95,8 @@ class PythonTypeUtilsTest {
         for (Map.Entry<TypeInformation, FlinkFnApi.TypeInfo.TypeName> entry :
                 typeInformationTypeNameMap.entrySet()) {
             assertThat(
-                            PythonTypeUtils.TypeInfoToProtoConverter.toTypeInfoProto(entry.getKey())
+                            PythonTypeUtils.TypeInfoToProtoConverter.toTypeInfoProto(
+                                            entry.getKey(), null)
                                     .getTypeName())
                     .isEqualTo(entry.getValue());
         }
@@ -104,7 +105,7 @@ class PythonTypeUtilsTest {
                 PrimitiveArrayTypeInfo.INT_PRIMITIVE_ARRAY_TYPE_INFO;
         FlinkFnApi.TypeInfo convertedFieldType =
                 PythonTypeUtils.TypeInfoToProtoConverter.toTypeInfoProto(
-                        primitiveIntegerArrayTypeInfo);
+                        primitiveIntegerArrayTypeInfo, null);
         assertThat(convertedFieldType.getTypeName())
                 .isEqualTo(FlinkFnApi.TypeInfo.TypeName.PRIMITIVE_ARRAY);
         assertThat(convertedFieldType.getCollectionElementType().getTypeName())
@@ -112,7 +113,8 @@ class PythonTypeUtilsTest {
 
         TypeInformation basicIntegerArrayTypeInfo = BasicArrayTypeInfo.INT_ARRAY_TYPE_INFO;
         FlinkFnApi.TypeInfo convertedBasicFieldType =
-                PythonTypeUtils.TypeInfoToProtoConverter.toTypeInfoProto(basicIntegerArrayTypeInfo);
+                PythonTypeUtils.TypeInfoToProtoConverter.toTypeInfoProto(
+                        basicIntegerArrayTypeInfo, null);
         assertThat(convertedBasicFieldType.getTypeName())
                 .isEqualTo(FlinkFnApi.TypeInfo.TypeName.BASIC_ARRAY);
         assertThat(convertedBasicFieldType.getCollectionElementType().getTypeName())
@@ -120,7 +122,7 @@ class PythonTypeUtilsTest {
 
         TypeInformation objectArrayTypeInfo = Types.OBJECT_ARRAY(Types.ROW(Types.INT));
         FlinkFnApi.TypeInfo convertedTypeInfoProto =
-                PythonTypeUtils.TypeInfoToProtoConverter.toTypeInfoProto(objectArrayTypeInfo);
+                PythonTypeUtils.TypeInfoToProtoConverter.toTypeInfoProto(objectArrayTypeInfo, null);
         assertThat(convertedTypeInfoProto.getTypeName())
                 .isEqualTo(FlinkFnApi.TypeInfo.TypeName.OBJECT_ARRAY);
         assertThat(convertedTypeInfoProto.getCollectionElementType().getTypeName())
@@ -135,14 +137,15 @@ class PythonTypeUtilsTest {
                 .isEqualTo(FlinkFnApi.TypeInfo.TypeName.INT);
 
         TypeInformation rowTypeInfo = Types.ROW(Types.INT);
-        convertedFieldType = PythonTypeUtils.TypeInfoToProtoConverter.toTypeInfoProto(rowTypeInfo);
+        convertedFieldType =
+                PythonTypeUtils.TypeInfoToProtoConverter.toTypeInfoProto(rowTypeInfo, null);
         assertThat(convertedFieldType.getTypeName()).isEqualTo(FlinkFnApi.TypeInfo.TypeName.ROW);
         assertThat(convertedFieldType.getRowTypeInfo().getFields(0).getFieldType().getTypeName())
                 .isEqualTo(FlinkFnApi.TypeInfo.TypeName.INT);
 
         TypeInformation tupleTypeInfo = Types.TUPLE(Types.INT);
         convertedFieldType =
-                PythonTypeUtils.TypeInfoToProtoConverter.toTypeInfoProto(tupleTypeInfo);
+                PythonTypeUtils.TypeInfoToProtoConverter.toTypeInfoProto(tupleTypeInfo, null);
         assertThat(convertedFieldType.getTypeName()).isEqualTo(FlinkFnApi.TypeInfo.TypeName.TUPLE);
         assertThat(convertedFieldType.getTupleTypeInfo().getFieldTypes(0).getTypeName())
                 .isEqualTo(FlinkFnApi.TypeInfo.TypeName.INT);


### PR DESCRIPTION

## What is the purpose of the change

This PR supports AvroInputFormat in PyFlink.


## Verifying this change


This change added tests and can be verified as follows:

- integration test `FileSourceAvroInputFormatTests` in test_file_system.py

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (Python Sphinx doc)
