### PR TITLE
[FLINK-27556][state] Inline state handle id generation

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FileStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FileStateHandle.java
@@ -44,8 +44,6 @@ public class FileStateHandle implements StreamStateHandle {
     /** The size of the state in the file. */
     private final long stateSize;
 
-    private final PhysicalStateHandleID physicalID;
-
     /**
      * Creates a new file state for the given file path.
      *
@@ -55,7 +53,6 @@ public class FileStateHandle implements StreamStateHandle {
         checkArgument(stateSize >= -1);
         this.filePath = checkNotNull(filePath);
         this.stateSize = stateSize;
-        this.physicalID = new PhysicalStateHandleID(filePath.toUri().toString());
     }
 
     /**
@@ -79,7 +76,7 @@ public class FileStateHandle implements StreamStateHandle {
 
     @Override
     public PhysicalStateHandleID getStreamStateHandleID() {
-        return physicalID;
+        return new PhysicalStateHandleID(filePath.toUri().toString());
     }
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/ByteStreamStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/ByteStreamStateHandle.java
@@ -41,13 +41,10 @@ public class ByteStreamStateHandle implements StreamStateHandle {
      */
     private final String handleName;
 
-    private final PhysicalStateHandleID physicalID;
-
     /** Creates a new ByteStreamStateHandle containing the given data. */
     public ByteStreamStateHandle(String handleName, byte[] data) {
         this.handleName = Preconditions.checkNotNull(handleName);
         this.data = Preconditions.checkNotNull(data);
-        this.physicalID = new PhysicalStateHandleID(handleName);
     }
 
     @Override
@@ -62,7 +59,7 @@ public class ByteStreamStateHandle implements StreamStateHandle {
 
     @Override
     public PhysicalStateHandleID getStreamStateHandleID() {
-        return physicalID;
+        return new PhysicalStateHandleID(handleName);
     }
 
     public byte[] getData() {


### PR DESCRIPTION
...  to avoid unnecessary overhead when it's not used.

Original benchmark results (good): http://codespeed.dak8s.net:8080/job/flink-benchmark-request/165/
Current  benchmark results (bad): http://codespeed.dak8s.net:8080/job/flink-master-benchmarks-java8/468/
Benchmark results with this change (good): http://codespeed.dak8s.net:8080/job/flink-benchmark-request/170/

(the benchmark is somewhat unstable so I ran it twice)