### PR TITLE
[FLINK-28404][tests] Invert isAssignableFrom order

### DIFF
--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/junit5/MiniClusterExtension.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/junit5/MiniClusterExtension.java
@@ -170,7 +170,7 @@ public final class MiniClusterExtension
             throws ParameterResolutionException {
         Class<?> parameterType = parameterContext.getParameter().getType();
         if (parameterContext.isAnnotated(InjectClusterClient.class)
-                && parameterType.isAssignableFrom(ClusterClient.class)) {
+                && ClusterClient.class.isAssignableFrom(parameterType)) {
             return true;
         }
         return internalMiniClusterExtension.supportsParameter(parameterContext, extensionContext);

--- a/flink-test-utils-parent/flink-test-utils/src/test/java/org/apache/flink/test/junit5/MiniClusterExtensionTest.java
+++ b/flink-test-utils-parent/flink-test-utils/src/test/java/org/apache/flink/test/junit5/MiniClusterExtensionTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.junit5;
+
+import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.client.program.rest.RestClusterClient;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.minicluster.MiniCluster;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.net.URI;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MiniClusterExtension.class)
+class MiniClusterExtensionTest {
+
+    @Test
+    void testInjectClusterClient(@InjectClusterClient ClusterClient<?> clusterClient) {
+        assertThat(clusterClient).isNotNull();
+    }
+
+    @Test
+    void testInjectRestClusterClient(@InjectClusterClient RestClusterClient<?> clusterClient) {
+        assertThat(clusterClient).isNotNull();
+    }
+
+    @Test
+    void testInjectMiniCluster(@InjectMiniCluster MiniCluster miniCluster) {
+        assertThat(miniCluster).isNotNull();
+    }
+
+    @Test
+    void testInjectClusterRESTAddress(@InjectClusterRESTAddress URI address) {
+        assertThat(address).isNotNull();
+    }
+
+    @Test
+    void testInjectClusterClientConfiguration(
+            @InjectClusterClientConfiguration Configuration config) {
+        assertThat(config).isNotNull();
+    }
+}


### PR DESCRIPTION
Fixes an issue where `@InjectClusterClient` did not work with the `RestClusterClient`, and adds a simple test for all supported injections.