### PR TITLE
[FLINK-28405][Connector/Kafka] Update Confluent Platform images used for testing to v7.2.2

### DIFF
--- a/flink-connectors/flink-connector-kafka/pom.xml
+++ b/flink-connectors/flink-connector-kafka/pom.xml
@@ -111,11 +111,12 @@ under the License.
 		</dependency>
 
 		<!-- Required to execute the kafka server for testing. Please change the zookeeper version accordingly when changing the Kafka version
+			 Currently synced with Kafka 3.2.1
              https://github.com/apache/kafka/blob/839b886f9b732b151e1faeace7303c80641c08c4/gradle/dependencies.gradle#L122 -->
 		<dependency>
 			<groupId>org.apache.zookeeper</groupId>
 			<artifactId>zookeeper</artifactId>
-			<version>3.5.9</version>
+			<version>3.6.3</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/flink-connectors/flink-connector-kafka/pom.xml
+++ b/flink-connectors/flink-connector-kafka/pom.xml
@@ -110,13 +110,10 @@ under the License.
 			<scope>test</scope>
 		</dependency>
 
-		<!-- Required to execute the kafka server for testing. Please change the zookeeper version accordingly when changing the Kafka version
-			 Currently synced with Kafka 3.2.1
-             https://github.com/apache/kafka/blob/839b886f9b732b151e1faeace7303c80641c08c4/gradle/dependencies.gradle#L122 -->
 		<dependency>
 			<groupId>org.apache.zookeeper</groupId>
 			<artifactId>zookeeper</artifactId>
-			<version>3.6.3</version>
+			<version>${zookeeper.version}</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/pom.xml
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/pom.xml
@@ -156,6 +156,11 @@ under the License.
 			<version>${project.version}</version>
 			<type>test-jar</type>
 		</dependency>
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>31.1-jre</version>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -236,6 +241,14 @@ under the License.
 							<artifactId>kafka-clients</artifactId>
 							<version>3.2.3</version>
 							<destFileName>kafka-clients.jar</destFileName>
+							<type>jar</type>
+							<outputDirectory>${project.build.directory}/dependencies</outputDirectory>
+						</artifactItem>
+						<artifactItem>
+							<groupId>com.google.guava</groupId>
+							<artifactId>guava</artifactId>
+							<version>31.1-jre</version>
+							<destFileName>guava-31.1-jre.jar</destFileName>
 							<type>jar</type>
 							<outputDirectory>${project.build.directory}/dependencies</outputDirectory>
 						</artifactItem>

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/pom.xml
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/pom.xml
@@ -115,14 +115,14 @@ under the License.
 			<!-- https://mvnrepository.com/artifact/io.confluent/kafka-avro-serializer -->
 			<groupId>io.confluent</groupId>
 			<artifactId>kafka-avro-serializer</artifactId>
-			<version>6.2.2</version>
+			<version>7.2.2</version>
 			<scope>test</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>io.confluent</groupId>
 			<artifactId>kafka-schema-registry-client</artifactId>
-			<version>6.2.2</version>
+			<version>7.2.2</version>
 			<scope>test</scope>
 			<exclusions>
 				<exclusion>

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/pom.xml
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/pom.xml
@@ -159,7 +159,7 @@ under the License.
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>31.1-jre</version>
+			<version>30.1.1-jre</version>
 		</dependency>
 	</dependencies>
 
@@ -247,8 +247,8 @@ under the License.
 						<artifactItem>
 							<groupId>com.google.guava</groupId>
 							<artifactId>guava</artifactId>
-							<version>31.1-jre</version>
-							<destFileName>guava-31.1-jre.jar</destFileName>
+							<version>30.1.1-jre</version>
+							<destFileName>guava.jar</destFileName>
 							<type>jar</type>
 							<outputDirectory>${project.build.directory}/dependencies</outputDirectory>
 						</artifactItem>

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/pom.xml
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/pom.xml
@@ -156,6 +156,7 @@ under the License.
 			<version>${project.version}</version>
 			<type>test-jar</type>
 		</dependency>
+		<!-- Needed by Schema Registry -->
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SQLClientSchemaRegistryITCase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SQLClientSchemaRegistryITCase.java
@@ -86,7 +86,7 @@ public class SQLClientSchemaRegistryITCase {
 
     @ClassRule
     public static final SchemaRegistryContainer REGISTRY =
-            new SchemaRegistryContainer("7.2.2")
+            new SchemaRegistryContainer(DockerImageName.parse(DockerImageVersions.SCHEMA_REGISTRY))
                     .withKafka(INTER_CONTAINER_KAFKA_ALIAS + ":9092")
                     .withNetwork(NETWORK)
                     .withNetworkAliases(INTER_CONTAINER_REGISTRY_ALIAS)

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SQLClientSchemaRegistryITCase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SQLClientSchemaRegistryITCase.java
@@ -84,7 +84,7 @@ public class SQLClientSchemaRegistryITCase {
 
     @ClassRule
     public static final SchemaRegistryContainer REGISTRY =
-            new SchemaRegistryContainer("6.2.2")
+            new SchemaRegistryContainer("7.2.2")
                     .withKafka(INTER_CONTAINER_KAFKA_ALIAS + ":9092")
                     .withNetwork(NETWORK)
                     .withNetworkAliases(INTER_CONTAINER_REGISTRY_ALIAS)

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SQLClientSchemaRegistryITCase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SQLClientSchemaRegistryITCase.java
@@ -71,7 +71,7 @@ public class SQLClientSchemaRegistryITCase {
     private static final Path sqlToolBoxJar = ResourceTestUtils.getResource(".*SqlToolbox.jar");
     private final Path sqlConnectorKafkaJar = ResourceTestUtils.getResource(".*kafka.jar");
 
-    private final Path sqlGuavaJar = ResourceTestUtils.getResource(".*guava-31.1-jre.jar");
+    private final Path sqlGuavaJar = ResourceTestUtils.getResource(".*guava.jar");
 
     @ClassRule public static final Network NETWORK = Network.newNetwork();
 

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SQLClientSchemaRegistryITCase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SQLClientSchemaRegistryITCase.java
@@ -71,6 +71,8 @@ public class SQLClientSchemaRegistryITCase {
     private static final Path sqlToolBoxJar = ResourceTestUtils.getResource(".*SqlToolbox.jar");
     private final Path sqlConnectorKafkaJar = ResourceTestUtils.getResource(".*kafka.jar");
 
+    private final Path sqlGuavaJar = ResourceTestUtils.getResource(".*guava-31.1-jre.jar");
+
     @ClassRule public static final Network NETWORK = Network.newNetwork();
 
     @ClassRule public static final Timeout TIMEOUT = new Timeout(10, TimeUnit.MINUTES);
@@ -254,7 +256,7 @@ public class SQLClientSchemaRegistryITCase {
         flink.submitSQLJob(
                 new SQLJobSubmission.SQLJobSubmissionBuilder(sqlLines)
                         .addJars(
-                                sqlAvroJar, sqlAvroRegistryJar, sqlConnectorKafkaJar, sqlToolBoxJar)
+                                sqlAvroJar, sqlAvroRegistryJar, sqlConnectorKafkaJar, sqlToolBoxJar, sqlGuavaJar)
                         .build());
     }
 }

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SQLClientSchemaRegistryITCase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SQLClientSchemaRegistryITCase.java
@@ -256,7 +256,11 @@ public class SQLClientSchemaRegistryITCase {
         flink.submitSQLJob(
                 new SQLJobSubmission.SQLJobSubmissionBuilder(sqlLines)
                         .addJars(
-                                sqlAvroJar, sqlAvroRegistryJar, sqlConnectorKafkaJar, sqlToolBoxJar, sqlGuavaJar)
+                                sqlAvroJar,
+                                sqlAvroRegistryJar,
+                                sqlConnectorKafkaJar,
+                                sqlToolBoxJar,
+                                sqlGuavaJar)
                         .build());
     }
 }

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SQLClientSchemaRegistryITCase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SQLClientSchemaRegistryITCase.java
@@ -71,7 +71,7 @@ public class SQLClientSchemaRegistryITCase {
     private static final Path sqlToolBoxJar = ResourceTestUtils.getResource(".*SqlToolbox.jar");
     private final Path sqlConnectorKafkaJar = ResourceTestUtils.getResource(".*kafka.jar");
 
-    private final Path sqlGuavaJar = ResourceTestUtils.getResource(".*guava.jar");
+    private final Path guavaJar = ResourceTestUtils.getResource(".*guava.jar");
 
     @ClassRule public static final Network NETWORK = Network.newNetwork();
 
@@ -260,7 +260,7 @@ public class SQLClientSchemaRegistryITCase {
                                 sqlAvroRegistryJar,
                                 sqlConnectorKafkaJar,
                                 sqlToolBoxJar,
-                                sqlGuavaJar)
+                                guavaJar)
                         .build());
     }
 }

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/containers/SchemaRegistryContainer.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/containers/SchemaRegistryContainer.java
@@ -19,6 +19,7 @@
 package org.apache.flink.tests.util.kafka.containers;
 
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
 
 /**
  * A container over an Confluent Schema Registry. It runs the schema registry on port 8082 in the
@@ -26,8 +27,8 @@ import org.testcontainers.containers.GenericContainer;
  */
 public class SchemaRegistryContainer extends GenericContainer<SchemaRegistryContainer> {
 
-    public SchemaRegistryContainer(String version) {
-        super("confluentinc/cp-schema-registry:" + version);
+    public SchemaRegistryContainer(DockerImageName imageName) {
+        super(imageName);
         withExposedPorts(8082);
     }
 

--- a/flink-end-to-end-tests/test-scripts/kafka-common.sh
+++ b/flink-end-to-end-tests/test-scripts/kafka-common.sh
@@ -52,11 +52,7 @@ function setup_kafka_dist {
 function setup_confluent_dist {
   # download confluent
   mkdir -p $TEST_DATA_DIR
-  if [[ $CONFLUENT_MAJOR_VERSION =~ ^[6] ]]; then
-    CONFLUENT_URL="http://packages.confluent.io/archive/$CONFLUENT_MAJOR_VERSION/confluent-community-$CONFLUENT_VERSION.tar.gz"
-  else
-    CONFLUENT_URL="http://packages.confluent.io/archive/$CONFLUENT_MAJOR_VERSION/confluent-community-$CONFLUENT_VERSION-2.12.tar.gz"
-  fi
+  CONFLUENT_URL="http://packages.confluent.io/archive/$CONFLUENT_MAJOR_VERSION/confluent-community-$CONFLUENT_VERSION.tar.gz"
   echo "Downloading confluent from $CONFLUENT_URL"
   cache_path=$(get_artifact $CONFLUENT_URL)
   ln "$cache_path" "${TEST_DATA_DIR}/confluent.tgz"

--- a/flink-end-to-end-tests/test-scripts/test_confluent_schema_registry.sh
+++ b/flink-end-to-end-tests/test-scripts/test_confluent_schema_registry.sh
@@ -20,8 +20,8 @@
 set -Eeuo pipefail
 
 KAFKA_VERSION="3.2.3"
-CONFLUENT_VERSION="6.2.2"
-CONFLUENT_MAJOR_VERSION="6.2"
+CONFLUENT_VERSION="7.2.2"
+CONFLUENT_MAJOR_VERSION="7.2"
 # Check the Confluent Platform <> Apache Kafka compatibility matrix when updating KAFKA_VERSION
 KAFKA_SQL_VERSION="universal"
 

--- a/flink-end-to-end-tests/test-scripts/test_pyflink.sh
+++ b/flink-end-to-end-tests/test-scripts/test_pyflink.sh
@@ -20,8 +20,8 @@
 set -Eeuo pipefail
 
 KAFKA_VERSION="3.2.3"
-CONFLUENT_VERSION="6.2.2"
-CONFLUENT_MAJOR_VERSION="6.2"
+CONFLUENT_VERSION="7.2.2"
+CONFLUENT_MAJOR_VERSION="7.2"
 # Check the Confluent Platform <> Apache Kafka compatibility matrix when updating KAFKA_VERSION
 KAFKA_SQL_VERSION="universal"
 SQL_JARS_DIR=${END_TO_END_DIR}/flink-sql-client-test/target/sql-jars

--- a/flink-formats/flink-avro-confluent-registry/pom.xml
+++ b/flink-formats/flink-avro-confluent-registry/pom.xml
@@ -33,7 +33,7 @@ under the License.
 
 	<properties>
 		<kafka.version>3.2.3</kafka.version>
-		<confluent.version>6.2.2</confluent.version>
+		<confluent.version>7.2.2</confluent.version>
 	</properties>
 
 	<repositories>

--- a/flink-formats/flink-sql-avro-confluent-registry/src/main/resources/META-INF/NOTICE
+++ b/flink-formats/flink-sql-avro-confluent-registry/src/main/resources/META-INF/NOTICE
@@ -11,10 +11,10 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.jackson.core:jackson-databind:2.13.2.2
 - com.fasterxml.jackson.core:jackson-annotations:2.13.2
 - org.apache.commons:commons-compress:1.21
-- io.confluent:kafka-schema-registry-client:6.2.2
-- org.apache.kafka:kafka-clients:6.2.2-ccs
-- io.confluent:common-config:6.2.2
-- io.confluent:common-utils:6.2.2
+- io.confluent:kafka-schema-registry-client:7.2.2
+- org.apache.kafka:kafka-clients:7.2.2-ccs
+- io.confluent:common-config:7.2.2
+- io.confluent:common-utils:7.2.2
 - org.glassfish.jersey.core:jersey-common:2.30
 
 The binary distribution of this product bundles these dependencies under the Eclipse Public License - v 2.0 (https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt)

--- a/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/util/DockerImageVersions.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/util/DockerImageVersions.java
@@ -28,7 +28,7 @@ package org.apache.flink.util;
  */
 public class DockerImageVersions {
 
-    public static final String KAFKA = "confluentinc/cp-kafka:6.2.2";
+    public static final String KAFKA = "confluentinc/cp-kafka:7.2.2";
 
     public static final String RABBITMQ = "rabbitmq:3.9.8-management-alpine";
 

--- a/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/util/DockerImageVersions.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/util/DockerImageVersions.java
@@ -30,6 +30,8 @@ public class DockerImageVersions {
 
     public static final String KAFKA = "confluentinc/cp-kafka:7.2.2";
 
+    public static final String SCHEMA_REGISTRY = "confluentinc/cp-schema-registry:7.2.2";
+
     public static final String RABBITMQ = "rabbitmq:3.9.8-management-alpine";
 
     public static final String KINESALITE = "instructure/kinesalite:latest";

--- a/tools/azure-pipelines/cache_docker_images.sh
+++ b/tools/azure-pipelines/cache_docker_images.sh
@@ -28,7 +28,7 @@ then
 fi
 
 # This is the pattern that determines which containers we save.
-DOCKER_IMAGE_CACHE_PATTERN="testcontainers|kafka|postgres|mysql|pulsar|cassandra|schema_registry"
+DOCKER_IMAGE_CACHE_PATTERN="testcontainers|kafka|postgres|mysql|pulsar|cassandra|schema-registry"
 
 # The path to the tar file that will contain the saved docker images.
 DOCKER_IMAGES_CACHE_PATH="${DOCKER_IMAGES_CACHE_FOLDER}/cache.tar"

--- a/tools/azure-pipelines/cache_docker_images.sh
+++ b/tools/azure-pipelines/cache_docker_images.sh
@@ -28,7 +28,7 @@ then
 fi
 
 # This is the pattern that determines which containers we save.
-DOCKER_IMAGE_CACHE_PATTERN="testcontainers|kafka|postgres|mysql|pulsar|cassandra"
+DOCKER_IMAGE_CACHE_PATTERN="testcontainers|kafka|postgres|mysql|pulsar|cassandra|schema_registry"
 
 # The path to the tar file that will contain the saved docker images.
 DOCKER_IMAGES_CACHE_PATH="${DOCKER_IMAGES_CACHE_FOLDER}/cache.tar"


### PR DESCRIPTION
## What is the purpose of the change

We have updated the used Kafka Clients to v3.1.1 via [FLINK-28060](https://issues.apache.org/jira/browse/FLINK-28060) and then to v3.2.1 via [FLINK-28060](https://issues.apache.org/jira/browse/FLINK-28060) and finally to v3.2.3 via [FLINK-29513](https://issues.apache.org/jira/browse/FLINK-29513), but we are using Confluent Platform 6.2.2 which supports up to Kafka 2.8.0.

We should update to Confluent Platform v7.2.2 (latest version of 7.2), which includes support for Kafka 3.2.3.

## Brief change log

* Updated all references to Confluent Platform versions (6.2.2) to 7.2.2
* Reset Zookeeper to match with the general Zookeeper version we use in Flink
* Refactored Schema Registry container to be included in `DockerImageVersions`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
