### PR TITLE
[FLINK-28391][runtime] Fix unstable test DefaultBlocklistHandlerTest#testRemoveTimeoutNodes

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blocklist/BlocklistContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blocklist/BlocklistContext.java
@@ -33,7 +33,7 @@ public interface BlocklistContext {
     /**
      * Unblock resources on the nodes.
      *
-     * @param unBlockedNodes the nodes to unblock resources
+     * @param unblockedNodes the nodes to unblock resources
      */
-    void unblockResources(Collection<BlockedNode> unBlockedNodes);
+    void unblockResources(Collection<BlockedNode> unblockedNodes);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blocklist/DefaultBlocklistHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blocklist/DefaultBlocklistHandler.java
@@ -81,6 +81,7 @@ public class DefaultBlocklistHandler implements BlocklistHandler, AutoCloseable 
     }
 
     private void removeTimeoutNodes() {
+        assertRunningInMainThread();
         Collection<BlockedNode> removedNodes =
                 blocklistTracker.removeTimeoutNodes(System.currentTimeMillis());
         if (!removedNodes.isEmpty()) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blocklist/DefaultBlocklistHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blocklist/DefaultBlocklistHandlerTest.java
@@ -86,15 +86,15 @@ class DefaultBlocklistHandlerTest {
 
             handler.addNewBlockedNodes(Arrays.asList(node1, node2));
             assertThat(handler.getAllBlockedNodeIds()).hasSize(2);
-            assertThat(context.allUnBlockedNodes).hasSize(0);
+            assertThat(context.allUnblockedNodes).hasSize(0);
 
             // wait node1 timeout
             CommonTestUtils.waitUntilCondition(() -> handler.getAllBlockedNodeIds().size() == 1);
-            assertThat(context.allUnBlockedNodes).containsExactly(node1);
+            assertThat(context.allUnblockedNodes).containsExactly(node1);
 
             // wait node2 timeout
             CommonTestUtils.waitUntilCondition(() -> handler.getAllBlockedNodeIds().size() == 0);
-            assertThat(context.allUnBlockedNodes).containsExactly(node1, node2);
+            assertThat(context.allUnblockedNodes).containsExactly(node1, node2);
         }
     }
 
@@ -158,7 +158,7 @@ class DefaultBlocklistHandlerTest {
     private static class TestBlocklistContext implements BlocklistContext {
         private final List<BlockedNode> allBlockedNodes = new ArrayList<>();
 
-        private final List<BlockedNode> allUnBlockedNodes = new ArrayList<>();
+        private final List<BlockedNode> allUnblockedNodes = new ArrayList<>();
 
         @Override
         public void blockResources(Collection<BlockedNode> blockedNodes) {
@@ -166,8 +166,8 @@ class DefaultBlocklistHandlerTest {
         }
 
         @Override
-        public void unblockResources(Collection<BlockedNode> unBlockedNodes) {
-            allUnBlockedNodes.addAll(unBlockedNodes);
+        public void unblockResources(Collection<BlockedNode> unblockedNodes) {
+            allUnblockedNodes.addAll(unblockedNodes);
         }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change
[FLINK-28391][runtime] Fix unstable test `DefaultBlocklistHandlerTest#testRemoveTimeoutNodes`

## Verifying this change
This change is already covered by existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**no**)
  - The serializers: (**no**)
  - The runtime per-record code paths (performance sensitive): (**no**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**no**)
  - The S3 file system connector: (**no**)

## Documentation

  - Does this pull request introduce a new feature? (**no**)
  - If yes, how is the feature documented? (**not applicable**)
