### PR TITLE
[FLINK-28370][connector/kafka] add close method to the interface KafkaRecordSerializationSchema

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/KafkaRecordSerializationSchema.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/KafkaRecordSerializationSchema.java
@@ -49,6 +49,12 @@ public interface KafkaRecordSerializationSchema<T> extends Serializable {
             throws Exception {}
 
     /**
+     * Closes this kafka serialization schema and releases any system resources associated with it.
+     * If the stream is already closed then invoking this method has no effect.
+     */
+    default void close() throws Exception {}
+
+    /**
      * Serializes given element and returns it as a {@link ProducerRecord}.
      *
      * @param element element to be serialized

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/KafkaWriter.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/KafkaWriter.java
@@ -242,6 +242,7 @@ class KafkaWriter<IN>
                     checkState(currentProducer.isClosed());
                     currentProducer = null;
                 });
+        recordSerializer.close();
     }
 
     private void abortCurrentProducer() {


### PR DESCRIPTION
## What is the purpose of the change

This pull request adds the close method to the interface KafkaRecordSerializationSchema  to release the opened resources..

## Brief change log

  - Add the close method to the interface KafkaRecordSerializationSchema

## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (JavaDocs)
