### PR TITLE
[FLINK-26323][tests] Allow CREATED state

### DIFF
--- a/flink-clients/src/test/java/org/apache/flink/client/program/PerJobMiniClusterFactoryTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/PerJobMiniClusterFactoryTest.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 import static org.apache.flink.core.testutils.CommonTestUtils.assertThrows;
+import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -82,7 +83,9 @@ public class PerJobMiniClusterFactoryTest extends TestLogger {
                         .get();
 
         assertThat(jobClient.getJobID(), is(cancellableJobGraph.getJobID()));
-        assertThat(jobClient.getJobStatus().get(), is(JobStatus.RUNNING));
+        assertThat(
+                jobClient.getJobStatus().get(),
+                anyOf(is(JobStatus.CREATED), is(JobStatus.RUNNING)));
 
         jobClient.cancel().get();
 


### PR DESCRIPTION
The test makes a generally incorrect assumption that the job is in a RUNNING state when the job submission returns, but we only guarantee that it is not in an initializing state.